### PR TITLE
should fix using humanized monkeys to farm souls

### DIFF
--- a/_std/macros/ismob.dm
+++ b/_std/macros/ismob.dm
@@ -16,6 +16,7 @@
 
 #define iscarbon(x) istype(x, /mob/living/carbon)
 #define ismonkey(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/monkey))
+#define isnpc(x) istype(x, /mob/living/carbon/human/npc)
 #define isnpcmonkey(x) (istype(x,/mob/living/carbon/human/npc/monkey) && istype(x:mutantrace, /datum/mutantrace/monkey))
 #define ishuman(x) istype(x, /mob/living/carbon/human)
 #define iscow(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/cow))

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2891,7 +2891,7 @@
 /mob/proc/sell_soul(var/amount, var/reduce_health=1, var/allow_overflow=0)
 	if(!src.mind)
 		return 0
-	if(isnpcmonkey(src))
+	if(isnpc(src))
 		return 0
 	if(allow_overflow)
 		amount = max(1, min(src.mind.soul, amount)) // can't sell less than 1

--- a/code/obj/machinery/navbeacon.dm
+++ b/code/obj/machinery/navbeacon.dm
@@ -204,7 +204,7 @@
 		interacted(user, 1)
 
 	attack_hand(var/mob/user)
-		if (isnpcmonkey(user))
+		if (isnpc(user))
 			return
 		interacted(user, 0)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes monkey souls AGAIN so that you really cannot steal them this time, even when turned into a human.

Also implements the macro isnpc() to supplement the already existing isnpcmonkey() macro.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugfix, restores intended balance of contracts.
