### PR TITLE
Locking Genebooth and Ruckingenur Kit

### DIFF
--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -462,6 +462,7 @@
 	anchored = 1
 	density = 1
 	//var/datum/electronics/electronics_items/link = null
+	req_access = list(access_heads)
 
 	var/processing = 0
 	var/net_id = null
@@ -586,6 +587,7 @@
 /obj/machinery/rkit/attack_hand(mob/user as mob)
 	src.add_fingerprint(user)
 	var/dat
+	var/hide_allowed = src.allowed(usr)
 	dat = "<b>Ruckingenur Kit</b><HR>"
 
 	dat += "<b>Scanned Items:</b><br>"
@@ -595,7 +597,12 @@
 		if (S.item_mats && src.olde)
 			dat += " * <A href='?src=\ref[src];op=\ref[S];tp=done'>Frame</A>"
 		else if (S.blueprint)
-			dat += " * <A href='?src=\ref[src];op=\ref[S];tp=blueprint'>Blueprint</A>"
+			if(!S.locked || hide_allowed)
+				dat += " * <A href='?src=\ref[src];op=\ref[S];tp=blueprint'>Blueprint</A>"
+			else
+				dat += " * Blueprint Disabled"
+		if(hide_allowed)
+			dat += " * <A href='?src=\ref[src];op=\ref[S];tp=lock'>[S.locked ? "Locked" : "Unlocked"]</A>"
 		dat += "</small><br>"
 	dat += "<br>"
 
@@ -636,6 +643,11 @@
 							SPAWN_DBG(2.5 SECONDS)
 								if (src)
 									new /obj/item/paper/manufacturer_blueprint(src.loc, M)
+
+			if("lock")
+				if(href_list["op"])
+					var/datum/electronics/scanned_item/O = locate(href_list["op"]) in mechanic_controls.scanned_items
+					O.locked = !O.locked
 
 		updateDialog()
 	else

--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -462,7 +462,7 @@
 	anchored = 1
 	density = 1
 	//var/datum/electronics/electronics_items/link = null
-	req_access = list(access_heads)
+	req_access = list(access_captain, access_head_of_personnel, access_maxsec, access_engineering_chief)
 
 	var/processing = 0
 	var/net_id = null

--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -597,7 +597,7 @@
 		if (S.item_mats && src.olde)
 			dat += " * <A href='?src=\ref[src];op=\ref[S];tp=done'>Frame</A>"
 		else if (S.blueprint)
-			if(!S.locked || hide_allowed)
+			if(!S.locked || hide_allowed || src.olde)
 				dat += " * <A href='?src=\ref[src];op=\ref[S];tp=blueprint'>Blueprint</A>"
 			else
 				dat += " * Blueprint Disabled"

--- a/code/datums/controllers/mechanic_controls.dm
+++ b/code/datums/controllers/mechanic_controls.dm
@@ -20,6 +20,7 @@ var/datum/mechanic_controller/mechanic_controls
 	var/item_type = ""
 	var/list/item_mats
 	var/finish_time = 0
+	var/locked = FALSE
 	var/datum/manufacture/mechanics/blueprint = null
 
 	proc

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -369,6 +369,8 @@
 				user.show_text("[target] is currently occupied. Wait until it's done.", "blue")
 				spamt = world.time
 				. = FALSE
+			if(.)
+				GB.show_admin_panel(user)
 
 	buildBackgroundIcon(atom/target, mob/user)
 		var/image/background = image('icons/ui/context32x32.dmi', src, "[getBackground(target, user)]0")

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -7,6 +7,7 @@
 	var/id = null
 	var/uses = 5
 	var/registered_sale_id = null
+	var/locked = FALSE
 
 	New(bioeffect, description, price, registered)
 		BE = bioeffect
@@ -41,6 +42,7 @@
 	density = 1
 	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
 	appearance_flags = TILE_BOUND | PIXEL_SCALE | LONG_GLIDE
+	req_access = list(access_heads)
 
 	var/letgo_hp = 50
 	var/mob/living/carbon/human/occupant = null
@@ -129,23 +131,24 @@
 			return
 
 		if (length(offered_genes))
-			user.show_text("Something went wrong, showing backup menu...", "blue")
 			var/list/names = list()
-
+			show_admin_panel(user)
 			for (var/datum/geneboothproduct/P as anything in offered_genes)
-				names += P.name
-
-			var/name_sel = input(user, "Offered Products", "Selection") as null|anything in names
-			if (!name_sel)
-				return
+				if(!P.locked)
+					names += P.name
+			if(length(names))
+				user.show_text("Something went wrong, showing backup menu...", "blue")
+				var/name_sel = input(user, "Offered Products", "Selection") as null|anything in names
+				if (!name_sel)
+					return
+				for (var/datum/geneboothproduct/P as anything in offered_genes)
+					if (name_sel == P.name)
+						select_product(P)
+						break
 			if(occupant && occupant != user)
 				user.show_text("There's someone else inside!")
 				return
 
-			for (var/datum/geneboothproduct/P as anything in offered_genes)
-				if (name_sel == P.name)
-					select_product(P)
-					break
 		else
 			user.show_text("[src] has no products available for purchase right now.", "blue")
 
@@ -155,10 +158,59 @@
 		src.contextActions = list()
 
 		for (var/datum/geneboothproduct/P as anything in offered_genes)
-			var/datum/contextAction/genebooth_product/newcontext = new /datum/contextAction/genebooth_product
-			newcontext.GBP = P
-			newcontext.GB = src
-			contextActions += newcontext
+			if(!P.locked)
+				var/datum/contextAction/genebooth_product/newcontext = new /datum/contextAction/genebooth_product
+				newcontext.GBP = P
+				newcontext.GB = src
+				contextActions += newcontext
+
+	proc/show_admin_panel(mob/user)
+		if(user && src.allowed(user))
+			if(length(offered_genes))
+				. = ""
+				for (var/datum/geneboothproduct/P as() in offered_genes)
+					. += "<u>[P.name]</u><small> "
+					. += " * Price: <A href='?src=\ref[src];op=\ref[P];action=price'>[P.cost]</A>"
+					. += " * <A href='?src=\ref[src];op=\ref[P];action=lock'>[P.locked ? "Locked" : "Unlocked"]</A></small><BR/>"
+
+			else
+				. += "[src] has no products available for purchase right now."
+			src.add_dialog(user)
+			user.Browse("<HEAD><TITLE>Genebooth Administrative Control Panel</TITLE></HEAD><TT>[.]</TT>", "window=genebooth")
+			onclose(user, "genebooth")
+
+	Topic(href, href_list)
+		if (usr.stat)
+			return
+		if ((in_interact_range(src, usr) && istype(src.loc, /turf)) || (issilicon(usr)))
+			var/datum/geneboothproduct/P
+			src.add_dialog(usr)
+
+			switch(href_list["action"])
+
+				if("price")
+					if(href_list["op"])
+						P = locate(href_list["op"])
+						var/price = input(usr, "Please enter price for [P.name].", "Gene Price", 0) as null|num
+						price = max(price,0)
+						P.cost = price
+
+				if("lock")
+					if(href_list["op"])
+						P = locate(href_list["op"])
+						if(P)
+							P.locked = !P.locked
+							if(!selected_product || selected_product.locked)
+								selected_product = null
+								just_pick_anything()
+								updateicon()
+							reload_contexts()
+
+			show_admin_panel(usr)
+		else
+			usr.Browse(null, "window=genebooth")
+			src.remove_dialog(usr)
+		return
 
 	proc/select_product(var/datum/geneboothproduct/P)
 		selected_product = P
@@ -170,6 +222,8 @@
 
 	proc/just_pick_anything()
 		for (var/datum/geneboothproduct/P as anything in offered_genes)
+			if(P.locked)
+				continue
 			selected_product = P
 			abilityoverlay = SafeGetOverlayImage("abil", P.BE.icon, P.BE.icon_state,src.layer + 0.1)
 			updateicon()

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -42,7 +42,7 @@
 	density = 1
 	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
 	appearance_flags = TILE_BOUND | PIXEL_SCALE | LONG_GLIDE
-	req_access = list(access_heads)
+	req_access = list(access_captain, access_head_of_personnel, access_maxsec, access_medical_director)
 
 	var/letgo_hp = 50
 	var/mob/living/carbon/human/occupant = null

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -9,6 +9,7 @@
 	density = 1
 	anchored = 1
 	mats = 20
+	req_access = list(access_heads)
 	event_handler_flags = NO_MOUSEDROP_QOL
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
 	flags = NOSPLASH
@@ -356,7 +357,9 @@
 				left: 0;
 				right: 0;
 				}
-
+			.product .delete {
+				color: #f66;
+				}
 			.required div {
 				position: absolute;
 				top: 0;
@@ -378,11 +381,16 @@
 			function product(ref) {
 				window.location = "?src=\ref[src];disp=" + ref;
 			}
+
+			function delete_product(ref) {
+				window.location = "?src=\ref[src];delete=1;disp=" + ref;
+			}
 		</script>
 		"}
 
 
 		var/list/dat = list()
+		var/delete_allowed = src.allowed(usr)
 
 		if (src.panelopen || isAI(user))
 			var/list/manuwires = list(
@@ -438,6 +446,7 @@
 
 		// Then make it
 		var/can_be_made = 0
+		var/delete_link
 		for(var/datum/manufacture/A in products)
 			var/list/mats_used = get_materials_needed(A)
 
@@ -447,6 +456,11 @@
 				continue
 
 			can_be_made = (mats_used.len >= A.item_paths.len)
+			if(delete_allowed && src.download.Find(A))
+				delete_link = {"<span class='delete' onclick='delete_product("\ref[A]");'>DELETE</span>"}
+
+			else
+				delete_link = ""
 
 			var/icon_text = "<img class='icon'>"
 			// @todo probably refactor this since it's copy pasted twice now.
@@ -479,9 +493,11 @@
 			<strong>[A.name]</strong>
 			<div class='required'><div>[material_text.Join("<br>")]</div></div>
 			[icon_text]
+			[delete_link]
 			<span class='mats'>[material_count] mat.</span>
 			<span class='time'>[A.time && src.speed ? round(A.time / src.speed / 10, 0.1) : "??"] sec.</span>
 		</div>"}
+
 
 		dat += "</div><div id='info'>"
 		dat += build_material_list(user)
@@ -646,7 +662,18 @@
 				if (src.action_bar)
 					src.action_bar.interrupt(INTERRUPT_ALWAYS)
 
-			if (href_list["disp"])
+			if (href_list["delete"])
+				if(!src.allowed(usr))
+					boutput(usr, "<span class='alert'>Access denied.</span>")
+					return
+				var/datum/manufacture/I = locate(href_list["disp"])
+				if (!istype(I,/datum/manufacture/mechanics/))
+					boutput(usr, "<span class='alert'>Cannot delete this schematic.</span>")
+					return
+				last_queue_op = world.time
+				if(alert("Are you sure you want to remove [I.name] from the [src]?",,"Yes","No") == "Yes")
+					src.download -= I
+			else if (href_list["disp"])
 				var/datum/manufacture/I = locate(href_list["disp"])
 				if (!istype(I,/datum/manufacture/))
 					return
@@ -675,13 +702,6 @@
 					src.begin_work(1)
 					src.updateUsrDialog()
 					return
-
-			/*if (href_list["delete"])
-				var/datum/manufacture/I = locate(href_list["disp"])
-				if (!istype(I,/datum/manufacture/mechanics/))
-					boutput(usr, "<span class='alert'>Cannot delete this schematic.</span>")
-					return
-				src.download -= I*/
 
 			if (href_list["ejectbeaker"])
 				var/obj/item/reagent_containers/glass/beaker/B = locate(href_list["ejectbeaker"])

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -358,7 +358,10 @@
 				right: 0;
 				}
 			.product .delete {
-				color: #f66;
+				color: #c44;
+				background: #222;
+				padding: 0.25em 0.5em;
+				border-radius: 10px;
 				}
 			.required div {
 				position: absolute;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature][balance][help wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Adds ability to disable printing of blueprints (on a per blueprint basis) on rkit, those with permission will get an additional option to lock/unlock or print directly. 
- Adds ability to remove downloaded (loaded through blueprint) schematics from fabricator, prompt is provided to ensure correct action is performed.
- Adds ability to disable specific mutations from genebooth, those with permission will get a separate dialog with options to adjust the price and lock/unlock.

- Access is gated using `allowed()` which makes it work without changing state of the device. (Input Wanted)
- Access is based on heads instead of Medical Director and CE. (Input Wanted)

Ruckingenur Kit
![Screenshot 2021-03-23 151723](https://user-images.githubusercontent.com/1017374/112228732-fc853e00-8bee-11eb-8db8-b69613a77170.png)

Fabricators
![Screenshot 2021-03-29 212545](https://user-images.githubusercontent.com/1017374/112933965-aaa05480-90d5-11eb-9b8a-8a74e8f680bd.png)
![Screenshot 2021-03-23 152029](https://user-images.githubusercontent.com/1017374/112228790-1757b280-8bef-11eb-9322-444437b4dd15.png)
![Screenshot 2021-03-29 212750](https://user-images.githubusercontent.com/1017374/112933969-ae33db80-90d5-11eb-8a87-3a4408a9a0e3.png)


Genebooth:
![Screenshot 2021-03-23 153727](https://user-images.githubusercontent.com/1017374/112228888-3a826200-8bef-11eb-8978-5cbafb43cd72.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gives Heads the ability to deal with undesirable genes and fabricated items non-destructively. 
Counter-play shenanigans is available by procuring sufficient access.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(*)Allows department head of staff to lock down output from Genebooth and Ruckingenur Kit.
(+)Department heads can now adjust price of Genebooth items as well as delete downloaded schematics from fabricators.
```
