### PR TITLE
nerfs Rathen's Secret

### DIFF
--- a/code/modules/events/gimmick/bigfart.dm
+++ b/code/modules/events/gimmick/bigfart.dm
@@ -91,7 +91,8 @@
 			ThrowRandom(B, dist = 6, speed = 1)
 		H.visible_message("<span class='alert'><b>[H]</b>'s [magical ? "arse" : "ass"] tears itself away from \his body[magical ? " in a magical explosion" : null]!</span>",\
 		"<span class='alert'>[changer ? "Our" : "Your"] [magical ? "arse" : "ass"] tears itself away from [changer ? "our" : "your"] body[magical ? " in a magical explosion" : null]!</span>")
-		H.changeStatus("weakened", 2 SECONDS)
+		if (!magical || prob(10))
+			H.changeStatus("weakened", 2 SECONDS)
 		severed_something = TRUE
 		H.force_laydown_standup()
 
@@ -157,7 +158,11 @@
 		boutput(H, "<span class='notification'>[changer ? "We" : "You"] hear an otherworldly force let out a short, disappointed cluck at [changer ? "our" : "your"] lack of an arse.</span>")
 	H.visible_message("<span class='alert'>[is_bot ? "Oily chunks of twisted shrapnel" : "Wadded hunks of blood and gore"] burst out of where <b>[H]</b>'s [magical ? "arse" : "ass"] used to be!</span>",\
 	"<span class='alert'>[nobutt_phrase[assmagic]]</span>")
-	H.changeStatus("weakened", 3 SECONDS)
+	if (!magical || prob(10))
+		H.changeStatus("weakened", 3 SECONDS)
+	else
+		H.lying = 1
+		H.update_lying()
 	H.force_laydown_standup()
 	if(!severed_something)
 		H.emote("scream")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [FEEDBACK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR nerfs the Rathen's Secret wizard spell to have a 10% chance to stun for 2 seconds and a 10% chance to stun for 3 seconds, otherwise knocking down the victim. The intended result is that Rathen's Secret loses the capability to combo, while retaining a crowd control effect.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Spell Combos are unfun, both to use and to fight.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Chickenish
(*)Rathen's Secret now only has a chance to stun, otherwise knocking down.
```
