### PR TITLE
Adds a hint to bloodpack on a beaker interaction

### DIFF
--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -385,6 +385,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 						boutput(user, "<span class='alert'>The [src.name] is full.</span>")
 				else
 					boutput(user, "The [W.name] is empty.")
+			else
+				boutput(user, "You need to slice open the [W.name] first!")
 
 			return
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a hint that, upon using a closed bloodpack on a container, tells the player that they need to slice open the bloodpack first to transfer the contents.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

New players have no way to learn that slicing open a bloodpack is a thing.  This PR changes it.

