### PR TITLE
Complete Donut 2 overhaul

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -135,11 +135,26 @@ var/global/list/mapNames = list(
 /datum/map_settings/donut2
 	name = "DONUT2"
 	goonhub_map = "https://goonhub.com/maps/donut2"
+	airlock_style = "pyro"
+	walls = /turf/simulated/wall/auto/supernorn
+	rwalls = /turf/simulated/wall/auto/reinforced/supernorn
+
 	escape_centcom = /area/shuttle/escape/centcom/donut2
 	escape_transit = /area/shuttle/escape/transit/donut2
 	escape_station = /area/shuttle/escape/station/donut2
 	escape_def = SHUTTLE_WEST
 	escape_dir = WEST
+
+	windows = /obj/window/auto
+	windows_thin = /obj/window/pyro
+	rwindows = /obj/window/auto/reinforced
+	rwindows_thin = /obj/window/reinforced/pyro
+	windows_crystal = /obj/window/auto/crystal
+	windows_rcrystal = /obj/window/auto/crystal/reinforced
+	window_layer_full = COG2_WINDOW_LAYER
+	window_layer_north = GRILLE_LAYER+0.1
+	window_layer_south = FLY_LAYER+1
+	auto_windows = 1
 
 	merchant_left_centcom = /area/shuttle/merchant_shuttle/left_centcom/donut2
 	merchant_left_station = /area/shuttle/merchant_shuttle/left_station/donut2

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -19428,6 +19428,7 @@
 	dir = 4;
 	name = "crematorium pipe"
 	},
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "aRb" = (
@@ -28439,7 +28440,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/glass,
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
@@ -28450,6 +28450,7 @@
 	icon_state = "2-8"
 	},
 /obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/security,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bjH" = (
@@ -33581,10 +33582,6 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "bve" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = -1
-	},
 /obj/disposalpipe/segment,
 /obj/stool/chair{
 	dir = 1;
@@ -33681,6 +33678,9 @@
 	c_tag = "autotag";
 	dir = 0;
 	name = "autoname - SS13"
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -34101,6 +34101,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "bwg" = (
@@ -34719,6 +34720,10 @@
 /obj/item/clothing/mask/breath{
 	pixel_x = -4;
 	pixel_y = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/red/checker{
 	dir = 4
@@ -40855,6 +40860,10 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/ranch)
+"erP" = (
+/obj/machinery/light,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/juryroom)
 "euy" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'Outpost mail hub'";
@@ -41670,6 +41679,14 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
+"jNf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/stairs{
+	dir = 4
+	},
+/area/station/hangar/sec)
 "jOp" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/brig,
@@ -43065,6 +43082,10 @@
 "sfE" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/arrivals)
+"shz" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "sih" = (
 /obj/cable{
 	d1 = 4;
@@ -43375,6 +43396,11 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"tvL" = (
+/obj/disposalpipe/segment,
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "txI" = (
 /obj/cable{
 	d1 = 4;
@@ -43770,6 +43796,13 @@
 /turf/space,
 /turf/simulated/floor,
 /area/station/science/lab)
+"vrM" = (
+/obj/machinery/vehicle/pod_smooth/heavy{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/sec)
 "vuf" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor,
@@ -58422,7 +58455,7 @@ bjx
 aVj
 aVi
 aVZ
-aSE
+shz
 aXu
 aYl
 aSE
@@ -59328,7 +59361,7 @@ aUB
 aUA
 aZb
 aWa
-aZb
+tvL
 aXv
 aYm
 aZb
@@ -82920,7 +82953,7 @@ bre
 bzM
 btY
 bvd
-bwh
+erP
 btU
 bpw
 byF
@@ -88656,7 +88689,7 @@ bgL
 bgL
 bgL
 bgL
-bvo
+jNf
 bvo
 bwy
 buj
@@ -89869,7 +89902,7 @@ bvr
 byQ
 bvq
 bvq
-byQ
+vrM
 buj
 aaa
 aaa

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -8363,14 +8363,6 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "asL" = (
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
 /obj/table/reinforced,
 /obj/cable{
 	d1 = 4;
@@ -8379,6 +8371,8 @@
 	},
 /obj/item/hand_labeler,
 /obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "asM" = (
@@ -8576,7 +8570,6 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/access_spawn/cargo,
 /obj/cable{
@@ -30303,7 +30296,6 @@
 /area/station/maintenance/southwest)
 "bnF" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/alt,
 /obj/access_spawn/kitchen,
 /turf/simulated/floor/specialroom/freezer,
@@ -32838,6 +32830,9 @@
 "btr" = (
 /obj/table/reinforced/auto,
 /obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/kitchen)
 "bts" = (
@@ -35175,15 +35170,11 @@
 /area/station/security/brig)
 "byl" = (
 /obj/table/reinforced/auto,
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
 /obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/access_spawn/hydro,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "bym" = (
@@ -35539,14 +35530,9 @@
 	pixel_y = 0
 	},
 /obj/table/reinforced/auto,
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 1
-	},
 /obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/engineering_mechanic,
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
@@ -36502,14 +36488,6 @@
 	icon_state = "pipe-s"
 	},
 /obj/table/reinforced/auto,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
 /obj/item/clipboard,
 /obj/item/pen/marker/blue,
 /obj/item/pen/marker/red,
@@ -36523,6 +36501,10 @@
 	name = "do-it-yourself joint construction kit"
 	},
 /obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/access_spawn/hydro,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "bBp" = (
@@ -38415,13 +38397,6 @@
 /area/station/solar/east)
 "bFC" = (
 /obj/table/reinforced/auto,
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 1
-	},
 /obj/item/clipboard,
 /obj/item/paper_bin,
 /obj/item/pen/marker/blue,
@@ -38430,6 +38405,8 @@
 	pixel_x = -7
 	},
 /obj/item/stamp,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/engineering_mechanic,
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -41935,6 +41935,9 @@
 /area/station/quartermaster/refinery)
 "loM" = (
 /obj/stool/chair/yellow,
+/obj/landmark/start{
+	name = "Miner"
+	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "ltc" = (
@@ -43153,6 +43156,9 @@
 /obj/stool/chair/yellow{
 	dir = 8
 	},
+/obj/landmark/start{
+	name = "Miner"
+	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "thY" = (
@@ -43183,6 +43189,9 @@
 "tmp" = (
 /obj/stool/chair/yellow{
 	dir = 1
+	},
+/obj/landmark/start{
+	name = "Miner"
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
@@ -43223,6 +43232,9 @@
 /area/station/maintenance/south)
 "tAY" = (
 /obj/stool/chair/yellow,
+/obj/landmark/start{
+	name = "Miner"
+	},
 /turf/simulated/floor/yellow/corner{
 	dir = 4
 	},

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -77,7 +77,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/wall,
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
 /area/listeningpost)
 "aan" = (
 /turf/simulated/wall/asteroid{
@@ -270,7 +272,9 @@
 /area/listeningpost)
 "aaL" = (
 /obj/securearea,
-/turf/simulated/shuttle/wall,
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
 /area/listeningpost)
 "aaM" = (
 /obj/cable{
@@ -848,13 +852,12 @@
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "acj" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
 	id = "scienceteleporter";
 	name = "teleporter lockdown"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "ack" = (
@@ -880,6 +883,7 @@
 	message = "1";
 	name = "mail chute-'Science Teleporter'"
 	},
+/obj/disposalpipe/trunk/mail,
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 1
 	},
@@ -948,6 +952,7 @@
 	dir = 8;
 	icon_state = "chair"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "acu" = (
@@ -1018,11 +1023,6 @@
 	dir = 5
 	},
 /area/station/science/teleporter)
-"acE" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/wall/auto/supernorn,
-/area/station/science/teleporter)
 "acF" = (
 /obj/lattice{
 	dir = 1;
@@ -1038,23 +1038,22 @@
 /turf/space,
 /area/space)
 "acH" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/door/poddoor/pyro{
 	id = "scienceteleporter";
 	name = "teleporter lockdown"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "acI" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/glass,
 /obj/machinery/door/poddoor/pyro{
 	id = "scienceteleporter";
 	name = "teleporter lockdown"
 	},
+/obj/machinery/door/airlock/pyro/glass/sci,
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "acJ" = (
@@ -1094,6 +1093,10 @@
 "acO" = (
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/orangeblack/corner/white{
 	dir = 1
@@ -1148,6 +1151,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "acV" = (
@@ -1233,6 +1237,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/orangeblack/side/white,
 /area/station/science/teleporter)
 "adg" = (
@@ -1265,13 +1270,6 @@
 /area/station/science/teleporter)
 "adj" = (
 /obj/machinery/vending/monkey,
-/mob/living/carbon/human/monkey,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/science/chemistry)
-"adk" = (
-/mob/living/carbon/human/monkey,
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -1301,15 +1299,6 @@
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
-/area/station/science/chemistry)
-"adn" = (
-/obj/grille/steel,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "ado" = (
 /obj/storage/secure/closet/animal,
@@ -1346,19 +1335,6 @@
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/shuttle/brig/outpost)
-"adu" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/medical{
-	name = "Teleporter Control Room";
-	req_access_txt = "8"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/science/teleporter)
 "adv" = (
 /obj/overlay{
 	anchored = 1;
@@ -1375,7 +1351,6 @@
 /obj/landmark/spawner{
 	name = "monkeyspawn_normal"
 	},
-/mob/living/carbon/human/monkey,
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -1391,12 +1366,11 @@
 	},
 /area/station/science/chemistry)
 "ady" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Monkey Pen";
-	req_access_txt = "5"
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4
 	},
+/obj/access_spawn/chemistry,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white/checker{
 	dir = 4
 	},
@@ -1430,41 +1404,20 @@
 /turf/simulated/floor/caution/south,
 /area/station/science/lobby)
 "adE" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	name = "VACUUM AREA"
 	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "adF" = (
-/obj/machinery/door/airlock/pyro/external{
-	name = "outpost external airlock";
-	req_access_txt = "11"
-	},
+/obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/delivery,
 /area/station/security/prison)
 "adG" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/teleporter)
 "adH" = (
@@ -1473,32 +1426,21 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 1
 	},
 /area/station/science/teleporter)
-"adI" = (
-/obj/grille/steel,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/science/chemistry)
 "adJ" = (
-/obj/grille/steel,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "adK" = (
-/obj/grille/steel,
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -1507,17 +1449,16 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "adL" = (
-/obj/grille/steel,
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "adM" = (
@@ -1529,8 +1470,7 @@
 	},
 /area/station/science/chemistry)
 "adO" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/airless,
 /area/station/science/lobby)
 "adP" = (
@@ -1545,8 +1485,7 @@
 /turf/space,
 /area/space)
 "adR" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "adS" = (
@@ -1558,22 +1497,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "adU" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/ai_monitored/storage/secure)
-"adV" = (
-/obj/machinery/door/poddoor/pyro{
-	id = "mixvent";
-	layer = 8;
-	name = "Mixing Vent"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4;
+	icon_state = "12";
+	initialize_directions = 12
 	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
+/turf/space,
+/area/space)
+"adV" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/space,
+/area/space)
 "adW" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "adX" = (
@@ -1661,8 +1601,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/prison)
 "aei" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
 "aej" = (
@@ -1675,35 +1614,32 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
-"aek" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
 "ael" = (
-/turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
-"aem" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/junction{
+	dir = 1
 	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
+/turf/space,
+/area/space)
+"aem" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/white,
+/area/station/science/teleporter)
 "aen" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light{
-	dir = 1;
-	name = "light fixture"
+/obj/machinery/driver_button{
+	desc = "An emergency ejection button.  Maybe some antique gizmo turns out to be an active bomb or something.  Maybe you want it away from you then.";
+	id = "artlabgun";
+	name = "Emergency Ejection Button";
+	pixel_x = 0;
+	pixel_y = 24
 	},
 /turf/simulated/floor/greenwhite/other{
 	dir = 9
 	},
 /area/station/science/lobby)
 "aeo" = (
-/obj/machinery/vending/snack,
 /turf/simulated/floor/greenwhite/other{
 	dir = 1
 	},
@@ -1752,19 +1688,18 @@
 /area/station/science/chemistry)
 "aew" = (
 /obj/decal/cleanable/cobweb,
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "aex" = (
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "aey" = (
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "aez" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "aeA" = (
@@ -1787,6 +1722,10 @@
 /area/station/security/prison)
 "aeE" = (
 /obj/storage/secure/closet/command/research_director,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
 "aeF" = (
@@ -1809,13 +1748,10 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
 "aeI" = (
-/obj/machinery/sparker{
-	id = "mixingsparker";
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold/northeast,
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "aeJ" = (
 /turf/simulated/floor/greenwhite/other{
 	dir = 8
@@ -1824,6 +1760,10 @@
 "aeK" = (
 /obj/machinery/chem_master{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 8
@@ -1851,13 +1791,11 @@
 /turf/simulated/floor/purple,
 /area/station/science/chemistry)
 "aeO" = (
-/obj/landmark/start{
-	name = "Chemist"
+/obj/machinery/door/poddoor/pyro/podbay_autoclose{
+	id = "artlabgun"
 	},
-/turf/simulated/floor/purplewhite{
-	dir = 8
-	},
-/area/station/science/chemistry)
+/turf/simulated/floor/plating,
+/area/station/science/lobby)
 "aeP" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Zeta_South";
@@ -1866,10 +1804,10 @@
 /turf/simulated/floor,
 /area/station/science/lobby)
 "aeQ" = (
-/obj/machinery/portable_atmospherics/canister/air,
 /obj/window{
 	dir = 2
 	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "aeR" = (
@@ -1888,13 +1826,15 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/table/auto,
+/obj/machinery/recharger,
 /turf/simulated/floor/black,
 /area/station/security/prison)
 "aeU" = (
-/obj/machinery/power/data_terminal,
 /obj/cable{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/security/prison)
@@ -1937,26 +1877,16 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
 "afa" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 2;
-	icon_state = "on";
-	on = 1
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	name = "purge valve"
 	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "afb" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
-	external_pressure_bound = 0;
-	icon_state = "in";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	on = 1;
-	pressure_checks = 2;
-	pump_direction = 0
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
+/obj/machinery/atmospherics/pipe/simple/insulated/southeast,
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "afc" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Zeta_West";
@@ -1966,7 +1896,9 @@
 /area/station/science/lobby)
 "afd" = (
 /obj/stool/bench/green/auto,
-/turf/simulated/floor,
+/turf/simulated/floor/greenwhite/other{
+	dir = 4
+	},
 /area/station/science/lobby)
 "afe" = (
 /obj/machinery/chem_dispenser,
@@ -2116,11 +2048,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Research Director's Office";
-	req_access_txt = "19"
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 8
 	},
+/obj/access_spawn/research_director,
 /turf/simulated/floor/white/side{
 	dir = 4
 	},
@@ -2170,34 +2101,18 @@
 /obj/table/auto,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
-"afx" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	name = "VACUUM AREA"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/ai_monitored/storage/secure)
 "afy" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/glass{
-	autoclose = 0;
-	frequency = 1449;
-	icon_state = "glass_locked";
-	id_tag = "tox_airlock_exterior";
-	locked = 1;
-	name = "Toxins Research Access";
-	req_access_txt = "7"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "afz" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
 /obj/stool/bench/green/auto,
-/turf/simulated/floor,
+/turf/simulated/floor/greenwhite/other{
+	dir = 4
+	},
 /area/station/science/lobby)
 "afA" = (
 /obj/machinery/chem_heater,
@@ -2210,18 +2125,14 @@
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "afC" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/mass_driver{
+	desc = "A device that launches objects, like ANCIENT BOMBS, for example, on it at great velocity when activated.";
+	dir = 1;
+	drive_range = 100;
+	id = "artlabgun"
 	},
-/obj/landmark/start{
-	name = "Chemist"
-	},
-/turf/simulated/floor/purplewhite{
-	dir = 4
-	},
-/area/station/science/chemistry)
+/turf/simulated/floor/plating,
+/area/station/science/lobby)
 "afD" = (
 /obj/item/storage/firstaid/regular,
 /obj/table/reinforced/chemistry/auto,
@@ -2256,24 +2167,23 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/window{
 	dir = 2
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "afJ" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/window{
 	dir = 2
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "afK" = (
-/obj/machinery/door/airlock{
-	req_access_txt = null
-	},
+/obj/machinery/door/airlock/pyro/glass/sci,
 /obj/access_spawn/tox_storage,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "afL" = (
@@ -2283,6 +2193,9 @@
 	icon_state = "1-2"
 	},
 /obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/research_director,
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/security/prison)
 "afM" = (
@@ -2367,39 +2280,32 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "afS" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/storage/secure)
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/decal/tile_edge/line/red,
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "afT" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "tox_airlock_sensor";
-	master_tag = "tox_airlock_control";
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
+/obj/machinery/atmospherics/pipe/simple/insulated/horizontal,
+/obj/machinery/light,
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "afU" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1449;
-	id = "tox_airlock_pump"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
+/obj/machinery/atmospherics/pipe/manifold/south,
+/obj/machinery/light,
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "afV" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 10;
-	icon_state = "intact";
-	layer = 3;
-	level = 2
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/storage/secure)
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "afW" = (
 /turf/simulated/shuttle/wall{
 	dir = 8;
@@ -2463,15 +2369,10 @@
 	},
 /area/station/science/chemistry)
 "agc" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/purplewhite/corner{
-	dir = 1
-	},
-/area/station/science/chemistry)
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/research,
+/turf/simulated/floor/plating,
+/area/station/science/lobby)
 "agd" = (
 /obj/machinery/light{
 	dir = 4;
@@ -2480,23 +2381,14 @@
 /obj/submachine/chem_extractor{
 	dir = 8
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/purplewhite{
 	dir = 4
 	},
 /area/station/science/chemistry)
 "age" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/chemistry)
+/obj/table/auto,
+/turf/simulated/floor/black,
+/area/station/security/prison)
 "agf" = (
 /obj/cable{
 	d1 = 4;
@@ -2506,13 +2398,14 @@
 /turf/simulated/floor,
 /area/station/science/lobby)
 "agg" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/storage)
+/turf/simulated/floor/greenwhite/other{
+	dir = 8
+	},
+/area/station/science/lobby)
 "agh" = (
 /obj/cable{
 	d2 = 4;
@@ -2524,10 +2417,7 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "agi" = (
@@ -2545,13 +2435,18 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/science/storage)
-"agk" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/science/storage)
+"agk" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -2560,54 +2455,41 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/nuclear_charge,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "agm" = (
-/obj/stool/chair{
+/obj/machinery/vending/snack,
+/turf/simulated/floor/greenwhite/other{
 	dir = 4
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/checker{
-	dir = 4
-	},
-/area/station/security/prison)
+/area/station/science/lobby)
 "agn" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/greenwhite/other{
+	dir = 4
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/red,
-/area/station/security/prison)
+/area/station/science/lobby)
 "ago" = (
 /turf/simulated/floor/red/checker{
 	dir = 4
 	},
 /area/station/security/prison)
 "agp" = (
-/obj/machinery/door/airlock/security{
-	name = "Outpost Security";
-	req_access_txt = "11"
-	},
 /obj/machinery/secscanner{
 	dir = 4;
 	icon_state = "scanner_on";
 	pixel_x = -20
+	},
+/obj/machinery/door/airlock/pyro/security/alt{
+	dir = 4
+	},
+/obj/access_spawn/research_director,
+/obj/access_spawn/security,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/red,
 /area/station/security/prison)
@@ -2617,20 +2499,31 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/black,
 /area/station/security/prison)
 "agr" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
 /area/station/security/prison)
 "ags" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4";
 	pixel_y = 0
+	},
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
@@ -2651,6 +2544,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
 "agu" = (
@@ -2663,6 +2560,9 @@
 	},
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/disposalpipe/trunk/mail{
+	dir = 8
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
@@ -2684,57 +2584,19 @@
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
-"agx" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	frequency = 1225;
-	icon_state = "intact_on";
-	id = "Burn Chamber Gas Injector";
-	on = 1
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/storage/secure)
 "agy" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/glass{
-	autoclose = 0;
-	frequency = 1449;
-	icon_state = "glass_locked";
-	id_tag = "tox_airlock_exterior";
-	locked = 1;
-	name = "Toxins Research Access";
-	req_access_txt = "7"
-	},
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
-"agz" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 0;
-	frequency = 1225;
-	icon_state = "intact_on";
-	id = "Burn Chamber Gas Extractor";
-	on = 1
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/storage/secure)
-"agA" = (
-/obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
-	level = 2
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/storage/secure)
+/obj/machinery/door/airlock/pyro/sci_alt,
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "agB" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance{
-	req_access_txt = null
-	},
+/obj/machinery/door/airlock/pyro/sci_alt,
 /obj/access_spawn/tox_storage,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/science/storage)
 "agC" = (
@@ -2753,7 +2615,9 @@
 	pixel_y = 0
 	},
 /obj/stool/bench/green/auto,
-/turf/simulated/floor,
+/turf/simulated/floor/greenwhite/other{
+	dir = 4
+	},
 /area/station/science/lobby)
 "agF" = (
 /obj/machinery/chem_master{
@@ -2813,21 +2677,26 @@
 	message = 1;
 	name = "mail chute-'Chemistry'"
 	},
+/obj/disposalpipe/trunk/mail,
 /turf/simulated/floor/purplewhite,
 /area/station/science/chemistry)
 "agK" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/purplewhite,
-/area/station/science/chemistry)
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
 "agL" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -2865,11 +2734,6 @@
 /turf/simulated/floor/plating,
 /area/station/science/storage)
 "agP" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/crowbar,
 /turf/simulated/floor/plating,
 /area/station/science/storage)
@@ -2890,6 +2754,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/red,
 /area/station/security/prison)
@@ -2957,81 +2825,62 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/orangeblack/side/white,
 /area/station/science/teleporter)
 "aha" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	airpump_tag = "tox_airlock_pump";
-	exterior_door_tag = "tox_airlock_exterior";
-	id_tag = "tox_airlock_control";
-	interior_door_tag = "tox_airlock_interior";
-	pixel_x = 0;
-	pixel_y = 24;
-	sanitize_external = 1;
-	sensor_tag = "tox_airlock_sensor"
+/obj/table/reinforced/chemistry/auto,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
 	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/screwdriver,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
-/obj/item/assembly/time_ignite,
-/obj/item/assembly/time_ignite,
-/obj/item/assembly/time_ignite,
-/obj/item/device/igniter,
-/obj/item/device/igniter,
-/obj/item/device/igniter,
-/obj/item/device/igniter,
-/obj/table/reinforced/chemistry/auto,
 /turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
-"ahb" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5;
-	icon_state = "intact"
-	},
-/obj/machinery/ignition_switch{
-	id = "mixingsparker";
-	pixel_x = 10;
-	pixel_y = 24
-	},
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
 "ahc" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10;
-	icon_state = "intact"
-	},
 /turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
 "ahd" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/door_control{
-	id = "mixvent";
-	name = "Mixing Room Vent Control";
-	pixel_x = 10;
-	pixel_y = 24
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/line/red,
+/turf/simulated/floor,
+/area/station/science/lab)
 "ahe" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 1
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/turf/simulated/floor/bot/white,
-/area/station/ai_monitored/storage/secure)
+/obj/machinery/door_control{
+	id = "tox_vent2";
+	name = "Chamber 2 Exhaust";
+	pixel_x = 23;
+	pixel_y = -9
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/grime{
+	dir = 8
+	},
+/area/station/science/lab)
 "ahf" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	external_pressure_bound = 0;
-	icon_state = "in";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	on = 1;
-	pressure_checks = 2;
-	pump_direction = 0
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
 "ahg" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio,
@@ -3072,7 +2921,10 @@
 	message = 1;
 	name = "mail chute-'Research Outpost'"
 	},
-/turf/simulated/floor,
+/obj/disposalpipe/trunk/mail,
+/turf/simulated/floor/greenwhite/other{
+	dir = 4
+	},
 /area/station/science/lobby)
 "ahk" = (
 /obj/securearea{
@@ -3088,50 +2940,46 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/medical{
-	name = "Chemistry Department Access";
-	req_access_txt = "33"
-	},
+/obj/machinery/door/airlock/pyro/glass/sci,
+/obj/access_spawn/chemistry,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "ahm" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4";
 	pixel_y = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "ahn" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	icon_state = "2-4"
 	},
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "aho" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
 "ahp" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/sci,
+/obj/access_spawn/research,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "ahq" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -3143,6 +2991,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "ahr" = (
@@ -3151,15 +3000,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/science/storage)
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
 "ahs" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass,
+/obj/machinery/door/airlock/pyro/glass/sci,
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/red,
 /area/station/security/prison)
 "aht" = (
@@ -3180,67 +3036,72 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/medical{
-	name = "Teleporter Control Room";
-	req_access_txt = "8"
-	},
+/obj/machinery/door/airlock/pyro/sci_alt,
+/obj/access_spawn/research,
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/orangeblack,
 /area/station/science/teleporter)
 "ahw" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/power/data_terminal,
 /obj/machinery/networked/storage/bomb_tester{
 	bank_id = "Mixer"
 	},
 /turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
 "ahx" = (
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
-"ahy" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 8;
-	icon_state = "manifold";
-	level = 2
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
 "ahz" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4;
-	icon_state = "intact"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
-/obj/machinery/atmospherics/valve,
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/turf/simulated/floor,
+/area/station/science/lab)
 "ahA" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/turf/simulated/floor/grime{
+	dir = 8
+	},
+/area/station/science/lab)
 "ahB" = (
-/obj/grille/steel,
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4;
-	icon_state = "intact";
-	layer = 3;
-	level = 2
-	},
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/ai_monitored/storage/secure)
-"ahC" = (
-/obj/machinery/door/poddoor/pyro{
-	dir = 4;
-	id = "mixingwaste";
-	name = "Waste Vent"
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/vacuum,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
+"ahC" = (
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/test_apparatus/gas_sensor{
+	setup_tag = "TOP"
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
 "ahD" = (
 /obj/table/auto,
 /obj/item/paper_bin{
@@ -3276,41 +3137,35 @@
 	},
 /area/shuttle/research/outpost)
 "ahH" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	name = "VACUUM AREA"
 	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "ahI" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4
+	},
+/obj/access_spawn/research,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "ahJ" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/purple/corner{
 	dir = 8
 	},
@@ -3319,6 +3174,10 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 1
@@ -3330,11 +3189,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
 /area/station/science/lobby)
 "ahM" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -3346,6 +3213,10 @@
 	name = "Outpost Camera";
 	network = "Zeta"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -3355,20 +3226,34 @@
 	pixel_y = 24;
 	text = "NF"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
 	},
 /area/station/science/lobby)
 "ahP" = (
-/obj/machinery/door/firedoor/pyro{
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/machinery/door/airlock/pyro/glass/sci{
 	dir = 4
 	},
+/obj/access_spawn/research,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "ahQ" = (
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -3386,14 +3271,13 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -3420,6 +3304,10 @@
 	pixel_y = 24;
 	text = "NF"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "ahV" = (
@@ -3432,6 +3320,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/red/corner{
 	dir = 4
 	},
@@ -3441,6 +3333,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -3462,6 +3358,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/switch_junction{
+	dir = 8;
+	mail_tag = "research_director";
+	name = "RD mail router"
+	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -3474,6 +3375,10 @@
 	},
 /obj/item/storage/wall/medical{
 	pixel_y = 32
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -3493,6 +3398,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/escape/corner{
 	dir = 1
 	},
@@ -3509,6 +3418,13 @@
 	name = "Outpost Camera";
 	network = "Zeta"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "aib" = (
@@ -3517,9 +3433,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro{
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/machinery/door/airlock/pyro/glass/sci{
 	dir = 4
 	},
+/obj/access_spawn/research,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "aic" = (
@@ -3531,6 +3453,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/orangeblack/corner{
 	dir = 4
@@ -3547,6 +3473,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/disposalpipe/switch_junction{
+	dir = 8;
+	mail_tag = "telesci";
+	name = "telesci mail router"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
@@ -3557,6 +3488,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
 	},
@@ -3565,12 +3500,16 @@
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/toxin,
 /obj/storage/closet/fire,
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "aig" = (
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -3578,85 +3517,62 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/machinery/camera{
-	c_tag = "Mixing Room";
-	dir = 4;
-	name = "Outpost Camera";
-	network = "Zeta"
-	},
-/obj/cable,
+/obj/table/reinforced/chemistry/auto,
 /obj/item/clothing/glasses/vr{
 	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
 	network = "bombtest";
-	pixel_x = 2;
 	pixel_y = 5
 	},
 /obj/item/clothing/glasses/vr{
 	desc = "A pair of VR goggles connected to a virtual bomb test chamber.  How fancy!";
 	network = "bombtest";
-	pixel_x = 0;
-	pixel_y = 0
+	pixel_y = 11
 	},
-/obj/table/reinforced/chemistry/auto,
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
-"aih" = (
-/obj/item/device/prox_sensor{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/device/prox_sensor{
-	pixel_x = 8;
-	pixel_y = -4
-	},
-/obj/item/device/prox_sensor{
-	pixel_x = 2;
-	pixel_y = -8
-	},
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
-"aii" = (
-/obj/machinery/atmospherics/valve,
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
-"aij" = (
-/obj/machinery/door_control{
-	id = "mixingwaste";
-	name = "Waste Vent Control";
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/wirecutters,
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
-"aik" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
+/obj/machinery/light{
 	dir = 8;
-	icon_state = "rwindow"
+	icon_state = "tube1"
 	},
-/obj/window/reinforced{
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"aih" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"aij" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
 	dir = 4;
-	icon_state = "rwindow"
+	icon_state = "tube1"
 	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
+/turf/simulated/floor/grime,
+/area/station/science/lab)
+"aik" = (
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/shuttle{
 	icon_state = "floor6"
 	},
 /area/shuttle/research/outpost)
 "ail" = (
 /obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/access_spawn/research,
+/obj/forcefield/energyshield/perma{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
 	dir = 4;
-	name = "Zeta Access";
-	req_access_txt = "24|5"
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor6"
@@ -3664,10 +3580,9 @@
 /area/shuttle/research/outpost)
 "aim" = (
 /obj/machinery/door/airlock/pyro/external{
-	dir = 4;
-	name = "Zeta Access";
-	req_access_txt = "24|5"
+	dir = 4
 	},
+/obj/access_spawn/research,
 /turf/simulated/floor/delivery,
 /area/station/science/lobby)
 "ain" = (
@@ -3687,7 +3602,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/greenwhite/other{
+	dir = 4
+	},
 /area/station/science/lobby)
 "aip" = (
 /obj/cable{
@@ -3705,13 +3622,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Research Outpost Zeta"
-	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "aiq" = (
@@ -3730,16 +3641,16 @@
 "air" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/science/lobby)
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/white,
+/area/station/crew_quarters/observatory)
 "ais" = (
 /obj/cable{
 	d2 = 2;
@@ -3759,43 +3670,72 @@
 	codes_txt = "patrol;next_patrol=Zeta_North";
 	location = "Zeta_East"
 	},
+/obj/disposalpipe/switch_junction/left/north{
+	mail_tag = "toxins";
+	name = "toxins mail junction"
+	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "aiu" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/machinery/door/airlock/pyro/sci_alt{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/tox,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/medical{
-	dir = 4;
-	name = "Mixing Room";
-	req_access_txt = "8"
-	},
 /turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
 "aiv" = (
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /obj/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
 "aiw" = (
 /obj/machinery/atmospherics/portables_connector{
-	dir = 1
+	dir = 4
 	},
-/turf/simulated/floor/bot/white,
-/area/station/ai_monitored/storage/secure)
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/line/blue,
+/turf/simulated/floor,
+/area/station/science/lab)
 "aix" = (
 /obj/machinery/computer/atmosphere/pumpcontrol{
 	dir = 8;
-	icon_state = "computer_generic"
+	frequency = 1229
 	},
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/door_control{
+	id = "tox_mix";
+	name = "Mixing Vent Control";
+	pixel_x = 24
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "aiy" = (
 /obj/cable{
 	d1 = 2;
@@ -3812,26 +3752,52 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/obj/disposalpipe/switch_junction{
+	dir = 4;
+	mail_tag = "research_hangar";
+	name = "research hangar mail router"
+	},
+/turf/simulated/floor/greenwhite/other{
+	dir = 4
+	},
 /area/station/science/lobby)
 "aiA" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4
+	},
+/obj/access_spawn/research,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
 "aiB" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor{
 	icon_state = "orangecorner"
 	},
 /area/station/science/lobby)
 "aiC" = (
 /obj/machinery/light,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor{
 	icon_state = "orange"
 	},
 /area/station/science/lobby)
 "aiD" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor{
 	icon_state = "orange"
 	},
@@ -3842,11 +3808,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor{
 	icon_state = "orange"
 	},
 /area/station/science/lobby)
 "aiF" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "orangecorner"
@@ -3870,6 +3844,10 @@
 /area/station/science/lobby)
 "aiI" = (
 /obj/machinery/light,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "aiJ" = (
@@ -3878,6 +3856,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/neutral/corner,
 /area/station/science/lobby)
 "aiK" = (
@@ -3885,6 +3867,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 2
@@ -3895,6 +3881,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 8
@@ -3910,6 +3900,10 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/science/lobby)
 "aiN" = (
@@ -3919,20 +3913,10 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
 "aiO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/screwdriver{
-	pixel_y = 20
-	},
-/obj/machinery/light_switch{
-	name = "W light switch";
-	pixel_x = -24;
-	pixel_y = 0
+/obj/disposalpipe/trunk/mail{
+	dir = 1
 	},
 /obj/machinery/disposal/mail{
 	mail_tag = "toxins";
@@ -3940,8 +3924,13 @@
 	message = "1";
 	name = "mail chute-'Toxins'"
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
 "aiP" = (
 /obj/cable{
 	d1 = 2;
@@ -3949,104 +3938,85 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
 "aiQ" = (
-/obj/machinery/dispenser{
-	o2tanks = 10;
-	pltanks = 10
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
 "aiR" = (
 /obj/cable,
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/research_shuttle{
-	dir = 4
-	},
+/obj/machinery/computer/research_shuttle,
 /turf/simulated/floor/greenwhite/other{
-	dir = 10
+	dir = 8
 	},
 /area/station/science/lobby)
 "aiS" = (
-/obj/stool/bench/green/auto,
-/turf/simulated/floor/greenwhite/other,
-/area/station/science/lobby)
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/white,
+/area/station/science/teleporter)
 "aiT" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/storage/closet/emergency,
+/obj/disposalpipe/segment/mail,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/greenwhite/other{
-	dir = 6
+	dir = 4
 	},
 /area/station/science/lobby)
 "aiU" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/artifact)
 "aiV" = (
-/obj/machinery/door/airlock/pyro/medical{
-	dir = 2;
-	name = "Artifact Lab";
-	req_access_txt = "8"
-	},
+/obj/machinery/door/airlock/pyro/glass/sci,
+/obj/access_spawn/research,
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "aiW" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4";
 	pixel_y = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "aiX" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9;
-	icon_state = "intact";
-	layer = 3;
-	level = 2
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/table/reinforced/chemistry/auto,
-/obj/item/device/timer{
-	pixel_x = -3;
-	pixel_y = -5
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/machinery/door_control{
+	id = "tox_vent1";
+	name = "Chamber 1 Exhaust";
+	pixel_x = 23;
+	pixel_y = 10
 	},
-/obj/item/device/timer{
-	pixel_x = -3;
-	pixel_y = -5
-	},
-/obj/item/device/timer{
-	pixel_x = -3;
-	pixel_y = -5
-	},
-/obj/item/device/timer,
-/obj/item/device/timer{
-	pixel_x = -3;
-	pixel_y = -5
-	},
-/obj/item/device/timer{
-	pixel_x = 4;
-	pixel_y = -8
-	},
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/turf/simulated/floor,
+/area/station/science/lab)
 "aiY" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
 "aiZ" = (
@@ -4057,13 +4027,18 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/lobby)
 "ajb" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "ajc" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/glass,
+/obj/machinery/door/airlock/pyro/glass/sci,
+/obj/access_spawn/research,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/observatory)
 "ajd" = (
@@ -4072,24 +4047,26 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/science/lobby)
+/turf/simulated/floor/white,
+/area/station/crew_quarters/observatory)
 "aje" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "ajf" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/sci,
+/obj/access_spawn/research,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -4099,59 +4076,66 @@
 /area/station/science/bot_storage)
 "ajh" = (
 /obj/plasticflaps,
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/caution/northsouth,
 /area/station/science/bot_storage)
 "aji" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Guardbot Depot";
-	req_access_txt = "8"
-	},
+/obj/machinery/door/airlock/pyro/sci_alt,
+/obj/access_spawn/research,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "ajj" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/bot_storage)
 "ajk" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/obj/item/weldingtool,
-/obj/item/screwdriver{
+/obj/item/device/prox_sensor{
+	pixel_x = -8;
 	pixel_y = 10
 	},
-/obj/table/reinforced/chemistry/auto,
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
-"ajl" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/item/wrench,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/device/prox_sensor{
+	pixel_x = 1;
+	pixel_y = 10
 	},
-/turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
-"ajm" = (
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/bot/white,
-/area/station/ai_monitored/storage/secure)
-"ajn" = (
+/obj/item/device/prox_sensor{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/item/assembly/time_ignite{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/assembly/time_ignite{
+	pixel_x = 10;
+	pixel_y = -2
+	},
+/obj/item/assembly/time_ignite{
+	pixel_x = -9;
+	pixel_y = -2
+	},
+/obj/table/reinforced/chemistry/auto,
 /obj/machinery/light{
-	dir = 4;
+	dir = 8;
 	icon_state = "tube1"
 	},
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"ajm" = (
 /obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/bot/white,
-/area/station/ai_monitored/storage/secure)
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"ajn" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/grime{
+	dir = 8
+	},
+/area/station/science/lab)
 "ajo" = (
 /obj/decal/fakeobjects/shuttleengine{
 	icon_state = "alt_heater"
@@ -4165,6 +4149,10 @@
 	reinf = 1
 	},
 /obj/stool/bed,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
 	},
@@ -4186,6 +4174,10 @@
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
 /obj/item/clothing/mask/muzzle,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
 	},
@@ -4236,6 +4228,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white/checker2{
 	dir = 8
 	},
@@ -4311,38 +4304,30 @@
 	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
 "ajF" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+/obj/machinery/power/data_terminal,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/computer3frame{
+	anchored = 1;
+	dir = 4;
+	state = 1
+	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
 "ajG" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/observatory)
 "ajH" = (
 /obj/stool/bed,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor,
 /area/station/crew_quarters/observatory)
@@ -4352,21 +4337,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/science/lobby)
+/turf/simulated/floor/white,
+/area/station/crew_quarters/observatory)
 "ajJ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 9;
+	icon_state = "alt_propulsion"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/science/lobby)
+/turf/space,
+/area/shuttle/arrival/station)
 "ajK" = (
 /obj/cable{
 	d1 = 1;
@@ -4383,6 +4362,9 @@
 	mailgroup = "science";
 	message = "1";
 	name = "mail chute-'Robot Depot'"
+	},
+/obj/disposalpipe/trunk/mail{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
@@ -4445,52 +4427,51 @@
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
 "ajS" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/item/chem_grenade/firefighting{
+	pixel_x = 11;
+	pixel_y = 15
 	},
-/obj/item/extinguisher{
-	pixel_y = 8
+/obj/item/chem_grenade/firefighting{
+	pixel_x = 2;
+	pixel_y = 16
 	},
-/turf/simulated/floor/bot/white,
-/area/station/ai_monitored/storage/secure)
+/obj/item/chem_grenade/firefighting{
+	pixel_x = -6;
+	pixel_y = 16
+	},
+/obj/item/device/transfer_valve{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/device/transfer_valve{
+	pixel_x = -2
+	},
+/obj/item/device/transfer_valve{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/device/transfer_valve{
+	pixel_x = 5
+	},
+/obj/item/device/transfer_valve{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/table/reinforced/chemistry/auto,
+/turf/simulated/floor/white,
+/area/station/science/lab)
 "ajT" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
 /turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
+/area/station/science/lab)
 "ajU" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	icon_state = "manifold";
-	level = 2
-	},
+/obj/machinery/atmospherics/valve,
 /turf/simulated/floor/white,
-/area/station/ai_monitored/storage/secure)
-"ajV" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/grille/catwalk{
-	dir = 9
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross";
-	layer = 2
-	},
-/area/station/solar/west)
+/area/station/science/lab)
 "ajW" = (
 /obj/decal/fakeobjects/shuttlethruster{
 	icon_state = "alt_propulsion"
@@ -4517,12 +4498,13 @@
 	},
 /area/shuttle/research/outpost)
 "aka" = (
-/obj/machinery/light{
-	dir = 1;
-	name = "light fixture"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor,
+/area/station/hangar/science)
 "akb" = (
 /obj/table/auto,
 /obj/machinery/networked/printer{
@@ -4567,6 +4549,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/impact_pad,
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white/checker2{
 	dir = 4
 	},
@@ -4617,18 +4600,17 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
 "akk" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 10;
+	icon_state = "alt_propulsion"
 	},
-/turf/simulated/floor/white,
-/area/station/crew_quarters/observatory)
+/turf/space,
+/area/shuttle/arrival/station)
 "akl" = (
-/obj/machinery/door/window/westleft{
-	name = "Specimen Cell";
-	req_access_txt = "8"
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4
 	},
+/obj/access_spawn/research,
 /turf/simulated/floor,
 /area/station/crew_quarters/observatory)
 "akm" = (
@@ -4685,10 +4667,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
 /turf/simulated/floor/bot,
@@ -4701,13 +4679,16 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "aks" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/storage/secure)
+/turf/simulated/floor/white,
+/area/station/science/lab)
 "akt" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "wall_space"
@@ -4809,6 +4790,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white/checker2{
 	dir = 4
 	},
@@ -4857,20 +4839,19 @@
 /area/station/medical/cdc)
 "akG" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/observatory)
-"akH" = (
-/obj/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
+"akH" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 5;
+	icon_state = "alt_propulsion"
+	},
+/turf/space,
+/area/shuttle/arrival/station)
 "akI" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
@@ -4900,6 +4881,10 @@
 	},
 /obj/machinery/guardbot_dock,
 /obj/machinery/bot/guardbot,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
 "akL" = (
@@ -4929,28 +4914,13 @@
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
 "akN" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/grille/catwalk{
-	dir = 4
+/obj/lattice{
+	dir = 2;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
-	},
-/area/station/solar/west)
+/turf/space,
+/area/space)
 "akO" = (
 /obj/cable{
 	d2 = 4;
@@ -4994,6 +4964,9 @@
 	message = "1";
 	name = "mail chute-'Artifact Lab'"
 	},
+/obj/disposalpipe/trunk/mail{
+	dir = 4
+	},
 /turf/simulated/floor/white/checker2{
 	dir = 4
 	},
@@ -5013,6 +4986,10 @@
 	},
 /obj/machinery/networked/test_apparatus/pitching_machine{
 	dir = 1
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 8
@@ -5146,34 +5123,16 @@
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
 "alf" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
+"alh" = (
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/solar{
-	id = "rozetasolar";
-	name = "Outpost Zeta Solar Array"
-	},
-/turf/simulated/floor/airless{
-	icon_state = "solarpanel";
-	name = "solar paneling"
-	},
-/area/station/solar/west)
-"alg" = (
-/obj/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 2.5;
-	name = "VACUUM AREA"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/science/artifact)
-"alh" = (
-/obj/machinery/door/airlock/pyro/external{
-	req_access_txt = "13"
-	},
-/turf/simulated/floor/plating,
-/area/station/science/artifact)
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
 "ali" = (
 /obj/machinery/light{
 	dir = 8;
@@ -5208,9 +5167,11 @@
 /area/station/crew_quarters/observatory)
 "aln" = (
 /obj/table/auto,
+/obj/machinery/cell_charger,
 /obj/item/cell{
 	charge = 100;
-	maxcharge = 15000
+	maxcharge = 15000;
+	pixel_y = 5
 	},
 /obj/item/cell{
 	charge = 100;
@@ -5221,6 +5182,7 @@
 "alo" = (
 /obj/machinery/light,
 /obj/table/auto,
+/obj/machinery/recharger,
 /obj/item/device/multitool{
 	pixel_x = -7;
 	pixel_y = 1
@@ -5295,50 +5257,15 @@
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "alu" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/grille/catwalk/cross,
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross";
-	layer = 2
-	},
-/area/station/solar/west)
-"alv" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/grille/catwalk{
-	dir = 5;
-	icon_state = "catwalk"
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
+/obj/lattice{
 	dir = 4;
-	icon_state = "catwalk_cross";
-	layer = 2
+	icon_state = "lattice-dir"
 	},
-/area/station/solar/west)
+/turf/space,
+/area/space)
 "alw" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/paper_bin,
@@ -5353,8 +5280,9 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "aly" = (
-/turf/simulated/floor/plating,
-/area/station/science/artifact)
+/obj/storage/closet/welding_supply,
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
 "alz" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/supernorn,
@@ -5368,30 +5296,6 @@
 /obj/table/reinforced/chemistry/auto,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
-"alC" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/grille/catwalk{
-	dir = 9
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross";
-	layer = 2
-	},
-/area/station/solar/west)
 "alD" = (
 /obj/cable{
 	d1 = 1;
@@ -5418,7 +5322,10 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/Zeta)
 "alG" = (
-/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /obj/machinery/power/solar{
 	id = "rozetasolar";
 	name = "Outpost Zeta Solar Array"
@@ -5582,16 +5489,17 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "alV" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "alW" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Monkey Pen";
 	req_access_txt = ""
 	},
+/obj/access_spawn/research,
+/obj/access_spawn/pathology,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery/white,
 /area/station/medical/cdc)
 "alX" = (
@@ -5636,12 +5544,11 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "ame" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
 "amf" = (
@@ -5652,23 +5559,15 @@
 /turf/simulated/floor/caution/north,
 /area/station/turret_protected/Zeta)
 "amg" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
 "amh" = (
-/obj/grille/catwalk{
-	dir = 6
-	},
-/obj/machinery/light/runway_light,
+/obj/machinery/vehicle/pod_smooth/light,
 /turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
-	icon_state = "catwalk_cross";
-	layer = 2
-	},
-/area/space)
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
 "ami" = (
 /obj/machinery/light{
 	dir = 8;
@@ -5742,12 +5641,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Computer Core Access";
-	req_access_txt = "19"
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 8
 	},
+/obj/access_spawn/research_director,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "amt" = (
@@ -5855,30 +5753,17 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "amB" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4;
+	icon_state = "12";
+	initialize_directions = 12
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/grille/catwalk{
-	dir = 6
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 2;
-	icon_state = "catwalk_cross";
-	layer = 2
-	},
-/area/station/solar/west)
+/area/space)
 "amC" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -5904,6 +5789,7 @@
 	},
 /area/station/medical/cdc)
 "amE" = (
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/green/corner{
 	dir = 8
 	},
@@ -5938,11 +5824,10 @@
 /turf/simulated/floor/caution/south,
 /area/station/turret_protected/Zeta)
 "amI" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/Zeta)
 "amJ" = (
@@ -6020,6 +5905,7 @@
 	name = "BIOHAZARD";
 	pixel_x = -32
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
@@ -6196,7 +6082,6 @@
 	},
 /area/station/medical/cdc)
 "ane" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -6204,12 +6089,12 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Pathology Lab";
-	req_access = list(5);
-	req_access_txt = "8"
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4
 	},
+/obj/access_spawn/research,
+/obj/access_spawn/pathology,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "anf" = (
@@ -6220,6 +6105,7 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
+/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
@@ -6249,61 +6135,73 @@
 /turf/space,
 /area/shuttle/escape/station/donut2)
 "anj" = (
-/turf/simulated/shuttle/wall{
-	dir = 8;
-	icon_state = "wall_space"
+/obj/indestructible/shuttle_corner{
+	dir = 0
 	},
+/turf/space,
 /area/shuttle/arrival/station)
 "ank" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 9;
-	icon_state = "alt_propulsion"
+/obj/window/reinforced{
+	dir = 2;
+	icon_state = "rwindow"
 	},
-/turf/space,
+/obj/grille/steel,
+/obj/window/reinforced{
+	dir = 8;
+	icon_state = "rwindow"
+	},
+/obj/window/reinforced{
+	dir = 1;
+	icon_state = "rwindow"
+	},
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-R"
+	},
+/turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "anl" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 10;
-	icon_state = "alt_propulsion"
+/obj/window/reinforced{
+	dir = 2;
+	icon_state = "rwindow"
 	},
-/turf/space,
+/obj/grille/steel,
+/obj/window/reinforced{
+	dir = 1;
+	icon_state = "rwindow"
+	},
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-M"
+	},
+/turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "anm" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 5;
-	icon_state = "alt_propulsion"
+/obj/window/reinforced{
+	dir = 2;
+	icon_state = "rwindow"
 	},
-/turf/space,
+/obj/grille/steel,
+/obj/window/reinforced{
+	dir = 4;
+	icon_state = "rwindow"
+	},
+/obj/window/reinforced{
+	dir = 1;
+	icon_state = "rwindow"
+	},
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-L"
+	},
+/turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "ann" = (
-/turf/simulated/shuttle/wall{
-	dir = 1;
-	icon_state = "wall_space"
-	},
-/area/shuttle/arrival/station)
-"ano" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/grille/catwalk{
-	dir = 4
+/obj/indestructible/shuttle_corner{
+	dir = 1
 	},
 /turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
-	},
-/area/station/solar/west)
+/area/shuttle/arrival/station)
 "anp" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor,
@@ -6322,13 +6220,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/cdc)
 "ans" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 2;
-	name = "Quarantine";
-	req_access = list(5);
-	req_access_txt = "8"
-	},
+/obj/machinery/door/airlock/pyro/glass/sci,
+/obj/access_spawn/research,
+/obj/access_spawn/pathology,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery/white,
 /area/station/medical/cdc)
 "ant" = (
@@ -6364,12 +6259,20 @@
 	pixel_y = 6
 	},
 /obj/machinery/drainage,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/caution/north,
 /area/station/medical/cdc)
 "any" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
 	pixel_x = 4
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/medical/cdc)
@@ -6397,39 +6300,14 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "anC" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Pathology Lab";
-	req_access = list(5);
-	req_access_txt = "8"
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4
 	},
+/obj/access_spawn/research,
+/obj/access_spawn/pathology,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
-"anD" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/grille/catwalk{
-	dir = 5;
-	icon_state = "catwalk"
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross";
-	layer = 2
-	},
-/area/station/solar/west)
 "anE" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/glasses/spectro,
@@ -6446,74 +6324,15 @@
 	},
 /area/station/quartermaster/office)
 "anG" = (
-/turf/simulated/shuttle/wall,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "9"
+	},
 /area/shuttle/arrival/station)
-"anH" = (
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/machinery/shuttle/engine/heater{
-	dir = 1;
-	icon_state = "alt_heater-R"
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"anI" = (
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/machinery/shuttle/engine/heater{
-	dir = 1;
-	icon_state = "alt_heater-M"
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"anJ" = (
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/machinery/shuttle/engine/heater{
-	dir = 1;
-	icon_state = "alt_heater-L"
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/station)
-"anK" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/shuttle)
 "anL" = (
 /turf/simulated/floor/caution/north{
 	dir = 8
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "anM" = (
 /turf/simulated/wall/auto/supernorn,
 /area/space)
@@ -6555,16 +6374,8 @@
 /turf/simulated/floor/bot/white,
 /area/station/medical/cdc)
 "anQ" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
 /obj/decal/poster/wallsign/chsl,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
 "anR" = (
@@ -6616,25 +6427,26 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
-"anW" = (
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "wall_floor"
-	},
-/area/shuttle/arrival/station)
 "anX" = (
-/obj/machinery/computer/arcade,
+/obj/cryotron{
+	layer = 3.9
+	},
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "anY" = (
-/obj/item/crowbar,
-/turf/simulated/floor/shuttle,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "5"
+	},
 /area/shuttle/arrival/station)
 "anZ" = (
-/turf/simulated/shuttle/wall{
-	dir = 0;
-	icon_state = "wall_floor"
-	},
+/obj/storage/closet/emergency,
+/obj/item/tank/emergency_oxygen,
+/obj/item/tank/emergency_oxygen,
+/obj/item/tank/emergency_oxygen,
+/obj/item/tank/emergency_oxygen,
+/obj/item/crowbar,
+/obj/item/crowbar,
+/turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aoa" = (
 /obj/machinery/conveyor{
@@ -6686,6 +6498,9 @@
 	message = "1";
 	name = "mail chute-'Pathology'"
 	},
+/obj/disposalpipe/trunk/mail{
+	dir = 1
+	},
 /turf/simulated/floor/greenwhite{
 	dir = 1
 	},
@@ -6736,7 +6551,7 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aom" = (
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -6811,6 +6626,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/random_item_spawner/dressup/one_or_zero,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aow" = (
@@ -6825,7 +6641,7 @@
 /area/shuttle/arrival/station)
 "aoy" = (
 /turf/simulated/floor/caution/west,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aoz" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
@@ -6837,7 +6653,7 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aoB" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -6915,6 +6731,7 @@
 /area/shuttle_sound_spawn)
 "aoK" = (
 /obj/storage/closet/wardrobe/mixed,
+/obj/random_item_spawner/dressup/one_or_zero,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aoL" = (
@@ -6932,31 +6749,14 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aoN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/office)
 "aoO" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
-"aoP" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/arrival/station)
 "aoQ" = (
 /obj/landmark{
 	name = "Observer-Start"
@@ -6972,10 +6772,15 @@
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
 "aoS" = (
-/obj/machinery/launcher_loader/east,
+/obj/machinery/launcher_loader/east{
+	id = "qm_dock_out"
+	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
 "aoT" = (
+/obj/machinery/launcher_loader/east{
+	id = "qm_dock_out"
+	},
 /obj/machinery/mass_driver{
 	dir = 4;
 	id = "qm_dock_out"
@@ -6991,25 +6796,19 @@
 	id = "qm_dock_out";
 	name = "cargo outlet"
 	},
+/obj/forcefield/energyshield/perma{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "aoV" = (
 /turf/space,
 /area/supply/sell_point)
 "aoW" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aoX" = (
@@ -7028,7 +6827,6 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/tug_cart,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "apa" = (
@@ -7043,13 +6841,9 @@
 /turf/simulated/floor/arrival{
 	dir = 8
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "apb" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	name = "cargo belt - west";
-	operating = 1
-	},
+/obj/machinery/launcher_loader/south,
 /turf/simulated/floor/caution/northsouth,
 /area/station/quartermaster/office)
 "apc" = (
@@ -7063,10 +6857,6 @@
 /area/station/quartermaster/office)
 "apd" = (
 /obj/machinery/conveyor{
-	dir = 4;
-	id = "qmin"
-	},
-/obj/machinery/conveyor{
 	dir = 8;
 	name = "cargo belt - west";
 	operating = 1
@@ -7075,6 +6865,13 @@
 	id = "qm_dock";
 	name = "cargo inlet"
 	},
+/obj/forcefield/energyshield/perma{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/obj/machinery/launcher_loader/west,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "ape" = (
@@ -7082,6 +6879,9 @@
 	dir = 8;
 	name = "cargo belt - west";
 	operating = 1
+	},
+/obj/machinery/launcher_loader/west{
+	id = "qmdock"
 	},
 /turf/simulated/floor/plating/airless,
 /area/supply/delivery_point)
@@ -7133,24 +6933,12 @@
 	},
 /turf/space,
 /area/space)
-"apn" = (
-/obj/grille/steel,
-/obj/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	name = "VACUUM AREA"
-	},
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/shuttle)
 "apo" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/caution/north,
 /area/station/hallway/secondary/shuttle)
 "app" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/shuttle)
 "apq" = (
@@ -7163,9 +6951,9 @@
 /area/station/quartermaster/office)
 "aps" = (
 /obj/machinery/door/airlock/pyro/external{
-	dir = 4;
-	name = "Supply Dock Airlock"
+	dir = 4
 	},
+/obj/access_spawn/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "apt" = (
@@ -7186,18 +6974,13 @@
 /area/station/hangar/main)
 "apv" = (
 /obj/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "apw" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture"
@@ -7214,15 +6997,16 @@
 	pixel_y = 24;
 	text = "NF"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "apy" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/mainpod1_horizontal/vertical,
+/obj/forcefield/energyshield/perma{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "apz" = (
@@ -7241,14 +7025,14 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
 "apB" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall_space"
+/obj/indestructible/shuttle_corner{
+	dir = 4
 	},
+/turf/space,
 /area/shuttle/arrival/station)
 "apC" = (
-/turf/simulated/shuttle/wall{
-	dir = 1;
-	icon_state = "wall_floor"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
 	},
 /area/shuttle/arrival/station)
 "apD" = (
@@ -7268,16 +7052,15 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "apG" = (
-/turf/simulated/shuttle/wall{
-	dir = 8;
-	icon_state = "wall_floor"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
 	},
 /area/shuttle/arrival/station)
 "apH" = (
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "wall_space"
+/obj/indestructible/shuttle_corner{
+	dir = 8
 	},
+/turf/space,
 /area/shuttle/arrival/station)
 "apI" = (
 /obj/machinery/manufacturer/uniform,
@@ -7317,30 +7100,31 @@
 	id = "QMLoad"
 	},
 /obj/plasticflaps,
+/obj/forcefield/energyshield/perma,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "apN" = (
-/obj/machinery/door/airlock/pyro/external{
-	name = "Supply Dock Airlock"
+/obj/machinery/conveyor/south{
+	operating = 1
 	},
+/obj/plasticflaps,
+/obj/forcefield/energyshield/perma,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "apO" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	name = "VACUUM AREA"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "apP" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/securearea{
 	desc = "A warning sign which reads 'SECURE AREA, Violators WILL be shot.'"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "apQ" = (
@@ -7359,13 +7143,10 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "apT" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/main)
+/area/shuttle/arrival/station)
 "apU" = (
 /obj/lattice{
 	dir = 10;
@@ -7388,8 +7169,13 @@
 	},
 /area/station/quartermaster/office)
 "apY" = (
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/main)
 "apZ" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -7414,18 +7200,10 @@
 	},
 /area/station/quartermaster/office)
 "aqb" = (
-/obj/machinery/conveyor{
-	dir = 2;
-	id = "QMLoad"
+/obj/machinery/conveyor/south{
+	operating = 1
 	},
-/obj/machinery/door/poddoor{
-	density = 1;
-	icon_state = "pdoor1";
-	id = "QMLoaddoor";
-	name = "Supply Dock Loading Door";
-	opacity = 1
-	},
-/turf/simulated/floor/caution/south,
+/turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "aqc" = (
 /turf/simulated/floor/caution/south,
@@ -7483,28 +7261,20 @@
 	},
 /area/station/quartermaster/office)
 "aql" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
 	},
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/area/shuttle/arrival/station)
 "aqm" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/storage/crate,
+/obj/machinery/manufacturer/qm,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aqn" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
@@ -7521,34 +7291,17 @@
 	},
 /area/station/quartermaster/office)
 "aqo" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/computer/barcode/qm,
+/obj/machinery/computer/barcode/qm/no_belthell,
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
 /area/station/quartermaster/office)
 "aqp" = (
-/obj/machinery/conveyor{
-	dir = 2;
-	id = "QMLoad"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/caution/westeast,
+/obj/machinery/door/airlock/pyro/external,
+/obj/access_spawn/cargo,
+/turf/simulated/floor,
 /area/station/quartermaster/office)
 "aqq" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/auto,
 /obj/machinery/recharger{
 	pixel_y = 3
@@ -7556,19 +7309,6 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/cargotele,
 /obj/item/cargotele,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
-"aqr" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24;
-	pixel_y = 0
-	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aqs" = (
@@ -7584,11 +7324,20 @@
 /turf/simulated/floor/delivery,
 /area/station/quartermaster/office)
 "aqu" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/quartermaster/office)
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/main)
 "aqv" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "aqw" = (
@@ -7600,16 +7349,13 @@
 /area/station/hangar/main)
 "aqx" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "aqy" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -7723,13 +7469,12 @@
 /turf/space,
 /area/space)
 "aqH" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	name = "VACUUM AREA"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/shuttle)
 "aqI" = (
@@ -7752,13 +7497,14 @@
 	},
 /area/station/hallway/secondary/shuttle)
 "aqM" = (
-/obj/machinery/door/firedoor/pyro{
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
 /turf/simulated/floor/escape{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aqN" = (
 /obj/machinery/light{
 	dir = 1;
@@ -7767,12 +7513,12 @@
 /turf/simulated/floor/escape{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aqO" = (
 /turf/simulated/floor/escape{
 	dir = 5
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aqP" = (
 /obj/cable{
 	d1 = 1;
@@ -7789,10 +7535,12 @@
 	},
 /area/station/quartermaster/office)
 "aqQ" = (
-/obj/storage/crate,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "aqR" = (
+/obj/machinery/conveyor_switch{
+	id = "QMLoad"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -7805,20 +7553,9 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "aqT" = (
-/obj/machinery/conveyor_switch{
-	id = "QMLoad"
-	},
-/turf/simulated/floor,
-/area/station/quartermaster/office)
-"aqU" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
-	},
-/obj/machinery/door_control{
-	id = "QMLoaddoor";
-	name = "Loading Door Control";
-	pixel_x = 24
 	},
 /obj/machinery/door_control{
 	id = "qm_dock";
@@ -7826,7 +7563,13 @@
 	pixel_x = 24;
 	pixel_y = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/yellow,
+/area/station/quartermaster/office)
+"aqU" = (
+/obj/machinery/conveyor/south{
+	operating = 1
+	},
+/turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "aqV" = (
 /obj/cable{
@@ -7884,16 +7627,17 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
 "ard" = (
-/obj/machinery/door/firedoor/pyro{
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "are" = (
 /turf/simulated/floor/escape{
 	dir = 4
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arf" = (
 /obj/decoration/toiletholder{
 	pixel_y = -7
@@ -7901,19 +7645,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/toilets)
 "arg" = (
-/obj/item/device/radio/intercom{
-	dir = 8
+/turf/simulated/floor/yellow/side{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Cargo Bay East";
-	dir = 8
-	},
-/turf/simulated/floor,
 /area/station/quartermaster/office)
-"arh" = (
-/obj/storage/crate,
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
 "ari" = (
 /obj/submachine/slot_machine,
 /turf/simulated/floor/plating,
@@ -7931,6 +7666,7 @@
 	brightness = 2;
 	dir = 4
 	},
+/obj/storage/crate,
 /turf/simulated/floor,
 /area/station/maintenance/north)
 "arl" = (
@@ -7942,19 +7678,19 @@
 /turf/simulated/floor/escape/corner{
 	dir = 4
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arn" = (
 /obj/stool/chair,
 /turf/simulated/floor/escape{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aro" = (
 /obj/machinery/vending/cola/blue,
 /turf/simulated/floor/escape{
 	dir = 5
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arp" = (
 /obj/cable,
 /obj/cable{
@@ -7975,40 +7711,44 @@
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arq" = (
 /obj/critter/domestic_bee/bubs,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arr" = (
 /obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "ars" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/storage/secure/closet/security/equipment,
 /obj/item/crowbar,
+/obj/machinery/phone/wall{
+	pixel_x = 24;
+	pixel_y = 4
+	},
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "art" = (
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor/arrival{
 	dir = 9
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aru" = (
 /turf/simulated/floor/arrival/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arv" = (
 /obj/cable{
 	d1 = 1;
@@ -8022,6 +7762,10 @@
 	network = "SS13"
 	},
 /obj/machinery/nanofab/refining,
+/obj/machinery/phone/wall{
+	pixel_x = -24;
+	pixel_y = 4
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -8040,35 +7784,42 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "arx" = (
+/turf/simulated/floor/yellow/corner{
+	dir = 4
+	},
+/area/station/quartermaster/office)
+"ary" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
+/turf/simulated/floor/arrival{
+	dir = 8
+	},
+/area/station/hangar/arrivals)
+"arz" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
 /area/station/quartermaster/office)
-"ary" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor,
-/area/station/quartermaster/office)
-"arz" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	name = "Cargo Office";
-	req_access_txt = "31"
-	},
-/turf/simulated/floor/plating,
-/area/station/quartermaster/office)
 "arA" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/cargo,
 /turf/simulated/floor,
 /area/station/maintenance/north)
 "arB" = (
@@ -8122,14 +7873,6 @@
 	dir = 1
 	},
 /area/station/hangar/main)
-"arH" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hangar/main)
 "arI" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -8150,6 +7893,7 @@
 /area/ghostdrone_factory)
 "arL" = (
 /obj/machinery/secscanner,
+/obj/firedoor_spawn,
 /turf/simulated/floor/stairs{
 	dir = 1
 	},
@@ -8187,16 +7931,21 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arQ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/stool/chair/office/red,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arR" = (
 /obj/cable{
 	d1 = 2;
@@ -8209,7 +7958,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arS" = (
 /obj/cable{
 	d1 = 2;
@@ -8219,33 +7968,34 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arT" = (
-/obj/machinery/door/airlock/pyro/security{
+/obj/machinery/door/airlock/pyro/glass/security{
 	dir = 4;
-	name = "Customs";
-	req_access_txt = "1"
+	req_access = null
 	},
+/obj/access_spawn/head_of_personnel,
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arU" = (
 /obj/machinery/light/emergency{
 	dir = 4;
 	icon_state = "ebulb1"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "arV" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for the cargo bay door.";
 	id = "cargosto";
-	name = "Storage Shutter Control";
+	name = "Outer Shutter Control";
 	pixel_x = -26
 	},
 /obj/machinery/door_control{
 	id = "cargosto2";
-	name = "Test Chamber Shutter Control";
-	pixel_x = 0;
+	name = "Inner Shutter Control";
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -8253,6 +8003,7 @@
 	icon_state = "tube1";
 	tag = ""
 	},
+/obj/machinery/portable_reclaimer,
 /turf/simulated/floor/caution/south,
 /area/station/quartermaster/office)
 "arW" = (
@@ -8331,15 +8082,20 @@
 	dir = 8
 	},
 /turf/simulated/floor/yellow/side{
-	dir = 6
+	dir = 2
 	},
 /area/station/quartermaster/office)
 "ase" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/item/device/radio/intercom{
+	dir = 8
 	},
-/turf/simulated/floor,
+/obj/machinery/camera{
+	c_tag = "Cargo Bay East";
+	dir = 8
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 5
+	},
 /area/station/quartermaster/office)
 "asf" = (
 /obj/machinery/light/small{
@@ -8354,6 +8110,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1"
+	},
 /turf/simulated/floor/scorched,
 /area/station/maintenance/north)
 "ash" = (
@@ -8364,9 +8124,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "asj" = (
-/obj/machinery/door/airlock/pyro/maintenance{
+/obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "ask" = (
@@ -8438,6 +8199,12 @@
 	dir = 4;
 	icon_state = "airlock_closed"
 	},
+/obj/forcefield/energyshield/perma{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/caution/west,
 /area/station/hallway/secondary/shuttle)
 "asu" = (
@@ -8490,32 +8257,26 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
-"asA" = (
-/obj/grille/steel,
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "asB" = (
 /obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/window{
-	name = "Customs";
-	req_access_txt = "1"
-	},
 /obj/table/reinforced/auto,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/head_of_personnel,
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "asC" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "asD" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -8524,14 +8285,14 @@
 /turf/simulated/floor/arrival/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "asE" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "asF" = (
 /obj/machinery/disposal/mail{
 	mail_tag = "shuttlebay";
@@ -8541,7 +8302,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "asG" = (
 /obj/machinery/conveyor{
 	id = "cargo"
@@ -8589,12 +8350,11 @@
 	},
 /area/station/quartermaster/office)
 "asK" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "asL" = (
@@ -8613,6 +8373,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/hand_labeler,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "asM" = (
@@ -8622,13 +8383,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/window/northleft{
-	name = "Cargo Office";
-	req_access_txt = "31"
-	},
-/obj/machinery/door/window/southleft,
 /obj/machinery/cashreg,
 /obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/cargo,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "asN" = (
@@ -8640,6 +8399,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/wall,
 /area/station/quartermaster/office)
 "asO" = (
@@ -8655,29 +8415,19 @@
 "asP" = (
 /turf/simulated/floor/delivery,
 /area/station/quartermaster/office)
-"asQ" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/north)
 "asR" = (
+/obj/machinery/secscanner,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/firedoor_spawn,
+/turf/simulated/floor/stairs{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/area/station/hangar/main)
 "asS" = (
-/obj/storage/crate,
 /turf/simulated/floor,
 /area/station/maintenance/north)
 "asT" = (
@@ -8732,22 +8482,22 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atc" = (
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/stool/chair{
 	dir = 1
 	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atd" = (
 /obj/machinery/camera{
 	c_tag = "Shuttle Bay"
@@ -8756,25 +8506,30 @@
 	dir = 1;
 	name = "light fixture"
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/red/corner{
 	dir = 4
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "ate" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atf" = (
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atg" = (
 /obj/machinery/light{
 	dir = 1;
@@ -8783,16 +8538,16 @@
 /turf/simulated/floor/escape/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "ath" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "ati" = (
 /obj/disposalpipe/trunk,
 /obj/machinery/disposal,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atj" = (
 /obj/machinery/conveyor{
 	id = "cargo"
@@ -8811,29 +8566,31 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/window/northleft{
-	name = "Cargo Office";
-	req_access_txt = "31"
-	},
 /obj/machinery/door/firedoor/pyro,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/cargo,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/quartermaster/office)
 "atl" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "atm" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "atn" = (
@@ -8872,23 +8629,16 @@
 /turf/simulated/floor/bot,
 /area/station/quartermaster/office)
 "atr" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/north)
+"ats" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/landmark{
 	name = "blobstart"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
-"ats" = (
-/obj/cable,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24;
-	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
@@ -8896,6 +8646,11 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs{
 	dir = 1
@@ -8962,53 +8717,53 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atD" = (
 /turf/simulated/floor{
 	icon_state = "L1"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atE" = (
 /turf/simulated/floor{
 	icon_state = "L3"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atF" = (
+/turf/simulated/floor{
+	icon_state = "L5"
+	},
+/area/station/hangar/arrivals)
+"atG" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "L5"
-	},
-/area/station/hallway/secondary/shuttle)
-"atG" = (
-/turf/simulated/floor{
 	icon_state = "L7"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atH" = (
 /turf/simulated/floor{
 	icon_state = "L9"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atI" = (
 /turf/simulated/floor{
 	icon_state = "L11"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atJ" = (
 /turf/simulated/floor{
 	icon_state = "L13"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atK" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor{
 	icon_state = "L15"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atL" = (
 /obj/stool/chair{
 	dir = 8
@@ -9020,7 +8775,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "atM" = (
 /obj/cable{
 	d1 = 1;
@@ -9052,11 +8807,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -9066,11 +8816,6 @@
 	},
 /area/station/quartermaster/office)
 "atP" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -9079,11 +8824,6 @@
 	},
 /area/station/quartermaster/office)
 "atQ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -9097,32 +8837,21 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24;
-	pixel_y = 0
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
 /area/station/quartermaster/office)
 "atS" = (
-/obj/machinery/manufacturer/hangar,
-/turf/simulated/floor/grime,
-/area/station/hangar/main)
-"atT" = (
-/obj/submachine/cargopad{
-	name = "Pod Bay Pad"
+/turf/simulated/floor/yellow/corner{
+	dir = 8
 	},
+/area/station/quartermaster/office)
+"atT" = (
 /obj/machinery/light_switch{
 	name = "N light switch";
 	pixel_y = 24
 	},
+/obj/machinery/manufacturer/hangar,
 /turf/simulated/floor/grime,
 /area/station/hangar/main)
 "atU" = (
@@ -9143,8 +8872,12 @@
 /turf/simulated/floor/grime,
 /area/station/hangar/main)
 "atV" = (
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/wall/auto/supernorn,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/caution/north,
 /area/station/hangar/main)
 "atW" = (
 /obj/table/wood/auto,
@@ -9225,39 +8958,28 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "auh" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/obj/machinery/door/firedoor/pyro,
+/obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/head_of_personnel,
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/hangar/arrivals)
 "aui" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/shuttle)
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "auj" = (
 /obj/stool/chair{
 	dir = 4
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -9268,101 +8990,63 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "auk" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "L2"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aul" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "L4"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aum" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "L6"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aun" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "L8"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "auo" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "L10"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aup" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "L12"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "auq" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "L14"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aur" = (
 /obj/disposalpipe/segment/mail,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "L16"
 	},
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "aus" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/turf/simulated/floor/caution/south{
+	dir = 2
+	},
+/area/station/hangar/main)
 "aut" = (
 /obj/stool/chair{
 	dir = 8
@@ -9372,47 +9056,30 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/grime,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "auu" = (
+/obj/stool/chair{
+	dir = 1
+	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/quartermaster/office)
+/turf/simulated/floor,
+/area/station/hangar/arrivals)
 "auv" = (
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/caution/north,
 /area/station/quartermaster/office)
 "auw" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/caution/north,
 /area/station/quartermaster/office)
 "aux" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
 	id = "cargosto";
@@ -9424,11 +9091,6 @@
 /area/station/quartermaster/office)
 "auy" = (
 /obj/disposalpipe/segment/mail,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -9446,11 +9108,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
@@ -9475,10 +9132,21 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
 "auE" = (
-/obj/machinery/portable_reclaimer,
-/turf/simulated/floor/grime,
-/area/station/hangar/main)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/quartermaster/office)
 "auF" = (
+/obj/machinery/portable_reclaimer,
 /turf/simulated/floor/grime,
 /area/station/hangar/main)
 "auG" = (
@@ -9504,21 +9172,23 @@
 /area/station/hangar/main)
 "auI" = (
 /obj/cable{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
+	},
+/obj/submachine/cargopad{
+	name = "Pod Bay Pad"
 	},
 /turf/simulated/floor/grime,
 /area/station/hangar/main)
 "auJ" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hangar/main)
+/turf/simulated/floor,
+/area/station/hangar/arrivals)
 "auK" = (
 /obj/cable{
 	d1 = 1;
@@ -9526,10 +9196,14 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/north)
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/hangar/arrivals)
 "auL" = (
 /obj/machinery/door/airlock/pyro/engineering,
 /turf/simulated/floor/plating/random,
@@ -9575,18 +9249,18 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "auU" = (
 /obj/shrub,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "auV" = (
 /obj/stool/chair{
 	dir = 1
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grime,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "auW" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -9594,14 +9268,14 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/grime,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "auX" = (
 /obj/stool/chair{
 	dir = 8
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/grime,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "auY" = (
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -9662,13 +9336,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "avf" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	tag = ""
+/turf/simulated/floor/yellow/side{
+	dir = 8
 	},
-/turf/simulated/floor/grime,
-/area/station/hangar/main)
+/area/station/quartermaster/office)
 "avg" = (
 /turf/simulated/floor,
 /area/station/hangar/main)
@@ -9688,8 +9359,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/office)
 "avk" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chapel/office)
 "avl" = (
@@ -9766,30 +9436,26 @@
 "avu" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/toilets)
-"avv" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "avw" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "avx" = (
 /obj/decal/poster/wallsign/medbay_left,
 /turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "avy" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "avz" = (
 /obj/disposalpipe/switch_junction{
 	dir = 2;
@@ -9797,30 +9463,29 @@
 	mail_tag = "bridge mail router"
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/shuttle)
+/area/station/hangar/arrivals)
 "avA" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/auto/supernorn,
+/obj/cable,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "avB" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs2_wide"
-	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "avC" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/stairs{
 	dir = 1;
-	icon_state = "stairs_middle"
+	icon_state = "Stairs2_wide"
 	},
 /area/station/quartermaster/office)
 "avD" = (
@@ -9833,26 +9498,27 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "stairs_middle"
-	},
-/area/station/quartermaster/office)
-"avE" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/stairs{
 	dir = 1;
 	icon_state = "Stairs_wide"
 	},
 /area/station/quartermaster/office)
+"avE" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/purplewhite{
+	dir = 4
+	},
+/area/station/science/chemistry)
 "avF" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
 "avG" = (
@@ -9869,11 +9535,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
 "avI" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "avJ" = (
@@ -9888,29 +9555,32 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/north)
+/turf/simulated/floor,
+/area/station/hangar/arrivals)
 "avL" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "E APC";
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/cable,
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/quartermaster/office)
+"avM" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/hangar/main)
-"avM" = (
-/obj/reagent_dispensers/fueltank,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/grime,
 /area/station/hangar/main)
 "avN" = (
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor,
 /area/station/hangar/main)
 "avO" = (
@@ -10098,7 +9768,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "awr" = (
-/obj/machinery/door/firedoor/pyro{
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
 /turf/simulated/floor/orangeblack/corner{
@@ -10111,43 +9782,45 @@
 	},
 /area/station/hallway/primary/north)
 "awt" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/hangar/arrivals)
+"awu" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/hallway/primary/north)
-"awu" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/north)
 "awv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
 /area/station/hallway/primary/north)
 "aww" = (
+/obj/disposalpipe/segment/mail,
 /obj/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -10198,11 +9871,6 @@
 /turf/simulated/floor/plating,
 /area/station/storage/emergency2)
 "awB" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/clothing/shoes/moon,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency2)
@@ -10210,9 +9878,17 @@
 /turf/simulated/floor/plating,
 /area/station/storage/emergency2)
 "awD" = (
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/grime,
-/area/station/hangar/main)
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
 "awE" = (
 /obj/disposalpipe/trunk{
 	dir = 1
@@ -10280,11 +9956,6 @@
 	icon_state = "fred2"
 	},
 /area/station/chapel/office)
-"awM" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
 "awN" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/sanctuary)
@@ -10311,14 +9982,12 @@
 /turf/space,
 /area/space)
 "awR" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "awS" = (
-/obj/grille/steel,
 /obj/item/luggable_computer,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "awT" = (
@@ -10377,10 +10046,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Bathroom"
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/white/side{
 	dir = 8
 	},
@@ -10396,20 +10065,25 @@
 	},
 /area/station/hallway/primary/north)
 "axb" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	icon_state = "pipe-c";
 	name = "crematorium pipe"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -10429,6 +10103,16 @@
 	dir = 4;
 	name = "crematorium pipe"
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "axe" = (
@@ -10439,6 +10123,11 @@
 /obj/landmark{
 	icon_state = "x3";
 	name = "peststart"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -10463,20 +10152,23 @@
 	dir = 4;
 	name = "crematorium pipe"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "axi" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -10490,6 +10182,16 @@
 	name = "crematorium pipe"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "axk" = (
@@ -10510,16 +10212,11 @@
 	},
 /area/station/hallway/primary/north)
 "axm" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/decal/poster/wallsign/chsl,
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/emergency2)
 "axn" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Renovation Area"
@@ -10530,27 +10227,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pod Bay"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
-/area/station/maintenance/storage{
-	name = "Renovation Area"
-	})
+/area/station/hangar/main)
 "axp" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "axq" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "axr" = (
@@ -10589,6 +10282,7 @@
 /obj/table/wood/auto{
 	dir = 6
 	},
+/obj/machinery/phone,
 /turf/simulated/floor/carpet{
 	dir = 2;
 	icon_state = "fred2"
@@ -10601,11 +10295,11 @@
 	},
 /area/station/chapel/office)
 "axx" = (
-/obj/stool,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/stool,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
 	},
@@ -10633,11 +10327,10 @@
 	},
 /area/station/chapel/sanctuary)
 "axC" = (
-/obj/grille/steel,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chapel/sanctuary)
 "axD" = (
@@ -10714,13 +10407,13 @@
 	},
 /area/station/hallway/primary/north)
 "axO" = (
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/morgue{
-	name = "crematorium pipe"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -10781,7 +10474,8 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/machinery/door/firedoor/pyro{
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -10796,26 +10490,19 @@
 	name = "S APC";
 	pixel_y = -24
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/cable,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "axX" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/morgue{
 	dir = 4;
-	icon_state = "pipe-s"
+	name = "crematorium pipe"
 	},
 /obj/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -10892,17 +10579,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/securearea{
-	desc = "A poster that reads 'CLEAN HANDS SAVE LIVES'.";
-	icon_state = "chsl";
-	name = "CLEAN HANDS SAVE LIVES";
-	pixel_y = 32
-	},
 /turf/simulated/floor/grime,
 /area/station/storage/emergency2)
 "ayi" = (
@@ -10914,6 +10590,13 @@
 /obj/rack,
 /obj/item/tank/oxygen,
 /obj/item/clothing/mask/gas/emergency,
+/obj/item/clothing/suit/space/emerg{
+	pixel_x = 6
+	},
+/obj/item/clothing/head/emerg{
+	pixel_x = 5;
+	pixel_y = 10
+	},
 /turf/simulated/floor/grime,
 /area/station/storage/emergency2)
 "ayj" = (
@@ -10925,8 +10608,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/rack,
-/obj/item/tank/oxygen,
+/obj/machinery/dispenser{
+	pltanks = 0
+	},
 /turf/simulated/floor/grime,
 /area/station/storage/emergency2)
 "ayk" = (
@@ -10937,6 +10621,23 @@
 	},
 /obj/rack,
 /obj/item/clothing/mask/gas/emergency,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/item/clothing/suit/space/emerg{
+	pixel_x = 6
+	},
+/obj/item/clothing/head/emerg{
+	pixel_x = 5;
+	pixel_y = 10
+	},
 /turf/simulated/floor/grime,
 /area/station/storage/emergency2)
 "ayl" = (
@@ -10949,23 +10650,14 @@
 /turf/simulated/floor/grime,
 /area/station/storage/emergency2)
 "aym" = (
-/obj/cable,
 /obj/cable{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/storage/emergency2)
 "ayn" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/rack,
 /obj/item/storage/toolbox/mechanical,
 /obj/decal/cleanable/cobweb2,
@@ -10985,23 +10677,24 @@
 	},
 /area/station/chapel/sanctuary)
 "ayp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
 	},
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary)
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "ayq" = (
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
 "ayr" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
@@ -11010,6 +10703,10 @@
 /obj/shrub{
 	dir = 6;
 	icon_state = "shrub"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -11021,6 +10718,11 @@
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
 	dir = 1
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/office)
@@ -11064,6 +10766,9 @@
 /obj/window/reinforced{
 	dir = 2;
 	icon_state = "rwindow"
+	},
+/obj/shrub{
+	dir = 10
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
@@ -11185,10 +10890,10 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/toilets)
 "ayP" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Bathroom"
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/white/side{
 	dir = 8
 	},
@@ -11205,8 +10910,9 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/north)
 "ayS" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/maintenance/inner/central)
 "ayT" = (
@@ -11218,27 +10924,35 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/north)
 "ayV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
 	},
-/turf/simulated/wall/auto/supernorn,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
 /area/station/hallway/primary/north)
 "ayW" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/emergency)
 "ayX" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "ayY" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock{
-	name = "Emergency Storage";
-	req_access_txt = "0"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/alt,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "ayZ" = (
@@ -11274,11 +10988,6 @@
 /turf/simulated/floor,
 /area/station/storage/emergency2)
 "aze" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8;
 	pixel_x = 6
@@ -11309,27 +11018,32 @@
 	},
 /area/station/chapel/sanctuary)
 "azi" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"azj" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/chapel/office)
-"azj" = (
-/obj/machinery/door/window/northleft{
-	name = "Chaplain's Office";
-	req_access_txt = "22"
-	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/chapel_office,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
 /area/station/chapel/office)
 "azk" = (
-/obj/machinery/door/window/northright{
-	name = "Chaplain's Office";
-	req_access_txt = "22"
-	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/chapel_office,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 9
 	},
@@ -11458,7 +11172,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "azz" = (
 /obj/cable{
@@ -11499,10 +11214,20 @@
 	c_tag = "Locker Room North";
 	dir = 10
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "azF" = (
 /obj/machinery/light,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/locker)
 "azG" = (
@@ -11562,47 +11287,49 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/toilets)
 "azK" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
 /area/station/hallway/primary/north)
 "azL" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "azM" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
-/obj/machinery/door/firedoor/pyro,
-/obj/disposalpipe/segment/mail,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "azN" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
-/turf/simulated/wall/auto/supernorn,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/north)
 "azO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
@@ -11649,15 +11376,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "azW" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "azX" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
@@ -11732,11 +11458,6 @@
 /turf/simulated/floor,
 /area/station/storage/emergency2)
 "aAj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/storage/crate,
 /obj/item/crowbar,
 /obj/item/storage/belt/utility,
@@ -11750,6 +11471,11 @@
 /obj/table/wood/auto{
 	dir = 6
 	},
+/obj/item/paper_bin{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/pen,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
@@ -11759,11 +11485,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
@@ -11784,18 +11505,21 @@
 	icon_state = "4-8"
 	},
 /obj/stool,
+/obj/noticeboard{
+	pixel_y = 28
+	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "aAo" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
 /obj/stool,
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -11803,6 +11527,15 @@
 /area/station/chapel/sanctuary)
 "aAp" = (
 /obj/stool,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24;
+	text = "NF"
+	},
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "aAq" = (
@@ -11873,6 +11606,7 @@
 	req_access_txt = "22";
 	text = "chapel"
 	},
+/obj/item/instrument/large/organ,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 10
 	},
@@ -12038,13 +11772,12 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
 "aAN" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/locker)
 "aAO" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "aAP" = (
@@ -12096,7 +11829,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aAU" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12106,6 +11838,11 @@
 	dir = 4;
 	pixel_y = 0
 	},
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aAV" = (
@@ -12125,11 +11862,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -12164,6 +11896,11 @@
 	pixel_x = 24;
 	pixel_y = 0
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/grime,
 /area/station/storage/emergency)
 "aBb" = (
@@ -12179,24 +11916,18 @@
 "aBc" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/emergency2)
-"aBd" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/storage/emergency2)
 "aBe" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
-/turf/simulated/floor,
-/area/station/storage/emergency2)
-"aBf" = (
-/obj/grille/steel,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/window/auto/reinforced,
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/storage/emergency2)
+"aBf" = (
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency2)
 "aBg" = (
@@ -12228,20 +11959,27 @@
 	name = "S APC";
 	pixel_y = -24
 	},
+/obj/table/wood/auto,
+/obj/machinery/phone{
+	pixel_x = 5;
+	pixel_y = -1
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 5
 	},
 /area/station/chapel/sanctuary)
 "aBj" = (
 /obj/machinery/light,
+/obj/stool/chair/comfy{
+	dir = 8
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 9
 	},
 /area/station/chapel/sanctuary)
 "aBk" = (
-/obj/grille/steel,
 /obj/machinery/light/small,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chapel/sanctuary)
 "aBl" = (
@@ -12307,7 +12045,6 @@
 	},
 /area/station/solar/west)
 "aBs" = (
-/obj/table/auto,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	frequency = 1443;
@@ -12318,6 +12055,7 @@
 /obj/item/pen{
 	pixel_x = -7
 	},
+/obj/table/wood/auto,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
 "aBt" = (
@@ -12371,8 +12109,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "aBA" = (
@@ -12477,23 +12215,20 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/north)
 "aBN" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /obj/cable{
 	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
 "aBO" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
 "aBP" = (
@@ -12521,6 +12256,10 @@
 "aBT" = (
 /obj/disposalpipe/segment,
 /obj/machinery/portable_atmospherics/pump,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/grime,
 /area/station/storage/emergency)
 "aBU" = (
@@ -12534,11 +12273,6 @@
 	},
 /area/station/hallway/primary/north)
 "aBW" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -12654,8 +12388,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aCh" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
 "aCi" = (
@@ -12704,6 +12437,11 @@
 	dir = 4;
 	pixel_y = 0
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aCp" = (
@@ -12720,6 +12458,11 @@
 	},
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -12797,19 +12540,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aCA" = (
+/obj/machinery/light,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/storage/emergency)
+/turf/simulated/floor/black,
+/area/station/chapel/office)
 "aCB" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/trunk{
 	dir = 1
 	},
@@ -12817,11 +12556,6 @@
 /turf/simulated/floor/grime,
 /area/station/storage/emergency)
 "aCC" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/camera{
 	c_tag = "Emergency Storage";
 	dir = 10
@@ -12830,16 +12564,13 @@
 /turf/simulated/floor/grime,
 /area/station/storage/emergency)
 "aCD" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
 	pixel_y = -24
 	},
 /obj/storage/closet/fire,
+/obj/cable,
 /turf/simulated/floor/grime,
 /area/station/storage/emergency)
 "aCE" = (
@@ -12869,11 +12600,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aCI" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
@@ -12984,15 +12710,16 @@
 	},
 /area/station/chapel/sanctuary)
 "aCS" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/maintenance{
+/obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aCT" = (
@@ -13020,12 +12747,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aCV" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aCW" = (
@@ -13155,9 +12881,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aDn" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Electrical Substation"
+/obj/machinery/door/airlock/pyro/engineering/alt{
+	dir = 4
 	},
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor,
 /area/station/engine/substation/north)
 "aDo" = (
@@ -13191,19 +12918,19 @@
 /area/station/hallway/primary/north)
 "aDr" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
 /area/station/hallway/primary/north)
 "aDs" = (
-/obj/machinery/door/window/eastleft,
-/obj/machinery/door/firedoor/pyro{
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/chapel/sanctuary)
 "aDt" = (
@@ -13275,10 +13002,11 @@
 	},
 /area/station/chapel/sanctuary)
 "aDD" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance{
+/obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aDE" = (
@@ -13367,13 +13095,6 @@
 "aDN" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet,
-/obj/securearea{
-	desc = "You have no idea who these people are. Who's poster is this, anyway?";
-	icon_state = "rush";
-	name = "historic artifact";
-	pixel_x = -32;
-	pixel_y = 0
-	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
 "aDO" = (
@@ -13393,10 +13114,10 @@
 	},
 /area/station/crew_quarters/quarters)
 "aDR" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/green/side{
 	dir = 5
 	},
@@ -13537,15 +13258,19 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
 "aEl" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/pool)
 "aEm" = (
-/obj/machinery/door/window/eastright,
-/obj/machinery/door/firedoor/pyro{
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/chapel/sanctuary)
 "aEn" = (
@@ -13554,17 +13279,10 @@
 	dir = 1
 	},
 /area/station/chapel/sanctuary)
-"aEo" = (
-/obj/machinery/door/unpowered/wood{
-	name = "Confession Booth"
-	},
-/turf/simulated/floor/black,
-/area/station/chapel/sanctuary)
 "aEp" = (
-/obj/machinery/door{
-	icon = 'icons/obj/doors/Door1.dmi';
-	name = "Confession Booth (Chaplain)";
-	req_access_txt = "22"
+/obj/machinery/door/unpowered/wood/pyro{
+	autoclose = 0;
+	name = "Confession Booth"
 	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
@@ -13572,11 +13290,9 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/crematorium)
 "aEr" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro{
-	name = "Crematorium";
-	req_access_txt = "27"
-	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/crematorium,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aEs" = (
@@ -13634,8 +13350,7 @@
 /area/station/solar/west)
 "aEx" = (
 /obj/machinery/door/airlock/pyro/external{
-	dir = 4;
-	icon_state = "airlock_closed"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -13654,11 +13369,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aEA" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/light_switch{
 	name = "W light switch";
 	pixel_x = -24;
@@ -13668,47 +13378,35 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "aEB" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
 /area/station/crew_quarters/quarters)
 "aEC" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/decal/cleanable/rust,
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters)
 "aED" = (
 /obj/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/quarters)
+/turf/simulated/floor/black,
+/area/station/chapel/office)
 "aEE" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/green/side{
 	dir = 8
@@ -13723,20 +13421,15 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "aEG" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
@@ -13776,8 +13469,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 4;
@@ -13786,6 +13477,7 @@
 	name = "E.V.A.";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "aEM" = (
@@ -13941,6 +13633,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aEY" = (
@@ -13967,10 +13660,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aFb" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Pool"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aFc" = (
@@ -14032,37 +13725,29 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aFf" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aFg" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"aFh" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/maintenance/inner/central)
+"aFh" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Bridge Hallway";
 	location = "Chapel Hallway"
@@ -14072,21 +13757,10 @@
 	},
 /area/station/hallway/primary/north)
 "aFi" = (
-/obj/grille/steel,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/chapel/sanctuary)
 "aFj" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/shrub{
 	dir = 2;
 	icon = 'icons/obj/stationobjs.dmi';
@@ -14098,11 +13772,6 @@
 	},
 /area/station/chapel/sanctuary)
 "aFk" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred1"
@@ -14163,16 +13832,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aFu" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/light/small{
 	dir = 8;
 	icon_state = "bulb1"
 	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aFv" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aFw" = (
@@ -14183,9 +13856,19 @@
 /obj/table/auto,
 /obj/machinery/microwave,
 /obj/item/storage/box/donkpocket_kit,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "aFx" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/green/corner{
 	dir = 4
 	},
@@ -14193,6 +13876,11 @@
 "aFy" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/side{
 	dir = 1
@@ -14202,6 +13890,11 @@
 /obj/machinery/camera{
 	c_tag = "Crew Quarters"
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -14209,8 +13902,8 @@
 "aFA" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/green/corner{
 	dir = 1
@@ -14225,8 +13918,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/quarters)
+/turf/simulated/floor/grime,
+/area/station/storage/emergency2)
 "aFD" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room South";
@@ -14244,8 +13937,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 4;
@@ -14254,6 +13945,7 @@
 	name = "E.V.A.";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "aFF" = (
@@ -14297,19 +13989,38 @@
 /obj/item/sheet/glass/crystal{
 	amount = 20
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/ai_monitored/storage/eva)
 "aFI" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
 /area/station/ai_monitored/storage/eva)
 "aFJ" = (
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "E.V.A.";
-	req_access_txt = "18"
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 8
+	},
+/obj/access_spawn/eva,
 /turf/simulated/floor,
 /area/station/ai_monitored/storage/eva)
 "aFK" = (
@@ -14317,11 +14028,6 @@
 	c_tag = "Inner Maintenance";
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aFL" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aFM" = (
@@ -14508,6 +14214,9 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aGf" = (
@@ -14524,12 +14233,10 @@
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aGg" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
 "aGh" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -14594,11 +14301,16 @@
 "aGp" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/locker)
 "aGq" = (
 /obj/machinery/light{
 	dir = 4;
@@ -14608,8 +14320,6 @@
 /area/station/crew_quarters/quarters)
 "aGr" = (
 /obj/cable,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 4;
@@ -14618,6 +14328,7 @@
 	name = "E.V.A.";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "aGs" = (
@@ -14740,21 +14451,24 @@
 /turf/simulated/floor/greenwhite,
 /area/station/crew_quarters/pool)
 "aGH" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aGI" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aGJ" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -14764,12 +14478,33 @@
 /obj/table/wood/auto{
 	dir = 6
 	},
+/obj/item/device/light/candle,
+/obj/item/device/light/candle{
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/item/device/light/candle{
+	pixel_x = 7
+	},
+/obj/item/device/light/candle{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/obj/item/device/light/candle{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/device/light/candle{
+	pixel_x = -6;
+	pixel_y = 19
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
 /area/station/chapel/sanctuary)
 "aGL" = (
 /obj/machinery/light,
+/obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
@@ -14813,8 +14548,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aGS" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/crematorium)
 "aGT" = (
@@ -14889,11 +14623,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "aHd" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -14902,21 +14631,11 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "aHe" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/auto,
 /obj/item/game_kit,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "aHf" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/stool/chair{
 	dir = 8
 	},
@@ -14924,17 +14643,12 @@
 /area/station/crew_quarters/quarters)
 "aHg" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/quarters)
+/turf/simulated/floor,
+/area/station/crew_quarters/locker)
 "aHh" = (
 /obj/machinery/light,
 /obj/machinery/disposal/mail{
@@ -15019,11 +14733,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/item/storage/box/lightbox/tubes,
 /obj/item/storage/box/lightbox/tubes,
@@ -15143,25 +14852,35 @@
 	},
 /area/station/crew_quarters/pool)
 "aHy" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/plating,
+/area/station/science/storage)
 "aHz" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
-"aHA" = (
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor/neutral/side{
+/obj/stool/chair/comfy/shuttle/green{
 	dir = 4
 	},
-/area/station/hallway/primary/east)
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/shuttle{
+	icon_state = "floor6"
+	},
+/area/shuttle/research/outpost)
+"aHA" = (
+/obj/stool/chair/comfy/shuttle/green{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/shuttle{
+	icon_state = "floor6"
+	},
+/area/shuttle/research/outpost)
 "aHB" = (
 /obj/machinery/disposal/mail{
 	mail_tag = "chapel";
@@ -15218,7 +14937,6 @@
 /area/station/storage/tech)
 "aHH" = (
 /obj/table/auto,
-/obj/item/aiModule/reset,
 /obj/item/disk/data/cartridge/atmos,
 /obj/item/clothing/glasses/meson,
 /obj/machinery/light/small{
@@ -15268,6 +14986,7 @@
 /obj/item/clothing/suit/fire,
 /obj/item/clothing/mask/gas,
 /obj/decal/cleanable/cobweb,
+/obj/item/extinguisher,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aHM" = (
@@ -15276,6 +14995,7 @@
 /obj/item/clothing/shoes/black,
 /obj/item/clothing/suit/fire,
 /obj/item/clothing/mask/gas,
+/obj/item/extinguisher,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aHN" = (
@@ -15290,18 +15010,21 @@
 	},
 /area/station/solar/west)
 "aHO" = (
-/obj/machinery/camera,
-/obj/machinery/door/firedoor/pyro,
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aHP" = (
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
 "aHQ" = (
 /obj/disposalpipe/segment,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
 "aHR" = (
@@ -15317,12 +15040,11 @@
 	},
 /area/station/hallway/primary/north)
 "aHS" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "E.V.A.";
-	req_access_txt = "18"
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 8
 	},
+/obj/access_spawn/eva,
+/obj/firedoor_spawn,
 /turf/simulated/floor/orangeblack,
 /area/station/ai_monitored/storage/eva)
 "aHT" = (
@@ -15334,20 +15056,10 @@
 /turf/simulated/floor,
 /area/station/ai_monitored/storage/eva)
 "aHV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/item/storage/box/mousetraps,
 /turf/simulated/floor,
 /area/station/ai_monitored/storage/eva)
 "aHW" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -15362,25 +15074,20 @@
 /area/station/ai_monitored/storage/eva)
 "aHX" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/storage/eva)
-"aHY" = (
-/obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/grime,
+/area/station/storage/emergency)
+"aHY" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "aHZ" = (
 /obj/machinery/light{
 	dir = 8;
@@ -15560,29 +15267,22 @@
 /area/station/medical/crematorium)
 "aIs" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-4";
+	tag = "icon-1-4"
 	},
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aIt" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Crematorium";
-	req_access_txt = "22"
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
 	},
+/obj/access_spawn/crematorium,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aIu" = (
@@ -15610,17 +15310,14 @@
 /area/station/maintenance/northeast)
 "aIw" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/turf/simulated/floor/neutral/side{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
+/area/station/hallway/primary/north)
 "aIx" = (
 /obj/cable{
 	d1 = 4;
@@ -15658,6 +15355,7 @@
 	pixel_x = -7
 	},
 /obj/item/stamp,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -15674,16 +15372,16 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aIB" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Bridge"
-	},
 /obj/machinery/secscanner{
 	dir = 4;
 	icon_state = "scanner_on";
 	pixel_x = -20
 	},
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 8
+	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/bridge)
 "aIC" = (
@@ -15725,17 +15423,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aII" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
+	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "aIJ" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -15894,10 +15595,6 @@
 	},
 /area/station/teleporter)
 "aJa" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
@@ -15906,6 +15603,10 @@
 	},
 /obj/item/disk/data/fixed_disk,
 /obj/item/device/flash,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "aJb" = (
@@ -15914,6 +15615,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -15929,12 +15635,12 @@
 /area/station/storage/tech)
 "aJd" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/crematorium)
+/turf/simulated/floor/grime,
+/area/station/storage/emergency)
 "aJe" = (
 /obj/machinery/camera{
 	c_tag = "North East Maintenance";
@@ -15949,15 +15655,8 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"aJh" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
 "aJi" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aJj" = (
@@ -15966,16 +15665,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Bridge"
-	},
 /obj/machinery/secscanner{
 	dir = 4;
 	icon_state = "scanner_on";
 	pixel_x = -20
 	},
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 8
+	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/bridge)
 "aJk" = (
@@ -16025,16 +15724,12 @@
 /area/station/maintenance/west)
 "aJp" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor/grime,
+/area/station/storage/emergency)
 "aJq" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -16153,20 +15848,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/light/small,
 /turf/simulated/floor/blueblack,
 /area/station/teleporter)
 "aJG" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/rack,
 /obj/item/hand_tele,
 /turf/simulated/floor/blueblack{
@@ -16175,23 +15860,13 @@
 /area/station/teleporter)
 "aJH" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/storage/tech)
-"aJI" = (
-/obj/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/turf/simulated/floor/grime,
+/area/station/storage/emergency)
+"aJI" = (
 /obj/storage/crate,
 /obj/item/peripheral/card_scanner,
 /obj/item/peripheral/card_scanner,
@@ -16205,14 +15880,14 @@
 /area/station/storage/tech)
 "aJJ" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
@@ -16270,11 +15945,6 @@
 /area/station/storage/tech)
 "aJO" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -16284,13 +15954,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/northeast)
 "aJQ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/northeast)
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/storage/emergency)
 "aJR" = (
 /obj/rack,
 /obj/item/clothing/under/color/grey,
@@ -16324,10 +15993,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/external{
-	name = "External Access";
-	req_access_txt = "13;40"
-	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor/plating,
 /area/station/solar/west)
 "aJW" = (
@@ -16378,6 +16045,10 @@
 	icon_state = "1-4"
 	},
 /obj/table/wood/auto,
+/obj/machinery/phone/wall{
+	pixel_x = -24;
+	pixel_y = 4
+	},
 /turf/simulated/floor/white/checker2{
 	dir = 1
 	},
@@ -16456,8 +16127,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "aKi" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/maintenance/west)
 "aKj" = (
@@ -16517,34 +16189,34 @@
 	},
 /area/station/crew_quarters/pool)
 "aKq" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /obj/cable{
-	d1 = 2;
+	d1 = 1;
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
-/obj/shrub,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/crew_quarters/pool)
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "aKr" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/pool)
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "aKs" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -16560,11 +16232,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aKu" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/command{
-	name = "Teleport Access";
-	req_access_txt = "17"
-	},
+/obj/machinery/door/airlock/pyro/command/alt,
+/obj/access_spawn/teleporter,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/teleporter)
 "aKv" = (
@@ -16579,10 +16249,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/tech)
 "aKx" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Tech Storage";
-	req_access_txt = "23"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/tech_storage,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/storage/tech)
 "aKy" = (
@@ -16619,11 +16293,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aKD" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -16835,19 +16504,19 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aKW" = (
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/shuttle{
+	icon_state = "floor6"
+	},
+/area/shuttle/research/outpost)
 "aKX" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aKY" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture"
@@ -16855,47 +16524,37 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aKZ" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aLa" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/morgue{
-	name = "crematorium pipe"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
-"aLb" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
-"aLc" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"aLc" = (
+/obj/disposalpipe/segment/mail,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "aLd" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency,
@@ -16920,9 +16579,9 @@
 /area/station/crew_quarters/pool)
 "aLg" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -16932,10 +16591,6 @@
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
 	dir = 2;
@@ -16947,11 +16602,6 @@
 	},
 /area/station/crew_quarters/pool)
 "aLi" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -16961,20 +16611,15 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/arcade)
 "aLk" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/maintenance/inner/central)
-"aLl" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/east)
 "aLm" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -17084,11 +16729,11 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
 /obj/disposalpipe/segment/ejection{
 	dir = 4;
 	icon_state = "pipe-s"
 	},
+/obj/grille/steel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aLw" = (
@@ -17122,19 +16767,15 @@
 /area/station/maintenance/northeast)
 "aLy" = (
 /obj/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fred2"
 	},
-/obj/grille/steel{
-	density = 0;
-	icon_state = "brokengrille"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northeast)
+/area/station/chapel/sanctuary)
 "aLz" = (
 /obj/cable{
 	d2 = 8;
@@ -17187,13 +16828,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aLD" = (
-/obj/grille/steel,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aLE" = (
@@ -17216,6 +16856,9 @@
 /obj/cable,
 /obj/decal/cleanable/cobweb{
 	icon_state = "cobweb"
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
@@ -17271,11 +16914,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	name = "Robotics Maintenance";
-	req_access_txt = "12;29"
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
 	},
+/obj/access_spawn/robotics,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "aLL" = (
@@ -17293,6 +16935,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 30
 	},
 /turf/simulated/floor/black/side{
 	dir = 1
@@ -17411,12 +17056,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Medical Director";
-	req_access_txt = "53"
+	dir = 4
 	},
+/obj/access_spawn/medical_director,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white/side{
 	dir = 8
 	},
@@ -17439,8 +17083,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aLY" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/north)
 "aLZ" = (
@@ -17464,11 +17107,11 @@
 "aMc" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/carpet,
+/area/station/chapel/sanctuary)
 "aMd" = (
 /obj/cable{
 	d1 = 1;
@@ -17502,17 +17145,23 @@
 	icon_state = "pipe-s"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aMi" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/machinery/door/airlock/pyro/maintenance{
+/obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aMj" = (
@@ -17575,9 +17224,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Solar Substation"
-	},
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aMq" = (
@@ -17645,18 +17293,15 @@
 	},
 /area/station/medical/robotics)
 "aMu" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Medical Director";
-	req_access_txt = "53"
-	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/medical_director,
 /turf/simulated/floor/white/side{
 	dir = 1
 	},
 /area/station/medical/head)
 "aMv" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/head)
 "aMw" = (
@@ -17682,18 +17327,21 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aMy" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/machinery/light,
+/turf/simulated/floor,
+/area/station/science/lobby)
+"aMz" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
-"aMz" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "crematorium pipe"
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -17742,13 +17390,18 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"aMH" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"aMH" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -17805,17 +17458,14 @@
 /area/station/hallway/primary/east)
 "aMN" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/turf/simulated/floor/green/side{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/area/station/crew_quarters/quarters)
 "aMO" = (
 /obj/cable{
 	d1 = 4;
@@ -17842,6 +17492,21 @@
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -17900,6 +17565,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "aMW" = (
@@ -17922,8 +17592,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aMZ" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "aNa" = (
@@ -18082,9 +17751,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aNp" = (
-/obj/machinery/door/airlock/pyro/maintenance{
+/obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
 "aNq" = (
@@ -18095,18 +17765,21 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aNr" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/fitness)
 "aNs" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "Inner Maintenance";
+	dir = 4
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/east)
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "aNt" = (
 /obj/machinery/camera{
 	c_tag = "East Hallway MidFore";
@@ -18127,17 +17800,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/detectives_office)
 "aNw" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/window_blinds,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "aNx" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 2;
-	name = "Detective";
-	req_access_txt = "4"
-	},
+/obj/machinery/door/airlock/pyro/security/alt,
+/obj/access_spawn/forensics,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aNy" = (
@@ -18176,11 +17845,14 @@
 	name = "AI Module Storage"
 	})
 "aNC" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/command{
-	name = "AI Module Storage";
-	req_access_txt = "19"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/command/alt,
+/obj/access_spawn/ai_upload,
+/obj/firedoor_spawn,
 /turf/simulated/floor/caution/north,
 /area/station/turret_protected/ai_upload{
 	name = "AI Module Storage"
@@ -18266,10 +17938,12 @@
 /area/station/medical/robotics)
 "aNN" = (
 /obj/table/reinforced/auto,
-/obj/window/reinforced{
-	dir = 2
-	},
 /obj/machinery/cashreg,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -18325,6 +17999,10 @@
 	pixel_x = -7
 	},
 /obj/item/stamp,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aNU" = (
@@ -18369,10 +18047,7 @@
 	},
 /area/station/crew_quarters/fitness)
 "aNZ" = (
-/obj/machinery/light{
-	dir = 1;
-	name = "light fixture"
-	},
+/obj/decal/boxingrope,
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
@@ -18387,11 +18062,6 @@
 	},
 /area/station/crew_quarters/fitness)
 "aOb" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/computer/arcade,
 /obj/machinery/light{
 	dir = 4;
@@ -18473,10 +18143,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload{
-	name = "AI Module Storage"
-	})
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "aOk" = (
 /obj/machinery/turretid{
 	pixel_x = -24
@@ -18498,6 +18171,11 @@
 	name = "autoname  - SS13";
 	network = "SS13";
 	tag = ""
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
@@ -18621,12 +18299,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Robotics";
-	req_access_txt = "29"
+	dir = 4
 	},
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -18702,43 +18379,22 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aOI" = (
-/obj/decal/boxingrope{
-	dir = 9;
-	icon_state = "ringrope"
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
+/area/listeningpost)
 "aOJ" = (
-/obj/decal/boxingrope,
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
-"aOK" = (
+/obj/stool/bench/red,
 /obj/decal/boxingrope{
-	dir = 5;
+	dir = 4;
 	icon_state = "ringrope"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
+/turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aOL" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
-"aOM" = (
-/obj/machinery/door/window/westright,
-/turf/simulated/floor,
-/area/station/crew_quarters/fitness)
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "aON" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -18827,11 +18483,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
 	name = "AI Module Storage"
@@ -18845,6 +18496,11 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
@@ -18990,59 +18646,32 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/space)
-"aPq" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aPr" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
 "aPs" = (
-/obj/decal/boxingrope{
-	dir = 8;
-	icon_state = "ringrope"
-	},
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/science)
 "aPt" = (
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aPu" = (
-/obj/decal/boxingropeenter{
-	dir = 4;
-	icon_state = "ringrope";
-	pixel_x = 0
+/turf/simulated/floor/stairs{
+	dir = 4
 	},
-/obj/stool/bench/red,
-/turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aPv" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "aPw" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/obj/machinery/door/window/westleft,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/fitness)
 "aPx" = (
@@ -19058,18 +18687,15 @@
 /area/station/hallway/primary/east)
 "aPy" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/security/detectives_office)
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/crew_quarters/pool)
 "aPz" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	dir = 4;
@@ -19079,22 +18705,18 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aPA" = (
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "fred2"
-	},
-/area/station/security/detectives_office)
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "aPB" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/wood/auto{
 	dir = 10
 	},
@@ -19106,11 +18728,6 @@
 	},
 /area/station/security/detectives_office)
 "aPC" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/table/wood/auto,
 /obj/item/camera_test{
 	desc = "A one use - polaroid camera. 30 photos left.";
@@ -19157,11 +18774,6 @@
 	})
 "aPH" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -19180,11 +18792,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "AI Module Storage";
-	req_access_txt = "19"
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 8
 	},
+/obj/access_spawn/ai_upload,
 /turf/simulated/floor/caution/north,
 /area/station/turret_protected/ai_upload{
 	name = "AI Module Storage"
@@ -19195,6 +18806,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
 	name = "AI Module Storage"
@@ -19204,14 +18820,18 @@
 	dir = 10;
 	icon_state = "shrub"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
 	name = "AI Module Storage"
 	})
 "aPL" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/wall/auto/supernorn,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/medical/morgue)
 "aPM" = (
 /obj/morgue{
@@ -19247,8 +18867,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/medical/morgue)
 "aPQ" = (
@@ -19260,30 +18881,26 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "aPR" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Medical Maintenance";
-	req_access_txt = "5"
-	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "aPS" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Robotics";
-	req_access_txt = "29"
-	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black/side{
 	dir = 1
 	},
 /area/station/medical/robotics)
 "aPT" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "aPU" = (
@@ -19301,12 +18918,23 @@
 	name = "Renovation Area"
 	})
 "aPX" = (
-/obj/machinery/hair_dye_dispenser,
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Renovation Area"
-	})
+/area/station/crew_quarters/pool)
 "aPY" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/security/detectives_office)
+"aPZ" = (
 /obj/machinery/light/small{
 	dir = 1;
 	status = 2
@@ -19316,26 +18944,14 @@
 /area/station/maintenance/storage{
 	name = "Renovation Area"
 	})
-"aPZ" = (
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Renovation Area"
-	})
 "aQa" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24;
-	pixel_y = 0
-	},
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Renovation Area"
-	})
+/turf/simulated/floor/carpet/grime,
+/area/station/security/detectives_office)
 "aQb" = (
 /obj/machinery/camera{
 	c_tag = "Inner Maintenance";
@@ -19345,25 +18961,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aQc" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	icon_state = "camera";
-	invisibility = 101;
-	name = "autoname - Entertainment";
-	network = "Zeta";
-	tag = ""
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
+/turf/simulated/floor,
+/area/station/hangar/science)
 "aQd" = (
-/obj/decal/boxingrope{
-	dir = 4;
-	icon_state = "ringrope"
-	},
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
-"aQe" = (
 /obj/stool/chair{
 	dir = 8
 	},
@@ -19371,6 +18976,14 @@
 	icon_state = "0,6"
 	},
 /area/station/crew_quarters/fitness)
+"aQe" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/science)
 "aQf" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light{
@@ -19386,9 +18999,7 @@
 /area/station/security/detectives_office)
 "aQh" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -19405,15 +19016,15 @@
 	},
 /area/station/security/detectives_office)
 "aQk" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
 	name = "AI Module Storage"
 	})
 "aQl" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/cable,
 /obj/machinery/power/apc{
 	dir = 4;
@@ -19506,11 +19117,10 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/machinery/door/airlock/pyro/medical{
-	dir = 4;
-	name = "Morgue";
-	req_access_txt = "5"
+/obj/machinery/door/airlock/pyro/medical/alt{
+	dir = 4
 	},
+/obj/access_spawn/morgue,
 /turf/simulated/floor/black,
 /area/station/medical/medbay)
 "aQv" = (
@@ -19539,13 +19149,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aQx" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Medical Maintenance";
-	req_access_txt = "5"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/medbay)
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space,
+/area/space)
 "aQy" = (
 /obj/table/auto,
 /obj/item/circular_saw{
@@ -19556,6 +19168,10 @@
 /obj/item/staple_gun,
 /obj/item/suture,
 /obj/item/hemostat,
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = -1
+	},
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},
@@ -19589,65 +19205,49 @@
 	dir = 1
 	},
 /area/station/medical/medbay)
-"aQC" = (
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/table/auto,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/mask/muzzle,
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
 "aQD" = (
-/obj/stool/bed,
-/obj/landmark/start{
-	name = "Medical Doctor"
+/obj/storage/secure/closet/medical{
+	name = "locker"
 	},
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aQE" = (
 /obj/machinery/light{
 	dir = 1;
 	pixel_x = -1
 	},
-/obj/storage/secure/closet/medical/anesthetic,
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
+/obj/machinery/clonepod,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aQF" = (
-/obj/stool/bed,
 /obj/decal/cleanable/cobweb2,
-/obj/landmark/start{
-	name = "Medical Doctor"
+/obj/storage/secure/closet/medical{
+	name = "locker"
 	},
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aQG" = (
 /turf/simulated/floor/black/side{
 	dir = 6
 	},
 /area/station/hallway/primary/west)
 "aQH" = (
-/obj/stool/barber_chair{
-	desc = "A traditional barbershop chair, obviously a very old one at that.  What it is doing on a space station you haven't the foggiest.";
-	name = "Old Barber Chair"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Renovation Area"
-	})
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/medbay/cloner)
 "aQI" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "Medbay Cell #2";
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Renovation Area"
-	})
+/obj/machinery/door_control{
+	id = "cloning_exit";
+	name = "Cloning Exit Door Control";
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/table/reinforced/auto,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aQJ" = (
 /obj/cable{
 	d1 = 1;
@@ -19661,18 +19261,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aQK" = (
-/obj/decal/boxingropeenter{
-	dir = 8;
-	icon_state = "ringrope";
-	pixel_x = 0
-	},
-/obj/stool/bench/blue,
+/obj/decal/boxingrope,
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aQL" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/hallway/primary/east)
 "aQM" = (
 /obj/disposalpipe/segment/mail,
@@ -19682,19 +19276,17 @@
 /area/station/hallway/primary/east)
 "aQN" = (
 /obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/security{
-	dir = 2;
-	name = "Detective";
-	req_access_txt = "4"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/security/alt,
+/obj/access_spawn/forensics,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aQO" = (
 /obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "S APC";
@@ -19705,14 +19297,10 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
+/obj/machinery/vending/security,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aQP" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	layer = 3.5;
@@ -19722,22 +19310,12 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aQQ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/wood/auto{
 	dir = 9
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aQR" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/wood/auto{
 	dir = 5
 	},
@@ -19746,15 +19324,9 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aQS" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload{
-	name = "AI Module Storage"
-	})
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/medical/medbay/cloner)
 "aQT" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -19766,16 +19338,6 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "aQU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/auto,
 /obj/item/aiModule/oneHuman,
 /obj/item/aiModule/notHuman,
@@ -19793,11 +19355,10 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/machinery/door/airlock/pyro/medical{
-	dir = 4;
-	name = "Morgue";
-	req_access_txt = "5"
+/obj/machinery/door/airlock/pyro/medical/alt{
+	dir = 4
 	},
+/obj/access_spawn/morgue,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "aQW" = (
@@ -19857,11 +19418,10 @@
 	dir = 4;
 	name = "crematorium pipe"
 	},
-/obj/machinery/door/airlock/pyro/medical{
-	dir = 4;
-	name = "Morgue";
-	req_access_txt = "5"
+/obj/machinery/door/airlock/pyro/medical/alt{
+	dir = 4
 	},
+/obj/access_spawn/morgue,
 /turf/simulated/floor/black,
 /area/station/medical/medbay)
 "aRc" = (
@@ -19934,41 +19494,37 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aRj" = (
-/obj/machinery/door/window/westleft{
-	name = "Medbay";
-	req_access_txt = "5"
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
 	},
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
-"aRk" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "crematorium pipe"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aRl" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Cell #2";
-	dir = 8
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
 	},
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aRm" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/west)
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	id = "cloning_exit"
+	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aRn" = (
 /obj/shrub{
 	dir = 8;
@@ -20000,81 +19556,101 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aRq" = (
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aRr" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/stockex)
 "aRs" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/stockex)
 "aRt" = (
-/obj/storage/crate,
-/obj/item/scissors,
-/obj/item/razor_blade,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "E APC";
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Renovation Area"
 	})
 "aRu" = (
 /obj/cable{
-	icon_state = "1-4"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Renovation Area"
-	})
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "aRv" = (
-/obj/decal/cleanable/fungus,
+/obj/disposalpipe/segment/mail,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "aRw" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-8"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "aRx" = (
-/obj/decal/boxingrope{
-	dir = 9;
-	icon_state = "ringrope"
+/obj/decal/stage_edge,
+/obj/table{
+	layer = 4
 	},
-/turf/simulated/floor/specialroom/gym,
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
 /area/station/crew_quarters/fitness)
 "aRy" = (
-/obj/decal/boxingrope,
-/turf/simulated/floor/specialroom/gym,
+/obj/decal/stage_edge,
+/obj/table{
+	layer = 4
+	},
+/obj/item/wrestlingbell{
+	layer = 4.1
+	},
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
 /area/station/crew_quarters/fitness)
 "aRz" = (
-/obj/decal/boxingrope{
-	dir = 5;
-	icon_state = "ringrope"
-	},
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
-"aRA" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
+"aRA" = (
 /obj/table,
 /obj/item/storage/firstaid,
 /turf/simulated/floor/wood{
@@ -20112,6 +19688,11 @@
 	},
 /area/station/hallway/primary/east)
 "aRF" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red/side{
 	dir = 5
 	},
@@ -20122,19 +19703,12 @@
 "aRH" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload{
-	name = "AI Module Storage"
-	})
+/turf/simulated/floor/white,
+/area/station/medical/medbay/surgery)
 "aRI" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/auto,
 /obj/item/card/id/captains_spare,
 /obj/item/pinpointer,
@@ -20160,11 +19734,10 @@
 	dir = 4;
 	name = "crematorium pipe"
 	},
-/obj/machinery/door/airlock/pyro/medical{
-	dir = 4;
-	name = "Morgue";
-	req_access_txt = "5"
+/obj/machinery/door/airlock/pyro/medical/alt{
+	dir = 4
 	},
+/obj/access_spawn/morgue,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "aRM" = (
@@ -20224,6 +19797,11 @@
 	},
 /area/station/medical/medbay/surgery)
 "aRS" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "aRT" = (
@@ -20231,14 +19809,13 @@
 	dir = 8
 	},
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/window/reinforced{
 	dir = 4;
 	icon_state = "rwindow"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/redwhite{
 	dir = 4
@@ -20246,9 +19823,12 @@
 /area/station/medical/medbay/surgery)
 "aRU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -20261,9 +19841,6 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
-	},
-/obj/cable{
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -20312,6 +19889,7 @@
 	dir = 4;
 	name = "Stock Exchange"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/stockex)
 "aSc" = (
@@ -20414,30 +19992,23 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
 "aSm" = (
-/obj/storage/crate,
-/obj/item/clothing/head/wig,
-/obj/item/dye_bottle,
-/obj/item/dye_bottle,
-/obj/item/clothing/under/misc/barber,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage{
-	name = "Renovation Area"
-	})
-"aSn" = (
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
+/obj/machinery/hair_dye_dispenser,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Renovation Area"
 	})
 "aSo" = (
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aSp" = (
-/obj/decal/stage_edge,
+/obj/stool/chair{
+	dir = 1;
+	icon_state = "chair"
+	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
@@ -20459,11 +20030,6 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/clothing/gloves/boxing,
 /obj/item/clothing/gloves/boxing,
 /obj/item/clothing/gloves/boxing,
@@ -20483,6 +20049,11 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -20505,13 +20076,9 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "aSv" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/obj/machinery/clone_scanner,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aSw" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -20524,8 +20091,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "aSx" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
 "aSy" = (
@@ -20587,25 +20153,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"aSG" = (
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/storage/secure/closet/medical/medkit,
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
-"aSH" = (
-/obj/stool/bed,
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = -1
-	},
-/obj/landmark/start{
-	name = "Medical Doctor"
-	},
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
 "aSI" = (
 /obj/machinery/light{
 	dir = 8;
@@ -20624,6 +20171,7 @@
 	dir = 4;
 	name = "Stock Exchange"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/stockex)
 "aSK" = (
@@ -20694,45 +20242,29 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
 "aSV" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Renovation Area"
 	})
 "aSW" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/stool/barber_chair{
+	desc = "A traditional barbershop chair, obviously a very old one at that.  What it is doing on a space station you haven't the foggiest.";
+	name = "Old Barber Chair"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Renovation Area"
 	})
 "aSX" = (
-/obj/reagent_dispensers/heliumtank,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/storage{
+	name = "Renovation Area"
+	})
 "aSY" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -20753,13 +20285,14 @@
 	},
 /area/station/crew_quarters/fitness)
 "aTb" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/stool/chair/office/blue{
+	dir = 4
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/fitness)
+/obj/landmark/start{
+	name = "Medical Doctor"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aTc" = (
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -20850,11 +20383,6 @@
 /area/station/crew_quarters/captain)
 "aTk" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -20923,6 +20451,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "aTr" = (
@@ -20940,35 +20473,30 @@
 	},
 /area/station/medical/medbay/surgery)
 "aTs" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
+/obj/storage/crate,
+/obj/item/scissors,
+/obj/item/razor_blade,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage{
+	name = "Renovation Area"
+	})
 "aTt" = (
-/obj/machinery/door/window/westleft{
-	name = "Medbay";
-	req_access_txt = "5"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/neutral,
-/area/station/medical/medbay)
+/area/station/medical/medbay/cloner)
 "aTu" = (
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aTv" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Cell #1";
 	dir = 8
 	},
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
+/obj/machinery/computer/cloning{
+	dir = 8
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aTw" = (
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -20984,6 +20512,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/machinery/phone,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "aTz" = (
@@ -21026,83 +20555,50 @@
 	},
 /turf/space,
 /area/space)
-"aTD" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aTE" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light/small{
 	dir = 8;
 	icon_state = "bulb1"
 	},
 /obj/cable{
-	icon_state = "1-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/fitness)
 "aTF" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/fitness/stacklifter,
 /turf/simulated/floor/wood,
-/area/station/maintenance/inner/central)
-"aTG" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/fitness)
 "aTH" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/fitness/weightlifter,
 /turf/simulated/floor/wood,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/fitness)
 "aTI" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light/small{
 	brightness = 2;
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/fitness)
 "aTJ" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage{
+	name = "Renovation Area"
+	})
+"aTK" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/central)
-"aTK" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aTL" = (
@@ -21218,12 +20714,18 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "aTV" = (
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/space,
-/area/space)
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage{
+	name = "Renovation Area"
+	})
 "aTW" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -21304,29 +20806,22 @@
 	},
 /area/station/medical/medbay/surgery)
 "aUe" = (
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/obj/table/auto,
-/obj/bedsheetbin,
-/obj/item/device/analyzer/healthanalyzer,
+/obj/access_spawn/medical,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/neutral,
-/area/station/medical/medbay)
+/area/station/medical/medbay/cloner)
 "aUf" = (
-/obj/stool/bed,
 /obj/machinery/light,
-/obj/landmark/start{
-	name = "Medical Doctor"
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 1;
-	frequency = 1445;
-	name = "Medical Intercom"
-	},
-/turf/simulated/floor/neutral,
-/area/station/medical/medbay)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aUg" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/plating,
@@ -21397,53 +20892,69 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "aUk" = (
-/obj/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aUl" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aUm" = (
-/obj/machinery/camera{
-	c_tag = "Inner Maintenance";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/maintenance/inner/central)
-"aUn" = (
-/turf/simulated/floor/wood,
-/area/station/maintenance/inner/central)
-"aUo" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/station/maintenance/inner/central)
-"aUp" = (
 /obj/cable{
 	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
+"aUl" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/maintenance{
+/obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aUq" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/area/station/crew_quarters/fitness)
+"aUm" = (
+/obj/machinery/camera{
+	c_tag = "Inner Maintenance";
+	dir = 1
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aUn" = (
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aUo" = (
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
+"aUp" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/fitness)
+"aUq" = (
 /obj/machinery/camera{
 	c_tag = "Inner Maintenance"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
@@ -21501,36 +21012,35 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/command{
-	name = "Captain's Quarters";
-	req_access_txt = "20"
-	},
+/obj/machinery/door/airlock/pyro/command/alt,
+/obj/access_spawn/captain,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
 "aUw" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aUx" = (
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "aUy" = (
 /obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aUz" = (
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
 "aUA" = (
 /obj/machinery/door/window/southleft{
 	name = "Operating Room";
@@ -21605,6 +21115,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aUG" = (
@@ -21612,7 +21127,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "E APC";
@@ -21627,7 +21141,7 @@
 "aUI" = (
 /obj/decal/poster/wallsign/medbay,
 /turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/west)
+/area/station/medical/medbay/cloner)
 "aUJ" = (
 /obj/machinery/computer/stockexchange{
 	dir = 4;
@@ -21661,7 +21175,7 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "aUO" = (
 /obj/machinery/power/data_terminal,
@@ -21670,7 +21184,7 @@
 	},
 /obj/cable,
 /obj/machinery/emitter,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "aUP" = (
 /obj/machinery/power/apc{
@@ -21680,10 +21194,9 @@
 	pixel_y = 0
 	},
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aUQ" = (
@@ -21691,7 +21204,16 @@
 	codes_txt = "patrol;next_patrol=Security Hallway";
 	location = "Bridge Hallway"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aUR" = (
@@ -21701,7 +21223,6 @@
 	mail_tag = "chief_engineer";
 	name = "Chief Engineer mail router"
 	},
-/obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -21765,11 +21286,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Chief Engineer";
-	req_access_txt = "49"
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 8
 	},
+/obj/access_spawn/engineering_chief,
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -21863,32 +21383,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aVg" = (
-/obj/machinery/clone_scanner,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/machinery/chem_master,
 /turf/simulated/floor/red/corner{
 	dir = 8
 	},
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aVh" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/cloning,
+/obj/machinery/chem_dispenser,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aVi" = (
-/obj/machinery/clonepod,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/machinery/chem_heater,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aVj" = (
 /obj/machinery/light{
 	dir = 1
@@ -21897,18 +21404,12 @@
 	c_tag = "Medical Research West";
 	dir = 2
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/clonegrinder,
+/obj/table/reinforced/chemistry/beakers,
+/obj/machinery/glass_recycler,
+/obj/item/storage/box/beakerbox,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aVk" = (
-/obj/table/auto,
-/obj/item/storage/firstaid/regular,
-/obj/item/reagent_containers/syringe,
-/obj/item/paper/Cloning,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -21918,16 +21419,20 @@
 	name = "N APC";
 	pixel_y = 24
 	},
-/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat,
-/obj/item/reagent_containers/food/snacks/ingredient/meat/monkeymeat,
+/obj/table/reinforced/chemistry/beakers,
+/obj/item/device/reagentscanner{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/item/device/reagentscanner,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aVl" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/redwhite{
 	dir = 5
 	},
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aVm" = (
 /obj/machinery/vending/medical,
 /obj/window/reinforced{
@@ -21941,8 +21446,10 @@
 	dir = 1;
 	pixel_x = -1
 	},
-/obj/storage/secure/closet/medical/medicine,
 /obj/disposalpipe/segment/morgue,
+/obj/stool/chair/comfy/wheelchair{
+	dir = 4
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aVo" = (
@@ -21995,59 +21502,37 @@
 	icon_state = "red2"
 	},
 /area/station/medical/medbay/lobby)
-"aVs" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/medbay/lobby)
 "aVt" = (
+/obj/machinery/power/apc/autoname_south,
 /obj/cable{
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aVu" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/morgue{
-	name = "crematorium pipe"
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
+/obj/machinery/clonegrinder,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/cloner)
 "aVv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail,
+/obj/storage/crate,
+/obj/item/clothing/head/wig,
+/obj/item/dye_bottle,
+/obj/item/dye_bottle,
+/obj/item/clothing/under/misc/barber,
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/storage{
+	name = "Renovation Area"
+	})
 "aVw" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/area/station/maintenance/storage{
+	name = "Renovation Area"
+	})
 "aVx" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/west)
@@ -22064,24 +21549,28 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "aVB" = (
-/turf/simulated/floor/plating/scorched,
-/area/space)
-"aVC" = (
-/turf/space,
-/turf/simulated/floor/plating/damaged2,
-/area/space)
-"aVD" = (
 /obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"aVC" = (
+/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/plating/damaged2,
 /area/space)
 "aVE" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/field_generator,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "aVF" = (
 /obj/machinery/emitter{
@@ -22105,17 +21594,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aVI" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -22127,6 +21613,8 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aVK" = (
@@ -22138,6 +21626,8 @@
 	name = "Bridge Lockdown Doors";
 	opacity = 0
 	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -22247,11 +21737,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	name = "Medical Maintenance";
-	req_access_txt = "5"
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aVX" = (
@@ -22263,15 +21753,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/white/checker{
 	dir = 9
 	},
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aVY" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -22280,11 +21765,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/stool/chair/office/blue{
 	dir = 1;
@@ -22296,7 +21776,7 @@
 /turf/simulated/floor/red/corner{
 	dir = 8
 	},
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aVZ" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -22306,13 +21786,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aWa" = (
 /obj/disposalpipe/junction{
 	dir = 8;
@@ -22324,7 +21799,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aWb" = (
 /obj/window/reinforced{
 	dir = 8;
@@ -22388,11 +21863,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aWg" = (
@@ -22404,35 +21874,16 @@
 	dir = 8;
 	pixel_x = 6
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aWh" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/decal/cleanable/fungus,
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/medbay)
+/area/station/crew_quarters/fitness)
 "aWi" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Lobby";
 	dir = 4
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/stool/chair/comfy/blue{
 	dir = 4;
@@ -22444,57 +21895,46 @@
 	},
 /area/station/medical/medbay/lobby)
 "aWj" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/carpet{
 	dir = 2;
 	icon_state = "red2"
 	},
 /area/station/medical/medbay/lobby)
 "aWk" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "red2"
 	},
 /area/station/medical/medbay/lobby)
 "aWl" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
 "aWm" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
 	},
-/turf/simulated/floor/blue/side{
-	dir = 8
-	},
-/area/station/hallway/primary/west)
-"aWn" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
+"aWn" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aWo" = (
-/obj/cable,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "E APC";
@@ -22504,22 +21944,18 @@
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aWp" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aWq" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/indestructible/shuttle_corner{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/shuttle,
+/area/shuttle/arrival/station)
 "aWr" = (
 /obj/machinery/power/monitor,
 /obj/cable{
@@ -22537,12 +21973,11 @@
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
 "aWt" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
 "aWu" = (
@@ -22564,7 +21999,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "aWw" = (
 /obj/machinery/power/data_terminal,
@@ -22577,7 +22012,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/field_generator,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "aWx" = (
 /turf/simulated/floor/circuit,
@@ -22592,13 +22027,13 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "aWz" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/scorched,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "aWA" = (
 /obj/machinery/power/data_terminal,
@@ -22610,7 +22045,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "aWB" = (
 /obj/cable{
@@ -22618,21 +22053,29 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aWC" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/pharmacy)
 "aWD" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -22740,24 +22183,24 @@
 /turf/simulated/floor/redwhite{
 	dir = 10
 	},
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aWO" = (
 /turf/simulated/floor/white/checker{
 	dir = 9
 	},
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aWP" = (
 /turf/simulated/floor/red/corner{
 	dir = 8
 	},
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aWQ" = (
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aWR" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aWS" = (
 /obj/window/reinforced{
 	dir = 8;
@@ -22803,16 +22246,14 @@
 /obj/table/reinforced/auto,
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/clothing/glasses/healthgoggles,
+/obj/machinery/phone{
+	pixel_y = 7
+	},
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
 	},
 /area/station/medical/medbay)
 "aWY" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/bluewhite{
 	dir = 9
@@ -22868,10 +22309,13 @@
 /turf/simulated/floor/circuit,
 /area/space)
 "aXf" = (
-/obj/lattice,
-/obj/item/clothing/head/apprentice,
-/turf/space,
-/area/space)
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "aXg" = (
 /obj/disposalpipe/junction,
 /obj/item/mousetrap,
@@ -22958,11 +22402,9 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aXp" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Medical Maintenance";
-	req_access_txt = "5"
-	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aXq" = (
@@ -22979,7 +22421,7 @@
 /obj/item/clothing/glasses/healthgoggles,
 /obj/item/clothing/glasses/healthgoggles,
 /turf/simulated/floor/red,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aXr" = (
 /obj/window/reinforced{
 	dir = 2;
@@ -22992,7 +22434,7 @@
 /turf/simulated/floor/redwhite{
 	dir = 10
 	},
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aXs" = (
 /obj/machinery/door/window/southright{
 	name = "Medical Storage";
@@ -23004,7 +22446,7 @@
 /turf/simulated/floor/white/checker{
 	dir = 9
 	},
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aXt" = (
 /obj/machinery/door/window/southleft{
 	name = "Medical Storage";
@@ -23016,11 +22458,8 @@
 /turf/simulated/floor/red/corner{
 	dir = 8
 	},
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aXu" = (
-/obj/storage/secure/closet/medical{
-	name = "locker"
-	},
 /obj/window/reinforced{
 	dir = 2;
 	icon_state = "rwindow"
@@ -23028,13 +22467,11 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/storage/secure/closet/medical/medkit,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aXv" = (
 /obj/disposalpipe/segment,
-/obj/storage/secure/closet/medical{
-	name = "locker"
-	},
 /obj/window/reinforced{
 	dir = 2;
 	icon_state = "rwindow"
@@ -23042,8 +22479,9 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/storage/secure/closet/medical/medkit,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/cloner)
+/area/station/medical/medbay/pharmacy)
 "aXw" = (
 /obj/window/reinforced{
 	dir = 8;
@@ -23120,24 +22558,19 @@
 	},
 /area/station/medical/medbay)
 "aXC" = (
-/obj/machinery/door/window/eastleft{
-	name = "Pharmacy";
-	req_access_txt = "5"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
 	},
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
 "aXD" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
@@ -23274,7 +22707,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating/damaged3,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "aXS" = (
 /obj/cable{
@@ -23304,12 +22737,10 @@
 	dir = 1;
 	pixel_x = -1
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 5
 	},
@@ -23332,10 +22763,11 @@
 	name = "Bridge Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/door/window/eastleft{
-	name = "Bridge";
-	req_access_txt = "19"
+/obj/machinery/door/airlock/pyro/glass/command{
+	dir = 8
 	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -23370,6 +22802,7 @@
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred1"
@@ -23548,11 +22981,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "aYu" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -23565,12 +22993,10 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 9
 	},
@@ -23602,31 +23028,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aYA" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aYB" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/engine/substation/west)
+/obj/reagent_dispensers/heliumtank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "aYC" = (
 /obj/cable{
 	d2 = 4;
@@ -23729,37 +23137,24 @@
 /turf/simulated/floor,
 /area/station/engine/substation/east)
 "aYM" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/simulated/floor/shuttle,
+/area/shuttle/arrival/station)
+"aYN" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"aYN" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/east)
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "aYO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/camera{
 	c_tag = "East Hallway Center";
 	c_tag_order = 999;
@@ -23768,12 +23163,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aYP" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -23799,10 +23192,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/window/eastright{
-	name = "Bridge";
-	req_access_txt = "19"
+/obj/machinery/door/airlock/pyro/glass/command{
+	dir = 8
 	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -24004,11 +23398,6 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -24127,17 +23516,13 @@
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred1"
 	},
 /area/station/bridge)
 "aZu" = (
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 3;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/syringe,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -24146,10 +23531,7 @@
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
-/obj/item/reagent_containers/glass/bottle/antitoxin{
-	pixel_x = -3;
-	pixel_y = 9
-	},
+/obj/machinery/phone,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred1"
@@ -24248,15 +23630,14 @@
 	},
 /area/station/medical/medbay)
 "aZC" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Break Room";
-	req_access_txt = "5"
+	dir = 4
 	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aZD" = (
@@ -24360,14 +23741,12 @@
 	},
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/reagent_containers/syringe,
-/obj/machinery/door/window/southright{
-	name = "Medbay";
-	req_access_txt = "5"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/medical,
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
 	},
@@ -24404,12 +23783,15 @@
 /area/station/medical/medbay)
 "aZP" = (
 /obj/machinery/light,
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -24517,16 +23899,21 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/security{
-	dir = 2
-	},
+/obj/machinery/computer/card,
 /turf/simulated/floor,
 /area/station/bridge)
 "aZY" = (
-/obj/shrub{
-	dir = 1;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
+/obj/machinery/computer/security{
+	dir = 2
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -24586,8 +23973,7 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bae" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "baf" = (
@@ -24647,16 +24033,17 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "bal" = (
+/obj/machinery/door_control{
+	id = "medbay_front";
+	name = "Medbay Door Control";
+	pixel_x = 21;
+	pixel_y = 23
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
 /area/station/medical/medbay)
 "bam" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
@@ -24670,26 +24057,26 @@
 	icon_state = "plant";
 	tag = "icon-plant (NORTH)"
 	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 9
 	},
 /area/station/medical/medbay/lobby)
 "ban" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 1
-	},
-/area/station/medical/medbay/lobby)
-"bao" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
+"bao" = (
 /obj/health_scanner/floor{
 	find_in_range = 0;
 	id = "lobby"
@@ -24709,9 +24096,9 @@
 /area/station/medical/medbay/lobby)
 "baq" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 1
@@ -24719,9 +24106,15 @@
 /area/station/medical/medbay/lobby)
 "bar" = (
 /obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance{
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor,
 /area/station/maintenance/inner/central)
 "bas" = (
@@ -24729,6 +24122,11 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
@@ -24747,18 +24145,22 @@
 /turf/simulated/floor,
 /area/station/engine/substation/west)
 "bau" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	id = "medbay_front";
-	name = "Medical Bay";
-	req_access_txt = "5"
-	},
 /obj/machinery/secscanner{
 	dir = 4;
 	icon_state = "scanner_on";
 	pixel_x = -20
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	id = "medbay_front"
+	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "bav" = (
@@ -24775,7 +24177,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "baw" = (
 /obj/machinery/power/data_terminal,
@@ -24787,7 +24189,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "bax" = (
 /obj/cable{
@@ -24819,6 +24221,10 @@
 /area/station/maintenance/inner/central)
 "baA" = (
 /obj/table/reinforced,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "baB" = (
@@ -24838,43 +24244,26 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "baC" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/door_control{
 	id = "east blast";
 	name = "Blast Door Control";
 	pixel_x = 25;
 	pixel_y = 0
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/station/bridge)
 "baD" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/bridge)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "baE" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	dir = 4;
@@ -24885,14 +24274,7 @@
 /area/station/bridge)
 "baF" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -25021,6 +24403,16 @@
 /area/station/medical/medbay/lobby)
 "baR" = (
 /obj/disposalpipe/segment/morgue,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -25030,20 +24422,25 @@
 	codes_txt = "patrol;next_patrol=Cafeteria";
 	location = "Medical Hallway"
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "baT" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/lobby)
-"baU" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
+"baU" = (
 /obj/table/auto,
 /obj/item/aiModule/freeform,
 /obj/item/aiModule/rename,
@@ -25068,9 +24465,13 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "baW" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Electrical Substation"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor,
 /area/station/engine/substation/west)
 "baX" = (
@@ -25079,15 +24480,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Solar Substation"
-	},
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor,
 /area/station/engine/substation/east)
 "baY" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "baZ" = (
@@ -25150,6 +24549,9 @@
 	dir = 1;
 	frequency = 1445;
 	name = "Medical Intercom"
+	},
+/obj/landmark/start{
+	name = "Medical Doctor"
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -25269,12 +24671,11 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "bbt" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
 "bbu" = (
@@ -25306,7 +24707,7 @@
 "bbx" = (
 /obj/machinery/power/data_terminal,
 /obj/cable,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "bby" = (
 /obj/machinery/emitter{
@@ -25320,30 +24721,48 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "bbA" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/obj/item/clothing/head/apprentice,
+/turf/space,
+/area/space)
 "bbB" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/lobby)
 "bbC" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/blue/side{
+	dir = 8
+	},
+/area/station/hallway/primary/west)
+"bbE" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/neutral/side{
+	dir = 2
+	},
+/area/station/science/lobby)
+"bbF" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -25351,46 +24770,12 @@
 	},
 /obj/cable{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"bbD" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor,
-/area/station/hallway/primary/east)
-"bbE" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/pyro,
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
-"bbF" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/bridge)
+/area/station/hallway/primary/west)
 "bbG" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/vehicle/segway,
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -25430,6 +24815,7 @@
 	layer = 3;
 	level = 2
 	},
+/obj/storage/secure/closet/medical/medicine,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -25450,10 +24836,9 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/lobby)
 "bbN" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Medical Maintenance";
-	req_access_txt = "5"
-	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bbO" = (
@@ -25465,11 +24850,6 @@
 	},
 /area/station/hallway/primary/west)
 "bbP" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -25502,6 +24882,16 @@
 /obj/disposalpipe/segment/mail{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
@@ -25630,21 +25020,24 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bch" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance{
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/maintenance/west)
 "bci" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
 "bcj" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "bck" = (
@@ -25654,61 +25047,17 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/external{
-	name = "Engine Supply Dock";
-	req_access_txt = "40"
-	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
-"bcm" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/inner)
-"bcn" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/inner)
 "bco" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bcp" = (
-/obj/machinery/door/airlock/pyro/external{
-	name = "Engine Supply Dock";
-	req_access_txt = "40"
-	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
 "bcq" = (
@@ -25985,11 +25334,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/command{
-	dir = 2;
-	name = "Head of Personnel";
-	req_access_txt = "55"
-	},
+/obj/machinery/door/airlock/pyro/command/alt,
+/obj/access_spawn/head_of_personnel,
 /turf/simulated/floor/grey/side{
 	dir = 1
 	},
@@ -25998,23 +25344,30 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "bcX" = (
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+/obj/disposalpipe/segment/morgue{
+	name = "crematorium pipe"
 	},
-/turf/space,
-/area/space)
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "bcY" = (
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/lattice{
-	dir = 2;
-	icon_state = "lattice-dir"
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bcZ" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -26028,27 +25381,23 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bda" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/obj/storage/closet/wardrobe/pride,
+/turf/simulated/floor,
+/area/station/crew_quarters/locker)
 "bdb" = (
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
 	},
 /obj/cable{
-	d1 = 2;
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -26060,13 +25409,15 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/west)
 "bdd" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "bde" = (
@@ -26185,6 +25536,7 @@
 "bdp" = (
 /obj/table/auto,
 /obj/item/device/light/flashlight,
+/obj/item/aiModule/reset,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bdq" = (
@@ -26263,11 +25615,6 @@
 	},
 /area/station/crew_quarters/heads)
 "bdv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/genetics_booth,
 /turf/simulated/floor/bluewhite{
 	dir = 1
@@ -26284,27 +25631,26 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/phone/wall{
+	pixel_y = 30
+	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
 "bdx" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/heads)
 "bdy" = (
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "bdz" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/plating,
@@ -26315,64 +25661,52 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light/small{
-	dir = 1
+/turf/simulated/floor/bluewhite{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/area/station/medical/medbay)
 "bdB" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
 	pixel_y = 24
 	},
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bdC" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
 	},
-/obj/machinery/camera,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "bdD" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/space_heater,
 /obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "bdE" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/vending/medical_public,
 /turf/simulated/floor/blue/side{
 	dir = 10
 	},
 /area/station/hallway/primary/west)
 "bdF" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/blue/side{
 	dir = 0
 	},
@@ -26398,11 +25732,6 @@
 	},
 /area/station/hallway/primary/west)
 "bdI" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
@@ -26484,11 +25813,11 @@
 	},
 /area/station/engine/inner)
 "bdS" = (
-/obj/item/storage/toolbox/mechanical,
 /obj/machinery/light_switch{
 	name = "S light switch";
 	pixel_y = -24
 	},
+/obj/storage/closet/radiation,
 /turf/simulated/floor,
 /area/station/engine/inner)
 "bdT" = (
@@ -26557,11 +25886,6 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat,
 /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat{
 	icon = 'icons/effects/blood.dmi';
@@ -26596,11 +25920,6 @@
 	},
 /area/station/crew_quarters/kitchen)
 "bdX" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/red/corner{
 	dir = 2
 	},
@@ -26689,11 +26008,6 @@
 "bei" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
@@ -26734,11 +26048,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/camera{
-	c_tag = "Inner Maintenance";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/green/side,
 /area/station/maintenance/inner/central)
 "bem" = (
 /obj/machinery/computer3/generic/engine{
@@ -26789,6 +26099,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/phone/wall{
+	pixel_x = 24;
+	pixel_y = 4
+	},
 /turf/simulated/floor/caution/south{
 	dir = 2
 	},
@@ -26800,11 +26114,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/inner)
 "ber" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -26860,11 +26169,6 @@
 	},
 /area/station/crew_quarters/heads)
 "bey" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/wood/auto,
 /obj/machinery/recharger{
 	pixel_y = 3
@@ -26889,15 +26193,20 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/heads)
 "beB" = (
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/space,
-/area/space)
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
 "beC" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "beD" = (
@@ -26922,8 +26231,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/engineering,
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_power,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
 "beI" = (
@@ -26943,19 +26253,20 @@
 /area/station/maintenance/inner/central)
 "beK" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
 /area/station/hallway/primary/east)
 "beL" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance{
+/obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
 	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "beM" = (
@@ -26986,13 +26297,16 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/heads)
 "beS" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/heads)
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "beT" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
@@ -27064,12 +26378,6 @@
 	dir = 5
 	},
 /area/station/medical/research)
-"bfb" = (
-/obj/disposalpipe/segment,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/research)
 "bfc" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_normal"
@@ -27078,10 +26386,10 @@
 	dir = 1;
 	icon_state = "tube1"
 	},
-/mob/living/carbon/human/monkey,
 /turf/simulated/floor/grass/random,
 /area/station/medical/research)
 "bfd" = (
+/obj/machinery/vending/monkey,
 /turf/simulated/floor/grass/random,
 /area/station/medical/research)
 "bfe" = (
@@ -27112,14 +26420,18 @@
 /turf/simulated/floor/caution/north,
 /area/station/engine/inner)
 "bfi" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/west)
 "bfj" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -27128,19 +26440,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bfl" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/junction{
 	dir = 0;
 	icon_state = "pipe-y"
@@ -27149,16 +26451,17 @@
 /area/station/maintenance/east)
 "bfm" = (
 /obj/cable{
-	d1 = 4;
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "bfn" = (
 /obj/cable{
 	d1 = 4;
@@ -27168,19 +26471,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bfo" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/maintenance/inner/central)
 "bfp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bfq" = (
@@ -27223,16 +26520,13 @@
 	},
 /area/space)
 "bfu" = (
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/turf/space,
-/area/space)
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "bfv" = (
 /obj/cable{
 	d1 = 1;
@@ -27297,7 +26591,6 @@
 	},
 /area/station/medical/research)
 "bfB" = (
-/mob/living/carbon/human/monkey,
 /turf/simulated/floor/grass/random,
 /area/station/medical/research)
 "bfC" = (
@@ -27377,11 +26670,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "bfK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
@@ -27408,11 +26696,6 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/east)
 "bfN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
@@ -27448,23 +26731,21 @@
 /area/station/maintenance/east)
 "bfR" = (
 /obj/cable{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/disposal_pipedispenser/mobile{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bfS" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	icon_state = "airlock_closed"
@@ -27472,16 +26753,23 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bfT" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4;
-	icon_state = "airlock_closed"
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bfU" = (
-/obj/landmark/spawner{
-	name = "monkeyspawn_stirstir"
+/obj/disposalpipe/trunk/ejection{
+	dir = 1
 	},
+/obj/machinery/floorflusher/genpop,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bfV" = (
@@ -27522,16 +26810,14 @@
 	},
 /area/station/medical/research)
 "bga" = (
-/obj/overlay{
-	anchored = 1;
-	icon = 'icons/misc/beach2.dmi';
-	icon_state = "palm1";
-	layer = 10;
-	name = "palm tree"
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/mob/living/carbon/human/monkey,
-/turf/simulated/floor/grass/random,
-/area/station/medical/research)
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
 "bgb" = (
 /obj/stool/bench/green/auto,
 /turf/simulated/floor/white/checker2{
@@ -27640,6 +26926,7 @@
 /area/station/maintenance/east)
 "bgo" = (
 /obj/machinery/light/small,
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bgp" = (
@@ -27669,7 +26956,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bgt" = (
-/obj/storage/closet/emergency,
+/obj/storage/closet/fire,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bgu" = (
@@ -27690,6 +26977,7 @@
 /area/station/medical/research)
 "bgw" = (
 /obj/table/auto,
+/obj/machinery/phone,
 /turf/simulated/floor/white/checker2{
 	dir = 9
 	},
@@ -27706,20 +26994,16 @@
 	},
 /area/station/medical/research)
 "bgz" = (
-/obj/machinery/door/window/southleft{
-	name = "Monkey Pen";
-	req_access_txt = "9"
-	},
-/mob/living/carbon/human/monkey,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/medlab,
 /turf/simulated/floor/grass/random,
 /area/station/medical/research)
 "bgA" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Med-Sci";
-	req_access_txt = "9"
+	dir = 4
 	},
+/obj/access_spawn/medlab,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/research)
 "bgB" = (
@@ -27733,7 +27017,9 @@
 	},
 /area/station/medical/research)
 "bgD" = (
-/obj/machinery/door/window/eastleft,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
 /turf/simulated/floor/green/side{
 	dir = 5
 	},
@@ -27793,13 +27079,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
 "bgO" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/decal/boxingrope{
+	dir = 9;
+	icon_state = "ringrope"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/hos)
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/fitness)
 "bgP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/armory)
@@ -27898,18 +27185,19 @@
 /turf/simulated/floor/white,
 /area/station/medical/research)
 "bgW" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -27942,8 +27230,7 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "bgZ" = (
@@ -27963,21 +27250,19 @@
 /turf/simulated/floor/white,
 /area/station/medical/research)
 "bha" = (
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-s"
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/secdetector{
+	area_access = 99;
+	detector_id = "AI Core";
+	dir = 4
 	},
-/turf/simulated/floor/white,
-/area/station/medical/research)
+/turf/simulated/floor/plating/airless,
+/area/station/security/armory)
 "bhb" = (
 /obj/cable{
 	d1 = 4;
@@ -28007,7 +27292,6 @@
 	},
 /area/station/medical/research)
 "bhd" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -28018,10 +27302,10 @@
 	icon_state = "pipe-s"
 	},
 /obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Med-Sci";
-	req_access_txt = "9"
+	dir = 4
 	},
+/obj/access_spawn/medlab,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/research)
 "bhe" = (
@@ -28056,7 +27340,6 @@
 /turf/simulated/floor/green/side,
 /area/station/medical/research)
 "bhg" = (
-/obj/machinery/door/window/eastright,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -28065,6 +27348,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
 /turf/simulated/floor/green/side{
 	dir = 6
@@ -28090,11 +27376,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
@@ -28102,18 +27383,26 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "bhj" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
 	},
+/obj/machinery/light,
 /turf/simulated/floor,
-/area/station/hallway/primary/west)
+/area/station/science/lobby)
 "bhk" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
+	},
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -28174,7 +27463,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/engineering,
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_power,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/substation/pylon)
 "bht" = (
@@ -28195,24 +27486,19 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bhv" = (
-/obj/disposalpipe/segment/mail,
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
+/obj/stool/bench/green/auto,
+/turf/simulated/floor/greenwhite/other{
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/science/lobby)
 "bhw" = (
-/obj/machinery/door/firedoor/pyro{
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "bhx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_x = -1
@@ -28227,13 +27513,15 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "bhz" = (
-/obj/decal/skeleton{
-	desc = "Um.  Uh.  Oh dear."
-	},
-/turf/simulated/floor/plating/random,
+/obj/machinery/port_a_brig,
+/turf/simulated/floor/black,
 /area/station/security/brig)
 "bhA" = (
-/turf/simulated/floor/plating/random,
+/obj/stool/chair/red,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/black,
 /area/station/security/brig)
 "bhB" = (
 /obj/stool,
@@ -28271,6 +27559,9 @@
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "bhG" = (
+/obj/machinery/phone/wall{
+	pixel_y = 30
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fred2"
@@ -28311,7 +27602,6 @@
 /area/station/security/hos)
 "bhK" = (
 /obj/machinery/power/data_terminal,
-/obj/cable,
 /obj/machinery/computer/security,
 /turf/simulated/floor/carpet{
 	dir = 5;
@@ -28368,31 +27658,35 @@
 	},
 /area/station/medical/research)
 "bhR" = (
-/obj/machinery/door/window/eastleft{
-	name = "Medical Research";
-	req_access_txt = "9"
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/white,
-/area/station/medical/research)
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "bhS" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bhT" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"bhU" = (
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "bhV" = (
 /obj/critter/roach,
 /turf/simulated/floor/plating,
@@ -28406,7 +27700,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
 /turf/simulated/floor/caution/north,
 /area/station/engine/substation/pylon)
 "bhY" = (
@@ -28415,29 +27708,31 @@
 	name = "Upload Station"
 	})
 "bhZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Engineering Hallway";
 	location = "Security Hallway"
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"bia" = (
-/obj/machinery/sparker{
-	id = "securitychamber";
+"bib" = (
+/obj/table/auto,
+/obj/item/device/audio_log/wall_mounted{
+	anchored = 1;
+	max_lines = 350;
+	mode = 1;
+	name = "Security Recorder";
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating/random,
-/area/station/security/brig)
-"bib" = (
-/obj/machinery/atmospherics/pipe/vent,
-/obj/stool/chair,
-/turf/simulated/floor/plating/random,
+/obj/machinery/light/lamp,
+/obj/item/remote/porter/port_a_brig,
+/obj/item/paper/Port_A_Brig,
+/turf/simulated/floor/black,
 /area/station/security/brig)
 "bic" = (
 /obj/machinery/camera{
@@ -28445,7 +27740,13 @@
 	dir = 8;
 	network = "Gas Chamber"
 	},
-/turf/simulated/floor/plating/random,
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	dir = 8;
+	frequency = 1489;
+	name = "Brig Intercom"
+	},
+/turf/simulated/floor/black,
 /area/station/security/brig)
 "bid" = (
 /obj/disposalpipe/segment/ejection{
@@ -28455,12 +27756,10 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bie" = (
-/obj/machinery/floorflusher{
-	id = "solitary1"
-	},
 /obj/disposalpipe/trunk/ejection{
 	dir = 8
 	},
+/obj/machinery/floorflusher/solitary2,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bif" = (
@@ -28532,25 +27831,28 @@
 	},
 /area/station/security/hos)
 "bil" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/security{
 	aiControlDisabled = 1;
 	dir = 4;
 	name = "Armory";
 	req_access_txt = "37"
 	},
-/turf/simulated/floor/black,
-/area/station/security/armory)
-"bim" = (
 /obj/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
+/obj/access_spawn/hos,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/security/hos)
 "bin" = (
-/turf/simulated/floor/black,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/caution/west,
 /area/station/security/armory)
 "bio" = (
 /obj/table/auto,
@@ -28568,12 +27870,9 @@
 	},
 /area/station/medical/research)
 "biq" = (
-/obj/machinery/door/window/eastright{
-	name = "Medical Research";
-	req_access_txt = "9"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/research)
+/obj/machinery/weapon_stand/shotgun_rack,
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bir" = (
 /obj/machinery/light{
 	dir = 4;
@@ -28615,6 +27914,7 @@
 	name = "N APC";
 	pixel_y = 24
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/caution/corner/misc{
 	dir = 10
 	},
@@ -28699,25 +27999,27 @@
 /area/station/hallway/primary/south)
 "biE" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "biF" = (
-/obj/machinery/door/firedoor/pyro{
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/east)
 "biG" = (
+/obj/machinery/vending/security_ammo,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "biH" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -28737,19 +28039,15 @@
 	},
 /area/station/hallway/primary/east)
 "biJ" = (
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1489;
-	name = "Brig Intercom"
+/turf/simulated/floor/yellow/side{
+	dir = 10
 	},
-/turf/simulated/floor/plating/random,
-/area/station/security/brig)
+/area/station/quartermaster/office)
 "biK" = (
-/obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
-	level = 2
+/obj/stool/chair/red{
+	dir = 1
 	},
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor/black,
 /area/station/security/brig)
 "biL" = (
 /obj/disposalpipe/segment/ejection,
@@ -28842,13 +28140,6 @@
 /obj/table/reinforced/auto{
 	icon_state = "12"
 	},
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	icon_state = "left";
-	name = "Security";
-	req_access_txt = "1";
-	tag = "icon-left (WEST)"
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
@@ -28861,46 +28152,57 @@
 	},
 /obj/machinery/door/firedoor/pyro,
 /obj/item/device/audio_log,
+/obj/access_spawn/security,
+/obj/machinery/door/airlock/pyro/glass/windoor,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "biV" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory";
-	dir = 2
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	frequency = 1485;
-	name = "Security Intercom"
-	},
-/obj/storage/secure/crate/gear/armory/grenades,
-/turf/simulated/floor/black,
-/area/station/security/armory)
-"biW" = (
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/storage/secure/crate/plasma/armory/anti_biological,
-/obj/item/gun/kinetic/flaregun,
-/obj/item/ammo/bullets/flare,
+/obj/table/auto,
+/obj/item/device/radio/electropack,
+/obj/item/device/radio/electropack,
+/obj/item/device/radio/signaler,
+/obj/item/device/radio/signaler,
+/obj/item/storage/box/stinger_kit,
+/obj/item/storage/box/flashbang_kit,
+/obj/item/storage/box/revimp_kit,
+/obj/item/chem_grenade/pepper,
 /turf/simulated/floor/caution/west,
 /area/station/security/armory)
+"biW" = (
+/obj/rack,
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = -10;
+	pixel_y = -1
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "biX" = (
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/turf/space,
-/area/space)
+/obj/machinery/weapon_stand/rifle_rack/recharger,
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "biY" = (
 /obj/cable{
 	d1 = 2;
@@ -28967,23 +28269,7 @@
 /area/station/medical/research)
 "bjf" = (
 /obj/disposalpipe/segment,
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/research)
 "bjg" = (
@@ -29006,10 +28292,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/research)
 "bjj" = (
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
 /obj/storage/secure/closet/medical/uniforms,
 /turf/simulated/floor/white,
 /area/station/medical/research)
@@ -29038,19 +28320,22 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen)
 "bjn" = (
+/obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/kitchen)
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bjo" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/bar)
 "bjp" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/bar)
 "bjq" = (
@@ -29074,9 +28359,9 @@
 "bjt" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
-	name = "Engine Supply Dock";
-	req_access_txt = "40"
+	icon_state = "airlock_closed"
 	},
+/obj/access_spawn/engineering,
 /turf/simulated/floor/delivery,
 /area/station/engine/substation/pylon)
 "bju" = (
@@ -29149,18 +28434,26 @@
 /area/station/security/main)
 "bjD" = (
 /obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/main)
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bjE" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/main)
 "bjF" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "bjG" = (
@@ -29173,6 +28466,13 @@
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/access_spawn/security,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bjH" = (
@@ -29180,48 +28480,38 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "bjI" = (
-/obj/machinery/atmospherics/pipe/simple{
-	icon_state = "intact";
-	level = 2
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
+/obj/storage/secure/crate/gear/armory/grenades,
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bjJ" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Interrogation Room";
-	req_access_txt = "1"
-	},
+/obj/machinery/door/airlock/pyro/security/alt,
+/obj/access_spawn/brig,
 /turf/simulated/floor/black,
 /area/station/security/brig)
 "bjK" = (
 /obj/disposalpipe/segment/ejection,
-/obj/machinery/door/window{
-	name = "Solitary Cell 1";
-	req_access_txt = "2"
-	},
+/obj/machinery/door/airlock/pyro/glass/security,
+/obj/access_spawn/brig,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bjL" = (
-/obj/grille/steel,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bjM" = (
 /obj/disposalpipe/segment,
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4";
 	pixel_y = 0
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "bjN" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -29230,7 +28520,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "bjO" = (
@@ -29244,6 +28534,8 @@
 	name = "Head of Security";
 	req_access_txt = "37"
 	},
+/obj/access_spawn/hos,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/security/hos)
 "bjP" = (
@@ -29269,10 +28561,8 @@
 	},
 /area/station/medical/research)
 "bjS" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Med-Sci Maintenance";
-	req_access_txt = "9"
-	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/medlab,
 /turf/simulated/floor/white,
 /area/station/medical/research)
 "bjT" = (
@@ -29325,11 +28615,6 @@
 	},
 /area/station/crew_quarters/kitchen)
 "bjZ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -29375,10 +28660,6 @@
 	icon_state = "pipe-s"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "bke" = (
@@ -29393,19 +28674,9 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/market)
 "bkg" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/market)
+/turf/simulated/floor/black,
+/area/station/security/brig)
 "bkh" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -29413,28 +28684,32 @@
 	name = "Public Market";
 	opacity = 0
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bki" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/market)
 "bkj" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bkk" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4";
 	pixel_y = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bkl" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -29443,7 +28718,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bkm" = (
@@ -29571,11 +28846,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -29587,6 +28857,7 @@
 	},
 /area/station/security/main)
 "bkx" = (
+/obj/machinery/vending/security,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
@@ -29597,10 +28868,11 @@
 	},
 /area/station/security/main)
 "bkz" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	req_access_txt = "1"
+/obj/machinery/door/airlock/pyro/security/alt{
+	dir = 4
 	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bkA" = (
@@ -29629,26 +28901,13 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 5;
-	icon_state = "intact";
-	level = 2
-	},
-/obj/machinery/computer/security/telescreen{
-	name = "Chamber View";
-	network = "Gas Chamber";
-	pixel_y = 32
-	},
 /obj/decal/cleanable/cobweb,
+/obj/storage/secure/crate/plasma/armory/anti_biological{
+	req_access = null
+	},
 /turf/simulated/floor/black/side,
 /area/station/security/brig)
 "bkE" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 10;
-	icon_state = "intact";
-	layer = 3;
-	level = 2
-	},
 /turf/simulated/floor/black/side,
 /area/station/security/brig)
 "bkF" = (
@@ -29668,14 +28927,10 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "bkI" = (
-/obj/machinery/door_timer{
-	id = "solitary1";
-	name = "Solitary Cell 1";
-	pixel_y = 24
-	},
 /obj/disposalpipe/junction{
 	icon_state = "pipe-j2"
 	},
+/obj/machinery/door_timer/solitary2/new_walls/north,
 /turf/simulated/floor,
 /area/station/security/brig)
 "bkJ" = (
@@ -29706,22 +28961,39 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "bkN" = (
-/obj/machinery/door_timer{
-	id = "solitary2";
-	name = "Solitary Cell 2";
-	pixel_x = 0;
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
 	},
-/turf/simulated/floor,
-/area/station/security/brig)
+/turf/space,
+/area/space)
 "bkO" = (
-/obj/machinery/door/window{
-	dir = 4;
-	name = "Solitary Cell 2";
-	req_access_txt = "2"
+/obj/item/clothing/mask/gas{
+	pixel_x = 8;
+	pixel_y = 5
 	},
-/turf/simulated/floor,
-/area/station/security/brig)
+/obj/item/clothing/mask/gas{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/rack,
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 9;
+	pixel_y = 11
+	},
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bkP" = (
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -29731,7 +29003,7 @@
 /area/station/security/brig)
 "bkR" = (
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bkS" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southwest)
@@ -29956,13 +29228,12 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "blu" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "blv" = (
@@ -29971,7 +29242,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
 /turf/simulated/floor/caution/south{
 	dir = 2
 	},
@@ -30047,6 +29320,10 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 4
 	},
+/obj/machinery/phone/wall{
+	pixel_x = -24;
+	pixel_y = 4
+	},
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -30059,11 +29336,6 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "blF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/security/main)
@@ -30122,13 +29394,25 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "blM" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 1;
-	icon_state = "intact";
-	level = 2
+/obj/rack,
+/obj/item/clothing/glasses/thermal{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/simulated/floor,
-/area/station/security/brig)
+/obj/item/clothing/glasses/thermal{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "blN" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4;
@@ -30170,14 +29454,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/door_timer{
-	id = "genpop";
-	name = "General Population Cell";
-	pixel_y = -24
-	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
+/obj/machinery/door_timer/genpop/new_walls/south,
 /turf/simulated/floor,
 /area/station/security/brig)
 "blS" = (
@@ -30214,17 +29494,12 @@
 /area/station/security/brig)
 "blU" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2";
-	name = "ejection pipe"
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "blV" = (
 /obj/cable{
 	d1 = 2;
@@ -30242,33 +29517,35 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "blW" = (
-/obj/grille/steel,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/obj/window/auto/crystal/reinforced,
-/turf/simulated/floor/plating,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
 /area/station/security/brig)
 "blX" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/obj/storage/secure/closet/brig,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "blY" = (
-/obj/machinery/floorflusher{
-	id = "solitary2"
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/disposalpipe/trunk/ejection{
-	dir = 8
+/obj/disposalpipe/segment/ejection{
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -30295,36 +29572,32 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bmd" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/storage/secure/closet/security/armory{
+	req_access_txt = "37"
 	},
-/obj/machinery/atmospherics/pipe/simple/junction/east,
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/kitchen)
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bme" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating/airless,
 /turf/simulated/floor/plating/damaged2,
 /area/space)
 "bmf" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment/mail,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4;
@@ -30357,16 +29630,6 @@
 	},
 /area/station/crew_quarters/bar)
 "bmj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/item/device/radio/intercom{
 	dir = 8;
 	frequency = 1463;
@@ -30381,13 +29644,14 @@
 	},
 /area/station/crew_quarters/kitchen)
 "bmk" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Culinary Maintenance";
-	req_access_txt = null
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/kitchen,
-/obj/access_spawn/bar,
-/turf/simulated/floor/sanitary,
+/turf/simulated/floor/plating,
 /area/station/crew_quarters/kitchen)
 "bml" = (
 /obj/stool,
@@ -30398,13 +29662,11 @@
 	},
 /area/station/crew_quarters/bar)
 "bmm" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
 	name = "Ronalds"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/stairs{
 	dir = 4;
 	icon_state = "stairs_middle"
@@ -30437,8 +29699,7 @@
 	},
 /area/station/hallway/primary/south)
 "bmr" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bms" = (
@@ -30526,10 +29787,11 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	req_access_txt = "1"
+/obj/machinery/door/airlock/pyro/security/alt{
+	dir = 4
 	},
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -30545,29 +29807,22 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment/brig{
-	dir = 4;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
-"bmD" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 1;
-	icon_state = "intact";
-	level = 2
-	},
 /obj/disposalpipe/junction{
 	dir = 4;
 	name = "brig pipe"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
+"bmD" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/obj/lattice{
+	dir = 2;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "bmE" = (
 /obj/cable{
 	d1 = 4;
@@ -30612,6 +29867,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bmI" = (
@@ -30621,58 +29881,35 @@
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/ejection,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "bmJ" = (
-/obj/grille/steel,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/cable,
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bmK" = (
-/obj/machinery/door/window{
-	autoclose = 1;
-	name = "General Population Cell";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/window/northright{
-	autoclose = 1;
-	name = "General Population Cell";
-	req_access_txt = "2"
-	},
+/obj/disposalpipe/segment/ejection,
+/obj/machinery/door/airlock/pyro/glass/security,
+/obj/access_spawn/brig,
 /turf/simulated/floor,
 /area/station/security/brig)
 "bmL" = (
-/obj/window/crystal/reinforced/north,
-/obj/window/crystal/reinforced/south,
-/turf/simulated/floor,
-/area/station/security/brig)
-"bmM" = (
-/obj/machinery/floorflusher{
-	id = "genpop"
-	},
-/obj/disposalpipe/trunk/ejection{
-	dir = 1
-	},
-/obj/window/crystal/reinforced/south,
-/obj/window/crystal/reinforced/north,
-/turf/simulated/floor,
-/area/station/security/brig)
-"bmN" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/cable,
-/obj/window/auto/crystal/reinforced,
-/turf/simulated/floor/plating,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
 /area/station/security/brig)
-"bmO" = (
-/obj/grille/steel,
+"bmM" = (
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -30681,7 +29918,32 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/crystal/reinforced,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/security/brig)
+"bmN" = (
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"bmO" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "bmP" = (
@@ -30727,7 +29989,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/command,
+/obj/machinery/door/airlock/pyro/glass/command,
+/obj/access_spawn/heads,
 /turf/simulated/floor/grey/side,
 /area/station/bridge)
 "bmW" = (
@@ -30777,50 +30040,47 @@
 "bnc" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
-"bnd" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/supernorn,
+/turf/simulated/floor,
 /area/station/hallway/primary/south)
+"bnd" = (
+/obj/decal/boxingrope,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/fitness)
 "bne" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light/emergency{
-	dir = 8;
-	icon_state = "ebulb1"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/hallway/primary/east)
 "bnf" = (
 /obj/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/primary/south)
+/area/station/hallway/primary/east)
 "bng" = (
-/obj/grille/steel,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bnh" = (
@@ -30832,7 +30092,6 @@
 "bni" = (
 /obj/table/auto,
 /obj/item/storage/box/revimp_kit,
-/obj/item/implantcase/sec,
 /obj/item/implanter,
 /obj/machinery/camera{
 	c_tag = "Security";
@@ -30920,17 +30179,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/brig)
 "bnt" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 1;
-	icon_state = "intact";
-	level = 2
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/disposal/brig,
-/obj/disposalpipe/trunk/brig{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
+/turf/simulated/floor/black,
+/area/station/security/prison)
 "bnu" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -30943,6 +30198,16 @@
 /obj/disposalpipe/segment/brig{
 	dir = 4;
 	icon_state = "pipe-s"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -30958,6 +30223,14 @@
 	frequency = 1485;
 	name = "Security Intercom"
 	},
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor,
 /area/station/security/brig)
 "bnx" = (
@@ -31001,9 +30274,14 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bnD" = (
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
+/obj/decal/boxingrope{
+	dir = 5;
+	icon_state = "ringrope"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/fitness)
 "bnE" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
 	dir = 8;
@@ -31016,11 +30294,7 @@
 "bnF" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/medical{
-	name = "Meat Locker";
-	req_access_txt = null
-	},
-/obj/access_spawn/bar,
+/obj/machinery/door/airlock/pyro/alt,
 /obj/access_spawn/kitchen,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen)
@@ -31077,6 +30351,7 @@
 "bnN" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/cashreg,
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/carpet{
 	dir = 2;
 	icon_state = "blue1"
@@ -31153,13 +30428,13 @@
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bnS" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bnT" = (
@@ -31172,7 +30447,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bnU" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -31182,7 +30456,7 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bnV" = (
@@ -31204,21 +30478,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/engineering)
-"bnX" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/pyro/command{
-	name = "AI Upload";
-	req_access_txt = "19"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/AIbasecore1{
-	name = "Upload Station"
-	})
 "bnY" = (
 /obj/machinery/light{
 	dir = 8;
@@ -31235,16 +30494,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "boa" = (
-/obj/table/reinforced/auto{
-	icon_state = "3"
-	},
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	icon_state = "left";
-	name = "Security";
-	req_access_txt = "1";
-	tag = "icon-left (WEST)"
-	},
 /obj/machinery/cashreg{
 	name = "bail payment device"
 	},
@@ -31256,9 +30505,17 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
+/obj/table/reinforced/auto,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bob" = (
@@ -31299,28 +30556,16 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "bod" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/security/main)
 "boe" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
@@ -31328,11 +30573,6 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "bof" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -31370,6 +30610,10 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -31384,18 +30628,14 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/obj/window{
-	dir = 4
-	},
 /obj/storage/closet/emergency,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/bot,
 /area/station/security/brig)
 "bom" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 1;
-	icon_state = "intact";
-	level = 2
-	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
@@ -31420,6 +30660,16 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/stool/chair/office/red{
+	dir = 4;
+	icon_state = "office_chair_red";
+	tag = "icon-office_chair_red (EAST)"
+	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "boq" = (
@@ -31437,13 +30687,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bos" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+/obj/decal/boxingrope{
+	dir = 8;
+	icon_state = "ringrope"
 	},
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "bot" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -31467,10 +30716,10 @@
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "boy" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/camera/motion{
+	c_tag = "Armory";
+	dir = 2
 	},
-/obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/black,
 /area/station/security/armory)
 "boz" = (
@@ -31509,25 +30758,24 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "boC" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/light/emergency{
 	dir = 1;
 	icon_state = "ebulb1"
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "boD" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "boE" = (
@@ -31566,22 +30814,7 @@
 /area/station/turret_protected/AIbasecore1{
 	name = "Upload Station"
 	})
-"boI" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/AIbasecore1{
-	name = "Upload Station"
-	})
 "boJ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -31591,28 +30824,24 @@
 	name = "Upload Station"
 	})
 "boK" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/AIbasecore1{
-	name = "Upload Station"
-	})
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/station/hallway/primary/east)
 "boL" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "boM" = (
-/obj/grille/steel,
 /obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "boN" = (
@@ -31721,29 +30950,20 @@
 	},
 /area/station/security/main)
 "boX" = (
-/obj/window{
-	dir = 4
-	},
-/obj/storage/secure/closet/personal,
+/obj/storage/closet/fire,
 /turf/simulated/floor/bot,
 /area/station/security/brig)
 "boY" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 1;
-	icon_state = "intact";
-	level = 2
-	},
 /turf/simulated/floor/caution/west,
 /area/station/security/brig)
 "boZ" = (
-/obj/machinery/light,
-/obj/machinery/port_a_brig,
-/turf/simulated/floor/delivery,
-/area/station/security/brig)
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/manifold/east,
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "bpa" = (
 /obj/table/auto,
-/obj/item/paper/Port_A_Brig,
-/obj/item/remote/porter/port_a_brig,
+/obj/machinery/recharger,
 /turf/simulated/floor,
 /area/station/security/brig)
 "bpb" = (
@@ -31751,11 +30971,6 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bpc" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table/auto,
 /obj/item/kitchen/rollingpin,
 /obj/item/storage/box/cutlery,
@@ -31786,11 +31001,6 @@
 	},
 /area/station/crew_quarters/bar)
 "bpe" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table,
 /obj/item/reagent_containers/food/snacks/breadloaf,
 /obj/item/reagent_containers/food/snacks/breadloaf,
@@ -31822,6 +31032,10 @@
 /area/station/maintenance/southwest)
 "bph" = (
 /obj/machinery/chem_dispenser/soda,
+/obj/machinery/phone/wall{
+	pixel_x = -24;
+	pixel_y = 4
+	},
 /turf/simulated/floor/carpet{
 	dir = 2;
 	icon_state = "blue1"
@@ -31863,8 +31077,7 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "bpn" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/market)
 "bpo" = (
@@ -31909,19 +31122,36 @@
 /turf/space,
 /area/station/crew_quarters/market)
 "bps" = (
-/turf/simulated/floor/black,
-/area/station/turret_protected/AIbasecore1{
-	name = "Upload Station"
-	})
-"bpt" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/black,
+/area/station/turret_protected/AIbasecore1{
+	name = "Upload Station"
+	})
+"bpt" = (
+/obj/machinery/turret{
+	dir = 8
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bpu" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light{
@@ -31933,12 +31163,11 @@
 	},
 /area/station/hallway/primary/south)
 "bpv" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bpw" = (
@@ -31951,22 +31180,20 @@
 /area/station/maintenance/east)
 "bpx" = (
 /obj/disposalpipe/segment,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bpy" = (
-/obj/machinery/door/airlock/pyro/security{
-	name = "Courtroom";
-	req_access_txt = "1"
-	},
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/machinery/door/airlock/pyro/security/alt,
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/security/main)
 "bpz" = (
@@ -31983,20 +31210,18 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/brig)
 "bpC" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 1;
-	icon_state = "intact";
-	level = 2
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
-"bpD" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Solitary Controls";
-	req_access_txt = "1"
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/red,
-/area/station/security/brig)
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bpE" = (
 /obj/table/auto,
 /obj/item/game_kit,
@@ -32031,17 +31256,17 @@
 	icon_state = "lattice-dir-b"
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bpI" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bpJ" = (
 /obj/lattice{
 	dir = 10;
 	icon_state = "lattice-dir-b"
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bpK" = (
 /obj/machinery/light{
 	dir = 8;
@@ -32078,13 +31303,17 @@
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bpO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/storage/secure/crate/plasma/armory/anti_biological,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	icon_state = "camera";
+	name = "autoname  - SS13";
+	network = "SS13";
+	tag = ""
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/bar)
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bpP" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -32130,11 +31359,6 @@
 	},
 /area/station/crew_quarters/courtroom)
 "bpT" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/carpet{
 	dir = 2;
 	icon_state = "fblue2"
@@ -32152,13 +31376,13 @@
 	},
 /area/station/security/main)
 "bpW" = (
-/obj/machinery/door/airlock/glass,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/market)
 "bpX" = (
 /obj/disposalpipe/segment/mail,
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/market)
 "bpY" = (
@@ -32177,30 +31401,34 @@
 /turf/simulated/floor/grime,
 /area/station/engine/engineering)
 "bqa" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/command{
-	name = "AI Upload";
-	req_access_txt = "19"
-	},
-/turf/simulated/floor/black,
-/area/station/turret_protected/AIbasecore1{
-	name = "Upload Station"
-	})
-"bqb" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
-"bqc" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
+/obj/machinery/door/airlock/pyro/command/alt,
+/obj/access_spawn/ai_upload,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/turret_protected/AIbasecore1{
+	name = "Upload Station"
+	})
+"bqb" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/simulated/floor,
 /area/station/hallway/primary/south)
+"bqc" = (
+/obj/storage/secure/crate/weapon/armory/tranquilizer,
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bqd" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -32209,7 +31437,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
 "bqe" = (
@@ -32272,19 +31500,15 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bqk" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/storage/secure/crate/weapon/armory/pod_weapons,
+/obj/machinery/light,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/courtroom)
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bql" = (
 /obj/cable{
 	d1 = 4;
@@ -32297,6 +31521,10 @@
 	},
 /obj/item/stamp/hop,
 /obj/item/pen/fancy,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/access_spawn/head_of_personnel,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -32341,6 +31569,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/phone/wall{
+	pixel_y = 30
+	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -32361,52 +31592,43 @@
 	},
 /obj/item/wrench,
 /turf/simulated/floor,
-/area/station/maintenance/east)
+/area/station/security/brig)
 "bqr" = (
-/obj/machinery/computer/security/telescreen{
-	name = "Chamber View";
-	network = "Gas Chamber";
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/valve,
+/obj/machinery/flasher/portable,
 /turf/simulated/floor,
-/area/station/maintenance/east)
+/area/station/security/brig)
 "bqs" = (
+/obj/machinery/flasher/portable,
 /turf/simulated/floor/scorched,
-/area/station/maintenance/east)
+/area/station/security/brig)
 "bqt" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	name = "Solitary Controls";
-	req_access_txt = "1"
-	},
-/turf/simulated/floor/red,
-/area/station/maintenance/east)
+/obj/storage/secure/crate/weapon/armory/phaser,
+/turf/simulated/floor/black,
+/area/station/security/armory)
 "bqu" = (
-/turf/simulated/floor/red/side{
-	dir = 1
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/maintenance/east)
+/obj/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2";
+	name = "ejection pipe"
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
 "bqv" = (
 /obj/disposalpipe/segment,
-/obj/securearea{
-	pixel_y = 32
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/caution{
-	desc = "Caution! Construction Zone!";
-	name = "caution sign"
-	},
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
-/area/station/maintenance/east)
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "bqw" = (
 /obj/machinery/turret,
 /turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bqx" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -32425,11 +31647,6 @@
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bqA" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/table,
 /obj/item/shaker/ketchup{
 	pixel_x = -9
@@ -32454,6 +31671,10 @@
 	},
 /obj/item/shaker/salt{
 	pixel_x = 9
+	},
+/obj/machinery/phone/wall{
+	pixel_x = 24;
+	pixel_y = 4
 	},
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -32553,6 +31774,7 @@
 	codes_txt = "delivery;dir=4";
 	location = "Engineering"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/engine/storage)
 "bqM" = (
@@ -32572,6 +31794,9 @@
 	frequency = 1441;
 	name = "Station Intercom (Engineering)"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/engine/storage)
 "bqP" = (
@@ -32583,9 +31808,6 @@
 /turf/simulated/floor,
 /area/station/engine/storage)
 "bqQ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor,
 /area/station/engine/storage)
@@ -32599,7 +31821,7 @@
 	brightness = 2;
 	dir = 4
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/engine/engineering)
 "bqS" = (
@@ -32616,6 +31838,11 @@
 	},
 /area/station/hallway/primary/south)
 "bqT" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -32635,15 +31862,14 @@
 	},
 /area/station/hallway/primary/south)
 "bqW" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "N APC";
 	pixel_y = 24
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -32709,6 +31935,10 @@
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/access_spawn/head_of_personnel,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -32756,36 +31986,29 @@
 	dir = 8
 	},
 /turf/simulated/floor/grime,
-/area/station/maintenance/east)
+/area/station/security/brig)
 "brl" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 5;
-	icon_state = "intact";
-	level = 2
-	},
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/obj/machinery/door_timer/solitary/new_walls/east,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "brm" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8;
-	icon_state = "intact"
-	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/security/brig)
 "brn" = (
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "bro" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/maintenance/east)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/bar)
 "brp" = (
-/turf/simulated/floor,
-/area/station/maintenance/east)
-"brq" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/simulated/floor/grime,
-/area/station/maintenance/east)
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/delivery,
+/area/station/engine/substation/pylon)
 "brr" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -32796,57 +32019,58 @@
 	tag = ""
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "brs" = (
 /obj/machinery/turretid,
 /turf/simulated/wall/r_wall,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "brt" = (
 /obj/lattice{
 	dir = 8;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bru" = (
 /obj/lattice{
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "brv" = (
 /obj/lattice,
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "brw" = (
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
 /turf/simulated/floor/red,
-/area/station/maintenance/east)
+/area/station/hangar/sec)
 "brx" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/market)
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/disposalpipe/segment/ejection,
+/turf/simulated/floor,
+/area/station/security/brig)
 "bry" = (
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/storage/secure/crate/weapon/armory/tranquilizer,
-/turf/simulated/floor/caution/west,
-/area/station/security/armory)
-"brz" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/black,
+/area/station/security/armory)
+"brz" = (
 /obj/table,
 /obj/machinery/microwave,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "brA" = (
@@ -32863,7 +32087,7 @@
 	tag = ""
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "brB" = (
 /obj/disposalpipe/junction{
 	icon_state = "pipe-j2"
@@ -32890,16 +32114,6 @@
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "brE" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/door_control{
 	id = "kitchen";
 	name = "Privacy Shutters";
@@ -32917,11 +32131,6 @@
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "brF" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
@@ -32969,7 +32178,6 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/light,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "brK" = (
@@ -33001,19 +32209,15 @@
 /turf/simulated/floor/yellow/corner,
 /area/station/hallway/primary/south)
 "brO" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
 "brP" = (
 /obj/table/auto,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/item/sheet/steel{
 	amount = 50
 	},
@@ -33056,7 +32260,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/engineering,
+/obj/machinery/door/airlock/pyro/engineering/alt{
+	dir = 4
+	},
+/obj/access_spawn/engineering,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "brS" = (
@@ -33088,8 +32295,7 @@
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "brV" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/storage/autolathe)
 "brW" = (
@@ -33102,13 +32308,15 @@
 /area/station/hallway/primary/south)
 "brY" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
-"brZ" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
@@ -33118,9 +32326,14 @@
 /area/station/hallway/primary/south)
 "bsa" = (
 /obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -33145,6 +32358,7 @@
 	dir = 4;
 	name = "Information Office"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bsd" = (
@@ -33174,11 +32388,10 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "bsf" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/courtroom)
+/obj/machinery/door/airlock/pyro/glass/security,
+/obj/access_spawn/brig,
+/turf/simulated/floor,
+/area/station/security/brig)
 "bsg" = (
 /obj/machinery/recharger{
 	pixel_y = 3
@@ -33186,6 +32399,10 @@
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/access_spawn/head_of_personnel,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -33214,74 +32431,81 @@
 	},
 /area/station/crew_quarters/courtroom)
 "bsk" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"bsl" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
-/area/station/maintenance/east)
-"bsm" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/turf/simulated/floor/grime,
-/area/station/maintenance/east)
-"bsn" = (
+/obj/storage/crate,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
 /obj/machinery/camera{
 	c_tag = "East Maintenance";
 	dir = 4
 	},
-/turf/simulated/floor/red/side,
-/area/station/maintenance/east)
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"bsl" = (
+/obj/disposalpipe/segment/brig{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/disposalpipe/segment/ejection,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"bsm" = (
+/obj/storage/crate,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"bsn" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "bso" = (
 /obj/disposalpipe/segment,
-/turf/simulated/floor/red/side,
-/area/station/maintenance/east)
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "bsp" = (
-/turf/simulated/floor/red/side,
-/area/station/maintenance/east)
+/obj/storage/secure/closet/brig/automatic/solitary,
+/obj/disposalpipe/segment/ejection,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "bsq" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/window{
-	dir = 1;
-	icon_state = "window"
+/obj/machinery/shower{
+	dir = 8
 	},
-/turf/simulated/floor/red/side,
-/area/station/maintenance/east)
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "bsr" = (
 /obj/lattice{
 	dir = 9;
 	icon_state = "lattice-dir-b"
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bss" = (
 /obj/lattice{
 	dir = 10;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bst" = (
 /obj/lattice{
 	dir = 5;
 	icon_state = "lattice-dir-b"
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bsu" = (
 /obj/lattice{
 	dir = 6;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bsv" = (
 /obj/lattice{
 	dir = 1;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bsw" = (
 /obj/stove,
 /obj/item/ladle,
@@ -33294,26 +32518,29 @@
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bsy" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/table/reinforced/bar/auto,
-/obj/machinery/door/window/southleft{
-	req_access_txt = "35"
-	},
 /obj/item/clothing/head/cakehat,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/hydro,
 /turf/simulated/floor,
 /area/station/crew_quarters/bar)
 "bsz" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/table/reinforced/bar/auto,
-/obj/machinery/door/window/southleft{
-	req_access_txt = "35"
-	},
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/hydro,
 /turf/simulated/floor,
 /area/station/crew_quarters/bar)
 "bsA" = (
 /obj/critter/mouse/remy,
 /obj/machinery/drainage,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bsB" = (
@@ -33351,8 +32578,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
 "bsH" = (
@@ -33384,10 +32610,11 @@
 /area/station/engine/storage)
 "bsL" = (
 /obj/table/auto,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/cell_charger,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor,
 /area/station/engine/storage)
 "bsM" = (
@@ -33466,8 +32693,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/courtroom)
 "bta" = (
@@ -33511,13 +32737,13 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "btd" = (
-/obj/machinery/light/small,
-/obj/machinery/door/window/eastleft{
-	name = "Heads of Staff";
-	req_access_txt = "19"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/courtroom)
+/turf/unsimulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "bte" = (
 /obj/cable{
 	d1 = 2;
@@ -33531,11 +32757,6 @@
 "btf" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
@@ -33546,30 +32767,22 @@
 	},
 /area/station/crew_quarters/courtroom)
 "btg" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/courtroom)
 "bth" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Solitary Controls";
-	req_access_txt = "1"
-	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/brig,
 /turf/simulated/floor/red,
-/area/station/maintenance/east)
+/area/station/security/brig)
 "bti" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/east)
+/area/station/security/brig)
 "btj" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "btk" = (
@@ -33586,7 +32799,7 @@
 "btl" = (
 /obj/grille/steel,
 /turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "btm" = (
 /obj/cable{
 	d1 = 1;
@@ -33595,42 +32808,44 @@
 	},
 /obj/grille/steel,
 /turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "btn" = (
 /obj/table/reinforced/bar/auto,
 /obj/random_item_spawner/snacks/three,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "bto" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Kitchen";
-	req_access_txt = null
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/access_spawn/bar,
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4
+	},
 /obj/access_spawn/kitchen,
+/obj/access_spawn/bar,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "btp" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "btq" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 8;
-	name = "Serving Area"
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4
 	},
-/obj/access_spawn/bar,
 /obj/access_spawn/kitchen,
+/obj/access_spawn/bar,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "btr" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/table/reinforced/auto,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/kitchen)
 "bts" = (
@@ -33680,6 +32895,7 @@
 	name = "Delivery";
 	req_access_txt = "34"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bot,
 /area/station/hydroponics/bay)
 "btA" = (
@@ -33691,11 +32907,11 @@
 	name = "Hydroponics Delivery";
 	req_access_txt = "35"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/hydroponics/bay)
 "btB" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "btC" = (
@@ -33708,13 +32924,12 @@
 	},
 /area/station/hallway/primary/south)
 "btD" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
 "btE" = (
@@ -33784,23 +32999,18 @@
 /turf/simulated/floor,
 /area/station/storage/autolathe)
 "btM" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor,
 /area/station/storage/autolathe)
 "btN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor,
 /area/station/storage/autolathe)
@@ -33845,16 +33055,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro{
-	name = "Custodial Closet";
-	req_access_txt = "26"
-	},
+/obj/machinery/door/airlock/pyro/alt,
+/obj/access_spawn/janitor,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/janitor/office)
 "btT" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/maintenance/disposal)
 "btU" = (
@@ -33877,7 +33087,6 @@
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/juryroom)
 "btW" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4";
@@ -33887,7 +33096,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/juryroom)
 "btX" = (
@@ -33896,13 +33105,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
-/obj/grille/steel,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/juryroom)
 "btY" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/juryroom)
 "btZ" = (
@@ -33950,6 +33157,9 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "buf" = (
@@ -33972,11 +33182,11 @@
 /area/station/maintenance/east)
 "buh" = (
 /obj/reagent_dispensers/fueltank,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/red,
-/area/station/maintenance/east)
-"bui" = (
-/turf/simulated/floor/red,
-/area/station/maintenance/east)
+/area/station/hangar/sec)
 "buj" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
@@ -33992,7 +33202,7 @@
 /area/station/hangar/sec)
 "bul" = (
 /turf/simulated/wall/r_wall,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIsat)
 "bum" = (
 /obj/cable{
 	d1 = 1;
@@ -34000,10 +33210,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIsat)
 "bun" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "buo" = (
@@ -34083,6 +33292,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/phone/wall{
+	pixel_y = 30
+	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -34096,6 +33308,9 @@
 	},
 /obj/machinery/plantpot{
 	anchored = 1
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -34224,6 +33439,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/light,
 /turf/simulated/floor,
 /area/station/engine/storage)
 "buI" = (
@@ -34279,11 +33495,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -34292,37 +33503,27 @@
 /area/station/engine/engineering)
 "buN" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/engineering)
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "buO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
 /turf/simulated/floor,
 /area/station/storage/autolathe)
 "buP" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/machinery/bot/firebot,
+/turf/simulated/floor,
+/area/station/storage/autolathe)
+"buQ" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/bot/firebot,
-/turf/simulated/floor,
-/area/station/storage/autolathe)
-"buQ" = (
 /turf/simulated/floor,
 /area/station/storage/autolathe)
 "buR" = (
@@ -34336,19 +33537,8 @@
 /obj/storage/closet/fire,
 /turf/simulated/floor,
 /area/station/storage/autolathe)
-"buT" = (
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/hallway/primary/south)
 "buU" = (
-/obj/rack,
-/obj/item/mop,
-/obj/item/sponge,
-/obj/item/storage/box/lightbox/tubes,
-/obj/item/storage/box/lightbox/bulbs,
-/obj/item/device/radio,
+/obj/machinery/vending/janitor,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "buV" = (
@@ -34367,11 +33557,13 @@
 	},
 /area/station/janitor/office)
 "buX" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/light_switch{
 	pixel_y = 25
+	},
+/obj/submachine/chef_sink{
+	desc = "A common utility sink.";
+	name = "utility sink";
+	pixel_y = 7
 	},
 /turf/simulated/floor/white/checker{
 	dir = 4
@@ -34380,6 +33572,9 @@
 "buY" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/vehicle/floorbuffer,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "buZ" = (
@@ -34424,13 +33619,12 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "bvf" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4";
 	pixel_y = 0
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Renovation Area"
@@ -34472,6 +33666,11 @@
 	})
 "bvj" = (
 /obj/disposalpipe/segment,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "bvk" = (
@@ -34479,20 +33678,7 @@
 	dir = 4
 	},
 /area/station/maintenance/east)
-"bvl" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Secure Transport";
-	req_access_txt = "1"
-	},
-/turf/simulated/floor/red,
-/area/station/maintenance/east)
 "bvm" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Secure Transport";
-	req_access_txt = "1"
-	},
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
 "bvn" = (
@@ -34501,6 +33687,10 @@
 	},
 /area/station/hangar/sec)
 "bvo" = (
+/obj/machinery/light{
+	dir = 1;
+	name = "light fixture"
+	},
 /turf/simulated/floor/stairs{
 	dir = 4
 	},
@@ -34574,6 +33764,12 @@
 /area/station/hangar/sec)
 "bvw" = (
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/security_horizontal/vertical,
+/obj/forcefield/energyshield/perma{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "bvx" = (
@@ -34582,24 +33778,25 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bvy" = (
-/turf/simulated/floor/engine,
-/area/station/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/circuit/green,
+/area/station/turret_protected/AIsat)
 "bvz" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/turret_protected/ai_upload_foyer)
-"bvA" = (
-/obj/machinery/door/airlock/pyro{
+/obj/disposalpipe/segment/mail,
+/obj/machinery/light{
 	dir = 4;
-	name = "Hydroponics";
-	req_access_txt = "35"
+	icon_state = "tube1"
 	},
+/turf/simulated/floor/greenwhite/other{
+	dir = 4
+	},
+/area/station/science/lobby)
+"bvA" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/hydro,
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "bvB" = (
@@ -34662,25 +33859,23 @@
 	},
 /area/station/hydroponics/bay)
 "bvI" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Hydroponics";
-	req_access_txt = "35"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
+/obj/access_spawn/hydro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "bvJ" = (
-/obj/grille/steel,
 /obj/cable,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
 "bvK" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -34689,7 +33884,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
 "bvL" = (
@@ -34706,20 +33901,18 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/door/window{
-	name = "Engineering Storage";
-	req_access_txt = "40"
-	},
+/obj/machinery/door/airlock/pyro/glass/engineering,
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/engine/storage)
 "bvM" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/disposalpipe/segment,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/storage)
 "bvN" = (
@@ -34827,26 +34020,34 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/autolathe)
 "bvU" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/cable,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/autolathe)
 "bvV" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/door/window,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/storage/autolathe)
 "bvW" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -34855,16 +34056,15 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/autolathe)
 "bvX" = (
-/obj/grille/steel,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/autolathe)
 "bvY" = (
@@ -34930,6 +34130,10 @@
 /obj/item/spraybottle,
 /obj/item/spraybottle/cleaner,
 /obj/item/spraybottle/cleaner,
+/obj/machinery/phone/wall{
+	pixel_x = 24;
+	pixel_y = 4
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "bwc" = (
@@ -34976,7 +34180,9 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "bwi" = (
-/obj/item/device/radio/intercom,
+/obj/item/device/radio/intercom{
+	dir = 1
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
 "bwj" = (
@@ -34994,29 +34200,24 @@
 	name = "Renovation Area"
 	})
 "bwl" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/floorflusher/solitary,
+/obj/disposalpipe/trunk/ejection{
+	dir = 1
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/storage{
-	name = "Renovation Area"
-	})
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "bwm" = (
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -35025,7 +34226,6 @@
 	dir = 4;
 	pixel_y = 0
 	},
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -35051,29 +34251,33 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
 "bwq" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/east)
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/unsimulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "bwr" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
@@ -35091,23 +34295,6 @@
 	dir = 4
 	},
 /area/station/maintenance/east)
-"bwt" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Secure Transport";
-	req_access_txt = "1"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red,
-/area/station/maintenance/east)
 "bwu" = (
 /obj/cable{
 	d1 = 4;
@@ -35119,7 +34306,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/red,
-/area/station/maintenance/east)
+/area/station/hangar/sec)
 "bwv" = (
 /obj/item/device/multitool,
 /obj/cable{
@@ -35132,13 +34319,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/red,
-/area/station/maintenance/east)
+/area/station/hangar/sec)
 "bww" = (
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4;
-	name = "Secure Transport";
-	req_access_txt = "1"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
@@ -35148,6 +34330,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/security/alt{
+	dir = 4
+	},
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
 "bwx" = (
@@ -35450,15 +34636,11 @@
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Engineering Storage";
-	req_access_txt = "40"
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
 	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "bwZ" = (
@@ -35476,6 +34658,9 @@
 /area/station/engine/engineering)
 "bxb" = (
 /obj/item/device/radio/beacon,
+/obj/submachine/cargopad{
+	name = "Engineering Pad"
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "bxc" = (
@@ -35484,6 +34669,10 @@
 "bxd" = (
 /obj/disposalpipe/segment/mail,
 /obj/storage/secure/closet/engineering/electrical,
+/obj/machinery/phone/wall{
+	pixel_x = 24;
+	pixel_y = 4
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -35524,7 +34713,12 @@
 "bxj" = (
 /obj/machinery/light,
 /obj/disposalpipe/junction,
-/obj/reagent_dispensers/watertank/big,
+/obj/rack,
+/obj/item/mop,
+/obj/item/sponge,
+/obj/item/storage/box/lightbox/bulbs,
+/obj/item/storage/box/lightbox/tubes,
+/obj/item/device/radio,
 /turf/simulated/floor/white/checker{
 	dir = 4
 	},
@@ -35539,7 +34733,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/mopbucket,
 /turf/simulated/floor/white/checker{
 	dir = 4
 	},
@@ -35550,6 +34743,7 @@
 /obj/item/chem_grenade/cleaner,
 /obj/item/chem_grenade/cleaner,
 /obj/item/sponge,
+/obj/mopbucket,
 /turf/simulated/floor/white/checker{
 	dir = 4
 	},
@@ -35570,38 +34764,10 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
-"bxp" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
 "bxq" = (
-/obj/grille/steel,
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/maintenance/east)
+/area/station/hangar/sec)
 "bxr" = (
 /obj/rack,
 /obj/item/tank/air,
@@ -35649,6 +34815,10 @@
 	icon_state = "pipe-c"
 	},
 /obj/reagent_dispensers/compostbin,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "bxz" = (
@@ -35678,11 +34848,6 @@
 /area/station/hydroponics/bay)
 "bxC" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -35711,11 +34876,12 @@
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
-/obj/machinery/door/window/eastright{
-	name = "Hydroponics";
-	req_access_txt = "35"
-	},
 /obj/machinery/cashreg,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/access_spawn/hydro,
+/obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "bxF" = (
@@ -35769,11 +34935,11 @@
 /area/station/hallway/primary/south)
 "bxK" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Engineering Storage";
-	req_access_txt = "40"
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
 	},
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "bxL" = (
@@ -35841,10 +35007,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Custodial Closet";
-	req_access_txt = "26"
-	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/janitor,
 /turf/simulated/floor/plating,
 /area/station/janitor/office)
 "bxS" = (
@@ -35871,6 +35035,9 @@
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
 /obj/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bxW" = (
@@ -35906,26 +35073,21 @@
 /area/station/maintenance/east)
 "bya" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/market)
+"byb" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/east)
-"byb" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -35967,7 +35129,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "byg" = (
 /obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
@@ -35989,15 +35151,11 @@
 	},
 /area/station/hydroponics/bay)
 "byk" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/landmark/spawner{
+	name = "monkeyspawn_stirstir"
 	},
-/turf/simulated/floor/green/side{
-	dir = 8
-	},
-/area/station/hydroponics/bay)
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "byl" = (
 /obj/table/reinforced/auto,
 /obj/window/reinforced{
@@ -36008,6 +35166,7 @@
 	dir = 2;
 	icon_state = "rwindow"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "bym" = (
@@ -36039,8 +35198,8 @@
 /area/station/hallway/primary/south)
 "byp" = (
 /obj/machinery/light,
-/turf/simulated/floor/orangeblack/corner{
-	dir = 8
+/turf/simulated/floor/yellow/side{
+	dir = 2
 	},
 /area/station/hallway/primary/south)
 "byq" = (
@@ -36053,27 +35212,19 @@
 	},
 /area/station/hallway/primary/south)
 "byr" = (
-/obj/table/reinforced/auto,
-/obj/window/reinforced{
-	dir = 8
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/item/clothing/gloves/yellow,
-/turf/simulated/floor/yellow,
-/area/station/engine/engineering)
+/turf/unsimulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "bys" = (
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/monitor,
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
 /turf/simulated/floor/yellow/corner{
 	dir = 4
 	},
@@ -36171,16 +35322,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "byE" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/machinery/door/airlock/pyro/classic{
-	dir = 4;
-	req_access_txt = "12"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "byF" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -36236,15 +35380,11 @@
 	dir = 4;
 	pixel_y = 0
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "East Maintenance Solar";
 	dir = 1
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "byL" = (
@@ -36257,37 +35397,8 @@
 /obj/item/clothing/suit/apron,
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"byM" = (
-/obj/rack,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/cable,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "S APC";
-	pixel_y = -24
-	},
-/turf/simulated/floor/black,
-/area/station/security/armory)
 "byN" = (
-/obj/table/auto,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/signaler,
-/obj/item/device/radio/signaler,
-/obj/item/storage/box/stinger_kit,
-/obj/item/storage/box/flashbang_kit,
-/obj/item/storage/box/revimp_kit,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/machinery/light/small,
-/turf/simulated/floor/black,
+/turf/simulated/floor/caution/west,
 /area/station/security/armory)
 "byO" = (
 /obj/machinery/disposal,
@@ -36310,6 +35421,7 @@
 /area/station/hangar/sec)
 "byQ" = (
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "byR" = (
@@ -36335,7 +35447,6 @@
 /obj/item/shipcomponent/mainweapon/taser,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
 /obj/item/shipcomponent/secondary_system/tractor_beam,
-/obj/machinery/light,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "byU" = (
@@ -36423,6 +35534,7 @@
 	dir = 1
 	},
 /obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bzd" = (
@@ -36437,6 +35549,9 @@
 	},
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
+/obj/access_spawn/engineering_mechanic,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bze" = (
@@ -36453,25 +35568,28 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "bzf" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Electronics Lab";
-	req_access_txt = "45"
-	},
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_mechanic,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bzg" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/elect)
 "bzh" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
 "bzi" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering)
 "bzj" = (
-/obj/machinery/door/airlock/pyro/engineering,
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bzk" = (
@@ -36581,6 +35699,7 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bzx" = (
@@ -36589,17 +35708,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/classic{
-	dir = 4;
-	req_access_txt = "12"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/turf/simulated/floor/black,
+/area/station/crew_quarters/bar)
 "bzy" = (
 /obj/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
@@ -36607,34 +35722,23 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/solar/east)
 "bzA" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Solar Substation"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/solar/east)
-"bzB" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_power,
+/turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
+"bzB" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "bzC" = (
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/storage/secure/closet/security/armory{
-	req_access_txt = "37"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/item/gun/kinetic/riotgun,
-/obj/item/gun/kinetic/riotgun,
-/turf/simulated/floor/caution/west,
+/turf/simulated/floor/black,
 /area/station/security/armory)
 "bzD" = (
 /obj/table/auto,
@@ -36675,16 +35779,17 @@
 	},
 /area/station/solar/east)
 "bzG" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/sec)
+/obj/item/storage/toilet/random{
+	dir = 8
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "bzH" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bzI" = (
 /obj/cable,
 /obj/machinery/power/terminal,
@@ -36696,9 +35801,10 @@
 	tag = ""
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bzJ" = (
 /obj/machinery/door/airlock/pyro/classic,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bzK" = (
@@ -36716,17 +35822,9 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
 "bzM" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hydroponics/bay)
+/obj/machinery/light/small,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/courtroom)
 "bzN" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -36786,8 +35884,10 @@
 	dir = 4;
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
 "bzU" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -36824,7 +35924,8 @@
 	dir = 4;
 	pixel_y = 0
 	},
-/obj/machinery/door/firedoor/pyro{
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
@@ -36979,8 +36080,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bAo" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bAp" = (
@@ -37011,11 +36111,6 @@
 /area/station/maintenance/solar/east)
 "bAt" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -37027,6 +36122,9 @@
 	broadcasting = 0;
 	frequency = 1441;
 	name = "Station Intercom (Engineering)"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
@@ -37063,15 +36161,20 @@
 /turf/space,
 /area/space)
 "bAx" = (
+/obj/machinery/networked/radio,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-6"
+	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bAy" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
 /obj/cable,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bAz" = (
 /obj/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -37137,11 +36240,6 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bAJ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -37176,6 +36274,10 @@
 /area/station/engine/elect)
 "bAO" = (
 /obj/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bAP" = (
@@ -37193,33 +36295,34 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bAS" = (
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bAT" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Bar Hallway";
 	location = "Engineering Hallway"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bAU" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
 "bAV" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Tool Storage";
-	req_access_txt = "12"
-	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/storage/tools)
 "bAW" = (
@@ -37292,15 +36395,27 @@
 	network = "SS13";
 	tag = ""
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bBe" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/camera{
 	c_tag = "East Maintenance";
 	dir = 6;
 	icon_state = "camera"
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "bBf" = (
@@ -37375,7 +36490,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bBl" = (
 /obj/rack,
 /obj/machinery/light/small{
@@ -37417,6 +36532,7 @@
 	desc = "not at all a paper bin. no sir.";
 	name = "do-it-yourself joint construction kit"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "bBo" = (
@@ -37424,10 +36540,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bBp" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	req_access_txt = "45"
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
 	},
+/obj/access_spawn/engineering_mechanic,
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "bBq" = (
@@ -37441,6 +36557,11 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
@@ -37472,6 +36593,11 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
@@ -37520,7 +36646,8 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/machinery/door/firedoor/pyro{
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
 /turf/simulated/floor/blue/side{
@@ -37545,6 +36672,11 @@
 	desc = "Caution! Room full of death!";
 	name = "decompression hazard sign"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/blue/side{
 	dir = 0
 	},
@@ -37560,11 +36692,6 @@
 	},
 /area/station/hallway/primary/south)
 "bBE" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
@@ -37607,8 +36734,7 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
 "bBJ" = (
@@ -37696,9 +36822,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/disposal)
 "bBT" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/mail,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bBU" = (
@@ -37713,8 +36838,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bBV" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
 "bBW" = (
@@ -37723,10 +36847,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/external{
-	name = "External Access";
-	req_access_txt = "13;40"
-	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/east)
 "bBX" = (
@@ -37783,8 +36905,16 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/turret,
+/obj/cable{
+	icon_state = "5-9"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "9-10"
+	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bCc" = (
 /obj/cable{
 	d1 = 2;
@@ -37792,7 +36922,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bCd" = (
 /obj/cable{
 	d2 = 8;
@@ -37807,16 +36937,28 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "8-9"
+	},
+/obj/machinery/computer/announcement,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bCe" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bCf" = (
 /obj/lattice{
 	dir = 10;
@@ -37867,17 +37009,20 @@
 	c_tag = "Electronics";
 	dir = 1
 	},
-/turf/simulated/floor/yellow,
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/turf/simulated/floor/plating,
 /area/station/engine/elect)
 "bCm" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/obj/machinery/manufacturer/mechanic,
-/turf/simulated/floor/yellow,
-/area/station/engine/elect)
+/obj/access_spawn/security,
+/obj/access_spawn/head_of_personnel,
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/courtroom)
 "bCn" = (
 /obj/table/auto,
 /obj/item/storage/belt/utility,
@@ -37907,17 +37052,20 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bCq" = (
-/obj/storage/closet/emergency,
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir";
+	tag = "icon-lattice-dir (SOUTHWEST)"
+	},
+/turf/space,
+/area/space)
 "bCr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/atmos/highcap_storage)
 "bCs" = (
 /obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance{
-	req_access_txt = "46"
-	},
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_atmos,
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
 "bCt" = (
@@ -37926,8 +37074,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/atmos/highcap_storage)
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering,
+/turf/simulated/floor,
+/area/station/engine/engineering)
 "bCu" = (
 /obj/machinery/camera{
 	c_tag = "General Storage Entrance";
@@ -38061,8 +37211,13 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/machinery/computer3/generic/communications,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-6"
+	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bCM" = (
 /obj/cable{
 	d1 = 4;
@@ -38075,7 +37230,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bCN" = (
 /obj/cable{
 	d1 = 1;
@@ -38083,17 +37238,12 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bCO" = (
 /obj/cable,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "S APC";
-	pixel_y = -24
-	},
-/obj/machinery/turretid,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bCP" = (
 /obj/cable{
 	d1 = 1;
@@ -38101,7 +37251,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bCQ" = (
 /obj/cable{
 	d1 = 4;
@@ -38114,7 +37264,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bCR" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor,
@@ -38138,17 +37288,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/south)
 "bCW" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/obj/machinery/atmospherics/pipe/vent,
+/turf/simulated/floor/plating/airless,
+/area/space)
 "bCX" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/engine/elect)
+/area/station/hangar/sec)
 "bCY" = (
 /obj/disposalpipe/segment,
 /obj/table/auto,
@@ -38163,9 +37308,14 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bDa" = (
-/obj/storage/closet/fire,
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/south)
 "bDb" = (
 /obj/cable{
 	d2 = 2;
@@ -38199,29 +37349,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
-"bDe" = (
-/obj/grille/steel,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "atmoswindow";
-	name = "Atmospherics Window Shutters";
-	opacity = 0
-	},
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/turf/simulated/floor,
-/area/station/atmos/highcap_storage)
 "bDf" = (
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
@@ -38230,13 +37357,12 @@
 /area/station/atmos/highcap_storage)
 "bDh" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/tank/air_repressurization,
 /turf/simulated/floor/grime,
-/area/station/atmos/highcap_storage)
+/area/station/maintenance/east)
 "bDi" = (
 /obj/machinery/atmospherics/pipe/tank/air_repressurization,
 /obj/machinery/light/small{
@@ -38379,18 +37505,18 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bDB" = (
 /obj/machinery/light,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bDC" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bDD" = (
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -38408,6 +37534,9 @@
 /area/station/maintenance/south)
 "bDF" = (
 /obj/decal/cleanable/cobweb2,
+/obj/rack,
+/obj/item/clothing/suit/fire,
+/obj/item/clothing/mask/gas/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "bDG" = (
@@ -38425,11 +37554,12 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bDH" = (
-/obj/landmark{
-	name = "SR Welder"
+/obj/decal/tile_edge/line/blue,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "bDI" = (
 /obj/cable{
 	d1 = 1;
@@ -38446,10 +37576,10 @@
 /area/station/atmos/highcap_storage)
 "bDK" = (
 /obj/table/auto,
+/obj/machinery/phone,
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
 "bDL" = (
-/obj/grille/steel,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -38457,29 +37587,18 @@
 	name = "Atmospherics Window Shutters";
 	opacity = 0
 	},
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/atmos/highcap_storage)
 "bDM" = (
+/obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/valve,
 /turf/simulated/floor/grime,
-/area/station/atmos/highcap_storage)
+/area/station/maintenance/east)
 "bDN" = (
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/plating,
@@ -38549,7 +37668,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bDZ" = (
 /obj/cable{
 	d1 = 4;
@@ -38557,15 +37676,19 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIsat)
 "bEa" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
 /turf/simulated/floor/engine,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIsat)
 "bEb" = (
 /obj/cable{
 	d1 = 4;
@@ -38573,7 +37696,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bEc" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -38583,7 +37706,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bEd" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -38593,7 +37716,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bEe" = (
 /obj/cable{
 	d1 = 4;
@@ -38606,21 +37729,10 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bEf" = (
 /obj/landmark/start{
 	name = "AI"
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 1
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 8;
-	frequency = 1447
-	},
-/obj/item/device/radio/intercom{
-	dir = 4
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -38630,8 +37742,13 @@
 /obj/landmark{
 	name = "AI-Sat"
 	},
+/obj/machinery/door_control{
+	id = "ai_core";
+	name = "AI Shield Control";
+	pixel_y = 26
+	},
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bEg" = (
 /obj/cable{
 	d1 = 4;
@@ -38644,7 +37761,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bEh" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -38654,7 +37771,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bEi" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -38664,7 +37781,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bEj" = (
 /obj/item/sheet/steel{
 	amount = 50
@@ -38693,14 +37810,7 @@
 /area/station/maintenance/south)
 "bEm" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
@@ -38720,43 +37830,28 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bEp" = (
-/obj/rack,
-/obj/item/clothing/under/color/grey,
-/obj/item/clothing/shoes/black,
-/obj/item/clothing/suit/fire,
-/obj/item/clothing/mask/gas/emergency,
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/obj/machinery/atmospherics/pipe/simple/insulated/cold/northwest,
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "bEq" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/window{
-	dir = 2
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
 "bEr" = (
-/obj/machinery/door/window/southright{
-	name = "Atmospherics Control";
-	req_access_txt = "46"
-	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/engineering_atmos,
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
 "bEs" = (
-/obj/window{
-	dir = 2
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
 "bEt" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/decal/cleanable/cobweb{
 	icon_state = "cobweb"
 	},
@@ -38884,25 +37979,36 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bEJ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/turretid{
+	pixel_y = -24
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/turf/simulated/wall/r_wall,
-/area/station/turret_protected/ai_upload_foyer)
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
 "bEK" = (
 /obj/cable{
 	d1 = 4;
@@ -38919,7 +38025,7 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bEL" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/solar/south)
@@ -38929,9 +38035,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Solar Substation"
-	},
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "bEN" = (
@@ -38994,10 +38099,14 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
 "bEU" = (
-/obj/cable,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -39006,8 +38115,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/atmos/highcap_storage)
 "bEV" = (
@@ -39019,8 +38127,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/atmos/highcap_storage)
 "bEW" = (
@@ -39028,8 +38135,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/atmos/highcap_storage)
 "bEX" = (
@@ -39059,14 +38165,14 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "bFb" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/maintenance,
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bFc" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bFd" = (
@@ -39082,7 +38188,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bFf" = (
 /obj/machinery/turret,
 /obj/cable{
@@ -39090,13 +38196,10 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bFg" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bFh" = (
 /obj/cable{
 	d2 = 2;
@@ -39160,21 +38263,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "bFm" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	req_access_txt = "45"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/engineering_mechanic,
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "bFn" = (
-/obj/storage/crate,
-/obj/item/weldingtool,
-/obj/item/storage/belt/utility,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/device/light/glowstick,
+/obj/machinery/atmospherics/pipe/simple/insulated/horizontal,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/area/station/science/lab)
 "bFo" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/grime,
@@ -39196,11 +38298,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -39233,31 +38330,22 @@
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
 "bFu" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
 	},
-/turf/simulated/floor/grime,
-/area/station/atmos/highcap_storage)
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "bFv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/landmark/start{
+	name = "Janitor"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/atmos/highcap_storage)
+/turf/simulated/floor/white/checker{
+	dir = 4
+	},
+/area/station/janitor/office)
 "bFw" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
@@ -39268,6 +38356,10 @@
 	pixel_y = 8
 	},
 /obj/storage/closet/fire,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor,
 /area/station/storage/tools)
 "bFx" = (
@@ -39295,11 +38387,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -39307,8 +38394,23 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bFB" = (
 /obj/cable,
 /obj/cable{
@@ -39349,6 +38451,7 @@
 	pixel_x = -7
 	},
 /obj/item/stamp,
+/obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bFD" = (
@@ -39493,25 +38596,24 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
-"bFM" = (
-/obj/machinery/door/firedoor/pyro,
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
-"bFN" = (
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24;
-	pixel_y = 0
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"bFM" = (
+/obj/decal/boxingropeenter{
+	dir = 4;
+	icon_state = "ringrope";
+	pixel_x = 0
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
+"bFN" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/horizontal,
+/turf/space,
+/area/space)
 "bFO" = (
 /obj/machinery/light,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -39530,14 +38632,17 @@
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
 "bFR" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
 	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/grime,
-/area/station/atmos/highcap_storage)
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "bFS" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating,
@@ -39558,11 +38663,6 @@
 /obj/table/auto,
 /obj/item/wirecutters,
 /obj/item/device/light/flashlight,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/item/device/gps,
 /turf/simulated/floor,
 /area/station/storage/tools)
@@ -39666,11 +38766,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bGe" = (
-/obj/grille/steel,
 /obj/item/clothing/under/misc/clown,
 /obj/item/clothing/shoes/clown_shoes,
 /obj/item/clothing/mask/clown_hat,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "bGf" = (
@@ -39679,15 +38778,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/external{
-	name = "External Access";
-	req_access_txt = "13;40"
-	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "bGg" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "bGh" = (
@@ -39696,43 +38792,49 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/item/storage/belt/utility,
+/obj/storage/crate,
+/obj/item/weldingtool,
+/obj/item/device/light/glowstick,
+/obj/item/device/light/glowstick,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "bGi" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/stool/bench/blue,
+/obj/decal/boxingrope{
+	dir = 8;
+	icon_state = "ringrope"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "bGj" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/south)
 "bGk" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/storage/tools)
-"bGl" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Tool Storage";
-	req_access_txt = "12"
+/turf/simulated/floor/yellow/side{
+	dir = 1
 	},
+/area/station/hallway/primary/south)
+"bGl" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
 "bGm" = (
@@ -39746,9 +38848,13 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/east)
 "bGn" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/obj/machinery/atmospherics/pipe/simple/insulated/northwest,
+/obj/lattice{
+	dir = 2;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "bGo" = (
 /obj/grille/catwalk{
 	dir = 9
@@ -39802,7 +38908,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bGr" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -39813,10 +38919,9 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bGs" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "bGt" = (
@@ -39830,21 +38935,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/south)
 "bGu" = (
+/obj/disposalpipe/segment,
 /obj/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/area/station/maintenance/east)
 "bGv" = (
 /obj/cable{
 	d1 = 4;
@@ -39875,20 +38978,16 @@
 	icon_state = "4-8"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
-"bGy" = (
-/obj/cable{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/area/station/maintenance/east)
+"bGy" = (
+/obj/machinery/vending/standard,
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "bGz" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -39907,9 +39006,8 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/wall/r_wall,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bGB" = (
-/obj/machinery/door/airlock/external,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -39920,16 +39018,16 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/door/airlock/pyro/command/alt,
+/obj/access_spawn/ai_upload,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/ai)
 "bGC" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/turf/simulated/floor/yellow/side{
+	dir = 10
 	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/area/station/hallway/primary/south)
 "bGD" = (
 /obj/cable{
 	d1 = 1;
@@ -39938,22 +39036,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
-"bGE" = (
-/obj/machinery/door{
-	icon = 'icons/obj/doors/Door1.dmi'
-	},
-/turf/simulated/floor/engine,
-/area/station/turret_protected/ai_upload_foyer)
 "bGF" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	icon_state = "camera";
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/engine,
-/area/station/turret_protected/ai_upload_foyer)
+/turf/simulated/floor/circuit/red,
+/area/station/turret_protected/AIsat)
 "bGG" = (
 /obj/grille/catwalk/cross{
 	dir = 5
@@ -40004,14 +39089,10 @@
 	},
 /area/space)
 "bGJ" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/obj/machinery/atmospherics/pipe/manifold/west,
+/obj/machinery/meter,
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "bGK" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/plating,
@@ -40022,15 +39103,29 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/pyro/command/alt,
+/obj/access_spawn/ai_upload,
+/obj/firedoor_spawn,
 /turf/simulated/floor/engine,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIsat)
 "bGM" = (
-/obj/machinery/camera,
-/turf/simulated/floor/plating/airless,
-/area/space)
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/access_spawn/research,
+/obj/forcefield/energyshield/perma{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/delivery,
+/area/station/science/lobby)
 "bGN" = (
 /obj/machinery/computer/mining_shuttle,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "bGO" = (
@@ -40080,37 +39175,33 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "bGS" = (
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/tank{
+	dir = 8
 	},
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 0;
-	icon_state = "eng_closed";
-	name = "Mining";
-	req_access_txt = "50"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/turf/simulated/floor/black,
+/area/station/science/lab)
 "bGT" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/south)
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	icon_state = "glass_locked";
+	locked = 1
+	},
+/obj/access_spawn/tox,
+/obj/firedoor_spawn,
+/obj/machinery/atmospherics/pipe/simple/insulated/horizontal,
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "bGU" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/refinery)
 "bGV" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
 "bGW" = (
-/obj/decal/cleanable/cobweb,
-/obj/storage/secure/closet/engineering/mining,
-/turf/simulated/floor/shuttlebay{
-	name = "reinforced plating"
-	},
-/area/station/quartermaster/refinery)
+/obj/machinery/atmospherics/pipe/simple/insulated/horizontal,
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "bGX" = (
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
@@ -40186,11 +39277,12 @@
 	},
 /area/station/solar/east)
 "bHb" = (
-/obj/storage/secure/closet/engineering/mining,
-/turf/simulated/floor/shuttlebay{
-	name = "reinforced plating"
+/obj/machinery/atmospherics/pipe/simple/insulated/southwest,
+/obj/machinery/light{
+	dir = 1
 	},
-/area/station/quartermaster/refinery)
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "bHc" = (
 /obj/cable{
 	d1 = 1;
@@ -40241,14 +39333,8 @@
 	},
 /area/station/solar/east)
 "bHe" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 8;
-	icon_state = "eng_closed";
-	name = "Mining";
-	req_access_txt = "50"
-	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/science/lab)
 "bHf" = (
 /obj/cable,
 /obj/item/cable_coil/cut{
@@ -40274,81 +39360,59 @@
 	},
 /area/station/solar/east)
 "bHg" = (
-/obj/machinery/neosmelter,
-/turf/simulated/floor/shuttlebay{
-	name = "reinforced plating"
-	},
+/turf/simulated/floor/caution/north,
 /area/station/quartermaster/refinery)
 "bHh" = (
-/obj/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/jetpack,
-/obj/item/clothing/suit/space/engineer,
-/obj/item/clothing/head/helmet/space/engineer,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/jetpack,
-/obj/item/clothing/suit/space/engineer,
-/obj/item/clothing/head/helmet/space/engineer,
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
-/obj/item/clothing/mask/breath,
-/obj/item/tank/jetpack,
-/obj/item/clothing/suit/space/engineer,
-/obj/item/clothing/head/helmet/space/engineer,
-/turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/turf/simulated/floor/red/checker{
+	dir = 4
+	},
+/area/station/security/prison)
 "bHi" = (
-/obj/machinery/door/airlock/external,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/turret_protected/ai_upload_foyer)
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
 "bHj" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 8;
-	icon_state = "eng_closed";
-	name = "Mining";
-	req_access_txt = "50"
-	},
-/turf/simulated/floor/plating,
-/area/space)
-"bHk" = (
-/obj/securearea{
-	desc = "";
-	icon_state = "shock";
-	name = "Danger: High Voltage";
-	pixel_x = 0
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/quartermaster/refinery)
-"bHl" = (
-/obj/machinery/light/small{
+/turf/simulated/floor/redblack{
 	dir = 8
 	},
-/obj/item/slag_shovel,
-/turf/simulated/floor/caution/north,
-/area/station/quartermaster/refinery)
-"bHm" = (
-/turf/simulated/floor/caution/north,
-/area/station/quartermaster/refinery)
-"bHn" = (
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
+/area/station/security/prison)
+"bHk" = (
+/obj/machinery/arc_electroplater{
+	dir = 4
 	},
-/turf/simulated/floor/caution/north,
+/turf/simulated/floor/grime,
 /area/station/quartermaster/refinery)
+"bHl" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/southeast,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
+"bHm" = (
+/obj/machinery/atmospherics/pipe/manifold/east,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
+"bHn" = (
+/obj/machinery/door/airlock/pyro/glass{
+	icon_state = "glass_locked";
+	locked = 1
+	},
+/obj/access_spawn/tox,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating,
+/area/station/science/lab)
 "bHo" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -40358,7 +39422,7 @@
 	tag = ""
 	},
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bHp" = (
 /obj/cable{
 	d1 = 1;
@@ -40366,7 +39430,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bHq" = (
 /obj/machinery/computer/magnet{
 	dir = 4
@@ -40425,7 +39489,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/processor,
+/obj/machinery/ore_cloud_storage_container,
 /turf/simulated/floor/grime,
 /area/station/quartermaster/refinery)
 "bHy" = (
@@ -40433,7 +39497,7 @@
 	name = "S light switch";
 	pixel_y = -24
 	},
-/obj/machinery/nanofab,
+/obj/machinery/processor,
 /turf/simulated/floor/grime,
 /area/station/quartermaster/refinery)
 "bHz" = (
@@ -40495,7 +39559,7 @@
 "bHC" = (
 /obj/grille/steel,
 /turf/space,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/AIbaseoutside)
 "bHD" = (
 /obj/cable{
 	d1 = 1;
@@ -40662,8 +39726,11 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/quartermaster/refinery)
 "bHP" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -40673,8 +39740,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/quartermaster/refinery)
 "bHQ" = (
 /obj/cable{
 	d1 = 2;
@@ -40711,8 +39781,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/quartermaster/refinery)
 "bHT" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -40727,8 +39800,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/quartermaster/refinery)
 "bHU" = (
 /obj/cable,
 /obj/cable{
@@ -40778,11 +39854,14 @@
 /area/station/solar/east)
 "bHW" = (
 /obj/storage/closet/welding_supply,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/quartermaster/refinery)
 "bHX" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/space)
 "bHY" = (
@@ -40793,7 +39872,7 @@
 /obj/item/device/matanalyzer,
 /obj/item/device/matanalyzer,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/quartermaster/refinery)
 "bHZ" = (
 /obj/lattice,
 /obj/machinery/camera{
@@ -40809,13 +39888,13 @@
 "bIa" = (
 /obj/storage/crate,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/quartermaster/refinery)
 "bIb" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency,
 /obj/item/paper/book/materials,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/quartermaster/refinery)
 "bIc" = (
 /obj/cable{
 	d2 = 2;
@@ -40925,7 +40004,7 @@
 	tag = ""
 	},
 /turf/space,
-/area/space)
+/area/station/quartermaster/refinery)
 "bIi" = (
 /obj/cable,
 /obj/cable{
@@ -40982,7 +40061,7 @@
 	dir = 8
 	},
 /turf/space,
-/area/space)
+/area/station/quartermaster/refinery)
 "bIl" = (
 /obj/cable{
 	d2 = 2;
@@ -41036,66 +40115,11 @@
 	layer = 2
 	},
 /area/station/solar/south)
-"bIo" = (
-/obj/grille/catwalk/cross{
-	dir = 9
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9;
-	layer = 2
-	},
-/area/space)
-"bIp" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
-	},
-/area/space)
-"bIq" = (
-/obj/grille/catwalk,
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
-"bIr" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/grille/catwalk/cross{
-	dir = 9
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9;
-	layer = 2
-	},
-/area/space)
 "bIs" = (
 /obj/landmark/map{
 	name = "DONUT2"
 	},
 /turf/space,
-/area/space)
-"bIt" = (
-/obj/grille/catwalk,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "bIu" = (
 /obj/cable{
@@ -41252,11 +40276,8 @@
 	},
 /area/mining/magnet)
 "bIB" = (
-/obj/machinery/recharge_station,
-/obj/grille/catwalk{
-	dir = 4
-	},
-/turf/space,
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/quartermaster/refinery)
 "bIC" = (
@@ -41320,60 +40341,27 @@
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/mining/magnet)
-"bIG" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/grille/catwalk/cross{
-	dir = 6
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6;
-	layer = 2
-	},
-/area/space)
 "bIH" = (
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/grille/catwalk/cross{
-	dir = 9
+/obj/grille/catwalk{
+	icon_state = "catwalk_cross"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9;
 	layer = 2
 	},
-/area/space)
-"bII" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	intact = 0
-	},
-/area/space)
+/area/station/quartermaster/refinery)
 "bIJ" = (
-/obj/grille/catwalk/cross{
-	dir = 6
-	},
 /turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6;
-	layer = 2
-	},
+/turf/space,
 /area/space)
 "bIK" = (
 /obj/landmark/magnet_shield,
@@ -41406,13 +40394,16 @@
 /area/mining/magnet)
 "bIM" = (
 /obj/grille/catwalk/cross,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
-/area/space)
+/area/station/quartermaster/refinery)
 "bIN" = (
 /obj/grille/catwalk{
 	dir = 5;
@@ -41423,13 +40414,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
-/area/space)
+/area/station/quartermaster/refinery)
 "bIO" = (
 /obj/cable{
 	d1 = 4;
@@ -41437,13 +40431,16 @@
 	icon_state = "4-8"
 	},
 /obj/grille/catwalk/cross,
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
-/area/space)
+/area/station/quartermaster/refinery)
 "bIP" = (
 /obj/grille/catwalk{
 	dir = 5
@@ -41453,24 +40450,30 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
-/area/space)
+/area/station/quartermaster/refinery)
 "bIQ" = (
 /obj/grille/catwalk{
 	dir = 5
 	},
-/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross";
 	layer = 2
 	},
-/area/space)
+/area/station/quartermaster/refinery)
 "bIR" = (
 /obj/landmark/magnet_shield,
 /obj/securearea{
@@ -41595,12 +40598,3491 @@
 	layer = 2
 	},
 /area/space)
+"bOY" = (
+/obj/table/auto,
+/obj/item/cargotele{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/cargotele{
+	pixel_x = -3
+	},
+/turf/simulated/floor/grime,
+/area/station/quartermaster/refinery)
+"bPk" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	frequency = 1229;
+	icon_state = "intact_on";
+	id = "Chamber One Inlet";
+	on = 1;
+	target_pressure = 1000
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
+"cei" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	icon_state = "on";
+	on = 1
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"cjG" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"ctZ" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/red,
+/area/station/security/prison)
+"cxA" = (
+/turf/simulated/floor/yellow/corner{
+	dir = 8
+	},
+/area/station/mining/staff_room)
+"cCh" = (
+/obj/grille/catwalk{
+	dir = 5
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
+/area/station/quartermaster/refinery)
+"cLq" = (
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1;
+	icon_state = "catwalk_cross"
+	},
+/area/station/quartermaster/refinery)
+"cOs" = (
+/obj/table/auto,
+/obj/item/paper_bin,
+/obj/item/clipboard/with_pen,
+/obj/item/pen,
+/turf/simulated/floor/black,
+/area/station/security/brig)
+"cVV" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 8;
+	name = "The Owlery"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/delivery,
+/area/station/garden/owlery)
+"cZN" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
+"dbr" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "9-10"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"dbM" = (
+/obj/decal/boxingrope{
+	dir = 4;
+	icon_state = "ringrope"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
+"dhK" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/turret_protected/ai)
+"dlx" = (
+/turf/simulated/wall/false_wall,
+/area/station/maintenance/inner/central)
+"doj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
+"drg" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
+"dsu" = (
+/obj/grille/catwalk,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/quartermaster/refinery)
+"dsM" = (
+/obj/storage/closet/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"dtP" = (
+/obj/machinery/portableowl/attached{
+	name = "A Pretty Owl"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"dAF" = (
+/obj/machinery/computer/supplycomp,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-10"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"dCE" = (
+/obj/machinery/vending/security,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"dHA" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/plating,
+/area/station/medical/cdc)
+"dJU" = (
+/obj/table/wood/auto,
+/obj/item/storage/bible{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 6
+	},
+/area/station/chapel/sanctuary)
+"dMh" = (
+/obj/machinery/door/airlock/pyro/glass/sci,
+/obj/firedoor_spawn,
+/obj/access_spawn/research,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hangar/science)
+"dTg" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"dXg" = (
+/obj/reagent_dispensers/fueltank,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
+"efc" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	layer = 3.5;
+	pixel_y = -24
+	},
+/turf/simulated/floor/circuit/red,
+/area/station/turret_protected/AIsat)
+"efQ" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/storage/tools)
+"ega" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/yellow,
+/area/station/engine/elect)
+"ejB" = (
+/obj/grille/catwalk/cross{
+	dir = 6
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6;
+	layer = 2
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6;
+	layer = 2
+	},
+/area/station/quartermaster/refinery)
+"ekx" = (
+/obj/stool/chair/red{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/black,
+/area/station/security/brig)
+"elf" = (
+/turf/simulated/floor/green/side{
+	dir = 5
+	},
+/area/station/maintenance/inner/central)
+"eoV" = (
+/obj/disposalpipe/trunk/brig{
+	dir = 1
+	},
+/obj/machinery/disposal/brig,
+/turf/simulated/floor,
+/area/station/security/brig)
+"epJ" = (
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/airless,
+/area/station/security/armory)
+"ere" = (
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"euy" = (
+/obj/securearea{
+	desc = "A warning sign which reads 'Outpost mail hub'";
+	name = "OUTPOST MAIL HUB"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/space)
+"euD" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
+"eAq" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"eFB" = (
+/obj/machinery/phone/wall{
+	pixel_y = 30
+	},
+/turf/simulated/floor/yellow,
+/area/station/engine/elect)
+"eJS" = (
+/obj/machinery/recharge_station,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	icon_state = "camera";
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"eKV" = (
+/obj/machinery/portable_reclaimer,
+/turf/simulated/floor,
+/area/station/storage/tools)
+"eNL" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	frequency = 1229;
+	icon_state = "intact_on";
+	id = "Chamber Two Inlet";
+	on = 1;
+	target_pressure = 1000
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
+"eSy" = (
+/obj/grille/catwalk{
+	dir = 9
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9;
+	layer = 2
+	},
+/area/station/quartermaster/refinery)
+"eWy" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
+"eYy" = (
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"eYM" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 4
+	},
+/area/station/science/lobby)
+"eZZ" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"fcs" = (
+/obj/machinery/recharge_station,
+/obj/machinery/light,
+/turf/simulated/floor/circuit,
+/area/station/medical/robotics)
+"fii" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	icon_state = "camera";
+	name = "autoname - SS13";
+	tag = ""
+	},
+/obj/submachine/weapon_vendor/security,
+/obj/machinery/phone/wall{
+	pixel_y = 30
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"fiX" = (
+/obj/mug_rack{
+	pixel_x = -26
+	},
+/obj/table/auto,
+/obj/machinery/coffeemaker{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 10
+	},
+/area/station/mining/staff_room)
+"fpl" = (
+/turf/simulated/floor/yellow/corner{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
+"fqz" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/mining/staff_room)
+"fzy" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/quartermaster/refinery)
+"fAk" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9;
+	icon_state = "xtra_bigstripe-corner2"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
+"fGE" = (
+/obj/machinery/portableowl/attached{
+	name = "The Sexiest Owl"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"fTr" = (
+/obj/tree1,
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"fTT" = (
+/obj/stool/chair/office/red,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"fUf" = (
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/research_horizontal{
+	icon_state = "bdoorleft1"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
+"fUX" = (
+/obj/securearea{
+	desc = "";
+	icon_state = "shock";
+	name = "Danger: High Voltage";
+	pixel_x = 0
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/quartermaster/refinery)
+"fVw" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/mining/staff_room)
+"fWe" = (
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"fXQ" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"gcq" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"gha" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/cdc)
+"gjf" = (
+/obj/disposalpipe/switch_junction{
+	dir = 8;
+	mail_tag = "research";
+	name = "research mail router"
+	},
+/turf/simulated/floor/greenwhite/other{
+	dir = 4
+	},
+/area/station/science/lobby)
+"gjN" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
+"gqo" = (
+/obj/machinery/door/airlock/pyro/security/alt,
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"gqN" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-9"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"gJo" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor,
+/area/station/science/lobby)
+"gMJ" = (
+/obj/rack,
+/obj/item/tank/jetpack{
+	pixel_x = -6
+	},
+/obj/item/clothing/suit/space/engineer{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/helmet/space/engineer{
+	pixel_y = 13
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 10
+	},
+/area/station/mining/staff_room)
+"gNq" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"gPo" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/grime,
+/area/station/atmos/highcap_storage)
+"gRh" = (
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"gRT" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24;
+	text = "NF"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/hydroponics/bay)
+"gTE" = (
+/obj/table/reinforced/auto,
+/obj/item/paper/book/minerals{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/device/matanalyzer{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/item/device/matanalyzer{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/simulated/floor/yellow/side,
+/area/station/mining/staff_room)
+"gUg" = (
+/turf/simulated/floor/green/side{
+	dir = 6
+	},
+/area/station/maintenance/inner/central)
+"gYd" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-6"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"gYw" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/secdetector{
+	area_access = 99;
+	detector_id = "AI Core";
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/security/armory)
+"hfe" = (
+/obj/machinery/nanofab/refining,
+/turf/simulated/floor/yellow/side,
+/area/station/mining/staff_room)
+"hou" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/garden/owlery)
+"hoK" = (
+/turf/simulated/floor/green/side,
+/area/station/hallway/primary/west)
+"hqn" = (
+/obj/machinery/manufacturer/qm,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/refinery)
+"hrF" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
+"hAR" = (
+/obj/rack,
+/obj/item/tank/jetpack{
+	pixel_x = -6
+	},
+/obj/item/clothing/suit/space/engineer{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/helmet/space/engineer{
+	pixel_y = 13
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/mining/staff_room)
+"hBo" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/science/artifact)
+"hMH" = (
+/obj/decal/boxingrope{
+	dir = 9;
+	icon_state = "ringrope"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
+"hOE" = (
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/glass/sci,
+/obj/access_spawn/research,
+/turf/simulated/floor,
+/area/station/science/lobby)
+"hPt" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
+"hXb" = (
+/obj/storage/closet/dresser{
+	anchored = 1;
+	name = "costume dresser"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 9
+	},
+/area/station/chapel/sanctuary)
+"idF" = (
+/obj/machinery/portable_atmospherics/canister/air/large,
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"ifA" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 6;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"igT" = (
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/test_apparatus/gas_sensor{
+	setup_tag = "BOTTOM"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"inn" = (
+/obj/stool,
+/obj/bookshelf/persistent,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 10
+	},
+/area/station/chapel/sanctuary)
+"inq" = (
+/obj/disposalpipe/switch_junction{
+	dir = 4;
+	mail_tag = "artlab";
+	name = "artlab mail router"
+	},
+/turf/simulated/floor{
+	icon_state = "orange"
+	},
+/area/station/science/lobby)
+"ivo" = (
+/obj/table/auto,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor,
+/area/station/hangar/science)
+"iAy" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/hangar/science)
+"iAR" = (
+/obj/landmark/start{
+	name = "Mechanic"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow,
+/area/station/engine/elect)
+"iAV" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"iCI" = (
+/mob/living/silicon/hivebot/eyebot{
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"iCO" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/turf/space,
+/area/space)
+"iHi" = (
+/obj/grille/catwalk{
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/quartermaster/refinery)
+"iLc" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/quartermaster/refinery)
+"iLJ" = (
+/obj/decal/cleanable/cobweb,
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/station/quartermaster/refinery)
+"iRE" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"iSb" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/elect)
+"iWu" = (
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/grille/catwalk{
+	dir = 9
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/west)
+"iWz" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/storage/tools)
+"iYx" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor/grime,
+/area/station/science/lab)
+"jey" = (
+/obj/machinery/door/airlock/pyro/security/alt{
+	dir = 4
+	},
+/obj/access_spawn/security,
+/turf/simulated/floor/red,
+/area/station/hangar/sec)
+"jfc" = (
+/obj/cable,
+/obj/machinery/power/solar{
+	id = "rozetasolar";
+	name = "Outpost Zeta Solar Array"
+	},
+/turf/simulated/floor/airless{
+	icon_state = "solarpanel";
+	name = "solar paneling"
+	},
+/area/station/solar/west)
+"jhA" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/quartermaster/refinery)
+"jnM" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hangar/main)
+"juY" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
+"jwx" = (
+/obj/shrub{
+	dir = 8
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"jzo" = (
+/obj/stool,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/bar)
+"jDc" = (
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "N APC";
+	pixel_y = 24
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/mining/staff_room)
+"jGa" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor,
+/area/station/hangar/arrivals)
+"jJi" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	icon_state = "on";
+	on = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"jKp" = (
+/obj/disposalpipe/switch_junction{
+	dir = 4;
+	mail_tag = "pathology";
+	name = "path mail router"
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
+"jMM" = (
+/obj/machinery/phone/wall{
+	pixel_y = -20
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
+"jOp" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"jPK" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"jZO" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	icon_state = "camera";
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"kav" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"kbT" = (
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/hallway/primary/west)
+"klQ" = (
+/obj/machinery/phone/wall{
+	pixel_x = 24;
+	pixel_y = 4
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/market)
+"kpr" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/mining/staff_room)
+"kqB" = (
+/turf/simulated/floor/yellow/corner{
+	dir = 4
+	},
+/area/station/mining/staff_room)
+"kuy" = (
+/obj/machinery/door/airlock/pyro/security/alt{
+	dir = 4
+	},
+/obj/access_spawn/security,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"kvs" = (
+/obj/storage/secure/closet/brig,
+/turf/simulated/floor,
+/area/station/security/brig)
+"kvy" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
+"kvZ" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/south)
+"kxs" = (
+/obj/machinery/computer/barcode/qm/no_belthell{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/refinery)
+"kyI" = (
+/obj/storage/secure/closet/security/equipment,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"kzt" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/west)
+"kzT" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "5-9"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"kDP" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/solar/west)
+"kHm" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	frequency = 1229;
+	icon_state = "intact_on";
+	id = "Chamber Two Outlet";
+	on = 1;
+	target_pressure = 1000
+	},
+/obj/decal/poster/wallsign/stencil/right/two{
+	pixel_x = 0;
+	pixel_y = 20
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
+"kKM" = (
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "lockdown";
+	name = "Bridge Lockdown Doors";
+	opacity = 0
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
+"kMs" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "E APC";
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/north)
+"kWD" = (
+/turf/simulated/floor/circuit/purple,
+/area/station/turret_protected/AIsat)
+"kYn" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 5
+	},
+/area/station/mining/staff_room)
+"kZP" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay4,
+/obj/warp_beacon{
+	name = "Ghost Drone Factory"
+	},
+/turf/space,
+/area/space)
+"lbg" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/cdc)
+"lcr" = (
+/obj/stool/chair,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/escape{
+	dir = 1
+	},
+/area/station/hangar/arrivals)
+"ldw" = (
+/obj/machinery/computer3/generic/med_data,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-10"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"lfr" = (
+/obj/machinery/manufacturer/gas,
+/turf/simulated/floor/grime,
+/area/station/atmos/highcap_storage)
+"lgv" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/west)
+"lis" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/station/quartermaster/refinery)
+"loM" = (
+/obj/stool/chair/yellow,
+/turf/simulated/floor,
+/area/station/mining/staff_room)
+"ltc" = (
+/obj/storage/secure/closet/engineering/mining,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/mining/staff_room)
+"lzl" = (
+/obj/machinery/computer3/generic/radio,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-6"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"lCb" = (
+/obj/stool/chair/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/yellow/corner,
+/area/station/mining/staff_room)
+"lDT" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/switch_junction{
+	dir = 8;
+	mail_tag = "chemistry";
+	name = "chemistry mail router"
+	},
+/turf/simulated/floor/purple/side{
+	dir = 1
+	},
+/area/station/science/lobby)
+"lIf" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-5"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"lKq" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor,
+/area/station/hangar/science)
+"lNU" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"lQh" = (
+/obj/decal/stage_edge,
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/fitness)
+"lSw" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"lTL" = (
+/obj/disposalpipe/segment,
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"lYX" = (
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/mining/staff_room)
+"mgh" = (
+/obj/grille/catwalk,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/quartermaster/refinery)
+"mgS" = (
+/obj/player_piano,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 9
+	},
+/area/station/chapel/sanctuary)
+"moS" = (
+/obj/table/wood/auto,
+/turf/simulated/floor/black,
+/area/station/chapel/sanctuary)
+"mro" = (
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/quartermaster/refinery)
+"mtT" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/space,
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"muY" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grime,
+/area/station/storage/tools)
+"mvZ" = (
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/mining/staff_room)
+"mwp" = (
+/obj/machinery/drainage,
+/obj/machinery/light/small,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"mIj" = (
+/obj/decal/boxingrope{
+	dir = 5;
+	icon_state = "ringrope"
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
+"mID" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/circuit/red,
+/area/station/turret_protected/AIsat)
+"mKC" = (
+/obj/machinery/computer/telescope{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 6
+	},
+/area/station/mining/staff_room)
+"mNm" = (
+/turf/simulated/floor/plating,
+/area/station/quartermaster/refinery)
+"mNB" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/hangar/arrivals)
+"mNN" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/office)
+"mRX" = (
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/mining,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/mining/staff_room)
+"mXG" = (
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 10;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"naG" = (
+/obj/stool/bed,
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr";
+	throwforce = 0
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"nbJ" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"nct" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"njK" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
+"nlS" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	layer = 3.5;
+	pixel_y = -24
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/circuit/red,
+/area/station/turret_protected/AIsat)
+"nml" = (
+/obj/rack,
+/obj/item/clothing/mask/gas/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"nzf" = (
+/turf/simulated/wall{
+	desc = "Upon closer inspection, you see that this is a cleverly painted wall.";
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "grass";
+	name = "tall grass"
+	},
+/area/station/garden/owlery)
+"nEX" = (
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"nFv" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"nJk" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
+"nKm" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	icon_state = "camera";
+	name = "autoname - SS13";
+	tag = ""
+	},
+/obj/machinery/computer/secure_data,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-10"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"nWJ" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
+"nZu" = (
+/obj/machinery/neosmelter,
+/turf/simulated/floor/shuttlebay{
+	name = "reinforced plating"
+	},
+/area/station/quartermaster/refinery)
+"nZy" = (
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 9;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"obE" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"oio" = (
+/obj/machinery/portableowl/attached{
+	name = "an Owl with a chip out of his beak"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"ojG" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 6
+	},
+/area/station/hallway/primary/south)
+"omo" = (
+/obj/machinery/teleport/portal_ring,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	icon_state = "camera";
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"omO" = (
+/obj/table/auto,
+/obj/item/storage/box/revimp_kit{
+	pixel_x = -10;
+	pixel_y = 8
+	},
+/obj/item/storage/box/flashbang_kit{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/device/prisoner_scanner,
+/turf/simulated/floor,
+/area/station/security/brig)
+"ont" = (
+/obj/machinery/computer/ordercomp,
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/hangar/science)
+"opZ" = (
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/quartermaster/refinery)
+"otU" = (
+/obj/cable{
+	icon_state = "5-9"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "6-9"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"oyl" = (
+/obj/machinery/turretid{
+	pixel_x = -24;
+	pixel_y = 1
+	},
+/turf/simulated/floor/black,
+/area/station/security/armory)
+"oyG" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/grille/catwalk/cross,
+/turf/space,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/west)
+"oDS" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grime{
+	dir = 8
+	},
+/area/station/science/lab)
+"oGA" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/disposal_pipedispenser/mobile{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"oMJ" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/turf/space,
+/area/space)
+"oNh" = (
+/obj/random_pod_spawner/random_putt_spawner,
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
+"oQj" = (
+/obj/machinery/recharger/wall/sticky{
+	dir = 4;
+	pixel_x = 23
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"oQR" = (
+/obj/machinery/nanofab/mining,
+/turf/simulated/floor/yellow/side,
+/area/station/mining/staff_room)
+"oRN" = (
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass,
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/south)
+"oTV" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/circuit/red,
+/area/station/turret_protected/AIsat)
+"pcA" = (
+/obj/storage/closet/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"pix" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"pjE" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4;
+	icon_state = "airlock_closed"
+	},
+/turf/simulated/floor,
+/area/station/hangar/arrivals)
+"ptL" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/obj/securearea{
+	desc = "A warning sign which reads 'Outpost mail hub'";
+	name = "OUTPOST MAIL HUB"
+	},
+/turf/space,
+/area/space)
+"pup" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"pxc" = (
+/obj/grille/steel{
+	layer = 2.7
+	},
+/obj/machinery/door/poddoor/blast/pyro{
+	dir = 4;
+	icon_state = "bdoorleft1";
+	id = "tox_vent1";
+	name = "Exhaust Vent"
+	},
+/turf/simulated/floor/engine/vacuum{
+	icon_state = "engine_caution_east"
+	},
+/area/station/science/lab)
+"pxN" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "N APC";
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"pzj" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
+"pHL" = (
+/obj/reagent_dispensers/watertank/fountain,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"pLv" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24;
+	text = "NF"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"pLx" = (
+/obj/storage/secure/closet/brig/automatic/genpop,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"pLY" = (
+/obj/machinery/portableowl/attached{
+	name = "A Prettier Owl"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"pMs" = (
+/obj/table/auto,
+/turf/simulated/floor,
+/area/station/mining/staff_room)
+"pNA" = (
+/turf/simulated/wall/r_wall,
+/area/station/turret_protected/ai)
+"pQI" = (
+/obj/machinery/door_control{
+	id = "medbay_front";
+	name = "Medbay Door Control";
+	pixel_y = -23
+	},
+/turf/simulated/floor/specialroom/medbay{
+	dir = 2
+	},
+/area/station/medical/medbay)
+"pSU" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"pTo" = (
+/obj/reagent_dispensers/fueltank,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"pTr" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/security/alt{
+	dir = 4
+	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
+/turf/simulated/floor/red,
+/area/station/hangar/sec)
+"pWp" = (
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/hydroponics/bay)
+"pZV" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/science/lobby)
+"qfx" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/science/lab)
+"qgr" = (
+/obj/grille/catwalk,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/quartermaster/refinery)
+"qgJ" = (
+/obj/machinery/sparker{
+	id = "tox_ignition1";
+	layer = 7;
+	name = "Mounted Igniter";
+	pixel_y = -22
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"qgX" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	icon_state = "camera";
+	name = "autoname - SS13";
+	network = "SS13";
+	tag = ""
+	},
+/turf/simulated/floor/circuit/red,
+/area/station/turret_protected/AIsat)
+"qmH" = (
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/networked/secdetector{
+	area_access = 99;
+	detector_id = "AI Core"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/plating/airless,
+/area/station/security/armory)
+"qoa" = (
+/obj/machinery/teleport/portal_generator,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"qot" = (
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"qtM" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/turret_protected/ai)
+"qwY" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 30
+	},
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/crew_quarters/quarters)
+"qAy" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	icon_state = "in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/junction,
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"qKF" = (
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/airless,
+/area/station/security/armory)
+"qLS" = (
+/obj/cable{
+	icon_state = "5-9"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "5-10"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"qNg" = (
+/obj/machinery/door/firedoor/pyro,
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_atmos,
+/obj/firedoor_spawn,
+/turf/simulated/floor/grime,
+/area/station/atmos/highcap_storage)
+"qNq" = (
+/turf/simulated/floor,
+/area/station/hangar/arrivals)
+"qRV" = (
+/obj/storage/closet/emergency,
+/obj/item/clothing/suit/space/emerg{
+	pixel_x = 6
+	},
+/obj/item/clothing/head/emerg{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/east)
+"qWA" = (
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"qWR" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/greenwhite/other,
+/area/station/science/lobby)
+"qYg" = (
+/obj/submachine/cargopad{
+	name = "Mechanical Workshop Pad"
+	},
+/turf/simulated/floor/yellow,
+/area/station/engine/elect)
+"rab" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"rfL" = (
+/obj/securearea{
+	desc = "A warning sign which reads 'Biohazard'";
+	icon_state = "bio";
+	layer = 2.5;
+	name = "BIOHAZARD";
+	pixel_x = -32
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/science/lobby)
+"rhi" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/circuit/red,
+/area/station/turret_protected/AIsat)
+"rqk" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/plating,
+/area/station/quartermaster/refinery)
+"rro" = (
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/engine/elect)
+"rze" = (
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/caution/north,
+/area/station/quartermaster/refinery)
+"rBH" = (
+/obj/machinery/r_door_control/podbay/research,
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/science)
+"rDK" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
+"rMl" = (
+/obj/machinery/computer/teleporter{
+	dir = 4
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"rNH" = (
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"rTC" = (
+/obj/submachine/slot_machine,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"rWV" = (
+/obj/machinery/computer/riotgear{
+	pixel_y = 28
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"rZP" = (
+/obj/lattice,
+/obj/warp_beacon{
+	name = "Science Hangar Beacon"
+	},
+/turf/space,
+/area/space)
+"saZ" = (
+/obj/storage/secure/closet/engineering/mining,
+/turf/simulated/floor/yellow/side{
+	dir = 5
+	},
+/area/station/mining/staff_room)
+"sbg" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/armory)
+"sdc" = (
+/obj/landmark{
+	name = "SR Welder"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"sfE" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hangar/arrivals)
+"sih" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/mining/staff_room)
+"skk" = (
+/turf/simulated/floor,
+/area/station/mining/staff_room)
+"slP" = (
+/obj/machinery/door/airlock/pyro/security,
+/obj/access_spawn/hos,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/security/armory)
+"smO" = (
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/airless,
+/area/station/security/armory)
+"snf" = (
+/obj/storage/crate,
+/turf/simulated/floor/plating,
+/area/station/quartermaster/refinery)
+"snW" = (
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/grille/catwalk{
+	dir = 9
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/west)
+"sqw" = (
+/obj/machinery/phone/wall{
+	pixel_y = -20
+	},
+/turf/simulated/floor/black,
+/area/station/security/armory)
+"stQ" = (
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"svD" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/engineering_atmos,
+/obj/firedoor_spawn,
+/turf/simulated/floor/grime,
+/area/station/atmos/highcap_storage)
+"szc" = (
+/obj/table/auto,
+/obj/item/clothing/under/gimmick/owl{
+	pixel_x = -9;
+	pixel_y = -1
+	},
+/obj/item/clothing/under/gimmick/owl{
+	pixel_x = 9;
+	pixel_y = -1
+	},
+/obj/item/clothing/mask/owl_mask{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/owl_mask{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/clothing/under/gimmick/owl{
+	pixel_y = -1
+	},
+/obj/item/clothing/mask/owl_mask{
+	pixel_x = -9;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/owl_mask{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"sDe" = (
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/turret,
+/obj/cable{
+	icon_state = "5-9"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "5-6"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"sDu" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/security/detectives_office)
+"sFC" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/mining/staff_room)
+"sFT" = (
+/obj/machinery/door/airlock/pyro/security/alt{
+	dir = 4
+	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
+/turf/simulated/floor/red,
+/area/station/hangar/sec)
+"sJD" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"sLS" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"sQe" = (
+/obj/landmark{
+	name = "kudzustart"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"sQU" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/mining/staff_room)
+"sRd" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/hallway/primary/south)
+"sRo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/engine/storage)
+"sTU" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
+"sXz" = (
+/obj/lattice{
+	dir = 2;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
+"tbf" = (
+/obj/stool/chair/yellow{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
+"thY" = (
+/obj/machinery/firealarm{
+	pixel_y = 24;
+	text = "NF"
+	},
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"tia" = (
+/turf/simulated/floor/plating/airless,
+/area/station/quartermaster/refinery)
+"tjO" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor,
+/area/station/hangar/science)
+"tkT" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/slag_shovel,
+/turf/simulated/floor/caution/north,
+/area/station/quartermaster/refinery)
+"tmp" = (
+/obj/stool/chair/yellow{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
+"toZ" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor,
+/area/station/hangar/arrivals)
+"tpk" = (
+/obj/machinery/door/firedoor/pyro,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_atmos,
+/obj/firedoor_spawn,
+/turf/simulated/floor/grime,
+/area/station/atmos/highcap_storage)
+"tpV" = (
+/obj/shrub{
+	dir = 6
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"txI" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"tAY" = (
+/obj/stool/chair/yellow,
+/turf/simulated/floor/yellow/corner{
+	dir = 4
+	},
+/area/station/mining/staff_room)
+"tCu" = (
+/obj/disposalpipe/segment/ejection{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/computer3/generic/secure_data{
+	dir = 8
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/phone/wall{
+	pixel_x = 24;
+	pixel_y = 4
+	},
+/turf/simulated/floor,
+/area/station/security/brig)
+"tLJ" = (
+/obj/submachine/cargopad{
+	name = "Botany Pad"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
+"tTO" = (
+/obj/grille/catwalk{
+	dir = 6
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 2;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 2;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/quartermaster/refinery)
+"tWQ" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	icon_state = "camera";
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/circuit/red,
+/area/station/turret_protected/AIsat)
+"tXf" = (
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/science/bot_storage)
+"tXY" = (
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/mining,
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/mining/staff_room)
+"tZf" = (
+/obj/table/wood/auto{
+	dir = 6
+	},
+/obj/item/ghostboard,
+/obj/item/ghostboard,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/sanctuary)
+"tZo" = (
+/obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
+"ugu" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"uhL" = (
+/obj/storage/closet/fire,
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"ujl" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/maintenance/inner/central)
+"ukm" = (
+/obj/submachine/cargopad{
+	name = "Mineral Magnet Pad"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/quartermaster/refinery)
+"umD" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/grime,
+/area/station/atmos/highcap_storage)
+"upn" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/solar/west)
+"uqg" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/switch_junction{
+	dir = 4;
+	mail_tag = "buddy_depot";
+	name = "buddydepot mail router"
+	},
+/turf/simulated/floor/neutral/side{
+	dir = 2
+	},
+/area/station/science/lobby)
+"uqk" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/quartermaster/refinery)
+"uqL" = (
+/obj/lattice{
+	dir = 2;
+	icon_state = "lattice-dir"
+	},
+/obj/grille/steel{
+	layer = 2.7
+	},
+/turf/space,
+/area/station/science/lab)
+"uvO" = (
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/airless,
+/area/station/security/armory)
+"uwR" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
+"uxt" = (
+/obj/cable{
+	icon_state = "1-4";
+	tag = "icon-1-4"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"uyM" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/yellow,
+/area/station/engine/elect)
+"uDi" = (
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"uFs" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/machinery/disposal/mail{
+	mail_tag = "research_hangar";
+	mailgroup = "science";
+	message = 1;
+	name = "mail chute-'Research Hangar"
+	},
+/obj/disposalpipe/trunk/mail{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
+"uHm" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/quartermaster/refinery)
+"uMP" = (
+/obj/tree1,
+/turf/simulated/wall{
+	desc = "Upon closer inspection, you see that this is a cleverly painted wall.";
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "grass";
+	name = "tall grass"
+	},
+/area/station/garden/owlery)
+"uPW" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/yellow,
+/area/station/engine/elect)
+"uUE" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"uWa" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	icon_state = "in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	on = 1;
+	pressure_checks = 2;
+	pump_direction = 0
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"uZK" = (
+/obj/grille/catwalk,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/station/quartermaster/refinery)
+"vdH" = (
+/obj/submachine/cargopad{
+	name = "Security Pad"
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"vdU" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/turf/space,
+/area/space)
+"vjd" = (
+/obj/machinery/computer/robotics,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-6"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"vkH" = (
+/obj/machinery/manufacturer/mining,
+/turf/simulated/floor/yellow/side,
+/area/station/mining/staff_room)
+"vmR" = (
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/space,
+/turf/simulated/floor,
+/area/station/science/lab)
+"vuf" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
+"vvM" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"vDc" = (
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/airless,
+/area/station/security/armory)
+"vEk" = (
+/obj/stool/bench/green/auto,
+/turf/simulated/floor/greenwhite/other{
+	dir = 10
+	},
+/area/station/science/lobby)
+"vFi" = (
+/obj/machinery/dispenser{
+	o2tanks = 10;
+	pltanks = 10
+	},
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"vFV" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
+"vIK" = (
+/obj/machinery/light,
+/turf/simulated/floor/black,
+/area/station/security/armory)
+"vLf" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
+"vLU" = (
+/obj/machinery/manufacturer/robotics,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/black/side{
+	dir = 8
+	},
+/area/station/medical/robotics)
+"vSU" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/floor,
+/turf/simulated/floor,
+/area/station/quartermaster/office)
+"vTd" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/science/lobby)
+"wfC" = (
+/obj/warp_beacon{
+	name = "Secure Hangar"
+	},
+/obj/lattice,
+/turf/space,
+/area/space)
+"wfT" = (
+/obj/machinery/light,
+/turf/simulated/floor,
+/area/station/security/brig)
+"wgM" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/greenwhite/other{
+	dir = 6
+	},
+/area/station/science/lobby)
+"wlU" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "zeta_mail_in";
+	operating = 1
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
+"wnU" = (
+/obj/rack,
+/obj/item/sheet/steel{
+	amount = 50
+	},
+/obj/item/sheet/glass{
+	amount = 50
+	},
+/obj/random_item_spawner/tools,
+/obj/item/cargotele,
+/turf/simulated/floor,
+/area/station/science/lobby)
+"woR" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/armory)
+"wvT" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space,
+/turf/space,
+/area/space)
+"wzk" = (
+/obj/table/auto,
+/obj/machinery/recharger,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -6
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 6
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 6
+	},
+/area/station/mining/staff_room)
+"wDo" = (
+/obj/lattice{
+	dir = 2;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
+"wEi" = (
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"wFo" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
+"wHO" = (
+/obj/stool,
+/obj/submachine/ATM{
+	pixel_y = -32
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"wIi" = (
+/obj/grille/steel{
+	layer = 2.7
+	},
+/obj/machinery/door/poddoor/blast/pyro{
+	dir = 4;
+	icon_state = "bdoorleft1";
+	id = "tox_vent2";
+	name = "Exhaust Vent"
+	},
+/turf/simulated/floor/engine/vacuum{
+	icon_state = "engine_caution_east"
+	},
+/area/station/science/lab)
+"wJl" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/solar/east)
+"wJS" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/greenwhite/other{
+	dir = 4
+	},
+/area/station/science/lobby)
 "wLu" = (
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
 /area/station/medical/robotics)
+"wMB" = (
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 5;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"wNb" = (
+/obj/grille/steel{
+	layer = 2.7
+	},
+/obj/machinery/door/poddoor/pyro{
+	id = "tox_mix";
+	layer = 8;
+	name = "Mixing Vent"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"wOm" = (
+/obj/grille/catwalk{
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/quartermaster/refinery)
+"wOn" = (
+/turf/simulated/floor/yellow/side{
+	dir = 6
+	},
+/area/station/quartermaster/office)
+"wRA" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	frequency = 1229;
+	icon_state = "intact_on";
+	id = "Chamber One Outlet";
+	on = 1;
+	target_pressure = 1000
+	},
+/obj/decal/poster/wallsign/stencil/right/one{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lab)
+"wTp" = (
+/obj/storage/secure/closet/engineering/mining,
+/turf/simulated/floor/yellow/side{
+	dir = 9
+	},
+/area/station/mining/staff_room)
+"wYe" = (
+/obj/shrub{
+	dir = 1
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/garden/owlery)
+"xbg" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
+"xeP" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
+"xkl" = (
+/obj/machinery/light,
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/sec)
+"xqE" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"xsP" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/south)
+"xvt" = (
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/power/data_terminal,
+/obj/machinery/networked/secdetector{
+	area_access = 99;
+	detector_id = "AI Core";
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/security/armory)
+"xwm" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 5
+	},
+/area/station/mining/staff_room)
+"xBk" = (
+/obj/machinery/atmospherics/pipe/manifold,
+/turf/simulated/floor/white,
+/area/station/science/lab)
+"xCI" = (
+/obj/machinery/camera{
+	c_tag = "Inner Maintenance South North"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"xEz" = (
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	intact = 0
+	},
+/area/station/solar/west)
+"xHP" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
+	},
+/obj/decal/tile_edge/line/red,
+/turf/simulated/floor,
+/area/station/science/lab)
+"xIm" = (
+/obj/lrteleporter,
+/turf/simulated/floor/yellow,
+/area/station/mining/staff_room)
+"xQx" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor,
+/area/station/science/lobby)
+"xRw" = (
+/obj/machinery/sparker{
+	id = "tox_ignition2";
+	layer = 7;
+	name = "Mounted Igniter";
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/junction,
+/turf/simulated/floor/engine/vacuum,
+/area/station/science/lab)
+"xUC" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/grille/catwalk{
+	dir = 6
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 2;
+	icon_state = "catwalk_cross";
+	layer = 2
+	},
+/area/station/solar/west)
+"xVE" = (
+/turf/space,
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/science)
+"xXK" = (
+/obj/machinery/light,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"xXS" = (
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "ai_core";
+	layer = 4;
+	name = "AI Core Shield";
+	opacity = 0
+	},
+/obj/cable,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"xZI" = (
+/obj/lattice,
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
+"yaN" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "5-9"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "9-10"
+	},
+/turf/simulated/floor/black,
+/area/station/turret_protected/ai)
+"ycv" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = -1
+	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
+"yfp" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/simulated/floor/engine,
+/area/station/turret_protected/AIsat)
+"yiQ" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/machinery/vending/security,
+/turf/simulated/floor/grime,
+/area/station/security/brig)
+"yjg" = (
+/obj/machinery/door/firedoor/pyro,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/engineering/alt,
+/obj/access_spawn/engineering_atmos,
+/turf/simulated/floor/grime,
+/area/station/atmos/highcap_storage)
 
 (1,1,1) = {"
 aaa
@@ -48998,7 +51480,7 @@ aaa
 aaa
 avp
 aaa
-avp
+kZP
 aaa
 avp
 aaa
@@ -54465,7 +56947,7 @@ aRN
 aNE
 arN
 aOr
-aUz
+bbN
 arN
 aVV
 aOZ
@@ -54787,11 +57269,11 @@ aaa
 aaa
 aaa
 aaa
-beB
-beB
-beB
-beB
-beB
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -55086,17 +57568,17 @@ arN
 bcZ
 avq
 aaa
-beB
-beB
-bfu
+aaa
+aaa
+aaa
 beC
 beC
 beC
 beC
 beC
-biX
-beB
-beB
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -55987,7 +58469,7 @@ bak
 baP
 aSE
 aSE
-aXp
+avq
 arN
 bcZ
 avq
@@ -56279,14 +58761,14 @@ aUH
 aUH
 aUH
 aVk
-aVZ
+aWC
 aWQ
 aXu
-aYl
-aSE
-aSE
-aSE
-aSE
+ban
+baD
+baD
+baD
+bdy
 aSE
 aSE
 aXp
@@ -56588,12 +59070,12 @@ aYm
 aZb
 aZI
 bal
-bal
+bdA
 bhL
 aUH
 avq
-aUz
-bda
+arN
+aOr
 avq
 avq
 beD
@@ -56744,12 +59226,12 @@ aab
 aaa
 aaa
 aaa
+aGg
+aaa
+aGg
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aGg
 aaa
 aaa
 aac
@@ -56864,7 +59346,7 @@ aaa
 aaa
 avq
 aHL
-aIC
+bfi
 arN
 arN
 arN
@@ -56874,7 +59356,7 @@ aQv
 aNF
 aOt
 arN
-aQx
+aUH
 aSY
 aRd
 aRQ
@@ -57195,11 +59677,11 @@ bam
 baR
 bbl
 bbM
-aMX
-arN
+beS
+aQv
 bdb
+aQv
 aug
-arN
 beD
 beZ
 bfz
@@ -57348,17 +59830,17 @@ aab
 aab
 aaa
 aaa
+aGg
 aaa
 aaa
 aaa
 aaa
 aaa
+aGg
 aaa
+aGg
 aaa
-aaa
-aaa
-aaa
-aaa
+aGg
 aaa
 aaa
 aaa
@@ -57482,11 +59964,11 @@ aKL
 aQy
 aRf
 aRS
-aRS
+aRH
 aTq
 aUc
 aUD
-baZ
+aSE
 aWd
 aWU
 aXy
@@ -57497,11 +59979,11 @@ bdv
 baS
 bbm
 bbN
-arN
+asx
 arN
 aJX
-azy
-arN
+avq
+asx
 beD
 bfa
 bfA
@@ -57661,7 +60143,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aGg
 aaa
 aaa
 aad
@@ -57777,7 +60259,7 @@ aKL
 aLL
 aMq
 wLu
-aNG
+vLU
 aNG
 aPc
 aMZ
@@ -57793,22 +60275,22 @@ aWe
 aWV
 aXz
 aYq
-aZe
+pQI
 aZL
-ban
-aYv
+aWZ
+bbB
 bbn
 bbM
-arN
+asx
 arN
 bdc
-aLJ
 aGl
+aLJ
 beE
-bfb
-bfb
-bfb
-bfb
+bjf
+bjf
+bjf
+bjf
 bgY
 bhQ
 bip
@@ -57951,7 +60433,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aGg
 aaa
 aaa
 aak
@@ -57964,9 +60446,9 @@ aaa
 aaa
 aaa
 aad
+aGg
 aaa
-aaa
-aaa
+aGg
 aaa
 aaa
 aaa
@@ -58085,10 +60567,10 @@ aPd
 aPS
 aQA
 aRh
-aRU
+aSE
 aSE
 aRU
-aSE
+aUk
 aUF
 aSF
 aWf
@@ -58098,18 +60580,18 @@ aYr
 aZf
 aZM
 bao
-aYv
+bbB
 bbo
 bbM
-arN
+asx
 arN
 avq
-bdA
-arN
+aMX
+asx
 beF
 bfc
 bfB
-bga
+bfD
 beC
 bgV
 bfy
@@ -58120,7 +60602,7 @@ blZ
 blc
 bmQ
 blZ
-bos
+bqx
 blZ
 blZ
 blZ
@@ -58267,8 +60749,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aGg
+aGg
 aaa
 aaa
 aaa
@@ -58373,7 +60855,7 @@ aEx
 avq
 aGj
 avq
-arN
+aOp
 arN
 avq
 aJY
@@ -58387,10 +60869,10 @@ aPe
 aPT
 aQB
 aRi
+aSF
 aRV
-aSF
-aTs
-aSF
+aZD
+aUx
 aUG
 aVo
 aWg
@@ -58403,11 +60885,11 @@ bap
 baT
 bbp
 bbM
-arN
+asx
 arN
 avq
 bdB
-arN
+avs
 beF
 bfd
 bfC
@@ -58568,9 +61050,9 @@ aao
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aGg
+aGg
+aGg
 aaa
 aaa
 aaa
@@ -58687,28 +61169,28 @@ aNH
 aNb
 aPf
 aKL
-aQC
+aTt
 aRj
-aUH
-aSG
+aTt
+aTt
 aTt
 aUe
+aQH
 aUH
 aUH
-aWh
 aWX
 aXC
 aIq
 aZh
 aZO
-aVs
+aWl
 baQ
-aVs
+aWl
 bbM
-arN
+asx
 arN
 avq
-bdC
+aOp
 arN
 beF
 bfe
@@ -58990,12 +61472,12 @@ aNb
 aPg
 aKL
 aQD
-aRk
-aUH
-aQD
+aRl
 aTu
-aQD
-aUH
+aSo
+aTu
+aVt
+aQH
 aVp
 aWi
 aWY
@@ -59007,19 +61489,19 @@ baq
 baV
 bbq
 bbM
-arN
+asx
 arN
 avq
-asx
+arN
 arN
 beF
 beF
 beD
 beC
 beC
-bha
-bhR
-biq
+bgV
+bfy
+bfy
 bjj
 beD
 bgF
@@ -59166,10 +61648,10 @@ aaK
 aaK
 aaK
 aak
-aaq
-aaq
-aaq
-aaq
+aOI
+aOI
+aOI
+aOI
 aab
 aaa
 aaa
@@ -59292,12 +61774,12 @@ aOu
 aPh
 aKL
 aQE
-aRk
-aUH
-aSH
+aRl
 aTu
+aTu
+aTb
 aUf
-aUH
+aQH
 aVq
 aWj
 aWZ
@@ -59305,14 +61787,14 @@ aXE
 aYv
 aYv
 aYv
-aYv
+bbB
 aYv
 bbr
 bbM
-arN
+asx
 arN
 avq
-asx
+arN
 arN
 arN
 arN
@@ -59468,10 +61950,10 @@ aaK
 aaK
 aaY
 abg
-aaq
+aOI
 abs
 abA
-aaq
+aOI
 aao
 aao
 aaa
@@ -59595,11 +62077,11 @@ aPi
 aKL
 aQF
 aRl
-aUH
-aQD
+aQI
+aSv
 aTv
-aQD
-aUH
+aVu
+aQH
 aVr
 aWk
 aWZ
@@ -59607,11 +62089,11 @@ aXE
 aYv
 aYv
 aYv
-aYv
+bbB
 aYv
 bbs
 bbM
-arN
+asx
 arN
 avq
 bdD
@@ -59769,11 +62251,11 @@ aaB
 aaL
 aaR
 aaL
-aaq
-aaq
+aOI
+aOI
 abt
 abB
-aaq
+aOI
 aac
 aao
 aao
@@ -59895,28 +62377,28 @@ aNL
 aOx
 aPj
 aKL
-aYy
+aQH
 aRm
-aYy
-aYy
-aYy
-aYy
+aQS
+aQS
+aQS
+aQS
 aUI
-aVs
+aWl
 aWl
 aXW
 aYw
-aVs
-aVs
+aWl
+aWl
 aYP
 aZP
-aVs
+aWl
 bbt
 bbM
 bch
 avq
 aYy
-aOD
+aYy
 aYy
 arN
 arN
@@ -60065,19 +62547,19 @@ aag
 aag
 aak
 aac
-aaq
-aaq
-aaq
-aaq
+aOI
+aOI
+aOI
+aOI
 aaS
-aaq
+aOI
 abh
-aaq
-aaq
+aOI
+aOI
 abC
-aaq
-aaq
-aaq
+aOI
+aOI
+aOI
 aao
 aao
 aad
@@ -60196,7 +62678,7 @@ aNh
 aNb
 aOw
 aPk
-aPU
+fcs
 aYy
 aRn
 aRW
@@ -60205,17 +62687,17 @@ aTw
 aTw
 aTw
 aTw
-aWm
+aTw
 aTw
 aXG
 aTw
 aTw
 aTw
-aTw
+bbC
 aTw
 bbu
 bbO
-aTw
+bbC
 aTw
 aTw
 bdE
@@ -60223,7 +62705,7 @@ aYy
 arN
 arN
 arN
-avv
+bbN
 bgB
 bhe
 bhS
@@ -60242,8 +62724,8 @@ bov
 bov
 bCH
 bjm
-bis
-bqx
+bFu
+bFR
 blZ
 blZ
 blZ
@@ -60367,19 +62849,19 @@ aaf
 aaf
 aal
 aac
-aaq
+aOI
 aau
 aaC
-aaq
+aOI
 aaR
-aaq
+aOI
 abi
 abm
 abu
 abD
 abD
 abI
-aaq
+aOI
 aac
 aab
 aaa
@@ -60506,26 +62988,26 @@ aLX
 aLX
 aLX
 aLX
-aVt
+aLX
 aWn
-aLX
-aXH
-aLX
-aLX
-aLX
-aLX
-aLX
-aRX
-aLX
-aLX
-aLX
-aLX
+bcE
+aYN
+bcE
+bcE
+bcE
+bbF
+bcE
+bdC
+bcE
+bfm
+bcE
+bcE
 bdF
 aYy
 aMX
 arN
 arN
-avv
+bbN
 bgC
 bhf
 bhT
@@ -60535,9 +63017,9 @@ aKh
 bjW
 bmc
 bmk
-bov
-bpL
-bov
+btd
+bwq
+btd
 brz
 bsw
 bzD
@@ -60672,7 +63154,7 @@ aam
 aam
 aav
 aaD
-aaq
+aOI
 aaT
 aaZ
 abj
@@ -60681,7 +63163,7 @@ abj
 abj
 abj
 abJ
-aaq
+aOI
 aac
 aab
 aaa
@@ -60808,14 +63290,14 @@ aPn
 aPn
 aPn
 aPn
-aVu
+aRo
 aWo
 aXa
 aXI
 aYx
 aPn
 aPn
-aPn
+bcX
 aNm
 bbv
 aLX
@@ -60835,7 +63317,7 @@ aYy
 bjm
 aNa
 bjm
-bmd
+aNa
 bjm
 bow
 bpL
@@ -60971,7 +63453,7 @@ aaf
 aaf
 aal
 aac
-aaq
+aOI
 aaw
 aaE
 aaM
@@ -60983,7 +63465,7 @@ abv
 abE
 aba
 aba
-aaq
+aOI
 aac
 aao
 aao
@@ -61088,7 +63570,7 @@ aAI
 azA
 azA
 aEC
-aDQ
+qwY
 aFB
 aGZ
 azA
@@ -61110,7 +63592,7 @@ aLX
 aYy
 aYy
 aYy
-aOD
+aYy
 aYy
 aYy
 aXJ
@@ -61142,7 +63624,7 @@ bnF
 box
 bpN
 bqz
-brg
+byr
 bsA
 bov
 bov
@@ -61273,21 +63755,21 @@ aai
 aai
 aak
 aac
-aaq
+aOI
 aax
 aaF
-aaq
-aaq
-aaq
-aaq
+aOI
+aOI
+aOI
+aOI
 abp
-aaq
-aaq
-aaq
+aOI
+aOI
+aOI
 aaS
-aaq
-aaq
-aaq
+aOI
+aOI
+aOI
 aaW
 aaW
 aaa
@@ -61412,20 +63894,20 @@ aLW
 aTx
 aUg
 aUg
-aVv
-aWp
+aUg
+aUg
 aUg
 aXK
 aYz
 aZj
 aZj
-aZj
+bcY
 aZj
 aZj
 bbP
 bci
-bcE
-bcE
+aLX
+aLX
 bdI
 bcE
 bcE
@@ -61434,18 +63916,18 @@ bcE
 bcE
 bcE
 bhi
-bcE
-bcE
-bjn
+aLX
+aLX
+bjm
 bdW
 bjZ
 bmj
-bjn
+bjm
 bpc
 bpe
 bqA
 brE
-bov
+brg
 bAv
 bCE
 bov
@@ -61575,21 +64057,21 @@ aaa
 aaa
 aak
 aac
-aaq
+aOI
 aay
 aaG
 aaN
-aaq
+aOI
 abb
 abk
 abq
 abw
-aaq
+aOI
 abF
 abK
 abK
 abT
-aaq
+aOI
 aac
 abY
 aaa
@@ -61691,7 +64173,7 @@ aBw
 aCi
 aDf
 aDO
-aED
+azA
 aFz
 aGo
 aHb
@@ -61714,11 +64196,11 @@ aLX
 aYy
 aEQ
 aBS
-aVw
-aWq
 aBS
 aBS
-aYA
+aBS
+aBS
+aEY
 azU
 azU
 azU
@@ -61746,7 +64228,7 @@ bjo
 bjo
 bjo
 bjo
-bpO
+bjo
 bto
 bjo
 bjo
@@ -61877,21 +64359,21 @@ aaa
 aaa
 aan
 aan
-aaq
+aOI
 aaz
 aaH
 aaO
-aaq
+aOI
 abc
 abk
 abk
 abx
-aaq
+aOI
 abG
 abL
 abL
 abU
-aaq
+aOI
 aac
 abY
 aaa
@@ -61976,9 +64458,9 @@ aaa
 aaa
 aaa
 aaa
-anK
+app
 aom
-anK
+app
 aaa
 aaa
 aaa
@@ -61994,16 +64476,16 @@ aCj
 azA
 azA
 aEC
-aDQ
+aMN
 aFB
 aHc
 aCh
 aIG
 aJo
 aYy
-aKW
-aKW
-aMy
+aLX
+aLX
+aRX
 aYy
 aYy
 aOD
@@ -62020,7 +64502,7 @@ aVx
 aVx
 aXb
 aVx
-aXN
+aVx
 aVx
 aVx
 aVx
@@ -62030,16 +64512,16 @@ bbQ
 bci
 bci
 aYy
+kbT
+hoK
 aYy
 aYy
 aYy
 aYy
 aYy
-aYy
-aYy
-bhj
-aKW
-aKW
+aXH
+aLX
+aLX
 bjo
 aPQ
 bkV
@@ -62049,7 +64531,7 @@ bpd
 bph
 bqB
 brF
-bqD
+bzx
 bBY
 bjo
 bts
@@ -62179,21 +64661,21 @@ aaa
 aaa
 aaa
 aak
-aaq
-aaq
-aaq
-aaq
-aaq
+aOI
+aOI
+aOI
+aOI
+aOI
 abd
 abk
 abk
 aby
-aaq
+aOI
 abH
 abM
 abQ
 abV
-aaq
+aOI
 aac
 abY
 aaa
@@ -62274,15 +64756,15 @@ aaa
 aaa
 aaa
 aaa
-anK
-anK
-anK
-anK
+app
+app
+app
+app
 aqh
 aoz
 aqh
-anK
-anK
+app
+app
 aqh
 avq
 avq
@@ -62297,14 +64779,14 @@ aDg
 aDP
 aEE
 aFA
-aGp
+aFB
 aHd
 aHQ
 aIH
 aJo
 ayR
 aKX
-aKX
+rab
 aMz
 ayR
 azU
@@ -62312,36 +64794,36 @@ azQ
 aBS
 aBS
 aBS
-aRp
+aTK
 aSc
 aSK
-aRp
+aTK
 aEY
 azU
 aVx
 aWr
 aXc
 aXL
-aYB
+aXL
 aXL
 aXL
 bas
 baW
-azU
+aBS
 bbR
 aZj
 aZj
 bdd
-aZj
+ujl
 bel
-aZj
+bdd
 aZj
 bfF
 bgf
 bgH
 bhk
-bhU
-bhU
+bAS
+gRh
 bjo
 aQq
 bqD
@@ -62485,17 +64967,17 @@ aar
 aan
 aac
 aac
-aaq
+aOI
 abe
 abl
 abr
 abz
-aaq
-aaq
-aaq
+aOI
+aOI
+aOI
 abR
-aaq
-aaq
+aOI
+aOI
 aac
 abY
 aaa
@@ -62576,7 +65058,7 @@ aaa
 aaa
 aaa
 aaa
-anK
+app
 aqJ
 aqY
 aqY
@@ -62629,14 +65111,14 @@ aZk
 aZQ
 bat
 aVx
+xCI
 azU
 azU
 azU
-azU
-azW
-azU
-azU
-azU
+aRq
+elf
+gUg
+aRq
 azU
 azP
 bgg
@@ -62659,7 +65141,7 @@ bjo
 btu
 buq
 bts
-bwD
+tLJ
 btB
 bis
 bot
@@ -62787,17 +65269,17 @@ aaa
 aan
 aac
 aac
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
+aOI
+aOI
+aOI
+aOI
+aOI
+aOI
+aOI
 abN
 abN
 abN
-aaq
+aOI
 abX
 abX
 aaa
@@ -62878,7 +65360,7 @@ ani
 aaa
 aaa
 aaa
-anK
+app
 aqK
 aom
 aom
@@ -62931,13 +65413,13 @@ aXN
 aVx
 aVx
 aVx
-aFL
-aFL
-bcj
-aFL
 aCy
 aCy
 aCy
+aCy
+aCy
+cVV
+cVV
 aCy
 aCy
 azP
@@ -63095,11 +65577,11 @@ aac
 aac
 aac
 aac
-aaq
+aOI
 abO
 abS
 abW
-aaq
+aOI
 abX
 aaa
 aaa
@@ -63180,7 +65662,7 @@ ani
 apm
 aaa
 aap
-anK
+app
 aqK
 aom
 aqh
@@ -63198,17 +65680,17 @@ aAP
 azA
 azA
 azA
-aCh
-aCh
+azA
+azA
 aDR
 aEG
-aFC
-aFC
-aHg
-aFC
-aII
-aJp
-ayV
+azA
+azA
+azA
+azA
+aIG
+aJo
+ayR
 aKY
 awm
 axc
@@ -63231,16 +65713,16 @@ aXO
 aYD
 aXO
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aFL
+hou
+nzf
+nzf
+nzf
+nzf
+nzf
+nzf
+qWA
+qWA
+aCy
 bfg
 azP
 bgh
@@ -63397,11 +65879,11 @@ aaV
 aaV
 aaV
 aaI
-aaq
+aOI
 abP
 abN
 abN
-aaq
+aOI
 aac
 aac
 aaa
@@ -63479,9 +65961,9 @@ ani
 ani
 ani
 ani
-apn
-anK
-anK
+aqH
+app
+app
 aqh
 aqL
 aqZ
@@ -63498,7 +65980,7 @@ aAP
 axH
 ayI
 azB
-azB
+bda
 aBy
 aCm
 awe
@@ -63511,7 +65993,7 @@ aAP
 aCs
 aJq
 ayR
-aKZ
+awm
 awm
 axc
 ayR
@@ -63533,16 +66015,16 @@ aXO
 aYD
 aXO
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aFL
+hou
+nzf
+qWA
+qWA
+fTr
+oio
+fTr
+qWA
+qWA
+aCy
 aDm
 azP
 bfL
@@ -63572,8 +66054,8 @@ byY
 bzL
 bis
 bis
-bnD
-bCW
+bis
+bAP
 bAP
 bAP
 bCV
@@ -63699,7 +66181,7 @@ aaa
 aac
 aac
 aaI
-aaq
+aOI
 aaq
 aaq
 aaq
@@ -63813,7 +66295,7 @@ aAN
 aIJ
 axS
 awm
-aKZ
+awm
 awm
 axc
 ayR
@@ -63828,23 +66310,23 @@ aSN
 aTy
 aKg
 aUJ
-aVy
+aSN
 aRr
 aaa
 aXO
 aYD
 aXO
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aFL
+hou
+nzf
+qWA
+qWA
+qWA
+stQ
+tpV
+qWA
+qWA
+aCy
 aBK
 azP
 bfL
@@ -63874,8 +66356,8 @@ byZ
 bzK
 bwB
 bis
-bnD
-bCW
+bis
+bAP
 bAP
 bAP
 bCV
@@ -64083,9 +66565,9 @@ ani
 ani
 ani
 ani
-apn
-anK
-anK
+aqH
+app
+app
 aqh
 aqL
 arb
@@ -64101,7 +66583,7 @@ aAP
 aAP
 axJ
 ayJ
-azD
+aGp
 awV
 aAN
 aCm
@@ -64115,13 +66597,13 @@ aAN
 aIJ
 axS
 awm
-aKZ
+awm
 awm
 aMA
 ayR
 azU
 azU
-aFL
+bcj
 aaa
 aaA
 aRs
@@ -64131,21 +66613,21 @@ aSN
 aSN
 aUK
 aSN
-aRs
+aRr
 aaa
 aXO
 aYD
 aXO
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hou
+nzf
+qWA
+fTr
+dtP
+qWA
+qWA
+qWA
+pLY
 aCy
 aGx
 bfG
@@ -64157,7 +66639,7 @@ bhn
 bjq
 bkd
 blj
-blh
+jzo
 bli
 bli
 blh
@@ -64172,7 +66654,7 @@ bvE
 bwI
 bwI
 bvG
-bwI
+pWp
 bzL
 bzg
 bBp
@@ -64388,10 +66870,10 @@ ani
 aaa
 adQ
 aaa
-anK
+app
 aqL
 aom
-anK
+app
 arN
 asx
 aAP
@@ -64417,7 +66899,7 @@ aAP
 aIJ
 axS
 aKj
-aLa
+aye
 aye
 aMB
 ayR
@@ -64439,16 +66921,16 @@ aXO
 aYD
 aXO
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hou
+nzf
+qWA
+szc
+qWA
+qWA
+qWA
+qWA
+qWA
+nzf
 aCy
 azP
 azU
@@ -64459,11 +66941,11 @@ bhm
 bjo
 bke
 bjp
-bjp
+bro
 bmm
 bmm
-bjp
-bjp
+bro
+bro
 bjo
 bqH
 bjo
@@ -64690,10 +67172,10 @@ ani
 aaa
 adQ
 aaa
-anK
+app
 aqL
 aom
-anK
+app
 arN
 asx
 aAP
@@ -64719,12 +67201,12 @@ aHR
 aIK
 aBH
 aKk
-azN
+ayR
 aLY
 aLY
 ayR
-azW
-azW
+azU
+azU
 aCy
 aag
 aas
@@ -64741,16 +67223,16 @@ aXO
 aYD
 aXO
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hou
+nzf
+qWA
+fTr
+jwx
+fGE
+wYe
+qWA
+qWA
+uMP
 aCy
 azP
 azU
@@ -64780,7 +67262,7 @@ bza
 bzL
 bAE
 bBq
-bAI
+qYg
 bzg
 bAP
 bAP
@@ -64989,9 +67471,9 @@ ani
 ani
 ani
 ani
-apn
-anK
-anK
+aqH
+app
+app
 aqh
 aqL
 arc
@@ -65007,10 +67489,10 @@ awe
 awU
 axL
 ayK
-awe
+aHg
 aAO
-aBB
-awp
+aIw
+aKq
 axg
 aDU
 aEJ
@@ -65021,7 +67503,7 @@ aDU
 aIL
 axS
 awm
-aLb
+aLY
 aLZ
 aEQ
 aNn
@@ -65043,17 +67525,17 @@ aXO
 aYD
 aXO
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aGx
+hou
+nzf
+nzf
+qWA
+qWA
+fTr
+qWA
+fTr
+sQe
+qWA
+dlx
 azP
 azU
 bgH
@@ -65323,12 +67805,12 @@ aEK
 aEK
 aJr
 aKl
-aLb
+aLY
 aMa
 aER
 azU
 azU
-azU
+aNo
 aCy
 aaa
 aaA
@@ -65345,16 +67827,16 @@ aXO
 aYD
 aXO
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hou
+hou
+nzf
+nzf
+nzf
+nzf
+nzf
+nzf
+nzf
+nzf
 aCy
 azP
 azU
@@ -65375,16 +67857,16 @@ bhm
 bhm
 bsD
 btx
-buy
+gRT
 bvG
 bwL
 bwI
 bvG
-bwI
+pWp
 bzL
 bAG
-bAI
-bAI
+ega
+rro
 bzg
 bAP
 bEk
@@ -65593,9 +68075,9 @@ ani
 ani
 ani
 ani
-apn
-anK
-anK
+aqH
+app
+app
 aqh
 aqL
 aqZ
@@ -65614,7 +68096,7 @@ ayL
 azG
 aAP
 aBD
-aCp
+aKr
 aDj
 aDW
 aEL
@@ -65625,12 +68107,12 @@ aHS
 aHS
 aDW
 aDW
-azN
+ayR
 aMb
 azP
-aFL
-aFL
-aFL
+aCy
+aVG
+aCy
 aCy
 aaa
 aaA
@@ -65648,15 +68130,15 @@ aYD
 aXO
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
 aCy
 azP
 azU
@@ -65685,8 +68167,8 @@ bvG
 bvG
 bzL
 bAH
-bAI
-bAI
+uyM
+rro
 bzg
 bAP
 bEl
@@ -65898,7 +68380,7 @@ ani
 ani
 aaa
 abZ
-anK
+app
 aqL
 aom
 aqh
@@ -65916,7 +68398,7 @@ aAP
 aAP
 aAP
 aBE
-aCp
+aKr
 axc
 aDW
 aEM
@@ -65927,12 +68409,12 @@ aHT
 aHT
 aJs
 aDW
-aLc
+aEQ
 aBS
 aEY
-aFL
-aaa
-aaa
+aCy
+azU
+aCy
 aaa
 aaa
 aaA
@@ -65966,8 +68448,8 @@ bgJ
 aBS
 aBS
 aBS
-aBS
-bkg
+aXf
+bkf
 blm
 bmn
 bmW
@@ -65986,11 +68468,11 @@ buy
 bvG
 bza
 bzL
-bAI
-bAI
+eFB
+uyM
 bCl
 bzg
-bAP
+sdc
 bEl
 bEL
 bEL
@@ -66200,7 +68682,7 @@ ani
 ani
 aaa
 aaa
-anK
+app
 aqL
 aom
 aqh
@@ -66218,7 +68700,7 @@ ayM
 asZ
 avu
 aBD
-aCp
+aKr
 axc
 aDW
 aEN
@@ -66232,9 +68714,9 @@ aDW
 azP
 azU
 aBK
-aFL
-aaa
-aaa
+aCy
+aVG
+aCy
 aaa
 aaa
 aaA
@@ -66262,13 +68744,13 @@ aaa
 aaa
 aaa
 aCy
-azU
+aNo
 azP
 azU
 azU
 bhV
 azU
-azU
+azQ
 bkh
 bln
 bln
@@ -66285,14 +68767,14 @@ buB
 buB
 bwN
 bxC
-byk
-byk
-bzM
+buB
+buB
+bzL
 bAJ
-bAM
-bCm
-bCX
-bDE
+uPW
+bAG
+bzg
+bAP
 bEm
 bDE
 bit
@@ -66502,7 +68984,7 @@ ani
 ani
 aaa
 aaa
-anK
+app
 aqL
 ara
 aqh
@@ -66520,7 +69002,7 @@ ayN
 awh
 avu
 aBF
-aCp
+aKr
 axc
 aDW
 aEO
@@ -66600,14 +69082,14 @@ bAP
 bis
 bAP
 bEl
-bGs
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fVw
+fVw
+fVw
+fqz
+fqz
+fqz
+fVw
+fVw
 aaa
 aaa
 aaa
@@ -66804,14 +69286,14 @@ ani
 aaa
 aaa
 aaa
-aqh
+sfE
 aqM
 ard
-aqh
-aqh
-aqh
-aqh
-aqh
+sfE
+sfE
+sfE
+sfE
+sfE
 asx
 arN
 avu
@@ -66822,7 +69304,7 @@ ayO
 azJ
 avu
 aBD
-aCp
+aKr
 axc
 aDW
 aDI
@@ -66902,15 +69384,15 @@ bzg
 bzg
 bAP
 bEl
-bGs
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kpr
+wTp
+sFC
+sQU
+hAR
+hAR
+gMJ
+fVw
+fVw
 aaa
 aaa
 aaa
@@ -67106,14 +69588,14 @@ ani
 aaa
 aaa
 aaa
-anK
+mNB
 aqN
-aom
-aom
-aom
+qNq
+qNq
+qNq
 asz
 atb
-aqh
+sfE
 asx
 auS
 avu
@@ -67124,14 +69606,14 @@ ayP
 avu
 aAQ
 aBD
-aCp
+aKr
 axc
 aDW
 aDW
 aFJ
 aDW
 aDW
-aHX
+aDW
 aDW
 aDW
 aFK
@@ -67178,7 +69660,7 @@ aaa
 bkj
 blq
 blp
-blp
+klQ
 blp
 boB
 bpq
@@ -67204,15 +69686,15 @@ bEN
 bzg
 bAP
 bEl
-bFZ
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kpr
+ltc
+skk
+skk
+skk
+skk
+cxA
+fiX
+fqz
 aaa
 aaa
 aaa
@@ -67408,17 +69890,17 @@ aaa
 aaa
 aaa
 aaa
-anK
+mNB
 aqO
 are
 arm
-aom
-aom
+qNq
+qNq
 atb
-aqh
+sfE
 asx
 arN
-avv
+bbN
 awj
 axa
 axN
@@ -67426,14 +69908,14 @@ axN
 azK
 axN
 aBG
-aCp
+aKr
 axc
 ayR
 azU
-aFK
+aNs
 aGw
 azU
-azP
+azU
 azU
 azU
 azU
@@ -67481,7 +69963,7 @@ bkj
 blr
 bki
 bki
-brx
+bki
 boC
 bpo
 bpX
@@ -67498,23 +69980,23 @@ bzd
 bzP
 bAM
 bBu
-bBq
-bBq
-bAI
-bAI
-bAL
+iAR
+iAR
+bAM
+bAM
+iSb
 bFm
-bAP
-bEl
-bCV
-aaA
-acF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bDE
+xsP
+kpr
+saZ
+kqB
+skk
+skk
+skk
+skk
+hfe
+fqz
 aaa
 aaa
 aaa
@@ -67710,15 +70192,15 @@ aaa
 aaa
 aaa
 aaa
-anK
-anK
-app
+mNB
+mNB
+mNB
 arn
-aom
-aom
+qNq
+qNq
 atc
-atB
-auh
+sfE
+asy
 aQv
 avw
 awk
@@ -67726,20 +70208,20 @@ axb
 axO
 axO
 azL
-aye
-aBH
+axO
+aII
 aCq
 aDk
 ayR
 aEQ
+aOj
 aBS
 aBS
 aBS
-aHY
 aBS
 aBS
 aBS
-aEY
+oGA
 aCy
 aCy
 aaa
@@ -67784,7 +70266,7 @@ bls
 blp
 blp
 bnS
-blp
+bya
 blp
 bpW
 bhm
@@ -67807,16 +70289,16 @@ bAI
 bAL
 bzg
 bFL
-bEl
-bCV
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xsP
+fVw
+fVw
+mvZ
+loM
+pMs
+tmp
+skk
+oQR
+fqz
 aaa
 aaa
 aaa
@@ -68014,20 +70496,20 @@ aaa
 aaa
 aaa
 aaa
-anK
-arn
-aom
-aom
-atb
-aqh
-aui
-aqh
-aqh
+mNB
+lcr
+qNq
+qNq
+auu
+sfE
+sfE
+sfE
+sfE
 awl
-axc
+axi
 axP
 ayQ
-azM
+aGI
 awo
 aBI
 aCp
@@ -68037,10 +70519,10 @@ azP
 azU
 aGx
 aCy
-aFL
-aFL
-aFL
-aFL
+bcj
+bcj
+bcj
+bcj
 aCy
 aCy
 aaa
@@ -68108,17 +70590,17 @@ bCZ
 bEo
 bEO
 bzg
-bFM
-bGi
-bCV
-acK
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pxN
+bEl
+fVw
+xIm
+xwm
+tAY
+pMs
+tmp
+skk
+gTE
+fqz
 aaa
 aaa
 aaa
@@ -68303,33 +70785,33 @@ aaa
 aaa
 aaa
 anj
-anG
-anG
-anG
-anG
-aoP
+apC
+apC
+apC
+apG
 aoW
-anG
-anG
-anG
+aoW
+apT
+apC
+apC
 apB
 apV
 aaa
 aaa
-anK
+mNB
 arn
-aom
-aom
-aom
+qNq
+qNq
+auJ
 atC
 auj
 auT
 avx
 awm
-axc
+axi
 axQ
 ayR
-azN
+ayR
 ayR
 aBJ
 aCr
@@ -68410,17 +70892,17 @@ bzg
 bzg
 bzg
 bzg
-bAP
-bEl
-bCV
-bCV
-bCV
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
+lSw
+iAV
+fVw
+fVw
+fVw
+jDc
+tbf
+skk
+skk
+vkH
+fqz
 aaa
 aaa
 aaa
@@ -68605,7 +71087,7 @@ aaa
 aaa
 anj
 anG
-anW
+anZ
 aoi
 aov
 aoK
@@ -68614,21 +71096,21 @@ aoK
 aov
 aoK
 apq
-apC
-apV
+aWp
+apB
 apV
 aaa
-anK
+mNB
 aro
 are
 arm
-aom
+auJ
 atD
 auk
-aom
-anK
+qNq
+mNB
 awm
-axc
+axi
 axR
 ayR
 azO
@@ -68701,28 +71183,28 @@ buE
 bvK
 bwT
 bxH
-bhm
+fpl
 bzh
 bzT
-bAP
-bAP
-bAP
-bAP
-bAP
-bAP
-bCW
-bAP
-bAP
-bEl
-bAP
+bsT
+bsT
+bsT
+eWy
+bsT
+bsT
+bsT
+bsT
+bsT
+sRd
+eWy
 bGC
-bCV
-acK
-aaa
-aaa
-aaa
-aaa
-aaa
+tXY
+sih
+skk
+skk
+lCb
+wzk
+fqz
 aaa
 aaa
 aaa
@@ -68904,9 +71386,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ajJ
 ank
-anH
+aoW
 anX
 aoj
 aow
@@ -68917,23 +71399,23 @@ aow
 aoj
 aow
 apD
-anG
+aql
 apV
 aaa
-aqh
-aqh
-aqh
-aqh
+sfE
+sfE
+sfE
+sfE
 atd
 atE
 aul
-aom
-anK
+qNq
+mNB
 awm
-axc
+axi
 axS
 ayS
-azP
+azU
 azU
 aBK
 aCt
@@ -69004,27 +71486,27 @@ bvK
 bwT
 bxH
 bhm
-bzh
-bzT
-bAP
-bGn
-bCq
+oRN
+kvZ
+byq
+bsF
+bsF
 bDa
-bDH
-bEp
-bCV
-bFn
-bFN
+bsF
+bsF
+byq
+bsF
+bsF
 bGj
 bGt
-bGD
-bCV
-acK
-acF
-aaa
-aaa
-aaa
-aaa
+ojG
+mRX
+kYn
+lYX
+lYX
+mKC
+fVw
+fVw
 aaa
 aaa
 aaa
@@ -69206,10 +71688,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
+akk
 anl
-anI
-anY
+aoW
+aow
 aoj
 aow
 aoj
@@ -69219,30 +71701,30 @@ aow
 aoj
 aow
 apE
-anG
+aql
 aqj
 aaa
-anK
+mNB
 arp
 arP
-asA
+asC
 ate
 atF
 aum
 auU
-anK
+mNB
 awn
-axc
-axS
-ayS
-azQ
+awu
+azM
+aFg
+aBS
 aAR
 aBL
 aCu
 aBS
 aBS
 aER
-aFL
+bcj
 aaa
 aaa
 aaa
@@ -69268,7 +71750,7 @@ aag
 aSR
 aSS
 aai
-aJS
+acK
 aai
 aSU
 aST
@@ -69318,14 +71800,14 @@ bCr
 bCr
 bCr
 bCr
-bEl
-bAP
-bFZ
-acK
-aaa
-aaa
-aaa
-aaa
+iAV
+lSw
+fVw
+fVw
+hPt
+hPt
+fVw
+fVw
 aaa
 aaa
 aaa
@@ -69508,10 +71990,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
+akH
 anm
-anJ
-anX
+aoW
+aow
 aoj
 aow
 aoj
@@ -69521,19 +72003,19 @@ aow
 aoj
 aow
 apF
-anG
+aql
 apV
 aaa
-anK
+mNB
 arq
 arQ
 asB
-atf
+auK
 atG
 aun
-aom
-avy
-awm
+avK
+awt
+awk
 axd
 axS
 ayR
@@ -69544,7 +72026,7 @@ azU
 azU
 azU
 azP
-aFL
+bcj
 aaa
 aaa
 aaa
@@ -69566,15 +72048,15 @@ aaa
 aTA
 aaa
 aaa
-aVB
-aWu
-acd
+acK
+kvy
+acK
 aaa
 adQ
 aaa
-acd
+acK
 bme
-aJS
+acK
 bbw
 aaa
 bck
@@ -69622,11 +72104,11 @@ bFo
 bCr
 bEl
 bAP
-bGs
-aaa
-aaa
-aaa
-aaa
+bCV
+fVw
+ycv
+skk
+fVw
 aaa
 aaa
 aaa
@@ -69639,10 +72121,10 @@ apU
 adQ
 adQ
 aaA
-bIp
+uqk
 bIh
 bIk
-bIp
+uqk
 aaa
 aaa
 adQ
@@ -69812,7 +72294,7 @@ aaa
 aaa
 aaa
 ann
-anG
+anY
 anZ
 aok
 aow
@@ -69822,18 +72304,18 @@ aow
 aoL
 aow
 aok
-apG
-apV
+aYM
+apH
 apV
 aaa
-anK
+mNB
 arr
 arR
-asB
+auh
 atf
 atH
 auo
-aom
+qNq
 avy
 awm
 axe
@@ -69868,17 +72350,17 @@ aaa
 aTA
 aaa
 aUM
-aJS
+acK
 aWv
-aVD
 aXR
-aVD
-aVD
-aVD
+aXR
+aXR
+aXR
+aXR
 bav
-aVD
-aVD
-aVD
+aXR
+aXR
+aXR
 bcl
 bcH
 bde
@@ -69922,13 +72404,13 @@ bEQ
 bFo
 bFo
 bCr
-bEl
-bAP
-bGs
-aaa
-aaa
-aaa
-aaa
+uUE
+uDi
+bCV
+fVw
+hPt
+hPt
+fVw
 aaa
 aaa
 aaa
@@ -69941,10 +72423,10 @@ aas
 aas
 aas
 bHZ
-bIp
-acd
-acd
-bIp
+uHm
+bGU
+bGU
+fzy
 aaa
 aaa
 adQ
@@ -70115,20 +72597,20 @@ aaa
 aaa
 aaa
 ann
-anG
-anG
+apC
+apG
 aox
-anG
-aoP
+apT
 aoW
-anG
+aoW
+apG
 aox
-anG
+apT
 apH
 apV
 aaa
 aaa
-anK
+mNB
 ars
 arS
 asC
@@ -70136,9 +72618,9 @@ atf
 atI
 aup
 auU
-anK
+mNB
 awn
-axc
+axi
 axS
 ayR
 azT
@@ -70171,17 +72653,17 @@ adQ
 aaa
 aaA
 aVC
-aWu
+aWz
 apU
 aaa
 aaa
 aaa
 aZR
-aWu
+aWz
 aas
 aaa
 bbS
-bcm
+bco
 bcI
 bdf
 bdK
@@ -70204,7 +72686,7 @@ adQ
 aaa
 bpY
 bpY
-bqN
+sRo
 bqN
 bsJ
 buI
@@ -70224,29 +72706,29 @@ bER
 bDf
 bFO
 bCr
-bGi
-bFM
+bEl
+bAP
 bCV
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-bHG
-bIo
-alx
-alx
-alx
-alx
+cLq
+iHi
+qgr
+mro
+mro
+mro
+mro
+mro
+mro
+mro
+eSy
+bIB
+bIB
+bIB
+bIB
 bIM
 bIO
 bIM
-aEP
+tTO
 acG
 acG
 bHG
@@ -70418,29 +72900,29 @@ alH
 aaa
 aaa
 aaa
-anK
+mNB
 aoy
-anK
+mNB
 aaa
 aaa
-anK
+mNB
 aoy
-anK
+mNB
 aaa
 aaa
 aaa
 aaa
-aqh
-aqh
+sfE
+sfE
 arT
-aqh
+sfE
 atg
 atJ
 auq
 atb
-anK
+mNB
 awm
-axc
+axi
 axS
 ayT
 azU
@@ -70470,9 +72952,9 @@ aaa
 aaa
 aaa
 aSR
-aPo
+xbg
 aUN
-aVD
+aXR
 aWw
 aXe
 aXe
@@ -70480,10 +72962,10 @@ aXe
 aXe
 aXe
 baw
-aVD
+aXR
 bbx
-aJS
-bcn
+acK
+bco
 bcJ
 bdf
 bdL
@@ -70513,13 +72995,13 @@ bzi
 bzi
 bwY
 bxK
-byr
+bzi
 bzi
 bzY
 bAS
 bBA
 bCr
-bDe
+bDL
 bDL
 bCr
 bES
@@ -70529,26 +73011,26 @@ bCr
 bEl
 bAP
 bCV
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bIB
-bIp
+acG
+opZ
+cCh
+mro
+mro
+mro
+dsu
+mro
+mro
+mro
+uZK
+wOm
 bIH
-bIt
-bIt
-bIt
+mgh
+mgh
+mgh
 bIN
 bIP
 bIQ
-bIJ
+ejB
 aaa
 aaa
 aaa
@@ -70717,22 +73199,22 @@ alH
 alH
 alH
 alH
-aqh
-anK
-aqh
-aqh
-aoz
-aqh
-anK
-anK
-aqh
-aoz
-aqh
-anK
-anK
-anK
-anK
-anK
+sfE
+mNB
+sfE
+sfE
+pjE
+sfE
+mNB
+mNB
+sfE
+pjE
+sfE
+mNB
+mNB
+mNB
+mNB
+mNB
 art
 aoA
 asD
@@ -70740,9 +73222,9 @@ ath
 atK
 aur
 auV
-anK
+mNB
 awo
-axf
+axX
 axT
 ayT
 azU
@@ -70776,16 +73258,16 @@ aaa
 aaA
 aai
 aWx
-aJS
+acK
 apU
 aaa
 aaA
-aJS
+acK
 aWx
 aai
 apU
 bby
-bcn
+bco
 bcI
 bdf
 bdM
@@ -70820,7 +73302,7 @@ bzi
 bzZ
 bhm
 bBB
-bCs
+qNg
 bDf
 bDf
 bCs
@@ -70829,25 +73311,25 @@ bFp
 bFP
 bCr
 bEl
-bAP
+idF
 bCV
 aaa
+adQ
 aaa
-aap
-aag
-acF
+aaa
 aaa
 aaa
 bGU
+bGV
 bGV
 bGV
 bGU
 bHO
 bHS
-acd
-bHX
-bHX
-acd
+bGU
+mNm
+hqn
+bGU
 aaa
 aaa
 aaa
@@ -71019,9 +73501,9 @@ alH
 alH
 alH
 alH
-anp
+toZ
 anL
-anp
+toZ
 aol
 aoA
 aoM
@@ -71031,20 +73513,20 @@ apa
 aoA
 aol
 aoA
+aoM
 aoA
 aoA
-aoA
-aoA
+ary
 aru
-aom
+qNq
 asE
-aom
-aom
-aus
+qNq
+qNq
+qNq
 auW
-aqh
+sfE
 awp
-axg
+ayp
 axU
 ayU
 azV
@@ -71087,7 +73569,7 @@ aWx
 aaa
 adQ
 aaa
-bcn
+bco
 bcI
 bdg
 bdN
@@ -71120,36 +73602,36 @@ bxM
 byt
 bzi
 bAa
-bhm
+buN
 bBC
-bCs
-bDf
-bDf
-bCs
+tpk
+bDI
+gPo
+yjg
 bET
 bFq
 bFQ
 bCr
 bEl
-bAP
+uhL
 bCV
 acK
-ajz
-aai
+aas
 bGU
 bGV
 bGV
 bGV
+fUX
 bHk
 bHq
 bHv
 bGU
-bHO
+iLc
 bHS
-acK
-acK
-acK
-bHX
+jhA
+tia
+tia
+kxs
 aaa
 aaa
 aaa
@@ -71321,23 +73803,23 @@ alH
 alH
 alH
 alH
-anp
+toZ
 anL
-anp
-aom
-aom
-aom
-aom
-aom
-aom
-aom
-aom
-aom
-aom
-aom
-aom
-aom
-apA
+toZ
+qNq
+qNq
+qNq
+qNq
+qNq
+qNq
+qNq
+qNq
+qNq
+qNq
+qNq
+qNq
+avy
+jGa
 arU
 asF
 ati
@@ -71346,7 +73828,7 @@ aut
 auX
 avz
 awq
-axc
+axi
 axQ
 ayR
 azW
@@ -71389,7 +73871,7 @@ aWx
 acG
 aas
 bbS
-bcn
+bco
 bcK
 bdh
 bdO
@@ -71405,7 +73887,7 @@ biw
 biw
 biw
 blv
-bhs
+brp
 bmZ
 bnW
 boG
@@ -71414,7 +73896,7 @@ bpZ
 bqR
 brS
 bsM
-brR
+bCt
 buJ
 bvQ
 bxb
@@ -71422,7 +73904,7 @@ bxc
 byu
 bzj
 bAa
-bhm
+bxH
 bBD
 bCr
 bDg
@@ -71430,28 +73912,28 @@ bDg
 bCr
 bDg
 bFr
-bFR
-bCt
-bGu
-bAP
+bFP
+bCr
+bEl
+dsM
 bCV
-acK
 aaa
 aaa
 bGV
-bGW
-bHb
+iLJ
 bGX
-bHl
+bGX
+tkT
+bHs
 bHr
 bHw
 bHH
 bHP
 bHT
-acK
-acK
-acK
-bHX
+tia
+ukm
+tia
+mNm
 aaa
 aaa
 aaa
@@ -71623,30 +74105,30 @@ alH
 alH
 alH
 alH
-aqh
-anK
-aqh
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
-anK
+sfE
+mNB
+sfE
+mNB
+mNB
+mNB
+mNB
+mNB
+mNB
+mNB
+mNB
+mNB
+mNB
+mNB
+mNB
+mNB
 aoN
 aoN
 aoN
-aqu
-aqu
-auu
-aqu
-avA
+auD
+auD
+auD
+auD
+avG
 awr
 axh
 axV
@@ -71691,7 +74173,7 @@ aWx
 aaa
 adQ
 aaa
-bcn
+bco
 bcI
 bdi
 bdP
@@ -71726,9 +74208,9 @@ bzk
 bAb
 bAT
 bBE
-bCt
-bDh
-bDM
+bCr
+bDj
+bDP
 bEt
 bEU
 bFs
@@ -71737,23 +74219,23 @@ bCr
 bEl
 bAP
 bCV
-bGM
-aaa
+bDv
 aaa
 bGV
 bGX
 bGX
+nZu
 bHg
-bHm
+bHs
 bHs
 bHx
 bGU
 bHO
 bHS
-acK
-acK
-acK
-bHX
+tia
+tia
+bIa
+snf
 aaa
 aaa
 aaa
@@ -71950,7 +74432,7 @@ auv
 auY
 aoO
 aws
-axc
+ayV
 axW
 ayR
 azU
@@ -71961,8 +74443,8 @@ azV
 aEc
 aEX
 aCy
-aaa
-aaa
+aCy
+aCy
 aaa
 aaa
 adQ
@@ -71984,16 +74466,16 @@ aaa
 aaA
 aag
 aWx
-aJS
+acK
 apU
 aaa
 aaA
-aJS
+acK
 aWx
 aag
 apU
 aaa
-bcn
+bco
 bcI
 bdf
 bdQ
@@ -72026,7 +74508,7 @@ bxc
 byw
 bzl
 bAa
-bhm
+bxH
 bwR
 bCr
 bDi
@@ -72039,23 +74521,23 @@ bCr
 bGv
 bAP
 bCV
-acK
-acK
+aaa
 aaa
 bGV
+lis
 bGX
 bGX
-bGX
-bHm
+bHg
+bHs
 bHs
 bHy
 bGU
 bHO
 bHS
-acK
-acK
+tia
+tia
 bIa
-bHX
+snf
 aaa
 aaa
 aaa
@@ -72249,22 +74731,22 @@ asG
 atj
 asG
 auw
-apY
+auB
 aoO
-awt
+aws
 axi
-axX
-ayV
+axS
+ayR
 azX
 aAW
 aBS
-aCz
+aBS
 aBS
 aEd
 aEY
-aCy
-aaa
-aaa
+aOL
+azU
+aOL
 aaa
 aaa
 adQ
@@ -72282,7 +74764,7 @@ aaa
 aaa
 aaa
 aSU
-aPo
+xbg
 aUO
 aVE
 aWy
@@ -72294,8 +74776,8 @@ aXe
 aWy
 aVE
 bbx
-aJS
-bcn
+acK
+bco
 bcJ
 bdf
 bdR
@@ -72328,7 +74810,7 @@ bxN
 byx
 bzm
 bAc
-bhn
+rNH
 bBF
 bCr
 bDj
@@ -72342,22 +74824,22 @@ bEl
 bAP
 bCV
 acK
-aaa
-aaa
+acG
 bGV
 bGX
 bGX
 bGX
-bHn
+rze
+bHs
 bHs
 bHs
 bHI
 bHO
 bHS
-acK
-acK
+tia
+tia
 bIa
-bHX
+snf
 aaa
 aaa
 aaa
@@ -72546,27 +75028,27 @@ aoN
 aoN
 aoN
 aoN
-apY
+auB
 asH
-aoO
-aoO
+awD
+mNN
 aux
 aoO
 aoO
-awu
-axc
+aws
+axi
 axY
 ayW
 ayW
 aAX
 ayW
-aCA
+ayW
 ayW
 aEe
 azU
 aCy
-aaa
-aaa
+aCy
+aCy
 aaa
 aaa
 acK
@@ -72593,7 +75075,7 @@ aaa
 aaa
 aaa
 aaA
-aWu
+aWz
 aas
 bby
 bbS
@@ -72623,14 +75105,14 @@ aaa
 bzi
 bzi
 bzi
-buN
+bzi
 bzi
 bzi
 bzi
 bzi
 bzi
 bAd
-bhm
+bxH
 bwR
 bCr
 bDk
@@ -72638,28 +75120,28 @@ bDO
 bEw
 bEW
 bEQ
-bDf
+lfr
 bCr
 bEl
 bAP
 bGs
 aaa
-acK
-ajz
+aaa
 bGU
 bGV
 bGV
 bGV
-bHk
+fUX
+bOY
 bHt
 bHz
 bGU
-bHO
+iLc
 bHS
 bHW
 bHY
 bIb
-bHX
+rqk
 aaa
 aaa
 aaa
@@ -72856,7 +75338,7 @@ auy
 auZ
 avB
 awv
-axf
+axX
 axZ
 ayX
 azY
@@ -72892,13 +75374,13 @@ aVF
 aWA
 aas
 acG
-aYG
+acK
 acG
 aZS
 aWv
-aVD
-aVD
-aVD
+aXR
+aXR
+aXR
 bcp
 bcL
 bdj
@@ -72932,7 +75414,7 @@ bxO
 byy
 bzn
 bAe
-bhm
+bxH
 bBG
 bCr
 bDl
@@ -72945,24 +75427,24 @@ bCr
 bEl
 bAP
 bGs
-acK
-acK
 aaa
 aaa
 aaa
+adQ
 aaa
 aae
 bGU
 bGV
 bGV
+bGV
 bGU
 bHO
 bHS
-acd
-bHX
-bHX
-acd
-aaa
+bGU
+mNm
+mNm
+bGU
+acv
 aaa
 aaa
 aaa
@@ -73146,19 +75628,19 @@ aaa
 aoO
 apI
 apX
-aql
-apY
-apY
-aql
+auz
+auB
+auB
+auz
 arY
 asJ
 atl
 atN
-auz
+auB
 ava
 avC
-awu
-axc
+aws
+axi
 aya
 ayX
 azZ
@@ -73191,13 +75673,13 @@ aTA
 aaa
 aaa
 aaa
-aWu
-acd
+wFo
+acK
 aaa
 adQ
 aaa
-acd
-aWu
+acK
+wFo
 aVC
 aas
 aaa
@@ -73234,37 +75716,37 @@ bhm
 bhm
 bhm
 bAf
-bhm
+bxH
 bwR
 bCr
 bDm
 bDP
 bEu
 bEX
-bEQ
-bDf
-bCs
-bEl
+umD
+bDI
+svD
+txI
 bAP
 bCV
 acK
 aaa
 aaa
-aaa
-bIo
-bIq
-bIt
-bIt
-bIt
-bIt
-bIt
-bIG
-bII
-aai
-apU
-aaa
+adQ
+bIJ
+bIJ
+bIJ
+bIJ
+bIJ
+bIJ
+wvT
+iCO
+iCO
+acy
 aaa
 aaa
+abZ
+acy
 aaa
 aaa
 aaa
@@ -73447,11 +75929,11 @@ aaa
 aaa
 aoO
 apJ
-apY
+auB
 apL
-aqQ
-aqQ
-aql
+auB
+vuf
+auz
 arZ
 asK
 atm
@@ -73465,7 +75947,7 @@ ayb
 ayX
 aAa
 aAa
-aAb
+aJd
 aCD
 ayW
 aEe
@@ -73476,10 +75958,10 @@ aCy
 aCy
 aCy
 aCy
-aFL
-aFL
-aFL
-aFL
+bcj
+bcj
+bcj
+bcj
 aCy
 aCy
 aaa
@@ -73496,7 +75978,7 @@ aai
 aSU
 aST
 aag
-aJS
+acK
 aag
 aSR
 aSS
@@ -73531,40 +76013,40 @@ bsP
 btN
 buQ
 bvV
-bxf
-bhm
-bhm
-bhm
-bAf
-bhm
+bGk
+bnZ
+bnZ
+bnZ
+sTU
+obE
 bBH
 bCr
 bDn
 bDN
 bEu
 bDg
-bFu
+bFo
 bFT
 bCr
-bGi
-bFM
+bEl
+bAP
 bCV
 acK
-aaa
-aaa
-aaa
-bIp
-bIr
-alx
-alx
-alx
-alx
-alx
-alx
+acG
+acG
+acy
+bIJ
+bIJ
+bIJ
+bIJ
+bIJ
+bIJ
+bIJ
+bIJ
 bIJ
 aaa
-aaA
-acF
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73749,25 +76231,25 @@ aaa
 aaa
 aoO
 apK
-apY
+auB
 aqm
-aqQ
-aqQ
-aql
+auB
+auB
+auz
 aqi
 asL
 atn
 atP
 auB
 avc
-avE
+avF
 aws
-axc
+axi
 aya
 ayX
 aAb
 aAb
-aAb
+aJp
 aCE
 ayW
 aEf
@@ -73845,7 +76327,7 @@ bCr
 bCr
 bCr
 bCr
-bFv
+bCr
 bCr
 bCr
 bGw
@@ -73853,19 +76335,19 @@ bAP
 bCV
 aaa
 aaa
-anM
-acd
-bHe
-bHj
-acd
-ajz
-ajz
-aas
-ajz
-ajz
-aai
-ajz
-acy
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74052,10 +76534,10 @@ aaa
 aoO
 anF
 aoH
-aql
-apY
-apY
-aql
+auz
+auB
+auB
+auz
 asb
 asM
 ato
@@ -74064,12 +76546,12 @@ auB
 avc
 avF
 aws
-axc
-aya
+azi
+azN
 ayY
-aAb
+aHX
 aBa
-aAb
+aJH
 aCF
 ayW
 aEg
@@ -74085,12 +76567,12 @@ azU
 azU
 azU
 azU
-aFL
-aaa
-aaa
-aaa
-aaa
-aaa
+aCy
+aCy
+bcj
+bcj
+aCy
+aCy
 aaa
 aaa
 aaa
@@ -74149,17 +76631,17 @@ bEy
 bEY
 bFw
 bFU
-bGk
-bGx
+bAW
+bEl
 bAP
 bCV
-bGs
-bGs
-bGT
-bAP
-bAP
-bEl
-bGT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74355,8 +76837,8 @@ aoO
 aoO
 aqa
 aqn
-apY
-apY
+auB
+vuf
 arw
 asc
 asN
@@ -74371,14 +76853,14 @@ ayc
 ayW
 ayW
 ayW
-ayY
+aJQ
 ayW
 ayW
 aCy
 aCy
 aFQ
 aCy
-aCy
+aPv
 aCy
 aCy
 aEl
@@ -74387,12 +76869,12 @@ aEl
 aCy
 aMC
 azU
-aFL
-aaa
-aaa
-aaa
-aaa
-aaa
+azU
+azU
+azU
+azU
+azU
+aCy
 aaa
 aaa
 aaa
@@ -74449,19 +76931,19 @@ bCv
 bCv
 bCv
 bCw
-bCv
+efQ
 bFV
 bAW
-bGy
-bDE
-bGJ
-bDE
-bDE
-bGS
-bDE
-bDE
-bHh
-bGT
+bEl
+bAP
+bCV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74658,11 +77140,11 @@ aoO
 aoO
 aqo
 aqR
-aqR
 arx
+auz
 asd
-aoO
-aoO
+aui
+avA
 aoN
 auD
 auD
@@ -74689,12 +77171,12 @@ aLd
 aCy
 aMD
 azU
-aFL
-aaa
-aaa
-aaa
-aaa
-aaa
+azU
+azU
+azU
+azU
+azU
+aCy
 aaa
 aaa
 aaa
@@ -74737,7 +77219,7 @@ bqS
 brX
 bsT
 bsT
-buT
+bzh
 bsT
 bxh
 bhm
@@ -74751,19 +77233,19 @@ bDp
 bDR
 bCv
 bDS
-bCv
-bDS
+iWz
+muY
 bGl
+bGD
 bAP
-bAP
 bCV
-bGs
-bGs
-bCV
-bGT
-bGT
-bGT
-bCV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74957,14 +77439,14 @@ aoX
 aph
 aoX
 apM
-aqb
-aqp
-aqS
-aqS
-aqp
 aqS
 aqS
 aqS
+arg
+auz
+atS
+avf
+biJ
 aoN
 asf
 asi
@@ -74994,9 +77476,9 @@ aNp
 aLj
 aLj
 aLj
-aaa
-aaa
-aaa
+azU
+azU
+aCy
 aaa
 aaa
 aaa
@@ -75031,15 +77513,15 @@ bkr
 blw
 blw
 blw
-bnX
-boI
+bqa
+bps
 bps
 bqa
 bqT
+bnc
 bhm
 bhm
-bhm
-bhm
+bAS
 bhm
 bhm
 bhm
@@ -75051,7 +77533,7 @@ bBM
 bCv
 bCv
 bDS
-bCv
+eKV
 bEZ
 bCv
 bFW
@@ -75254,17 +77736,17 @@ aaa
 aaa
 aoO
 aoR
-aoY
-apb
+api
+auD
 aoY
 apr
 aoO
 aoO
 aqq
-aqT
-apY
-aql
-apY
+auB
+arg
+vSU
+auB
 asO
 atq
 aoN
@@ -75296,9 +77778,9 @@ aMe
 aNQ
 aNQ
 aLj
-aaa
-aaa
-aaa
+azU
+azU
+aCy
 aaa
 aaa
 aaa
@@ -75338,10 +77820,10 @@ boJ
 bty
 bhY
 bqU
-bhm
+bxH
 bhm
 btQ
-bhU
+fWe
 bjs
 bhm
 bxP
@@ -75556,17 +78038,17 @@ aaa
 aaa
 aoO
 aoS
-aoY
+api
 apb
-api
-api
+aqb
+aqb
 apN
-apY
-aqr
+aqU
+aqU
 aqU
 arg
-ary
-ase
+auz
+auB
 asP
 asP
 aoN
@@ -75598,14 +78080,14 @@ aMe
 aMe
 aOE
 aLj
+azU
+azU
 aPW
 aPW
 aPW
 aPW
 aPW
-aaa
-aaa
-aaa
+aPW
 aaa
 aaa
 aaa
@@ -75636,11 +78118,11 @@ bjw
 bhY
 bhY
 bhY
-boK
+bhY
 bhY
 bhY
 bqV
-bhm
+bxH
 bsU
 bgH
 bgH
@@ -75862,15 +78344,15 @@ aoZ
 apc
 apj
 api
-apO
+aqp
 aqc
-aoN
-aoN
-aoN
+aqQ
+aqT
+ase
 arz
-aoN
-aoN
-aoN
+auE
+avL
+wOn
 aoN
 asi
 asi
@@ -75886,28 +78368,28 @@ axc
 axS
 aEj
 aEl
-aFT
+doj
 aGF
 aHu
 aIb
 aIb
 aJw
 aKo
-aHs
-aEl
+aPy
+aPX
 aMG
 aMe
 aNR
 aNR
 aLj
-aPX
-aPZ
-aRt
-aSm
+azU
+azU
 aPW
-aaa
-aaa
-aaa
+aSm
+aSV
+aTs
+aVv
+aPW
 aaa
 aaa
 aaa
@@ -75942,7 +78424,7 @@ boL
 azU
 bgH
 bhm
-bhm
+bxH
 bsV
 bgH
 buU
@@ -75963,7 +78445,7 @@ bAW
 bAW
 bAW
 bAP
-bAP
+xqE
 bFZ
 bGN
 bGs
@@ -76167,16 +78649,16 @@ aps
 apP
 aqd
 aqs
-aqu
-arh
-arA
-asf
-asQ
+auD
 atr
-arj
-arj
-arj
-avK
+arA
+atr
+atr
+atr
+atr
+asi
+asi
+avJ
 awB
 axm
 ayh
@@ -76196,20 +78678,20 @@ aIQ
 aJw
 aKp
 aLg
-aMc
+aLj
 aMH
 aMe
 aNS
 aNS
 aLj
-aPY
-aPZ
-aPZ
+azU
+azU
+aPW
 aPZ
 aSV
-aaa
-aaa
-aaa
+aSV
+aSV
+axn
 aaa
 aaa
 aaa
@@ -76240,11 +78722,11 @@ aCy
 aCy
 aCy
 aCy
-azP
+azU
 azU
 bgH
 bhm
-bhm
+bxH
 bsW
 btR
 buV
@@ -76469,11 +78951,11 @@ acK
 apO
 aqe
 aqt
-aqu
-ari
+auD
+asi
 arB
 asg
-asR
+arj
 ats
 asi
 asi
@@ -76484,7 +78966,7 @@ aBc
 ayi
 azc
 aAf
-aBd
+aBf
 aBB
 axc
 axS
@@ -76504,14 +78986,14 @@ aMe
 aIA
 aOF
 aLj
-aPZ
-aQH
-aPZ
-aSn
+azU
+azU
+aPW
+aSV
 aSW
-aaa
-aaa
-aaa
+aSV
+aVw
+axn
 aaa
 aaa
 aaa
@@ -76542,10 +79024,10 @@ azU
 azU
 azU
 azU
-azP
-azU
+aEQ
+aBS
 bqb
-bhm
+bnZ
 brY
 bsX
 btS
@@ -76770,23 +79252,23 @@ anM
 acK
 aoO
 aoO
-aqu
-aqu
+auD
+auD
 ari
 arC
 ash
-arh
+asi
+kMs
+asi
+asi
+asi
 asm
-apk
-apk
-apk
-avL
-apk
-apk
+aBc
+aBc
 ayj
 azd
 aAg
-aBd
+aBf
 aBB
 axc
 axQ
@@ -76798,7 +79280,7 @@ aHx
 aId
 aHs
 aJy
-aKq
+aKn
 aLi
 aLj
 aMJ
@@ -76806,14 +79288,14 @@ aMe
 aNU
 aOG
 aLj
-aQa
-aQI
-aRu
+azU
+azU
+aPW
+aRt
+aSX
+aTJ
 aPW
 aPW
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -76825,9 +79307,9 @@ aaa
 aaa
 aaa
 aCy
-aFL
-aFL
-aFL
+bcj
+bcj
+bcj
 aCy
 aaa
 aaa
@@ -76842,20 +79324,20 @@ bjy
 aBS
 aBS
 aBS
-bnc
 aBS
-aHY
-bpt
-bqc
+aBS
+aEY
+bgm
+bgH
 bqW
-brZ
+bsa
 bsW
 bgH
 buX
-buV
+bFv
 bxl
 buZ
-byC
+vLf
 bzt
 bxT
 bAY
@@ -77067,7 +79549,7 @@ aaa
 ace
 aaa
 ace
-aaa
+apf
 abZ
 aai
 aai
@@ -77078,19 +79560,19 @@ arj
 arD
 asi
 asS
+aBc
 apk
-atS
-auE
-avf
+apk
+apk
 avM
-awD
-axn
+apk
+apk
 ayk
-azc
-azd
+aFC
+azb
 aBe
-aBB
-axc
+aIw
+aKZ
 axS
 aEk
 aEk
@@ -77100,7 +79582,7 @@ aEl
 aEl
 aEl
 aEl
-aKr
+aEk
 aLj
 aLj
 aMK
@@ -77108,17 +79590,17 @@ aMe
 aNS
 aNS
 aLj
+azU
+azU
+aPW
+aPW
+aPW
+aTV
+aPW
+aPW
 aCy
 aCy
-aRv
 aCy
-aCy
-aCy
-aCy
-aCy
-aaa
-aaa
-aaa
 aXO
 aYD
 aXO
@@ -77132,7 +79614,7 @@ bcM
 bdk
 aCy
 aCy
-anM
+aaa
 aCy
 aCy
 aCy
@@ -77144,13 +79626,13 @@ bgH
 bgH
 bgH
 bgH
-bnd
+bgH
 bgH
 bgH
 bgH
 bgH
 bhm
-bhm
+bxH
 bsW
 bgH
 buY
@@ -77369,7 +79851,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+apf
 apk
 apk
 apk
@@ -77383,22 +79865,22 @@ asT
 apk
 atT
 auF
-avg
+pTo
 avN
 awE
-axn
+jnM
 ayl
 azc
 aAh
-aBd
+aBf
 aBB
-axc
-axS
-awm
+azi
+azM
+aLa
 aFf
 awk
 aGH
-aHy
+aIe
 aIe
 aIS
 aIe
@@ -77412,28 +79894,28 @@ aOH
 aLj
 aQb
 azU
+azU
+azU
+azU
 azP
-aSo
-aSX
-aNo
-aUk
-aCy
-aaa
-aaa
-aaa
+azU
+azU
+azU
+azU
+aYA
 aXO
 aYD
 aXO
 aaa
 aaa
 aaa
-aFL
+bcj
 bbT
 bcr
 bcN
 bdl
 aZW
-aFL
+bcj
 aaa
 aGx
 azU
@@ -77446,13 +79928,13 @@ bjz
 bhm
 blx
 bhm
-bne
+bjr
 bnY
 bhm
 bhm
 bhm
 bhm
-bhm
+bxH
 bsY
 bgH
 buZ
@@ -77692,50 +80174,50 @@ axo
 aym
 azd
 aAi
-aBd
+aBf
 aBB
 axc
 aDq
+aLc
 awo
-aFg
 aFW
-aGI
-aHz
+tZo
+aIf
 aIf
 aIf
 aJz
 aJC
-aLl
+aQL
 aMe
 aMe
 aNq
 aNW
 aMd
-aPq
+aRp
 aBS
 aQJ
-aRw
 aBS
 aBS
-aTD
-azU
-aFL
-aaa
-aaa
-aaa
+aBS
+aWB
+aVB
+aBS
+aBS
+aXf
+aNo
 aXO
 aYD
 aXO
 aaa
 aaa
 aaa
-aFL
+bcj
 bbU
 bcs
 bcO
 bdm
 bdV
-aFL
+bcj
 aaa
 aCy
 aEQ
@@ -77748,8 +80230,8 @@ bhp
 bhm
 bhm
 bhm
-bnf
-bnZ
+bhm
+buN
 bnZ
 bnZ
 bnZ
@@ -77990,26 +80472,26 @@ auH
 avg
 avg
 avg
-axn
+jnM
 ayn
 aze
 aAj
 aBf
 aBW
 aCI
-aDr
+ayf
 aDr
 aFh
 aFX
 aGJ
-aHA
+aIg
 aIg
 aIT
 aJA
 aJC
-aLl
-aLl
-aLl
+aQL
+aQL
+aQL
 aXV
 aNr
 aNr
@@ -78019,27 +80501,27 @@ aPr
 aPr
 aPr
 aPr
-aEa
+aPr
 aUl
-aCy
-acv
-aaa
-aaa
+aPr
+azU
+azP
+aYB
 aXO
 aYD
 aXO
 aaa
 aaa
 aaa
-aFL
+bcj
 bbV
 bct
 bcP
 bdn
 bcw
-aFL
+bcj
 aaa
-aFL
+bcj
 azP
 bbX
 bgH
@@ -78051,7 +80533,7 @@ bhm
 bly
 bmq
 bmq
-bmq
+bsb
 bmq
 bpu
 bmq
@@ -78278,16 +80760,16 @@ aaa
 aaa
 apk
 apv
-apR
-apR
-apR
-apR
-apR
-arL
-ask
-asU
+apY
+apY
+aqu
+apY
+apY
+asR
+atV
+aus
 att
-ask
+atV
 auI
 avi
 avO
@@ -78298,7 +80780,7 @@ awN
 awN
 awN
 awN
-awM
+aFi
 aDs
 aEm
 aFi
@@ -78313,20 +80795,20 @@ aJz
 aJC
 aMM
 aXV
-aNX
-aNY
-aNY
-aNY
-aNY
-aNY
+bgO
+bos
+bos
+bGi
+hMH
+lQh
 aNX
 aOm
 aTE
 aUm
-aCy
-acK
-acv
-aaa
+aPr
+azU
+azP
+azO
 aXO
 aYD
 aXO
@@ -78341,7 +80823,7 @@ bdo
 aCy
 aCy
 aaa
-aFL
+bcj
 azP
 azU
 bgH
@@ -78579,18 +81061,18 @@ aaa
 aaa
 aaa
 apk
-apv
+apR
 apS
 apR
-apR
+aqx
 apR
 arl
 arF
 asj
 asj
 apk
-atV
-auJ
+apk
+apk
 apk
 apk
 apk
@@ -78598,11 +81080,11 @@ apk
 ayo
 azf
 aAk
-azf
+tZf
 aBX
 aCJ
 aDt
-aDt
+aLy
 aFj
 aFZ
 aGK
@@ -78614,21 +81096,21 @@ aJC
 aJA
 aJC
 aJC
-aLl
-aNY
-aOI
-aPs
-aPs
+aQL
+aNZ
+aPt
+aPt
+aPt
 aQK
 aRx
 aSp
 aSZ
 aTF
 aUn
-aCy
-acK
-aas
-ajz
+aPr
+azU
+azP
+azU
 aXO
 aYD
 aXO
@@ -78638,17 +81120,17 @@ aaa
 aaa
 aCy
 aCy
-aUl
+bfo
 aCy
 aCy
 aaa
 aaa
-aFL
-azP
-azU
-ayS
-bhm
-bhm
+bcj
+bhR
+aBS
+aFg
+bnZ
+bnc
 bhm
 bhm
 bhm
@@ -78667,8 +81149,8 @@ bvc
 bwe
 btU
 bxT
-byE
-bzx
+byC
+bzu
 bxT
 bxT
 bxT
@@ -78885,26 +81367,26 @@ apw
 apR
 apR
 aqx
-apT
-apT
-arH
-arj
-arj
-arj
-arj
-auK
-arj
-arj
-arj
+apR
+apR
+apk
+asi
+asi
+asi
+asi
+asi
+asi
+asi
+asi
 axp
-ayp
-azg
+aAq
+aBg
 aAl
 azg
 aBY
 aCK
 aDu
-aDu
+aMc
 aFk
 aFm
 aAq
@@ -78917,20 +81399,20 @@ aJA
 aJC
 aJC
 aNr
-aNY
-aOJ
+bnd
 aPt
 aPt
 aPt
+aQK
 aRy
 aSp
 aSZ
-aTG
 aUn
-aCy
-acK
-acK
-aaa
+aUn
+aPr
+azU
+azP
+aDm
 aXO
 aYD
 aXO
@@ -78945,12 +81427,12 @@ aCy
 apU
 aaa
 aaa
-aFL
+bcj
 azP
 bgm
 bgH
 bhm
-bhm
+bxH
 biD
 bjA
 bkt
@@ -78975,7 +81457,7 @@ beM
 beM
 beM
 beM
-beM
+bfq
 beM
 bDX
 btj
@@ -79184,8 +81666,8 @@ aaa
 aaa
 apl
 apx
-apT
-apT
+apR
+apR
 aqy
 apR
 apR
@@ -79220,19 +81702,19 @@ aJC
 aJC
 aNr
 aNZ
-aOJ
 aPt
-aQc
 aPt
-aRy
+aPt
+aQK
+aRx
 aSp
 aSZ
 aTH
 aUo
-aCy
-aVG
-aCy
-aaa
+aPr
+azU
+azP
+aDm
 aXO
 aYD
 aXO
@@ -79247,12 +81729,12 @@ aCy
 apU
 aaa
 aaa
-aFL
+bcj
 bfI
 aUg
 bgG
-bhv
-bhv
+bhn
+rNH
 biE
 bjB
 bjB
@@ -79521,30 +82003,30 @@ aLn
 aJC
 aJC
 aNr
-aNY
+bnD
 aOJ
-aPt
-aPt
-aPt
-aRy
-aSp
+bFM
+dbM
+mIj
+lQh
+aNY
 aSZ
-aTG
 aUn
-aGx
+aUn
+aWh
 aVH
-aCy
-aaa
+azP
+nml
 aSU
 aYI
 aXO
-aaa
+bbA
 aaa
 aCy
 aCy
-aFL
+bcj
 aVz
-aUl
+bfo
 aCy
 apU
 aaa
@@ -79554,7 +82036,7 @@ bfJ
 azU
 aXV
 bhw
-bhw
+bne
 biF
 bjC
 bku
@@ -79575,8 +82057,8 @@ btU
 bxW
 byH
 bfR
-beM
-beM
+bzy
+gNq
 beM
 bCC
 beT
@@ -79804,7 +82286,7 @@ avQ
 awG
 aAD
 ayr
-azi
+avj
 aAo
 azh
 aAm
@@ -79824,19 +82306,19 @@ aJC
 aJC
 aNr
 aNY
-aOK
+aQd
 aPu
 aQd
-aQd
-aRz
-aSp
+aNY
+aNY
+aNY
 aSZ
 aTF
 aUn
-aCy
-aVG
-aCy
-aXf
+aPr
+azU
+azP
+aBK
 aXT
 aYJ
 aZn
@@ -79856,7 +82338,7 @@ bfJ
 azU
 aXV
 aJC
-aJC
+aMP
 bdZ
 bjC
 bkv
@@ -79876,10 +82358,10 @@ bwi
 btU
 beT
 byI
-bwq
+beT
 beT
 bBe
-bfi
+beL
 beT
 aaa
 aaa
@@ -80105,7 +82587,7 @@ avk
 avR
 awH
 axr
-ays
+aCA
 avj
 aAp
 aBg
@@ -80128,17 +82610,17 @@ aXV
 aOa
 aNY
 aNY
-aQe
-aQe
+aNY
+aNY
 aNY
 aNY
 aTa
 aTI
 aUn
-aCy
+aPr
 azU
-aCy
-aai
+azP
+aBK
 aXT
 aYK
 aZo
@@ -80150,17 +82632,17 @@ aBS
 aBS
 aBS
 aBS
-aWq
+aBS
 aBS
 beJ
 aBS
 bfK
-aBS
-aNs
+azU
+aXV
 bhx
 bhZ
-biG
-bjD
+bdZ
+bjC
 bkw
 blF
 blF
@@ -80171,16 +82653,16 @@ bjC
 bqj
 bre
 bre
-bre
+bzM
 btY
 bvd
 bwh
 btU
 bpw
 byF
+beM
+beM
 bfn
-beM
-beM
 beM
 beT
 aaa
@@ -80409,7 +82891,7 @@ asa
 axs
 ayt
 avj
-ayq
+aAm
 azh
 aAm
 aCN
@@ -80425,34 +82907,34 @@ aJG
 aIj
 aLo
 aMg
-aMN
-aNs
+aMf
+aXV
 aOb
-aOL
-aPv
-aOL
-aOL
+aQd
+aNY
+aNY
+aQd
 aRA
 aSq
-aTb
-aTJ
+aPr
+aPr
 aUp
-aCy
+aPr
 azU
-aCy
-aaa
+azP
+azU
 aXT
 aYL
 aZp
 aZU
 bay
 baX
-bbA
+aEY
 azU
 azU
 azU
 azU
-azW
+azU
 azU
 azU
 azU
@@ -80460,7 +82942,7 @@ bfL
 azU
 aXV
 aJC
-aJC
+aMP
 bdZ
 bjC
 bpV
@@ -80470,10 +82952,10 @@ bnl
 bog
 boT
 bjC
-bqk
-bra
-bsf
-btd
+bqi
+bre
+bre
+bre
 btY
 bvd
 bwh
@@ -80481,8 +82963,8 @@ btU
 bxY
 byJ
 bzy
-beM
-beM
+bzy
+bfj
 beM
 beT
 aaa
@@ -80709,39 +83191,39 @@ avk
 avS
 awJ
 axt
-avR
+aED
 azj
-aAq
+aHY
 aBg
 aBZ
 aCO
 aAq
-aEo
+aEp
 aFo
 aGb
 aGO
 aKw
 aKw
 aKw
-aJH
+aKw
 aKw
 aLq
 aJC
 aMO
 aXV
 aXV
-aOM
-aPw
 aNr
+aPw
+aPw
 aQL
 aQL
 aQL
 aXV
 aXV
-azP
-aDm
 azU
-aCy
+azU
+azU
+azP
 aBQ
 aXU
 aXT
@@ -80749,7 +83231,7 @@ aXT
 aZn
 aXT
 aXT
-bbB
+azR
 azU
 aXV
 aXV
@@ -80762,7 +83244,7 @@ bfM
 aXV
 aXV
 bhy
-aJC
+aMP
 biH
 bjC
 bky
@@ -80775,7 +83257,7 @@ bjC
 bql
 brf
 bsg
-brh
+bCm
 btZ
 bvf
 bwj
@@ -81020,7 +83502,7 @@ aCP
 aDz
 awN
 awN
-awN
+moS
 aGO
 aHG
 aIo
@@ -81033,7 +83515,7 @@ aMP
 aNt
 aJC
 aJC
-aMP
+aJC
 aJC
 aJC
 aRB
@@ -81044,14 +83526,14 @@ aUq
 aBS
 aBS
 aWB
+aTK
 aBS
 aBS
-aYM
 aBS
 aZV
 baz
 azU
-azP
+azU
 bbX
 aXV
 bcS
@@ -81064,7 +83546,7 @@ aJA
 aJC
 aSr
 aJC
-aJC
+aMP
 bdY
 bjE
 bkz
@@ -81329,44 +83811,44 @@ aIp
 aJb
 aJJ
 aKx
-aJB
+aPA
 aMh
 aMQ
-aJC
-aJC
-aJC
-aMP
-aJC
-aJC
-aJC
-aJC
-aJC
+aIe
+aIe
+aIe
+aIe
+aIe
+aIe
+aIe
+aRu
+aIe
 aTK
+aEY
 azU
 azU
 azU
-azW
+aRq
 azU
 azU
-azP
 aZq
 azU
 azU
 azU
-bbC
-aBS
-aNs
-aMf
+azU
+azU
+aXV
 aJC
 aJC
 aJC
 aJC
 aJC
-aJA
-aJC
-aJC
-aJC
-aJC
+bfu
+aVI
+aIe
+aIe
+aIe
+bnf
 bdZ
 bjF
 bkA
@@ -81384,10 +83866,10 @@ bua
 bvh
 bwk
 btZ
-bfn
-byF
+bGx
+byJ
 bzA
-bAs
+wJl
 bAs
 bBV
 aaa
@@ -81637,11 +84119,11 @@ aMR
 aNu
 aOc
 aON
-aPx
+aQM
 aQf
 aQM
 aRC
-aJC
+aMP
 aJC
 aXV
 aXV
@@ -81650,25 +84132,25 @@ aIj
 aXV
 aXV
 aXV
-aYN
+aXV
 aXV
 aXV
 aXV
 aIj
-aYN
 aXV
 aXV
-aMg
-aIe
+aXV
+aJC
+aJC
 bdX
 ber
-beK
+aTc
 beK
 bfN
-beK
-beK
-beK
-ber
+aTc
+aTc
+aTc
+boK
 biI
 bjG
 bkB
@@ -81686,9 +84168,9 @@ bub
 bvi
 bwk
 btZ
-bya
+bfn
 byK
-bzB
+bzz
 bAt
 bBg
 bBW
@@ -81939,25 +84421,25 @@ aCS
 aNv
 aNw
 aNv
-aPy
+aNv
 aNw
 aNv
 aRD
-aIf
+aRv
 aIf
 aTL
 aJz
 aUP
-aVI
-aWC
-aIe
-aIe
+aVJ
+aRB
+aJC
+aJC
 aYO
 aJC
 aRB
 aSr
 aVJ
-bbD
+aJC
 bbY
 aJC
 aJC
@@ -81965,7 +84447,7 @@ aJC
 bdY
 aXV
 beL
-beL
+bfT
 bfM
 beT
 bgL
@@ -81984,10 +84466,10 @@ bqp
 brj
 bsj
 btg
-bua
-bua
-bwl
-bua
+btZ
+btZ
+btZ
+btZ
 byb
 byc
 bzz
@@ -82221,7 +84703,7 @@ avj
 avj
 avj
 avj
-aAu
+inn
 axA
 aCa
 aCP
@@ -82245,21 +84727,21 @@ aPz
 aQg
 aNw
 aRE
-aJC
-aJC
-aJC
-aJA
+aRw
+aIe
+aIe
+aVI
 aUQ
-aVJ
+aWm
+aIe
+aIe
+aIe
+aMf
 aJC
 aJC
 aJC
-aMP
+kKM
 aJC
-aJC
-aJC
-aVJ
-bbD
 aJC
 aJC
 aJC
@@ -82267,13 +84749,13 @@ aJC
 bdZ
 aXV
 beM
-beM
+bfn
 bfO
 bgn
 bgL
 bhz
-bia
-biJ
+bib
+biK
 bjC
 bjC
 bjC
@@ -82289,8 +84771,8 @@ bjE
 beT
 beO
 bwm
-beQ
-byc
+bGu
+ere
 beM
 bzz
 bzz
@@ -82519,7 +85001,7 @@ aaa
 aaa
 aaa
 aaa
-awM
+aFi
 axx
 ayv
 axz
@@ -82543,8 +85025,8 @@ aIx
 aNw
 aOe
 aOP
-aPA
-aQg
+aQi
+aPY
 aQN
 aRF
 aSs
@@ -82561,7 +85043,7 @@ aQf
 aQM
 aQM
 aVK
-bbE
+aQM
 bbZ
 aQf
 aQM
@@ -82569,29 +85051,29 @@ aQM
 bea
 bes
 beN
-beN
+bga
 bfP
 bgo
 bgL
 bhA
-bib
-biK
-bjI
+cOs
+ekx
+bgL
 bkD
 blL
 bmC
-bns
+eoV
 bol
 boX
 bpB
 bqq
 brk
 bsk
-beO
+bgL
 beO
 beO
 bwn
-bfi
+beM
 beT
 beT
 beT
@@ -82821,7 +85303,7 @@ aaa
 aaa
 aaa
 aaa
-awM
+aFi
 axy
 ayw
 azl
@@ -82836,17 +85318,17 @@ aGf
 aGR
 aHJ
 aIs
-aJd
+aEq
 aJO
 aKA
 aLt
 aMj
 aIx
 aNv
-aOf
+sDu
 aOQ
 aPB
-aQg
+aQa
 aNv
 aRG
 aSt
@@ -82863,7 +85345,7 @@ bcW
 aNT
 baA
 bcW
-bbF
+bcW
 bca
 bcW
 bcW
@@ -82871,25 +85353,25 @@ bcW
 bcW
 bcW
 beM
-beM
+bfn
 beM
 beM
 bgL
-bhA
+bkg
 bic
-bhA
+bkg
 bjJ
 bkE
-blM
-bmD
-bnt
+bkH
+bmF
+bkH
 bom
 boY
-bpC
+bgL
 bqr
-brl
-bsl
-beO
+bkH
+bkH
+bgL
 buc
 brn
 bwo
@@ -83123,11 +85605,11 @@ aaa
 aaa
 aaa
 aaa
-awM
+aFi
 axz
 ayx
 azm
-ayx
+dJU
 aBi
 awN
 aCS
@@ -83173,8 +85655,8 @@ bdp
 beb
 bcW
 beO
-bfi
-bfi
+bfn
+beM
 beT
 bgL
 bgL
@@ -83186,12 +85668,12 @@ blN
 bmE
 bkG
 bon
-bkH
+wfT
 bgL
 bqs
 brm
 bsm
-beO
+bgL
 bud
 bvj
 bwp
@@ -83425,7 +85907,7 @@ aaa
 aaa
 aaa
 aaa
-awM
+aFi
 axA
 ayw
 azn
@@ -83436,7 +85918,7 @@ aCT
 aDE
 aDE
 aFt
-aGg
+aDE
 aDE
 aDE
 aIu
@@ -83467,7 +85949,7 @@ aUw
 aZY
 baC
 bmV
-aVT
+bbH
 aVb
 aVb
 aVb
@@ -83488,15 +85970,15 @@ blO
 bmF
 bkH
 boo
-boZ
+bkH
+jOp
+bkP
+vdH
+bsm
 bgL
-bqt
-beT
-beT
-beO
 bue
-brn
-bwq
+bDh
+beT
 beT
 beT
 byd
@@ -83727,7 +86209,7 @@ aaa
 aaa
 aaa
 aaa
-awM
+aFi
 axB
 ayy
 azo
@@ -83767,9 +86249,9 @@ aXZ
 aYR
 aXh
 aXh
-baD
+aXh
 baY
-aVb
+aUX
 aVb
 bcx
 bcU
@@ -83792,12 +86274,12 @@ bnu
 boo
 bpa
 bgL
-bqu
-brn
-bsn
+bkP
+bkP
+bkP
 bth
 buf
-bvj
+bDM
 bwr
 beT
 aaa
@@ -84029,12 +86511,12 @@ aaa
 aaa
 aaa
 aaa
-awM
-axA
+aFi
+mgS
 ayz
 azp
 aAx
-axA
+hXb
 awN
 aCV
 aDG
@@ -84043,9 +86525,9 @@ aDG
 aDG
 aGU
 aDG
-aIw
-aDF
-aJQ
+aIx
+aJf
+aDG
 aKD
 aLw
 aJf
@@ -84071,7 +86553,7 @@ aZr
 aZZ
 baE
 aVb
-aVS
+beB
 bba
 bcy
 bcW
@@ -84092,10 +86574,10 @@ blP
 bmH
 bnv
 bop
-blP
+lTL
 bgM
 bqv
-bro
+blP
 bso
 bti
 bug
@@ -84357,7 +86839,7 @@ aNB
 aNB
 aNB
 aNB
-aQS
+aNB
 aNB
 aRK
 aTg
@@ -84381,7 +86863,7 @@ bdr
 bee
 beu
 beR
-bfm
+byc
 beM
 beM
 bgN
@@ -84393,17 +86875,17 @@ bkJ
 blQ
 bmI
 bnw
-blO
-bkH
-bpD
-bqu
-brp
-bsp
-beT
-beT
-bvl
-bwt
-beT
+tCu
+omO
+bgL
+dCE
+kvs
+biM
+bns
+bCX
+sFT
+pTr
+bCX
 aap
 bEH
 bFG
@@ -84651,7 +87133,7 @@ aIx
 aJf
 aDG
 aJf
-aLy
+aLx
 aJf
 aIx
 aNy
@@ -84663,7 +87145,7 @@ baU
 aNB
 aRK
 aTh
-aTQ
+jMM
 aRK
 aUY
 aVb
@@ -84683,7 +87165,7 @@ bds
 bef
 bev
 beA
-bfn
+beM
 bfQ
 beT
 bgN
@@ -84698,14 +87180,14 @@ bnx
 bgL
 bgL
 bgL
-beO
-brq
-bsq
-btj
+bgL
+bns
+bns
+bns
 buh
-bui
+bvm
 bwu
-bxp
+bxq
 byd
 bFB
 bzF
@@ -84957,12 +87439,12 @@ aLz
 aJf
 aMU
 aNz
-aOj
+aNB
 aOW
 aPH
 aQl
 aQU
-aRH
+aNB
 aSu
 aTi
 aTR
@@ -84985,7 +87467,7 @@ bdt
 beg
 bew
 beA
-bfn
+beM
 beM
 bgs
 bgN
@@ -84998,14 +87480,14 @@ blS
 bmJ
 bny
 boq
-boq
-boq
-beO
-brq
+pLx
+pHL
+bgL
 bsq
-btj
+bsq
+bns
 brw
-bui
+bvm
 bwv
 bxq
 byd
@@ -85264,7 +87746,7 @@ aNB
 aPI
 aNB
 aNB
-aQS
+aNB
 aRK
 aTj
 aTS
@@ -85287,8 +87769,8 @@ bdu
 beh
 bez
 beA
-bfo
-bfj
+beM
+beM
 beM
 bgN
 bhG
@@ -85296,20 +87778,20 @@ bih
 biP
 bgN
 bkH
-blT
+bqu
 bmK
-bnz
+bsl
 bfU
 bkP
 bkP
-beO
-beT
-beT
-beT
-beT
-bvm
+byE
+bpb
+mwp
+bns
+bCX
+jey
 bww
-beT
+bCX
 byd
 bFD
 bzF
@@ -85567,7 +88049,7 @@ aPJ
 aQm
 aNB
 aRI
-aSv
+aTQ
 aTk
 aTT
 aUv
@@ -85588,10 +88070,10 @@ bcW
 bdw
 bei
 bey
-beS
-bfp
-bfR
+beA
 beM
+beM
+bgt
 bgN
 bhH
 bii
@@ -85603,12 +88085,12 @@ bmL
 bnz
 bkP
 bkP
-bkQ
+wHO
 bgL
-acK
-aaa
-aaa
-buj
+bzB
+bzG
+bns
+bCX
 bvn
 bwx
 buj
@@ -85892,7 +88374,7 @@ bej
 bhM
 beA
 beM
-bfn
+beM
 bgt
 bgN
 bhI
@@ -85900,16 +88382,16 @@ bij
 biR
 bgN
 bkL
-blU
+blT
 bmM
 bnA
 bkP
 bkQ
 bpE
-bns
-acK
-ajz
-ajz
+bgL
+bgL
+bgL
+bgL
 buj
 bvo
 bwy
@@ -86193,9 +88675,9 @@ bdx
 bdx
 beA
 beA
-beT
+beO
 bfS
-beT
+beO
 bgN
 bhJ
 bij
@@ -86460,13 +88942,13 @@ aaa
 aaa
 aaa
 aaa
-aJh
+aJi
 aJR
 aKF
 aLC
 aMo
 aOq
-aJh
+aJi
 aaa
 aaa
 aaa
@@ -86475,7 +88957,7 @@ aaa
 aaa
 aaa
 aaa
-aTV
+aaa
 aUw
 aVd
 aVS
@@ -86490,15 +88972,15 @@ bba
 bbH
 aVb
 aUw
-bcX
-bdy
-aUx
 aaa
-beT
+adQ
+aaa
+aaa
+beO
 bfq
-bfo
-bfp
-bgO
+beM
+pcA
+bgN
 bhK
 bik
 biT
@@ -86508,7 +88990,7 @@ blT
 bmO
 bnC
 bkP
-bkP
+byk
 bpG
 bgL
 acK
@@ -86763,12 +89245,12 @@ aaa
 aaa
 aaa
 aJi
-aJh
-aJh
+aJi
+aJi
 aLD
-aJh
-aJh
-aJh
+aJi
+aJi
+aJi
 aaa
 aaa
 aaa
@@ -86777,7 +89259,7 @@ aaa
 aaa
 aaa
 aaa
-aTV
+aaa
 aUw
 aVe
 aVT
@@ -86792,23 +89274,23 @@ bbe
 aZx
 bcd
 aUw
-bcY
+acG
 acK
 acG
 acG
-beT
+bfp
 beM
 beM
-beM
-bgP
-bgP
+qRV
+bgN
+bgN
 bil
-bgP
-bgP
-bkN
+bgN
+bgN
+bkH
 blT
 bmO
-bkP
+bkQ
 bkP
 bkP
 bkP
@@ -87079,7 +89561,7 @@ aaa
 aaa
 aaa
 aaa
-aTV
+aaa
 aUw
 aUw
 aUw
@@ -87094,25 +89576,25 @@ aUw
 aUw
 aUw
 aUw
-bcX
 aaa
 aaa
 aaa
-beT
-beT
-bfT
-beT
+aaa
+beO
+beO
+beO
+beO
 bgP
 boy
-bim
-byM
-bgP
-bkO
+bry
+oyl
+slP
+bkH
 blW
 bgL
+rTC
 bhC
-bhC
-bhC
+naG
 bhC
 bgL
 acK
@@ -87124,7 +89606,7 @@ bvt
 bvq
 bvq
 byQ
-bzG
+buj
 aaa
 aaa
 aaa
@@ -87382,34 +89864,34 @@ aaa
 aaa
 aaa
 aaa
-aUx
-aUx
-aUx
-aUx
-aUx
-aUx
-aUx
-aUx
-aUx
-aUx
-aUx
-aUx
-aUx
-aUx
 aaa
 aaa
 aaa
 aaa
 aaa
-acK
-acK
-acK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bgP
 bgP
 biV
 bin
 byN
 bgP
-bkP
+rWV
 blX
 bgL
 bgL
@@ -87426,7 +89908,7 @@ bvt
 bvq
 bvq
 byR
-bzG
+buj
 aaa
 aaa
 aaa
@@ -87705,19 +90187,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bgP
 bgP
 biW
 bry
-bzC
+vIK
 bgP
 bkP
 blY
+brx
+bsp
+bwl
+bkQ
 bgL
-acK
-acK
-acK
-ace
 aaa
 aaa
 aaa
@@ -87728,7 +90210,7 @@ bvt
 bxt
 bvq
 byS
-bzG
+buj
 aaa
 aaa
 aaa
@@ -88005,21 +90487,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-acd
-acd
-acd
-acd
-bgL
-bkQ
+bgP
+bgP
+bgP
+bgP
+bkO
+bry
+bzC
+bgP
+yiQ
+brl
+bsf
+bkP
+bkP
 bhC
 bgL
-acK
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -88030,7 +90512,7 @@ bvt
 bvq
 bvq
 byT
-bzG
+buj
 aaa
 aaa
 aaa
@@ -88307,21 +90789,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abZ
+bha
+bgP
+bgP
+bgP
+blM
+bry
+sqw
+bgP
+bgP
+bgP
 bgL
 bgL
 bgL
 bgL
-aas
-acF
-aaa
-aaa
+bgL
 aaa
 aaa
 aaa
@@ -88331,8 +90813,8 @@ bvu
 bvt
 bxu
 bvq
-bvq
-bzG
+xkl
+buj
 aaa
 aaa
 aaa
@@ -88609,18 +91091,18 @@ aaa
 aaa
 aaa
 aaa
+vDc
+bgP
+biq
+bjn
+bzC
+bry
+bzC
+bzC
+bqc
+bgP
+bha
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abZ
-acy
 aaa
 aaa
 aaa
@@ -88634,7 +91116,7 @@ bwA
 bxv
 bxv
 byU
-bzG
+buj
 aaa
 aaa
 aaa
@@ -88911,17 +91393,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+smO
+woR
+biG
+bjD
+blU
+bpt
+blU
+blU
+bqk
+woR
+epJ
 aaa
 aaa
 aaa
@@ -89213,6 +91695,17 @@ aaa
 aaa
 aaa
 aaa
+vDc
+bgP
+biX
+bzC
+bzC
+bry
+bzC
+bzC
+bqt
+bgP
+vDc
 aaa
 aaa
 aaa
@@ -89221,24 +91714,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abZ
+aai
+aai
+xZI
+aai
+aai
+acy
 aaa
 aaa
 aaa
@@ -89515,6 +91997,17 @@ aaa
 aaa
 aaa
 aaa
+gYw
+bgP
+bgP
+bjI
+bzC
+bry
+bzC
+bpO
+bgP
+bgP
+gYw
 aaa
 aaa
 aaa
@@ -89526,18 +92019,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+adQ
 aaa
 aaa
 aaa
@@ -89817,6 +92299,17 @@ aaa
 aaa
 aaa
 aaa
+bgP
+bgP
+bgP
+bgP
+bmd
+bpC
+bmd
+bgP
+bgP
+bgP
+bgP
 aaa
 aaa
 aaa
@@ -89828,18 +92321,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gjN
 aaa
 aaa
 aaa
@@ -90120,6 +92602,15 @@ aaa
 aaa
 aaa
 aaa
+bgP
+bgP
+bgP
+bgP
+sbg
+bgP
+bgP
+bgP
+bgP
 aaa
 aaa
 aaa
@@ -90132,16 +92623,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+adQ
 aaa
 aaa
 aaa
@@ -90423,6 +92905,13 @@ aaa
 aaa
 aaa
 aaa
+bgP
+qmH
+qKF
+uvO
+qKF
+xvt
+bgP
 aaa
 aaa
 aaa
@@ -90436,14 +92925,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gjN
 aaa
 aaa
 aaa
@@ -90744,9 +93226,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+sXz
+wfC
+xeP
 aaa
 aaa
 aaa
@@ -91047,7 +93529,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+uwR
 aaa
 aaa
 aaa
@@ -103619,7 +106101,7 @@ aaa
 afW
 agD
 ahg
-ahE
+aHz
 ahE
 ahE
 ahE
@@ -103923,7 +106405,7 @@ agC
 ahh
 ahF
 ahF
-ahF
+aKW
 ahF
 ajq
 ajY
@@ -104223,7 +106705,7 @@ aaa
 afY
 agD
 ahi
-ahG
+aHA
 ahF
 ahG
 ahG
@@ -104344,7 +106826,7 @@ aTA
 aTA
 aTA
 aTA
-aTA
+acG
 aTA
 aTA
 aTA
@@ -104828,7 +107310,7 @@ aaa
 aaa
 aaa
 ahH
-aim
+bGM
 ahH
 afY
 ajo
@@ -105436,17 +107918,17 @@ aim
 adW
 adW
 adW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+adW
+adW
+adW
+aPs
+aPs
+aPs
+aPs
+aPs
+aPs
+rBH
+acv
 aaa
 aaa
 aaa
@@ -105723,11 +108205,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+adW
+adW
 adW
 aen
-aeJ
+agg
 aeJ
 aeJ
 aeJ
@@ -105737,18 +108219,18 @@ aeJ
 aeJ
 aiy
 aiR
-adW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bhv
+aeJ
+bhv
+vEk
+iAy
+ivo
+tjO
+njK
+oNh
+cZN
+fUf
+rDK
 aaa
 aaa
 aaa
@@ -106025,9 +108507,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-adW
+aeO
+afC
+agc
 aeo
 adq
 afc
@@ -106035,27 +108517,27 @@ adq
 adq
 adq
 adq
-adq
-adq
-agf
-aiS
-adW
+vTd
+xQx
+pzj
+aiH
+aiH
+aiH
+aiH
+qWR
+dMh
 aka
+aQc
+njK
+aUz
+aUz
+fUf
+apU
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hrF
 aaa
 aaa
 aaa
@@ -106327,38 +108809,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+adW
+adW
 adW
 aep
-adq
-afd
+agm
+agn
 afz
 afd
 agE
 ahj
-adq
+gjf
 aio
 aiz
 aiT
-adW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+wJS
+wJS
+bvz
+wgM
+lKq
+ont
+aQe
+njK
+oNh
+aUz
+fUf
+xZI
+acG
+wDo
+acG
+wDo
+rZP
+xeP
 aaa
 aaa
 aaa
@@ -106648,18 +109130,18 @@ aiU
 aiU
 aiU
 aiU
+uFs
+vFV
+fAk
+aUz
+aUz
+fUf
+apU
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uwR
 aaa
 aaa
 aaa
@@ -106931,8 +109413,8 @@ aaa
 aaa
 acV
 adj
-adk
-adI
+adw
+ahm
 adX
 aeq
 aeK
@@ -106949,14 +109431,14 @@ ahD
 akb
 aky
 akO
-alg
 aiU
-aiU
-alg
-aaa
-acf
-aaa
-aaa
+alh
+aRz
+aUz
+aUz
+aUz
+fUf
+rDK
 aaa
 aaa
 aaa
@@ -107232,7 +109714,7 @@ aaa
 aaa
 aaa
 acV
-adk
+adw
 adv
 adJ
 adY
@@ -107251,14 +109733,14 @@ ajt
 akc
 akd
 akP
-alh
+aiU
 aly
-aly
-alh
-alx
+aUz
+aUz
+xVE
 amh
-acF
-aaa
+rBH
+acy
 aaa
 aaa
 aaa
@@ -107358,7 +109840,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGp
@@ -107370,7 +109852,7 @@ bBj
 bGp
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -107541,7 +110023,7 @@ adZ
 aes
 aeL
 aeL
-afC
+aeL
 aga
 agH
 ahl
@@ -107553,24 +110035,24 @@ aju
 akd
 akz
 akQ
-alg
 aiU
-aiU
-alg
-aaa
-ace
-aaa
+dXg
+aUz
+aUz
+aUz
+nJk
+aPs
 aaa
 aaa
 aaa
 aaa
 anM
 anM
-acK
-aaa
-aaa
-aaa
-aaa
+euy
+acG
+acG
+acG
+ptL
 aaa
 aaa
 aaa
@@ -107660,7 +110142,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGp
@@ -107672,7 +110154,7 @@ bBj
 bGp
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -107849,19 +110331,19 @@ agI
 ahm
 ahM
 agf
-aiD
+inq
 aiV
 ajv
 ake
 akA
 akR
 aiU
-adQ
-aaa
-adQ
-aaa
-aaa
-aaa
+aPs
+aPs
+aPs
+aPs
+aPs
+aPs
 aaa
 aaa
 anM
@@ -107962,7 +110444,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGp
@@ -107974,7 +110456,7 @@ bBj
 bGp
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -108138,7 +110620,7 @@ aaa
 aaa
 aaa
 acV
-adn
+aho
 ady
 adM
 aeb
@@ -108149,7 +110631,7 @@ afE
 agb
 agJ
 ahn
-ahL
+lDT
 ahT
 aiD
 aiW
@@ -108157,10 +110639,10 @@ ajw
 akf
 akB
 akS
-aiU
-adQ
+hBo
 aaa
-adQ
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -108168,7 +110650,7 @@ aaa
 aaa
 anM
 aoa
-aon
+wlU
 aon
 aaa
 aaa
@@ -108264,7 +110746,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGp
@@ -108276,7 +110758,7 @@ bBj
 bGp
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -108445,11 +110927,11 @@ adz
 adz
 aec
 aeu
-aeO
+adz
 afh
 afF
-agc
-agK
+aec
+agI
 aho
 ahN
 aiq
@@ -108459,10 +110941,10 @@ ajx
 akg
 ajx
 akT
-aiU
-adQ
+hBo
 aaa
-adQ
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -108566,7 +111048,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGp
@@ -108578,7 +111060,7 @@ bBj
 bGp
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -108743,11 +111225,11 @@ aaa
 aaa
 acV
 adp
-adN
+avE
 adA
 adN
 aev
-adN
+avE
 afi
 adN
 agd
@@ -108761,13 +111243,13 @@ ajy
 akh
 akC
 akU
-aiU
-adQ
-aaa
-adQ
+hBo
 aaa
 aaa
-aae
+aaa
+aaa
+aaa
+aap
 amW
 anq
 anN
@@ -108868,7 +111350,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGp
@@ -108880,7 +111362,7 @@ bBj
 bGp
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -109052,10 +111534,10 @@ acV
 acV
 acV
 acV
-age
 acV
 acV
-adq
+acV
+euD
 agf
 aiG
 aiZ
@@ -109076,11 +111558,11 @@ alz
 alz
 aop
 aki
-aaa
-aaa
-aaa
-aaa
-aaa
+euy
+acG
+acG
+acG
+ptL
 aaa
 aaa
 aaa
@@ -109170,7 +111652,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGp
@@ -109182,7 +111664,7 @@ bBj
 bGp
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -109354,12 +111836,12 @@ adq
 adq
 adq
 afG
-agf
+adq
 adq
 ahp
-adq
+euD
 agf
-adq
+euD
 aja
 ajz
 aki
@@ -109472,7 +111954,7 @@ bkR
 bkR
 bkR
 bpH
-aTA
+bHC
 aaa
 bBj
 bGp
@@ -109484,7 +111966,7 @@ bBj
 bGp
 bCK
 aaa
-aTA
+bHC
 bsr
 bkR
 bkR
@@ -109656,12 +112138,12 @@ adq
 aeP
 adq
 adq
+adq
+adq
+ajb
+euD
 agf
-adq
-ahp
-adq
-agf
-adq
+aMy
 aja
 aaa
 aki
@@ -109774,7 +112256,7 @@ bvx
 bvx
 bvx
 brv
-aTA
+bHC
 aaa
 abZ
 bGG
@@ -109786,7 +112268,7 @@ amA
 bBZ
 acy
 aaa
-aTA
+bHC
 brv
 bvx
 bvx
@@ -109958,12 +112440,12 @@ adq
 adq
 adq
 afH
-agf
+adq
 adq
 ahp
-adq
+euD
 agf
-adq
+euD
 aja
 ajz
 aki
@@ -110076,7 +112558,7 @@ bkR
 bkR
 bkR
 brt
-aTA
+bHC
 aaa
 aaa
 aaa
@@ -110088,7 +112570,7 @@ aaa
 aaa
 aaa
 aaa
-aTA
+bHC
 bss
 bkR
 bkR
@@ -110260,11 +112742,11 @@ aeg
 aeg
 aeg
 aeg
-agg
+aeg
 aeg
 aeg
 ahP
-aib
+pZV
 ahP
 aja
 ajA
@@ -110567,11 +113049,11 @@ agM
 aeg
 ahQ
 agf
-adq
+euD
 ajb
 ajB
 akj
-ajD
+ajF
 akX
 ajD
 ajD
@@ -110867,13 +113349,13 @@ afJ
 agi
 agM
 aeg
-adq
+euD
 agf
-adq
+euD
 aja
 ajC
 ajD
-ajD
+ajI
 akY
 alj
 alA
@@ -111162,19 +113644,19 @@ aaa
 aaa
 ace
 aeg
-aey
+aHy
 aey
 aey
 aey
 agj
 agN
 agB
-ahR
-agf
-adq
+agK
+ahr
+juY
 ajc
-ajD
-ajD
+air
+ajd
 akG
 akY
 alk
@@ -111285,17 +113767,17 @@ bul
 bul
 bvy
 bvy
-bul
-bul
-bul
-bul
-bul
-bDZ
-bul
-bul
-bul
-bul
-bul
+kWD
+kWD
+kWD
+kWD
+kWD
+bEa
+kWD
+kWD
+kWD
+kWD
+kWD
 bvy
 bvy
 bul
@@ -111468,16 +113950,16 @@ aez
 aez
 aez
 aez
-aey
+agk
 aey
 aeg
 ahS
-air
-aiH
-ajd
+adq
+euD
+aja
 ajE
-akk
-akH
+ajD
+ajD
 akZ
 all
 alw
@@ -111586,19 +114068,19 @@ bul
 bul
 bvy
 bvy
-bul
-bul
-bvy
-bvy
-bvy
-bvy
+kWD
+kWD
+bGF
+bGF
+bGF
+rhi
 bEa
-bvy
-bvy
-bvy
-bvy
-bul
-bul
+bGF
+bGF
+bGF
+bGF
+kWD
+kWD
 bvy
 bvy
 bul
@@ -111770,14 +114252,14 @@ aeA
 aeA
 aey
 aez
-aey
+agk
 agO
 aeg
-agf
+nWJ
 adq
-adq
+euD
 ajb
-ajF
+ajD
 ajD
 akI
 ajD
@@ -111789,8 +114271,8 @@ amp
 ajG
 alV
 ane
-alV
-alV
+gha
+dHA
 aof
 aot
 aoE
@@ -111887,21 +114369,21 @@ bul
 bul
 bvy
 bvy
-bul
-bul
-bvy
-bvy
-bpI
-bpI
-bpI
+kWD
+kWD
+bGF
+mID
+bFg
+bFg
+bFg
 bEb
-bpI
-bpI
-bpI
-bvy
-bvy
-bul
-bul
+bFg
+bFg
+bFg
+tWQ
+bGF
+kWD
+kWD
 bvy
 bvy
 bul
@@ -112074,10 +114556,10 @@ aey
 afK
 agk
 agP
-ahr
-ahT
+aeg
+nWJ
 adq
-adq
+euD
 aja
 ajG
 akl
@@ -112188,23 +114670,23 @@ bul
 bul
 bvy
 bvy
-bul
-bul
-bvy
-bvy
-bpI
-bpI
-bul
-bul
-bDZ
-bul
-bul
-bpI
-bpI
-bvy
-bvy
-bul
-bul
+kWD
+kWD
+bGF
+bGF
+bFg
+bFg
+pNA
+pNA
+qtM
+pNA
+pNA
+bFg
+bFg
+bGF
+bGF
+kWD
+kWD
 bvy
 bul
 btl
@@ -112379,7 +114861,7 @@ agQ
 aeg
 ahU
 adq
-adq
+euD
 aja
 ajH
 akm
@@ -112475,39 +114957,39 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+bHC
+bHC
+bHC
+bHC
+bHC
+bHC
+bHC
+bHC
+bHC
+bHC
 btl
 bul
 bvy
 bvy
-bul
-bul
-bvy
-bvy
-bpI
-bpI
-bul
-bul
+kWD
+kWD
+bGF
+bGF
+bFg
+bFg
+pNA
+pNA
 bDA
 bEc
 bDA
-bul
-bul
-bpI
-bpI
+pNA
+pNA
+bFg
+bFg
+bGF
+bGF
+kWD
 bvy
-bvy
-bul
-bvy
 bul
 btl
 btl
@@ -112515,13 +114997,13 @@ btl
 btl
 btl
 btl
-acG
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+bvx
+bHC
+bHC
+bHC
+bHC
+bHC
+bHC
 aTA
 aTA
 aTA
@@ -112676,14 +115158,14 @@ aeg
 aeg
 aeg
 aeg
-agg
+aeg
 aeg
 aeg
 ahV
 adq
 aiI
 aja
-ajI
+aja
 aja
 aja
 aja
@@ -112695,7 +115177,7 @@ aja
 aja
 aki
 anC
-aki
+lbg
 aki
 aki
 aki
@@ -112790,24 +115272,24 @@ aaa
 btl
 bul
 bvy
-bul
-bul
-bvy
-bvy
-bpI
-bpI
-bul
-bul
+kWD
+kWD
+bGF
+bGF
+bFg
+bFg
+pNA
+pNA
 bCL
-bAx
+wEi
 bEd
-bAx
-bAx
-bul
-bul
-bpI
-bpI
-bvy
+wEi
+wEi
+pNA
+pNA
+bFg
+bFg
+bGF
 bul
 bul
 bul
@@ -112974,30 +115456,30 @@ acg
 adE
 adR
 adR
-aeB
+age
 aeT
 afl
 adR
-agm
+agR
 agR
 adR
 ahW
 adq
-adq
-ahp
-agf
-adq
-adq
-adq
-adq
-afG
-adq
-adq
-adq
+jKp
+hOE
+xQx
+xQx
+xQx
+xQx
+xQx
+gJo
+xQx
+xQx
+xQx
 amE
 amP
 anf
-amP
+rfL
 anT
 adW
 aaa
@@ -113092,31 +115574,31 @@ aaa
 btl
 bul
 bvy
-bul
-bvy
-bvy
-bpI
-bpI
-bul
-bul
-bAx
-bAx
-bAx
+kWD
+bGF
+bGF
+bFg
+bFg
+pNA
+pNA
+lzl
+wEi
+otU
 bEe
 bCP
 bFe
-bAx
+wEi
+pNA
+pNA
+bFg
+bGF
 bul
-bul
-bpI
-bvy
-bul
-bvy
-bvy
-bvy
-bvy
-bvy
-bvy
+nEX
+pix
+nEX
+yfp
+nEX
+nEX
 bul
 btl
 aaa
@@ -113280,14 +115762,14 @@ aeB
 aeB
 afm
 afL
-agn
 agS
+ctZ
 ahs
 ahX
 ais
-aiH
+juY
 aje
-ajJ
+aiH
 aiH
 aiH
 aiH
@@ -113300,7 +115782,7 @@ aiH
 amQ
 ang
 anz
-anU
+wnU
 adW
 aaa
 aaa
@@ -113394,31 +115876,31 @@ aaa
 btl
 bul
 bvy
-bul
-bvy
-bpI
-bpI
-bul
-bul
-bAx
-bAx
-bCc
+kWD
+bGF
+bFg
+bFg
+pNA
+pNA
+vjd
+wEi
+yaN
 bBk
-bCN
+gqN
 bEI
-bCN
-bAx
-bAx
+lNU
+uxt
+wEi
+pNA
+bFg
+bGF
 bul
-bpI
-bvy
+eJS
+iCI
+gcq
 bul
-bvy
-bvy
-bvy
-bul
-bvy
-bvy
+nEX
+nEX
 bul
 btl
 aaa
@@ -113582,7 +116064,7 @@ aeB
 aeB
 afn
 adR
-ago
+bHh
 ago
 adR
 ahW
@@ -113593,7 +116075,7 @@ ajK
 ajK
 akJ
 ajK
-ajK
+eYM
 alD
 alM
 alY
@@ -113696,31 +116178,31 @@ aaa
 btl
 bul
 bvy
-bul
-bvy
-bpI
-bul
-bul
+kWD
+bGF
+bFg
+pNA
+pNA
 bAx
-bAx
+wEi
 bCb
 bCM
 bDB
-bul
-bDZ
-bAx
-bAx
-bAx
+pNA
+qtM
+pNA
+jPK
+wEi
 bGq
 bGA
-bGE
-bul
-bul
-bul
-bul
-bul
 bGF
-bvy
+bul
+bul
+bul
+bul
+bul
+jZO
+xXK
 bul
 btl
 aaa
@@ -113998,31 +116480,31 @@ aaa
 btl
 bul
 bvy
-bul
-bvy
-bpI
-bul
+kWD
+efc
+bFg
+pNA
 bzH
-bAx
-bAx
+wEi
+dbr
 bCc
 bCN
-bAx
-bAx
-bDZ
-bul
-bAx
-bAx
+nZy
+qot
+mXG
+pNA
+pLv
+wEi
 bGr
-bDZ
-bvy
+qtM
+tWQ
 bul
-bvy
-bvy
-bvy
-bvy
-bvy
-bvy
+omo
+qoa
+rMl
+bul
+thY
+nEX
 bul
 btl
 aaa
@@ -114182,11 +116664,11 @@ aaa
 aaa
 aaa
 adR
-aeB
+bnt
 aeU
 afp
 afM
-afM
+bHj
 afM
 aeh
 ahY
@@ -114277,7 +116759,7 @@ aaa
 aaa
 aaa
 aaa
-aTA
+adQ
 aaa
 aaa
 aaa
@@ -114299,32 +116781,32 @@ bzE
 amA
 btm
 bum
-bvz
-bum
-bvz
+cjG
+cjG
+cjG
 byf
-bum
+dhK
 bzI
 bAy
 bBk
 bCd
 bCO
-bul
+pNA
 bEf
 bEJ
-bum
+dhK
 bFA
 bBk
 bCN
 bGB
-bvz
+cjG
 bGL
-bvz
-bvz
-bvz
-bvz
-bvz
-bvz
+pSU
+pSU
+pSU
+bGL
+nFv
+nct
 bHi
 bHp
 amA
@@ -114346,7 +116828,7 @@ aaa
 aaa
 aaa
 aaa
-aTA
+adQ
 aaa
 aaa
 aaa
@@ -114493,9 +116975,9 @@ agT
 adR
 ahW
 adq
-aiK
+uqg
 ajh
-ajM
+tXf
 ajP
 ajP
 ajP
@@ -114602,31 +117084,31 @@ aTC
 btl
 bul
 bvy
-bul
-bvy
-bpI
-bul
+kWD
+nlS
+bFg
+pNA
 bzH
-bAx
-bAx
+wEi
+gYd
 bCe
 bCP
-bAx
-bAx
-bDZ
-bul
-bAx
-bAx
+wMB
+xXS
+ifA
+pNA
+jPK
+wEi
 bDB
-bul
+pNA
 bGF
 bul
-bvy
-bvy
-bvy
-bvy
-bvy
-bvy
+kuy
+sJD
+sJD
+bul
+nEX
+nEX
 bul
 btl
 aaa
@@ -114795,7 +117277,7 @@ agU
 aeh
 ahW
 adq
-aiK
+bbE
 ajg
 ajN
 ajP
@@ -114904,31 +117386,31 @@ aaa
 btl
 bul
 bvy
-bul
-bvy
-bpI
-bul
-bul
-bAx
-bAx
-bCb
+kWD
+bGF
+bFg
+pNA
+pNA
+wEi
+wEi
+sDe
 bCQ
 bDB
+pNA
+qtM
+pNA
+jPK
+wEi
+wEi
+pNA
+bGF
 bul
-bDZ
-bAx
-bAx
-bAx
-bAx
-bul
-bGE
-bul
-bul
-bul
-bul
-bul
-bvy
-bvy
+thY
+nEX
+kav
+nbJ
+nEX
+xXK
 bul
 btl
 aaa
@@ -115206,31 +117688,31 @@ aaa
 btl
 bul
 bvy
-bul
-bvy
-bpI
-bpI
-bul
-bul
-bAx
-bAx
-bCe
+kWD
+bGF
+bFg
+bFg
+pNA
+pNA
+ldw
+wEi
+kzT
 bBk
-bCP
+lIf
 bEK
-bCP
-bAx
-bAx
-bul
-bpI
-bvy
-bul
-bvy
-bvy
-bvy
-bul
-bvy
-bvy
+ugu
+bCN
+wEi
+pNA
+bFg
+bGF
+gqo
+nEX
+nEX
+fTT
+nbJ
+nEX
+nEX
 bul
 btl
 aaa
@@ -115397,7 +117879,7 @@ afP
 agt
 agV
 aht
-agf
+nWJ
 adq
 aiK
 ajj
@@ -115508,31 +117990,31 @@ aaa
 btl
 bul
 bvy
-bul
-bvy
-bvy
-bpI
-bpI
-bul
-bul
-bAx
-bAx
-bAx
+kWD
+bGF
+bGF
+bFg
+bFg
+pNA
+pNA
+dAF
+wEi
+qLS
 bEg
 bCN
 bFf
-bAx
+wEi
+pNA
+pNA
+bFg
+bGF
 bul
-bul
-bpI
-bvy
-bul
-bvy
-bvy
-bvy
-bvy
-bvy
-bvy
+fii
+kyI
+oQj
+gqo
+nEX
+nEX
 bul
 btl
 aaa
@@ -115699,7 +118181,7 @@ aeX
 agu
 agW
 aht
-agf
+nWJ
 adq
 aiK
 ajj
@@ -115810,24 +118292,24 @@ aaa
 btl
 bul
 bvy
-bul
-bul
-bvy
-bvy
-bpI
-bpI
-bul
-bul
-bCL
-bAx
+kWD
+kWD
+bGF
+bGF
+bFg
+bFg
+pNA
+pNA
+nKm
+wEi
 bEh
-bAx
-bAx
-bul
-bul
-bpI
-bpI
-bvy
+wEi
+wEi
+pNA
+pNA
+bFg
+bFg
+bGF
 bul
 bul
 bul
@@ -116099,38 +118581,38 @@ aTA
 aTA
 aTA
 aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
-aTA
+bHC
+bHC
+bHC
+bHC
+bHC
+bHC
+bHC
+bHC
+bHC
+bHC
 btl
 bul
 bvy
 bvy
-bul
-bul
-bvy
-bvy
-bpI
-bpI
-bul
-bul
+kWD
+kWD
+bGF
+bGF
+bFg
+bFg
+pNA
+pNA
 bDC
 bEi
 bDC
-bul
-bul
-bpI
-bpI
-bvy
-bvy
-bul
+pNA
+pNA
+bFg
+bFg
+bGF
+bGF
+kWD
 bvy
 bul
 btl
@@ -116304,7 +118786,7 @@ agw
 agY
 aht
 aib
-ahP
+ajb
 aib
 ajg
 ajg
@@ -116416,23 +118898,23 @@ bul
 bul
 bvy
 bvy
-bul
-bul
-bvy
-bvy
-bpI
-bpI
-bul
-bul
-bDZ
-bul
-bul
-bpI
-bpI
-bvy
-bvy
-bul
-bul
+kWD
+kWD
+bGF
+bGF
+bFg
+bFg
+pNA
+pNA
+qtM
+pNA
+pNA
+bFg
+bFg
+bGF
+bGF
+kWD
+kWD
 bvy
 bul
 btl
@@ -116607,10 +119089,12 @@ aca
 ahu
 aic
 adq
-agf
+nWJ
 adW
 aaa
 adQ
+aaa
+aaa
 aaa
 aaa
 adQ
@@ -116622,8 +119106,6 @@ aaa
 aaa
 aaa
 acf
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -116719,21 +119201,21 @@ bul
 bul
 bvy
 bvy
-bul
-bul
-bvy
-bvy
-bpI
-bpI
-bpI
-bEb
-bpI
+kWD
+kWD
+bGF
+mID
 bFg
-bpI
-bvy
-bvy
-bul
-bul
+bFg
+bFg
+bEb
+bFg
+bFg
+bFg
+tWQ
+bGF
+kWD
+kWD
 bvy
 bvy
 bul
@@ -116896,7 +119378,7 @@ acA
 acO
 acU
 adf
-adu
+ahv
 adH
 adT
 aej
@@ -116909,24 +119391,24 @@ agZ
 ahv
 aid
 adq
-agf
+nWJ
 adW
 aaa
 adQ
 aaa
-alf
-ajV
+aaa
+bIJ
 alG
-aaa
-alf
-alC
+iWu
+jfc
+bIJ
 alG
-aaa
-alf
-alC
+snW
+jfc
+bIJ
 alG
-aaa
-aaa
+snW
+jfc
 aaa
 aaa
 aaa
@@ -117022,19 +119504,19 @@ bul
 bul
 bvy
 bvy
-bul
-bul
-bvy
-bvy
-bvy
-bvy
+kWD
+kWD
+bGF
+bGF
+bGF
+oTV
 bEa
-bvy
-bvy
-bvy
-bvy
-bul
-bul
+qgX
+bGF
+bGF
+bGF
+kWD
+kWD
 bvy
 bvy
 bul
@@ -117193,9 +119675,9 @@ aaa
 acb
 acl
 act
-acB
-acB
-acB
+aem
+aem
+aiS
 acB
 adg
 acb
@@ -117211,24 +119693,24 @@ aca
 ahu
 aie
 ahR
-agf
+bhj
 adW
 aaa
 akr
 acG
-alf
+acG
 akN
 alG
-aaa
-alf
-akN
+xEz
+jfc
+bIJ
 alG
-aaa
-alf
-akN
+xEz
+jfc
+bIJ
 alG
-aaa
-aaa
+xEz
+jfc
 aaa
 aaa
 aaa
@@ -117325,17 +119807,17 @@ bul
 bul
 bvy
 bvy
-bul
-bul
-bul
-bul
-bul
-bDZ
-bul
-bul
-bul
-bul
-bul
+kWD
+kWD
+kWD
+kWD
+kWD
+bEa
+kWD
+kWD
+kWD
+kWD
+kWD
 bvy
 bvy
 bul
@@ -117518,19 +120000,19 @@ adW
 aaa
 adQ
 aaa
-alf
-akN
+aaa
+bIJ
 alG
-aaa
-alf
-akN
+xEz
+jfc
+bIJ
 alG
-aaa
-alf
-akN
+xEz
+jfc
+bIJ
 alG
-aaa
-aaa
+xEz
+jfc
 aaa
 aaa
 aaa
@@ -117805,34 +120287,34 @@ adi
 acb
 aaa
 aaa
-aaA
-acK
 aaa
-acK
-aaa
-afS
-afS
-afS
-afS
+alf
+alf
+alf
+alf
+alf
+alf
+alf
+alf
 aiu
 aiN
-afS
-afS
-afS
-aaa
 alf
-akN
-alG
-aaa
 alf
-akN
-alG
-aaa
 alf
-akN
+alf
+alf
+bIJ
 alG
-aaa
-aaa
+xEz
+jfc
+bIJ
+alG
+xEz
+jfc
+bIJ
+alG
+xEz
+jfc
 aaa
 aaa
 aaa
@@ -118099,20 +120581,20 @@ aaa
 aaa
 aaa
 acb
-acE
-acE
-acE
-acE
-acE
+adG
+adG
+adG
+adG
+adG
 acb
-aag
-adU
-adU
-adU
-adU
-adU
+aap
+acG
+acG
+alf
+bDH
+bGy
 afS
-afS
+alf
 aha
 ahw
 aig
@@ -118120,21 +120602,21 @@ aiv
 aiO
 ajk
 ajS
-afS
-acf
+pup
+vFi
 alf
-akN
+oMJ
 alG
-acf
-alf
-akN
+xEz
+jfc
+oMJ
 alG
-acf
-alf
-akN
+xEz
+jfc
+oMJ
 alG
-aaa
-aaa
+xEz
+jfc
 aaa
 aaa
 aaa
@@ -118407,36 +120889,36 @@ aaa
 aaa
 abZ
 acG
-acK
+alu
 adV
-aek
+ael
 aeI
 afa
-afx
+afy
 afT
-agx
-ahb
+alf
+ahc
 ahx
 aih
-ahx
+vvM
 aiP
-ajl
+ajT
 ajT
 aks
+mtT
+vmR
 ajs
 ajs
-alu
-ajs
-ajs
-ajs
-alu
+oyG
 ajs
 ajs
 ajs
-amB
-alG
-aaa
-aaa
+oyG
+ajs
+ajs
+upn
+xUC
+jfc
 aaa
 aaa
 aaa
@@ -118532,7 +121014,7 @@ bkR
 bkR
 bkR
 brt
-aTA
+bHC
 aaa
 aaa
 aaa
@@ -118544,7 +121026,7 @@ aaa
 aaa
 aaa
 aaa
-aTA
+bHC
 bss
 bkR
 bkR
@@ -118709,36 +121191,36 @@ aaa
 aaa
 aaa
 aaa
-abZ
-adV
+amB
+bkN
 ael
-ael
-ael
+boZ
+bEp
 afy
-ael
+afV
 agy
 ahc
-ahy
-aii
-aiw
-ahx
+aiP
+ajT
+dTg
+ahc
 ajm
 ajU
-afS
-ace
-alf
-akN
+xBk
+ahc
+drg
+vdU
 alG
-ace
-alf
-akN
+xEz
+jfc
+vdU
 alG
-ace
-alf
-akN
+xEz
+jfc
+vdU
 alG
-aaa
-aaa
+xEz
+jfc
 aaa
 aaa
 aaa
@@ -118834,7 +121316,7 @@ bvx
 bvx
 bvx
 brv
-aTA
+bHC
 aaa
 aap
 bGH
@@ -118846,7 +121328,7 @@ amA
 bHF
 bGb
 aaa
-aTA
+bHC
 brv
 bvx
 bvx
@@ -119011,36 +121493,36 @@ aaa
 aaa
 aaa
 aaa
+amB
+adU
 aaa
-adV
-aem
-ael
+bsn
 afb
-afx
+bGJ
 afU
-agz
+alf
 ahd
 ahz
 aiw
-ahx
-ahx
-ahx
-ahA
-afS
-aaa
-alf
-akN
+oDS
+aiw
+iYx
+xHP
+sLS
+ahc
+qfx
+bIJ
 alG
-aaa
-alf
-akN
+xEz
+jfc
+bIJ
 alG
-aaa
-alf
-akN
+xEz
+jfc
+bIJ
 alG
-aaa
-aaa
+xEz
+jfc
 aaa
 aaa
 aaa
@@ -119136,7 +121618,7 @@ bkR
 bkR
 bkR
 bpJ
-aTA
+bHC
 aaa
 bBj
 bGI
@@ -119148,7 +121630,7 @@ bBj
 bGI
 bCK
 aaa
-aTA
+bHC
 bst
 bkR
 bkR
@@ -119313,14 +121795,14 @@ aaa
 aaa
 aaa
 aaa
+amB
+adU
 aaa
-adU
-adU
-adU
-adU
-adU
+alf
+afa
+bGS
 afV
-agA
+alf
 ahe
 ahA
 aij
@@ -119328,21 +121810,21 @@ aix
 aiQ
 ajn
 aiX
-afS
-acG
+eZZ
+eAq
 alf
 akN
 alG
-aaa
-alf
-akN
+xEz
+jfc
+bIJ
 alG
-aaa
-alf
-ano
+xEz
+jfc
+bIJ
 alG
-aaa
-aaa
+kDP
+jfc
 aaa
 aaa
 aaa
@@ -119438,7 +121920,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGI
@@ -119450,7 +121932,7 @@ bBj
 bGI
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -119615,36 +122097,36 @@ aaa
 aaa
 aaa
 aaa
+amB
+adU
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-afS
-afS
+alf
+bFn
+alf
+bGT
+alf
+kHm
 ahB
-afS
-afS
-afS
-afS
-afS
-afS
-aaa
+eNL
 alf
-akN
-alG
-aaa
+bPk
+ahB
+wRA
 alf
-akN
-alG
-aaa
 alf
-ano
+alf
+bIJ
 alG
-aaa
-aaa
+xEz
+jfc
+bIJ
+alG
+xEz
+jfc
+bIJ
+alG
+kDP
+jfc
 aaa
 aaa
 aaa
@@ -119740,7 +122222,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGI
@@ -119752,7 +122234,7 @@ bBj
 bGI
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -119917,36 +122399,36 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-afS
-ael
+aQx
+bmD
+acG
+bCq
+bFN
+alf
+bGW
+bHl
+qAy
 ahf
-ael
-afS
-aaa
-aaa
-aaa
-aaa
-aaa
+jJi
 alf
-akN
-alG
-aaa
+cei
+iRE
+uWa
 alf
-akN
+aaa
+aaa
+bIJ
 alG
-aaa
-alf
-ano
+xEz
+jfc
+bIJ
 alG
-aaa
-aaa
+xEz
+jfc
+bIJ
+alG
+kDP
+jfc
 aaa
 aaa
 aaa
@@ -120042,7 +122524,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGI
@@ -120054,7 +122536,7 @@ bBj
 bGI
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -120222,33 +122704,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-afS
-afS
+bCW
+bGn
+alf
+bHb
+bHm
+xRw
 ahC
-afS
-afS
-aaa
-aaa
-aaa
-aaa
-aaa
+fXQ
+wNb
+eYy
+igT
+qgJ
 alf
-alv
+aaa
+aaa
+bIJ
 alG
-aaa
-alf
-akN
+lgv
+jfc
+bIJ
 alG
-aaa
-alf
-ano
+xEz
+jfc
+bIJ
 alG
-aaa
-aaa
+kDP
+jfc
 aaa
 aaa
 aaa
@@ -120344,7 +122826,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGI
@@ -120356,7 +122838,7 @@ bBj
 bGI
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -120526,31 +123008,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+alf
+bHe
+bHn
+eYy
+eYy
+eYy
+alf
+eYy
+eYy
+eYy
+alf
 aaa
 aaa
 aaa
 aaa
 ace
 aaa
-aaa
-alf
-akN
+bIJ
 alG
-aaa
-alf
-ano
+xEz
+jfc
+bIJ
 alG
-aaa
-aaa
+kDP
+jfc
 aaa
 aaa
 aaa
@@ -120646,7 +123128,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGI
@@ -120658,7 +123140,7 @@ bBj
 bGI
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -120828,31 +123310,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 alf
-akN
-alG
-aaa
 alf
-ano
+alf
+wIi
+wIi
+wIi
+alf
+pxc
+pxc
+pxc
+alf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bIJ
 alG
-aaa
-aaa
+xEz
+jfc
+bIJ
+alG
+kDP
+jfc
 aaa
 aaa
 aaa
@@ -120948,7 +123430,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGI
@@ -120960,7 +123442,7 @@ bBj
 bGI
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -121132,29 +123614,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+alf
 aaa
 aaa
 aaa
 alf
-akN
-alG
+aaa
+aaa
 aaa
 alf
-ano
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bIJ
 alG
-aaa
-aaa
+xEz
+jfc
+bIJ
+alG
+kDP
+jfc
 aaa
 aaa
 aaa
@@ -121250,7 +123732,7 @@ bkR
 bkR
 bkR
 bkR
-aTA
+bHC
 aaa
 bBj
 bGI
@@ -121262,7 +123744,7 @@ bBj
 bGI
 bCK
 aaa
-aTA
+bHC
 bkR
 bkR
 bkR
@@ -121434,29 +123916,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 alf
-alv
-alG
-aaa
+uqL
+uqL
+uqL
 alf
-anD
+uqL
+uqL
+uqL
+alf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bIJ
 alG
-aaa
-aaa
+lgv
+jfc
+bIJ
+alG
+kzt
+jfc
 aaa
 aaa
 aaa
@@ -121751,13 +124233,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 ace
 aaa
 aaa
 aaa
 ace
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -124276,7 +126758,7 @@ aTA
 aTA
 aTA
 aTA
-aTA
+acG
 aTA
 aTA
 aTA

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -18023,6 +18023,7 @@
 	dir = 8
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/heads,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "aNU" = (
@@ -24240,6 +24241,7 @@
 	dir = 8
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/heads,
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "baB" = (
@@ -40601,6 +40603,16 @@
 	layer = 2
 	},
 /area/space)
+"bKA" = (
+/obj/machinery/camera{
+	c_tag = "Assistant Lounge";
+	dir = 8
+	},
+/obj/stool/chair{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
 "bOY" = (
 /obj/table/auto,
 /obj/item/cargotele{
@@ -40631,13 +40643,6 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
-"cgn" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "cjG" = (
 /obj/cable{
 	d1 = 1;
@@ -40833,13 +40838,6 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
-"ebF" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/ranch)
 "efc" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -40921,6 +40919,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"erm" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/ranch)
 "euy" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'Outpost mail hub'";
@@ -40993,17 +40998,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/south)
-"eWY" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 4
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "eYy" = (
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -41151,13 +41145,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
-"geh" = (
-/obj/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/ranch)
 "gha" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail{
@@ -41184,16 +41171,6 @@
 /obj/machinery/light/runway_light/delay5,
 /turf/space,
 /area/space)
-"goS" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/machinery/camera/ranch{
-	dir = 4
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "gqo" = (
 /obj/machinery/door/airlock/pyro/security/alt,
 /obj/access_spawn/security,
@@ -41213,14 +41190,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
-"gFd" = (
-/obj/stool/bed,
-/obj/landmark{
-	name = "NASSA spawn"
-	},
-/obj/item/game_kit,
-/turf/simulated/floor,
-/area/station/maintenance/southwest)
 "gJo" = (
 /obj/machinery/light{
 	dir = 8;
@@ -41253,6 +41222,13 @@
 	dir = 10
 	},
 /area/station/mining/staff_room)
+"gNe" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/ranch)
 "gNq" = (
 /obj/cable{
 	d1 = 1;
@@ -41389,6 +41365,13 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/science/artifact)
+"hKD" = (
+/obj/item/rods{
+	amount = 10
+	},
+/obj/grille/steel,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "hMH" = (
 /obj/decal/boxingrope{
 	dir = 9;
@@ -41473,13 +41456,6 @@
 	icon_state = "orange"
 	},
 /area/station/science/lobby)
-"ipw" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/ranch)
 "ivo" = (
 /obj/table/auto,
 /obj/machinery/light{
@@ -41708,13 +41684,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
-"jOh" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "jOp" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/brig,
@@ -41729,13 +41698,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
-"jRp" = (
-/obj/item/rods{
-	amount = 10
-	},
-/obj/grille/steel,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
 "jZO" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -41803,13 +41765,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
-"kxc" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "kxs" = (
 /obj/machinery/computer/barcode/qm/no_belthell{
 	dir = 4
@@ -42027,10 +41982,6 @@
 	dir = 1
 	},
 /area/station/mining/staff_room)
-"lyT" = (
-/obj/storage/closet/wardrobe/grey,
-/turf/simulated/floor,
-/area/station/maintenance/southwest)
 "lzl" = (
 /obj/machinery/computer3/generic/radio,
 /obj/machinery/power/data_terminal,
@@ -42267,6 +42218,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
+"nfU" = (
+/obj/machinery/vending/standard,
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
 "njK" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -42300,6 +42255,13 @@
 	name = "tall grass"
 	},
 /area/station/garden/owlery)
+"nAt" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "nEX" = (
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
@@ -42393,10 +42355,6 @@
 	dir = 6
 	},
 /area/station/hallway/primary/south)
-"oma" = (
-/obj/machinery/vending/standard,
-/turf/simulated/floor,
-/area/station/maintenance/southwest)
 "omo" = (
 /obj/machinery/teleport/portal_ring,
 /obj/cable{
@@ -42510,6 +42468,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
+"oIp" = (
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
+"oLw" = (
+/obj/storage/closet/wardrobe/grey,
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
 "oMJ" = (
 /obj/lattice{
 	dir = 9;
@@ -42629,6 +42595,19 @@
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
+"pLc" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 8;
+	icon_state = "swampgrass_edge"
+	},
+/area/station/ranch)
 "pLv" = (
 /obj/cable{
 	d1 = 4;
@@ -42728,19 +42707,14 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/science/lobby)
-"qeb" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
+"qdy" = (
+/obj/stool/bed,
+/obj/landmark{
+	name = "NASSA spawn"
 	},
-/obj/railing/orange/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/grasstodirt{
-	dir = 8;
-	icon_state = "swampgrass_edge"
-	},
-/area/station/ranch)
+/obj/item/game_kit,
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
 "qfx" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -42824,6 +42798,13 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"qrl" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "qtM" = (
 /obj/cable{
 	d1 = 4;
@@ -42921,6 +42902,13 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"rei" = (
+/obj/item/rods{
+	amount = 10
+	},
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
 "rfL" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'Biohazard'";
@@ -43049,6 +43037,17 @@
 "skk" = (
 /turf/simulated/floor,
 /area/station/mining/staff_room)
+"slc" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 4
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "slP" = (
 /obj/machinery/door/airlock/pyro/security,
 /obj/access_spawn/hos,
@@ -43153,16 +43152,6 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
-"sBT" = (
-/obj/machinery/camera{
-	c_tag = "Assistant Lounge";
-	dir = 8
-	},
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/maintenance/southwest)
 "sDe" = (
 /obj/cable{
 	d2 = 2;
@@ -43256,13 +43245,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"sWT" = (
-/obj/item/rods{
-	amount = 10
-	},
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor,
-/area/station/maintenance/southwest)
 "sXz" = (
 /obj/lattice{
 	dir = 2;
@@ -43336,6 +43318,13 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"tsm" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "txI" = (
 /obj/cable{
 	d1 = 4;
@@ -43383,19 +43372,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"tSM" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/railing/orange/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/grasstodirt{
-	dir = 4;
-	icon_state = "swampgrass_edge"
-	},
-/area/station/ranch)
 "tTO" = (
 /obj/grille/catwalk{
 	dir = 6
@@ -43491,6 +43467,13 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
+"upg" = (
+/obj/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/ranch)
 "upn" = (
 /obj/cable{
 	d1 = 1;
@@ -43616,6 +43599,10 @@
 	intact = 0
 	},
 /area/station/quartermaster/refinery)
+"uIe" = (
+/obj/item/raw_material/shard/glass,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "uMP" = (
 /obj/tree1,
 /turf/simulated/wall{
@@ -43690,6 +43677,19 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
+"vke" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/railing/orange/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 4;
+	icon_state = "swampgrass_edge"
+	},
+/area/station/ranch)
 "vkH" = (
 /obj/machinery/manufacturer/mining,
 /turf/simulated/floor/yellow/side,
@@ -43708,10 +43708,6 @@
 /turf/space,
 /turf/simulated/floor,
 /area/station/science/lab)
-"vue" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor,
-/area/station/maintenance/southwest)
 "vuf" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor,
@@ -43800,6 +43796,16 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
+"vYE" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/machinery/camera/ranch{
+	dir = 4
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "wfC" = (
 /obj/warp_beacon{
 	name = "Secure Hangar"
@@ -44231,10 +44237,6 @@
 /obj/access_spawn/engineering_atmos,
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
-"ykc" = (
-/obj/item/raw_material/shard/glass,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
 
 (1,1,1) = {"
 aaa
@@ -61371,8 +61373,8 @@ bkU
 blZ
 byW
 bCT
-gFd
-vue
+qdy
+oIp
 blZ
 aaa
 aaa
@@ -61674,7 +61676,7 @@ blZ
 bze
 bze
 bCU
-oma
+nfU
 bun
 aaa
 aaa
@@ -61976,7 +61978,7 @@ blZ
 bCi
 bze
 bze
-sWT
+rei
 bun
 aaa
 aaa
@@ -62277,8 +62279,8 @@ bqx
 bwD
 bCj
 bCU
-sBT
-lyT
+bKA
+oLw
 blZ
 aaa
 aaa
@@ -62578,7 +62580,7 @@ bis
 bqx
 blZ
 bun
-jRp
+hKD
 blZ
 blZ
 blZ
@@ -63786,7 +63788,7 @@ bis
 bis
 bGd
 bGd
-ipw
+erm
 bGd
 bGd
 bGd
@@ -64088,7 +64090,7 @@ bis
 bwB
 bGd
 bCS
-goS
+vYE
 bzJ
 bAA
 bGd
@@ -64390,7 +64392,7 @@ bvA
 btx
 bGd
 bAB
-jOh
+qrl
 bAB
 bAB
 bGd
@@ -64692,7 +64694,7 @@ bts
 bts
 bxw
 bAC
-qeb
+pLc
 bAC
 bAC
 bGd
@@ -64994,7 +64996,7 @@ bts
 bts
 bxw
 byh
-tSM
+vke
 byh
 byh
 bGd
@@ -65296,12 +65298,12 @@ bts
 tLJ
 bxx
 bAB
-cgn
-kxc
+nAt
+tsm
 bAB
 bGd
 bis
-ykc
+uIe
 blZ
 aaa
 aaa
@@ -65599,7 +65601,7 @@ bwE
 bGd
 bCS
 bAB
-eWY
+slc
 bAA
 bGd
 bis
@@ -65900,8 +65902,8 @@ bvB
 bwF
 bGd
 bGd
-ebF
-geh
+gNe
+upg
 bGd
 bGd
 bis

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -17314,6 +17314,16 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/blue/side{
 	dir = 8
 	},
@@ -17323,6 +17333,11 @@
 	dir = 4;
 	icon_state = "pipe-c";
 	name = "crematorium pipe"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -17342,6 +17357,11 @@
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
@@ -18310,47 +18330,46 @@
 /area/station/hallway/primary/west)
 "aOA" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
 /area/station/hallway/primary/west)
 "aOB" = (
+/obj/disposalpipe/segment/mail,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aOC" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/morgue{
-	name = "crematorium pipe"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aOD" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/west)
+/turf/simulated/floor,
+/area/station/maintenance/inner/central)
 "aOE" = (
 /obj/machinery/light,
 /turf/simulated/floor/carpet/arcade,
@@ -20313,13 +20332,9 @@
 	name = "Chief Engineer's Office"
 	})
 "aTe" = (
-/obj/item/wrench{
-	desc = "A wrench, but made of gold.  Isn't gold a little soft for that?";
-	icon_state = "gold_wrench";
-	name = "gold wrench"
-	},
 /obj/item/rcd_ammo,
 /obj/table/reinforced/auto,
+/obj/item/wrench/gold,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/eva{
 	name = "Chief Engineer's Office"
@@ -32862,6 +32877,9 @@
 	c_tag = "Hydroponics Office";
 	dir = 2
 	},
+/obj/submachine/cargopad{
+	name = "Botany Pad"
+	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "btv" = (
@@ -33241,11 +33259,25 @@
 /area/station/hydroponics/bay)
 "buq" = (
 /obj/table/auto,
+/obj/item/paper_bin,
+/obj/item/pen{
+	pixel_x = -7
+	},
+/obj/item/hand_labeler,
+/obj/item/screwdriver,
+/obj/item/reagent_containers/food/drinks/bowl,
+/obj/item/bee_egg_carton,
+/obj/item/bee_egg_carton,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "bur" = (
 /obj/table/auto,
 /obj/item/storage/box/beakerbox,
+/obj/item/reagent_containers/glass/water_pipe{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/device/camera_viewer/ranch,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "bus" = (
@@ -34411,12 +34443,19 @@
 	},
 /area/space)
 "bwD" = (
-/obj/storage/crate,
-/turf/simulated/floor,
-/area/station/hydroponics/bay)
+/obj/machinery/door/airlock/pyro/classic,
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "bwE" = (
 /obj/machinery/light,
-/obj/storage/crate,
+/obj/submachine/chicken_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn{
+	doants = 0
+	},
+/obj/item/reagent_containers/food/snacks/plant/corn{
+	doants = 0
+	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "bwF" = (
@@ -34801,14 +34840,14 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "bxw" = (
-/obj/storage/crate,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
+/turf/simulated/floor/grasstodirt{
+	icon_state = "swampgrass"
+	},
+/area/station/ranch)
 "bxx" = (
-/obj/disposalpipe/segment,
-/obj/storage/crate,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
+/area/station/ranch)
 "bxy" = (
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -35130,14 +35169,15 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/turret_protected/ai)
-"byg" = (
-/obj/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
 "byh" = (
-/obj/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
+/obj/railing/orange/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 4;
+	icon_state = "swampgrass_edge"
+	},
+/area/station/ranch)
 "byi" = (
 /obj/reagent_dispensers/watertank/big,
 /turf/simulated/floor/green,
@@ -35471,11 +35511,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
 "byW" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/storage/crate,
+/obj/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "byX" = (
@@ -35555,18 +35591,8 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bze" = (
-/obj/table/auto,
-/obj/item/paper_bin,
-/obj/item/pen{
-	pixel_x = -7
-	},
-/obj/item/hand_labeler,
-/obj/item/screwdriver,
-/obj/item/reagent_containers/food/drinks/bowl,
-/obj/item/bee_egg_carton,
-/obj/item/bee_egg_carton,
 /turf/simulated/floor,
-/area/station/hydroponics/bay)
+/area/station/maintenance/southwest)
 "bzf" = (
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/access_spawn/engineering_mechanic,
@@ -35803,10 +35829,12 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bzJ" = (
-/obj/machinery/door/airlock/pyro/classic,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -4
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "bzK" = (
 /obj/disposalpipe/junction{
 	dir = 4;
@@ -36175,25 +36203,25 @@
 /obj/cable,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
-"bAz" = (
-/obj/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
 "bAA" = (
-/turf/simulated/floor,
-/area/station/maintenance/southwest)
-"bAB" = (
-/obj/table/auto,
-/obj/item/wrench,
-/turf/simulated/floor,
-/area/station/maintenance/southwest)
-"bAC" = (
-/obj/stool/chair,
-/obj/item/raw_material/shard/glass{
-	icon_state = "shard3"
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg{
+	rand_pos = 0
 	},
-/turf/simulated/floor,
-/area/station/maintenance/southwest)
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
+"bAB" = (
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
+"bAC" = (
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 8;
+	icon_state = "swampgrass_edge"
+	},
+/area/station/ranch)
 "bAD" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -36491,21 +36519,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
-"bBl" = (
-/obj/rack,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/clothing/shoes/black,
-/obj/item/clothing/suit/fire,
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/glasses/sunglasses,
-/turf/simulated/floor,
-/area/station/maintenance/southwest)
-"bBm" = (
-/obj/item/tile,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
 "bBn" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -36535,10 +36548,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
-"bBo" = (
-/obj/item/raw_material/shard/glass,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
 "bBp" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4
@@ -36983,20 +36992,14 @@
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bCi" = (
-/obj/stool/bed,
-/obj/landmark{
-	name = "NASSA spawn"
-	},
-/obj/item/game_kit,
+/obj/table/auto,
+/obj/item/wrench,
 /turf/simulated/floor,
 /area/station/maintenance/southwest)
 "bCj" = (
-/obj/machinery/camera{
-	c_tag = "Assistant Lounge";
-	dir = 8
-	},
-/obj/stool/chair{
-	dir = 8
+/obj/stool/chair,
+/obj/item/raw_material/shard/glass{
+	icon_state = "shard3"
 	},
 /turf/simulated/floor,
 /area/station/maintenance/southwest)
@@ -37266,23 +37269,27 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bCR" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor,
+/obj/storage/crate,
+/turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bCS" = (
-/obj/machinery/vending/standard,
-/turf/simulated/floor,
-/area/station/maintenance/southwest)
+/obj/chicken_nesting_box,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "bCT" = (
-/obj/item/rods{
-	amount = 10
+/obj/rack,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/reagent_dispensers/foamtank,
+/obj/item/clothing/shoes/black,
+/obj/item/clothing/suit/fire,
+/obj/item/clothing/mask/gas/emergency,
+/obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor,
 /area/station/maintenance/southwest)
 "bCU" = (
-/obj/storage/closet/wardrobe/grey,
-/turf/simulated/floor,
+/obj/item/tile,
+/turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "bCV" = (
 /turf/simulated/wall/auto/supernorn,
@@ -38759,12 +38766,8 @@
 	},
 /area/station/solar/south)
 "bGd" = (
-/obj/item/rods{
-	amount = 10
-	},
-/obj/grille/steel,
-/turf/simulated/floor/plating,
-/area/station/maintenance/southwest)
+/turf/simulated/wall/auto/supernorn,
+/area/station/ranch)
 "bGe" = (
 /obj/item/clothing/under/misc/clown,
 /obj/item/clothing/shoes/clown_shoes,
@@ -40628,6 +40631,13 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
+"cgn" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "cjG" = (
 /obj/cable{
 	d1 = 1;
@@ -40823,6 +40833,13 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
+"ebF" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/ranch)
 "efc" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -40976,6 +40993,17 @@
 	dir = 8
 	},
 /area/station/hallway/primary/south)
+"eWY" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 4
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "eYy" = (
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
@@ -41123,6 +41151,13 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
+"geh" = (
+/obj/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/ranch)
 "gha" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail{
@@ -41149,6 +41184,16 @@
 /obj/machinery/light/runway_light/delay5,
 /turf/space,
 /area/space)
+"goS" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/machinery/camera/ranch{
+	dir = 4
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "gqo" = (
 /obj/machinery/door/airlock/pyro/security/alt,
 /obj/access_spawn/security,
@@ -41168,6 +41213,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
+"gFd" = (
+/obj/stool/bed,
+/obj/landmark{
+	name = "NASSA spawn"
+	},
+/obj/item/game_kit,
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
 "gJo" = (
 /obj/machinery/light{
 	dir = 8;
@@ -41420,6 +41473,13 @@
 	icon_state = "orange"
 	},
 /area/station/science/lobby)
+"ipw" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/ranch)
 "ivo" = (
 /obj/table/auto,
 /obj/machinery/light{
@@ -41648,6 +41708,13 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
+"jOh" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "jOp" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt,
 /obj/access_spawn/brig,
@@ -41662,6 +41729,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
+"jRp" = (
+/obj/item/rods{
+	amount = 10
+	},
+/obj/grille/steel,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 "jZO" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -41729,6 +41803,13 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
+"kxc" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "kxs" = (
 /obj/machinery/computer/barcode/qm/no_belthell{
 	dir = 4
@@ -41946,6 +42027,10 @@
 	dir = 1
 	},
 /area/station/mining/staff_room)
+"lyT" = (
+/obj/storage/closet/wardrobe/grey,
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
 "lzl" = (
 /obj/machinery/computer3/generic/radio,
 /obj/machinery/power/data_terminal,
@@ -42308,6 +42393,10 @@
 	dir = 6
 	},
 /area/station/hallway/primary/south)
+"oma" = (
+/obj/machinery/vending/standard,
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
 "omo" = (
 /obj/machinery/teleport/portal_ring,
 /obj/cable{
@@ -42639,6 +42728,19 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor,
 /area/station/science/lobby)
+"qeb" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 8;
+	icon_state = "swampgrass_edge"
+	},
+/area/station/ranch)
 "qfx" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -43051,6 +43153,16 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"sBT" = (
+/obj/machinery/camera{
+	c_tag = "Assistant Lounge";
+	dir = 8
+	},
+/obj/stool/chair{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
 "sDe" = (
 /obj/cable{
 	d2 = 2;
@@ -43144,6 +43256,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"sWT" = (
+/obj/item/rods{
+	amount = 10
+	},
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
 "sXz" = (
 /obj/lattice{
 	dir = 2;
@@ -43264,6 +43383,19 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"tSM" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/railing/orange/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 4;
+	icon_state = "swampgrass_edge"
+	},
+/area/station/ranch)
 "tTO" = (
 /obj/grille/catwalk{
 	dir = 6
@@ -43576,6 +43708,10 @@
 /turf/space,
 /turf/simulated/floor,
 /area/station/science/lab)
+"vue" = (
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor,
+/area/station/maintenance/southwest)
 "vuf" = (
 /obj/machinery/light/small/floor,
 /turf/simulated/floor,
@@ -44095,6 +44231,10 @@
 /obj/access_spawn/engineering_atmos,
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
+"ykc" = (
+/obj/item/raw_material/shard/glass,
+/turf/simulated/floor/plating,
+/area/station/maintenance/southwest)
 
 (1,1,1) = {"
 aaa
@@ -60927,11 +61067,11 @@ bun
 blZ
 blZ
 blZ
-aaa
-aaa
-aaa
-aaa
-aaa
+blZ
+blZ
+blZ
+blZ
+blZ
 aaa
 aaa
 aaa
@@ -61229,11 +61369,11 @@ bma
 bma
 bkU
 blZ
-aaa
-aap
-acF
-aaa
-aaa
+byW
+bCT
+gFd
+vue
+blZ
 aaa
 aaa
 aaa
@@ -61531,11 +61671,11 @@ bis
 bkW
 bqx
 blZ
-acK
-apU
-aaa
-aaa
-aaa
+bze
+bze
+bCU
+oma
+bun
 aaa
 aaa
 aaa
@@ -61833,11 +61973,11 @@ bjm
 bis
 bqx
 blZ
-aaa
-acK
-aaa
-aaa
-aaa
+bCi
+bze
+bze
+sWT
+bun
 aaa
 aaa
 aaa
@@ -62134,12 +62274,12 @@ bCG
 bjm
 bis
 bqx
+bwD
+bCj
+bCU
+sBT
+lyT
 blZ
-acK
-acK
-acv
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -62437,11 +62577,11 @@ bjm
 bis
 bqx
 blZ
-aas
-acK
-acK
-aaa
-aaa
+bun
+jRp
+blZ
+blZ
+blZ
 aaa
 aaa
 aaa
@@ -62739,14 +62879,14 @@ bjm
 bFu
 bFR
 blZ
+bCR
+bCR
+bCR
+bCR
 blZ
 blZ
 blZ
-aaa
-aaa
-aaa
-aaa
-aaa
+blZ
 aaa
 aaa
 aaa
@@ -63040,15 +63180,15 @@ bCI
 bjm
 bis
 bqx
-bxw
-bxw
-bxw
+bis
+bis
+bis
+bis
+bis
+bis
+bis
+bis
 blZ
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 bFh
@@ -63342,14 +63482,14 @@ bCJ
 bjm
 bis
 bot
-bxx
-bxx
-byW
-blZ
-blZ
-blZ
-blZ
-blZ
+bma
+bma
+bkU
+bis
+bis
+bis
+bis
+bis
 blZ
 acG
 acG
@@ -63644,14 +63784,14 @@ bDw
 bjm
 bis
 bis
+bGd
+bGd
+ipw
+bGd
+bGd
+bGd
 bis
 bis
-bqx
-blZ
-bAz
-bBl
-bCi
-bCR
 blZ
 aaa
 aaa
@@ -63893,10 +64033,10 @@ aJn
 aTx
 aKU
 aLW
-aLW
+aOB
 aNl
 aLW
-aOB
+aLW
 aLW
 aLW
 aLW
@@ -63946,15 +64086,15 @@ bov
 bjm
 bis
 bwB
-bis
-bis
-bqx
+bGd
+bCS
+goS
 bzJ
 bAA
-bAA
-bBm
-bCS
-bun
+bGd
+bis
+bis
+blZ
 aaa
 aaa
 bFh
@@ -64198,7 +64338,7 @@ aLX
 aMx
 aNm
 aNP
-aOC
+aPn
 aPn
 aPn
 aPn
@@ -64248,15 +64388,15 @@ btr
 bjm
 bvA
 btx
-btx
-bis
-bqx
-blZ
+bGd
 bAB
-bAA
-bAA
-bCT
-bun
+jOh
+bAB
+bAB
+bGd
+bis
+bis
+blZ
 aaa
 aaa
 bFh
@@ -64497,10 +64637,10 @@ aJo
 aYy
 aLX
 aLX
-aRX
+aOC
 aYy
 aYy
-aOD
+aYy
 aYy
 aYy
 aYy
@@ -64549,15 +64689,15 @@ bjo
 bts
 bts
 bts
-bze
-btB
-byg
-bqx
-blZ
+bts
+bxw
 bAC
-bBm
-bCj
-bCU
+qeb
+bAC
+bAC
+bGd
+bis
+bis
 blZ
 aaa
 aaa
@@ -64802,7 +64942,7 @@ rab
 aMz
 ayR
 azU
-azQ
+aEQ
 aBS
 aBS
 aBS
@@ -64851,15 +64991,15 @@ bjo
 btt
 bup
 bts
-bwD
-btB
+bts
+bxw
 byh
-bqx
-blZ
-bun
+tSM
+byh
+byh
 bGd
-blZ
-blZ
+bis
+bis
 blZ
 acG
 acG
@@ -65101,10 +65241,10 @@ aJo
 aKi
 awm
 awm
-axc
+axi
 ayR
 azU
-azU
+azP
 azU
 azU
 azU
@@ -65154,15 +65294,15 @@ btu
 buq
 bts
 tLJ
-btB
+bxx
+bAB
+cgn
+kxc
+bAB
+bGd
 bis
-bot
-bkU
-bis
-bBo
+ykc
 blZ
-acK
-acf
 aaa
 aaa
 bFh
@@ -65403,10 +65543,10 @@ aJo
 ayR
 awm
 awm
-axc
+axi
 ayR
 azT
-azU
+azP
 aCy
 aCy
 aGx
@@ -65456,15 +65596,15 @@ bts
 bur
 bts
 bwE
-btx
-byg
-bis
-bqx
+bGd
+bCS
+bAB
+eWY
+bAA
+bGd
 bis
 bis
 blZ
-acK
-aas
 ajz
 ajz
 bFh
@@ -65705,10 +65845,10 @@ aJo
 ayR
 aKY
 awm
-axc
-ayS
-azU
-azU
+azi
+aOD
+aBS
+aEY
 aCy
 aaa
 aaA
@@ -65758,15 +65898,15 @@ btv
 bus
 bvB
 bwF
-btx
-btx
-byX
-bzK
+bGd
+bGd
+ebF
+geh
+bGd
+bGd
 bis
 bis
 blZ
-bCV
-bCV
 bCV
 bCV
 aai

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -19291,7 +19291,6 @@
 	},
 /area/station/hallway/primary/east)
 "aQN" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -19299,6 +19298,7 @@
 	},
 /obj/machinery/door/airlock/pyro/security/alt,
 /obj/access_spawn/forensics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aQO" = (

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -7892,8 +7892,13 @@
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "arL" = (
-/obj/machinery/secscanner,
 /obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Pod Bay"
+	},
+/obj/machinery/secscanner{
+	pixel_y = 11
+	},
 /turf/simulated/floor/stairs{
 	dir = 1
 	},
@@ -8416,13 +8421,18 @@
 /turf/simulated/floor/delivery,
 /area/station/quartermaster/office)
 "asR" = (
-/obj/machinery/secscanner,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Pod Bay"
+	},
+/obj/machinery/secscanner{
+	pixel_y = 11
+	},
 /turf/simulated/floor/stairs{
 	dir = 1
 	},
@@ -13591,9 +13601,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/landmark/start{
-	name = "Engineer"
-	},
 /turf/simulated/floor/grime,
 /area/station/engine/substation/north)
 "aEU" = (
@@ -15340,15 +15347,7 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
 /obj/table/reinforced/auto,
-/obj/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
-	},
 /obj/item/clipboard,
 /obj/item/paper_bin,
 /obj/item/pen{
@@ -15356,6 +15355,10 @@
 	},
 /obj/item/stamp,
 /obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 4
+	},
+/obj/access_spawn/robotics,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -22295,16 +22298,9 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/west)
 "aXc" = (
-/obj/landmark/start{
-	name = "Engineer"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor,
-/area/station/engine/substation/west)
+/area/station/hallway/primary/east)
 "aXd" = (
 /obj/cable{
 	d1 = 1;
@@ -23849,9 +23845,6 @@
 	pixel_x = -24;
 	pixel_y = 0
 	},
-/obj/landmark/start{
-	name = "Engineer"
-	},
 /turf/simulated/floor,
 /area/station/engine/substation/east)
 "aZU" = (
@@ -24121,7 +24114,6 @@
 	},
 /area/station/medical/medbay/lobby)
 "bar" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -24131,6 +24123,7 @@
 	dir = 4
 	},
 /obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/maintenance/inner/central)
 "bas" = (
@@ -31601,12 +31594,6 @@
 	},
 /area/station/crew_quarters/courtroom)
 "bqq" = (
-/obj/machinery/ignition_switch{
-	id = "securitychamber";
-	name = "Solitary Sparker Switch";
-	pixel_x = -24;
-	pixel_y = 0
-	},
 /obj/item/wrench,
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -31828,19 +31815,6 @@
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor,
 /area/station/engine/storage)
-"bqR" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	brightness = 2;
-	dir = 4
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/grime,
-/area/station/engine/engineering)
 "bqS" = (
 /obj/shrub{
 	dir = 10;
@@ -32281,6 +32255,7 @@
 	dir = 4
 	},
 /obj/access_spawn/engineering,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "brS" = (
@@ -37067,12 +37042,6 @@
 "bCr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/atmos/highcap_storage)
-"bCs" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/machinery/door/airlock/pyro/engineering/alt,
-/obj/access_spawn/engineering_atmos,
-/turf/simulated/floor/grime,
-/area/station/atmos/highcap_storage)
 "bCt" = (
 /obj/cable{
 	d1 = 1;
@@ -37081,6 +37050,7 @@
 	},
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/access_spawn/engineering,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "bCu" = (
@@ -40838,14 +40808,6 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
-"efc" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
-/turf/simulated/floor/circuit/red,
-/area/station/turret_protected/AIsat)
 "efQ" = (
 /obj/cable{
 	d1 = 4;
@@ -41860,17 +41822,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
-"kKM" = (
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
 "kMs" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -42229,11 +42180,6 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
 "nlS" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
@@ -42506,13 +42452,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
-"oTV" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/circuit/red,
-/area/station/turret_protected/AIsat)
 "pcA" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
@@ -42602,6 +42541,9 @@
 	},
 /obj/railing/orange/reinforced{
 	dir = 8
+	},
+/obj/landmark/start{
+	name = "Rancher"
 	},
 /turf/simulated/floor/grasstodirt{
 	dir = 8;
@@ -42741,10 +42683,6 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "qgX" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -42861,7 +42799,6 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "qNg" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/access_spawn/engineering_atmos,
 /obj/firedoor_spawn,
@@ -43300,18 +43237,6 @@
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
-"tpk" = (
-/obj/machinery/door/firedoor/pyro,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/pyro/engineering/alt,
-/obj/access_spawn/engineering_atmos,
-/obj/firedoor_spawn,
-/turf/simulated/floor/grime,
-/area/station/atmos/highcap_storage)
 "tpV" = (
 /obj/shrub{
 	dir = 6
@@ -44227,7 +44152,6 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "yjg" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -44235,6 +44159,7 @@
 	},
 /obj/machinery/door/airlock/pyro/engineering/alt,
 /obj/access_spawn/engineering_atmos,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
 
@@ -64956,7 +64881,7 @@ aEY
 azU
 aVx
 aWr
-aXc
+aXL
 aXL
 aXL
 aXL
@@ -73459,7 +73384,7 @@ bBB
 qNg
 bDf
 bDf
-bCs
+qNg
 bER
 bFp
 bFP
@@ -73758,7 +73683,7 @@ bzi
 bAa
 buN
 bBC
-tpk
+yjg
 bDI
 gPo
 yjg
@@ -74047,7 +73972,7 @@ bnW
 boG
 boG
 bpZ
-bqR
+bnW
 brS
 bsM
 bCt
@@ -84592,8 +84517,8 @@ aYO
 aJC
 aRB
 aSr
-aVJ
 aJC
+aVJ
 bbY
 aJC
 aJC
@@ -84894,8 +84819,8 @@ aMf
 aJC
 aJC
 aJC
-kKM
 aJC
+aXc
 aJC
 aJC
 aJC
@@ -85196,8 +85121,8 @@ aPx
 aQf
 aQM
 aQM
-aVK
 aQM
+aVK
 bbZ
 aQf
 aQM
@@ -116635,7 +116560,7 @@ btl
 bul
 bvy
 kWD
-efc
+bGF
 bFg
 pNA
 bzH
@@ -119663,7 +119588,7 @@ kWD
 bGF
 bGF
 bGF
-oTV
+bGF
 bEa
 qgX
 bGF

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -1258,7 +1258,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/item/remote/porter/port_a_sci,
 /obj/machinery/light,
 /turf/simulated/floor/orangeblack/side/white,
 /area/station/science/teleporter)
@@ -2099,6 +2098,7 @@
 	},
 /obj/item/disk/data/tape/master/readonly,
 /obj/table/auto,
+/obj/item/remote/porter/port_a_sci,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
 "afy" = (
@@ -4076,7 +4076,6 @@
 /area/station/science/bot_storage)
 "ajh" = (
 /obj/plasticflaps,
-/obj/firedoor_spawn,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/caution/northsouth,
 /area/station/science/bot_storage)
@@ -4765,6 +4764,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/landmark/artifact,
 /turf/simulated/floor/white/checker2{
 	dir = 4
 	},
@@ -5666,6 +5666,7 @@
 	dir = 8;
 	icon = 'icons/obj/doors/windoor.dmi'
 	},
+/obj/access_spawn/research_director,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "amv" = (
@@ -8264,7 +8265,6 @@
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
 "asB" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/table/reinforced/auto,
 /obj/cable{
 	d1 = 1;
@@ -8961,7 +8961,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "auh" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/access_spawn/head_of_personnel,
@@ -11092,8 +11091,9 @@
 	},
 /obj/machinery/door/window/westleft{
 	name = "Chapel Mass Driver";
-	req_access_txt = "22"
+	req_access_txt = null
 	},
+/obj/access_spawn/chapel_office,
 /turf/simulated/floor/plating,
 /area/station/chapel/sanctuary)
 "azp" = (
@@ -14233,8 +14233,8 @@
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aGg" = (
-/obj/machinery/light/runway_light/delay5,
-/turf/space,
+/obj/landmark/artifact,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "aGh" = (
 /obj/cable{
@@ -18194,6 +18194,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/ai_upload,
 /turf/simulated/floor,
 /area/station/turret_protected/ai_upload{
 	name = "AI Module Storage"
@@ -18804,7 +18805,6 @@
 	name = "AI Module Storage"
 	})
 "aPI" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -18812,6 +18812,7 @@
 	dir = 8
 	},
 /obj/access_spawn/ai_upload,
+/obj/firedoor_spawn,
 /turf/simulated/floor/caution/north,
 /area/station/turret_protected/ai_upload{
 	name = "AI Module Storage"
@@ -18884,10 +18885,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/access_spawn/maint,
 /obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/plating,
-/area/station/medical/morgue)
+/area/station/maintenance/west)
 "aPQ" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -18897,11 +18898,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "aPR" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/access_spawn/medical,
-/obj/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/medical/medbay)
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/medbay/surgery)
 "aPS" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/access_spawn/robotics,
@@ -18921,6 +18919,9 @@
 /area/station/medical/robotics)
 "aPU" = (
 /obj/machinery/recharge_station,
+/obj/landmark/start{
+	name = "Cyborg"
+	},
 /turf/simulated/floor/circuit,
 /area/station/medical/robotics)
 "aPV" = (
@@ -19138,7 +19139,7 @@
 	},
 /obj/access_spawn/morgue,
 /turf/simulated/floor/black,
-/area/station/medical/medbay)
+/area/station/medical/medbay/surgery)
 "aQv" = (
 /obj/cable{
 	d1 = 1;
@@ -19439,7 +19440,7 @@
 	},
 /obj/access_spawn/morgue,
 /turf/simulated/floor/black,
-/area/station/medical/medbay)
+/area/station/medical/medbay/surgery)
 "aRc" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -20087,8 +20088,9 @@
 	},
 /obj/machinery/door/window/southleft{
 	pixel_y = 2;
-	req_access_txt = "20"
+	req_access_txt = null
 	},
+/obj/access_spawn/captain,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "aSv" = (
@@ -20114,13 +20116,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
-"aSz" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aSA" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -20413,12 +20408,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/pharmacy)
 "aTn" = (
 /obj/cable{
 	d1 = 1;
@@ -20473,13 +20464,14 @@
 "aTr" = (
 /obj/machinery/door/window/eastleft{
 	name = "Operating Room";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/redwhite{
 	dir = 4
 	},
@@ -20739,17 +20731,39 @@
 	name = "Renovation Area"
 	})
 "aTW" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/table/auto,
+/obj/item/clothing/suit/straight_jacket{
+	pixel_x = -4;
+	pixel_y = 7
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/obj/item/clothing/suit/straight_jacket{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/blindfold{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/blindfold{
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/syringe/haloperidol{
+	pixel_x = 1;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/syringe/haloperidol{
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/syringe/haloperidol{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "aTX" = (
 /obj/cable{
 	d1 = 4;
@@ -20760,8 +20774,10 @@
 	dir = 8;
 	icon_state = "pipe-j1"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor/redwhite{
+	dir = 10
+	},
+/area/station/medical/medbay/pharmacy)
 "aTY" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -20772,8 +20788,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/pharmacy)
 "aTZ" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 2;
@@ -21045,20 +21061,20 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/maintenance/alt,
-/obj/access_spawn/maint,
-/obj/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/obj/machinery/door/airlock/pyro/medical/alt,
+/obj/access_spawn/morgue,
+/turf/simulated/floor/white,
+/area/station/medical/morgue)
 "aUz" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
 "aUA" = (
 /obj/machinery/door/window/southleft{
 	name = "Operating Room";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment,
+/obj/access_spawn/medical,
 /turf/simulated/floor/caution/south,
 /area/station/medical/medbay/surgery)
 "aUB" = (
@@ -21387,39 +21403,33 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aVf" = (
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
-/obj/storage/closet/emergency,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
-"aVg" = (
+/obj/disposalpipe/segment,
 /obj/machinery/chem_master,
-/turf/simulated/floor/red/corner{
-	dir = 8
+/turf/simulated/floor/white/checker{
+	dir = 9
 	},
+/area/station/medical/medbay/pharmacy)
+"aVg" = (
+/obj/table/reinforced/chemistry/beakers,
+/obj/item/device/reagentscanner,
+/obj/item/device/reagentscanner{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/pharmacy)
 "aVh" = (
-/obj/machinery/chem_dispenser,
-/turf/simulated/floor/white,
+/turf/simulated/floor/red,
 /area/station/medical/medbay/pharmacy)
 "aVi" = (
-/obj/machinery/chem_heater,
-/turf/simulated/floor/white,
+/turf/simulated/floor/redwhite{
+	dir = 10
+	},
 /area/station/medical/medbay/pharmacy)
 "aVj" = (
-/obj/machinery/light{
-	dir = 1
+/turf/simulated/floor/white/checker{
+	dir = 9
 	},
-/obj/machinery/camera{
-	c_tag = "Medical Research West";
-	dir = 2
-	},
-/obj/table/reinforced/chemistry/beakers,
-/obj/machinery/glass_recycler,
-/obj/item/storage/box/beakerbox,
-/turf/simulated/floor/white,
 /area/station/medical/medbay/pharmacy)
 "aVk" = (
 /obj/cable{
@@ -21431,37 +21441,49 @@
 	name = "N APC";
 	pixel_y = 24
 	},
-/obj/table/reinforced/chemistry/beakers,
-/obj/item/device/reagentscanner{
-	pixel_x = 12;
+/obj/rack,
+/obj/item/clothing/suit/bio_suit/paramedic{
+	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/device/reagentscanner,
-/turf/simulated/floor/white,
+/obj/item/clothing/suit/bio_suit/paramedic,
+/obj/item/storage/belt/medical{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/storage/belt/medical,
+/obj/item/clothing/glasses/healthgoggles{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/healthgoggles,
+/turf/simulated/floor/red/corner{
+	dir = 8
+	},
 /area/station/medical/medbay/pharmacy)
 "aVl" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/redwhite{
-	dir = 5
+/obj/machinery/chem_dispenser,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/red/corner{
+	dir = 8
 	},
 /area/station/medical/medbay/pharmacy)
 "aVm" = (
-/obj/machinery/vending/medical,
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+/obj/machinery/chem_heater,
+/obj/machinery/camera{
+	c_tag = "Medical Research West";
+	dir = 2
 	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/pharmacy)
 "aVn" = (
 /obj/machinery/light{
 	dir = 1;
 	pixel_x = -1
 	},
 /obj/disposalpipe/segment/morgue,
-/obj/stool/chair/comfy/wheelchair{
-	dir = 4
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aVo" = (
@@ -21718,18 +21740,6 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aVU" = (
-/obj/disposalpipe/junction{
-	icon_state = "pipe-j2"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
-"aVV" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -21738,8 +21748,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/obj/iv_stand,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "aVW" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -21749,13 +21760,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4
-	},
-/obj/access_spawn/medical,
-/obj/firedoor_spawn,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/area/station/medical/medbay)
 "aVX" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -21765,30 +21772,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/white/checker{
-	dir = 9
-	},
-/area/station/medical/medbay/pharmacy)
-"aVY" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/stool/chair/office/blue{
-	dir = 1;
-	icon_state = "office_chair_blue"
-	},
-/obj/landmark/start{
-	name = "Medical Doctor"
-	},
-/turf/simulated/floor/red/corner{
-	dir = 8
-	},
-/area/station/medical/medbay/pharmacy)
+/obj/machinery/vending/medical,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "aVZ" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -21799,7 +21785,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/pharmacy)
+/area/station/medical/medbay)
 "aWa" = (
 /obj/disposalpipe/junction{
 	dir = 8;
@@ -21811,12 +21797,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/pharmacy)
+/area/station/medical/medbay)
 "aWb" = (
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -21851,13 +21833,14 @@
 "aWe" = (
 /obj/machinery/door/window/southright{
 	name = "Medbay";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aWf" = (
@@ -22087,7 +22070,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/pharmacy)
+/area/station/medical/medbay)
 "aWD" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -22192,37 +22175,76 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 10
-	},
-/area/station/medical/medbay/pharmacy)
+/obj/storage/secure/closet/medical/medkit,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "aWO" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/surgery)
+"aWP" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"aWQ" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"aWR" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4
+	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"aWS" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/stool/chair/office/blue{
+	dir = 1;
+	icon_state = "office_chair_blue"
+	},
+/obj/landmark/start{
+	name = "Medical Doctor"
+	},
 /turf/simulated/floor/white/checker{
 	dir = 9
 	},
 /area/station/medical/medbay/pharmacy)
-"aWP" = (
-/turf/simulated/floor/red/corner{
-	dir = 8
-	},
-/area/station/medical/medbay/pharmacy)
-"aWQ" = (
-/turf/simulated/floor/white,
-/area/station/medical/medbay/pharmacy)
-"aWR" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/pharmacy)
-"aWS" = (
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay)
 "aWT" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/white,
@@ -22413,85 +22435,30 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aXq" = (
-/obj/rack,
-/obj/item/storage/box/stma_kit,
-/obj/item/clothing/suit/bio_suit/paramedic,
-/obj/item/clothing/suit/bio_suit/paramedic,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/item/clothing/glasses/healthgoggles,
-/obj/item/clothing/glasses/healthgoggles,
-/turf/simulated/floor/red,
-/area/station/medical/medbay/pharmacy)
-"aXr" = (
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/machinery/disposal/morgue,
-/obj/disposalpipe/trunk/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/redwhite{
-	dir = 10
-	},
-/area/station/medical/medbay/pharmacy)
-"aXs" = (
-/obj/machinery/door/window/southright{
-	name = "Medical Storage";
-	req_access_txt = "5"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/white/checker{
-	dir = 9
-	},
-/area/station/medical/medbay/pharmacy)
-"aXt" = (
-/obj/machinery/door/window/southleft{
-	name = "Medical Storage";
-	req_access_txt = "5"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/turf/simulated/floor/red/corner{
-	dir = 8
-	},
-/area/station/medical/medbay/pharmacy)
-"aXu" = (
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
 /obj/storage/secure/closet/medical/medkit,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/pharmacy)
+/area/station/medical/medbay)
+"aXr" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
+"aXu" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "aXv" = (
 /obj/disposalpipe/segment,
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/storage/secure/closet/medical/medkit,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/pharmacy)
+/area/station/medical/medbay)
 "aXw" = (
-/obj/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
-	},
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
@@ -22861,11 +22828,13 @@
 /area/station/bridge)
 "aYh" = (
 /obj/disposalpipe/segment{
-	dir = 4;
+	dir = 8;
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -22894,6 +22863,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/trunk/morgue{
+	dir = 4
+	},
+/obj/machinery/disposal/morgue,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aYl" = (
@@ -22935,12 +22908,13 @@
 "aYp" = (
 /obj/machinery/door/window/westright{
 	name = "Medbay";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-s"
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/specialroom/medbay{
 	dir = 2
 	},
@@ -23669,15 +23643,17 @@
 "aZF" = (
 /obj/machinery/door/window/northleft{
 	name = "Cyrogenics";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "aZG" = (
 /obj/machinery/door/window/northright{
 	name = "Cyrogenics";
-	req_access_txt = "5"
+	req_access_txt = null
 	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "aZH" = (
@@ -27612,9 +27588,6 @@
 	},
 /area/station/security/hos)
 "bhL" = (
-/obj/stool/chair/comfy/wheelchair{
-	dir = 8
-	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
 	},
@@ -28153,7 +28126,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/door/firedoor/pyro,
+/obj/firedoor_spawn,
 /obj/item/device/audio_log,
 /obj/access_spawn/security,
 /obj/machinery/door/airlock/pyro/glass/windoor,
@@ -28391,18 +28364,19 @@
 	name = "Upload Station"
 	})
 "bjx" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/landmark/start{
-	name = "Cyborg"
+/turf/simulated/floor/red/corner{
+	dir = 8
 	},
-/turf/simulated/floor/circuit/off,
-/area/station/turret_protected/AIbasecore1{
-	name = "Upload Station"
-	})
+/area/station/medical/medbay/pharmacy)
 "bjy" = (
 /obj/cable{
 	d1 = 1;
@@ -28779,9 +28753,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/landmark/start{
-	name = "Cyborg"
 	},
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/AIbasecore1{
@@ -31764,21 +31735,22 @@
 "bqL" = (
 /obj/machinery/door/window/westleft{
 	name = "Delivery";
-	req_access_txt = "34"
+	req_access_txt = null
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	location = "Engineering"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/engineering,
 /turf/simulated/floor/bot,
 /area/station/engine/storage)
 "bqM" = (
 /obj/machinery/door/window/eastright{
-	dir = 4;
 	name = "Engineering Delivery";
-	req_access_txt = "40"
+	req_access_txt = null
 	},
+/obj/access_spawn/engineering,
 /turf/simulated/floor/delivery,
 /area/station/engine/storage)
 "bqN" = (
@@ -32715,9 +32687,10 @@
 /obj/machinery/light/small,
 /obj/machinery/door/window/eastleft{
 	name = "Security";
-	req_access_txt = "1"
+	req_access_txt = null
 	},
 /obj/disposalpipe/segment,
+/obj/access_spawn/security,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "btd" = (
@@ -32770,16 +32743,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "btk" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	icon_state = "camera";
-	name = "autoname - SS13";
-	pixel_x = 0;
-	tag = ""
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/space,
-/area/space)
+/obj/machinery/door/airlock/pyro/maintenance/alt,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "btl" = (
 /obj/grille/steel,
 /turf/simulated/floor/plating/airless,
@@ -32883,9 +32855,10 @@
 	},
 /obj/machinery/door/window/northright{
 	name = "Delivery";
-	req_access_txt = "34"
+	req_access_txt = null
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/hydro,
 /turf/simulated/floor/bot,
 /area/station/hydroponics/bay)
 "btA" = (
@@ -32895,9 +32868,10 @@
 	},
 /obj/machinery/door/window/southleft{
 	name = "Hydroponics Delivery";
-	req_access_txt = "35"
+	req_access_txt = null
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/hydro,
 /turf/simulated/floor/delivery,
 /area/station/hydroponics/bay)
 "btB" = (
@@ -33181,15 +33155,11 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
 "buk" = (
-/obj/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 2.5;
-	name = "VACUUM AREA";
-	pixel_x = 0
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/sec)
+/obj/table/reinforced/chemistry/beakers,
+/obj/machinery/glass_recycler,
+/obj/item/storage/box/beakerbox,
+/turf/simulated/floor/red,
+/area/station/medical/medbay/pharmacy)
 "bul" = (
 /turf/simulated/wall/r_wall,
 /area/station/turret_protected/AIsat)
@@ -33691,91 +33661,57 @@
 	},
 /area/station/hangar/sec)
 "bvo" = (
-/obj/machinery/light{
-	dir = 1;
-	name = "light fixture"
-	},
 /turf/simulated/floor/stairs{
 	dir = 4
 	},
 /area/station/hangar/sec)
 "bvp" = (
-/turf/simulated/floor/caution/east,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/red/checker{
+	dir = 4
+	},
 /area/station/hangar/sec)
 "bvq" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "bvr" = (
-/obj/machinery/light{
-	dir = 1;
-	name = "light fixture"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "bvs" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
+/turf/simulated/floor/red/corner{
+	dir = 8
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
-"bvt" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
+/area/station/medical/medbay/pharmacy)
 "bvu" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1;
-	name = "light fixture"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
-"bvv" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24;
 	text = "NF"
 	},
+/obj/storage/closet/emergency,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"bvv" = (
+/obj/disposalpipe/segment,
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "bvw" = (
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/security_horizontal/vertical,
-/obj/forcefield/energyshield/perma{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
+/obj/lattice{
 	dir = 4;
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
 "bvx" = (
 /obj/lattice{
 	dir = 2;
@@ -34334,10 +34270,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/security/alt{
-	dir = 4
-	},
-/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
 "bwx" = (
@@ -34355,44 +34287,41 @@
 	},
 /area/station/hangar/sec)
 "bwy" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
 	},
 /turf/simulated/floor/stairs{
 	dir = 4
 	},
 /area/station/hangar/sec)
 "bwz" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/caution/east,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red/checker{
+	dir = 4
+	},
 /area/station/hangar/sec)
 "bwA" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
+/obj/stool/bed/moveable,
+/obj/item/clothing/suit/bedsheet,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "bwB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -34782,35 +34711,47 @@
 "bxr" = (
 /obj/rack,
 /obj/item/tank/air,
-/obj/item/tank/air,
-/obj/item/clothing/mask/breath,
 /obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/head/emerg,
-/turf/simulated/floor/delivery,
+/obj/item/clothing/head/emerg{
+	pixel_x = -3;
+	pixel_y = 16
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/red/checker{
+	dir = 4
+	},
 /area/station/hangar/sec)
 "bxs" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
 /obj/disposalpipe/segment,
-/turf/simulated/floor/caution/east,
+/turf/simulated/floor/red/checker{
+	dir = 4
+	},
 /area/station/hangar/sec)
 "bxt" = (
-/obj/machinery/vehicle/pod_smooth/heavy,
+/obj/machinery/door_control{
+	id = "hangar_security";
+	name = "Secure Bay Door Control";
+	pixel_x = 24
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "bxu" = (
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
+/obj/iv_stand,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "bxv" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
+/obj/storage/secure/closet/medical/anesthetic,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "bxw" = (
 /turf/simulated/floor/grasstodirt{
 	icon_state = "swampgrass"
@@ -35124,14 +35065,10 @@
 	},
 /area/station/solar/east)
 "bye" = (
-/obj/rack,
-/obj/item/tank/air,
-/obj/item/tank/air,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/head/emerg,
-/turf/simulated/floor/delivery,
+/obj/storage/closet/welding_supply,
+/turf/simulated/floor/red/checker{
+	dir = 4
+	},
 /area/station/hangar/sec)
 "byf" = (
 /obj/cable{
@@ -35416,68 +35353,80 @@
 /turf/simulated/floor/delivery,
 /area/station/hangar/sec)
 "byP" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	frequency = 1485;
-	name = "Security Intercom"
+/turf/simulated/floor/red/checker{
+	dir = 4
 	},
-/turf/simulated/floor/caution/east,
 /area/station/hangar/sec)
 "byQ" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light,
+/obj/machinery/vehicle/pod_smooth/heavy{
+	dir = 4
+	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
 "byR" = (
-/obj/machinery/door_control{
-	id = "hangar_main";
-	name = "Mechanic's Bay Door Control";
-	pixel_x = -24
-	},
-/obj/storage/closet/welding_supply,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
-"byS" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
-"byT" = (
-/obj/storage/crate,
-/obj/item/shipcomponent/mainweapon/taser,
-/obj/item/shipcomponent/mainweapon/taser,
-/obj/item/shipcomponent/secondary_system/tractor_beam,
-/obj/item/shipcomponent/secondary_system/tractor_beam,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
-"byU" = (
-/obj/machinery/door_control{
-	id = "hangar_security";
-	name = "Secure Bay Door Control";
-	pixel_x = 24
+/obj/disposalpipe/junction{
+	icon_state = "pipe-j2"
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
-"byV" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"byS" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"byT" = (
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/security_horizontal/vertical,
+/obj/forcefield/energyshield/perma{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
+"byU" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/medical/medbay)
+"byV" = (
+/obj/stool/bed/moveable,
+/obj/item/clothing/suit/bedsheet,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "byW" = (
 /obj/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -36142,15 +36091,18 @@
 /turf/unsimulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bAw" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	icon_state = "camera";
-	name = "autoname - SS13";
-	tag = ""
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/space,
-/area/space)
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/reagent_dispensers/foamtank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "bAx" = (
 /obj/machinery/networked/radio,
 /obj/machinery/power/data_terminal,
@@ -37228,6 +37180,9 @@
 /area/station/maintenance/southwest)
 "bCS" = (
 /obj/chicken_nesting_box,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "bCT" = (
@@ -40590,6 +40545,20 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
+"cfh" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red/checker{
+	dir = 4
+	},
+/area/station/hangar/sec)
 "cjG" = (
 /obj/cable{
 	d1 = 1;
@@ -40644,6 +40613,16 @@
 /obj/item/pen,
 /turf/simulated/floor/black,
 /area/station/security/brig)
+"cQm" = (
+/obj/storage/crate,
+/obj/item/shipcomponent/mainweapon/taser,
+/obj/item/shipcomponent/mainweapon/taser,
+/obj/item/shipcomponent/secondary_system/tractor_beam,
+/obj/item/shipcomponent/secondary_system/tractor_beam,
+/turf/simulated/floor/red/checker{
+	dir = 4
+	},
+/area/station/hangar/sec)
 "cVV" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 8;
@@ -40652,6 +40631,13 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/garden/owlery)
+"cXg" = (
+/obj/lattice,
+/obj/warp_beacon{
+	name = "Mining Pad"
+	},
+/turf/space,
+/area/space)
 "cZN" = (
 /obj/machinery/light{
 	dir = 8;
@@ -40785,6 +40771,10 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
+"ead" = (
+/obj/machinery/light,
+/turf/simulated/floor/shuttlebay,
+/area/station/quartermaster/refinery)
 "efQ" = (
 /obj/cable{
 	d1 = 4;
@@ -40967,6 +40957,9 @@
 "fcs" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light,
+/obj/landmark/start{
+	name = "Cyborg"
+	},
 /turf/simulated/floor/circuit,
 /area/station/medical/robotics)
 "fii" = (
@@ -41057,6 +41050,12 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
+"fUj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/quartermaster/refinery)
 "fUX" = (
 /obj/securearea{
 	desc = "";
@@ -41092,6 +41091,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
+"ghM" = (
+/turf/space,
+/turf/simulated/floor/shuttlebay,
+/area/station/quartermaster/refinery)
 "gjf" = (
 /obj/disposalpipe/switch_junction{
 	dir = 8;
@@ -41103,11 +41106,10 @@
 	},
 /area/station/science/lobby)
 "gjN" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
+/obj/warp_beacon{
+	name = "Secure Hangar"
 	},
-/obj/machinery/light/runway_light/delay5,
+/obj/lattice,
 /turf/space,
 /area/space)
 "gqo" = (
@@ -41129,6 +41131,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
+"gvK" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "gJo" = (
 /obj/machinery/light{
 	dir = 8;
@@ -41396,11 +41408,11 @@
 	},
 /area/station/science/lobby)
 "ivo" = (
-/obj/table/auto,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/machinery/manufacturer/hangar,
 /turf/simulated/floor,
 /area/station/hangar/science)
 "iAy" = (
@@ -41438,13 +41450,18 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "iCO" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
+/obj/grille/catwalk{
+	icon_state = "catwalk_cross"
 	},
-/turf/space,
-/turf/space,
-/area/space)
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/area/station/quartermaster/refinery)
 "iHi" = (
 /obj/grille/catwalk{
 	icon_state = "catwalk_cross"
@@ -41489,6 +41506,37 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
+"iSW" = (
+/obj/rack,
+/obj/item/tank/air,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/clothing/head/emerg{
+	pixel_x = -3;
+	pixel_y = 16
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/machinery/door_control{
+	id = "hangar_security";
+	name = "Secure Bay Door Control";
+	pixel_y = 24
+	},
+/turf/simulated/floor/red/checker{
+	dir = 4
+	},
+/area/station/hangar/sec)
+"iTB" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 6;
+	icon_state = "xtra_bigstripe-corner2"
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/red/checker{
+	dir = 4
+	},
+/area/station/hangar/sec)
 "iWu" = (
 /obj/cable{
 	d2 = 4;
@@ -41523,12 +41571,11 @@
 /turf/simulated/floor/grime,
 /area/station/science/lab)
 "jey" = (
-/obj/machinery/door/airlock/pyro/security/alt{
-	dir = 4
-	},
-/obj/access_spawn/security,
-/turf/simulated/floor/red,
-/area/station/hangar/sec)
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "jfc" = (
 /obj/cable,
 /obj/machinery/power/solar{
@@ -41658,6 +41705,14 @@
 	dir = 1
 	},
 /area/station/hallway/primary/west)
+"kcf" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar,
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/reagent_containers/food/drinks/fueltank,
+/turf/simulated/floor/red,
+/area/station/hangar/sec)
 "klQ" = (
 /obj/machinery/phone/wall{
 	pixel_x = 24;
@@ -41999,6 +42054,10 @@
 	dir = 4
 	},
 /area/station/mining/staff_room)
+"mdZ" = (
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor/shuttlebay,
+/area/station/quartermaster/refinery)
 "mgh" = (
 /obj/grille/catwalk,
 /obj/cable{
@@ -42170,6 +42229,14 @@
 /obj/item/clothing/mask/gas/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
+"nwq" = (
+/obj/lattice{
+	dir = 2;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space,
+/area/space)
 "nzf" = (
 /turf/simulated/wall{
 	desc = "Upon closer inspection, you see that this is a cleverly painted wall.";
@@ -42219,6 +42286,18 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
+"nOr" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "N APC";
+	pixel_y = 24
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/sec)
 "nWJ" = (
 /obj/cable{
 	d1 = 4;
@@ -42429,6 +42508,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
+"oWl" = (
+/obj/machinery/vehicle/pod_smooth/industrial{
+	dir = 4
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/quartermaster/refinery)
 "pcA" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
@@ -42447,6 +42532,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
+"pqA" = (
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/turf/space,
+/area/space)
 "ptL" = (
 /obj/lattice{
 	dir = 1;
@@ -42511,6 +42604,20 @@
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
+"pJD" = (
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	layer = 2
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	layer = 2
+	},
+/area/station/quartermaster/refinery)
 "pLc" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -42755,6 +42862,16 @@
 /obj/machinery/atmospherics/pipe/simple/junction,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
+"qEP" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6;
+	layer = 2
+	},
+/area/station/quartermaster/refinery)
 "qKF" = (
 /obj/cable{
 	d2 = 2;
@@ -42823,6 +42940,16 @@
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor,
 /area/station/maintenance/southwest)
+"rfa" = (
+/obj/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 2.5;
+	name = "VACUUM AREA";
+	pixel_x = 0
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/sec)
 "rfL" = (
 /obj/securearea{
 	desc = "A warning sign which reads 'Biohazard'";
@@ -43011,6 +43138,16 @@
 	layer = 2
 	},
 /area/station/solar/west)
+"spf" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	icon_state = "camera";
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/space,
+/area/space)
 "sqw" = (
 /obj/machinery/phone/wall{
 	pixel_y = -20
@@ -43109,6 +43246,10 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
+"sIC" = (
+/obj/machinery/light,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "sJD" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/engine,
@@ -43160,13 +43301,20 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "sXz" = (
-/obj/lattice{
-	dir = 2;
-	icon_state = "lattice-dir-b"
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/light/runway_light/delay5,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
+"sZG" = (
+/obj/machinery/manufacturer/hangar,
 /turf/space,
-/area/space)
+/turf/simulated/floor/shuttlebay,
+/area/station/quartermaster/refinery)
 "tbf" = (
 /obj/stool/chair/yellow{
 	dir = 8
@@ -43514,6 +43662,10 @@
 	name = "tall grass"
 	},
 /area/station/garden/owlery)
+"uPG" = (
+/turf/space,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/space)
 "uPW" = (
 /obj/cable{
 	d1 = 4;
@@ -43569,6 +43721,14 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
+/turf/space,
+/area/space)
+"viW" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir";
+	tag = "icon-lattice-dir (SOUTHEAST)"
+	},
 /turf/space,
 /area/space)
 "vjd" = (
@@ -43708,13 +43868,21 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"wfC" = (
-/obj/warp_beacon{
-	name = "Secure Hangar"
+"wdh" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	icon_state = "camera";
+	name = "autoname - SS13";
+	pixel_x = 0;
+	tag = ""
 	},
-/obj/lattice,
 /turf/space,
 /area/space)
+"wfC" = (
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "wfT" = (
 /obj/machinery/light,
 /turf/simulated/floor,
@@ -43758,13 +43926,23 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/armory)
 "wvT" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir-b"
+/obj/grille/catwalk{
+	dir = 9;
+	icon_state = "catwalk_cross"
 	},
-/turf/space,
-/turf/space,
-/area/space)
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9;
+	layer = 2
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9;
+	layer = 2
+	},
+/area/station/quartermaster/refinery)
 "wzk" = (
 /obj/table/auto,
 /obj/machinery/recharger,
@@ -43912,6 +44090,19 @@
 	dir = 9
 	},
 /area/station/mining/staff_room)
+"wUy" = (
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
+/area/station/quartermaster/refinery)
 "wYe" = (
 /obj/shrub{
 	dir = 1
@@ -43936,9 +44127,14 @@
 /turf/space,
 /area/space)
 "xkl" = (
-/obj/machinery/light,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/sec)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay)
 "xqE" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -43956,6 +44152,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"xtE" = (
+/turf/simulated/floor/shuttlebay,
+/area/station/quartermaster/refinery)
 "xvt" = (
 /obj/cable,
 /obj/wingrille_spawn/auto/crystal,
@@ -44026,6 +44225,14 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/science/lobby)
+"xQJ" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/sec)
 "xRw" = (
 /obj/machinery/sparker{
 	id = "tox_ignition2";
@@ -44054,6 +44261,7 @@
 /obj/grille/catwalk{
 	dir = 6
 	},
+/obj/landmark/artifact,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 2;
 	icon_state = "catwalk_cross";
@@ -46716,7 +46924,7 @@ apU
 aqg
 aqg
 aaA
-acF
+aaa
 aaa
 aaa
 aaa
@@ -47320,7 +47528,7 @@ alx
 aEP
 aas
 aas
-acF
+aaa
 aaa
 aaa
 aaa
@@ -47924,7 +48132,7 @@ apU
 aqg
 aqg
 aaA
-acF
+aaa
 aaa
 aaa
 aaa
@@ -53693,7 +53901,7 @@ aaa
 aaa
 aaa
 aaa
-acf
+aaa
 aaa
 acf
 aaa
@@ -53987,15 +54195,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-acK
 acK
 aaa
 aaa
-aaA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 acK
 apU
 aaa
@@ -54266,7 +54474,6 @@ azH
 aBr
 aaa
 aaa
-acf
 aaa
 aaa
 aaa
@@ -54289,15 +54496,16 @@ aaa
 aaa
 aaa
 aaa
+avq
+avq
+awR
 aaa
 aaa
 aaa
 aaa
-abZ
-acv
 aaa
 aaa
-aaA
+aaa
 acK
 apU
 aaa
@@ -54568,8 +54776,7 @@ azH
 aBr
 aaa
 azu
-awI
-aBr
+bIJ
 aaa
 aaa
 aaa
@@ -54588,11 +54795,12 @@ aaa
 aaa
 aaa
 aaa
+acf
 aaa
 aaa
 avq
-avq
-awR
+arN
+arN
 awR
 awR
 awR
@@ -54870,13 +55078,7 @@ azH
 aBr
 aaa
 azu
-azH
-aBr
-aaa
-aaa
-aaa
-aaa
-acf
+bIJ
 aaa
 aaa
 aaa
@@ -54888,13 +55090,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
 acf
+aaa
+aaa
+aaa
 aaa
 aaa
 avq
+avq
+avq
+avq
+avq
 arN
-arN
+sXz
 arN
 arN
 arN
@@ -55172,8 +55380,8 @@ azH
 aBr
 aaa
 azu
-azH
-aBr
+bIJ
+aaa
 aaa
 aaa
 aaa
@@ -55191,11 +55399,11 @@ awR
 awR
 avq
 avq
-aJS
-aaa
-acf
 avq
-arN
+bvu
+arO
+bAw
+aPb
 aYh
 aPb
 aZy
@@ -55474,8 +55682,8 @@ azH
 aBr
 aaa
 azu
-azH
-aBr
+bIJ
+aaa
 aaa
 aaa
 aaa
@@ -55492,13 +55700,13 @@ arN
 arN
 arN
 arN
-avq
-aaA
-aag
-acy
-avq
+aWP
+btk
+bvv
+byR
+aYh
 arN
-aYi
+arN
 aUH
 aUH
 bae
@@ -55776,10 +55984,10 @@ azH
 aBr
 aaa
 azu
-azH
-aBr
+bIJ
 aaa
-aJS
+aaa
+aaa
 aaa
 aaA
 avq
@@ -55794,19 +56002,19 @@ arN
 aOZ
 arN
 arN
-avq
-avq
-avq
-avq
-avq
+aOr
+bbN
 arN
-aYi
+byS
+aOZ
+arN
+arN
 aUH
 aZz
 aZe
 aZe
 aZe
-aPR
+aXp
 aYi
 arN
 avq
@@ -56096,13 +56304,13 @@ aPL
 aNE
 arN
 arN
+aOr
+aUH
+aUH
+byU
+aUH
+aUH
 arN
-avq
-aVf
-arO
-arN
-arN
-aYi
 aUH
 aZA
 aZe
@@ -56398,13 +56606,13 @@ aQW
 aNE
 aNE
 arN
-arN
-avq
-arN
-arN
+aWQ
+aUH
+bwA
+byV
 aTW
-aPb
-aTY
+aUH
+wfC
 aUH
 aZB
 baf
@@ -56700,13 +56908,13 @@ aQo
 aRM
 aNE
 arN
-aTW
-aUy
-aSz
+aOr
+aUH
+bxu
 aVU
-aTY
-avq
-avq
+aSE
+aUH
+aUH
 aUH
 aZC
 aUH
@@ -57003,11 +57211,11 @@ aRN
 aNE
 arN
 aOr
-bbN
-arN
-aVV
-aOZ
-aXp
+aUH
+bxv
+aVZ
+aSE
+jey
 aYj
 aZa
 aZD
@@ -57303,13 +57511,13 @@ aQo
 aQo
 aUi
 aNE
-arN
-aOr
 avq
-avq
+aWR
+aUH
+bae
 aVW
-avq
-avq
+bae
+bae
 aYk
 aSE
 aZE
@@ -57605,14 +57813,14 @@ aQr
 aQX
 aRO
 aSy
-aGl
+aVf
 aTX
-avq
+buk
 aVg
 aVX
 aWN
 aXq
-aYl
+xkl
 aSE
 aZF
 bah
@@ -57907,14 +58115,14 @@ aQT
 aQY
 aXF
 aNE
-arN
-aOr
-avq
+aVl
+aWS
+aVi
 aVh
-aVY
-aWO
+aVZ
+aSE
 aXr
-aYl
+gvK
 aSE
 aZG
 bai
@@ -58209,13 +58417,13 @@ aQV
 aRL
 aNE
 aNE
-arN
-aOr
-avq
+aVm
+bjx
+aVj
 aVi
 aVZ
-aWP
-aXs
+aSE
+aXu
 aYl
 aSE
 aZH
@@ -58509,21 +58717,21 @@ aPb
 aPP
 aQt
 aRa
-aPP
-aSz
+aUy
+aTm
 aTm
 aTY
-avq
+bvs
 aVj
 aVZ
-aWQ
-aXt
+aSE
+aXu
 aYl
 aSE
 baZ
 bak
 baP
-aSE
+baZ
 aSE
 avq
 arN
@@ -58808,17 +59016,17 @@ arN
 arN
 aOr
 arN
-aUH
+aPR
 aQu
 aRb
-aUH
-aUH
-aUH
-aUH
-aUH
+aPR
+aPR
+aWO
+aWO
+aPR
 aVk
 aWC
-aWQ
+aSE
 aXu
 ban
 baD
@@ -59110,7 +59318,7 @@ arN
 arN
 aOr
 arN
-aUH
+aPR
 aQZ
 aRc
 aRP
@@ -59118,9 +59326,9 @@ aSA
 aTn
 aUB
 aUA
-aVl
+aZb
 aWa
-aWR
+aZb
 aXv
 aYm
 aZb
@@ -59282,12 +59490,12 @@ aab
 aaa
 aaa
 aaa
-aGg
-aaa
-aGg
 aaa
 aaa
-aGg
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aac
@@ -59412,7 +59620,7 @@ aQv
 aNF
 aOt
 arN
-aUH
+aPR
 aSY
 aRd
 aRQ
@@ -59420,9 +59628,9 @@ aSB
 aTo
 aUa
 aNA
-aVm
+aSE
 aWb
-aWS
+baD
 aXw
 aYn
 aSE
@@ -59714,7 +59922,7 @@ aGl
 aGl
 aEz
 arN
-aUH
+aPR
 aTZ
 aRe
 aRR
@@ -59886,17 +60094,17 @@ aab
 aab
 aaa
 aaa
-aGg
 aaa
 aaa
 aaa
 aaa
 aaa
-aGg
 aaa
-aGg
 aaa
-aGg
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60199,7 +60407,7 @@ aaa
 aaa
 aaa
 aaa
-aGg
+aaa
 aaa
 aaa
 aad
@@ -60489,7 +60697,7 @@ aaa
 aaa
 aaa
 aaa
-aGg
+aaa
 aaa
 aaa
 aak
@@ -60502,9 +60710,9 @@ aaa
 aaa
 aaa
 aad
-aGg
 aaa
-aGg
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -60805,8 +61013,8 @@ aaa
 aaa
 aaa
 aaa
-aGg
-aGg
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -61106,9 +61314,9 @@ aao
 aaa
 aaa
 aaa
-aGg
-aGg
-aGg
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -64296,7 +64504,7 @@ bGd
 bAB
 qrl
 bAB
-bAB
+sIC
 bGd
 bis
 bis
@@ -64599,7 +64807,7 @@ bAC
 pLc
 bAC
 bAC
-bGd
+bxx
 bis
 bis
 blZ
@@ -64901,7 +65109,7 @@ byh
 vke
 byh
 byh
-bGd
+bxx
 bis
 bis
 blZ
@@ -65202,7 +65410,7 @@ bxx
 bAB
 nAt
 tsm
-bAB
+sIC
 bGd
 bis
 uIe
@@ -73688,7 +73896,7 @@ jhA
 tia
 tia
 kxs
-aaa
+acv
 aaa
 aaa
 aaa
@@ -73990,12 +74198,12 @@ tia
 ukm
 tia
 mNm
+apU
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+acf
 aaa
 aaa
 aaa
@@ -74292,13 +74500,13 @@ tia
 tia
 bIa
 snf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aas
+acG
+acG
+acG
+acG
+cXg
+acF
 aaa
 aaa
 aaa
@@ -74594,12 +74802,12 @@ tia
 tia
 bIa
 snf
+apU
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+ace
 aaa
 aaa
 aaa
@@ -74896,7 +75104,7 @@ tia
 tia
 bIa
 snf
-aaa
+acy
 aaa
 aaa
 aaa
@@ -75490,15 +75698,15 @@ adQ
 aaa
 aae
 bGU
-bGV
+bGU
 bGV
 bGV
 bGU
 bHO
 bHS
 bGU
-mNm
-mNm
+bGU
+bGU
 bGU
 acv
 aaa
@@ -75792,16 +76000,16 @@ adQ
 bIJ
 bIJ
 bIJ
-bIJ
-bIJ
-bIJ
+uPG
+ghM
+sZG
 wvT
 iCO
 iCO
-acy
-aaa
-aaa
-abZ
+wUy
+mdZ
+xtE
+acd
 acy
 aaa
 aaa
@@ -76090,20 +76298,20 @@ bCV
 acK
 acG
 acG
-acy
+apU
 bIJ
 bIJ
 bIJ
-bIJ
-bIJ
-bIJ
-bIJ
-bIJ
-bIJ
-aaa
-aaa
-aaa
-aaa
+pqA
+ghM
+ghM
+pJD
+bIB
+bIB
+qEP
+xtE
+xtE
+apU
 aaa
 aaa
 aaa
@@ -76392,20 +76600,20 @@ bCV
 aaa
 aaa
 aaa
+adQ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaA
+xtE
+xtE
+oWl
+xtE
+xtE
+xtE
+oWl
+xtE
+apU
 aaa
 aaa
 aaa
@@ -76691,24 +76899,24 @@ bAW
 bEl
 bAP
 bCV
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+acG
+acG
+acG
+aai
+acG
+acG
+viW
+aas
+xtE
+xtE
+xtE
+xtE
+xtE
+xtE
+xtE
+xtE
+aas
+acv
 aaa
 aaa
 aaa
@@ -76999,18 +77207,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaA
+acd
+fUj
+xtE
+xtE
+xtE
+xtE
+xtE
+xtE
+ead
+acd
+bCq
 aaa
 aaa
 aaa
@@ -77295,24 +77503,24 @@ bGl
 bGD
 bAP
 bCV
+acv
 aaa
 aaa
 aaa
 aaa
 aaa
+aaA
+acd
+acd
+aas
+acy
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abZ
+aas
+acd
+acd
+bCq
 aaa
 aaa
 aaa
@@ -77564,7 +77772,7 @@ aaa
 bht
 bhY
 biB
-bjx
+blw
 bkr
 blw
 blw
@@ -77597,24 +77805,24 @@ bAW
 bAP
 bAP
 bGs
+aas
+acG
+acG
+acG
+acG
+acG
+aai
+aai
+aai
+acy
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abZ
+aai
+aai
+acy
 aaa
 aaa
 aaa
@@ -77899,7 +78107,7 @@ bAW
 bAP
 bAP
 bGs
-aaa
+acy
 aaa
 bGQ
 bGQ
@@ -87844,8 +88052,8 @@ byE
 bpb
 mwp
 bns
-bCX
-jey
+kcf
+bvm
 bww
 bCX
 byd
@@ -88146,7 +88354,7 @@ bgL
 bzB
 bzG
 bns
-bCX
+cQm
 bvn
 bwx
 buj
@@ -88448,7 +88656,7 @@ bgL
 bgL
 bgL
 bgL
-buj
+bvo
 bvo
 bwy
 buj
@@ -88749,10 +88957,10 @@ bpF
 bgL
 apU
 aaa
-aaa
 buj
+iSW
 bvn
-bwx
+cfh
 bxr
 bye
 byO
@@ -89051,8 +89259,8 @@ bpG
 bgL
 acK
 aaa
-aaa
 buj
+iTB
 bvp
 bwz
 bxs
@@ -89353,11 +89561,11 @@ bkP
 bns
 apU
 aaa
-aaa
-buk
+buj
+buj
+nOr
+xQJ
 bvq
-bvt
-bxt
 bvq
 bvq
 buj
@@ -89658,7 +89866,7 @@ aaa
 aaa
 buj
 bvr
-bvt
+byQ
 bvq
 bvq
 byQ
@@ -89960,10 +90168,10 @@ ajz
 ajz
 buj
 bvq
-bvt
 bvq
 bvq
-byR
+bvq
+bvq
 buj
 aaa
 aaa
@@ -90260,13 +90468,13 @@ aaa
 aaa
 aaa
 aaa
-buj
-bvs
-bvt
+rfa
+bvq
+bvq
 bxt
 bvq
-byS
-buj
+bvq
+rfa
 aaa
 aaa
 aaa
@@ -90561,15 +90769,15 @@ bgL
 aaa
 aaa
 aaa
-aaa
-buk
-bvt
-bvt
-bvq
-bvq
+wdh
+buj
+byT
 byT
 buj
-aaa
+byT
+byT
+buj
+spf
 aaa
 aaa
 aaa
@@ -90864,13 +91072,13 @@ aaa
 aaa
 aaa
 aaa
-buj
-bvu
-bvt
-bxu
-bvq
-xkl
-buj
+abZ
+aai
+aai
+xZI
+aai
+aai
+acy
 aaa
 aaa
 aaa
@@ -91166,13 +91374,13 @@ aaa
 aaa
 aaa
 aaa
-buj
-bvv
-bwA
-bxv
-bxv
-byU
-buj
+aaa
+aaa
+aaa
+adQ
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91467,15 +91675,15 @@ aaa
 aaa
 aaa
 aaa
-btk
-buj
+aaa
+aaa
+aaa
+aaa
 bvw
-bvw
-bvw
-bvw
-byV
-buj
-bAw
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91770,13 +91978,13 @@ aaa
 aaa
 aaa
 aaa
-abZ
-aai
-aai
-xZI
-aai
-aai
-acy
+aaa
+aaa
+aaa
+adQ
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92075,7 +92283,7 @@ aaa
 aaa
 aaa
 aaa
-adQ
+bvw
 aaa
 aaa
 aaa
@@ -92376,9 +92584,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
+nwq
 gjN
-aaa
+xeP
 aaa
 aaa
 aaa
@@ -92679,7 +92887,7 @@ aaa
 aaa
 aaa
 aaa
-adQ
+uwR
 aaa
 aaa
 aaa
@@ -92981,7 +93189,7 @@ aaa
 aaa
 aaa
 aaa
-gjN
+aaa
 aaa
 aaa
 aaa
@@ -93282,9 +93490,9 @@ aaa
 aaa
 aaa
 aaa
-sXz
-wfC
-xeP
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93585,7 +93793,7 @@ aaa
 aaa
 aaa
 aaa
-uwR
+aaa
 aaa
 aaa
 aaa
@@ -113094,7 +113302,7 @@ aaa
 aaa
 aaa
 abZ
-acK
+aGg
 aeg
 aew
 aeQ


### PR DESCRIPTION
[MAPPING]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Buckle up, this is a fun one.

Big bad list of changes:
**Doors**
- Replaced all doors with pyro doors (better looking IMO)
- Gave all doors access spawners
- Removed as many old thindoors as possible, replacing some with new windoors
- Used new firedoor spawners
- Gave all (unless I missed any) old thindoors access spawners

**Security**
- Security proper is mostly untouched
- Little foyer area between Sec and Brig is now access locked

**Brig**
- The, ehm, "interrogation room" is now actually an interrogation room and not, uhhhhh, what it was before
- Security station with recharger and computers for ease of use
- Armory access door added near end of brig
- Solitary cell 2 moved slightly to accommodate armory access door
- Small storage area below brig
- Genpop now has a bathroom/shower.

**Armory**
- Armory now meets modern expectations, full equipment setup and interior defenses

**Medbay**
- Removed two patient rooms on north side of medbay
- Moved cloning into old patient rooms with an exit door into main hallway
- Added exit buttons on medbay main entrance
- Old cloning area is now a pharmacy/general area
- New patient room
- Changes make main medbay area much more open

**Mining**
- Completely rebuilt mining department
- New mining landing pad for pods

**Zeta**
- Toxins completely remade from the ground up
- Science hangar
- Rebuilt mail loop (doesn't support sending mail to station yet until I figure out what's wrong with that)
- Proper artifact ejector...I sure hope no one uses the OTHER ejector that ships stuff directly to QM....

**AI Satellite**
- Split into 3 areas: Perimeter defenses, satellite proper, and core
- Added all the computers AIs players enjoy having
- Added a foyer area with security station, teleporter, and cyborg charging docks

**General Station Changes**
- QM now has separate buy/sell conveyors
- Phones, everywheerreee
- Chapel touched up, added some gimmick stuff
- Maint behind/around the pool, arcade, and fitness room changed. Maint now goes behind all these rooms instead of through them
- Touched up fitness room slightly
- Added an owlery
- In the bridge, added an ID computer into the small room near the entrance for HoP use
- Cut out a couple walls around the singularity core so there's more space for engineers to work with
- Added some of the newer manufacturers people might want, like gas extractor in atmo and crate manufacturers in mining/qm
- Added a few more cargo teleporter pads and cargo teleporters
- Added a couple new pod warp beacons, definitely not so syndies have more than one beacon to warp to
- Added a couple more exterior airlocks to both the interior of the donut hole and exterior of the station
- Fixed a LOT of wiring issues the station had. Some areas were actually unpowered due to cut wires, some areas had redundant loops
- Replaced ALL large windows with new wingrille spawners. Cleans up real nice.
- Added airlocks into the main hallway. I don't like it but due to the way atmos works nowadays if a single tile was broken the entire hallway would vent. Sad, sad sad sad.
- Replaced ugly white walls of listening post with menacing (and less harsh on the eyes) gray walls
- Replaced Electrician spawners with Mechanic spawners (wow that's old)
- Changed arrival shuttle from eye melting white to gray
- Added Cryotron to arrival shuttle
- Split arrivals into two areas. Added a couple airlocks to hopefully prevent arrivals from being depressurized completely all the time
- Adds a ranch
- Moves AI reset module from tech storage to bridge

A few questions may arise like "why is this like that" and the answer will almost always be: That's how it was before and I didn't see fit to change it. I tried to retain a lot of the aspects that made donut 2 popular, a lot of the charm the old map had. Obviously some things just aren't the same as they were back when this map was live so we can't do things the exact same as we did before. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Donut 2 has been lacking some mapper love for a while now, even though it's technically playable (admin selection only) on the main servers. I wanted to bring it up to modern standards as well as possible. I don't intend for Donut 2 to re enter rotation (would be cool but I'm sure there's still issues that will crop up during play), just for it to be not a nightmare when an admin selects the map.


Map image (click image for full size)
![donut2](https://user-images.githubusercontent.com/71185626/111667999-43d09080-87e3-11eb-8fff-c1b8cb8c39c5.png)
