### PR TITLE
Remove boomboots from syndicate crates

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -480,6 +480,7 @@ This is basically useless for anyone but miners.
 	vr_allowed = 0
 	desc = "These big red boots have an explosive step sound. The entire station is sure to want to show you their appreciation."
 	job = list("Clown")
+	not_in_crates = 1
 	blockedmode = list(/datum/game_mode/spy)
 
 /datum/syndicate_buylist/traitor/clown_mask


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes Boom Boots to not spawn in syndicate surplus crates.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Boom Boots spawn in surplus crates and suck up 12TC of your budget for a gimmick item with no functionality.
We already block the syndicate big hat for presumably the same reason.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Stopped Boom Boots spawning in syndicate Surplus Crate.
```
