### PR TITLE
makes all cleanables set sampled to initial on pool

### DIFF
--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -96,6 +96,9 @@ proc/make_cleanable(var/type,var/loc,var/list/viral_list)
 
 		src.diseases.len = 0
 
+	pooled()
+		..()
+		src.sampled = initial(src.sampled) //I had to fix fire not resetting on magnesium, and now I find out sampled only resets on magnesium?
 
 	proc/process()
 		if (world.time > last_dry_start + dry_time)
@@ -1560,10 +1563,6 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 		var/turf/T = get_turf(src)
 		..()
 		updateSurroundingMagnesium(T)
-
-	pooled()
-		..()
-		src.sampled = 0 // stop fucking breaking butthead! >:(
 
 	Sample(var/obj/item/W as obj, var/mob/user as mob)
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes all cleanables set sampled to initial on pool, removing the effect where unpooling could lead to a cleanable that is unable to be sampled.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug bad.