### PR TITLE
Destiny Escape Shuttle Doors Lock

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -313,6 +313,9 @@ var/global/list/mapNames = list(
 	rwalls = /turf/simulated/wall/auto/reinforced/gannets
 	auto_walls = 1
 
+	ext_airlocks = /obj/machinery/door/airlock/pyro/external
+	airlock_style = "pyro"
+
 	escape_centcom = /area/shuttle/escape/centcom/destiny
 	escape_transit = /area/shuttle/escape/transit/destiny
 	escape_station = /area/shuttle/escape/station/destiny


### PR DESCRIPTION
[mapping][bugfix]

## About the PR
Makes the external airlocks on the Destiny/North-facing escape shuttle lock when the shuttle is en route to CentComm. Because it was like the only map that didn't do that.


## Why's this needed?
This is for all the chickens I've accidentally pushed out of the shuttle while it was in transit.

Separate from other Destiny Edits PR since this'll create merge conflicts with 3989