### PR TITLE
Adds drains to manta's mining prefab

### DIFF
--- a/assets/maps/prefabs/prefab_water_miner_manta.dmm
+++ b/assets/maps/prefabs/prefab_water_miner_manta.dmm
@@ -1,87 +1,715 @@
-"aa" = (/turf/simulated/wall/auto/reinforced/supernorn,/area/prefab/sea_mining)
-"ab" = (/turf/variableTurf/clear,/area/space)
-"ac" = (/obj/wingrille_spawn/auto,/turf/simulated/floor,/area/prefab/sea_mining)
-"ad" = (/obj/rack,/obj/item/clothing/suit/space/diving/engineering,/obj/item/clothing/head/helmet/space/engineer/diving/engineering,/obj/item/clothing/shoes/flippers,/obj/machinery/light/small/floor/netural,/turf/simulated/floor,/area/prefab/sea_mining)
-"ae" = (/turf/simulated/floor,/area/prefab/sea_mining)
-"af" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor,/area/prefab/sea_mining)
-"ag" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/floor,/area/prefab/sea_mining)
-"ah" = (/obj/rack,/obj/item/clothing/suit/space/diving/engineering,/obj/item/clothing/head/helmet/space/engineer/diving/engineering,/obj/item/clothing/shoes/flippers,/turf/simulated/floor,/area/prefab/sea_mining)
-"ai" = (/obj/machinery/door/airlock/pyro/engineering/alt{name = "Mining"},/obj/access_spawn/mining,/turf/simulated/floor,/area/prefab/sea_mining)
-"aj" = (/obj/machinery/door/airlock/pyro/external,/turf/simulated/floor,/area/prefab/sea_mining)
-"ak" = (/obj/wingrille_spawn/auto,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"al" = (/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"am" = (/obj/table/reinforced/auto,/obj/item/shipcomponent/secondary_system/cargo,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"an" = (/obj/table/reinforced/auto,/obj/item/shipcomponent/communications/mining,/obj/machinery/light/small/floor/harsh,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"ao" = (/obj/table/reinforced/auto,/obj/item/shipcomponent/mainweapon/mining,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"ap" = (/turf/variableTurf/clear,/area/noGenerate)
-"aq" = (/obj/reagent_dispensers/watertank,/obj/machinery/light/small/floor/harsh,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"ar" = (/obj/reagent_dispensers/foamtank,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"as" = (/obj/table/auto,/obj/item/hand_labeler,/turf/simulated/floor,/area/prefab/sea_mining)
-"at" = (/obj/table/reinforced/auto,/obj/item/ore_scoop,/obj/item/ore_scoop,/turf/simulated/floor,/area/prefab/sea_mining)
-"au" = (/obj/table/reinforced/auto,/obj/item/storage/firstaid/regular,/obj/item/device/gps,/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"av" = (/obj/table/reinforced/auto,/obj/item/oreprospector,/obj/item/oreprospector,/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"aw" = (/obj/table/reinforced/auto,/obj/item/storage/toolbox/mechanical,/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"ax" = (/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"ay" = (/obj/machinery/manufacturer/general,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"az" = (/turf/simulated/floor/caution/south,/area/prefab/sea_mining)
-"aA" = (/obj/machinery/bot/medbot,/obj/machinery/light/small/floor/netural,/turf/simulated/floor/caution/south,/area/prefab/sea_mining)
-"aB" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/caution/south,/area/prefab/sea_mining)
-"aC" = (/obj/machinery/vehicle/tank/minisub/mining,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"aD" = (/obj/machinery/light/small/floor/netural,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"aE" = (/obj/machinery/light/small/floor/warm,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"aF" = (/obj/machinery/manufacturer/hangar,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"aG" = (/obj/table/auto,/obj/item/sheet/glass/fullstack,/obj/item/sheet/glass/reinforced/fullstack,/turf/simulated/floor/caution/north,/area/prefab/sea_mining)
-"aH" = (/turf/simulated/floor/caution/north,/area/prefab/sea_mining)
-"aI" = (/obj/table/auto,/obj/item/clothing/gloves/yellow,/obj/item/paper/book/minerals,/turf/simulated/floor/caution/north,/area/prefab/sea_mining)
-"aJ" = (/obj/table/reinforced/auto,/obj/item/shipcomponent/sensor/mining,/obj/item/shipcomponent/sensor/mining,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"aK" = (/obj/table/reinforced/auto,/obj/item/shipcomponent/secondary_system/repair,/obj/machinery/light/small/floor/harsh,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"aL" = (/obj/table/reinforced/auto,/obj/item/wrench,/obj/item/clothing/shoes/magnetic,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"aM" = (/obj/reagent_dispensers/fueltank,/obj/machinery/light/small/floor/harsh,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"aN" = (/obj/storage/closet/welding_supply,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
-"aO" = (/obj/table/auto,/obj/item/sheet/steel/fullstack,/obj/item/sheet/steel/reinforced/fullstack,/turf/simulated/floor/damaged2,/area/prefab/sea_mining)
-"aP" = (/obj/machinery/light/small/floor/warm,/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"aQ" = (/obj/machinery/manufacturer/mining,/obj/decal/tile_edge/stripe/extra_big{dir = 6; icon_state = "xtra_bigstripe-corner2"},/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"aR" = (/obj/decal/tile_edge/stripe/extra_big,/turf/simulated/floor,/area/prefab/sea_mining)
-"aS" = (/obj/machinery/light/small/floor/warm,/turf/simulated/floor/scorched2,/area/prefab/sea_mining)
-"aT" = (/obj/table/auto,/obj/item/storage/toolbox/electrical,/obj/item/storage/toolbox/electrical,/obj/item/device/multitool,/obj/item/device/multitool,/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"aU" = (/obj/item/tank/oxygen,/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"aV" = (/obj/machinery/manufacturer/mining,/obj/decal/tile_edge/stripe/extra_big{dir = 10; icon_state = "xtra_bigstripe-corner2"},/turf/simulated/floor,/area/prefab/sea_mining)
-"aW" = (/obj/machinery/manufacturer/qm,/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"aX" = (/obj/machinery/oreaccumulator,/turf/simulated/floor/bot,/area/prefab/sea_mining)
-"aY" = (/obj/item/extinguisher,/turf/simulated/floor/bot,/area/prefab/sea_mining)
-"aZ" = (/obj/machinery/vending/cigarette,/turf/simulated/floor/bot,/area/prefab/sea_mining)
-"ba" = (/obj/machinery/vending/coffee,/turf/simulated/floor/bot,/area/prefab/sea_mining)
-"bb" = (/obj/machinery/portable_reclaimer,/turf/simulated/floor/bot,/area/prefab/sea_mining)
-"bc" = (/obj/machinery/vending/snack,/turf/simulated/floor/bot,/area/prefab/sea_mining)
-"bd" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/floor/bot,/area/prefab/sea_mining)
-"be" = (/obj/item/device/gps{identifier = "NT-MO"},/turf/simulated/floor/caution/north,/area/prefab/sea_mining)
-"bf" = (/obj/miningteleporter{layer = 4},/turf/simulated/floor,/area/prefab/sea_mining)
-"bg" = (/turf/variableTurf/clear,/area/prefab/sea_mining)
-"bh" = (/obj/lattice{dir = 2; icon_state = "lattice-dir"},/obj/machinery/light/runway_light,/turf/variableTurf/clear,/area/prefab/sea_mining)
-"bi" = (/obj/lattice{dir = 1; icon_state = "lattice-dir-b"},/obj/warp_beacon/trench_mining,/turf/variableTurf/clear,/area/prefab/sea_mining)
-"bj" = (/obj/decal/tile_edge/stripe/extra_big{dir = 4},/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"bk" = (/obj/submachine/cargopad{name = "Mining Outpost Teleport Pad"},/turf/simulated/floor/orange,/area/prefab/sea_mining)
-"bl" = (/obj/decal/tile_edge/stripe/extra_big{dir = 8},/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"bm" = (/obj/machinery/recharger,/obj/item/cargotele{pixel_x = 5; pixel_y = 8},/obj/table/auto,/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"bn" = (/obj/decal/tile_edge/stripe/extra_big{dir = 5; icon_state = "xtra_bigstripe-corner2"},/turf/simulated/floor/grime,/area/prefab/sea_mining)
-"bo" = (/obj/machinery/light/small/floor/warm,/obj/decal/tile_edge/stripe/extra_big{dir = 1},/turf/simulated/floor,/area/prefab/sea_mining)
-"bp" = (/obj/decal/tile_edge/stripe/extra_big{dir = 9; icon_state = "xtra_bigstripe-corner2"},/turf/simulated/floor/damaged2,/area/prefab/sea_mining)
-"rD" = (/obj/machinery/ore_cloud_storage_container,/turf/simulated/floor/shuttlebay,/area/prefab/sea_mining)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/prefab/sea_mining)
+"ab" = (
+/turf/variableTurf/clear,
+/area/space)
+"ac" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"ad" = (
+/obj/rack,
+/obj/item/clothing/suit/space/diving/engineering,
+/obj/item/clothing/head/helmet/space/engineer/diving/engineering,
+/obj/item/clothing/shoes/flippers,
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"ae" = (
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"af" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"ag" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"ah" = (
+/obj/rack,
+/obj/item/clothing/suit/space/diving/engineering,
+/obj/item/clothing/head/helmet/space/engineer/diving/engineering,
+/obj/item/clothing/shoes/flippers,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"ai" = (
+/obj/machinery/door/airlock/pyro/engineering/alt{
+	name = "Mining"
+	},
+/obj/access_spawn/mining,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"aj" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"ak" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"al" = (
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"am" = (
+/obj/table/reinforced/auto,
+/obj/item/shipcomponent/secondary_system/cargo,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"an" = (
+/obj/table/reinforced/auto,
+/obj/item/shipcomponent/communications/mining,
+/obj/machinery/light/small/floor/harsh,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"ao" = (
+/obj/table/reinforced/auto,
+/obj/item/shipcomponent/mainweapon/mining,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"ap" = (
+/turf/variableTurf/clear,
+/area/noGenerate)
+"aq" = (
+/obj/reagent_dispensers/watertank,
+/obj/machinery/light/small/floor/harsh,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"ar" = (
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"as" = (
+/obj/table/auto,
+/obj/item/hand_labeler,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"at" = (
+/obj/table/reinforced/auto,
+/obj/item/ore_scoop,
+/obj/item/ore_scoop,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"au" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/obj/item/device/gps,
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"av" = (
+/obj/table/reinforced/auto,
+/obj/item/oreprospector,
+/obj/item/oreprospector,
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"aw" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"ax" = (
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"ay" = (
+/obj/machinery/manufacturer/general,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"az" = (
+/turf/simulated/floor/caution/south,
+/area/prefab/sea_mining)
+"aA" = (
+/obj/machinery/bot/medbot,
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/caution/south,
+/area/prefab/sea_mining)
+"aB" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/caution/south,
+/area/prefab/sea_mining)
+"aC" = (
+/obj/machinery/vehicle/tank/minisub/mining,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"aD" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"aE" = (
+/obj/machinery/light/small/floor/warm,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"aF" = (
+/obj/machinery/manufacturer/hangar,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"aG" = (
+/obj/table/auto,
+/obj/item/sheet/glass/fullstack,
+/obj/item/sheet/glass/reinforced/fullstack,
+/turf/simulated/floor/caution/north,
+/area/prefab/sea_mining)
+"aH" = (
+/turf/simulated/floor/caution/north,
+/area/prefab/sea_mining)
+"aI" = (
+/obj/table/auto,
+/obj/item/clothing/gloves/yellow,
+/obj/item/paper/book/minerals,
+/turf/simulated/floor/caution/north,
+/area/prefab/sea_mining)
+"aJ" = (
+/obj/table/reinforced/auto,
+/obj/item/shipcomponent/sensor/mining,
+/obj/item/shipcomponent/sensor/mining,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"aK" = (
+/obj/table/reinforced/auto,
+/obj/item/shipcomponent/secondary_system/repair,
+/obj/machinery/light/small/floor/harsh,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"aL" = (
+/obj/table/reinforced/auto,
+/obj/item/wrench,
+/obj/item/clothing/shoes/magnetic,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"aM" = (
+/obj/reagent_dispensers/fueltank,
+/obj/machinery/light/small/floor/harsh,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"aN" = (
+/obj/storage/closet/welding_supply,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"aO" = (
+/obj/table/auto,
+/obj/item/sheet/steel/fullstack,
+/obj/item/sheet/steel/reinforced/fullstack,
+/turf/simulated/floor/damaged2,
+/area/prefab/sea_mining)
+"aP" = (
+/obj/machinery/light/small/floor/warm,
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"aQ" = (
+/obj/machinery/manufacturer/mining,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 6;
+	icon_state = "xtra_bigstripe-corner2"
+	},
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"aR" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"aS" = (
+/obj/machinery/light/small/floor/warm,
+/turf/simulated/floor/scorched2,
+/area/prefab/sea_mining)
+"aT" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/electrical,
+/obj/item/device/multitool,
+/obj/item/device/multitool,
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"aU" = (
+/obj/item/tank/oxygen,
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"aV" = (
+/obj/machinery/manufacturer/mining,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10;
+	icon_state = "xtra_bigstripe-corner2"
+	},
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"aW" = (
+/obj/machinery/manufacturer/qm,
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"aX" = (
+/obj/machinery/oreaccumulator,
+/turf/simulated/floor/bot,
+/area/prefab/sea_mining)
+"aY" = (
+/obj/item/extinguisher,
+/turf/simulated/floor/bot,
+/area/prefab/sea_mining)
+"aZ" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/bot,
+/area/prefab/sea_mining)
+"ba" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/bot,
+/area/prefab/sea_mining)
+"bb" = (
+/obj/machinery/portable_reclaimer,
+/turf/simulated/floor/bot,
+/area/prefab/sea_mining)
+"bc" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/bot,
+/area/prefab/sea_mining)
+"bd" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/bot,
+/area/prefab/sea_mining)
+"be" = (
+/obj/item/device/gps{
+	identifier = "NT-MO"
+	},
+/turf/simulated/floor/caution/north,
+/area/prefab/sea_mining)
+"bf" = (
+/obj/miningteleporter{
+	layer = 4
+	},
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"bg" = (
+/turf/variableTurf/clear,
+/area/prefab/sea_mining)
+"bh" = (
+/obj/lattice{
+	dir = 2;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light,
+/turf/variableTurf/clear,
+/area/prefab/sea_mining)
+"bi" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/obj/warp_beacon/trench_mining,
+/turf/variableTurf/clear,
+/area/prefab/sea_mining)
+"bj" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"bk" = (
+/obj/submachine/cargopad{
+	name = "Mining Outpost Teleport Pad"
+	},
+/turf/simulated/floor/orange,
+/area/prefab/sea_mining)
+"bl" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"bm" = (
+/obj/machinery/recharger,
+/obj/item/cargotele{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/table/auto,
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"bn" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 5;
+	icon_state = "xtra_bigstripe-corner2"
+	},
+/turf/simulated/floor/grime,
+/area/prefab/sea_mining)
+"bo" = (
+/obj/machinery/light/small/floor/warm,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"bp" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9;
+	icon_state = "xtra_bigstripe-corner2"
+	},
+/turf/simulated/floor/damaged2,
+/area/prefab/sea_mining)
+"rD" = (
+/obj/machinery/ore_cloud_storage_container,
+/turf/simulated/floor/shuttlebay,
+/area/prefab/sea_mining)
+"UC" = (
+/obj/machinery/drainage,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
+"WU" = (
+/obj/machinery/drainage/big,
+/turf/simulated/floor,
+/area/prefab/sea_mining)
 
 (1,1,1) = {"
-abababababababapapapapabababababababababab
-abababababababababaaaaaaacacacaaaaaaaaaaab
-abababababababababaaadaeaeaeaeaeaeafagaaab
-abababababababababaaahaeaeaeaeaeaeaeaeaaab
-abaaaaaaaaaaaaaaaaaaacaiaaaaaaaaacaaajaaab
-abakalamanaoalaqaraaasaeatauavawbfaaaeaaab
-abakayalalalalalalaaazaAazazazaBazaaajaaab
-abakalalaCalalalalaDalalalaEalalrDaaababab
-abakaFalalalalalalaaaGaHaHbeaHaHaIaaababab
-abakalaJaKaLalaMaNaaaOaPaQaRaVaSaTaaababab
-abaaaaaaaaaaaaaaaaaaaWaUbjbkblaxbmaaababab
-ababbgbgbgbhbgbgbgaaaxaxbnbobpaXaYaaababab
-abababababbibgbgbgaaaZbabbbcaebdaXaaababab
-abababababbgbgbgbgaaaaacacacacacaaaaababab
-ababababababababababababapapapapababababab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(2,1,1) = {"
+ab
+ab
+ab
+ab
+aa
+ak
+ak
+ak
+ak
+ak
+aa
+ab
+ab
+ab
+ab
+"}
+(3,1,1) = {"
+ab
+ab
+ab
+ab
+aa
+al
+ay
+al
+aF
+al
+aa
+bg
+ab
+ab
+ab
+"}
+(4,1,1) = {"
+ab
+ab
+ab
+ab
+aa
+am
+al
+al
+al
+aJ
+aa
+bg
+ab
+ab
+ab
+"}
+(5,1,1) = {"
+ab
+ab
+ab
+ab
+aa
+an
+al
+aC
+al
+aK
+aa
+bg
+ab
+ab
+ab
+"}
+(6,1,1) = {"
+ab
+ab
+ab
+ab
+aa
+ao
+al
+al
+al
+aL
+aa
+bh
+bi
+bg
+ab
+"}
+(7,1,1) = {"
+ab
+ab
+ab
+ab
+aa
+al
+al
+al
+al
+al
+aa
+bg
+bg
+bg
+ab
+"}
+(8,1,1) = {"
+ap
+ab
+ab
+ab
+aa
+aq
+al
+al
+al
+aM
+aa
+bg
+bg
+bg
+ab
+"}
+(9,1,1) = {"
+ap
+ab
+ab
+ab
+aa
+ar
+al
+al
+al
+aN
+aa
+bg
+bg
+bg
+ab
+"}
+(10,1,1) = {"
+ap
+aa
+aa
+aa
+aa
+aa
+aa
+aD
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+"}
+(11,1,1) = {"
+ap
+aa
+ad
+ah
+ac
+as
+az
+al
+aG
+aO
+aW
+ax
+aZ
+aa
+ab
+"}
+(12,1,1) = {"
+ab
+aa
+ae
+ae
+ai
+ae
+aA
+al
+aH
+aP
+aU
+ax
+ba
+ac
+ab
+"}
+(13,1,1) = {"
+ab
+ac
+ae
+ae
+aa
+at
+az
+al
+aH
+aQ
+bj
+bn
+bb
+ac
+ap
+"}
+(14,1,1) = {"
+ab
+ac
+ae
+ae
+aa
+au
+az
+aE
+be
+aR
+bk
+bo
+bc
+ac
+ap
+"}
+(15,1,1) = {"
+ab
+ac
+UC
+UC
+aa
+av
+az
+al
+aH
+aV
+bl
+bp
+ae
+ac
+ap
+"}
+(16,1,1) = {"
+ab
+aa
+ae
+ae
+aa
+aw
+aB
+al
+aH
+aS
+ax
+aX
+bd
+ac
+ap
+"}
+(17,1,1) = {"
+ab
+aa
+ae
+ae
+ac
+bf
+az
+rD
+aI
+aT
+bm
+aY
+aX
+aa
+ab
+"}
+(18,1,1) = {"
+ab
+aa
+af
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+"}
+(19,1,1) = {"
+ab
+aa
+ag
+ae
+aj
+WU
+aj
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(20,1,1) = {"
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(21,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 "}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a large drain to the manta mining prefab's airlock, and a couple small ones in the middle of the hall around the top.

It seems that the map file was also converted to tgm or something, I hope that's not a bad thing even if it makes review difficult. 
(I don't know if the map diff bot does prefabs too, but we'll find out!)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Request by End on discord.