### PR TITLE
Kondaru Tau fix batch 1

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -24631,7 +24631,6 @@
 	dir = 4
 	},
 /obj/access_spawn/rancher,
-/obj/access_spawn/hydro,
 /obj/firedoor_spawn,
 /turf/simulated/floor/green/side{
 	dir = 8

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -27860,10 +27860,10 @@
 	},
 /area/station/hallway/primary/south)
 "bCJ" = (
-/obj/disposalpipe/junction/middle/east,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
+/obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -3334,7 +3334,7 @@
 /area/station/chapel/sanctuary)
 "aiS" = (
 /obj/decal/cleanable/dirt,
-/obj/storage/closet/wardrobe/black,
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aiU" = (
@@ -3697,7 +3697,7 @@
 	},
 /area/station/chapel/sanctuary)
 "ajR" = (
-/obj/storage/closet/fire,
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "ajS" = (
@@ -4058,8 +4058,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/turf/simulated/floor/wood/seven,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "akK" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -4433,16 +4435,26 @@
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "alE" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/obj/stool/chair/couch{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/blind_switch/north,
+/turf/simulated/floor/wood/seven,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "alF" = (
-/obj/disposalpipe/segment/bent/north,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/wood/seven,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "alI" = (
 /obj/table/auto,
 /obj/item/clothing/gloves/latex,
@@ -4582,6 +4594,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "ama" = (
@@ -4885,9 +4898,10 @@
 	},
 /area/station/chapel/sanctuary)
 "amJ" = (
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/turf/simulated/floor/wood/seven,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "amK" = (
 /obj/cable{
 	d1 = 1;
@@ -4912,10 +4926,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "amM" = (
-/obj/disposalpipe/segment/bent/south,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/obj/table/wood/round/auto,
+/obj/machinery/light/lamp{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "amN" = (
 /obj/machinery/optable{
 	name = "Autopsy Table"
@@ -6008,19 +6027,30 @@
 	},
 /area/station/chapel/sanctuary)
 "apU" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
+/obj/reagent_dispensers/watertank/fountain,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "apW" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "apX" = (
 /obj/disposalpipe/segment/bent/east,
 /obj/stool/chair/pew/fancy/left{
@@ -6781,13 +6811,11 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
 "asa" = (
-/obj/machinery/computer/airbr{
-	density = 0;
-	icon = 'icons/obj/airtunnel.dmi';
-	id = "northconnector";
-	pixel_y = 32
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
 	},
-/turf/simulated/floor/grey,
+/obj/firedoor_spawn,
+/turf/simulated/floor,
 /area/station/hallway/primary/north)
 "asb" = (
 /obj/lattice{
@@ -6808,23 +6836,16 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/chapel/sanctuary)
 "ase" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"asf" = (
-/obj/disposalpipe/segment/vertical,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
+/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"asf" = (
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
 "asg" = (
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
@@ -7345,7 +7366,9 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "atH" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -7898,7 +7921,9 @@
 /area/station/crew_quarters/arcade/dungeon)
 "avq" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "avr" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -8251,10 +8276,20 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/arcade/dungeon)
 "awi" = (
-/obj/grille/steel,
-/obj/disposalpipe/segment/mail/bent/west,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
+/obj/table/auto,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/gloves/yellow,
+/obj/item/device/multitool,
+/obj/item/device/radio/intercom/engineering{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
+/area/station/engine/storage)
 "awj" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/wreath/ephemeral,
@@ -8275,9 +8310,6 @@
 	amount = 50
 	},
 /obj/item/storage/box/cablesbox,
-/obj/item/device/radio/intercom/engineering{
-	dir = 4
-	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "awl" = (
@@ -8677,41 +8709,29 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
-"axh" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/space,
-/area/space)
 "axi" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/turf/simulated/floor/stairs/wood2/wide{
+	dir = 10
+	},
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "axk" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
-"axl" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/vertical,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/turf/simulated/floor/stairs/wood2/wide{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
+"axl" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "axm" = (
 /obj/morgue,
 /obj/machinery/light/small{
@@ -8729,18 +8749,12 @@
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "axo" = (
-/obj/table/auto,
-/obj/item/sheet/steel/reinforced{
-	amount = 50
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/item/sheet/steel/reinforced{
-	amount = 50
+/turf/simulated/floor/yellow/side{
+	dir = 1
 	},
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/chem_grenade/metalfoam,
-/turf/simulated/floor/black,
 /area/station/engine/storage)
 "axq" = (
 /obj/machinery/light_switch/east,
@@ -9085,20 +9099,22 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
 "ayq" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/electrical,
-/obj/item/clothing/gloves/yellow,
-/obj/item/device/multitool,
-/turf/simulated/floor/black,
+/obj/stool/chair/yellow{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Engineer"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
 /area/station/engine/storage)
 "ayr" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
+/turf/simulated/floor,
 /area/station/engine/storage)
 "ays" = (
 /obj/disposalpipe/segment/horizontal,
@@ -9448,10 +9464,9 @@
 	},
 /area/station/engine/power)
 "aze" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 4
-	},
-/area/station/hallway/primary/north)
+/obj/storage/closet/wardrobe/black,
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
 "azf" = (
 /obj/rack,
 /obj/machinery/power/apc/autoname_north,
@@ -9545,47 +9560,27 @@
 /obj/item/reagent_containers/food/drinks/fueltank,
 /obj/item/reagent_containers/food/drinks/fueltank,
 /obj/item/reagent_containers/food/drinks/fueltank,
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/item/clothing/suit/hi_vis,
 /obj/item/clothing/suit/hi_vis,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "azp" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Engineer"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 9
-	},
-/area/station/engine/storage)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "azq" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
+/turf/simulated/floor,
 /area/station/engine/storage)
 "azr" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/yellow/corner{
-	dir = 1
-	},
+/turf/simulated/floor,
 /area/station/engine/storage)
 "azt" = (
 /obj/item/sheet/steel{
@@ -9875,12 +9870,11 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/obj/machinery/vending/book,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "aAe" = (
 /obj/machinery/disposal/mail/autoname/chapel,
 /obj/disposalpipe/trunk/mail/east,
@@ -10380,8 +10374,12 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "aBm" = (
-/obj/disposalpipe/segment/mail/bent/east,
-/turf/simulated/floor/grey,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/firedoor_spawn,
+/turf/simulated/floor/yellow/corner,
 /area/station/hallway/primary/north)
 "aBn" = (
 /obj/storage/secure/closet/engineering/engineer,
@@ -10395,11 +10393,12 @@
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "aBo" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/light/emergency,
-/turf/simulated/floor/stairs/wide/other{
-	dir = 4
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/north)
 "aBp" = (
 /obj/wingrille_spawn/auto/crystal,
@@ -11232,12 +11231,11 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "aDt" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
-/turf/simulated/floor/stairs/wide{
-	dir = 4
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aDu" = (
 /obj/machinery/light{
@@ -11750,8 +11748,8 @@
 /area/station/crew_quarters/pool)
 "aEI" = (
 /obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/yellow/side{
-	dir = 8
+/turf/simulated/floor/yellow/corner{
+	dir = 1
 	},
 /area/station/engine/storage)
 "aEJ" = (
@@ -12083,19 +12081,26 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "aFv" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/stool/chair/couch{
+	dir = 8
 	},
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/north)
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "aFw" = (
-/obj/disposalpipe/segment/vertical,
+/obj/disposalpipe/segment/bent/south,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -12568,14 +12573,6 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/t_scanner,
 /obj/item/wrench,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
@@ -12949,13 +12946,17 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
 "aHP" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
+/obj/stool/chair/comfy{
+	dir = 8
 	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/firedoor_spawn,
-/turf/simulated/floor/yellow/corner,
-/area/station/hallway/primary/north)
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/wood/seven,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "aHR" = (
 /obj/storage/secure/closet/personal,
 /obj/cable{
@@ -14049,7 +14050,6 @@
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
 "aKD" = (
-/obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/north)
 "aKE" = (
@@ -14383,9 +14383,15 @@
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
 "aLW" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
+/obj/machinery/power/apc/autoname_west,
+/obj/bookshelf/persistent,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "aLY" = (
 /obj/disposalpipe/segment/mail/bent/south,
 /turf/simulated/floor/neutral/side{
@@ -27062,15 +27068,15 @@
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "bAs" = (
-/obj/railing/orange/reinforced{
-	dir = 8
-	},
 /obj/machinery/disposal/mail{
 	mail_tag = "ranch";
 	mailgroup = "botany";
 	name = "Ranch"
 	},
 /obj/disposalpipe/trunk/mail,
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/grasstodirt{
 	dir = 8
 	},
@@ -44078,6 +44084,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
+"dvf" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "dvx" = (
 /obj/machinery/door_control{
 	id = "kitchen";
@@ -45207,6 +45223,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"ePU" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/north)
 "eQE" = (
 /obj/grille/catwalk,
 /obj/machinery/oreaccumulator,
@@ -46158,6 +46180,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/chapel/office)
+"fUJ" = (
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
 "fUN" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -46955,6 +46982,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"gOY" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "gPC" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -47773,6 +47804,20 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
+"hHb" = (
+/obj/table/auto,
+/obj/item/sheet/steel/reinforced{
+	amount = 50
+	},
+/obj/item/sheet/steel/reinforced{
+	amount = 50
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/chem_grenade/metalfoam,
+/turf/simulated/floor/black,
+/area/station/engine/storage)
 "hHf" = (
 /obj/stool/bar,
 /obj/machinery/light/small/floor,
@@ -48852,6 +48897,10 @@
 /obj/item/pen,
 /turf/simulated/floor/yellowblack,
 /area/station/crew_quarters/ce)
+"jgM" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/north)
 "jgX" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -49406,6 +49455,14 @@
 "jUy" = (
 /turf/simulated/floor/delivery,
 /area/station/mining/magnet)
+"jVm" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/gloves/yellow,
+/obj/item/device/multitool,
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/black,
+/area/station/engine/storage)
 "jVX" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -50243,6 +50300,21 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/escape)
+"kYh" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "kYu" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -53135,6 +53207,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
+"oBl" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 9
+	},
+/area/station/engine/storage)
 "oCW" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbooth)
@@ -53272,6 +53352,13 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
+"oLV" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light/emergency,
+/turf/simulated/floor/stairs/wide/other{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
 "oNK" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/disposalpipe/junction/right/north,
@@ -53631,6 +53718,13 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"ppm" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "ppQ" = (
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -53870,6 +53964,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"pBW" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro{
+	name = "The Book Nook"
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "pCp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
@@ -55315,6 +55421,14 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"rqF" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "rrc" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Courtroom"
@@ -55392,6 +55506,10 @@
 	dir = 8
 	},
 /area/station/routing/security)
+"rtN" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/north)
 "rtZ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/sauna)
@@ -55811,6 +55929,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"rZC" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "rZQ" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/decal/garland/ephemeral{
@@ -55983,6 +56107,15 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"slr" = (
+/obj/machinery/computer/airbr{
+	density = 0;
+	icon = 'icons/obj/airtunnel.dmi';
+	id = "northconnector";
+	pixel_y = 32
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "sml" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/plate,
@@ -56331,10 +56464,6 @@
 "sKR" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/vertical,
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/north)
 "sLF" = (
@@ -57601,6 +57730,11 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"udF" = (
+/obj/grille/steel,
+/obj/disposalpipe/segment/mail/bent/west,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/north)
 "udL" = (
 /obj/machinery/sleep_console{
 	dir = 4
@@ -57630,6 +57764,10 @@
 /obj/machinery/light/runway_light,
 /turf/space,
 /area/space)
+"ueM" = (
+/obj/disposalpipe/segment/mail/bent/east,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "ufA" = (
 /obj/machinery/light,
 /turf/simulated/floor/caution/east,
@@ -57984,6 +58122,15 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
+"uBh" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "uBM" = (
 /obj/machinery/atmospherics/valve{
 	name = "Security Repressurization"
@@ -58568,6 +58715,13 @@
 	dir = 9
 	},
 /area/station/hangar/main)
+"vqu" = (
+/obj/grille/steel,
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/north)
 "vrp" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -58781,7 +58935,6 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/bookshelf/persistent,
 /turf/simulated/floor/neutral/side{
 	dir = 9
 	},
@@ -59752,6 +59905,12 @@
 /obj/machinery/meter,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"wLx" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/primary/north)
 "wMb" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light,
@@ -60004,6 +60163,14 @@
 	dir = 1
 	},
 /area/station/security/interrogation)
+"xaU" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "xcb" = (
 /obj/decal/poster/wallsign/poster_rand{
 	pixel_y = 28
@@ -60618,10 +60785,12 @@
 /turf/simulated/floor,
 /area/station/security/secwing)
 "xIe" = (
-/obj/machinery/door/airlock/pyro/external{
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/stairs/wide{
 	dir = 4
 	},
-/turf/simulated/floor/caution/westeast,
 /area/station/hallway/primary/north)
 "xJq" = (
 /obj/lattice{
@@ -112786,7 +112955,7 @@ bvI
 etm
 emI
 ltn
-bAt
+gOY
 jnb
 tvw
 fGA
@@ -113030,15 +113199,15 @@ aci
 aaa
 aaa
 aaa
-aaa
+abX
 apK
 aaa
 aaa
-aaa
+asY
 aaa
 aaa
 avX
-aaa
+abX
 aaa
 aaa
 aaa
@@ -113332,15 +113501,15 @@ aci
 aaa
 aaa
 aaa
-aaa
-apK
-aaa
-aaa
-aaa
-aaa
-aaa
-avX
-aaa
+aKD
+ePU
+aKD
+wLx
+aGL
+wLx
+aKD
+rtN
+aKD
 aaa
 aaa
 aaa
@@ -113634,15 +113803,15 @@ aci
 aaa
 aaa
 aaa
-abX
-apK
-aaa
-aaa
-asY
-aaa
-aaa
-avX
-abX
+aKD
+vqu
+aKD
+slr
+xaU
+ueM
+jgM
+udF
+aKD
 aaa
 aaa
 aaa
@@ -113932,18 +114101,18 @@ aqh
 aaa
 aaa
 aaa
-aci
-aaa
-aaa
-axh
+axl
+azp
+azp
+axl
 avq
 atC
 avq
 xIe
-aGL
-xIe
-avq
-aLW
+fUJ
+oLV
+auT
+auT
 auT
 auT
 aSY
@@ -114234,19 +114403,19 @@ adp
 adp
 adp
 adp
-adp
-adp
-aqh
-adp
-avq
+axl
+aFv
+amJ
+axl
+aLW
 apU
 avq
 asa
-aFv
+aGL
 aBm
-aKD
-awi
 auT
+awi
+jVm
 aGI
 azo
 aAj
@@ -114536,21 +114705,21 @@ bgv
 ahT
 alY
 ajR
-adp
+axl
 alE
 amJ
 axi
-avq
-atC
-avq
+dvf
+rqF
+ppm
 aDt
-aze
+uzL
 aBo
 auT
-auT
-auT
+hHb
+oBl
 ayq
-azp
+gGT
 aAk
 gGT
 gGT
@@ -114840,18 +115009,18 @@ aiQ
 ajS
 akJ
 alF
-aeg
+alF
 axk
-aoE
+kYh
 apW
-avq
+pBW
 ase
-aGL
-aHP
+uBh
+aum
 auT
 awk
 axo
-ayq
+aIU
 azq
 aAl
 bcb
@@ -115135,19 +115304,19 @@ aaa
 aaa
 ach
 adp
-adE
+asf
 aeh
 ahW
 aeh
 gih
-adp
-amM
-afP
 axl
-ajS
+amM
+aHP
+axl
+rZC
 aAd
-akJ
-asf
+ppm
+uzL
 aFw
 sKR
 aNR
@@ -115437,7 +115606,7 @@ aaa
 aaa
 ach
 adp
-adE
+aze
 agO
 ahW
 aiS

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -6755,6 +6755,9 @@
 	dir = 8;
 	pixel_x = 14
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "arR" = (
@@ -6762,17 +6765,32 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "arS" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "arT" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs/wide/other{
 	dir = 8
@@ -6785,6 +6803,11 @@
 	id = "northconnector";
 	pixel_y = 32;
 	starts_established = 1
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/west)
@@ -6810,6 +6833,11 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "asb" = (
@@ -6835,6 +6863,11 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "asf" = (
@@ -7140,10 +7173,15 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
 "asW" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/caution/westeast,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/grey,
 /area/station/hallway/primary/west)
 "asX" = (
 /turf/simulated/floor/stairs/wide/middle{
@@ -7151,10 +7189,15 @@
 	},
 /area/station/hallway/primary/west)
 "asY" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/caution/westeast,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
 "asZ" = (
 /obj/table/auto,
@@ -7545,11 +7588,6 @@
 	},
 /area/station/hallway/primary/west)
 "aug" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/west)
 "auh" = (
@@ -11246,6 +11284,11 @@
 /obj/decal/garland/ephemeral{
 	dir = 4;
 	pixel_x = -14
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -43477,6 +43520,17 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
+"cOF" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/west)
 "cPy" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
@@ -43566,6 +43620,12 @@
 	},
 /turf/simulated/floor,
 /area/station/security/secwing)
+"cUb" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "cVi" = (
 /obj/machinery/light{
 	dir = 8;
@@ -43697,6 +43757,17 @@
 /obj/item/raw_material/shard/glass,
 /turf/simulated/floor/plating/damaged1,
 /area/station/crew_quarters/quarters_south)
+"daE" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "daF" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -43922,6 +43993,11 @@
 "dlP" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs/wide{
 	dir = 4
@@ -46032,6 +46108,11 @@
 	dir = 10
 	},
 /area/station/mining/magnet)
+"fJh" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/north)
 "fJx" = (
 /obj/machinery/sim/vr_bed{
 	name = "VR simulation pod";
@@ -47675,6 +47756,13 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
+"hvp" = (
+/obj/airbridge_controller{
+	id = "northconnector";
+	tunnel_width = 2
+	},
+/turf/space,
+/area/space)
 "hvr" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right,
@@ -48401,6 +48489,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"iCZ" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/north)
 "iDR" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -52700,6 +52795,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"nTq" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/primary/north)
 "nVl" = (
 /obj/shrub{
 	dir = 1;
@@ -54230,6 +54331,12 @@
 /obj/item/disk/data/floppy/read_only/communications,
 /turf/simulated/floor/greenblack,
 /area/station/turret_protected/Zeta)
+"pQZ" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/primary/west)
 "pRd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -57097,12 +57204,12 @@
 	},
 /area/station/medical/medbooth)
 "tna" = (
-/obj/airbridge_controller{
-	id = "northconnector";
-	tunnel_width = 2
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/west)
 "tnf" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -58133,6 +58240,11 @@
 /area/station/maintenance/storage{
 	name = "Secure Atmospherics"
 	})
+"uBR" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/west)
 "uCy" = (
 /obj/machinery/space_heater,
 /obj/machinery/light/small{
@@ -58788,6 +58900,12 @@
 /obj/decal/poster/wallsign/security_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
+"vzs" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/west)
 "vzv" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -59855,11 +59973,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/ranch)
 "wHG" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
 "wHZ" = (
@@ -60804,6 +60917,11 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "xJq" = (
@@ -60979,6 +61097,11 @@
 	icon = 'icons/obj/airtunnel.dmi';
 	id = "northconnector";
 	pixel_y = 32
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
@@ -109608,11 +109731,11 @@ aaa
 aaa
 aaT
 apK
-aqN
+tna
 asW
-asV
-asW
-aqN
+cOF
+vzs
+uBR
 avX
 aaT
 chj
@@ -109910,11 +110033,11 @@ aaa
 aaa
 aaa
 apK
-aaa
-aaa
-tna
-aaa
-aaa
+aqN
+pQZ
+aGL
+pQZ
+aqN
 avX
 aaa
 chj
@@ -110214,7 +110337,7 @@ aaa
 apK
 aaa
 aaa
-aaa
+hvp
 aaa
 aaa
 avX
@@ -112630,7 +112753,7 @@ aaa
 apK
 aaa
 aaa
-aaa
+hvp
 aaa
 aaa
 avX
@@ -112930,11 +113053,11 @@ aaa
 aaa
 aaa
 apK
-aaa
-aaa
-tna
-aaa
-aaa
+aFv
+nTq
+aGL
+nTq
+aFv
 avX
 aaa
 aaa
@@ -113232,11 +113355,11 @@ aaa
 aaa
 abX
 apK
-aFv
+iCZ
 asY
-aGL
-asY
-aFv
+daE
+cUb
+fJh
 avX
 abX
 aaa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -4058,6 +4058,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood/seven,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
@@ -4931,6 +4932,7 @@
 	pixel_x = 1;
 	pixel_y = 10
 	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/wood/seven,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
@@ -6763,21 +6765,20 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "arS" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
 /obj/machinery/firealarm{
-	pixel_x = 6;
 	pixel_y = 24
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
+"arT" = (
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
 	},
 /turf/simulated/floor/stairs/wide/other{
 	dir = 8
 	},
 /area/station/hallway/primary/west)
-"arT" = (
+"arU" = (
 /obj/machinery/computer/airbr{
 	density = 0;
 	icon = 'icons/obj/airtunnel.dmi';
@@ -6786,12 +6787,6 @@
 	starts_established = 1
 	},
 /turf/simulated/floor/grey,
-/area/station/hallway/primary/west)
-"arU" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/caution/westeast,
 /area/station/hallway/primary/west)
 "arV" = (
 /obj/decal/poster/wallsign/space,
@@ -7145,25 +7140,22 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
 "asW" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/primary/west)
+"asX" = (
 /turf/simulated/floor/stairs/wide/middle{
 	dir = 8
 	},
 /area/station/hallway/primary/west)
-"asX" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/west)
 "asY" = (
-/obj/airbridge_controller{
-	id = "northconnector";
-	tunnel_width = 2
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/primary/north)
 "asZ" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -7553,15 +7545,19 @@
 	},
 /area/station/hallway/primary/west)
 "aug" = (
-/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/west)
+"auh" = (
+/obj/disposalpipe/segment/mail/bent/south,
 /obj/machinery/light/emergency,
 /turf/simulated/floor/stairs/wide{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
-"auh" = (
-/obj/disposalpipe/segment/mail/bent/south,
-/turf/simulated/floor/grey,
 /area/station/hallway/primary/west)
 "aui" = (
 /obj/disposalpipe/segment/morgue{
@@ -8283,11 +8279,6 @@
 /obj/item/device/radio/intercom/engineering{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "awj" = (
@@ -8749,9 +8740,6 @@
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "axo" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -9104,6 +9092,9 @@
 	},
 /obj/landmark/start{
 	name = "Engineer"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -9581,6 +9572,9 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/wood/seven,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
@@ -9592,7 +9586,10 @@
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
-/obj/machinery/light_switch/east,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
 /turf/simulated/floor/wood/seven,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
@@ -12576,6 +12573,10 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/t_scanner,
 /obj/item/wrench,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "aGK" = (
@@ -43919,13 +43920,12 @@
 	},
 /area/station/turret_protected/Zeta)
 "dlP" = (
-/obj/machinery/computer/airbr{
-	density = 0;
-	icon = 'icons/obj/airtunnel.dmi';
-	id = "northconnector";
+/obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
-/turf/simulated/floor/grey,
+/turf/simulated/floor/stairs/wide{
+	dir = 4
+	},
 /area/station/hallway/primary/north)
 "dma" = (
 /obj/storage/secure/closet/brig,
@@ -44764,6 +44764,14 @@
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
+"ejI" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "ejP" = (
 /obj/stool/bench/red,
 /obj/disposalpipe/segment/brig{
@@ -47502,9 +47510,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "hly" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
@@ -50320,9 +50325,10 @@
 /obj/item/storage/toolbox/electrical,
 /obj/item/clothing/gloves/yellow,
 /obj/item/device/multitool,
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
@@ -51154,10 +51160,7 @@
 /area/station/hallway/primary/west)
 "lRA" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/light/emergency,
-/turf/simulated/floor/stairs/wide/other{
-	dir = 4
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/north)
 "lSk" = (
 /turf/simulated/floor/black,
@@ -52592,7 +52595,10 @@
 /area/station/chapel/sanctuary)
 "nNQ" = (
 /obj/disposalpipe/segment/mail/bent/east,
-/turf/simulated/floor/grey,
+/obj/machinery/light/emergency,
+/turf/simulated/floor/stairs/wide/other{
+	dir = 4
+	},
 /area/station/hallway/primary/north)
 "nNY" = (
 /obj/storage/secure/closet/brig,
@@ -55634,6 +55640,15 @@
 	},
 /turf/simulated/floor,
 /area/station/routing/security)
+"rDI" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "rFf" = (
 /obj/machinery/atmospherics/valve{
 	high_risk = 1;
@@ -57082,10 +57097,12 @@
 	},
 /area/station/medical/medbooth)
 "tna" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 4
+/obj/airbridge_controller{
+	id = "northconnector";
+	tunnel_width = 2
 	},
-/area/station/hallway/primary/north)
+/turf/space,
+/area/space)
 "tnf" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -59512,7 +59529,7 @@
 	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/storage)
@@ -59837,6 +59854,14 @@
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/supernorn,
 /area/station/ranch)
+"wHG" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "wHZ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
@@ -60195,6 +60220,7 @@
 	name = "The Book Nook"
 	},
 /obj/disposalpipe/segment/vertical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
@@ -60383,12 +60409,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "xnb" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 4
 	},
-/turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
 "xnq" = (
 /obj/wingrille_spawn/auto,
@@ -60781,9 +60804,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/stairs/wide{
-	dir = 4
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/north)
 "xJq" = (
 /obj/lattice{
@@ -60953,10 +60974,13 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "xQm" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
+/obj/machinery/computer/airbr{
+	density = 0;
+	icon = 'icons/obj/airtunnel.dmi';
+	id = "northconnector";
+	pixel_y = 32
 	},
-/turf/simulated/floor/caution/westeast,
+/turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
 "xQB" = (
 /obj/grille/catwalk{
@@ -61386,6 +61410,14 @@
 	},
 /turf/simulated/floor,
 /area/station/security/main)
+"yjd" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/west)
 "ykc" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -108672,8 +108704,8 @@ aoC
 apI
 aqN
 arS
-asW
-aug
+awR
+arA
 auQ
 auQ
 auQ
@@ -109276,8 +109308,8 @@ aoC
 apI
 aqN
 arU
-asV
-arU
+aug
+yjd
 aqN
 avW
 aqN
@@ -109576,11 +109608,11 @@ aaa
 aaa
 aaT
 apK
-aaa
-aaa
-asY
-aaa
-aaa
+aqN
+asW
+asV
+asW
+aqN
 avX
 aaT
 chj
@@ -109880,7 +109912,7 @@ aaa
 apK
 aaa
 aaa
-aaa
+tna
 aaa
 aaa
 avX
@@ -112900,7 +112932,7 @@ aaa
 apK
 aaa
 aaa
-aaa
+tna
 aaa
 aaa
 avX
@@ -113200,11 +113232,11 @@ aaa
 aaa
 abX
 apK
-aaa
-aaa
+aFv
 asY
-aaa
-aaa
+aGL
+asY
+aFv
 avX
 abX
 aaa
@@ -113496,23 +113528,23 @@ aqh
 agk
 aaa
 aaa
-aci
-aaa
-aaa
-aaa
+ach
+abZ
+abZ
+abZ
 aFv
 cCG
 aFv
 xQm
-aGL
-xQm
+wHG
+rDI
 aFv
 nbW
 aFv
-aaa
-aaa
-aaa
-aaa
+abZ
+abZ
+abZ
+abZ
 aCo
 aDw
 aCh
@@ -114108,7 +114140,7 @@ avq
 atC
 avq
 xIe
-tna
+uzL
 lRA
 auT
 auT
@@ -114712,7 +114744,7 @@ aKD
 uIf
 oIc
 aDt
-uzL
+ejI
 aBo
 auT
 guJ
@@ -115617,7 +115649,7 @@ aqd
 aqd
 apY
 aBv
-aDu
+bDr
 lkQ
 aum
 aKG
@@ -116221,7 +116253,7 @@ asg
 asg
 aqa
 avs
-bDr
+aDu
 atd
 aum
 auT

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -8750,7 +8750,7 @@
 /area/station/chapel/sanctuary)
 "axo" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -9112,7 +9112,7 @@
 "ayr" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/storage)
@@ -9571,17 +9571,32 @@
 	name = "Book Nook"
 	})
 "azq" = (
-/obj/cable{
-	icon_state = "2-4"
+/obj/stool/chair/couch{
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/engine/storage)
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "azr" = (
-/obj/cable{
-	icon_state = "1-8"
+/obj/stool/chair/comfy{
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/engine/storage)
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/wood/seven,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "azt" = (
 /obj/item/sheet/steel{
 	amount = 50
@@ -12081,20 +12096,8 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "aFv" = (
-/obj/stool/chair/couch{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/crew_quarters/info{
-	name = "Book Nook"
-	})
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/north)
 "aFw" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
@@ -12573,7 +12576,6 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/t_scanner,
 /obj/item/wrench,
-/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "aGK" = (
@@ -12946,14 +12948,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
 "aHP" = (
-/obj/stool/chair/comfy{
-	dir = 8
+/obj/machinery/power/apc/autoname_west,
+/obj/bookshelf/persistent,
+/obj/cable{
+	icon_state = "0-4"
 	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/machinery/light_switch/east,
-/turf/simulated/floor/wood/seven,
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
 	})
@@ -14050,8 +14050,15 @@
 /turf/simulated/floor/darkblue,
 /area/station/turret_protected/ai)
 "aKD" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "aKE" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/engineering)
@@ -14383,11 +14390,16 @@
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
 "aLW" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/bookshelf/persistent,
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/vertical,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/landmark/gps_waypoint,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
@@ -43258,6 +43270,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/research_director)
+"cCG" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/north)
 "cCI" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -43731,6 +43749,10 @@
 "deR" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/md)
+"dfb" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "dfl" = (
 /obj/cable{
 	d1 = 4;
@@ -43896,6 +43918,15 @@
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
+"dlP" = (
+/obj/machinery/computer/airbr{
+	density = 0;
+	icon = 'icons/obj/airtunnel.dmi';
+	id = "northconnector";
+	pixel_y = 32
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "dma" = (
 /obj/storage/secure/closet/brig,
 /obj/disposalpipe/segment/transport{
@@ -44084,16 +44115,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
-"dvf" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/info{
-	name = "Book Nook"
-	})
 "dvx" = (
 /obj/machinery/door_control{
 	id = "kitchen";
@@ -44996,6 +45017,13 @@
 /obj/machinery/bot/duckbot,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
+"ezu" = (
+/obj/grille/steel,
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/north)
 "ezM" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/decal/tile_edge/floorguide/evac{
@@ -45223,12 +45251,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"ePU" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
 "eQE" = (
 /obj/grille/catwalk,
 /obj/machinery/oreaccumulator,
@@ -46180,11 +46202,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/chapel/office)
-"fUJ" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 4
-	},
-/area/station/hallway/primary/north)
 "fUN" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -46655,6 +46672,20 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"guJ" = (
+/obj/table/auto,
+/obj/item/sheet/steel/reinforced{
+	amount = 50
+	},
+/obj/item/sheet/steel/reinforced{
+	amount = 50
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/chem_grenade/metalfoam,
+/turf/simulated/floor/black,
+/area/station/engine/storage)
 "guN" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -46982,10 +47013,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"gOY" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "gPC" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -47474,6 +47501,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"hly" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 9
+	},
+/area/station/engine/storage)
 "hlR" = (
 /obj/machinery/door/airlock/pyro/glass/command{
 	name = "Command Centre"
@@ -47804,20 +47839,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
-"hHb" = (
-/obj/table/auto,
-/obj/item/sheet/steel/reinforced{
-	amount = 50
-	},
-/obj/item/sheet/steel/reinforced{
-	amount = 50
-	},
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/chem_grenade/metalfoam,
-/turf/simulated/floor/black,
-/area/station/engine/storage)
 "hHf" = (
 /obj/stool/bar,
 /obj/machinery/light/small/floor,
@@ -48732,6 +48753,10 @@
 /obj/lattice,
 /turf/space,
 /area/station/ai_monitored/armory)
+"iRP" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/north)
 "iSr" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -48837,6 +48862,11 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/brig)
+"iZx" = (
+/obj/grille/steel,
+/obj/disposalpipe/segment/mail/bent/west,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/north)
 "jal" = (
 /obj/grille/catwalk{
 	dir = 5
@@ -48897,10 +48927,6 @@
 /obj/item/pen,
 /turf/simulated/floor/yellowblack,
 /area/station/crew_quarters/ce)
-"jgM" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
 "jgX" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -48939,6 +48965,15 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
+"jjV" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/bent/north,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "jmu" = (
 /obj/machinery/light{
 	dir = 1;
@@ -49455,14 +49490,6 @@
 "jUy" = (
 /turf/simulated/floor/delivery,
 /area/station/mining/magnet)
-"jVm" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/electrical,
-/obj/item/clothing/gloves/yellow,
-/obj/item/device/multitool,
-/obj/machinery/power/apc/autoname_west,
-/turf/simulated/floor/black,
-/area/station/engine/storage)
 "jVX" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -50288,6 +50315,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"kWb" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/gloves/yellow,
+/obj/item/device/multitool,
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/black,
+/area/station/engine/storage)
 "kYe" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -50300,21 +50338,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/escape)
-"kYh" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/vertical,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/info{
-	name = "Book Nook"
-	})
 "kYu" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -51129,6 +51152,13 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/west)
+"lRA" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light/emergency,
+/turf/simulated/floor/stairs/wide/other{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
 "lSk" = (
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
@@ -51990,6 +52020,10 @@
 "nbR" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
+"nbW" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/north)
 "ncc" = (
 /obj/rack,
 /obj/machinery/light/small{
@@ -52556,6 +52590,10 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
+"nNQ" = (
+/obj/disposalpipe/segment/mail/bent/east,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "nNY" = (
 /obj/storage/secure/closet/brig,
 /turf/simulated/floor/red/side{
@@ -52987,6 +53025,12 @@
 	dir = 1
 	},
 /area/station/garden/aviary)
+"onU" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "onX" = (
 /obj/table/auto,
 /obj/item/disk/data/cartridge/diagnostics{
@@ -53207,14 +53251,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
-"oBl" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 9
-	},
-/area/station/engine/storage)
 "oCW" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbooth)
@@ -53323,6 +53359,13 @@
 	dir = 1
 	},
 /area/research_outpost/indigo_rye)
+"oIc" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "oIf" = (
 /obj/stool/chair{
 	dir = 4
@@ -53352,13 +53395,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
-"oLV" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/light/emergency,
-/turf/simulated/floor/stairs/wide/other{
-	dir = 4
-	},
-/area/station/hallway/primary/north)
 "oNK" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/disposalpipe/junction/right/north,
@@ -53718,13 +53754,6 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"ppm" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/info{
-	name = "Book Nook"
-	})
 "ppQ" = (
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -53964,18 +53993,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"pBW" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/pyro{
-	name = "The Book Nook"
-	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/info{
-	name = "Book Nook"
-	})
 "pCp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
@@ -55421,14 +55438,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"rqF" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/info{
-	name = "Book Nook"
-	})
 "rrc" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Courtroom"
@@ -55506,10 +55515,6 @@
 	dir = 8
 	},
 /area/station/routing/security)
-"rtN" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
 "rtZ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/sauna)
@@ -55929,12 +55934,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"rZC" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/info{
-	name = "Book Nook"
-	})
 "rZQ" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/decal/garland/ephemeral{
@@ -56107,15 +56106,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"slr" = (
-/obj/machinery/computer/airbr{
-	density = 0;
-	icon = 'icons/obj/airtunnel.dmi';
-	id = "northconnector";
-	pixel_y = 32
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/north)
 "sml" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/plate,
@@ -57091,6 +57081,11 @@
 	dir = 1
 	},
 /area/station/medical/medbooth)
+"tna" = (
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
 "tnf" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -57730,11 +57725,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
-"udF" = (
-/obj/grille/steel,
-/obj/disposalpipe/segment/mail/bent/west,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
 "udL" = (
 /obj/machinery/sleep_console{
 	dir = 4
@@ -57764,10 +57754,6 @@
 /obj/machinery/light/runway_light,
 /turf/space,
 /area/space)
-"ueM" = (
-/obj/disposalpipe/segment/mail/bent/east,
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/north)
 "ufA" = (
 /obj/machinery/light,
 /turf/simulated/floor/caution/east,
@@ -58122,15 +58108,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
-"uBh" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment/bent/north,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
 "uBM" = (
 /obj/machinery/atmospherics/valve{
 	name = "Security Repressurization"
@@ -58231,6 +58208,14 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/sw)
+"uIf" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "uIA" = (
 /obj/table/reinforced/auto,
 /obj/item/body_bag{
@@ -58715,13 +58700,6 @@
 	dir = 9
 	},
 /area/station/hangar/main)
-"vqu" = (
-/obj/grille/steel,
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
 "vrp" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -59529,6 +59507,15 @@
 /obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
+"wrg" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/engine/storage)
 "wrE" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
@@ -59905,12 +59892,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"wLx" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/caution/westeast,
-/area/station/hallway/primary/north)
 "wMb" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light,
@@ -60163,14 +60144,6 @@
 	dir = 1
 	},
 /area/station/security/interrogation)
-"xaU" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/north)
 "xcb" = (
 /obj/decal/poster/wallsign/poster_rand{
 	pixel_y = 28
@@ -60214,6 +60187,18 @@
 /obj/item/reagent_containers/food/snacks/condiment/chocchips,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"xdO" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro{
+	name = "The Book Nook"
+	},
+/obj/disposalpipe/segment/vertical,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "xew" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -60397,6 +60382,14 @@
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"xnb" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "xnq" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport,
@@ -60959,6 +60952,12 @@
 /obj/decal/tile_edge/floorguide/arrow_n,
 /turf/simulated/floor,
 /area/station/engine/power)
+"xQm" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/primary/north)
 "xQB" = (
 /obj/grille/catwalk{
 	dir = 6;
@@ -112955,7 +112954,7 @@ bvI
 etm
 emI
 ltn
-gOY
+dfb
 jnb
 tvw
 fGA
@@ -113501,15 +113500,15 @@ aci
 aaa
 aaa
 aaa
-aKD
-ePU
-aKD
-wLx
+aFv
+cCG
+aFv
+xQm
 aGL
-wLx
-aKD
-rtN
-aKD
+xQm
+aFv
+nbW
+aFv
 aaa
 aaa
 aaa
@@ -113803,15 +113802,15 @@ aci
 aaa
 aaa
 aaa
-aKD
-vqu
-aKD
-slr
-xaU
-ueM
-jgM
-udF
-aKD
+aFv
+ezu
+aFv
+dlP
+xnb
+nNQ
+iRP
+iZx
+aFv
 aaa
 aaa
 aaa
@@ -114109,8 +114108,8 @@ avq
 atC
 avq
 xIe
-fUJ
-oLV
+tna
+lRA
 auT
 auT
 auT
@@ -114404,10 +114403,10 @@ adp
 adp
 adp
 axl
-aFv
+azq
 amJ
 axl
-aLW
+aHP
 apU
 avq
 asa
@@ -114415,7 +114414,7 @@ aGL
 aBm
 auT
 awi
-jVm
+kWb
 aGI
 azo
 aAj
@@ -114709,15 +114708,15 @@ axl
 alE
 amJ
 axi
-dvf
-rqF
-ppm
+aKD
+uIf
+oIc
 aDt
 uzL
 aBo
 auT
-hHb
-oBl
+guJ
+hly
 ayq
 gGT
 aAk
@@ -115011,17 +115010,17 @@ akJ
 alF
 alF
 axk
-kYh
+aLW
 apW
-pBW
+xdO
 ase
-uBh
+jjV
 aum
 auT
 awk
 axo
-aIU
-azq
+wrg
+bcb
 aAl
 bcb
 gYf
@@ -115311,11 +115310,11 @@ aeh
 gih
 axl
 amM
-aHP
+azr
 axl
-rZC
+onU
 aAd
-ppm
+oIc
 uzL
 aFw
 sKR
@@ -115323,7 +115322,7 @@ aNR
 aDH
 aEI
 ayr
-azr
+aIU
 aIU
 aIU
 tik

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -6755,9 +6755,6 @@
 	dir = 8;
 	pixel_x = 14
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "arR" = (
@@ -6765,32 +6762,17 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "arS" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "arT" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs/wide/other{
 	dir = 8
@@ -6803,11 +6785,6 @@
 	id = "northconnector";
 	pixel_y = 32;
 	starts_established = 1
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/west)
@@ -6833,11 +6810,6 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "asb" = (
@@ -6863,11 +6835,6 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/vertical,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "asf" = (
@@ -7172,33 +7139,11 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
-"asW" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/west)
 "asX" = (
 /turf/simulated/floor/stairs/wide/middle{
 	dir = 8
 	},
 /area/station/hallway/primary/west)
-"asY" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/north)
 "asZ" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -11284,11 +11229,6 @@
 /obj/decal/garland/ephemeral{
 	dir = 4;
 	pixel_x = -14
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -43520,17 +43460,6 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
-"cOF" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/west)
 "cPy" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
@@ -43620,12 +43549,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/secwing)
-"cUb" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/north)
 "cVi" = (
 /obj/machinery/light{
 	dir = 8;
@@ -43757,17 +43680,6 @@
 /obj/item/raw_material/shard/glass,
 /turf/simulated/floor/plating/damaged1,
 /area/station/crew_quarters/quarters_south)
-"daE" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/north)
 "daF" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -43993,11 +43905,6 @@
 "dlP" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/stairs/wide{
 	dir = 4
@@ -46108,11 +46015,6 @@
 	dir = 10
 	},
 /area/station/mining/magnet)
-"fJh" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
 "fJx" = (
 /obj/machinery/sim/vr_bed{
 	name = "VR simulation pod";
@@ -46938,6 +46840,14 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"gBY" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "gCb" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor/sanitary/white,
@@ -47756,13 +47666,12 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters_south)
-"hvp" = (
-/obj/airbridge_controller{
-	id = "northconnector";
-	tunnel_width = 2
+"hsM" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/caution/westeast,
+/area/station/hallway/primary/north)
 "hvr" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right,
@@ -48489,13 +48398,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
-"iCZ" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
 "iDR" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -52795,12 +52697,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
-"nTq" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/caution/westeast,
-/area/station/hallway/primary/north)
 "nVl" = (
 /obj/shrub{
 	dir = 1;
@@ -54331,12 +54227,6 @@
 /obj/item/disk/data/floppy/read_only/communications,
 /turf/simulated/floor/greenblack,
 /area/station/turret_protected/Zeta)
-"pQZ" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/caution/westeast,
-/area/station/hallway/primary/west)
 "pRd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56131,6 +56021,13 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"sdf" = (
+/obj/airbridge_controller{
+	id = "northconnector";
+	tunnel_width = 2
+	},
+/turf/space,
+/area/space)
 "sdA" = (
 /obj/stool{
 	desc = "A soft little bed the general size and shape of a space bee.";
@@ -57204,11 +57101,10 @@
 	},
 /area/station/medical/medbooth)
 "tna" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/caution/westeast,
 /area/station/hallway/primary/west)
 "tnf" = (
 /obj/disposalpipe/segment/brig{
@@ -58240,11 +58136,6 @@
 /area/station/maintenance/storage{
 	name = "Secure Atmospherics"
 	})
-"uBR" = (
-/obj/wingrille_spawn/auto,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/west)
 "uCy" = (
 /obj/machinery/space_heater,
 /obj/machinery/light/small{
@@ -58900,12 +58791,6 @@
 /obj/decal/poster/wallsign/security_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
-"vzs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/west)
 "vzv" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -59282,6 +59167,14 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
+"vVG" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/west)
 "vXe" = (
 /obj/table/auto,
 /obj/machinery/microwave,
@@ -60917,11 +60810,6 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "xJq" = (
@@ -61097,11 +60985,6 @@
 	icon = 'icons/obj/airtunnel.dmi';
 	id = "northconnector";
 	pixel_y = 32
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
@@ -109731,11 +109614,11 @@ aaa
 aaa
 aaT
 apK
-tna
-asW
-cOF
-vzs
-uBR
+aqN
+aug
+vVG
+aug
+aqN
 avX
 aaT
 chj
@@ -110034,9 +109917,9 @@ aaa
 aaa
 apK
 aqN
-pQZ
+tna
 aGL
-pQZ
+tna
 aqN
 avX
 aaa
@@ -110337,7 +110220,7 @@ aaa
 apK
 aaa
 aaa
-hvp
+sdf
 aaa
 aaa
 avX
@@ -112753,7 +112636,7 @@ aaa
 apK
 aaa
 aaa
-hvp
+sdf
 aaa
 aaa
 avX
@@ -113054,9 +112937,9 @@ aaa
 aaa
 apK
 aFv
-nTq
+hsM
 aGL
-nTq
+hsM
 aFv
 avX
 aaa
@@ -113355,11 +113238,11 @@ aaa
 aaa
 abX
 apK
-iCZ
-asY
-daE
-cUb
-fJh
+aFv
+wHG
+gBY
+wHG
+aFv
 avX
 abX
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Supplementary fix batch for Kondaru upgrade Tau.

- **Issue Fix:** Modified north station rooms and geometry to reduce size of the main hallway airbridge, correcting an issue introduced in Tau where it was too long to consistently pressurize.
- **Major:** A new room, the Book Nook, has been added at the east side of the airbridge to fill the extended space. It's the new home of the persistent bookshelf, and a great spot to unwind and stare out the window into the span between station segments.
- Introduced a GPS waypoint for the Ranch and Book Nook.
- Adjusted some Ranch object layering.
- Turned a pipe juncture that no longer needed to be a juncture into a plain bend.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Airbridge is better with air. Book Nook's cool too.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(+)Kondaru airbridge issue introduced in upgrade Tau has been fixed, partially by adding a new Book Nook, the home of the persistent bookshelf. See PR 3973 for Tau's changes.
```
