### PR TITLE
Plate / tray smashing nerf

### DIFF
--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -740,12 +740,12 @@ TRAYS
 						has_helmet = TRUE
 						break
 				if(has_helmet)
-					M.do_disorient(150, 0.1 SECONDS, 0, 0, 1 SECOND)
+					M.do_disorient(stamina_damage = 150, weakened = 0.1 SECONDS, disorient = 1 SECOND)
 				else
 					M.changeStatus("weakened", 1 SECONDS)
 					M.force_laydown_standup()
 			else //borgs, ghosts, whatever
-				M.do_disorient(150, 0.1 SECONDS, 0, 0, 1 SECOND)
+				M.do_disorient(stamina_damage = 150, weakened = 0.1 SECONDS, disorient = 1 SECOND)
 
 			unique_attack_garbage_fuck(M, user)
 		else

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -544,6 +544,7 @@ TRAYS
 	var/list/throw_targets = list()
 	var/throw_dist = 3
 	tooltip_flags = REBUILD_DIST
+	var/hit_sound = "sound/items/plate_tap.ogg"
 
 	New()
 		..()
@@ -590,8 +591,6 @@ TRAYS
 	proc/unique_attack_garbage_fuck(mob/M as mob, mob/user as mob)
 		attack_particle(user,M)
 		M.TakeDamageAccountArmor("head", force, 0, 0, DAMAGE_BLUNT)
-		M.changeStatus("weakened", 2 SECONDS)
-		M.force_laydown_standup()
 		playsound(get_turf(src), "sound/impact_sounds/plate_break.ogg", 50, 1)
 
 		var/turf/shardturf = get_turf(M)
@@ -611,9 +610,6 @@ TRAYS
 			O.throw_at(get_offset_target_turf(shardturf, rand(-4,4), rand(-4,4)), 7, 1)
 
 		qdel(src)
-
-	proc/unique_tap_garbage_fluck(mob/M as mob, mob/user as mob)
-		playsound(get_turf(src), "sound/items/plate_tap.ogg", 30, 1)
 
 	throw_impact(atom/A, datum/thrown_thing/thr)
 		..()
@@ -726,12 +722,34 @@ TRAYS
 			else
 				M.visible_message("<span class='alert'><B>[user] smashes [src] over [M]'s head!</B></span>")
 				logTheThing("combat", user, M, "smashes [src] over [constructTarget(M,"combat")]'s head! ")
-			if(ordered_contents.len != 0)
+			if(length(ordered_contents))
 				src.shit_goes_everywhere()
+
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				if(istype(H.head, /obj/item/clothing/head/helmet))
+					M.changeStatus("disorient", 1 SECONDS)
+				else
+					M.changeStatus("weakened", 1 SECONDS)
+					M.force_laydown_standup()
+			else if(ismobcritter(M))
+				var/mob/living/critter/L = M
+				var/has_helmet = FALSE
+				for(var/datum/equipmentHolder/head/head in L.equipment)
+					if(istype(head.item, /obj/item/clothing/head/helmet))
+						has_helmet = TRUE
+						break
+				if(has_helmet)
+					M.changeStatus("disorient", 1 SECONDS)
+				else
+					M.changeStatus("weakened", 1 SECONDS)
+					M.force_laydown_standup()
+					M.changeStatus("disorient", 1 SECONDS)
+
 			unique_attack_garbage_fuck(M, user)
 		else
 			M.visible_message("<span class='alert'>[user] taps [M] over the head with [src].</span>")
-			unique_tap_garbage_fluck(M,user)
+			playsound(get_turf(src), src.hit_sound, 30, 1)
 			logTheThing("combat", user, M, "taps [constructTarget(M,"combat")] over the head with [src].")
 
 	attack_hand(mob/user as mob)
@@ -792,6 +810,7 @@ TRAYS
 	var/y_counter = 0
 	var/y_mod = 0
 	var/tray_health = 5 //number of times u can smash with a tray + 1, get_desc values are hardcoded so please adjust them (i know im a bad coder)
+	hit_sound = "step_lattice"
 
 	New()
 		..()
@@ -871,7 +890,6 @@ TRAYS
 
 	unique_attack_garbage_fuck(mob/M as mob, mob/user as mob)
 		M.TakeDamageAccountArmor("head", src.force, 0, 0, DAMAGE_BLUNT)
-		M.changeStatus("weakened", 2 SECONDS)
 		playsound(get_turf(src), "sound/weapons/trayhit.ogg", 50, 1)
 		src.visible_message("\The [src] falls out of [user]'s hands due to the impact!")
 		user.drop_item(src)
@@ -886,9 +904,6 @@ TRAYS
 		tooltip_rebuild = 1
 
 		src.visible_message("\The [src] looks less sturdy now.")
-
-	unique_tap_garbage_fluck(mob/M as mob, mob/user as mob)
-		playsound(src, "step_lattice", 50, 1)
 
 //sushiiiiiii
 /obj/item/kitchen/sushi_roller

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -728,7 +728,7 @@ TRAYS
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
 				if(istype(H.head, /obj/item/clothing/head/helmet))
-					M.changeStatus("disorient", 1 SECONDS)
+					M.do_disorient(stamina_damage = 150, weakened = 0.1 SECONDS, disorient = 1 SECOND)
 				else
 					M.changeStatus("weakened", 1 SECONDS)
 					M.force_laydown_standup()
@@ -740,12 +740,12 @@ TRAYS
 						has_helmet = TRUE
 						break
 				if(has_helmet)
-					M.changeStatus("disorient", 1 SECONDS)
+					M.do_disorient(150, 0.1 SECONDS, 0, 0, 1 SECOND)
 				else
 					M.changeStatus("weakened", 1 SECONDS)
 					M.force_laydown_standup()
 			else //borgs, ghosts, whatever
-				M.changeStatus("disorient", 1 SECONDS)
+				M.do_disorient(150, 0.1 SECONDS, 0, 0, 1 SECOND)
 
 			unique_attack_garbage_fuck(M, user)
 		else

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -744,7 +744,8 @@ TRAYS
 				else
 					M.changeStatus("weakened", 1 SECONDS)
 					M.force_laydown_standup()
-					M.changeStatus("disorient", 1 SECONDS)
+			else //borgs, ghosts, whatever
+				M.changeStatus("disorient", 1 SECONDS)
 
 			unique_attack_garbage_fuck(M, user)
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BALANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* For mob critters and humans smashing a plate or tray applies 1 second of weakness, down from 2 seconds. Attacked mob falls down and stands back up which disarms them,
* helmet protection - wearing a helmet will instead apply a disorient effect. Targets receive 150 stamina damage, are disoriented for a second, weakened for 0.1 seconds, and fall over dropping their weapon if they have insufficient stamina to withstand the blow.
* All other mobs (borgs, wraiths, ghosts, the aeye) that you manage to bop are disoriented like mobs with helmets
* refactors a little bit of the weirdness of this code, not much.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* make plates and trays worse


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(+)Reduced stuns from plates and trays. Plates and trays respect helmet protection
```
