### PR TITLE
Multitool powernet ID on unpowered cables

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -233,16 +233,15 @@
 
 		var/datum/powernet/PN = get_powernet()		// find the powernet
 		var/powernet_id = ""
-
+		if(ispulsingtool(W))
+			// 3 Octets: Netnum, 4 Octets: Nodes+Data Nodes*2, 4 Octets: Cable Count
+			powernet_id = " ID#[num2text(PN.number,3,8)]:[num2text(length(PN.nodes)+(length(PN.data_nodes)<<2),4,8)]:[num2text(length(PN.cables),4,8)]"
 		if(PN && (PN.avail > 0))		// is it powered?
-			if(ispulsingtool(W))
-				// 3 Octets: Netnum, 4 Octets: Nodes+Data Nodes*2, 4 Octets: Cable Count
-				powernet_id = " ID#[num2text(PN.number,3,8)]:[num2text(length(PN.nodes)+(length(PN.data_nodes)<<2),4,8)]:[num2text(length(PN.cables),4,8)]"
-
 			boutput(user, "<span class='alert'>[PN.avail]W in power network.[powernet_id]</span>")
 
 		else
-			boutput(user, "<span class='alert'>The cable is not powered.</span>")
+			boutput(user, "<span class='alert'>The cable is not powered. [powernet_id]</span>")
+
 
 		if(prob(40))
 			shock(user, 10)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The multitool only showed powernet ID's of powered cables, but power isn't necessary for a powernet. This gimped this functionality somewhat.

![image](https://user-images.githubusercontent.com/13049028/111137824-7c9b0c00-853c-11eb-8d2f-dd251a1ce715.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Same reason this was added, diagnostics good.

