### PR TITLE
Fixed duplication issue with gift wrap

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -818,6 +818,9 @@
 /obj/item/proc/try_put_hand_mousedrop(mob/user)
 	var/oldloc = src.loc
 
+	if(src.equipped_in_slot && src.cant_self_remove)
+		return 0
+
 	if (!src.anchored)
 		if (!user.r_hand || !user.l_hand || (user.r_hand == src) || (user.l_hand == src))
 			if (!user.hand) //big messy ugly bad if() chunk here because we want to prefer active hand

--- a/code/obj/item/gift.dm
+++ b/code/obj/item/gift.dm
@@ -28,6 +28,8 @@
 		src.icon_state = "wrap_paper-[src.style]"
 
 /obj/item/wrapping_paper/attackby(obj/item/W as obj, mob/user as mob)
+	if(W.cant_drop || W.cant_self_remove)
+		return
 	if (!( locate(/obj/table, src.loc) ))
 		boutput(user, "<span class='notice'>You MUST put the paper on a table!</span>")
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Issue described in https://github.com/goonstation/goonstation/issues/3902
Not really "duplication" since it's the same item but you know what I mean.
Also fixes an issue where you could unequip items with self-removal restrictions by using mousedrop.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes https://github.com/goonstation/goonstation/issues/3902
