### PR TITLE
Lets ghostdrones remove their hats & sheets

### DIFF
--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -527,6 +527,11 @@
 			user.visible_message("<b>[user]</b> drapes a sheet over [src]!", "You cover [src] with a sheet!")
 			return
 
+		else if (istype(W, /obj/item/magtractor) && !W.holding)
+			if (src.hat)
+				takeoffHat()
+			else if (src.bedsheet)
+				takeoffSheet()
 		else
 			return ..(W, user)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR lets ghostdrones remove their hat and bedsheet (in that order) by using an empty magtractor on themselves. I guess they could also do it on other drones but that probably won't happen much.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gives them some autonomy over their fashion choices.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Ghostdrones can now remove their hat/sheet with an empty magtractor.
```
