### PR TITLE
makes cutting planks from logs remove one from the stack instead of deleting the stack

### DIFF
--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -257,10 +257,13 @@
 		..()
 	attackby(obj/item/W as obj, mob/user as mob)
 		if ((istool(W, TOOL_CUTTING | TOOL_SAWING)))
-			user.visible_message("[user] cuts [src] into a plank.", "You cut the [src] into a plank.")
+			user.visible_message("[user] cuts a plank from the [src].", "You cut a plank from the [src].")
 			var/obj/item/plankobj = new /obj/item/plank(user.loc)
 			plankobj.setMaterial(getMaterial("wood"), appearance = 0, setname = 0)
-			qdel (src)
+			if (src.amount > 1)
+				change_stack_amount(-1)
+			else
+				qdel (src)
 
 /obj/item/material_piece/organic/bamboo
 	name = "bamboo stalk"

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -276,7 +276,10 @@
 		if (istype(W, /obj/item/axe) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/sword) || istype(W,/obj/item/saw) || istype(W,/obj/item/knife/butcher))
 			user.visible_message("[user] carefully extracts a shoot from [src].", "You carefully cut a shoot from [src].")
 			new /obj/item/reagent_containers/food/snacks/plant/bamboo/(user.loc)
-			qdel (src)
+			if (src.amount > 1)
+				change_stack_amount(-1)
+			else
+				qdel (src)
 
 /obj/item/material_piece/cloth/spidersilk
 	name = "space spider silk"

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -273,7 +273,7 @@
 		src.setMaterial(getMaterial("bamboo"), appearance = 0, setname = 0)
 		..()
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/axe) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/sword) || istype(W,/obj/item/saw) || istype(W,/obj/item/knife/butcher))
+		if ((istool(W, TOOL_CUTTING | TOOL_SAWING)))
 			user.visible_message("[user] carefully extracts a shoot from [src].", "You carefully cut a shoot from [src].")
 			new /obj/item/reagent_containers/food/snacks/plant/bamboo/(user.loc)
 			if (src.amount > 1)


### PR DESCRIPTION
previous behavior was that it deleted the stack no matter how big it was.
[FIX]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that cutting planks from stacks of logs will reduce the stack amount, with the old behaviour having just been deleting the whole stack and making one plank. This PR also changes the visible message to be accurate.

Edit: I noticed bamboo was using very similar code as well, so I went along and updated that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because deleting the whole stack and making one plank makes no sense, and while splitting the stack over and over again until you get stacks of one is possible, it is tedious.

