### PR TITLE
Adds a new space prefab, the candy shop, fixes a couple minor bugs

### DIFF
--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -517,11 +517,15 @@
 /obj/table/wood/round/auto,
 /obj/item/reagent_containers/food/snacks/candy/negativeonebar{
 	pixel_y = 8
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/candy/negativeonebar{
 	pixel_y = 4
+	rand_pos = 0
 	},
-/obj/item/reagent_containers/food/snacks/candy/negativeonebar,
+/obj/item/reagent_containers/food/snacks/candy/negativeonebar{
+	rand_pos = 0
+},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
 "RU" = (

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -303,10 +303,12 @@
 	},
 /obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{
 	pixel_x = 5;
-	pixel_y = 7
+	pixel_y = 7;
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{
-	pixel_x = -4
+	pixel_x = -4;
+	rand_pos = 0
 	},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
@@ -516,16 +518,16 @@
 "Pp" = (
 /obj/table/wood/round/auto,
 /obj/item/reagent_containers/food/snacks/candy/negativeonebar{
-	pixel_y = 8
+	pixel_y = 8;
 	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/candy/negativeonebar{
-	pixel_y = 4
+	pixel_y = 4;
 	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/candy/negativeonebar{
 	rand_pos = 0
-},
+	},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
 "RU" = (

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -536,9 +536,12 @@
 /obj/machinery/light/incandescent/cool/very{
 	dir = 8
 	},
-/obj/item/reagent_containers/food/snacks/candy/nougat,
 /obj/item/reagent_containers/food/snacks/candy/nougat{
-	pixel_y = 8
+	rand_pos = 0
+	},
+/obj/item/reagent_containers/food/snacks/candy/nougat{
+	pixel_y = 4;
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/candy/nougat{
 	pixel_y = 8;

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -36,7 +36,6 @@
 /area/prefab/candy_shop)
 "hD" = (
 /obj/lattice{
-	dir = 2;
 	icon_state = "lattice-dir-b"
 	},
 /obj/machinery/light/runway_light/delay3,
@@ -542,7 +541,8 @@
 	pixel_y = 8
 	},
 /obj/item/reagent_containers/food/snacks/candy/nougat{
-	pixel_y = 4
+	pixel_y = 8;
+	rand_pos = 0
 	},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -138,13 +138,17 @@
 /obj/table/wood/round/auto,
 /obj/item/reagent_containers/food/snacks/candy/candy_apple{
 	pixel_x = -6;
-	pixel_y = 5
+	pixel_y = 5;
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/candy/candy_apple{
 	pixel_x = 6;
-	pixel_y = 3
+	pixel_y = 3;
+	rand_pos = 0
 	},
-/obj/item/reagent_containers/food/snacks/candy/candy_apple,
+/obj/item/reagent_containers/food/snacks/candy/candy_apple{
+	rand_pos = 0
+	},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
 "nE" = (
@@ -168,15 +172,18 @@
 	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/pie/pumpkin{
-	pixel_y = -7
+	pixel_y = -7;
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake{
 	pixel_x = 5;
-	pixel_y = 5
+	pixel_y = 5;
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/moon_pie/spooky{
 	pixel_x = -9;
-	pixel_y = 12
+	pixel_y = 12;
+	rand_pos = 0
 	},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
@@ -187,7 +194,8 @@
 "oP" = (
 /obj/table/wood/round/auto,
 /obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{
-	pixel_y = 7
+	pixel_y = 7;
+	rand_pos = 0
 	},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
@@ -224,6 +232,9 @@
 /obj/item/clothing/suit/lshirt/dan_blue,
 /obj/item/ticket/golden,
 /obj/item/reagent_containers/food/snacks/ice_cream/gross,
+/obj/item/kitchen/plasticpackage,
+/obj/item/kitchen/plasticpackage,
+/obj/item/kitchen/plasticpackage,
 /obj/storage/crate/bin{
 	desc = "Buy one, get the rest free.";
 	name = "bargain bin"
@@ -233,7 +244,8 @@
 "rV" = (
 /obj/table/wood/round/auto,
 /obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{
-	pixel_y = 10
+	pixel_y = 10;
+	rand_pos = 0
 	},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
@@ -264,7 +276,9 @@
 "we" = (
 /obj/table/wood/round/auto,
 /obj/table/wood/round/auto,
-/obj/item/reagent_containers/food/snacks/bagel,
+/obj/item/reagent_containers/food/snacks/bagel{
+	rand_pos = 0
+	},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
 "xC" = (
@@ -332,12 +346,16 @@
 "Ag" = (
 /obj/table/wood/round/auto,
 /obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{
-	pixel_x = 6
+	pixel_x = 6;
+	rand_pos = 0
 	},
-/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,
+/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{
+	rand_pos = 0
+	},
 /obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{
 	pixel_x = -4;
-	pixel_y = 6
+	pixel_y = 6;
+	rand_pos = 0
 	},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
@@ -406,27 +424,32 @@
 /obj/table/wood/round/auto,
 /obj/item/reagent_containers/food/snacks/candy/candy_cane{
 	dir = 8;
-	pixel_x = 4
+	pixel_x = 4;
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/candy/candy_cane{
 	dir = 8;
 	pixel_x = 13;
-	pixel_y = -6
+	pixel_y = -6;
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/candy/candy_cane{
 	dir = 8;
 	pixel_x = 14;
-	pixel_y = 4
+	pixel_y = 4;
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/candy/candy_cane{
 	dir = 8;
 	pixel_x = 5;
-	pixel_y = 6
+	pixel_y = 6;
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/candy/candy_cane{
 	dir = 8;
 	pixel_x = 14;
-	pixel_y = 10
+	pixel_y = 10;
+	rand_pos = 0
 	},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
@@ -463,12 +486,16 @@
 	dir = 8
 	},
 /obj/item/reagent_containers/food/snacks/candy/butterscotch{
-	pixel_y = 8
+	pixel_y = 8;
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/candy/butterscotch{
-	pixel_y = 4
+	pixel_y = 4;
+	rand_pos = 0
 	},
-/obj/item/reagent_containers/food/snacks/candy/butterscotch,
+/obj/item/reagent_containers/food/snacks/candy/butterscotch{
+	rand_pos = 0
+	},
 /turf/simulated/floor/wood/four,
 /area/prefab/candy_shop)
 "Jr" = (
@@ -589,7 +616,8 @@
 "Vt" = (
 /obj/item/reagent_containers/food/snacks/candy/candy_corn{
 	pixel_x = -10;
-	pixel_y = -9
+	pixel_y = -9;
+	rand_pos = 0
 	},
 /obj/item/storage/toilet/random{
 	dir = 8

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,45 +1,45 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"b" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"e" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"g" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"h" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"k" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"l" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"m" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"n" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"o" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"j" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"k" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"l" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"m" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"n" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"r" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"u" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"u" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"v" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"y" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"A" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"B" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"H" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"I" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"G" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"I" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"J" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"M" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"N" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"O" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"P" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"Q" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"R" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"M" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"N" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"O" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Q" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"V" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"U" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"V" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"W" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -47,22 +47,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaaRHzFzzFzkgaaaaa
-aaaaazZZLKinZZzaaaaa
+aaaaamezFzzFznUaaaaa
+aaaaazZZvKiuZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
-aaaaazeCEcwtCSzaaaaa
-aaaaazACCffCCdzaaaaa
-aaaaaFmCsCCsCSFaaaaa
-aaaaaFMCsffsCSFaaaaa
+aaaaazOCEcwlCSzaaaaa
+aaaaazQCCffCCdzaaaaa
+aaaaaFBCsCCsCSFaaaaa
+aaaaaFWCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazLCCffCCLzaaaaa
-aaaaazNNXNNXNNzaaaaa
-aaaaazqlblblbUzaaaaa
-aaaaazrVbDoljOzaaaaa
-aaaaazulblblbOzaaaaa
-aaaaazIQIQIQIQPaaaaa
+aaaaazvCCffCCvzaaaaa
+aaaaazhhXhhXhhzaaaaa
+aaaaazqkykykyVzaaaaa
+aaaaazNjyIMkbJzaaaaa
+aaaaazGkykykyJzaaaaa
+aaaaazAgAgAgAgraaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,32 +1,34 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"d" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"l" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"o" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"q" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"x" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"C" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"P" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"R" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"S" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"W" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"g" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"m" = (/obj/forcefield/energyshield/perma,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"n" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"r" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"w" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"B" = (/obj/machinery/door/unpowered/wood/pyro{name = Carlisle's Confections},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"D" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"F" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"H" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"J" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"N" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"O" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"S" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Z" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
-aaaCCCSCCSCCCaaa
-aaaCxxbWbbxxCaaa
-aaaCbbdjbbbbCaaa
-aaaClboqddblCaaa
-aaaClbbbbbblCaaa
-aaaSlbPbbPblSaaa
-aaaSlbPbbPblSaaa
-aaaSlbPbbPblSaaa
-aaaClbbbbbblCaaa
-aaaCRbbbbbblCaaa
-aaaCbbbbbbbbCaaa
-aaaCbbbbbbbbCaaa
-aaaaaaaaaaaaaaaa
+aaaDDDrDDrDDDaaa
+aaaDNNOgOONNDaaa
+aaaDOOJHOOOODaaa
+aaaDZOnSJJOZDaaa
+aaaDZOOOOOOZDaaa
+aaarZOwOOwOZraaa
+aaarZOwOOwOZraaa
+aaarZOwOOwOZraaa
+aaaDZOOOOOOZDaaa
+aaaDFOOOOOOZDaaa
+aaaDOOOOOOOODaaa
+aaaDrrBrrBrrDaaa
+aaaDmmmmmmmmDaaa
 aaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,23 +1,28 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"k" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"M" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"i" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"j" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"k" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"m" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"w" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"x" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"M" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"X" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
-aaakkkkkkkkkkaaa
-aaakMZZMMZZMkaaa
-aaakMMMMMMMMkaaa
-aaakMMMMMMMMkaaa
-aaakMMMMMMMMkaaa
-aaakMMMMMMMMkaaa
-aaakMMMMMMMMkaaa
-aaakMMMMMMMMkaaa
-aaakMMMMMMMMkaaa
-aaakMMMMMMMMkaaa
-aaakMMMMMMMMkaaa
-aaakMMMMMMMMkaaa
+aaaxxxxxxxxxxaaa
+aaaxXXmmmmXXxaaa
+aaaxmmijmmmmxaaa
+aaaxwmikiimmxaaa
+aaaxwmmmmmmmxaaa
+aaaxwmmmmmmmxaaa
+aaaxwmmmmmmmxaaa
+aaaxwmmmmmmmxaaa
+aaaxwmmmmmmmxaaa
+aaaxMmmmmmmmxaaa
+aaaxmmmmmmmmxaaa
+aaaxmmmmmmmmxaaa
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,81 +1,81 @@
-"bd" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"bi" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"cK" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"cY" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"dk" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"dG" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"gY" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"iF" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"jm" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = 5; pixel_y = 7},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = -4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"jL" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ky" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"lk" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"lB" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
-"oF" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"oZ" = (/obj/decal/skeleton{name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"qc" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
-"qX" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"rI" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"tz" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"uN" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"vm" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"xD" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"yw" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"yM" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"yS" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"zd" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
-"ze" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"zI" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Co" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"FJ" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"FW" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"FY" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
-"FZ" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Gf" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ID" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"IZ" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"Kt" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Kw" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Nb" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"Nf" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Oq" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"PS" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Qg" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"RF" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"SF" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"SM" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"SS" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
-"TA" = (/turf/variableTurf/clear,/area/noGenerate)
-"TB" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"Vd" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Vf" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"Vg" = (/obj/table/wood/round/auto,/obj/item/clothing/under/suit/purple/dress{pixel_x = 8; pixel_y = -7},/obj/item/clothing/under/suit/purple{pixel_x = -8; pixel_y = -7},/obj/item/clothing/head/that/purple{pixel_x = -8; pixel_y = 7},/obj/item/clothing/head/that/purple{pixel_x = 8; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"VN" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"VW" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Xq" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Xw" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ZJ" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ZU" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
+"bF" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"dE" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
+"eH" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"eT" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"fH" = (/obj/table/wood/round/auto,/obj/item/clothing/under/suit/purple/dress{pixel_x = 8; pixel_y = -7},/obj/item/clothing/under/suit/purple{pixel_x = -8; pixel_y = -7},/obj/item/clothing/head/that/purple{pixel_x = -8; pixel_y = 7},/obj/item/clothing/head/that/purple{pixel_x = 8; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"gy" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"gA" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"gK" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
+"hG" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"iH" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"ji" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
+"jS" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ks" = (/turf/variableTurf/clear,/area/noGenerate)
+"ld" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ll" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"ma" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"oA" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"oP" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ru" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"rB" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"sC" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"to" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = 5; pixel_y = 7},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = -4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Ay" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
+"AM" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Bl" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Cr" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Cs" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"DC" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"EE" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"FI" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Gb" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"GZ" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Hi" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"HH" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Ii" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Jr" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Jz" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Ke" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Kp" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"KJ" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
+"Lu" = (/obj/decal/skeleton{desc = "The remains of a confectioner."; name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"MV" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Nj" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Nz" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"NC" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"NM" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"OT" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Po" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"PX" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Qx" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
+"Ri" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ST" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Vi" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"VF" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"VT" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"WI" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"XV" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"YB" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 
 (1,1,1) = {"
-TATATATATATATATATATATATATATATATATATATATA
-TATATATATATATATATATATATATATATATATATATATA
-TATATATATAcYTBbdoFbdbdoFbdIZIDTATATATATA
-TATATATATAbdzezeGfVNuNKwzezebdTATATATATA
-TATATATATAbdRFRFQgoZRFRFRFRFbdTATATATATA
-TATATATATAbdjLRFXqdGbiqXRFvmbdTATATATATA
-TATATATATAbdywRFRFFJFJRFRFjmbdTATATATATA
-TATATATATAoFgYRFzIRFRFzIRFVdoFTATATATATA
-TATATATATAoFVWRFzIFJFJzIRFVgoFTATATATATA
-TATATATATAoFCoRFOqRFRFzIRFPSoFTATATATATA
-TATATATATAbdXwRFRFFJFJRFRFNfbdTATATATATA
-TATATATATAbdZJRFRFRFRFRFRFcKbdTATATATATA
-TATATATATAbdGfRFRFFJFJRFRFGfbdTATATATATA
-TATATATATAbdFWFWSMFWFWSMFWFWbdTATATATATA
-TATASSTATAbdVfkyiFkyiFkyiFdkbdTATATATATA
-TAlBFYqcqcbdxDrIiFKtNbkyyMFZbdTATATATATA
-TATAZUTATAbdSFkyiFkyiFkyiFFZbdTATATATATA
-TATATATATAbdlktzlktzlktzlktzySTATATATATA
-TATATATATAzdTATATATATATATATAzdTATATATATA
-TATATATATATATATATATATATATATATATATATATATA
+ksksksksksksksksksksksksksksksksksksksks
+ksksksksksksksksksksksksksksksksksksksks
+ksksksksksiHVFllDCllllDCllVTNCksksksksks
+ksksksksksllRiRimaPoeTbFRiRillksksksksks
+ksksksksksllgygyAMLugygygygyllksksksksks
+ksksksksksllFIgyWICsoABlgyGZllksksksksks
+ksksksksksllKpgygyKeKegygytollksksksksks
+ksksksksksDCrBgyeHgygyeHgyJrDCksksksksks
+ksksksksksDCMVgyeHKeKeeHgyfHDCksksksksks
+ksksksksksDCOTgyjSgygyeHgyoPDCksksksksks
+ksksksksksllSTgygyKeKegygygAllksksksksks
+ksksksksksllJzgygygygygygyldllksksksksks
+ksksksksksllmagygyKeKegygymallksksksksks
+ksksksksksllNMNMsCNMNMsCNMNMllksksksksks
+ksksgKksksllYBHHruHHruHHruEEllksksksksks
+ksAyKJdEdEllNzCrruViXVHHNjPXllksksksksks
+ksksjiksksllIiHHruHHruHHruPXllksksksksks
+ksksksksksllhGHihGHihGHihGHiGbksksksksks
+ksksksksksQxksksksksksksksksQxksksksksks
+ksksksksksksksksksksksksksksksksksksksks
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -2,13 +2,15 @@
 "cN" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "dg" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "du" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"hk" = (/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "hD" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
 "hV" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "iU" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
 "jp" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "jE" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
+"kr" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "Toilet"},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "kz" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"kC" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "restroom"},/turf/simulated/floor/sanitary/white,/area/prefab/candy_shop)
+"kR" = (/obj/decoration/toiletholder{desc = "Definitely a trendy new design and NOT just a standard toilet paper holder that's been installed incorrectly, no way no how."; dir = 8; name = "deluxe toilet paper holder"; pixel_x = 10},/obj/window/cubicle{dir = 1},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "nb" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "ng" = (/obj/table/wood/round/auto,/obj/item/clothing/under/suit/purple/dress{pixel_x = 8; pixel_y = -7},/obj/item/clothing/under/suit/purple{pixel_x = -8; pixel_y = -7},/obj/item/clothing/head/that/purple{pixel_x = -8; pixel_y = 7},/obj/item/clothing/head/that/purple{pixel_x = 8; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "nz" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -31,35 +33,33 @@
 "xT" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = 5; pixel_y = 7},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = -4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "yk" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "yA" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"za" = (/obj/item/storage/toilet/random{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"zI" = (/obj/item/storage/toilet/random{dir = 8},/obj/decoration/toiletholder{pixel_y = 33},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
+"zn" = (/obj/window/cubicle{dir = 9},/obj/item/reagent_containers/food/snacks/candy/candy_corn,/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Ag" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "AK" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "AU" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "Cu" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"CG" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "restroom"},/turf/simulated/floor/sanitary/white,/area/prefab/candy_shop)
 "Df" = (/obj/decal/skeleton{desc = "The remains of a confectioner."; name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "DL" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "Fq" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Fw" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "FS" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Hn" = (/obj/item/storage/secure/ssafe/candy_shop{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Hy" = (/obj/window/cubicle{dir = 1},/obj/window/cubicle{dir = 8; icon_state = "cubicle"},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
+"Ht" = (/obj/item/storage/toilet/random{dir = 8},/obj/decoration/toiletholder{pixel_y = 33},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "HJ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Jr" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "JQ" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "Kb" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "KG" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Lm" = (/obj/submachine/chef_sink/chem_sink{dir = 4; pixel_x = -4},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"Md" = (/obj/decoration/toiletholder{desc = "Definitely a trendy new design and NOT just a standard toilet paper holder that's been installed incorrectly, no way no how."; dir = 8; name = "deluxe toilet paper holder"; pixel_x = 10},/obj/window/cubicle{dir = 1},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Ne" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "Nj" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"NI" = (/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Pp" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Sn" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "Toilet"},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
+"RU" = (/obj/submachine/chef_sink/chem_sink{dir = 4; pixel_x = -4},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Tk" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "TX" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "Us" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "UE" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Vt" = (/obj/item/storage/toilet/random{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Wk" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
 "Yo" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "YM" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -69,9 +69,9 @@
 tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
 tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
 tBtBtBtBtBTXnEnbYonbnbYonbduCunbnbnbnbtB
-tBtBtBtBtBnbxCxCqNHndgryxCxCnbLmSnzInbtB
-tBtBtBtBtBnbxIxIcNDfxIxIxIxICGhkHyMdnbtB
-tBtBtBtBtBnbxQxIuRFqykxFxIFSnbLmSnzanbtB
+tBtBtBtBtBnbxCxCqNHndgryxCxCnbRUkrHtnbtB
+tBtBtBtBtBnbxIxIcNDfxIxIxIxIkCNIznkRnbtB
+tBtBtBtBtBnbxQxIuRFqykxFxIFSnbRUkrVtnbtB
 tBtBtBtBtBnbTkxIxIAKAKxIxIxTnbnbnbnbnbtB
 tBtBtBtBtBYoFwxIYMxIxIYMxIrVYotBtBtBtBtB
 tBtBtBtBtBYoAgxIYMAKAKYMxIngYotBtBtBtBtB

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -39,7 +39,7 @@
 "Fq" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Fw" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "FS" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Hn" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Hn" = (/obj/item/storage/secure/ssafe/candy_shop{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "HJ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Jr" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "JQ" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,31 +1,32 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
 "b" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"f" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"k" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"n" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"s" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"x" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"F" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"K" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Q" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"S" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"d" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"j" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"l" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"o" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"q" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"x" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"C" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"P" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"R" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"S" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"W" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
-aaaDDDDDDDDDDaaa
-aaaDkkbxbbkkDaaa
-aaaDbbfFbbbbDaaa
-aaaDKbQnffbKDaaa
-aaaDKbbbbbbKDaaa
-aaaDKbSbbSbKDaaa
-aaaDKbSbbSbKDaaa
-aaaDKbSbbSbKDaaa
-aaaDKbSbbSbKDaaa
-aaaDsbbbbbbKDaaa
-aaaDbbbbbbbbDaaa
-aaaDbbbbbbbbDaaa
+aaaCCCSCCSCCCaaa
+aaaCxxbWbbxxCaaa
+aaaCbbdjbbbbCaaa
+aaaClboqddblCaaa
+aaaClbbbbbblCaaa
+aaaSlbPbbPblSaaa
+aaaSlbPbbPblSaaa
+aaaSlbPbbPblSaaa
+aaaClbbbbbblCaaa
+aaaCRbbbbbblCaaa
+aaaCbbbbbbbbCaaa
+aaaCbbbbbbbbCaaa
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,26 +1,31 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"e" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"g" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"l" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
-"q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -24},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -24},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"r" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"v" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"t" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"B" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"B" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"D" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"J" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Q" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"P" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"U" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"V" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -29,7 +34,7 @@
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
 aaaaazzzFzzFzzzaaaaa
-aaaaazZZBKiCZZzaaaaa
+aaaaazZZVKiCZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
 aaaaazSCEcwwCSzaaaaa
 aaaaazYCCffCCdzaaaaa
@@ -38,12 +43,12 @@ aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazBCCffCCBzaaaaa
+aaaaazVCCffCCVzaaaaa
 aaaaazFFXFFXFFzaaaaa
-aaaaazqvrvrvrvzaaaaa
-aaaaaFrvrvrvrvFaaaaa
-aaaaaFrvrvrvrvFaaaaa
-aaaaazGyGyGyGyQaaaaa
+aaaaazqrgrgrgJzaaaaa
+aaaaazDBgrgrtJzaaaaa
+aaaaazUrgrgrgJzaaaaa
+aaaaazPlPlPlPleaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,33 +1,34 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
+"b" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"e" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"k" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"l" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"m" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"n" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"o" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"m" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
-"q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -24},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"u" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"t" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"v" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"A" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"H" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"G" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"I" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"N" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"L" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"N" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"O" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"P" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"R" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"V" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"W" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -36,7 +37,7 @@
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
 aaaaazzzFzzFzzzaaaaa
-aaaaazZZoKiCZZzaaaaa
+aaaaazZZmKiCZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
 aaaaazSCEcwwCSzaaaaa
 aaaaazYCCffCCdzaaaaa
@@ -45,12 +46,12 @@ aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazoCCffCCozaaaaa
+aaaaazmCCffCCmzaaaaa
 aaaaazFFXFFXFFzaaaaa
-aaaaazqnVnVnVNzaaaaa
-aaaaazmuVAlnkNzaaaaa
-aaaaazenVnVnVNzaaaaa
-aaaaazHgHgHgHgDaaaaa
+aaaaazqebebebtzaaaaa
+aaaaazLIbRGeAvzaaaaa
+aaaaazPebebebvzaaaaa
+aaaaazOWOWOWOWNaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,45 +1,45 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"b" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"e" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"h" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"h" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"j" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "k" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"l" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"m" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"n" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"m" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"n" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"o" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"u" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"v" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"t" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"u" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"y" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"B" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"A" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"B" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"D" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"I" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"J" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"H" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"I" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"J" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"M" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"N" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"O" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Q" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"L" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"M" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"N" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"O" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"P" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Q" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"R" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"V" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"W" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"W" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -47,22 +47,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaamezFzzFznUaaaaa
-aaaaazZZvKiuZZzaaaaa
+aaaaatjzFzzFzRbaaaaa
+aaaaazZZuKiOZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
-aaaaazOCEcwlCSzaaaaa
-aaaaazQCCffCCdzaaaaa
-aaaaaFBCsCCsCSFaaaaa
-aaaaaFWCsffsCSFaaaaa
+aaaaazeCEcwPCSzaaaaa
+aaaaazACCffCCdzaaaaa
+aaaaaFNCsCCsCSFaaaaa
+aaaaaFDCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazvCCffCCvzaaaaa
-aaaaazhhXhhXhhzaaaaa
-aaaaazqkykykyVzaaaaa
-aaaaazNjyIMkbJzaaaaa
-aaaaazGkykykyJzaaaaa
-aaaaazAgAgAgAgraaaaa
+aaaaazuCCffCCuzaaaaa
+aaaaazHHXHHXHHzaaaaa
+aaaaazqkokokoJzaaaaa
+aaaaazhQoyIkmLzaaaaa
+aaaaazBkokokoLzaaaaa
+aaaaazMnMnMnMnWaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,44 +1,45 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
+"b" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"e" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"g" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"l" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"m" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"n" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"j" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"k" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"l" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"m" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"n" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"o" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "r" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"u" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"v" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"t" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"u" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"B" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"A" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"D" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"H" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"J" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"H" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"I" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"M" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"N" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"O" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Q" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"R" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"L" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"M" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"N" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"O" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"P" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"Q" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"R" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"V" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"U" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"V" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -46,22 +47,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaaUyzFzzFzeGaaaaa
-aaaaazZZuKiQZZzaaaaa
+aaaaaRHzFzzFzkgaaaaa
+aaaaazZZLKinZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
-aaaaaztCEcwmCSzaaaaa
-aaaaazgCCffCCdzaaaaa
-aaaaaFJCsCCsCSFaaaaa
-aaaaaFSCsffsCSFaaaaa
+aaaaazeCEcwtCSzaaaaa
+aaaaazACCffCCdzaaaaa
+aaaaaFmCsCCsCSFaaaaa
+aaaaaFMCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazuCCffCCuzaaaaa
-aaaaazvvXvvXvvzaaaaa
-aaaaazqLVLVLVjzaaaaa
-aaaaazrOVNDLRBzaaaaa
-aaaaazMLVLVLVBzaaaaa
-aaaaaznlnlnlnlHaaaaa
+aaaaazLCCffCCLzaaaaa
+aaaaazNNXNNXNNzaaaaa
+aaaaazqlblblbUzaaaaa
+aaaaazrVbDoljOzaaaaa
+aaaaazulblblbOzaaaaa
+aaaaazIQIQIQIQPaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,31 +1,33 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"e" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"g" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"l" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"k" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"l" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"m" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"n" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"o" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -24},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"u" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"B" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"A" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"D" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"J" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"H" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"P" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"N" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"V" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"V" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -34,7 +36,7 @@
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
 aaaaazzzFzzFzzzaaaaa
-aaaaazZZVKiCZZzaaaaa
+aaaaazZZoKiCZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
 aaaaazSCEcwwCSzaaaaa
 aaaaazYCCffCCdzaaaaa
@@ -43,12 +45,12 @@ aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazVCCffCCVzaaaaa
+aaaaazoCCffCCozaaaaa
 aaaaazFFXFFXFFzaaaaa
-aaaaazqrgrgrgJzaaaaa
-aaaaazDBgrgrtJzaaaaa
-aaaaazUrgrgrgJzaaaaa
-aaaaazPlPlPlPleaaaaa
+aaaaazqnVnVnVNzaaaaa
+aaaaazmuVAlnkNzaaaaa
+aaaaazenVnVnVNzaaaaa
+aaaaazHgHgHgHgDaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,78 +1,81 @@
-"ar" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"aA" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"fr" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"fE" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"fM" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"fN" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"fT" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"gC" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"hn" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
-"iy" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"iH" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"iV" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"js" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"ky" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
-"lh" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"nR" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"nT" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
-"qD" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"sg" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"td" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ti" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"uo" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ur" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"uz" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"vW" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"xc" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"xd" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"zF" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"zJ" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"zM" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Bu" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"CR" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"CX" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"DR" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"EF" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Fr" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"FS" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"If" = (/turf/variableTurf/clear,/area/noGenerate)
-"IM" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Jp" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"Km" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Kp" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
-"Mv" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"MU" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"OQ" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"QU" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"TA" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"TL" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
-"UY" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"VJ" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"WF" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Xv" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
-"Yp" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Zl" = (/obj/decal/skeleton{name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ZJ" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"bd" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"bi" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"cK" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"cY" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"dk" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"dG" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"gY" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"iF" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"jm" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = 5; pixel_y = 7},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = -4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"jL" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ky" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"lk" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"lB" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
+"oF" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"oZ" = (/obj/decal/skeleton{name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"qc" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
+"qX" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"rI" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"tz" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"uN" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"vm" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"xD" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"yw" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"yM" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"yS" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"zd" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
+"ze" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"zI" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Co" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"FJ" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"FW" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"FY" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
+"FZ" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Gf" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ID" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"IZ" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"Kt" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Kw" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Nb" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Nf" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Oq" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"PS" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Qg" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"RF" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"SF" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"SM" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"SS" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
+"TA" = (/turf/variableTurf/clear,/area/noGenerate)
+"TB" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"Vd" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Vf" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Vg" = (/obj/table/wood/round/auto,/obj/item/clothing/under/suit/purple/dress{pixel_x = 8; pixel_y = -7},/obj/item/clothing/under/suit/purple{pixel_x = -8; pixel_y = -7},/obj/item/clothing/head/that/purple{pixel_x = -8; pixel_y = 7},/obj/item/clothing/head/that/purple{pixel_x = 8; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"VN" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"VW" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Xq" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Xw" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ZJ" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ZU" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
 
 (1,1,1) = {"
-IfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIf
-IfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIf
-IfIfIfIfIfZJJpFrurFrFrurFrargCIfIfIfIfIf
-IfIfIfIfIfFrfTfTnRfNaAuzfTfTFrIfIfIfIfIf
-IfIfIfIfIfFrFSFSzMZlFSFSFSFSFrIfIfIfIfIf
-IfIfIfIfIfFrfrFSzJqDKmEFFSWFFrIfIfIfIfIf
-IfIfIfIfIfFrYpFSFSDRDRFSFSlhFrIfIfIfIfIf
-IfIfIfIfIfurMvFSiyFSFSiyFSuourIfIfIfIfIf
-IfIfIfIfIfurQUFSiyDRDRiyFSiHurIfIfIfIfIf
-IfIfIfIfIfurCRFSiyFSFSiyFSiHurIfIfIfIfIf
-IfIfIfIfIfFrtdFSFSDRDRFSFSlhFrIfIfIfIfIf
-IfIfIfIfIfFrsgFSFSFSFSFSFStiFrIfIfIfIfIf
-IfIfIfIfIfFrnRFSFSDRDRFSFSnRFrIfIfIfIfIf
-IfIfIfIfIfFrIMIMvWIMIMvWIMIMFrIfIfIfIfIf
-IfIfXvIfIfFrjsiVxdiVxdiVxdTAFrIfIfIfIfIf
-IfhnKpkykyFrCXOQxdMUfEiVUYfMFrIfIfIfIfIf
-IfIfnTIfIfFrzFiVxdiVxdiVxdfMFrIfIfIfIfIf
-IfIfIfIfIfFrxcVJxcVJxcVJxcVJBuIfIfIfIfIf
-IfIfIfIfIfTLIfIfIfIfIfIfIfIfTLIfIfIfIfIf
-IfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIf
+TATATATATATATATATATATATATATATATATATATATA
+TATATATATATATATATATATATATATATATATATATATA
+TATATATATAcYTBbdoFbdbdoFbdIZIDTATATATATA
+TATATATATAbdzezeGfVNuNKwzezebdTATATATATA
+TATATATATAbdRFRFQgoZRFRFRFRFbdTATATATATA
+TATATATATAbdjLRFXqdGbiqXRFvmbdTATATATATA
+TATATATATAbdywRFRFFJFJRFRFjmbdTATATATATA
+TATATATATAoFgYRFzIRFRFzIRFVdoFTATATATATA
+TATATATATAoFVWRFzIFJFJzIRFVgoFTATATATATA
+TATATATATAoFCoRFOqRFRFzIRFPSoFTATATATATA
+TATATATATAbdXwRFRFFJFJRFRFNfbdTATATATATA
+TATATATATAbdZJRFRFRFRFRFRFcKbdTATATATATA
+TATATATATAbdGfRFRFFJFJRFRFGfbdTATATATATA
+TATATATATAbdFWFWSMFWFWSMFWFWbdTATATATATA
+TATASSTATAbdVfkyiFkyiFkyiFdkbdTATATATATA
+TAlBFYqcqcbdxDrIiFKtNbkyyMFZbdTATATATATA
+TATAZUTATAbdSFkyiFkyiFkyiFFZbdTATATATATA
+TATATATATAbdlktzlktzlktzlktzySTATATATATA
+TATATATATAzdTATATATATATATATAzdTATATATATA
+TATATATATATATATATATATATATATATATATATATATA
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,28 +1,29 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"i" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"k" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"m" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"w" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"x" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"M" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"X" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"d" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"m" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"n" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"p" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"v" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"I" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Q" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"R" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Y" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
-aaaxxxxxxxxxxaaa
-aaaxXXmmmmXXxaaa
-aaaxmmijmmmmxaaa
-aaaxwmikiimmxaaa
-aaaxwmmmmmmmxaaa
-aaaxwmmmmmmmxaaa
-aaaxwmmmmmmmxaaa
-aaaxwmmmmmmmxaaa
-aaaxwmmmmmmmxaaa
-aaaxMmmmmmmmxaaa
-aaaxmmmmmmmmxaaa
-aaaxmmmmmmmmxaaa
+aaappppppppppaaa
+aaapRRnvnnRRpaaa
+aaapnndYnnnnpaaa
+aaapmndQddnnpaaa
+aaapmnnnnnnnpaaa
+aaapmnnnnnnnpaaa
+aaapmnnnnnnnpaaa
+aaapmnnnnnnnpaaa
+aaapmnnnnnnnpaaa
+aaapInnnnnnnpaaa
+aaapnnnnnnnnpaaa
+aaapnnnnnnnnpaaa
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,47 +1,52 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"b" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"e" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"h" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"g" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"h" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"k" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"m" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"n" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"o" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"j" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"k" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"l" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
+"m" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
+"n" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
+"o" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections"},/turf/variableTurf/clear,/area/noGenerate)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"r" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"v" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"t" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"u" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"v" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"y" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"B" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"A" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
+"B" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"D" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"H" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"I" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"G" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"H" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"I" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "J" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"M" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"O" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"P" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"Q" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"R" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"L" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"M" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"N" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"O" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"P" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Q" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"R" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"V" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"U" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"V" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"W" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -49,22 +54,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaaBDzFzzFzbmaaaaa
-aaaaazZZVKiHZZzaaaaa
-aaaaazCCgxCCCCzaaaaa
-aaaaazoCEcwMCSzaaaaa
+aaaaajRzFzzFzDeaaaaa
+aaaaazZZyKiMZZzaaaaa
+aaaaazCChxCCCCzaaaaa
+aaaaazPCEcwtCSzaaaaa
 aaaaazYCCffCCdzaaaaa
-aaaaaFGCsCCsCSFaaaaa
-aaaaaFkCsffsCSFaaaaa
-aaaaaFRCsCCsCSFaaaaa
-aaaaazOCCffCCdzaaaaa
+aaaaaFOCsCCsCSFaaaaa
+aaaaaFQCsffsCSFaaaaa
+aaaaaFkCsCCsCSFaaaaa
+aaaaazbCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazVCCffCCVzaaaaa
-aaaaazAAXAAXAAzaaaaa
-aaaaazqjejejeQzaaaaa
-aaaaazPheUyjvLzaaaaa
-aaaaazJjejejeLzaaaaa
-aaaaazrnrnrnrnIaaaaa
+aaaaazyCCffCCyzaaaaa
+aaaaazBBXBBXBBzaaaaa
+aaAaazquWuWuWLzaaaaa
+anollzrUWNvugVzaaaaa
+aamaazJuWuWuWVzaaaaa
+aaaaazIHIHIHIHGaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,0 +1,20 @@
+"a" = (/turf/space,/area/prefab/candy_shop)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaa
+"}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,69 +1,69 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"b" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"e" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"h" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"g" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"h" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"k" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"l" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"m" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"n" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"o" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"j" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"k" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"m" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"n" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"r" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"u" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"v" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"t" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"u" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"y" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"A" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"B" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"D" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"I" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"G" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"H" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"I" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"J" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"M" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"N" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"O" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"P" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"Q" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"R" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"M" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"N" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"O" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"P" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Q" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"R" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"V" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"W" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"W" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaalDzFzzFzgjaaaaa
-aaaaazZZUKiNZZzaaaaa
+aaaaagMzFzzFzIGaaaaa
+aaaaazZZRKiWZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
-aaaaaznCEcwICSzaaaaa
-aaaaazbCCffCCdzaaaaa
-aaaaaFRCsCCsCSFaaaaa
-aaaaaFkCsffsCSFaaaaa
-aaaaaFGCsCCsCSFaaaaa
+aaaaazjCEcwrCSzaaaaa
 aaaaazYCCffCCdzaaaaa
+aaaaaFmCsCCsCSFaaaaa
+aaaaaFuCsffsCSFaaaaa
+aaaaaFBCsCCsCSFaaaaa
+aaaaazNCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazUCCffCCUzaaaaa
-aaaaazhhXhhXhhzaaaaa
-aaaaazqMuMuMuozaaaaa
-aaaaazPVuWQMeOzaaaaa
-aaaaazLMuMuMuOzaaaaa
-aaaaazvrvrvrvrmaaaaa
+aaaaazRCCffCCRzaaaaa
+aaaaazPPXPPXPPzaaaaa
+aaaaazqJOJOJObzaaaaa
+aaaaazAtODhJHkzaaaaa
+aaaaaznJOJOJOkzaaaaa
+aaaaazyeyeyeyeQaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,91 +1,1067 @@
-"au" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/obj/machinery/light/runway_light/delay4,/turf/variableTurf/clear,/area/noGenerate)
-"cN" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"dg" = (/obj/machinery/light/incandescent/netural{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"du" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"hD" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/obj/machinery/light/runway_light/delay3,/turf/variableTurf/clear,/area/noGenerate)
-"hV" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"iU" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
-"jp" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"jE" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/obj/machinery/light/runway_light/delay2,/turf/variableTurf/clear,/area/noGenerate)
-"kr" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "Toilet"},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"kz" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"kC" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "restroom"},/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/sanitary/white,/area/prefab/candy_shop)
-"kR" = (/obj/decoration/toiletholder{desc = "Definitely a trendy new design and NOT just a standard toilet paper holder that's been installed incorrectly, no way no how."; dir = 8; name = "deluxe toilet paper holder"; pixel_x = 10},/obj/window/cubicle{dir = 1},/obj/machinery/light/incandescent/cool{dir = 4},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"nb" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"ng" = (/obj/table/wood/round/auto,/obj/item/clothing/under/suit/purple/dress{pixel_x = 8; pixel_y = -7},/obj/item/clothing/under/suit/purple{pixel_x = -8; pixel_y = -7},/obj/item/clothing/head/that/purple{pixel_x = -8; pixel_y = 7},/obj/item/clothing/head/that/purple{pixel_x = 8; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"nz" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"nE" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"nQ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/pie/pumpkin{pixel_y = -7},/obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake{pixel_x = 5; pixel_y = 5},/obj/item/reagent_containers/food/snacks/moon_pie/spooky{pixel_x = -9; pixel_y = 12},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"oK" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"oP" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"qz" = (/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -28},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"qN" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ry" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/item/reagent_containers/food/snacks/ice_cream/gross,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"rV" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"tf" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"th" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/obj/machinery/light/runway_light/delay5,/turf/variableTurf/clear,/area/noGenerate)
-"tB" = (/turf/variableTurf/clear,/area/noGenerate)
-"uR" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"we" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"xC" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"xF" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"xI" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"xQ" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"xT" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = 5; pixel_y = 7},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = -4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"yk" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"yA" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"zn" = (/obj/window/cubicle{dir = 9},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"Ag" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"AK" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"AU" = (/obj/neon_lining{dir = 8},/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26; pixel_y = 2},/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26; pixel_y = 2},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"Cu" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"Df" = (/obj/decal/skeleton{desc = "The remains of a confectioner."; name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"DL" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"Fq" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Fw" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"FS" = (/obj/table/wood/round/auto,/obj/machinery/light/lamp/green{pixel_x = -5; pixel_y = 9},/obj/item/storage/goodybag{pixel_x = 5; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Hn" = (/obj/item/storage/secure/ssafe/candy_shop{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Ht" = (/obj/item/storage/toilet/random{dir = 8},/obj/decoration/toiletholder{pixel_y = 33},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"HJ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/cool/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Jr" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"JQ" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Kb" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"KG" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Ne" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 28},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Nj" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"NI" = (/obj/machinery/light/small/floor/cool,/obj/neon_lining{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"Pp" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"RU" = (/obj/submachine/chef_sink/chem_sink{dir = 4; pixel_x = -4},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"Tk" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/cool/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"TX" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"Us" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"UE" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages."; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Vt" = (/obj/item/reagent_containers/food/snacks/candy/candy_corn{pixel_x = -10; pixel_y = -9},/obj/item/storage/toilet/random{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"Wk" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/obj/machinery/light/runway_light/delay3,/turf/variableTurf/clear,/area/noGenerate)
-"Yo" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"YM" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages."; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"YO" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Zb" = (/obj/machinery/light/small/floor/cool/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"au" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir";
+	tag = "icon-lattice-dir (EAST)"
+	},
+/obj/machinery/light/runway_light/delay4,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"cN" = (
+/obj/table/wood/auto/desk,
+/obj/item/paper{
+	icon_state = "paper_caution_bloody";
+	info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye.";
+	name = "bloody note";
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"dg" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"du" = (
+/obj/decal/poster/wallsign/stencil/right/a{
+	pixel_y = 15
+	},
+/obj/decal/poster/wallsign/stencil/left/c{
+	pixel_y = 15
+	},
+/turf/simulated/wall/auto/reinforced/jen/cyan,
+/area/prefab/candy_shop)
+"hD" = (
+/obj/lattice{
+	dir = 2;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay3,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"hV" = (
+/obj/random_pod_spawner/random_putt_spawner,
+/turf/simulated/floor/engine/glow,
+/area/prefab/candy_shop)
+"iU" = (
+/obj/lattice,
+/obj/warp_beacon{
+	name = "Carlisle's Confections Beacon"
+	},
+/turf/variableTurf/clear,
+/area/noGenerate)
+"jp" = (
+/obj/forcefield/energyshield/perma,
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
+	id = "Candy Shop";
+	name = "Carlisle's Confections Parking"
+	},
+/turf/simulated/floor/engine/glow,
+/area/prefab/candy_shop)
+"jE" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay2,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"kr" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 4;
+	name = "Toilet"
+	},
+/turf/simulated/floor/sanitary/blue,
+/area/prefab/candy_shop)
+"kz" = (
+/obj/machinery/r_door_control{
+	id = "Candy Shop";
+	name = "Parking Door Control"
+	},
+/turf/simulated/wall/auto/reinforced/jen/cyan,
+/area/prefab/candy_shop)
+"kC" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 4;
+	name = "restroom"
+	},
+/obj/neon_lining{
+	dir = 8
+	},
+/obj/neon_lining{
+	dir = 4;
+	lining_color = "pink"
+	},
+/turf/simulated/floor/sanitary/white,
+/area/prefab/candy_shop)
+"kR" = (
+/obj/decoration/toiletholder{
+	desc = "Definitely a trendy new design and NOT just a standard toilet paper holder that's been installed incorrectly, no way no how.";
+	dir = 8;
+	name = "deluxe toilet paper holder";
+	pixel_x = 10
+	},
+/obj/window/cubicle{
+	dir = 1
+	},
+/obj/machinery/light/incandescent/cool{
+	dir = 4
+	},
+/turf/simulated/floor/sanitary/blue,
+/area/prefab/candy_shop)
+"nb" = (
+/turf/simulated/wall/auto/reinforced/jen/cyan,
+/area/prefab/candy_shop)
+"ng" = (
+/obj/table/wood/round/auto,
+/obj/item/clothing/under/suit/purple/dress{
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/obj/item/clothing/under/suit/purple{
+	pixel_x = -8;
+	pixel_y = -7
+	},
+/obj/item/clothing/head/that/purple{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/that/purple{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"nz" = (
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/snacks/candy/candy_apple{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/candy/candy_apple{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/candy/candy_apple,
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"nE" = (
+/obj/decal/poster/wallsign/stencil/left/n{
+	pixel_x = -7;
+	pixel_y = 15
+	},
+/obj/decal/poster/wallsign/stencil/right/d{
+	pixel_x = 5;
+	pixel_y = 15
+	},
+/obj/decal/poster/wallsign/stencil/right/y{
+	pixel_x = 17;
+	pixel_y = 15
+	},
+/turf/simulated/wall/auto/reinforced/jen/cyan,
+/area/prefab/candy_shop)
+"nQ" = (
+/obj/table/wood/round/auto,
+/obj/machinery/light/incandescent/warm/very{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/pie/pumpkin{
+	pixel_y = -7
+	},
+/obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/moon_pie/spooky{
+	pixel_x = -9;
+	pixel_y = 12
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"oK" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/engine/glow/blue,
+/area/prefab/candy_shop)
+"oP" = (
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"qz" = (
+/obj/neon_lining{
+	dir = 8
+	},
+/obj/decal/pole{
+	desc = "Definitely not a barber pole, nope, nuh-uh.";
+	name = "Spinning Candy Cane Pole";
+	pixel_x = -28
+	},
+/turf/simulated/floor/engine/glow,
+/area/prefab/candy_shop)
+"qN" = (
+/obj/machinery/light/flamp,
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"ry" = (
+/obj/submachine/cargopad{
+	active = 0;
+	desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing.";
+	name = "Candy Resupply Pad"
+	},
+/obj/item/reagent_containers/food/snacks/snack_cake,
+/obj/item/reagent_containers/food/snacks/snack_cake,
+/obj/item/reagent_containers/food/snacks/snack_cake,
+/obj/item/reagent_containers/food/snacks/snack_cake/golden,
+/obj/item/reagent_containers/food/snacks/snack_cake/golden,
+/obj/item/reagent_containers/food/snacks/snack_cake/golden,
+/obj/item/reagent_containers/food/snacks/strudel,
+/obj/item/reagent_containers/food/snacks/strudel,
+/obj/item/reagent_containers/food/snacks/strudel,
+/obj/item/clothing/suit/lshirt/dan_blue,
+/obj/item/ticket/golden,
+/obj/item/reagent_containers/food/snacks/ice_cream/gross,
+/obj/storage/crate/bin{
+	desc = "Buy one, get the rest free.";
+	name = "bargain bin"
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"rV" = (
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{
+	pixel_y = 10
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"tf" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/engine/glow,
+/area/prefab/candy_shop)
+"th" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir";
+	tag = "icon-lattice-dir (EAST)"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"tB" = (
+/turf/variableTurf/clear,
+/area/noGenerate)
+"uR" = (
+/obj/table/wood/auto/desk,
+/obj/item/kitchen/food_box/lollipop{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"we" = (
+/obj/table/wood/round/auto,
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/snacks/bagel,
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"xC" = (
+/obj/cabinet/taffy,
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"xF" = (
+/obj/table/wood/auto/desk,
+/obj/item/kitchen/food_box/donut_box{
+	desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038.";
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"xI" = (
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"xQ" = (
+/obj/table/wood/round/auto,
+/obj/item/item_box/swedish_bag{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/item_box/swedish_bag,
+/obj/item/item_box/swedish_bag{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"xT" = (
+/obj/table/wood/round/auto,
+/obj/machinery/light/incandescent/warm/very{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{
+	pixel_x = -4
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"yk" = (
+/obj/table/wood/auto/desk,
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"yA" = (
+/obj/neon_lining{
+	dir = 4;
+	lining_color = "pink"
+	},
+/turf/simulated/floor/engine/glow/blue,
+/area/prefab/candy_shop)
+"zn" = (
+/obj/window/cubicle{
+	dir = 9
+	},
+/turf/simulated/floor/sanitary/blue,
+/area/prefab/candy_shop)
+"Ag" = (
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,
+/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"AK" = (
+/obj/machinery/light/small/floor/warm/very,
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"AU" = (
+/obj/neon_lining{
+	dir = 8
+	},
+/obj/machinery/door_control/podbay{
+	id = "Candy Shop";
+	pixel_x = -26;
+	pixel_y = 2
+	},
+/obj/machinery/door_control/podbay{
+	id = "Candy Shop";
+	pixel_x = -26;
+	pixel_y = 2
+	},
+/turf/simulated/floor/engine/glow,
+/area/prefab/candy_shop)
+"Cu" = (
+/obj/decal/poster/wallsign/stencil/right/y{
+	pixel_x = 17;
+	pixel_y = 15
+	},
+/obj/decal/poster/wallsign/stencil/right/d{
+	pixel_x = 5;
+	pixel_y = 15
+	},
+/obj/decal/poster/wallsign/stencil/left/n{
+	pixel_x = -7;
+	pixel_y = 15
+	},
+/turf/simulated/wall/auto/reinforced/jen/cyan,
+/area/prefab/candy_shop)
+"Df" = (
+/obj/decal/skeleton{
+	desc = "The remains of a confectioner.";
+	name = "Carlisle"
+	},
+/obj/item/casing/derringer{
+	dir = 5;
+	pixel_x = -9;
+	pixel_y = 9
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"DL" = (
+/obj/neon_lining{
+	dir = 8
+	},
+/obj/neon_lining{
+	dir = 8
+	},
+/turf/simulated/floor/engine/glow,
+/area/prefab/candy_shop)
+"Fq" = (
+/obj/table/wood/auto/desk,
+/obj/machinery/cashreg,
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"Fw" = (
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/snacks/candy/candy_cane{
+	dir = 8;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/snacks/candy/candy_cane{
+	dir = 8;
+	pixel_x = 13;
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/food/snacks/candy/candy_cane{
+	dir = 8;
+	pixel_x = 14;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/candy/candy_cane{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/snacks/candy/candy_cane{
+	dir = 8;
+	pixel_x = 14;
+	pixel_y = 10
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"FS" = (
+/obj/table/wood/round/auto,
+/obj/machinery/light/lamp/green{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/storage/goodybag{
+	pixel_x = 5;
+	pixel_y = -7
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"Hn" = (
+/obj/item/storage/secure/ssafe/candy_shop{
+	pixel_y = 28
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"Ht" = (
+/obj/item/storage/toilet/random{
+	dir = 8
+	},
+/obj/decoration/toiletholder{
+	pixel_y = 33
+	},
+/turf/simulated/floor/sanitary/blue,
+/area/prefab/candy_shop)
+"HJ" = (
+/obj/table/wood/round/auto,
+/obj/machinery/light/incandescent/cool/very{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/snacks/candy/butterscotch{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/candy/butterscotch{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/candy/butterscotch,
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"Jr" = (
+/obj/window/auto/hardened/the_tuff_stuff,
+/obj/decal/tile_edge/stripe/big{
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"JQ" = (
+/turf/simulated/floor/engine/glow/blue,
+/area/prefab/candy_shop)
+"Kb" = (
+/obj/random_pod_spawner/random_putt_spawner,
+/turf/simulated/floor/engine/glow/blue,
+/area/prefab/candy_shop)
+"KG" = (
+/obj/forcefield/energyshield/perma,
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
+	id = "Candy Shop";
+	name = "Carlisle's Confections Parking"
+	},
+/turf/simulated/floor/engine/glow/blue,
+/area/prefab/candy_shop)
+"Ne" = (
+/obj/neon_lining{
+	dir = 4;
+	lining_color = "pink"
+	},
+/obj/decal/pole{
+	desc = "Definitely not a barber pole, nope, nuh-uh.";
+	name = "Spinning Candy Cane Pole";
+	pixel_x = 28
+	},
+/turf/simulated/floor/engine/glow/blue,
+/area/prefab/candy_shop)
+"Nj" = (
+/turf/simulated/floor/engine/glow,
+/area/prefab/candy_shop)
+"NI" = (
+/obj/machinery/light/small/floor/cool,
+/obj/neon_lining{
+	dir = 8
+	},
+/turf/simulated/floor/sanitary/blue,
+/area/prefab/candy_shop)
+"Pp" = (
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/snacks/candy/negativeonebar{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/candy/negativeonebar{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/candy/negativeonebar,
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"RU" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -4
+	},
+/turf/simulated/floor/sanitary/blue,
+/area/prefab/candy_shop)
+"Tk" = (
+/obj/table/wood/round/auto,
+/obj/machinery/light/incandescent/cool/very{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/snacks/candy/nougat,
+/obj/item/reagent_containers/food/snacks/candy/nougat{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/candy/nougat{
+	pixel_y = 4
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"TX" = (
+/obj/decal/poster/wallsign/stencil/left/c{
+	pixel_y = 15
+	},
+/obj/decal/poster/wallsign/stencil/right/a{
+	pixel_y = 15
+	},
+/turf/simulated/wall/auto/reinforced/jen/cyan,
+/area/prefab/candy_shop)
+"Us" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	name = "Carlisle's Confections"
+	},
+/obj/decal/tile_edge/stripe/big{
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"UE" = (
+/obj/rack/lunar,
+/obj/item/item_box/heartcandy{
+	desc = "Wow, you haven't seen this brand in ages.";
+	name = "Carlisle's Candy Hearts";
+	pixel_y = -7
+	},
+/obj/item/kitchen/peach_rings{
+	desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!";
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"Vt" = (
+/obj/item/reagent_containers/food/snacks/candy/candy_corn{
+	pixel_x = -10;
+	pixel_y = -9
+	},
+/obj/item/storage/toilet/random{
+	dir = 8
+	},
+/turf/simulated/floor/sanitary/blue,
+/area/prefab/candy_shop)
+"Wk" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b";
+	tag = "icon-lattice-dir-b (NORTHWEST)"
+	},
+/obj/machinery/light/runway_light/delay3,
+/turf/variableTurf/clear,
+/area/noGenerate)
+"Yo" = (
+/obj/window/auto/hardened/the_tuff_stuff,
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"YM" = (
+/obj/rack/lunar,
+/obj/item/kitchen/peach_rings{
+	desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!";
+	pixel_y = 7
+	},
+/obj/item/item_box/heartcandy{
+	desc = "Wow, you haven't seen this brand in ages.";
+	name = "Carlisle's Candy Hearts";
+	pixel_y = -7
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"YO" = (
+/obj/neon_lining{
+	dir = 4;
+	lining_color = "pink"
+	},
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
+"Zb" = (
+/obj/machinery/light/small/floor/cool/very,
+/turf/simulated/floor/wood/four,
+/area/prefab/candy_shop)
 
 (1,1,1) = {"
-tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
-tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
-tBtBtBtBtBTXnEnbYonbnbYonbduCunbnbnbnbtB
-tBtBtBtBtBnbxCxCqNHndgryxCxCnbRUkrHtnbtB
-tBtBtBtBtBnbxIxIcNDfxIxIxIYOkCNIznkRnbtB
-tBtBtBtBtBnbxQxIuRFqykxFxIFSnbRUkrVtnbtB
-tBtBtBtBtBnbTkxIxIxIxIxIxIxTnbnbnbnbnbtB
-tBtBtBtBtBYoFwxIYMxIxIYMxIrVYotBtBtBtBtB
-tBtBtBtBtBYoAgxIYMAKZbYMxIngYotBtBtBtBtB
-tBtBtBtBtBYonzxIUExIxIYMxIoPYotBtBtBtBtB
-tBtBtBtBtBnbHJxIxIxIxIxIxInQnbtBtBtBtBtB
-tBtBtBtBtBnbwexIxIxIxIxIxIPpnbtBtBtBtBtB
-tBtBtBtBtBnbqNxIxIAKZbxIxIqNnbtBtBtBtBtB
-tBtBtBtBtBnbJrJrUsJrJrUsJrJrnbtBtBtBtBtB
-tBtBhDtBtBnbqzJQNjJQNjJQNjNenbtBtBtBtBtB
-tBjEiUauthnbAUKbNjoKtfJQhVyAnbtBtBtBtBtB
-tBtBWktBtBnbDLJQNjJQNjJQNjyAnbtBtBtBtBtB
-tBtBtBtBtBnbjpKGjpKGjpKGjpKGkztBtBtBtBtB
-tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
-tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+"}
+(2,1,1) = {"
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+jE
+tB
+tB
+tB
+tB
+"}
+(3,1,1) = {"
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+hD
+iU
+Wk
+tB
+tB
+tB
+"}
+(4,1,1) = {"
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+au
+tB
+tB
+tB
+tB
+"}
+(5,1,1) = {"
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+th
+tB
+tB
+tB
+tB
+"}
+(6,1,1) = {"
+tB
+tB
+TX
+nb
+nb
+nb
+nb
+Yo
+Yo
+Yo
+nb
+nb
+nb
+nb
+nb
+nb
+nb
+nb
+tB
+tB
+"}
+(7,1,1) = {"
+tB
+tB
+nE
+xC
+xI
+xQ
+Tk
+Fw
+Ag
+nz
+HJ
+we
+qN
+Jr
+qz
+AU
+DL
+jp
+tB
+tB
+"}
+(8,1,1) = {"
+tB
+tB
+nb
+xC
+xI
+xI
+xI
+xI
+xI
+xI
+xI
+xI
+xI
+Jr
+JQ
+Kb
+JQ
+KG
+tB
+tB
+"}
+(9,1,1) = {"
+tB
+tB
+Yo
+qN
+cN
+uR
+xI
+YM
+YM
+UE
+xI
+xI
+xI
+Us
+Nj
+Nj
+Nj
+jp
+tB
+tB
+"}
+(10,1,1) = {"
+tB
+tB
+nb
+Hn
+Df
+Fq
+xI
+xI
+AK
+xI
+xI
+xI
+AK
+Jr
+JQ
+oK
+JQ
+KG
+tB
+tB
+"}
+(11,1,1) = {"
+tB
+tB
+nb
+dg
+xI
+yk
+xI
+xI
+Zb
+xI
+xI
+xI
+Zb
+Jr
+Nj
+tf
+Nj
+jp
+tB
+tB
+"}
+(12,1,1) = {"
+tB
+tB
+Yo
+ry
+xI
+xF
+xI
+YM
+YM
+YM
+xI
+xI
+xI
+Us
+JQ
+JQ
+JQ
+KG
+tB
+tB
+"}
+(13,1,1) = {"
+tB
+tB
+nb
+xC
+xI
+xI
+xI
+xI
+xI
+xI
+xI
+xI
+xI
+Jr
+Nj
+hV
+Nj
+jp
+tB
+tB
+"}
+(14,1,1) = {"
+tB
+tB
+du
+xC
+YO
+FS
+xT
+rV
+ng
+oP
+nQ
+Pp
+qN
+Jr
+Ne
+yA
+yA
+KG
+tB
+tB
+"}
+(15,1,1) = {"
+tB
+tB
+Cu
+nb
+kC
+nb
+nb
+Yo
+Yo
+Yo
+nb
+nb
+nb
+nb
+nb
+nb
+nb
+kz
+tB
+tB
+"}
+(16,1,1) = {"
+tB
+tB
+nb
+RU
+NI
+RU
+nb
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+"}
+(17,1,1) = {"
+tB
+tB
+nb
+kr
+zn
+kr
+nb
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+"}
+(18,1,1) = {"
+tB
+tB
+nb
+Ht
+kR
+Vt
+nb
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+"}
+(19,1,1) = {"
+tB
+tB
+nb
+nb
+nb
+nb
+nb
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+"}
+(20,1,1) = {"
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
+tB
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,81 +1,81 @@
-"bq" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = 5; pixel_y = 7},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = -4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"dn" = (/turf/variableTurf/clear,/area/noGenerate)
-"dw" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"dM" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"dR" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"dZ" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"fU" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"gS" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"hr" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"hA" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"iM" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/pie/pumpkin{pixel_y = -7},/obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake{pixel_x = 5; pixel_y = 5},/obj/item/reagent_containers/food/snacks/moon_pie/spooky{pixel_x = -9; pixel_y = 12},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"kh" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"lp" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"lH" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"lZ" = (/obj/table/wood/round/auto,/obj/item/clothing/under/suit/purple/dress{pixel_x = 8; pixel_y = -7},/obj/item/clothing/under/suit/purple{pixel_x = -8; pixel_y = -7},/obj/item/clothing/head/that/purple{pixel_x = -8; pixel_y = 7},/obj/item/clothing/head/that/purple{pixel_x = 8; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ne" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"nq" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"nR" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"ov" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"oN" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"pR" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"qx" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"sl" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"su" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"tB" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"tF" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"tM" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"uU" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"vB" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"wJ" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"xi" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"zy" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Aw" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Bz" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
-"BS" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/item/reagent_containers/food/snacks/ice_cream/gross,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"BY" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"DB" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"Eb" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"Gy" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Gz" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"GG" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"GN" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"JR" = (/obj/decal/skeleton{desc = "The remains of a confectioner."; name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"MO" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Nk" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"NA" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Oh" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Oz" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"Qh" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"Rp" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"RV" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Sz" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
-"TO" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
-"VK" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
-"VL" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Xy" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
-"Yl" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
-"Yr" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"au" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
+"cN" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"dg" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"du" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"hD" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
+"hV" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"iU" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
+"jp" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"jE" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
+"kz" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"nb" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"ng" = (/obj/table/wood/round/auto,/obj/item/clothing/under/suit/purple/dress{pixel_x = 8; pixel_y = -7},/obj/item/clothing/under/suit/purple{pixel_x = -8; pixel_y = -7},/obj/item/clothing/head/that/purple{pixel_x = -8; pixel_y = 7},/obj/item/clothing/head/that/purple{pixel_x = 8; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"nz" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"nE" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"nQ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/pie/pumpkin{pixel_y = -7},/obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake{pixel_x = 5; pixel_y = 5},/obj/item/reagent_containers/food/snacks/moon_pie/spooky{pixel_x = -9; pixel_y = 12},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"oK" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"oP" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"qz" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"qN" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ry" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/item/reagent_containers/food/snacks/ice_cream/gross,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"rV" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"tf" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"tB" = (/turf/variableTurf/clear,/area/noGenerate)
+"uR" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"we" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"xC" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"xF" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"xI" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"xQ" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"xT" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = 5; pixel_y = 7},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = -4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"yk" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"yA" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Ag" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"AK" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"AU" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Cu" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"Df" = (/obj/decal/skeleton{desc = "The remains of a confectioner."; name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"DL" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Fq" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Fw" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"FS" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Hn" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"HJ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Jr" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"JQ" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Kb" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"KG" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Ne" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Nj" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Pp" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Tk" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"TX" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"Us" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"UE" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Wk" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
+"Yo" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"YM" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"YO" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 
 (1,1,1) = {"
-dndndndndndndndndndndndndndndndndndndndn
-dndndndndndndndndndndndndndndndndndndndn
-dndndndndnnREbdRtBdRdRtBdRlHqxdndndndndn
-dndndndndndRneneNAfUhrBSnenedRdndndndndn
-dndndndndndRpRpRovJRpRpRpRpRdRdndndndndn
-dndndndndndRuUpRtFdZVLvBpRAwdRdndndndndn
-dndndndndndRslpRpRoNoNpRpRbqdRdndndndndn
-dndndndndntBkhpRGGpRpRGGpRwJtBdndndndndn
-dndndndndntBdMpRGGoNoNGGpRlZtBdndndndndn
-dndndndndntBGNpRNkpRpRGGpRsutBdndndndndn
-dndndndndndRMOpRpRoNoNpRpRiMdRdndndndndn
-dndndndndndRBYpRpRpRpRpRpRRVdRdndndndndn
-dndndndndndRNApRpRoNoNpRpRNAdRdndndndndn
-dndndndndndROhOhYrOhOhYrOhOhdRdndndndndn
-dndnYldndndRnqtMlptMlptMlpzydRdndndndndn
-dnSzVKBzBzdRGzGylpRpgStMOzhAdRdndndndndn
-dndnTOdndndRdwtMlptMlptMlphAdRdndndndndn
-dndndndndndRQhxiQhxiQhxiQhxiDBdndndndndn
-dndndndndnXydndndndndndndndnXydndndndndn
-dndndndndndndndndndndndndndndndndndndndn
+tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
+tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
+tBtBtBtBtBTXnEnbYonbnbYonbduCutBtBtBtBtB
+tBtBtBtBtBnbxCxCqNHndgryxCxCnbtBtBtBtBtB
+tBtBtBtBtBnbxIxIcNDfxIxIxIxInbtBtBtBtBtB
+tBtBtBtBtBnbxQxIuRFqykxFxIFSnbtBtBtBtBtB
+tBtBtBtBtBnbTkxIxIAKAKxIxIxTnbtBtBtBtBtB
+tBtBtBtBtBYoFwxIYMxIxIYMxIrVYotBtBtBtBtB
+tBtBtBtBtBYoAgxIYMAKAKYMxIngYotBtBtBtBtB
+tBtBtBtBtBYonzxIUExIxIYMxIoPYotBtBtBtBtB
+tBtBtBtBtBnbHJxIxIAKAKxIxInQnbtBtBtBtBtB
+tBtBtBtBtBnbwexIxIxIxIxIxIPpnbtBtBtBtBtB
+tBtBtBtBtBnbqNxIxIAKAKxIxIqNnbtBtBtBtBtB
+tBtBtBtBtBnbJrJrUsJrJrUsJrJrnbtBtBtBtBtB
+tBtBhDtBtBnbqzJQNjJQNjJQNjNenbtBtBtBtBtB
+tBjEiUauaunbAUKbNjoKtfJQhVyAnbtBtBtBtBtB
+tBtBWktBtBnbDLJQNjJQNjJQNjyAnbtBtBtBtBtB
+tBtBtBtBtBnbjpKGjpKGjpKGjpKGkztBtBtBtBtB
+tBtBtBtBtBYOtBtBtBtBtBtBtBtBYOtBtBtBtBtB
+tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,21 +1,22 @@
-"a" = (/turf/space,/area/prefab/candy_shop)
-"h" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"a" = (/turf/variableTurf/clear,/area/noGenerate)
+"C" = (/turf/space,/area/prefab/candy_shop)
+"G" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
-aaahhhhhhhhhhaaa
-aaahaaaaaaaahaaa
-aaahaaaaaaaahaaa
-aaahaaaaaaaahaaa
-aaahaaaaaaaahaaa
-aaahaaaaaaaahaaa
-aaahaaaaaaaahaaa
-aaahaaaaaaaahaaa
-aaahaaaaaaaahaaa
-aaahaaaaaaaahaaa
-aaahaaaaaaaahaaa
-aaahaaaaaaaahaaa
+aaaGGGGGGGGGGaaa
+aaaGCCCCCCCCGaaa
+aaaGCCCCCCCCGaaa
+aaaGCCCCCCCCGaaa
+aaaGCCCCCCCCGaaa
+aaaGCCCCCCCCGaaa
+aaaGCCCCCCCCGaaa
+aaaGCCCCCCCCGaaa
+aaaGCCCCCCCCGaaa
+aaaGCCCCCCCCGaaa
+aaaGCCCCCCCCGaaa
+aaaGCCCCCCCCGaaa
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,42 +1,43 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "e" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"g" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"l" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"n" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"o" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"j" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"k" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"m" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"n" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"o" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"r" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"v" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"t" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"v" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"y" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"A" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "B" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"D" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"H" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"I" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"J" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"G" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"H" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"I" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"M" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"N" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"P" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Q" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"L" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"M" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"O" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"P" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"R" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"V" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"U" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -44,22 +45,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaaMbzFzzFzNtaaaaa
-aaaaazZZeKiCZZzaaaaa
+aaaaaDnzFzzFztUaaaaa
+aaaaazZZeKikZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
-aaaaazHCEcwQCSzaaaaa
-aaaaazVCCffCCdzaaaaa
+aaaaazmCEcwGCSzaaaaa
+aaaaazvCCffCCdzaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
 aaaaazeCCffCCezaaaaa
-aaaaazLLXLLXLLzaaaaa
-aaaaazqonononJzaaaaa
-aaaaazvAnIloBGzaaaaa
-aaaaazjonononGzaaaaa
-aaaaazyPyPyPyPDaaaaa
+aaaaazMMXMMXMMzaaaaa
+aaaaazqgHgHgHAzaaaaa
+aaaaazLRHOIgByzaaaaa
+aaaaazrgHgHgHyzaaaaa
+aaaaazjojojojoPaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,39 +1,43 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"l" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"n" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"o" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"s" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"w" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"x" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"z" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"F" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"K" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"N" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
-"O" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"R" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"U" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"W" = (/obj/forcefield/energyshield/perma,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"X" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Y" = (/obj/machinery/door/unpowered/wood/pyro{name = Carlisle's Confections},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Z" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
+"q" = (/obj/forcefield/energyshield/perma,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"s" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaRRRDRRDRRRaaa
-aaaRwwZntZwwRaaa
-aaaRZZsOZZZZRaaa
-aaaRoZXUssZoRaaa
-aaaRlZZxxZZFRaaa
-aaaDoZKZZKZoDaaa
-aaaDoZKxxKZoDaaa
-aaaDoZKZZKZoDaaa
-aaaRlZZxxZZFRaaa
-aaaRzZZZZZZoRaaa
-aaaRZZZxxZZZRaaa
-aaaRDDYDDYDDRaaa
-aaaRWWWWWWWWRaaa
-aaaNaaaaaaaaNaaa
+aaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaa
+aaaaazzzFzzFzzzaaaaa
+aaaaazZZCKiCZZzaaaaa
+aaaaazCCwxCCCCzaaaaa
+aaaaazSCEcwwCSzaaaaa
+aaaaazYCCffCCdzaaaaa
+aaaaaFSCsCCsCSFaaaaa
+aaaaaFSCsffsCSFaaaaa
+aaaaaFSCsCCsCSFaaaaa
+aaaaazYCCffCCdzaaaaa
+aaaaazTCCCCCCSzaaaaa
+aaaaazCCCffCCCzaaaaa
+aaaaazFFXFFXFFzaaaaa
+aaaaazqqqqqqqqzaaaaa
+aaaaazCCCCCCCCzaaaaa
+aaaaazCCCCCCCCzaaaaa
+aaaaazCCCCCCCCzaaaaa
+aaaaapaaaaaaaapaaaaa
+aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,34 +1,39 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"g" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"m" = (/obj/forcefield/energyshield/perma,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"n" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"r" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"w" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"B" = (/obj/machinery/door/unpowered/wood/pyro{name = Carlisle's Confections},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"F" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"H" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"J" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"N" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"O" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"S" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Z" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"l" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"n" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"o" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"s" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"t" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"w" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"x" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"z" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"D" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"F" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"K" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"N" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
+"O" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"R" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"U" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"W" = (/obj/forcefield/energyshield/perma,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"X" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Y" = (/obj/machinery/door/unpowered/wood/pyro{name = Carlisle's Confections},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Z" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
-aaaDDDrDDrDDDaaa
-aaaDNNOgOONNDaaa
-aaaDOOJHOOOODaaa
-aaaDZOnSJJOZDaaa
-aaaDZOOOOOOZDaaa
-aaarZOwOOwOZraaa
-aaarZOwOOwOZraaa
-aaarZOwOOwOZraaa
-aaaDZOOOOOOZDaaa
-aaaDFOOOOOOZDaaa
-aaaDOOOOOOOODaaa
-aaaDrrBrrBrrDaaa
-aaaDmmmmmmmmDaaa
-aaaaaaaaaaaaaaaa
+aaaRRRDRRDRRRaaa
+aaaRwwZntZwwRaaa
+aaaRZZsOZZZZRaaa
+aaaRoZXUssZoRaaa
+aaaRlZZxxZZFRaaa
+aaaDoZKZZKZoDaaa
+aaaDoZKxxKZoDaaa
+aaaDoZKZZKZoDaaa
+aaaRlZZxxZZFRaaa
+aaaRzZZZZZZoRaaa
+aaaRZZZxxZZZRaaa
+aaaRDDYDDYDDRaaa
+aaaRWWWWWWWWRaaa
+aaaNaaaaaaaaNaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -2,33 +2,34 @@
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"h" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"l" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"n" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"j" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"m" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"o" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "r" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"v" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"y" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"D" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"G" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"I" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"J" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"N" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"P" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"Q" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"R" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"N" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"O" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Q" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"R" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"W" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"U" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"V" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -47,11 +48,11 @@ aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
 aaaaazrCCffCCrzaaaaa
-aaaaazFFXFFXFFzaaaaa
-aaaaazqvnvnvnlzaaaaa
-aaaaazDQnUhvNRzaaaaa
-aaaaazjvnvnvnRzaaaaa
-aaaaazPAPAPAPAWaaaaa
+aaaaazNNXNNXNNzaaaaa
+aaaaazqIoIoIoyzaaaaa
+aaaaazQOojVIDUzaaaaa
+aaaaazmIoIoIoUzaaaaa
+aaaaazJRJRJRJRGaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,43 +1,43 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
+"b" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"g" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"h" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"k" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"m" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"n" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"o" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"j" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"k" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"l" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"m" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"v" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"r" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"u" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"y" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"B" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"B" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"D" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"H" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"I" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"G" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"H" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"I" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"J" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"M" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"O" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"P" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"R" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"L" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"M" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"O" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"Q" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"R" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"U" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"W" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -45,22 +45,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaaDnzFzzFztUaaaaa
-aaaaazZZeKikZZzaaaaa
+aaaaagMzFzzFzLmaaaaa
+aaaaazZZbKihZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
-aaaaazmCEcwGCSzaaaaa
-aaaaazvCCffCCdzaaaaa
+aaaaazjCEcwUCSzaaaaa
+aaaaazHCCffCCdzaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazeCCffCCezaaaaa
-aaaaazMMXMMXMMzaaaaa
-aaaaazqgHgHgHAzaaaaa
-aaaaazLRHOIgByzaaaaa
-aaaaazrgHgHgHyzaaaaa
-aaaaazjojojojoPaaaaa
+aaaaazbCCffCCbzaaaaa
+aaaaazBBXBBXBBzaaaaa
+aaaaazqWkWkWklzaaaaa
+aaaaazyIkJQWGuzaaaaa
+aaaaazRWkWkWkuzaaaaa
+aaaaazrDrDrDrDOaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,29 +1,29 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"d" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"m" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"n" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"p" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"v" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"I" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Q" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"R" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Y" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"h" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"k" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"x" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"H" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"K" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"N" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"U" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Y" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
-aaappppppppppaaa
-aaapRRnvnnRRpaaa
-aaapnndYnnnnpaaa
-aaapmndQddnnpaaa
-aaapmnnnnnnnpaaa
-aaapmnnnnnnnpaaa
-aaapmnnnnnnnpaaa
-aaapmnnnnnnnpaaa
-aaapmnnnnnnnpaaa
-aaapInnnnnnnpaaa
-aaapnnnnnnnnpaaa
-aaapnnnnnnnnpaaa
+aaazzzzzzzzzzaaa
+aaazhhKHKKhhzaaa
+aaazKKkxKKKKzaaa
+aaazYKkUkkKYzaaa
+aaazYKKKKKKYzaaa
+aaazYKKKKKKYzaaa
+aaazYKKKKKKYzaaa
+aaazYKKKKKKYzaaa
+aaazYKKKKKKYzaaa
+aaazNKKKKKKYzaaa
+aaazKKKKKKKKzaaa
+aaazKKKKKKKKzaaa
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -23,6 +23,7 @@
 "ry" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/item/reagent_containers/food/snacks/ice_cream/gross,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "rV" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "tf" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"th" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/obj/machinery/light/runway_light/delay5,/turf/variableTurf/clear,/area/noGenerate)
 "tB" = (/turf/variableTurf/clear,/area/noGenerate)
 "uR" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "we" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -33,7 +34,7 @@
 "xT" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = 5; pixel_y = 7},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = -4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "yk" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "yA" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"zn" = (/obj/window/cubicle{dir = 9},/obj/item/reagent_containers/food/snacks/candy/candy_corn,/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
+"zn" = (/obj/window/cubicle{dir = 9},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Ag" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "AK" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "AU" = (/obj/neon_lining{dir = 8},/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26; pixel_y = 2},/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26; pixel_y = 2},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
@@ -43,7 +44,6 @@
 "Fq" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Fw" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "FS" = (/obj/table/wood/round/auto,/obj/machinery/light/lamp/green{pixel_x = -5; pixel_y = 9},/obj/item/storage/goodybag{pixel_x = 5; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"GS" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/obj/machinery/light/runway_light/delay5,/turf/variableTurf/clear,/area/noGenerate)
 "Hn" = (/obj/item/storage/secure/ssafe/candy_shop{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Ht" = (/obj/item/storage/toilet/random{dir = 8},/obj/decoration/toiletholder{pixel_y = 33},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "HJ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/cool/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -51,7 +51,6 @@
 "JQ" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "Kb" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "KG" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"LT" = (/obj/machinery/light/small/floor/cool/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Ne" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 28},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "Nj" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "NI" = (/obj/machinery/light/small/floor/cool,/obj/neon_lining{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
@@ -61,11 +60,12 @@
 "TX" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "Us" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "UE" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages."; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Vt" = (/obj/item/storage/toilet/random{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
+"Vt" = (/obj/item/reagent_containers/food/snacks/candy/candy_corn{pixel_x = -10; pixel_y = -9},/obj/item/storage/toilet/random{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Wk" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/obj/machinery/light/runway_light/delay3,/turf/variableTurf/clear,/area/noGenerate)
 "Yo" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "YM" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages."; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "YO" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Zb" = (/obj/machinery/light/small/floor/cool/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
@@ -74,16 +74,16 @@ tBtBtBtBtBTXnEnbYonbnbYonbduCunbnbnbnbtB
 tBtBtBtBtBnbxCxCqNHndgryxCxCnbRUkrHtnbtB
 tBtBtBtBtBnbxIxIcNDfxIxIxIYOkCNIznkRnbtB
 tBtBtBtBtBnbxQxIuRFqykxFxIFSnbRUkrVtnbtB
-tBtBtBtBtBnbTkxIxIAKLTxIxIxTnbnbnbnbnbtB
+tBtBtBtBtBnbTkxIxIxIxIxIxIxTnbnbnbnbnbtB
 tBtBtBtBtBYoFwxIYMxIxIYMxIrVYotBtBtBtBtB
-tBtBtBtBtBYoAgxIYMAKLTYMxIngYotBtBtBtBtB
+tBtBtBtBtBYoAgxIYMAKZbYMxIngYotBtBtBtBtB
 tBtBtBtBtBYonzxIUExIxIYMxIoPYotBtBtBtBtB
-tBtBtBtBtBnbHJxIxIAKLTxIxInQnbtBtBtBtBtB
+tBtBtBtBtBnbHJxIxIxIxIxIxInQnbtBtBtBtBtB
 tBtBtBtBtBnbwexIxIxIxIxIxIPpnbtBtBtBtBtB
-tBtBtBtBtBnbqNxIxIAKLTxIxIqNnbtBtBtBtBtB
+tBtBtBtBtBnbqNxIxIAKZbxIxIqNnbtBtBtBtBtB
 tBtBtBtBtBnbJrJrUsJrJrUsJrJrnbtBtBtBtBtB
 tBtBhDtBtBnbqzJQNjJQNjJQNjNenbtBtBtBtBtB
-tBjEiUauGSnbAUKbNjoKtfJQhVyAnbtBtBtBtBtB
+tBjEiUauthnbAUKbNjoKtfJQhVyAnbtBtBtBtBtB
 tBtBWktBtBnbDLJQNjJQNjJQNjyAnbtBtBtBtBtB
 tBtBtBtBtBnbjpKGjpKGjpKGjpKGkztBtBtBtBtB
 tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,39 +1,40 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
+"b" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"h" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"h" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"m" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"o" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"j" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"l" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"n" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"o" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"r" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"u" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"t" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"v" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"y" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"B" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"A" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"B" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "D" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"H" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "I" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"J" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"J" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"M" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"N" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"O" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"P" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"L" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"M" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"O" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"R" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"V" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"W" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -41,22 +42,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaaMuzFzzFzImaaaaa
-aaaaazZZBKiCZZzaaaaa
+aaaaayvzFzzFzInaaaaa
+aaaaazZZOKiCZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
-aaaaazSCEcwwCSzaaaaa
+aaaaazLCEcwwCSzaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazBCCffCCBzaaaaa
-aaaaazOOXOOXOOzaaaaa
-aaaaazqVAVAVAyzaaaaa
-aaaaazNPADUVJrzaaaaa
-aaaaazhVAVAVArzaaaaa
-aaaaazoGoGoGoGWaaaaa
+aaaaazOCCffCCOzaaaaa
+aaaaazJJXJJXJJzaaaaa
+aaaaazqbRbRbRlzaaaaa
+aaaaaztoRDBbrhzaaaaa
+aaaaazAbRbRbRhzaaaaa
+aaaaazHMHMHMHMjaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,39 +1,39 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"h" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"h" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"l" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"n" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"o" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"m" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"o" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"s" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"u" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"v" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"r" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"u" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"y" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"B" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"A" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"B" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"D" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"I" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"J" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"G" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"I" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"J" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"N" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"O" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"P" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"R" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"M" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"N" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"O" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"P" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"W" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"U" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"V" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"W" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -41,8 +41,8 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaayNzFzzFzUoaaaaa
-aaaaazZZlKiCZZzaaaaa
+aaaaaMuzFzzFzImaaaaa
+aaaaazZZBKiCZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
 aaaaazSCEcwwCSzaaaaa
 aaaaazYCCffCCdzaaaaa
@@ -51,12 +51,12 @@ aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazlCCffCClzaaaaa
-aaaaazIIXIIXIIzaaaaa
-aaaaazqJLJLJLhzaaaaa
-aaaaaznWLgRJeuzaaaaa
-aaaaazBJLJLJLuzaaaaa
-aaaaazvPvPvPvPOaaaaa
+aaaaazBCCffCCBzaaaaa
+aaaaazOOXOOXOOzaaaaa
+aaaaazqVAVAVAyzaaaaa
+aaaaazNPADUVJrzaaaaa
+aaaaazhVAVAVArzaaaaa
+aaaaazoGoGoGoGWaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,52 +1,52 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"b" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"e" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"h" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"g" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"h" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"k" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"l" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
-"m" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
+"j" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
+"k" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"l" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"m" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "n" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
-"o" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections"},/turf/variableTurf/clear,/area/noGenerate)
+"o" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"r" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"u" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"v" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"t" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"u" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"v" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"y" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
-"B" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"A" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"B" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"D" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"H" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"I" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"J" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"G" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"H" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"I" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
+"J" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"M" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"N" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"O" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"P" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Q" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"R" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"L" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"M" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"N" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"O" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"P" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"Q" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"R" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"V" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"W" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"U" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"V" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
+"W" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -54,22 +54,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaajRzFzzFzDeaaaaa
-aaaaazZZyKiMZZzaaaaa
-aaaaazCChxCCCCzaaaaa
-aaaaazPCEcwtCSzaaaaa
+aaaaaOlzFzzFzLQaaaaa
+aaaaazZZgKiAZZzaaaaa
+aaaaazCCkxCCCCzaaaaa
+aaaaazJCEcwUCSzaaaaa
 aaaaazYCCffCCdzaaaaa
-aaaaaFOCsCCsCSFaaaaa
-aaaaaFQCsffsCSFaaaaa
-aaaaaFkCsCCsCSFaaaaa
-aaaaazbCCffCCdzaaaaa
+aaaaaFHCsCCsCSFaaaaa
+aaaaaFbCsffsCSFaaaaa
+aaaaaFuCsCCsCSFaaaaa
+aaaaazrCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazyCCffCCyzaaaaa
-aaaaazBBXBBXBBzaaaaa
-aaAaazquWuWuWLzaaaaa
-anollzrUWNvugVzaaaaa
-aamaazJuWuWuWVzaaaaa
-aaaaazIHIHIHIHGaaaaa
+aaaaazgCCffCCgzaaaaa
+aaaaazMMXMMXMMzaaaaa
+aajaazqmDmDmDvzaaaaa
+anVIIzGRDyNmoBzaaaaa
+aahaazemDmDmDBzaaaaa
+aaaaazWtWtWtWtPaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,20 +1,21 @@
 "a" = (/turf/space,/area/prefab/candy_shop)
+"h" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaa
+aaahhhhhhhhhhaaa
+aaahaaaaaaaahaaa
+aaahaaaaaaaahaaa
+aaahaaaaaaaahaaa
+aaahaaaaaaaahaaa
+aaahaaaaaaaahaaa
+aaahaaaaaaaahaaa
+aaahaaaaaaaahaaa
+aaahaaaaaaaahaaa
+aaahaaaaaaaahaaa
+aaahaaaaaaaahaaa
+aaahaaaaaaaahaaa
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,46 +1,47 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"b" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"e" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"h" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"g" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"h" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"k" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"m" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"n" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"j" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"k" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"m" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"n" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"o" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"r" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"u" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"v" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"x" = (/obj/decal/skeleton{name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"y" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"B" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"A" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"B" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"D" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"H" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"I" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"J" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"G" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"H" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"I" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"J" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"M" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"N" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"O" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"P" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Q" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"R" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"L" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"M" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"O" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"P" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Q" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"R" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"W" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"U" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"V" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -48,22 +49,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaagMzFzzFzIGaaaaa
-aaaaazZZRKiWZZzaaaaa
-aaaaazCCwxCCCCzaaaaa
-aaaaazjCEcwrCSzaaaaa
+aaaaaBDzFzzFzbmaaaaa
+aaaaazZZVKiHZZzaaaaa
+aaaaazCCgxCCCCzaaaaa
+aaaaazoCEcwMCSzaaaaa
 aaaaazYCCffCCdzaaaaa
-aaaaaFmCsCCsCSFaaaaa
-aaaaaFuCsffsCSFaaaaa
-aaaaaFBCsCCsCSFaaaaa
-aaaaazNCCffCCdzaaaaa
+aaaaaFGCsCCsCSFaaaaa
+aaaaaFkCsffsCSFaaaaa
+aaaaaFRCsCCsCSFaaaaa
+aaaaazOCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazRCCffCCRzaaaaa
-aaaaazPPXPPXPPzaaaaa
-aaaaazqJOJOJObzaaaaa
-aaaaazAtODhJHkzaaaaa
-aaaaaznJOJOJOkzaaaaa
-aaaaazyeyeyeyeQaaaaa
+aaaaazVCCffCCVzaaaaa
+aaaaazAAXAAXAAzaaaaa
+aaaaazqjejejeQzaaaaa
+aaaaazPheUyjvLzaaaaa
+aaaaazJjejejeLzaaaaa
+aaaaazrnrnrnrnIaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,16 +1,15 @@
-"au" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
+"au" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/obj/machinery/light/runway_light/delay4,/turf/variableTurf/clear,/area/noGenerate)
 "cN" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"dg" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"dg" = (/obj/machinery/light/incandescent/netural{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "du" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"et" = (/obj/machinery/light/small/sticky/warm/very,/turf/variableTurf/clear,/area/noGenerate)
-"hD" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
+"hD" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/obj/machinery/light/runway_light/delay3,/turf/variableTurf/clear,/area/noGenerate)
 "hV" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "iU" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
 "jp" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"jE" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
+"jE" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/obj/machinery/light/runway_light/delay2,/turf/variableTurf/clear,/area/noGenerate)
 "kr" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "Toilet"},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "kz" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"kC" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "restroom"},/obj/neon_lining{dir = 8},/turf/simulated/floor/sanitary/white,/area/prefab/candy_shop)
+"kC" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "restroom"},/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/sanitary/white,/area/prefab/candy_shop)
 "kR" = (/obj/decoration/toiletholder{desc = "Definitely a trendy new design and NOT just a standard toilet paper holder that's been installed incorrectly, no way no how."; dir = 8; name = "deluxe toilet paper holder"; pixel_x = 10},/obj/window/cubicle{dir = 1},/obj/machinery/light/incandescent/cool{dir = 4},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "nb" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "ng" = (/obj/table/wood/round/auto,/obj/item/clothing/under/suit/purple/dress{pixel_x = 8; pixel_y = -7},/obj/item/clothing/under/suit/purple{pixel_x = -8; pixel_y = -7},/obj/item/clothing/head/that/purple{pixel_x = -8; pixel_y = 7},/obj/item/clothing/head/that/purple{pixel_x = 8; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -19,14 +18,12 @@
 "nQ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/pie/pumpkin{pixel_y = -7},/obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake{pixel_x = 5; pixel_y = 5},/obj/item/reagent_containers/food/snacks/moon_pie/spooky{pixel_x = -9; pixel_y = 12},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "oK" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "oP" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"oT" = (/obj/machinery/light/small/sticky/warm/very{dir = 4},/turf/variableTurf/clear,/area/noGenerate)
-"qz" = (/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"qz" = (/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -28},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "qN" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "ry" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/item/reagent_containers/food/snacks/ice_cream/gross,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "rV" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "tf" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "tB" = (/turf/variableTurf/clear,/area/noGenerate)
-"tC" = (/obj/machinery/light/small/sticky/warm/very{dir = 8},/turf/variableTurf/clear,/area/noGenerate)
 "uR" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "we" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "xC" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -39,55 +36,56 @@
 "zn" = (/obj/window/cubicle{dir = 9},/obj/item/reagent_containers/food/snacks/candy/candy_corn,/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Ag" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "AK" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"AU" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"AU" = (/obj/neon_lining{dir = 8},/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26; pixel_y = 2},/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26; pixel_y = 2},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "Cu" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "Df" = (/obj/decal/skeleton{desc = "The remains of a confectioner."; name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "DL" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "Fq" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Fw" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"FS" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"FS" = (/obj/table/wood/round/auto,/obj/machinery/light/lamp/green{pixel_x = -5; pixel_y = 9},/obj/item/storage/goodybag{pixel_x = 5; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"GS" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/obj/machinery/light/runway_light/delay5,/turf/variableTurf/clear,/area/noGenerate)
 "Hn" = (/obj/item/storage/secure/ssafe/candy_shop{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Ht" = (/obj/item/storage/toilet/random{dir = 8},/obj/decoration/toiletholder{pixel_y = 33},/obj/machinery/light/incandescent/cool{dir = 4},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"HJ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"II" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Ht" = (/obj/item/storage/toilet/random{dir = 8},/obj/decoration/toiletholder{pixel_y = 33},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
+"HJ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/cool/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Jr" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "JQ" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "Kb" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "KG" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Ne" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"LT" = (/obj/machinery/light/small/floor/cool/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Ne" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 28},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "Nj" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "NI" = (/obj/machinery/light/small/floor/cool,/obj/neon_lining{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Pp" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "RU" = (/obj/submachine/chef_sink/chem_sink{dir = 4; pixel_x = -4},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"Tk" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Tk" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/cool/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "TX" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "Us" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "UE" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages."; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Vt" = (/obj/item/storage/toilet/random{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
-"Wk" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
+"Wk" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/obj/machinery/light/runway_light/delay3,/turf/variableTurf/clear,/area/noGenerate)
 "Yo" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "YM" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages."; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"YO" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
+"YO" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
-tBtBtBtBtBettBtBtBtBtBtBtBtBettBtBtBettB
-tBtBtBtBoTTXnEnbYonbnbYonbduCunbnbnbnbtC
+tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
+tBtBtBtBtBTXnEnbYonbnbYonbduCunbnbnbnbtB
 tBtBtBtBtBnbxCxCqNHndgryxCxCnbRUkrHtnbtB
-tBtBtBtBtBnbxIxIcNDfxIxIxIIIkCNIznkRnbtB
+tBtBtBtBtBnbxIxIcNDfxIxIxIYOkCNIznkRnbtB
 tBtBtBtBtBnbxQxIuRFqykxFxIFSnbRUkrVtnbtB
-tBtBtBtBtBnbTkxIxIAKAKxIxIxTnbnbnbnbnbtC
-tBtBtBtBtBYoFwxIYMxIxIYMxIrVYotBtBtBYOtB
-tBtBtBtBtBYoAgxIYMAKAKYMxIngYotBtBtBtBtB
+tBtBtBtBtBnbTkxIxIAKLTxIxIxTnbnbnbnbnbtB
+tBtBtBtBtBYoFwxIYMxIxIYMxIrVYotBtBtBtBtB
+tBtBtBtBtBYoAgxIYMAKLTYMxIngYotBtBtBtBtB
 tBtBtBtBtBYonzxIUExIxIYMxIoPYotBtBtBtBtB
-tBtBtBtBtBnbHJxIxIAKAKxIxInQnbtBtBtBtBtB
+tBtBtBtBtBnbHJxIxIAKLTxIxInQnbtBtBtBtBtB
 tBtBtBtBtBnbwexIxIxIxIxIxIPpnbtBtBtBtBtB
-tBtBtBtBtBnbqNxIxIAKAKxIxIqNnbtBtBtBtBtB
+tBtBtBtBtBnbqNxIxIAKLTxIxIqNnbtBtBtBtBtB
 tBtBtBtBtBnbJrJrUsJrJrUsJrJrnbtBtBtBtBtB
 tBtBhDtBtBnbqzJQNjJQNjJQNjNenbtBtBtBtBtB
-tBjEiUauaunbAUKbNjoKtfJQhVyAnbtBtBtBtBtB
+tBjEiUauGSnbAUKbNjoKtfJQhVyAnbtBtBtBtBtB
 tBtBWktBtBnbDLJQNjJQNjJQNjyAnbtBtBtBtBtB
-tBtBtBtBoTnbjpKGjpKGjpKGjpKGkztCtBtBtBtB
-tBtBtBtBtBYOtBtBtBtBtBtBtBtBYOtBtBtBtBtB
+tBtBtBtBtBnbjpKGjpKGjpKGjpKGkztBtBtBtBtB
+tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
 tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,34 +1,34 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"g" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"h" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"m" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"k" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"m" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"o" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
-"q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"r" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"v" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"t" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"y" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"B" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"I" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"H" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"N" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"O" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"P" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"R" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"L" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"O" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"W" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"U" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"W" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -37,7 +37,7 @@
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
 aaaaazzzFzzFzzzaaaaa
-aaaaazZZmKiCZZzaaaaa
+aaaaazZZWKiCZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
 aaaaazSCEcwwCSzaaaaa
 aaaaazYCCffCCdzaaaaa
@@ -46,12 +46,12 @@ aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazmCCffCCmzaaaaa
+aaaaazWCCffCCWzaaaaa
 aaaaazFFXFFXFFzaaaaa
-aaaaazqebebebtzaaaaa
-aaaaazLIbRGeAvzaaaaa
-aaaaazPebebebvzaaaaa
-aaaaazOWOWOWOWNaaaaa
+aaaaazqoOoOoOgzaaaaa
+aaaaazhLOtUoBkzaaaaa
+aaaaazHoOoOoOkzaaaaa
+aaaaazrmrmrmrmyaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,43 +1,44 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"e" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"h" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"g" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"k" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"l" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"m" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"j" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"l" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"m" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"n" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"r" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"u" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"t" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"u" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"v" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"y" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"B" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"B" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"D" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"H" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"I" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"J" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"G" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"H" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"J" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"M" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"O" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"Q" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"R" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"L" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"M" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"N" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"O" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Q" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"R" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"W" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"U" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"V" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -45,22 +46,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaagMzFzzFzLmaaaaa
-aaaaazZZbKihZZzaaaaa
+aaaaaUyzFzzFzeGaaaaa
+aaaaazZZuKiQZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
-aaaaazjCEcwUCSzaaaaa
-aaaaazHCCffCCdzaaaaa
-aaaaaFSCsCCsCSFaaaaa
+aaaaaztCEcwmCSzaaaaa
+aaaaazgCCffCCdzaaaaa
+aaaaaFJCsCCsCSFaaaaa
 aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazbCCffCCbzaaaaa
-aaaaazBBXBBXBBzaaaaa
-aaaaazqWkWkWklzaaaaa
-aaaaazyIkJQWGuzaaaaa
-aaaaazRWkWkWkuzaaaaa
-aaaaazrDrDrDrDOaaaaa
+aaaaazuCCffCCuzaaaaa
+aaaaazvvXvvXvvzaaaaa
+aaaaazqLVLVLVjzaaaaa
+aaaaazrOVNDLRBzaaaaa
+aaaaazMLVLVLVBzaaaaa
+aaaaaznlnlnlnlHaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,40 +1,42 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"b" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"e" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"h" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"l" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"n" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"o" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"j" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"l" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"n" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"o" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"v" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"t" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"v" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"y" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"B" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"A" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"B" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"D" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"H" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"I" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"J" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"G" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"H" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"I" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"J" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"M" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"O" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"R" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"L" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"M" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"N" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"P" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Q" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"V" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -42,22 +44,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaayvzFzzFzInaaaaa
-aaaaazZZOKiCZZzaaaaa
+aaaaaMbzFzzFzNtaaaaa
+aaaaazZZeKiCZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
-aaaaazLCEcwwCSzaaaaa
-aaaaazYCCffCCdzaaaaa
+aaaaazHCEcwQCSzaaaaa
+aaaaazVCCffCCdzaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazOCCffCCOzaaaaa
-aaaaazJJXJJXJJzaaaaa
-aaaaazqbRbRbRlzaaaaa
-aaaaaztoRDBbrhzaaaaa
-aaaaazAbRbRbRhzaaaaa
-aaaaazHMHMHMHMjaaaaa
+aaaaazeCCffCCezaaaaa
+aaaaazLLXLLXLLzaaaaa
+aaaaazqonononJzaaaaa
+aaaaazvAnIloBGzaaaaa
+aaaaazjonononGzaaaaa
+aaaaazyPyPyPyPDaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -2,34 +2,34 @@
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"h" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"h" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"k" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"m" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"o" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"j" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"l" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"n" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"r" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"v" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"B" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"A" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"D" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"H" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"O" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"N" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"P" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Q" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"R" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"W" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"U" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"W" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
@@ -37,7 +37,7 @@
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
 aaaaazzzFzzFzzzaaaaa
-aaaaazZZWKiCZZzaaaaa
+aaaaazZZrKiCZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
 aaaaazSCEcwwCSzaaaaa
 aaaaazYCCffCCdzaaaaa
@@ -46,12 +46,12 @@ aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazWCCffCCWzaaaaa
+aaaaazrCCffCCrzaaaaa
 aaaaazFFXFFXFFzaaaaa
-aaaaazqoOoOoOgzaaaaa
-aaaaazhLOtUoBkzaaaaa
-aaaaazHoOoOoOkzaaaaa
-aaaaazrmrmrmrmyaaaaa
+aaaaazqvnvnvnlzaaaaa
+aaaaazDQnUhvNRzaaaaa
+aaaaazjvnvnvnRzaaaaa
+aaaaazPAPAPAPAWaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -2,6 +2,7 @@
 "cN" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "dg" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "du" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"hk" = (/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "hD" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
 "hV" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "iU" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
@@ -30,24 +31,31 @@
 "xT" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = 5; pixel_y = 7},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = -4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "yk" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "yA" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"za" = (/obj/item/storage/toilet/random{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
+"zI" = (/obj/item/storage/toilet/random{dir = 8},/obj/decoration/toiletholder{pixel_y = 33},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Ag" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "AK" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "AU" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "Cu" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"CG" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "restroom"},/turf/simulated/floor/sanitary/white,/area/prefab/candy_shop)
 "Df" = (/obj/decal/skeleton{desc = "The remains of a confectioner."; name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "DL" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "Fq" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Fw" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "FS" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Hn" = (/obj/item/storage/secure/ssafe/candy_shop{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Hy" = (/obj/window/cubicle{dir = 1},/obj/window/cubicle{dir = 8; icon_state = "cubicle"},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "HJ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Jr" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "JQ" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "Kb" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "KG" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Lm" = (/obj/submachine/chef_sink/chem_sink{dir = 4; pixel_x = -4},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
+"Md" = (/obj/decoration/toiletholder{desc = "Definitely a trendy new design and NOT just a standard toilet paper holder that's been installed incorrectly, no way no how."; dir = 8; name = "deluxe toilet paper holder"; pixel_x = 10},/obj/window/cubicle{dir = 1},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Ne" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "Nj" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "Pp" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Sn" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "Toilet"},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Tk" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "TX" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "Us" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -60,11 +68,11 @@
 (1,1,1) = {"
 tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
 tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
-tBtBtBtBtBTXnEnbYonbnbYonbduCutBtBtBtBtB
-tBtBtBtBtBnbxCxCqNHndgryxCxCnbtBtBtBtBtB
-tBtBtBtBtBnbxIxIcNDfxIxIxIxInbtBtBtBtBtB
-tBtBtBtBtBnbxQxIuRFqykxFxIFSnbtBtBtBtBtB
-tBtBtBtBtBnbTkxIxIAKAKxIxIxTnbtBtBtBtBtB
+tBtBtBtBtBTXnEnbYonbnbYonbduCunbnbnbnbtB
+tBtBtBtBtBnbxCxCqNHndgryxCxCnbLmSnzInbtB
+tBtBtBtBtBnbxIxIcNDfxIxIxIxICGhkHyMdnbtB
+tBtBtBtBtBnbxQxIuRFqykxFxIFSnbLmSnzanbtB
+tBtBtBtBtBnbTkxIxIAKAKxIxIxTnbnbnbnbnbtB
 tBtBtBtBtBYoFwxIYMxIxIYMxIrVYotBtBtBtBtB
 tBtBtBtBtBYoAgxIYMAKAKYMxIngYotBtBtBtBtB
 tBtBtBtBtBYonzxIUExIxIYMxIoPYotBtBtBtBtB

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,35 +1,39 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"e" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"g" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"h" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"m" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"o" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"l" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"n" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"o" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"u" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"v" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"y" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"B" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"I" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"J" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"I" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"J" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"N" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"O" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Q" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"R" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"L" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"N" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"O" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"P" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"R" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"V" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"U" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"W" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -37,8 +41,8 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaazzzFzzFzzzaaaaa
-aaaaazZZrKiCZZzaaaaa
+aaaaayNzFzzFzUoaaaaa
+aaaaazZZlKiCZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
 aaaaazSCEcwwCSzaaaaa
 aaaaazYCCffCCdzaaaaa
@@ -47,12 +51,12 @@ aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazrCCffCCrzaaaaa
-aaaaazNNXNNXNNzaaaaa
-aaaaazqIoIoIoyzaaaaa
-aaaaazQOojVIDUzaaaaa
-aaaaazmIoIoIoUzaaaaa
-aaaaazJRJRJRJRGaaaaa
+aaaaazlCCffCClzaaaaa
+aaaaazIIXIIXIIzaaaaa
+aaaaazqJLJLJLhzaaaaa
+aaaaaznWLgRJeuzaaaaa
+aaaaazBJLJLJLuzaaaaa
+aaaaazvPvPvPvPOaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,29 +1,31 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"h" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"k" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"x" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"H" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"K" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"N" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Y" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"b" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"f" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"k" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"n" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"s" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"x" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"D" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"F" = (/obj/decal/skeleton,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"K" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Q" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"S" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
-aaazzzzzzzzzzaaa
-aaazhhKHKKhhzaaa
-aaazKKkxKKKKzaaa
-aaazYKkUkkKYzaaa
-aaazYKKKKKKYzaaa
-aaazYKKKKKKYzaaa
-aaazYKKKKKKYzaaa
-aaazYKKKKKKYzaaa
-aaazYKKKKKKYzaaa
-aaazNKKKKKKYzaaa
-aaazKKKKKKKKzaaa
-aaazKKKKKKKKzaaa
+aaaDDDDDDDDDDaaa
+aaaDkkbxbbkkDaaa
+aaaDbbfFbbbbDaaa
+aaaDKbQnffbKDaaa
+aaaDKbbbbbbKDaaa
+aaaDKbSbbSbKDaaa
+aaaDKbSbbSbKDaaa
+aaaDKbSbbSbKDaaa
+aaaDKbSbbSbKDaaa
+aaaDsbbbbbbKDaaa
+aaaDbbbbbbbbDaaa
+aaaDbbbbbbbbDaaa
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -2,6 +2,7 @@
 "cN" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "dg" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "du" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"et" = (/obj/machinery/light/small/sticky/warm/very,/turf/variableTurf/clear,/area/noGenerate)
 "hD" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
 "hV" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "iU" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
@@ -9,8 +10,8 @@
 "jE" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
 "kr" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "Toilet"},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "kz" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"kC" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "restroom"},/turf/simulated/floor/sanitary/white,/area/prefab/candy_shop)
-"kR" = (/obj/decoration/toiletholder{desc = "Definitely a trendy new design and NOT just a standard toilet paper holder that's been installed incorrectly, no way no how."; dir = 8; name = "deluxe toilet paper holder"; pixel_x = 10},/obj/window/cubicle{dir = 1},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
+"kC" = (/obj/machinery/door/unpowered/wood/pyro{dir = 4; name = "restroom"},/obj/neon_lining{dir = 8},/turf/simulated/floor/sanitary/white,/area/prefab/candy_shop)
+"kR" = (/obj/decoration/toiletholder{desc = "Definitely a trendy new design and NOT just a standard toilet paper holder that's been installed incorrectly, no way no how."; dir = 8; name = "deluxe toilet paper holder"; pixel_x = 10},/obj/window/cubicle{dir = 1},/obj/machinery/light/incandescent/cool{dir = 4},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "nb" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "ng" = (/obj/table/wood/round/auto,/obj/item/clothing/under/suit/purple/dress{pixel_x = 8; pixel_y = -7},/obj/item/clothing/under/suit/purple{pixel_x = -8; pixel_y = -7},/obj/item/clothing/head/that/purple{pixel_x = -8; pixel_y = 7},/obj/item/clothing/head/that/purple{pixel_x = 8; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "nz" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -18,12 +19,14 @@
 "nQ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/pie/pumpkin{pixel_y = -7},/obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake{pixel_x = 5; pixel_y = 5},/obj/item/reagent_containers/food/snacks/moon_pie/spooky{pixel_x = -9; pixel_y = 12},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "oK" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "oP" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"qz" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"oT" = (/obj/machinery/light/small/sticky/warm/very{dir = 4},/turf/variableTurf/clear,/area/noGenerate)
+"qz" = (/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "qN" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "ry" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/item/reagent_containers/food/snacks/ice_cream/gross,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "rV" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "tf" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "tB" = (/turf/variableTurf/clear,/area/noGenerate)
+"tC" = (/obj/machinery/light/small/sticky/warm/very{dir = 8},/turf/variableTurf/clear,/area/noGenerate)
 "uR" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "we" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "xC" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -44,36 +47,37 @@
 "Fw" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "FS" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Hn" = (/obj/item/storage/secure/ssafe/candy_shop{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Ht" = (/obj/item/storage/toilet/random{dir = 8},/obj/decoration/toiletholder{pixel_y = 33},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
+"Ht" = (/obj/item/storage/toilet/random{dir = 8},/obj/decoration/toiletholder{pixel_y = 33},/obj/machinery/light/incandescent/cool{dir = 4},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "HJ" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"II" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Jr" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "JQ" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Kb" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Kb" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "KG" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "Ne" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "Nj" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"NI" = (/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
+"NI" = (/obj/machinery/light/small/floor/cool,/obj/neon_lining{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Pp" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "RU" = (/obj/submachine/chef_sink/chem_sink{dir = 4; pixel_x = -4},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Tk" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "TX" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "Us" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"UE" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"UE" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages."; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Vt" = (/obj/item/storage/toilet/random{dir = 8},/turf/simulated/floor/sanitary/blue,/area/prefab/candy_shop)
 "Wk" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
 "Yo" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"YM" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"YM" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages."; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "YO" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 
 (1,1,1) = {"
 tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
-tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
-tBtBtBtBtBTXnEnbYonbnbYonbduCunbnbnbnbtB
+tBtBtBtBtBettBtBtBtBtBtBtBtBettBtBtBettB
+tBtBtBtBoTTXnEnbYonbnbYonbduCunbnbnbnbtC
 tBtBtBtBtBnbxCxCqNHndgryxCxCnbRUkrHtnbtB
-tBtBtBtBtBnbxIxIcNDfxIxIxIxIkCNIznkRnbtB
+tBtBtBtBtBnbxIxIcNDfxIxIxIIIkCNIznkRnbtB
 tBtBtBtBtBnbxQxIuRFqykxFxIFSnbRUkrVtnbtB
-tBtBtBtBtBnbTkxIxIAKAKxIxIxTnbnbnbnbnbtB
-tBtBtBtBtBYoFwxIYMxIxIYMxIrVYotBtBtBtBtB
+tBtBtBtBtBnbTkxIxIAKAKxIxIxTnbnbnbnbnbtC
+tBtBtBtBtBYoFwxIYMxIxIYMxIrVYotBtBtBYOtB
 tBtBtBtBtBYoAgxIYMAKAKYMxIngYotBtBtBtBtB
 tBtBtBtBtBYonzxIUExIxIYMxIoPYotBtBtBtBtB
 tBtBtBtBtBnbHJxIxIAKAKxIxInQnbtBtBtBtBtB
@@ -83,7 +87,7 @@ tBtBtBtBtBnbJrJrUsJrJrUsJrJrnbtBtBtBtBtB
 tBtBhDtBtBnbqzJQNjJQNjJQNjNenbtBtBtBtBtB
 tBjEiUauaunbAUKbNjoKtfJQhVyAnbtBtBtBtBtB
 tBtBWktBtBnbDLJQNjJQNjJQNjyAnbtBtBtBtBtB
-tBtBtBtBtBnbjpKGjpKGjpKGjpKGkztBtBtBtBtB
+tBtBtBtBoTnbjpKGjpKGjpKGjpKGkztCtBtBtBtB
 tBtBtBtBtBYOtBtBtBtBtBtBtBtBYOtBtBtBtBtB
 tBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtBtB
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -2,10 +2,14 @@
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"h" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"j" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"n" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
-"q" = (/obj/forcefield/energyshield/perma,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"q" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"u" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
@@ -13,6 +17,7 @@
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"M" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -23,7 +28,7 @@
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
 aaaaazzzFzzFzzzaaaaa
-aaaaazZZCKiCZZzaaaaa
+aaaaazZZnKiCZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
 aaaaazSCEcwwCSzaaaaa
 aaaaazYCCffCCdzaaaaa
@@ -32,12 +37,12 @@ aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazCCCffCCCzaaaaa
+aaaaaznCCffCCnzaaaaa
 aaaaazFFXFFXFFzaaaaa
-aaaaazqqqqqqqqzaaaaa
-aaaaazCCCCCCCCzaaaaa
-aaaaazCCCCCCCCzaaaaa
-aaaaazCCCCCCCCzaaaaa
+aaaaazququququzaaaaa
+aaaaaFququququFaaaaa
+aaaaaFququququFaaaaa
+aaaaazMhMhMhMhjaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,75 +1,78 @@
-"a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"g" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"h" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
-"i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
-"k" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"l" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"m" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"n" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
-"o" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
-"q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"r" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"u" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"v" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"x" = (/obj/decal/skeleton{name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"B" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"G" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"H" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"I" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
-"J" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"M" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"N" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"O" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"P" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"Q" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"R" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"U" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"V" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
-"W" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ar" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"aA" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"fr" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"fE" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"fM" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"fN" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"fT" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"gC" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"hn" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
+"iy" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"iH" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"iV" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"js" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"ky" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
+"lh" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"nR" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"nT" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
+"qD" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"sg" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"td" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ti" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"uo" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ur" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"uz" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"vW" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"xc" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"xd" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"zF" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"zJ" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"zM" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Bu" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"CR" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"CX" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"DR" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"EF" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Fr" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"FS" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"If" = (/turf/variableTurf/clear,/area/noGenerate)
+"IM" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Jp" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"Km" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Kp" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
+"Mv" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"MU" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"OQ" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"QU" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"TA" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"TL" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
+"UY" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"VJ" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"WF" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Xv" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
+"Yp" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Zl" = (/obj/decal/skeleton{name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ZJ" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaa
-aaaaaOlzFzzFzLQaaaaa
-aaaaazZZgKiAZZzaaaaa
-aaaaazCCkxCCCCzaaaaa
-aaaaazJCEcwUCSzaaaaa
-aaaaazYCCffCCdzaaaaa
-aaaaaFHCsCCsCSFaaaaa
-aaaaaFbCsffsCSFaaaaa
-aaaaaFuCsCCsCSFaaaaa
-aaaaazrCCffCCdzaaaaa
-aaaaazTCCCCCCSzaaaaa
-aaaaazgCCffCCgzaaaaa
-aaaaazMMXMMXMMzaaaaa
-aajaazqmDmDmDvzaaaaa
-anVIIzGRDyNmoBzaaaaa
-aahaazemDmDmDBzaaaaa
-aaaaazWtWtWtWtPaaaaa
-aaaaapaaaaaaaapaaaaa
-aaaaaaaaaaaaaaaaaaaa
+IfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIf
+IfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIf
+IfIfIfIfIfZJJpFrurFrFrurFrargCIfIfIfIfIf
+IfIfIfIfIfFrfTfTnRfNaAuzfTfTFrIfIfIfIfIf
+IfIfIfIfIfFrFSFSzMZlFSFSFSFSFrIfIfIfIfIf
+IfIfIfIfIfFrfrFSzJqDKmEFFSWFFrIfIfIfIfIf
+IfIfIfIfIfFrYpFSFSDRDRFSFSlhFrIfIfIfIfIf
+IfIfIfIfIfurMvFSiyFSFSiyFSuourIfIfIfIfIf
+IfIfIfIfIfurQUFSiyDRDRiyFSiHurIfIfIfIfIf
+IfIfIfIfIfurCRFSiyFSFSiyFSiHurIfIfIfIfIf
+IfIfIfIfIfFrtdFSFSDRDRFSFSlhFrIfIfIfIfIf
+IfIfIfIfIfFrsgFSFSFSFSFSFStiFrIfIfIfIfIf
+IfIfIfIfIfFrnRFSFSDRDRFSFSnRFrIfIfIfIfIf
+IfIfIfIfIfFrIMIMvWIMIMvWIMIMFrIfIfIfIfIf
+IfIfXvIfIfFrjsiVxdiVxdiVxdTAFrIfIfIfIfIf
+IfhnKpkykyFrCXOQxdMUfEiVUYfMFrIfIfIfIfIf
+IfIfnTIfIfFrzFiVxdiVxdiVxdfMFrIfIfIfIfIf
+IfIfIfIfIfFrxcVJxcVJxcVJxcVJBuIfIfIfIfIf
+IfIfIfIfIfTLIfIfIfIfIfIfIfIfTLIfIfIfIfIf
+IfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIfIf
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,45 +1,46 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"b" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"b" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"e" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"e" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"h" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"g" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"h" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"k" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"m" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"n" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"o" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"j" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"k" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"l" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"m" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"n" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"o" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
 "q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"r" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{pixel_x = -5; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_x = -3; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"t" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"u" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"u" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"v" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"y" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"A" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"B" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"D" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"D" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"H" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"I" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"J" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"G" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"I" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"L" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"M" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"N" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"O" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"P" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Q" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"R" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"L" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"M" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"N" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"O" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"P" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Q" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"R" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"W" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"U" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"V" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"W" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Y" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -47,22 +48,22 @@
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
-aaaaatjzFzzFzRbaaaaa
-aaaaazZZuKiOZZzaaaaa
+aaaaalDzFzzFzgjaaaaa
+aaaaazZZUKiNZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
-aaaaazeCEcwPCSzaaaaa
-aaaaazACCffCCdzaaaaa
-aaaaaFNCsCCsCSFaaaaa
-aaaaaFDCsffsCSFaaaaa
-aaaaaFSCsCCsCSFaaaaa
+aaaaaznCEcwICSzaaaaa
+aaaaazbCCffCCdzaaaaa
+aaaaaFRCsCCsCSFaaaaa
+aaaaaFkCsffsCSFaaaaa
+aaaaaFGCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaazuCCffCCuzaaaaa
-aaaaazHHXHHXHHzaaaaa
-aaaaazqkokokoJzaaaaa
-aaaaazhQoyIkmLzaaaaa
-aaaaazBkokokoLzaaaaa
-aaaaazMnMnMnMnWaaaaa
+aaaaazUCCffCCUzaaaaa
+aaaaazhhXhhXhhzaaaaa
+aaaaazqMuMuMuozaaaaa
+aaaaazPVuWQMeOzaaaaa
+aaaaazLMuMuMuOzaaaaa
+aaaaazvrvrvrvrmaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,22 +1,22 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"C" = (/turf/space,/area/prefab/candy_shop)
-"G" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"p" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"O" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
-aaaGGGGGGGGGGaaa
-aaaGCCCCCCCCGaaa
-aaaGCCCCCCCCGaaa
-aaaGCCCCCCCCGaaa
-aaaGCCCCCCCCGaaa
-aaaGCCCCCCCCGaaa
-aaaGCCCCCCCCGaaa
-aaaGCCCCCCCCGaaa
-aaaGCCCCCCCCGaaa
-aaaGCCCCCCCCGaaa
-aaaGCCCCCCCCGaaa
-aaaGCCCCCCCCGaaa
+aaappppppppppaaa
+aaapOOOOOOOOpaaa
+aaapOOOOOOOOpaaa
+aaapOOOOOOOOpaaa
+aaapOOOOOOOOpaaa
+aaapOOOOOOOOpaaa
+aaapOOOOOOOOpaaa
+aaapOOOOOOOOpaaa
+aaapOOOOOOOOpaaa
+aaapOOOOOOOOpaaa
+aaapOOOOOOOOpaaa
+aaapOOOOOOOOpaaa
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,22 +1,23 @@
 "a" = (/turf/variableTurf/clear,/area/noGenerate)
-"p" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"O" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"k" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"M" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Z" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
-aaappppppppppaaa
-aaapOOOOOOOOpaaa
-aaapOOOOOOOOpaaa
-aaapOOOOOOOOpaaa
-aaapOOOOOOOOpaaa
-aaapOOOOOOOOpaaa
-aaapOOOOOOOOpaaa
-aaapOOOOOOOOpaaa
-aaapOOOOOOOOpaaa
-aaapOOOOOOOOpaaa
-aaapOOOOOOOOpaaa
-aaapOOOOOOOOpaaa
+aaakkkkkkkkkkaaa
+aaakMZZMMZZMkaaa
+aaakMMMMMMMMkaaa
+aaakMMMMMMMMkaaa
+aaakMMMMMMMMkaaa
+aaakMMMMMMMMkaaa
+aaakMMMMMMMMkaaa
+aaakMMMMMMMMkaaa
+aaakMMMMMMMMkaaa
+aaakMMMMMMMMkaaa
+aaakMMMMMMMMkaaa
+aaakMMMMMMMMkaaa
 aaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -2,22 +2,23 @@
 "c" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "d" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "f" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"h" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "i" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"j" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"n" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "p" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
-"q" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"q" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -24},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"r" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "s" = (/obj/rack/lunar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"u" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"v" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "w" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "x" = (/obj/decal/skeleton{name = "Carlisle"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"y" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
 "z" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"B" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "C" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "E" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "F" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"G" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
 "K" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"M" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Q" = (/obj/machinery/r_door_control{id = "Candy Shop"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
 "S" = (/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "T" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 "X" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
@@ -28,7 +29,7 @@
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa
 aaaaazzzFzzFzzzaaaaa
-aaaaazZZnKiCZZzaaaaa
+aaaaazZZBKiCZZzaaaaa
 aaaaazCCwxCCCCzaaaaa
 aaaaazSCEcwwCSzaaaaa
 aaaaazYCCffCCdzaaaaa
@@ -37,12 +38,12 @@ aaaaaFSCsffsCSFaaaaa
 aaaaaFSCsCCsCSFaaaaa
 aaaaazYCCffCCdzaaaaa
 aaaaazTCCCCCCSzaaaaa
-aaaaaznCCffCCnzaaaaa
+aaaaazBCCffCCBzaaaaa
 aaaaazFFXFFXFFzaaaaa
-aaaaazququququzaaaaa
-aaaaaFququququFaaaaa
-aaaaaFququququFaaaaa
-aaaaazMhMhMhMhjaaaaa
+aaaaazqvrvrvrvzaaaaa
+aaaaaFrvrvrvrvFaaaaa
+aaaaaFrvrvrvrvFaaaaa
+aaaaazGyGyGyGyQaaaaa
 aaaaapaaaaaaaapaaaaa
 aaaaaaaaaaaaaaaaaaaa
 "}

--- a/assets/maps/prefabs/prefab_candy_shop.dmm
+++ b/assets/maps/prefabs/prefab_candy_shop.dmm
@@ -1,81 +1,81 @@
-"bF" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"dE" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
-"eH" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"eT" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"fH" = (/obj/table/wood/round/auto,/obj/item/clothing/under/suit/purple/dress{pixel_x = 8; pixel_y = -7},/obj/item/clothing/under/suit/purple{pixel_x = -8; pixel_y = -7},/obj/item/clothing/head/that/purple{pixel_x = -8; pixel_y = 7},/obj/item/clothing/head/that/purple{pixel_x = 8; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"gy" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"gA" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"gK" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
-"hG" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"iH" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"ji" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
-"jS" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ks" = (/turf/variableTurf/clear,/area/noGenerate)
-"ld" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ll" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"ma" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"oA" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"oP" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ru" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"rB" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"sC" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"to" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = 5; pixel_y = 7},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = -4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Ay" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
-"AM" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Bl" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Cr" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Cs" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"DC" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"EE" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"FI" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Gb" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"GZ" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Hi" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"HH" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Ii" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"Jr" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Jz" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Ke" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Kp" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"KJ" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
-"Lu" = (/obj/decal/skeleton{desc = "The remains of a confectioner."; name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"MV" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Nj" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"Nz" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"NC" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"NM" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"OT" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Po" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"PX" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"Qx" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
-"Ri" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"ST" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"Vi" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
-"VF" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"VT" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
-"WI" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
-"XV" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
-"YB" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"bq" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = 5; pixel_y = 7},/obj/item/reagent_containers/food/snacks/candy/jellybean/everyflavor{pixel_x = -4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"dn" = (/turf/variableTurf/clear,/area/noGenerate)
+"dw" = (/obj/neon_lining{dir = 8},/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"dM" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = 6},/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup,/obj/item/reagent_containers/food/snacks/candy/wrapped_pbcup{pixel_x = -4; pixel_y = 6},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"dR" = (/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"dZ" = (/obj/table/wood/auto/desk,/obj/machinery/cashreg,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"fU" = (/obj/item/storage/secure/ssafe/loot{pixel_y = 28},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"gS" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"hr" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"hA" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"iM" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 4},/obj/item/reagent_containers/food/snacks/pie/pumpkin{pixel_y = -7},/obj/item/reagent_containers/food/snacks/yellow_cake_uranium_cake{pixel_x = 5; pixel_y = 5},/obj/item/reagent_containers/food/snacks/moon_pie/spooky{pixel_x = -9; pixel_y = 12},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"kh" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 13; pixel_y = -6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 5; pixel_y = 6},/obj/item/reagent_containers/food/snacks/candy/candy_cane{dir = 8; pixel_x = 14; pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"lp" = (/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"lH" = (/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"lZ" = (/obj/table/wood/round/auto,/obj/item/clothing/under/suit/purple/dress{pixel_x = 8; pixel_y = -7},/obj/item/clothing/under/suit/purple{pixel_x = -8; pixel_y = -7},/obj/item/clothing/head/that/purple{pixel_x = -8; pixel_y = 7},/obj/item/clothing/head/that/purple{pixel_x = 8; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"ne" = (/obj/cabinet/taffy,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"nq" = (/obj/machinery/door_control/podbay{id = "Candy Shop"; pixel_x = -26},/obj/neon_lining{dir = 8},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = -14},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"nR" = (/obj/decal/poster/wallsign/stencil/left/c{pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/a{pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"ov" = (/obj/table/wood/auto/desk,/obj/item/paper{icon_state = "paper_caution_bloody"; info = "I can't sell this shit to you. Sorry. Help yourself to the last of our good stock. Goodbye."; name = "bloody note"; pixel_x = -2; pixel_y = 1},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"oN" = (/obj/machinery/light/small/floor/warm/very,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"pR" = (/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"qx" = (/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"sl" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/nougat,/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/nougat{pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"su" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/breadloaf/corn/sweet/honey{pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"tB" = (/obj/window/auto/hardened/the_tuff_stuff,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"tF" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/lollipop{pixel_x = 5; pixel_y = 3},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"tM" = (/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"uU" = (/obj/table/wood/round/auto,/obj/item/item_box/swedish_bag{pixel_x = 3; pixel_y = -2},/obj/item/item_box/swedish_bag,/obj/item/item_box/swedish_bag{pixel_x = -3; pixel_y = 4},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"vB" = (/obj/table/wood/auto/desk,/obj/item/kitchen/food_box/donut_box{desc = "A box of Dunkin-Kreme donuts.  The brand name made a lot more sense before the companies merged in 2038."; pixel_x = 1; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"wJ" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/cake/chocolate/gateau{pixel_y = 10},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"xi" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"zy" = (/obj/neon_lining{dir = 4; lining_color = "pink"},/obj/decal/pole{desc = "Definitely not a barber pole, nope, nuh-uh."; name = "Spinning Candy Cane Pole"; pixel_x = 14},/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Aw" = (/obj/table/wood/round/auto,/obj/item/storage/goodybag{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Bz" = (/obj/lattice{dir = 4; icon_state = "lattice-dir"; tag = "icon-lattice-dir (EAST)"},/turf/variableTurf/clear,/area/noGenerate)
+"BS" = (/obj/submachine/cargopad{active = 0; desc = "Used to receive objects transported by a cargo transporter. Carlisle must've warped in all their sweets using this thing."; name = "Candy Resupply Pad"},/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/snack_cake/golden,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/reagent_containers/food/snacks/strudel,/obj/item/clothing/suit/lshirt/dan_blue,/obj/item/ticket/golden,/obj/item/reagent_containers/food/snacks/ice_cream/gross,/obj/storage/crate/bin{desc = "Buy one, get the rest free."; name = "bargain bin"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"BY" = (/obj/table/wood/round/auto,/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/bagel,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"DB" = (/obj/machinery/r_door_control{id = "Candy Shop"; name = "Parking Door Control"},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"Eb" = (/obj/decal/poster/wallsign/stencil/left/n{pixel_x = -7; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/d{pixel_x = 5; pixel_y = 15},/obj/decal/poster/wallsign/stencil/right/y{pixel_x = 17; pixel_y = 15},/turf/simulated/wall/auto/reinforced/jen/cyan,/area/prefab/candy_shop)
+"Gy" = (/obj/random_pod_spawner,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"Gz" = (/obj/neon_lining{dir = 8},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"GG" = (/obj/rack/lunar,/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"GN" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = -6; pixel_y = 5},/obj/item/reagent_containers/food/snacks/candy/candy_apple{pixel_x = 6; pixel_y = 3},/obj/item/reagent_containers/food/snacks/candy/candy_apple,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"JR" = (/obj/decal/skeleton{desc = "The remains of a confectioner."; name = "Carlisle"},/obj/item/casing/derringer{dir = 5; pixel_x = -9; pixel_y = 9},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"MO" = (/obj/table/wood/round/auto,/obj/machinery/light/incandescent/warm/very{dir = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/butterscotch{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/butterscotch,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Nk" = (/obj/rack/lunar,/obj/item/item_box/heartcandy{desc = "Wow, you haven't seen this brand in ages"; name = "Carlisle's Candy Hearts"; pixel_y = -7},/obj/item/kitchen/peach_rings{desc = "A bag of gummy peach rings. Woah! Carlisle Confection brand! You thought they went out of business!"; pixel_y = 7},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"NA" = (/obj/machinery/light/flamp,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Oh" = (/obj/window/auto/hardened/the_tuff_stuff,/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Oz" = (/obj/random_pod_spawner/random_putt_spawner,/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Qh" = (/obj/forcefield/energyshield/perma,/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{id = "Candy Shop"; name = "Carlisle's Confections Parking"},/turf/simulated/floor/engine/glow,/area/prefab/candy_shop)
+"Rp" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/engine/glow/blue,/area/prefab/candy_shop)
+"RV" = (/obj/table/wood/round/auto,/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 8},/obj/item/reagent_containers/food/snacks/candy/negativeonebar{pixel_y = 4},/obj/item/reagent_containers/food/snacks/candy/negativeonebar,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Sz" = (/obj/lattice{dir = 9; icon_state = "lattice-dir"},/turf/variableTurf/clear,/area/noGenerate)
+"TO" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"; tag = "icon-lattice-dir-b (NORTHWEST)"},/turf/variableTurf/clear,/area/noGenerate)
+"VK" = (/obj/lattice,/obj/warp_beacon{name = "Carlisle's Confections Beacon"},/turf/variableTurf/clear,/area/noGenerate)
+"VL" = (/obj/table/wood/auto/desk,/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
+"Xy" = (/obj/machinery/light/small/sticky/warm/very{dir = 1},/turf/variableTurf/clear,/area/noGenerate)
+"Yl" = (/obj/lattice{dir = 2; icon_state = "lattice-dir-b"},/turf/variableTurf/clear,/area/noGenerate)
+"Yr" = (/obj/machinery/door/unpowered/wood/pyro{name = "Carlisle's Confections"},/obj/decal/tile_edge/stripe/big{icon_state = "xtra_bigstripe-edge"},/turf/simulated/floor/wood/four,/area/prefab/candy_shop)
 
 (1,1,1) = {"
-ksksksksksksksksksksksksksksksksksksksks
-ksksksksksksksksksksksksksksksksksksksks
-ksksksksksiHVFllDCllllDCllVTNCksksksksks
-ksksksksksllRiRimaPoeTbFRiRillksksksksks
-ksksksksksllgygyAMLugygygygyllksksksksks
-ksksksksksllFIgyWICsoABlgyGZllksksksksks
-ksksksksksllKpgygyKeKegygytollksksksksks
-ksksksksksDCrBgyeHgygyeHgyJrDCksksksksks
-ksksksksksDCMVgyeHKeKeeHgyfHDCksksksksks
-ksksksksksDCOTgyjSgygyeHgyoPDCksksksksks
-ksksksksksllSTgygyKeKegygygAllksksksksks
-ksksksksksllJzgygygygygygyldllksksksksks
-ksksksksksllmagygyKeKegygymallksksksksks
-ksksksksksllNMNMsCNMNMsCNMNMllksksksksks
-ksksgKksksllYBHHruHHruHHruEEllksksksksks
-ksAyKJdEdEllNzCrruViXVHHNjPXllksksksksks
-ksksjiksksllIiHHruHHruHHruPXllksksksksks
-ksksksksksllhGHihGHihGHihGHiGbksksksksks
-ksksksksksQxksksksksksksksksQxksksksksks
-ksksksksksksksksksksksksksksksksksksksks
+dndndndndndndndndndndndndndndndndndndndn
+dndndndndndndndndndndndndndndndndndndndn
+dndndndndnnREbdRtBdRdRtBdRlHqxdndndndndn
+dndndndndndRneneNAfUhrBSnenedRdndndndndn
+dndndndndndRpRpRovJRpRpRpRpRdRdndndndndn
+dndndndndndRuUpRtFdZVLvBpRAwdRdndndndndn
+dndndndndndRslpRpRoNoNpRpRbqdRdndndndndn
+dndndndndntBkhpRGGpRpRGGpRwJtBdndndndndn
+dndndndndntBdMpRGGoNoNGGpRlZtBdndndndndn
+dndndndndntBGNpRNkpRpRGGpRsutBdndndndndn
+dndndndndndRMOpRpRoNoNpRpRiMdRdndndndndn
+dndndndndndRBYpRpRpRpRpRpRRVdRdndndndndn
+dndndndndndRNApRpRoNoNpRpRNAdRdndndndndn
+dndndndndndROhOhYrOhOhYrOhOhdRdndndndndn
+dndnYldndndRnqtMlptMlptMlpzydRdndndndndn
+dnSzVKBzBzdRGzGylpRpgStMOzhAdRdndndndndn
+dndnTOdndndRdwtMlptMlptMlphAdRdndndndndn
+dndndndndndRQhxiQhxiQhxiQhxiDBdndndndndn
+dndndndndnXydndndndndndndndnXydndndndndn
+dndndndndndndndndndndndndndndndndndndndn
 "}

--- a/assets/maps/prefabs/prefab_drug_den.dmm
+++ b/assets/maps/prefabs/prefab_drug_den.dmm
@@ -619,7 +619,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/reagent_containers/glass/bottle/icing{
+/obj/item/reagent_containers/food/drinks/drinkingglass/icing{
 	pixel_x = 5;
 	pixel_y = -2
 	},

--- a/code/area.dm
+++ b/code/area.dm
@@ -1138,6 +1138,10 @@ ABSTRACT_TYPE(/area/prefab)
 	name ="Von Ricken"
 	icon_state = "blue"
 
+/area/prefab/candy_shop
+	name = "Candy Shop"
+	icon_state = "blue"
+
 // Sealab trench areas //
 
 /area/shuttle/sea_elevator_room

--- a/code/area.dm
+++ b/code/area.dm
@@ -1141,6 +1141,8 @@ ABSTRACT_TYPE(/area/prefab)
 /area/prefab/candy_shop
 	name = "Candy Shop"
 	icon_state = "blue"
+	sound_loop = 'sound/ambience/music/shoptheme.ogg'
+	sound_environment = 2
 
 // Sealab trench areas //
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -161,8 +161,8 @@
 
 
 //big standing lamps
-/obj/machinery/light/blamp
-	name = "big lamp"
+/obj/machinery/light/flamp
+	name = "floor lamp"
 	icon = 'icons/obj/lighting.dmi'
 	desc = "A tall and thin lamp that rests comfortably on the floor."
 	anchored = 1
@@ -171,7 +171,7 @@
 	fitting = "bulb"
 	brightness = 1.4
 	var/state
-	icon_state = "blamp1-off"
+	icon_state = "flamp1"
 	wallmounted = 0
 
 //regular light bulbs

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -171,6 +171,7 @@
 	fitting = "bulb"
 	brightness = 1.4
 	var/state
+	base_state = "flamp"
 	icon_state = "flamp1"
 	wallmounted = 0
 

--- a/code/modules/worldgen/prefabs.dm
+++ b/code/modules/worldgen/prefabs.dm
@@ -182,7 +182,7 @@ ABSTRACT_TYPE(/datum/generatorPrefab)
 
 	candy_shop //Ryn's store from out of time and out of place
 		maxNum = 1
-		probability = 60 //for initial release, reset to 30 or 25 after a week or so
+		probability = 25
 		prefabPath = "assets/maps/prefabs/prefab_candy_shop.dmm"
 		prefabSizeX = 20
 		prefabSizeY = 20

--- a/code/modules/worldgen/prefabs.dm
+++ b/code/modules/worldgen/prefabs.dm
@@ -179,6 +179,14 @@ ABSTRACT_TYPE(/datum/generatorPrefab)
 		prefabPath = "assets/maps/prefabs/prefab_von_ricken.dmm"
 		prefabSizeX = 42
 		prefabSizeY = 40
+
+	candy_shop //Ryn's store from out of time and out of place
+		maxNum = 1
+		probability = 25
+		prefabPath = "assets/maps/prefabs/prefab_candy_shop.dmm"
+		prefabSizeX = 16
+		prefabSizeY = 16
+
 	//UNDERWATER AREAS FOR OSHAN
 
 	pit

--- a/code/modules/worldgen/prefabs.dm
+++ b/code/modules/worldgen/prefabs.dm
@@ -182,7 +182,7 @@ ABSTRACT_TYPE(/datum/generatorPrefab)
 
 	candy_shop //Ryn's store from out of time and out of place
 		maxNum = 1
-		probability = 100 //for initial release, reset to 30 or 25 after a week or so
+		probability = 60 //for initial release, reset to 30 or 25 after a week or so
 		prefabPath = "assets/maps/prefabs/prefab_candy_shop.dmm"
 		prefabSizeX = 20
 		prefabSizeY = 20

--- a/code/modules/worldgen/prefabs.dm
+++ b/code/modules/worldgen/prefabs.dm
@@ -184,8 +184,8 @@ ABSTRACT_TYPE(/datum/generatorPrefab)
 		maxNum = 1
 		probability = 25
 		prefabPath = "assets/maps/prefabs/prefab_candy_shop.dmm"
-		prefabSizeX = 16
-		prefabSizeY = 16
+		prefabSizeX = 20
+		prefabSizeY = 20
 
 	//UNDERWATER AREAS FOR OSHAN
 

--- a/code/modules/worldgen/prefabs.dm
+++ b/code/modules/worldgen/prefabs.dm
@@ -182,7 +182,7 @@ ABSTRACT_TYPE(/datum/generatorPrefab)
 
 	candy_shop //Ryn's store from out of time and out of place
 		maxNum = 1
-		probability = 25
+		probability = 100 //for initial release, reset to 30 or 25 after a week or so
 		prefabPath = "assets/maps/prefabs/prefab_candy_shop.dmm"
 		prefabSizeX = 20
 		prefabSizeY = 20

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -413,6 +413,12 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 		set_current_projectile(new/datum/projectile/bullet/derringer)
 		..()
 
+/obj/item/gun/kinetic/derringer/empty
+	New()
+		..()
+		ammo.amount_left = 0
+		update_icon()
+
 /obj/item/gun/kinetic/faith
 	name = "Faith"
 	desc = "'Cause ya gotta have Faith."

--- a/code/obj/item/storage/secure_safe.dm
+++ b/code/obj/item/storage/secure_safe.dm
@@ -594,6 +594,7 @@
 	random_code = 1
 	spawn_contents = list(/obj/item/clothing/shoes/cyborg, /obj/item/clothing/suit/cyborg_suit, /obj/item/clothing/gloves/cyborg, /obj/item/paper/thevonricken)
 
+
 /obj/item/paper/thevonricken
 	name = "This is hell! Oh god!"
 
@@ -706,6 +707,13 @@
 	spawn_contents = list(/obj/item/gun/kinetic/revolver,
 	/obj/item/chilly_orb, // a thing to confuse people
 	/obj/item/spacecash/thousand = 3)
+
+/obj/item/storage/secure/ssafe/candy_shop
+	configure_mode = 0
+	random_code = 1
+	spawn_contents = list(/obj/item/robot_foodsynthesizer,\
+	/obj/item/spacecash/thousand,\
+	/obj/item/gun/kinetic/derringer/empty)
 
 /obj/item/storage/secure/ssafe/marsvault
 	name = "secure vault"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPING] [FEATURE] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a new prefab to the pool of possible space prefabs, the candy shop.
Comes complete with really smooth vibes, an open-ended mystery, and some clues that just don't quite add-up.
There are no wrong answers! But there IS a lot of candy.

Also fixes a bug with floor lamps not... existing, really.

Also fixes another bug where the old path for icing tubes was still being used on the drug den prefab

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Mystery! Candy! Bugfixes!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Camryn Buttes
(*)Added a new prefab to the pool of space prefabs: the candy shop! Complete with an open-ended mystery and some clues that don't quite add up. (also lots of candy)
```
