### PR TITLE
Fixes industrial tables to auto adjust and makes pew deconstructable

### DIFF
--- a/code/obj/item/table_rack_parts.dm
+++ b/code/obj/item/table_rack_parts.dm
@@ -200,7 +200,7 @@ RACK PARTS
 	name = "industrial table parts"
 	desc = "A collection of parts that can be used to make an industrial looking table."
 	icon = 'icons/obj/furniture/table_industrial.dmi'
-	furniture_type = /obj/table/reinforced/industrial
+	furniture_type = /obj/table/reinforced/industrial/auto
 
 /obj/item/furniture_parts/table/reinforced/bar
 	name = "bar table parts"

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1081,7 +1081,7 @@
 	rotatable = 0
 	foldable = 0
 	comfort_value = 2
-	deconstructable = 0
+	deconstructable = 1
 	securable = 0
 	parts_type = /obj/item/furniture_parts/bench/pew
 	var/image/arm_image = null

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1081,7 +1081,7 @@
 	rotatable = 0
 	foldable = 0
 	comfort_value = 2
-	deconstructable = 1
+	deconstructable = TRUE
 	securable = 0
 	parts_type = /obj/item/furniture_parts/bench/pew
 	var/image/arm_image = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes industrial tables to auto adjust and makes pew deconstructable


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
industrial tables should auto adjust and deconstructable pews are a common feature request in mentorhelps


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Carbadox
(+)Pews are now deconstructaable
```
