### PR TITLE
removes redundant bowl creation from cereal

### DIFF
--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -733,10 +733,6 @@
 			new /obj/item/razor_blade( get_turf(src) )
 		..()
 
-	disposing()
-		if (src.amount < 1)
-			new /obj/item/reagent_containers/food/drinks/bowl(get_turf(src))
-		..()
 
 	is_open_container()
 		return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cereal had an old method of creating a bowl on disposal, and then soup was created, cereal was made into a soup, and soup was made to drop a bowl on being eaten. The bowl made by cereal remained, while the bowl from soup also was created on eating it all, which ended up with two bowls per bowl of cereal. This PR removes the old method, with a result of one bowl per cereal eaten.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug.