### PR TITLE
reduces construction times, allow building multiple girders at the same time.

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -439,7 +439,7 @@ var/datum/action_controller/actions
 			INVOKE_ASYNC(src.owner, src.proc_path, src.proc_args)
 
 /datum/action/bar/icon/build
-	duration = 30
+	duration = 20
 	var/obj/item/sheet/sheet
 	var/objtype
 	var/cost
@@ -450,6 +450,7 @@ var/datum/action_controller/actions
 	var/obj/item/sheet/sheet2 // in case you need to pull from more than one sheet
 	var/cost2 // same as above
 	var/spot
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED //now you can build multiple girders at once
 	New(var/obj/item/sheet/csheet, var/cobjtype, var/ccost, var/datum/material/cmat, var/camount, var/cicon, var/cicon_state, var/cobjname, var/post_action_callback = null, var/obj/item/sheet/csheet2, var/ccost2, var/spot)
 		..()
 		icon = cicon

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1357,7 +1357,7 @@
 		boutput(user, "You begin to attach the light fixture to [src]...")
 
 
-		if (!do_after(user, 4 SECONDS))
+		if (!do_after(user, 2 SECONDS))
 			user.show_text("You were interrupted!", "red")
 			return
 

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -111,7 +111,7 @@
 		playsound(src, "sound/items/Screwdriver.ogg", 50, 1)
 		boutput(user, "You begin to attach the light fixture to [src]...")
 
-		if (!do_after(user, 4 SECONDS))
+		if (!do_after(user, 2 SECONDS))
 			user.show_text("You were interrupted!", "red")
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[BALANCE] [INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR reduces the length of the actionbar to build things like floor tiles, beds, lockers, etc.. It also allows building multiple girders at once, like you could before, also allows reinforcing multiple floors at once. Girders now take 2 seconds to build as opposed to 3. Attaching light fixtures only takes 2 seconds now instead of 4. Also allows building multiple things in parallel.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Construction is incredibly tedious, and the fact that we can't build multiple girders at once is a big part of that.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Matlap
(*)You can build multiple girders at once now!
(+)Reduced action bar lengths for various construction actions.
```
