### PR TITLE
Change rancher cams to use autoname and autotag

### DIFF
--- a/code/obj/machinery/camera.dm
+++ b/code/obj/machinery/camera.dm
@@ -33,9 +33,10 @@
 	var/oldy = 0
 
 	ranch
-		name = "baby monitor"
+		name = "autoname"
 		network = "ranch"
 		color = "#AAFF99"
+		c_tag = "autotag"
 
 /obj/machinery/camera/process()
 	.=..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change rancher cams to use autoname and autotag from name baby monitor with no tag at all


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #4083