### PR TITLE
Increase tgui max-len linting rule from 80 to 120

### DIFF
--- a/tgui/.eslintrc.yml
+++ b/tgui/.eslintrc.yml
@@ -371,7 +371,7 @@ rules:
   # max-depth: error
   ## Enforce a maximum line length
   max-len: [error, {
-    code: 80,
+    code: 120,
     ## Ignore imports
     ignorePattern: '^(import\s.+\sfrom\s|.*require\()',
     ignoreUrls: true,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Increases `max-len` lint rule for tgui from 80 to 120.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- It is the Year of our Lord Two Thousand Twenty-One, 80 characters per line is only a reasonable limit if you are printing your code on paper. Making the code less easy to read when printed will discourage printing, therefore saving paper, indirectly saving our planet's ever-shrinking rainforests from additional destruction. You're welcome.
- JavaScript as a language has no official style guide, thereby imposing arbitrary restrictions is restricting the freedoms that our countries' Armed Forces fight and die for. We should not dishonor their service.
- PHP uses 120 as their maximum line length, only saying that lines *should* be 80 characters or less [(source)](https://www.php-fig.org/psr/psr-2/). If PHP developers are trusted with the power of 120 characters, anyone can be. 80 characters is like saying we can only use the [16 pack of RoseArt crayons](https://images-na.ssl-images-amazon.com/images/I/51M61u-bmVL._AC_.jpg) instead of the [24 pack of Crayola crayons](https://images-na.ssl-images-amazon.com/images/I/81FgpYo1rkL._AC_SL1500_.jpg).
- 120 characters is 50% characters more per line, meaning that developers are able to accomplish the same task in less lines of code. As we are paid per line of code, this is a cost-cutting measure that will slash expenses by over 33%. We could spend this money on hotdogs instead.
- 80 characters was originally the limit due to the number of bits punch cards could hold per row. You gonna let a typewriter tell you what to do?
- Making it harder to code on small screens will reduce the ratio of coding done on our phones while we're using the toilet. This will reduce the quantity of shitcode.