### PR TITLE
bugfix for flashlight icons

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -337,6 +337,7 @@
 	execute_ability()
 		var/obj/item/device/light/flashlight/J = the_item
 		J.toggle()
+		src.icon_state = J.on ? "off" : "on"
 		..()
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes a minor issue where the ability button for regular flashlights wouldn't update to match the status of the flashlight.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugfix
