### PR TITLE
Fix RPG inhand not updating

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -929,6 +929,9 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 			src.item_state = "rpg7_empty"
 		else
 			src.item_state = "rpg7"
+		if (ishuman(src.loc))
+			var/mob/living/carbon/human/H = src.loc
+			H.update_inhands()
 
 	loaded
 		New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the RPG inhand not updating when fired.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug. Made it hard to tell it was safe to fight the RPG wielder.