### PR TITLE
somewhat balances (?) and brings back construction workers

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -738,7 +738,7 @@ ABSTRACT_TYPE(/datum/job/engineering)
 	slot_poc1 = /obj/item/material_shaper
 	slot_poc2 = /obj/item/room_planner
 
-	items_in_backpack = list(/obj/item/rcd/construction/safe, /obj/item/rcd_ammo/big, /obj/item/rcd_ammo/big, /obj/item/caution, /obj/item/lamp_manufacturer/organic)
+	items_in_backpack = list(/obj/item/rcd/construction/chiefEngineer, /obj/item/rcd_ammo/, /obj/item/rcd_ammo/, /obj/item/caution, /obj/item/lamp_manufacturer/organic)
 
 	special_setup(var/mob/living/carbon/human/M)
 		..()

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -711,6 +711,46 @@ ABSTRACT_TYPE(/datum/job/engineering)
 	linkcolor = "#FF9900"
 	slot_card = /obj/item/card/id/engineering
 
+/datum/job/engineering/construction_worker
+	name = "Construction Worker"
+	allow_traitors = 0
+	cant_spawn_as_rev = 1
+	limit = 1
+	wages = PAY_TRADESMAN
+
+	slot_back = /obj/item/storage/backpack/withO2
+	slot_belt = /obj/item/storage/belt/utility/prepared
+	slot_jump = /obj/item/clothing/under/rank/orangeoveralls
+	slot_foot = /obj/item/clothing/shoes/magnetic
+	slot_glov = /obj/item/clothing/gloves/black
+	slot_ears = /obj/item/device/radio/headset/engineer
+	slot_rhan = /obj/item/tank/jetpack
+	slot_eyes = /obj/item/clothing/glasses/construction
+#ifdef UNDERWATER_MAP
+	slot_suit = /obj/item/clothing/suit/space/diving/engineering
+	slot_head = /obj/item/clothing/head/helmet/space/engineer/diving
+#else
+	slot_suit = /obj/item/clothing/suit/space/engineer
+	slot_head = /obj/item/clothing/head/helmet/space/engineer
+#endif
+	slot_mask = /obj/item/clothing/mask/breath
+
+	slot_poc1 = /obj/item/material_shaper
+	slot_poc2 = /obj/item/room_planner
+
+	items_in_backpack = list(/obj/item/rcd/construction/safe, /obj/item/rcd_ammo/big, /obj/item/rcd_ammo/big, /obj/item/caution, /obj/item/lamp_manufacturer/organic)
+
+	special_setup(var/mob/living/carbon/human/M)
+		..()
+		if (!M)
+			return
+		M.traitHolder.addTrait("training_engineer")
+
+	New()
+		..()
+		src.access = get_access("Construction Worker")
+		return
+
 /datum/job/engineering/quartermaster
 	name = "Quartermaster"
 	limit = 3

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -1212,17 +1212,6 @@
 	containertype = /obj/storage/crate/classcrate/qm
 	containername = "Anti-Singularity Supply Pack"
 
-/datum/supply_packs/conworksupplies
-	name = "Construction Equipment"
-	desc = "The mothballed tools of our former Construction Workers, in a crate, for you!"
-	category = "Engineering Department"
-	contains = list(/obj/item/lamp_manufacturer/organic,/obj/item/material_shaper,/obj/item/room_planner,/obj/item/clothing/under/rank/orangeoveralls)
-	//i was going to add a version of the construction visualliser w/o seeing invisible monsters but FUCK SIGHT CODE WHAT THE FUCK
-	cost = 8000
-	containertype = /obj/storage/secure/crate
-	containername = "Construction Equipment (Cardlocked \[Engineering])"
-	access = access_engineering
-
 /* ================================================= */
 /* -------------------- Complex -------------------- */
 /* ================================================= */

--- a/strings/changelog.txt
+++ b/strings/changelog.txt
@@ -13,10 +13,6 @@
 (p)3997
 (e)|
 (+)Adds the tape drive to hacked CompTech vendors.
-(u)comradef191
-(p)2523
-(e)⛔|removal
-(*)Removed the Construction Worker job. Added QM crate containing most of their equipment.
 (u)TTerc
 (p)3885
 (e)⚖|balance


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] --> 

[FEEDBACK WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

adds back construction workers, yay!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

very few people wanted them gone, we need a role to fill in the gap left by the removal of conworker

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)matlap
(*) the construction worker is back from the grave
(-) he no longer has his RCDD
(+) but he has a shiny new yellow RCD, with 50 capacity, and the same cool door feature everyone loves!
(-) he also only starts with 100 rcd juice instead of 200. (2x 50 matter cartridges)
```
