### PR TITLE
Remove a few items from spy thief reward pool

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -780,7 +780,7 @@ This is basically useless for anyone but miners.
 	cost = 2
 	desc = "A box of shot glasses that hold WAAAY more that normal. Cheat at drinking games!"
 	job = list("Bartender")
-	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/vuvuzelagun
 	name = "Vuvuzela Gun"
@@ -872,7 +872,7 @@ This is basically useless for anyone but miners.
 	vr_allowed = 0
 	desc = "An add on to the genetics cloning pod that make anyone cloned loyal to whoever installed it."
 	job = list("Geneticist", "Medical Doctor", "Medical Director")
-	blockedmode = list(/datum/game_mode/revolution, /datum/game_mode/spy_theft)
+	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/deluxe_mindslave_module
 	name = "Deluxe Mindslave Cloning Module Kit"
@@ -890,7 +890,7 @@ This is basically useless for anyone but miners.
 	vr_allowed = 0
 	desc = "A device that allows PR-6S Guardbuddy units to use their internal charge to replenish kinetic ammunition."
 	job = list("Research Director")
-	blockedmode = list(/datum/game_mode/revolution, /datum/game_mode/spy_theft)
+	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/wiretap
 	name = "Wiretap Radio Upgrade"

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -481,7 +481,7 @@ This is basically useless for anyone but miners.
 	desc = "These big red boots have an explosive step sound. The entire station is sure to want to show you their appreciation."
 	job = list("Clown")
 	not_in_crates = 1
-	blockedmode = list(/datum/game_mode/spy)
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft)
 
 /datum/syndicate_buylist/traitor/clown_mask
 	name = "Clown Mask"
@@ -780,7 +780,7 @@ This is basically useless for anyone but miners.
 	cost = 2
 	desc = "A box of shot glasses that hold WAAAY more that normal. Cheat at drinking games!"
 	job = list("Bartender")
-	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/vuvuzelagun
 	name = "Vuvuzela Gun"
@@ -872,7 +872,7 @@ This is basically useless for anyone but miners.
 	vr_allowed = 0
 	desc = "An add on to the genetics cloning pod that make anyone cloned loyal to whoever installed it."
 	job = list("Geneticist", "Medical Doctor", "Medical Director")
-	blockedmode = list(/datum/game_mode/revolution)
+	blockedmode = list(/datum/game_mode/revolution, /datum/game_mode/spy_theft)
 
 /datum/syndicate_buylist/traitor/deluxe_mindslave_module
 	name = "Deluxe Mindslave Cloning Module Kit"
@@ -890,7 +890,7 @@ This is basically useless for anyone but miners.
 	vr_allowed = 0
 	desc = "A device that allows PR-6S Guardbuddy units to use their internal charge to replenish kinetic ammunition."
 	job = list("Research Director")
-	blockedmode = list(/datum/game_mode/revolution)
+	blockedmode = list(/datum/game_mode/revolution, /datum/game_mode/spy_theft)
 
 /datum/syndicate_buylist/traitor/wiretap
 	name = "Wiretap Radio Upgrade"
@@ -967,7 +967,7 @@ This is basically useless for anyone but miners.
 	item = /obj/item/storage/box/banana_grenade_kit
 	cost = 2
 	desc = "Honk."
-	blockedmode = list(/datum/game_mode/spy)
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft)
 
 /datum/syndicate_buylist/surplus/turboflash_box
 	name = "Flash/cell assembly box"

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -356,7 +356,7 @@ proc/build_syndi_buylist_cache()
 	cost = 12
 	vr_allowed = 0
 	desc = "A crate containing 18-24 credits worth of whatever junk we had lying around."
-	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
 
 	run_on_spawn(var/obj/storage/crate/syndicate_surplus/crate, var/mob/living/owner, in_surplus_crate)
 		crate.spawn_items(owner)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the following items from spy rewards: Boom Boots, Banana Grenade, Surplus Crate

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Boom Boots
This is a prestige traitor item. Syndicate Hat is blocked. Recently removed from surplus crates, Warcrimes confirmed these items shouldn't be devalued for the people who wish to buy them and flex.

Banana Grenades
Surplus crate only, very limited utility for a traitor item and redeeming them takes you closer to only getting payouts every other bounty.

Surplus crate
Way too much snowballing potential to be randomly available.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Removes the following items from spy rewards: Boom Boots, Banana Grenades, Surplus crate
```
