### PR TITLE
Server time is now displayed in status panel and PDA home screen

### DIFF
--- a/code/mob_stat.dm
+++ b/code/mob_stat.dm
@@ -102,7 +102,7 @@
 				stats["Time To Start:"] = 0
 				var/shiftTime = round(ticker.round_elapsed_ticks / 600)
 				saveStat("Shift Time:", "[shiftTime] minute[shiftTime == 1 ? "" : "s"]")
-				saveStat("Local Time:", time2text(world.timeofday, "hh:mm", world.timezone))
+				saveStat("Local Time:", time2text(world.timeofday, "hh:mm"))
 
 				//MBC : nah we don't run construction anyway
 				//if (ticker.mode && istype(ticker.mode, /datum/game_mode/construction))

--- a/code/mob_stat.dm
+++ b/code/mob_stat.dm
@@ -11,7 +11,7 @@
 	var/is_construction_mode = 0
 
 	var/list/stats = list()
-	var/list/statNames = list("Map:","Next Map:","Map Vote Link:","Map Vote Time:","Map Vote Spacer","Vote Link:","Vote Time:","Vote Spacer","Game Mode:","Time To Start:","Server Load:","Shift Time Spacer","Shift Time:","Shuttle")
+	var/list/statNames = list("Map:","Next Map:","Map Vote Link:","Map Vote Time:","Map Vote Spacer","Vote Link:","Vote Time:","Vote Spacer","Game Mode:","Time To Start:","Server Load:","Shift Time Spacer","Shift Time:","Local Time:","Shuttle")
 	//above : ORDER IS IMPORANT
 
 	New()
@@ -31,6 +31,7 @@
 		stats["Server Load:"] = 0
 		stats["Shift Time Spacer"] = -1
 		stats["Shift Time:"] = 0
+		stats["Local Time:"] = 0
 		stats["Shuttle:"] = 0
 
 	proc/update()
@@ -101,6 +102,7 @@
 				stats["Time To Start:"] = 0
 				var/shiftTime = round(ticker.round_elapsed_ticks / 600)
 				saveStat("Shift Time:", "[shiftTime] minute[shiftTime == 1 ? "" : "s"]")
+				saveStat("Local Time:", time2text(world.timeofday, "hh:mm", world.timezone))
 
 				//MBC : nah we don't run construction anyway
 				//if (ticker.mode && istype(ticker.mode, /datum/game_mode/construction))

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -94,6 +94,7 @@
 				if(MODE_MAINMENU)
 					. += {"<h2>PERSONAL DATA ASSISTANT</h2>
 					Owner: [src.master.owner]<br>
+					Time: [time2text(world.timeofday, "DDD MMM DD, hh:mm:ss", world.timezone)]<br>
 
 					<h4>General Functions</h4>
 					<ul>

--- a/code/obj/item/device/pda2/base_os.dm
+++ b/code/obj/item/device/pda2/base_os.dm
@@ -94,7 +94,7 @@
 				if(MODE_MAINMENU)
 					. += {"<h2>PERSONAL DATA ASSISTANT</h2>
 					Owner: [src.master.owner]<br>
-					Time: [time2text(world.timeofday, "DDD MMM DD, hh:mm:ss", world.timezone)]<br>
+					Time: [time2text(world.timeofday, "DDD MMM DD, hh:mm:ss")]<br>
 
 					<h4>General Functions</h4>
 					<ul>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The current server time is displayed on the PDA home screen and the client status panel. It uses `world.timeofday`.

![image](https://user-images.githubusercontent.com/66253095/111090274-ecc88280-857a-11eb-809d-acaff5ea93e8.png)
![image](https://user-images.githubusercontent.com/66253095/111090285-f651ea80-857a-11eb-872c-1a65165cbaab.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's an interesting addition for roleplaying, and makes scheduling events and stuff more convincing. After all, would you rather tell your friend to meet you at the bar at 21:30, or at 90 minutes?

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DisturbHerb
(+)You can now check the time on your PDA or the status screen, hooray!
```
