### PR TITLE
updates skull mask creation to accept all saws

### DIFF
--- a/code/obj/item/organs/skull.dm
+++ b/code/obj/item/organs/skull.dm
@@ -102,7 +102,7 @@
 			qdel(src)
 			return
 
-		if (istype(W, /obj/item/circular_saw))
+		if (istool(TOOL_SAWING))
 			user.visible_message("<span class='notice'>[user] hollows out [src].</span>")
 			var/obj/item/clothing/mask/skull/smask = new /obj/item/clothing/mask/skull
 			playsound(user.loc, "sound/machines/mixer.ogg", 50, 1)

--- a/code/obj/item/organs/skull.dm
+++ b/code/obj/item/organs/skull.dm
@@ -102,7 +102,7 @@
 			qdel(src)
 			return
 
-		if (istool(TOOL_SAWING))
+		if (istool(W, TOOL_SAWING))
 			user.visible_message("<span class='notice'>[user] hollows out [src].</span>")
 			var/obj/item/clothing/mask/skull/smask = new /obj/item/clothing/mask/skull
 			playsound(user.loc, "sound/machines/mixer.ogg", 50, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes the skull mask creation use the istool proc, instead of checking for a circular saw. This will allow all of the multiple sawing tools to make skull masks, and make it so even a staffie that hasn't broken into medical can make a skull mask.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Skull masks aren't as easy to make as they should be if you have skulls.