### PR TITLE
Documents and tweaks term_ping filtering option

### DIFF
--- a/code/modules/networks/computer3/terminal.dm
+++ b/code/modules/networks/computer3/terminal.dm
@@ -96,7 +96,7 @@ file_save - Save file to local disk."}
 							src.net_number = new_net_number
 
 					src.peripheral_command("subnet[src.net_number]", null, "\ref[src.netcard]")
-				if (length(command_list) > 0)
+				if (length(command_list))
 					src.ping_filter = lowertext(command_list[1])
 				else
 					src.ping_filter = null

--- a/code/modules/networks/computer3/terminal.dm
+++ b/code/modules/networks/computer3/terminal.dm
@@ -38,7 +38,7 @@
 term_status - View current status of terminal.<br>
 term_accept - Toggle connection auto-accept.<br>
 term_login - Transmit login file (ID Required)<br>
-term_ping - Scan network for terminal devices.<br>
+term_ping \[Device ID] - Scan network for devices.<br>
 term_break - Send break signal to host.<br>
 <b>Connection Commands:</b><br>
 connect \[Net ID] - Connect to a specified device.<br>
@@ -96,8 +96,8 @@ file_save - Save file to local disk."}
 							src.net_number = new_net_number
 
 					src.peripheral_command("subnet[src.net_number]", null, "\ref[src.netcard]")
-				if (length(command_list) > 1)
-					src.ping_filter = lowertext(command_list[2])
+				if (length(command_list) > 0)
+					src.ping_filter = lowertext(command_list[1])
 				else
 					src.ping_filter = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This documents the term_ping filtering functionality in the TermOS help command, and adjusts it so that it accepts the first argument as the filter- not the second

Old

`term_ping asdf PNET_MAINFRAME`

New

`term_ping PNET_MAINFRAME`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Documentation of features in game is good, and taking the first argument is consistent with the other commands like `connect`
I'm not sure taking the second argument was ever actually intended.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Penny
(+)The term_ping command now accepts a filter as the first option
(+)The TermOS help command now documents the term_ping filter
```
