### PR TITLE
Replaces Part-Time Vice Officer Token with Security Assistant Token

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2624,9 +2624,9 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 	slot_belt = /obj/item/device/pda2/security
 	slot_jump = /obj/item/clothing/under/misc/vice
 	slot_foot = /obj/item/clothing/shoes/brown
-	slot_ears =  /obj/item/device/radio/headset/security
+	slot_ears = /obj/item/device/radio/headset/security
 	slot_poc1 = /obj/item/storage/security_pouch //replaces sec starter kit
-	slot_poc2 = /obj/item/requisition_token/security
+	slot_poc2 = /obj/item/requisition_token/security/assistant
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the Part-Time Vice officers token with the ones used by Security Assistants


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Part Time Vice Officers should remain a gimmick, not an actual security officer with equipment.
Plus you'd think that Nanotrasen wouldn't entrust Security Equipment to a bunch of Part time stoners.
This shouldn't touch the Vice Officers job and only the daily job.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Nihisohel
(*)Replaces Part Time Viceoffs token with Assistant token
```
