### PR TITLE
Renames "Syndicate Robot Suit" to "Syndicate Robot Frame" in uplink

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -705,7 +705,7 @@ This is basically useless for anyone but miners.
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/robosuit
-	name = "Syndicate Robot Suit"
+	name = "Syndicate Robot Frame"
 	item = /obj/item/parts/robot_parts/robot_frame/syndicate
 	cost = 2
 	desc = "A cyborg shell crafted from the finest recycled steel and reverse-engineered microelectronics. A cyborg crafted from this will see only Syndicate operatives (Such as yourself!) as human. Cyborg also comes preloaded with popular game \"Angry About the Bird\" and is compatible with most headphones."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This renames the syndicate robot frame's name in the buylist from "Syndicate Robot Suit" to "Syndicate Robot Frame". This doesn't change the name of the syndicate robot frame item itself, just the name it goes by in the syndicate uplink!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Who calls the robot frame a "suit"? Does that mean a skeleton is a suit for humans? 

Also, the game usually uses "suit" to refer to clothing, so with the "Syndicate Robot Suit" name, a newbie might order this and think they're getting a power suit or something to wear, when they're actually getting a cyborg frame for someone else to inhabit. The "About" description already explains it's for creating cyborgs rather than making mecha, but renaming it clarifies it further.