### PR TITLE
Replaces cluwnespider milk with clownspider milk in prefab.

### DIFF
--- a/assets/maps/prefabs/prefab_clown_nest.dmm
+++ b/assets/maps/prefabs/prefab_clown_nest.dmm
@@ -17,7 +17,7 @@
 "mM" = (/obj/item/material_piece/cloth/spidersilk{pixel_x = 3; pixel_y = 2},/turf/simulated/floor/plating/airless/asteroid,/area/prefab/clown_nest)
 "om" = (/turf/simulated/floor/airless/solar,/area/noGenerate)
 "oz" = (/turf/simulated/wall/asteroid{name_old = "hardened"},/area/prefab/clown_nest)
-"oS" = (/obj/decal/cleanable/vomit/spiders,/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat{icon = 'icons/effects/blood.dmi'; icon_state = "gibhead"; name = "grody thing"},/obj/item/reagent_containers/food/drinks/milk/cluwnespider{pixel_x = 4; pixel_y = 4},/turf/simulated/floor/plating/airless/asteroid,/area/prefab/clown_nest)
+"oS" = (/obj/decal/cleanable/vomit/spiders,/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat{icon = 'icons/effects/blood.dmi'; icon_state = "gibhead"; name = "grody thing"},/obj/item/reagent_containers/food/drinks/milk/clownspider{pixel_x = 4; pixel_y = 4},/turf/simulated/floor/plating/airless/asteroid,/area/prefab/clown_nest)
 "pG" = (/obj/decal/cleanable/dirt/dirt3,/turf/simulated/floor/plating/airless/asteroid,/area/prefab/clown_nest)
 "rg" = (/obj/item/clothing/gloves/latex/pink{pixel_x = 3; pixel_y = 3},/obj/item/reagent_containers/food/drinks/milk/clownspider{layer = 2; pixel_x = -2; pixel_y = 5},/turf/simulated/floor/plating/airless/asteroid,/area/prefab/clown_nest)
 "rj" = (/obj/wingrille_spawn/auto/tuff,/turf/simulated/floor/airless/plating,/area/prefab/clown_nest)


### PR DESCRIPTION
[Mapping]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces cluwnespider milk with clownspider milk in the clownspider ranch prefab. I hated typing that sentence.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having a fairly easy to get source of painbow fluid is not that great. And with chem replication being easier to achieve, it's much more apparent that painbow fluid shouldn't be this easy to get your hands on. It should remain a lot more rare than this.
