### PR TITLE
Lets doorpass creatures pass through interior doors

### DIFF
--- a/code/obj/machinery/door/window.dm
+++ b/code/obj/machinery/door/window.dm
@@ -102,6 +102,13 @@
 				return 1
 
 		if (get_dir(loc, target) == dir) // Check for appropriate border.
+			if(density && mover && mover.flags & DOORPASS && !src.cant_emag)
+				if (ismob(mover) && mover:pulling && src.bumpopen(mover))
+					// If they're pulling something and the door would open anyway,
+					// just let the door open instead.
+					return 0
+				animate_door_squeeze(mover)
+				return 1 // they can pass through a closed door
 			return !density
 		else
 			return 1
@@ -113,6 +120,13 @@
 				return 1
 
 		if (get_dir(loc, target) == dir)
+			if(density && mover && mover.flags & DOORPASS && !src.cant_emag)
+				if (ismob(mover) && mover:pulling && src.bumpopen(mover))
+					// If they're pulling something and the door would open anyway,
+					// just let the door open instead.
+					return 0
+				animate_door_squeeze(mover)
+				return 1 // they can pass through a closed door
 			return !density
 		else
 			return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes stuff like ghostdrones/mentor mice/ghost critters able to phase through interior doors/thindoors by copy-pasting the appropriate code over.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More consistent, drones and mentor mice should be able to access stuff like cog1's cryo tubes.
Closes #4072 