### PR TITLE
Added single output mode to dispatch component

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -11,6 +11,7 @@
 #define WIFI_NOISE_COOLDOWN 5 SECONDS
 #define WIFI_NOISE_VOLUME 30
 #define LIGHT_UP_HOUSING SPAWN_DBG(0) src.light_up_housing()
+
 // mechanics containers for mechanics components (read: portable horn [read: vuvuzela] honkers! yaaaay!)
 //
 /obj/item/storage/mechanics // generic
@@ -1537,13 +1538,13 @@
 	//Called when mechanics_holder tries to fire out signals
 	proc/runFilter(var/comsig_target, atom/receiver, var/signal)
 		if(!(receiver in src.outgoing_filters))
-			return src.single_output? 2 : 0 //Not filtering this output, let anything pass
+			return src.single_output? _MECHCOMP_VALIDATE_RESPONSE_HALT_AFTER : _MECHCOMP_VALIDATE_RESPONSE_GOOD //Not filtering this output, let anything pass
 		for (var/filter in src.outgoing_filters[receiver])
 			var/text_found = findtext(signal, filter)
 			if (exact_match)
 				text_found = text_found && (length(signal) == length(filter))
 			if (text_found)
-				return src.single_output? 2 : 0 //Signal validated, let it pass
+				return src.single_output? _MECHCOMP_VALIDATE_RESPONSE_HALT_AFTER : _MECHCOMP_VALIDATE_RESPONSE_GOOD //Signal validated, let it pass
 		return 1 //Signal invalid, halt it
 
 	updateIcon()

--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -3,6 +3,11 @@
 #define TOGGLE_MATCH "Toggle Exact Match"
 #define MECHFAILSTRING "You must be holding a Multitool to change Connections or Options."
 
+#define _MECHCOMP_VALIDATE_RESPONSE_GOOD 0
+#define _MECHCOMP_VALIDATE_RESPONSE_BAD 1
+#define _MECHCOMP_VALIDATE_RESPONSE_HALT 2
+#define _MECHCOMP_VALIDATE_RESPONSE_HALT_AFTER 3
+
 /datum/mechanicsMessage
 	var/signal = "1"
 	var/list/nodes = list()
@@ -197,11 +202,13 @@
 	for(var/atom/A in src.connected_outgoing)
 		//Note: a target not handling a signal returns 0.
 		var/validated = SEND_SIGNAL(parent,_COMSIG_MECHCOMP_DISPATCH_VALIDATE, A, msg.signal)
-		if(validated == 1)
+		if(validated == _MECHCOMP_VALIDATE_RESPONSE_HALT) //The component wants signal processing to stop NOW
+			return fired
+		if(validated == _MECHCOMP_VALIDATE_RESPONSE_BAD) //The component wants this signal to be skipped
 			continue
 		SEND_SIGNAL(A, _COMSIG_MECHCOMP_RECEIVE_MSG, src.connected_outgoing[A], cloneMessage(msg))
 		fired = 1
-		if(validated == 2) //The component wants signal processing to stop AFTER this signal
+		if(validated == _MECHCOMP_VALIDATE_RESPONSE_HALT_AFTER) //The component wants signal processing to stop AFTER this signal
 			return fired
 	return fired
 

--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -196,10 +196,13 @@
 	var/fired = 0
 	for(var/atom/A in src.connected_outgoing)
 		//Note: a target not handling a signal returns 0.
-		if(SEND_SIGNAL(parent,_COMSIG_MECHCOMP_DISPATCH_VALIDATE, A, msg.signal) != 0)
+		var/validated = SEND_SIGNAL(parent,_COMSIG_MECHCOMP_DISPATCH_VALIDATE, A, msg.signal)
+		if(validated == 1)
 			continue
 		SEND_SIGNAL(A, _COMSIG_MECHCOMP_RECEIVE_MSG, src.connected_outgoing[A], cloneMessage(msg))
 		fired = 1
+		if(validated == 2) //The component wants signal processing to stop AFTER this signal
+			return fired
 	return fired
 
 //Used to copy a message because we don't want to pass a single message to multiple components which might end up modifying it both at the same time.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE][WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new option to the dispatch component: Toggle single output mode.
When active, the dispatch component will only pass a signal through the first route that successfully validates.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mechcomp doesn't have an easy way to do if-elseif-else.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sidewinder7
(*)Added a single-output mode to the mechcomp dispatch component.
```
