### PR TITLE
Secbots react to containers

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -649,7 +649,7 @@
 				else // his dad, though...
 					if(!ON_COOLDOWN(src, SECBOT_CAGE_RAGE_COOLDOWN, 1.5 SECONDS))
 						src.weeoo()
-						YellAtPerp(impotent_rage = 0)
+						YellAtPerp(impotent_rage = 1)
 						if(isobj(src.loc))
 							var/obj/O = src.loc
 							var/wiggle = 6

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -651,6 +651,7 @@
 						src.weeoo()
 						YellAtPerp(impotent_rage = 1)
 						if(isobj(src.loc))
+							var/obj/O = src.loc
 							if(prob(33))
 								src.visible_message("<span class='alert'><b>[src]</b> emits a loud thump and rattles a bit.</span>")
 								playsound(get_turf(O), "sound/impact_sounds/Metal_Hit_Heavy_1.ogg", 50, 1)

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -651,15 +651,6 @@
 						src.weeoo()
 						YellAtPerp(impotent_rage = 1)
 						if(isobj(src.loc))
-							var/obj/O = src.loc
-							var/wiggle = 6
-							while(wiggle > 0)
-								wiggle--
-								O.pixel_x = rand(-3,3)
-								O.pixel_y = rand(-3,3)
-								sleep(0.1 SECONDS)
-							O.pixel_x = initial(O.pixel_x)
-							O.pixel_y = initial(O.pixel_y)
 							if(prob(33))
 								src.visible_message("<span class='alert'><b>[src]</b> emits a loud thump and rattles a bit.</span>")
 								playsound(get_turf(O), "sound/impact_sounds/Metal_Hit_Heavy_1.ogg", 50, 1)


### PR DESCRIPTION
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Secbots now act more appropriately when stuck inside things.

If a secbot is locked in a closet, it'll sit there patiently and wait to be let out. If its emagged, it'll thrash around inside the closet and try to destroy it.

If a secbot somehow winds up inside a mob, it'll repeatedly try to attack and stun it until it's in crit, then burst out of them. They'll do this whether they're emagged or not, since eating an officer of the law is probably illegal.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Beepsky's dad got stuck in a locker and kicked everyone's butt so hard I had to put that unstoppable rage to good use.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Superlagg
(+)Emagged securitrons don't like being trapped in lockers, and will try to thrash their way out.
```
