### PR TITLE
Consistant Computer Lighting

### DIFF
--- a/code/WorkInProgress/TempEngine.dm
+++ b/code/WorkInProgress/TempEngine.dm
@@ -1632,6 +1632,7 @@ Present 	Unscrewed  Connected 	Unconnected		Missing
 			radio_connection = radio_controller.add_object(src, "[frequency]")
 
 	initialize()
+		..()
 		set_frequency(frequency)
 
 #undef PUMP_POWERLEVEL_1

--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -248,18 +248,6 @@
 /obj/machinery/computer/genetics/proc/update_occupant_preview()
 	src.scanner?.update_occupant()
 
-/obj/machinery/computer/genetics/power_change()
-	if(status & BROKEN)
-		icon_state = "commb"
-	else
-		if( powered() )
-			icon_state = initial(icon_state)
-			status &= ~NOPOWER
-		else
-			SPAWN_DBG(rand(0, 15))
-				src.icon_state = "c_unpowered"
-				status |= NOPOWER
-
 // There weren't any (Convair880)!
 /obj/machinery/computer/genetics/proc/log_me(var/mob/M, var/action = "", var/datum/bioEffect/BE)
 	if (!src || !M || !ismob(M) || !action)

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -8,7 +8,28 @@
 	density = 1
 	anchored = 1
 	desc = "Shows the power usage of the station."
+	var/datum/light/light
+	var/light_r = 1
+	var/light_g = 1
+	var/light_b = 1
 	var/window_tag = "powcomp"
+	/// does it have a glow in the dark screen? see computer_screens.dmi
+	var/glow_in_dark_screen = TRUE
+	var/image/screen_image
+
+/obj/machinery/power/monitor/New()
+	..()
+	light = new/datum/light/point
+	light.set_brightness(0.4)
+	light.set_color(light_r, light_g, light_b)
+	light.attach(src)
+	if(glow_in_dark_screen)
+		src.screen_image = image('icons/obj/computer_screens.dmi', src.icon_state, -1)
+		screen_image.plane = PLANE_LIGHTING
+		screen_image.blend_mode = BLEND_ADD
+		screen_image.layer = LIGHTING_LAYER_BASE
+		screen_image.color = list(0.33,0.33,0.33, 0.33,0.33,0.33, 0.33,0.33,0.33)
+		src.UpdateOverlays(screen_image, "screen_image")
 
 /obj/machinery/power/monitor/attack_ai(mob/user)
 	add_fingerprint(user)
@@ -82,35 +103,9 @@
 
 	src.updateDialog()
 
-/obj/machinery/power/monitor/power_change()
-
-	if(status & BROKEN)
-		icon_state = "broken"
-	else
-		if( powered() )
-			icon_state = initial(icon_state)
-			status &= ~NOPOWER
-		else
-			SPAWN_DBG(rand(0, 15))
-				src.icon_state = "c_unpowered"
-				status |= NOPOWER
-
 /obj/machinery/power/monitor/console_upper
 	icon = 'icons/obj/computerpanel.dmi'
 	icon_state = "power1"
-
-/obj/machinery/power/monitor/power_change()
-
-	if(status & BROKEN)
-		icon_state = "broken"
-	else
-		if( powered() )
-			icon_state = initial(icon_state)
-			status &= ~NOPOWER
-		else
-			SPAWN_DBG(rand(0, 15))
-				src.icon_state = "power10"
-				status |= NOPOWER
 
 /obj/machinery/power/monitor/console_lower
 	icon = 'icons/obj/computerpanel.dmi'
@@ -120,14 +115,27 @@
 
 	if(status & BROKEN)
 		icon_state = "broken"
+		light.disable()
+		if(glow_in_dark_screen)
+			src.ClearSpecificOverlays("screen_image")
 	else
 		if( powered() )
 			icon_state = initial(icon_state)
 			status &= ~NOPOWER
+			light.enable()
+			if(glow_in_dark_screen)
+				screen_image.plane = PLANE_LIGHTING
+				screen_image.blend_mode = BLEND_ADD
+				screen_image.layer = LIGHTING_LAYER_BASE
+				screen_image.color = list(0.33,0.33,0.33, 0.33,0.33,0.33, 0.33,0.33,0.33)
+				src.UpdateOverlays(screen_image, "screen_image")
 		else
 			SPAWN_DBG(rand(0, 15))
 				src.icon_state = "power20"
 				status |= NOPOWER
+				light.disable()
+				if(glow_in_dark_screen)
+					src.ClearSpecificOverlays("screen_image")
 
 // tweaked version to hook up to the engine->smes powernet and show SMES usage stats and power produced
 /obj/machinery/power/monitor/smes

--- a/code/obj/machinery/computer.dm
+++ b/code/obj/machinery/computer.dm
@@ -5,7 +5,7 @@
 	anchored = 1.0
 	power_usage = 250
 	var/datum/light/light
-	var/light_r =1
+	var/light_r = 1
 	var/light_g = 1
 	var/light_b = 1
 

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -371,19 +371,6 @@
 		JOB_XP(usr, "Medical Doctor", 15)
 		src.menu = 1
 
-/obj/machinery/computer/cloning/power_change()
-
-	if(status & BROKEN)
-		icon_state = "commb"
-	else
-		if( powered() )
-			icon_state = initial(icon_state)
-			status &= ~NOPOWER
-		else
-			SPAWN_DBG(rand(0, 15))
-				src.icon_state = "c_unpowered"
-				status |= NOPOWER
-
 /// find a ghost mob (or a ghost respawned as critter in vr/afterlife bar)
 proc/find_ghost_by_key(var/find_key)
 	if (!find_key)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pump Control properly initialize Light state by calling `power_change()` (Call your parents!)

Power Monitor and SMES power monitor now have Light and Flaborized's screen glow change.
- Uh... removed two dead procs of `power_change()`

Genetics Computer and Cloning computer removed copy-pasta of `power_change()`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Helps show off Flaborized and Pali's change