### PR TITLE
Fixes donkpocket and honkpocket cooling duration

### DIFF
--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -816,7 +816,6 @@
 		New()
 			. = ..()
 			src.cooltime()
-			return
 
 	on_bite(obj/item/I, mob/M, mob/user)
 		if(src.warm && M.reagents)

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -780,7 +780,7 @@
 
 	proc/cooltime()
 		if (src.warm)
-			SPAWN_DBG( 4200 )
+			SPAWN_DBG( 420 SECONDS )
 				src.warm = 0
 				src.name = "donk-pocket"
 		return
@@ -813,6 +813,11 @@
 		name = "warm honk-pocket"
 		warm = 1
 
+		New()
+			..()
+			src.cooltime()
+			return
+
 	on_bite(obj/item/I, mob/M, mob/user)
 		if(src.warm && M.reagents)
 			M.reagents.add_reagent("honk_fart",15)
@@ -823,7 +828,7 @@
 
 	cooltime()
 		if (src.warm)
-			SPAWN_DBG( 4200 )
+			SPAWN_DBG( 420 SECONDS )
 				src.warm = 0
 				src.name = "honk-pocket"
 		return

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -814,7 +814,7 @@
 		warm = 1
 
 		New()
-			..()
+			. = ..()
 			src.cooltime()
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Sets the donkpocket and honkpocket cooling duration to 420 seconds and makes the spawned honkpockets actually start the cooling timer

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Lets people experience the horrors of cold honk pockets. And fixes a bug
