### PR TITLE
Fixes the packet sniffer to correctly filter by sender rather than target.

### DIFF
--- a/code/modules/networks/computer3/sniffer.dm
+++ b/code/modules/networks/computer3/sniffer.dm
@@ -130,7 +130,7 @@
 		if(signal.transmission_method != TRANSMISSION_WIRE) //No radio for us thanks
 			return
 
-		var/target = signal.data["address_1"]
+		var/target = signal.data["sender"]
 		if(src.filter_id && src.filter_id != target)
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The packet sniffer for wired connections has an option for a sender filter. This change fixes the filter to filter by sender.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, the sender filter actually filters by packet destination 'address_1'. This change fixes this behavior.

