### PR TITLE
Fixes an issue where vampires could inadvertently be booted to null space

### DIFF
--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -217,7 +217,7 @@
 	var/turf/coffin_turf = 0
 
 	//contains the reference to the coffin if we're currently travelling to it, otherwise null
-	var/obj/storage/closet/coffin/vampire/traveling_to_coffin = null
+	var/obj/storage/closet/coffin/vampire/the_coffin = null
 	//theres a bug where projectiles get unpooled and moved elsewhere before theyre done with their currnent firing
 	//badly affects 'travel' projectile. band aid.
 
@@ -230,11 +230,11 @@
 
 	onLife(var/mult = 1)
 		..()
-		if (!(traveling_to_coffin?.disposed) && isturf(owner.loc) && istype(traveling_to_coffin,/obj/storage/closet/coffin))
-			owner.set_loc(traveling_to_coffin)
+		if (!(the_coffin?.disposed) && isturf(owner.loc) && istype(the_coffin,/obj/storage/closet/coffin))
+			owner.set_loc(the_coffin)
 
 		if (istype(owner.loc,/obj/storage/closet/coffin))
-			traveling_to_coffin = null
+			the_coffin = null
 			if (isdead(owner))
 				owner.full_heal()
 			else
@@ -243,7 +243,7 @@
 	set_loc_callback(newloc)
 		if (istype(newloc,/obj/storage/closet/coffin))
 			//var/obj/storage/closet/coffin/C = newloc
-			traveling_to_coffin = null
+			the_coffin = null
 
 	proc/blood_tracking_output(var/deduct = 0)
 		if (!src.owner || !ismob(src.owner))

--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -216,7 +216,8 @@
 	var/list/ghouls = list()
 	var/turf/coffin_turf = 0
 
-	var/traveling_to_coffin = 0 //shitty projectile hacky fix
+	//contains the reference to the coffin if we're currently travelling to it, otherwise null
+	var/obj/storage/closet/coffin/vampire/traveling_to_coffin = null
 	//theres a bug where projectiles get unpooled and moved elsewhere before theyre done with their currnent firing
 	//badly affects 'travel' projectile. band aid.
 
@@ -229,11 +230,11 @@
 
 	onLife(var/mult = 1)
 		..()
-		if (traveling_to_coffin && isturf(owner.loc) && istype(traveling_to_coffin,/obj/storage/closet/coffin))
+		if (!(traveling_to_coffin?.disposed) && isturf(owner.loc) && istype(traveling_to_coffin,/obj/storage/closet/coffin))
 			owner.set_loc(traveling_to_coffin)
 
 		if (istype(owner.loc,/obj/storage/closet/coffin))
-			traveling_to_coffin = 0
+			traveling_to_coffin = null
 			if (isdead(owner))
 				owner.full_heal()
 			else
@@ -242,7 +243,7 @@
 	set_loc_callback(newloc)
 		if (istype(newloc,/obj/storage/closet/coffin))
 			//var/obj/storage/closet/coffin/C = newloc
-			traveling_to_coffin = 0
+			traveling_to_coffin = null
 
 	proc/blood_tracking_output(var/deduct = 0)
 		if (!src.owner || !ismob(src.owner))

--- a/code/datums/abilities/vampire/coffin.dm
+++ b/code/datums/abilities/vampire/coffin.dm
@@ -112,7 +112,7 @@
 		var/obj/storage/closet/coffin/vampire/coffin = new(spawnturf)
 		animate_buff_in(coffin)
 
-		V.traveling_to_coffin = coffin
+		V.the_coffin = coffin
 
 		var/obj/projectile/proj = initialize_projectile_ST(M, new/datum/projectile/special/homing/travel, spawnturf)
 		var/tries = 5

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -662,7 +662,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	tick(var/obj/projectile/P)
 		..()
 
-		if (!(P.targets && P.targets.len && !(P.targets[1]?.disposed)))
+		if (!(P.targets && P.targets.len && P.targets[1] && !(P.targets[1]:disposed)))
 			P.die()
 
 	on_end(var/obj/projectile/P)

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -662,7 +662,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	tick(var/obj/projectile/P)
 		..()
 
-		if (!(P.targets && P.targets.len && P.targets[1]))
+		if (!(P.targets && P.targets.len && !(P.targets[1]?.disposed)))
 			P.die()
 
 	on_end(var/obj/projectile/P)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. This happened when a vampire's coffin was destroyed while they were en route to it using the Coffin Escape ability.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes https://github.com/goonstation/goonstation/issues/2734
