### PR TITLE
Makes flipping/rotating disposal pipes easier

### DIFF
--- a/code/WorkInProgress/recycling/disposal-construction.dm
+++ b/code/WorkInProgress/recycling/disposal-construction.dm
@@ -99,10 +99,11 @@
 			if(ptype == 2)
 				ptype = 3
 				set_dir(turn(dir, 180))
+				boutput(user, "You change the pipe junction's direction.")
 			else if (ptype == 3)
 				ptype = 2
 				set_dir(turn(dir, 180))
-			boutput(user, "You change the pipe junction's direction.")
+				boutput(user, "You change the pipe junction's direction.")
 			update()
 
 	// attackby item

--- a/code/WorkInProgress/recycling/disposal-construction.dm
+++ b/code/WorkInProgress/recycling/disposal-construction.dm
@@ -93,19 +93,17 @@
 				return /obj/disposalpipe/mechanics_sensor
 		return
 
-	// clickdrag with crowbar in hand to flip the pipe
-	MouseDrop(mob/user)
-		var/obj/item/I = user.equipped()
-		if(in_interact_range(src, user) && !anchored)
-			if(ispryingtool(I))
+	// click the junction with empty hand to change direction
+	attack_hand(mob/user)
+		if(!anchored)
+			if(ptype == 2)
+				ptype = 3
 				set_dir(turn(dir, 180))
-				if(ptype == 2)
-					ptype = 3
-				else if(ptype == 3)
-					ptype = 2
-				update()
-			else
-				boutput(user, "You need a crowbar to flip the pipe!")
+			else if (ptype == 3)
+				ptype = 2
+				set_dir(turn(dir, 180))
+			boutput(user, "You change the pipe junction's direction.")
+			update()
 
 	// attackby item
 	// crowbar: rotate

--- a/code/WorkInProgress/recycling/disposal-construction.dm
+++ b/code/WorkInProgress/recycling/disposal-construction.dm
@@ -117,6 +117,7 @@
 		if(ispryingtool(I) && !anchored)
 			set_dir(turn(dir, -90))
 			update()
+			return
 
 		if(isscrewingtool(I))
 			boutput(user, "You take the pipe segment apart.")

--- a/code/WorkInProgress/recycling/disposal-construction.dm
+++ b/code/WorkInProgress/recycling/disposal-construction.dm
@@ -94,9 +94,9 @@
 		return
 
 	// clickdrag with crowbar in hand to flip the pipe
-	MouseDrop_T(atom/target, mob/user)
+	MouseDrop(mob/user)
 		var/obj/item/I = user.equipped()
-		if(ismob(target) && in_interact_range(src, user) && !anchored)
+		if(in_interact_range(src, user) && !anchored)
 			if(ispryingtool(I))
 				set_dir(turn(dir, 180))
 				if(ptype == 2)

--- a/code/WorkInProgress/recycling/disposal-construction.dm
+++ b/code/WorkInProgress/recycling/disposal-construction.dm
@@ -93,8 +93,6 @@
 				return /obj/disposalpipe/mechanics_sensor
 		return
 
-
-
 	// clickdrag with crowbar in hand to flip the pipe
 	MouseDrop_T(atom/target, mob/user)
 		var/obj/item/I = user.equipped()

--- a/code/WorkInProgress/recycling/disposal-construction.dm
+++ b/code/WorkInProgress/recycling/disposal-construction.dm
@@ -95,27 +95,31 @@
 
 
 
+	// clickdrag with crowbar in hand to flip the pipe
+	MouseDrop_T(atom/target, mob/user)
+		var/obj/item/I = user.equipped()
+		if(ismob(target) && in_interact_range(src, user) && !anchored)
+			if(ispryingtool(I))
+				set_dir(turn(dir, 180))
+				if(ptype == 2)
+					ptype = 3
+				else if(ptype == 3)
+					ptype = 2
+				update()
+			else
+				boutput(user, "You need a crowbar to flip the pipe!")
+
 	// attackby item
+	// crowbar: rotate
+	// screwdriver: disassemble
 	// wrench: (un)anchor
 	// weldingtool: convert to real pipe
 
 	attackby(var/obj/item/I, var/mob/user)
-		if(ispryingtool(I))
-			if(!anchored)
-				var/input = input("Select a config to modify!", "Config", null) as null|anything in list("Rotate","Flip")
-				if((user in range(1,src)) && (!anchored))
-					switch(input)
-						if("Rotate")
-							set_dir(turn(dir, -90))
-							update()
-						if("Flip")
-							set_dir(turn(dir, 180))
-							if(ptype == 2)
-								ptype = 3
-							else if(ptype == 3)
-								ptype = 2
-							update()
-				return
+		if(ispryingtool(I) && !anchored)
+			set_dir(turn(dir, -90))
+			update()
+
 		if(isscrewingtool(I))
 			boutput(user, "You take the pipe segment apart.")
 			// var/obj/item/sheet/A = new /obj/item/sheet(get_turf(src))
@@ -128,7 +132,7 @@
 			return
 
 		var/turf/T = src.loc
-		if(T.intact)
+		if(T.intact && (iswrenchingtool(I) || isweldingtool(I))) //to stop it from screaming about it when rotating the pipe with crowbar
 			boutput(user, "You can only attach the pipe if the floor plating is removed.")
 			return
 
@@ -138,7 +142,7 @@
 			var/pdir = CP.dpdir
 			if(istype(CP, /obj/disposalpipe/broken))
 				pdir = CP.dir
-			if(pdir & dpdir)
+			if((pdir & dpdir) && (iswrenchingtool(I) || isweldingtool(I))) //see the comment above
 				boutput(user, "There is already a pipe at that location.")
 				return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes how flipping/rotating disposal pipes works: 

-clicking the pipe with a crowbar rotates it
-clicking a pipe junction with empty hand simply changes its direction

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently using a crowbar on a pipe opens a window that lets you choose between flipping and rotating. When you need to rotate multiple pipes, it gets tedious.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Removed the flip/rotate window for disposal pipes. Instead, you can click the pipe with a crowbar to rotate it and click the junction with empty hand to change its direction.
```
