### PR TITLE
Adds Hi-Vis to CE, engi, and mechanic lockers.

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -151,6 +151,7 @@
 	/obj/item/device/multitool,
 	/obj/item/device/flash,
 	/obj/item/stamp/ce,
+	/obj/item/clothing/suit/hi_vis,
 #ifdef UNDERWATER_MAP
 	/obj/item/clothing/suit/space/diving/engineering,
 	/obj/item/clothing/head/helmet/space/engineer/diving,
@@ -523,7 +524,8 @@
 	/obj/item/deconstructor,
 	/obj/item/electronics/frame/mech_cabinet=2,
 	/obj/item/storage/mechanics/housing_handheld=1,
-	/obj/item/paper/manufacturer_blueprint/ai_status_display)
+	/obj/item/paper/manufacturer_blueprint/ai_status_display,
+	/obj/item/clothing/suit/hi_vis)
 
 /obj/storage/secure/closet/engineering/atmos
 	name = "\improper Atmospheric Technician's locker"
@@ -546,7 +548,8 @@
 	/obj/item/clothing/head/helmet/hardhat,
 	/obj/item/clothing/glasses/meson,
 	/obj/item/pen/infrared,
-	/obj/item/clothing/head/helmet/welding)
+	/obj/item/clothing/head/helmet/welding,
+	/obj/item/clothing/suit/hi_vis)
 
 /obj/storage/secure/closet/engineering/mining
 	name = "\improper Miner's locker"


### PR DESCRIPTION
[QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Simply adds the Hi-Vi vest to three types of lockers: The CE's locker, Engineer lockers, and Mechanic lockers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A way to consistently get Hi-Vis as engineering seems like a good idea. More unfashionable fashion choices for the engineering department.

## Changelog

```changelog
(u)DimWhat
(+)Added Hi-Vis to CE, mechanic, and engineer lockers. Safety first!
```
