### PR TITLE
removes detective's roundstart lethals 

### DIFF
--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -60,11 +60,10 @@
 /obj/item/storage/box/detectivegun
 	name = ".38 revolver box"
 	icon_state = "hard_case"
-	desc = "A box containing a .38 caliber revolver and ammunition."
+	desc = "A box containing a .38 caliber revolver and non-lethal ammunition."
 	// Reduced the amount of ammo. The detective had four lethal and five stun speedloaders total in his closet, perhaps a bit too much (Convair880).
 	spawn_contents = list(/obj/item/gun/kinetic/detectiverevolver,\
-	/obj/item/ammo/bullets/a38 = 2,\
-	/obj/item/ammo/bullets/a38/stun = 2)
+	/obj/item/ammo/bullets/a38/stun = 3)
 
 /obj/item/storage/box/ak47 // cogwerks, terrorism update
 	name = "rifle box"


### PR DESCRIPTION
[BALANCE][FEEDBACK]

## About the PR
removes lethals from det's revolver box, adds an extra nonlethal speedloader to compensate

## Why's this needed? 
too many stinky dets using lethals when lethals are not necessary, which i feel is compounded by the fact that they literally spawn with lethal rounds in their backpack. if the det really wants to kill people, they can either put in the effort required to have lethal bullets by hacking a secvend, which will get a few raised eyebrows from real sec, or begging the head of security for the ammotech speedloaders. or they can do it like the rest of us (with blunt objects). hopefully reduces pain caused by stinko detectives

detective is also not meant to be making arrests or killing people in the first place, they're meant to be a forensics role. the gun is there for self defense, and using lethals in self defense and having that behavior encouraged by spawning them with lethals is not good.

## Changelog
```changelog
(u)mopcat
(+)removes lethals from det's revolver box, adds an extra nonlethal speedloader to compensate
```
