### PR TITLE
Remove some spy theft delivery areas

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -721,9 +721,15 @@
 	possible_areas = get_areas_with_unblocked_turfs(/area/station)
 	possible_areas += get_areas_with_unblocked_turfs(/area/diner)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/diner/tug)
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/medical/asylum)
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/security)
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/hangar/sec)
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/turret_protected)
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/ai_monitored/armory)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/maintenance)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/hallway)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/substation)
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/singcore)
 	possible_areas -= /area/sim/test_area
 
 	for (var/area/A in possible_areas)
@@ -731,7 +737,7 @@
 		if (A.virtual)
 			possible_areas -= A
 			break
-		if (A.name == "AI Perimeter Defenses" || A.name == "VR Test Area") //I have no idea what this "AI Perimeter Defenses" is, can't find it in code! All I know is that it's an area that the game can choose that DOESNT HAVE ANY TURFS
+		if (A.name == "AI Perimeter Defenses" || A.name == "VR Test Area" || A.name == "Ocean") //I have no idea what "AI Perimeter Defenses" or "Ocean" is, can't find it in code! All I know is that it's an area that the game can choose that DOESNT HAVE ANY TURFS
 			possible_areas -= A
 			break
 

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -722,14 +722,11 @@
 	possible_areas += get_areas_with_unblocked_turfs(/area/diner)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/diner/tug)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/medical/asylum)					// Donut 3 Asylum
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/security/armory)					// Cog1 armory
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/ai_monitored/armory)			// Other map armorys...
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/turret_protected/ai)			// AI core
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/turret_protected/AIsat)	// AI satellite
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/maintenance)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/hallway)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/substation)
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/core)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/singcore)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/combustion_chamber)
 	possible_areas -= /area/sim/test_area

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -721,15 +721,17 @@
 	possible_areas = get_areas_with_unblocked_turfs(/area/station)
 	possible_areas += get_areas_with_unblocked_turfs(/area/diner)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/diner/tug)
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/medical/asylum)
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/security)
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/hangar/sec)
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/turret_protected)
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/ai_monitored/armory)
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/medical/asylum)			// Donut 3 Asylum
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/security/hos)
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/security/armory)			// Cog1 armory
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/ai_monitored/armory)	// Other map armorys...
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/turret_protected)		// AI secure areas
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/maintenance)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/hallway)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/substation)
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/core)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/singcore)
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/combustion_chamber)
 	possible_areas -= /area/sim/test_area
 
 	for (var/area/A in possible_areas)

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -721,11 +721,11 @@
 	possible_areas = get_areas_with_unblocked_turfs(/area/station)
 	possible_areas += get_areas_with_unblocked_turfs(/area/diner)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/diner/tug)
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/medical/asylum)			// Donut 3 Asylum
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/security/hos)
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/security/armory)			// Cog1 armory
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/ai_monitored/armory)	// Other map armorys...
-	possible_areas -= get_areas_with_unblocked_turfs(/area/station/turret_protected)		// AI secure areas
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/medical/asylum)					// Donut 3 Asylum
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/security/armory)					// Cog1 armory
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/ai_monitored/armory)			// Other map armorys...
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/turret_protected/ai)			// AI core
+	possible_areas -= get_areas_with_unblocked_turfs(/area/station/turret_protected/AIsat)	// AI satellite
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/maintenance)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/hallway)
 	possible_areas -= get_areas_with_unblocked_turfs(/area/station/engine/substation)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes a number of spy areas that are unreasonably difficult to access.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There is no relationship between reward and area so you can be asked to deliver to the armory for a banana grenade. Maps are inconsistent in the difficulty of accessing areas and the usage of areas.

/area/station/medical/asylum
Outside of the clown room (which is not an asylum area) getting in and out of the asylum is a fair bit of tedious effort breaking walls/tables. This has very low chance of interacting with any crew and is just tedious. The clown room will still be selected as a destination so there will be occasional trips over there.

/area/station/turret_protected/ai
/area/station/turret_protected/AIsat
AI core areas that tend to be always monitored by AI viewports and have active turrets.
Maps vary significantly in these areas.

/area/station/engine/singcore
Yes, deliver to the singularity...

/area/station/engine/combustion_chamber
Yes, deliver to a raging inferno...


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Removed some spy delivery locations: Asylum, AI core, singularity core and combustion chamber.
```
