### PR TITLE
Destiny Edits Part V

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -4142,11 +4142,14 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northeast)
 "aqc" = (
-/obj/machinery/light_switch/west{
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/gannets/maintenance{
+	name = "airlock-'Chapel'"
+	},
+/turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/grime,
-/area/station/chapel/office)
+/area/station/chapel/sanctuary)
 "aqd" = (
 /obj/stool/chair/wooden,
 /turf/simulated/floor/grass/random/alt,
@@ -4786,12 +4789,15 @@
 	name = "Crew Quarters M03"
 	})
 "asj" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
+/obj/wingrille_spawn/reinforced_crystal/full,
+/obj/cable{
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/carpet/grime,
-/area/station/chapel/office)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/chapel/sanctuary)
 "asl" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 1;
@@ -5222,6 +5228,14 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/rack,
+/obj/item/clothing/suit/fire,
+/obj/item/clothing/mask/gas/emergency,
+/obj/item/clothing/head/helmet/hardhat,
+/obj/item/tank/air,
+/obj/item/extinguisher,
+/obj/item/device/light/flashlight,
+/obj/item/device/light/flashlight,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/east{
 	name = "East Central Maintenance"
@@ -5297,16 +5311,18 @@
 	},
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/black,
-/area/station/hydroponics/bay)
+/area/station/hallway/primary/central)
 "aus" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/wingrille_spawn/reinforced_crystal/full,
+/obj/cable{
+	icon_state = "0-4"
 	},
-/obj/decal/tile_edge/line/green{
-	icon_state = "line1"
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
+/obj/cable,
+/turf/simulated/floor/plating/random,
+/area/station/chapel/sanctuary)
 "aut" = (
 /obj/decal/tile_edge/line/black{
 	dir = 4;
@@ -5330,18 +5346,15 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "auv" = (
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1
-	},
-/obj/machinery/portable_atmospherics/canister/air/large,
+/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/inner/west{
-	name = "West Central Maintenance"
-	})
+/area/station/chapel/sanctuary)
 "aux" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -5353,15 +5366,11 @@
 	},
 /area/station/engine/power)
 "auy" = (
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1
+/obj/machinery/launcher_loader/east,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
 	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/inner/east{
-	name = "East Central Maintenance"
-	})
+/area/station/chapel/sanctuary)
 "auC" = (
 /obj/stool/chair/wooden{
 	dir = 8
@@ -5442,13 +5451,8 @@
 	},
 /area/station/medical/medbay/treatment)
 "auO" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/inner/east{
-	name = "East Central Maintenance"
-	})
+/turf/simulated/wall/auto/reinforced/gannets,
+/area/station/chapel/sanctuary)
 "auP" = (
 /obj/wingrille_spawn/reinforced,
 /obj/cable{
@@ -6111,6 +6115,9 @@
 /obj/machinery/door/window/eastleft{
 	req_access_txt = "25"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "axJ" = (
@@ -6502,10 +6509,9 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "azw" = (
-/obj/noticeboard{
-	pixel_y = 32
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/item/instrument/large/organ,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
@@ -6624,7 +6630,7 @@
 "azZ" = (
 /obj/machinery/drone_recharger,
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/west{
@@ -7124,12 +7130,11 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "aBY" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/junction{
+	dir = 4
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
@@ -7200,12 +7205,14 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "aCo" = (
-/obj/machinery/mass_driver{
-	dir = 4;
-	drive_range = 100;
-	id = "chapelgun"
+/obj/wingrille_spawn/reinforced_crystal/full,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/obj/cable,
+/turf/simulated/floor/specialroom/chapel{
+	dir = 8
+	},
 /area/station/chapel/sanctuary)
 "aCp" = (
 /obj/machinery/camera{
@@ -7219,17 +7226,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "aCr" = (
-/obj/machinery/door/poddoor/pyro{
+/obj/machinery/conveyor{
 	dir = 4;
-	id = "chapelgun";
-	name = "Chapel Mass Driver"
+	id = "chapel"
 	},
-/obj/machinery/mass_driver{
-	dir = 4;
-	drive_range = 100;
-	id = "chapelgun"
-	},
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "aCs" = (
 /obj/stool/chair/wooden,
@@ -7243,10 +7244,14 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "aCu" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/light/incandescent/cool{
+	dir = 1;
+	nostick = 1
 	},
 /obj/machinery/portable_atmospherics/canister/air/large,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/west{
 	name = "West Central Maintenance"
@@ -7362,9 +7367,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "aCU" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/stool/chair/wooden{
+	dir = 1
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -7453,16 +7457,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/atmos/highcap_storage)
 "aDj" = (
-/obj/cable{
-	icon_state = "2-4"
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 100;
+	id = "chapelgun"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/inner/west{
-	name = "West Central Maintenance"
-	})
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "aDn" = (
 /obj/machinery/vending/medical,
 /obj/decal/tile_edge/line/white{
@@ -7852,17 +7853,24 @@
 /turf/simulated/floor/purple,
 /area/station/medical/cdc)
 "aFe" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/door/poddoor/pyro{
+	dir = 4;
+	id = "chapelgun";
+	name = "Chapel Mass Driver"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Chapel'"
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 100;
+	id = "chapelgun"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/inner/east{
-	name = "East Central Maintenance"
-	})
+/area/station/chapel/sanctuary)
 "aFm" = (
 /obj/decal/poster/wallsign/portrait_scientist{
 	pixel_y = 32
@@ -8228,16 +8236,10 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "aGq" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
-	},
+/obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/inner/east{
-	name = "East Central Maintenance"
+/area/station/maintenance/inner/west{
+	name = "West Central Maintenance"
 	})
 "aGs" = (
 /obj/cable{
@@ -8409,19 +8411,21 @@
 	},
 /area/station/engine/elect)
 "aGX" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/disposalpipe/segment,
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/light/incandescent/cool{
+	dir = 1;
+	nostick = 1
 	},
-/obj/machinery/door/airlock/gannets/morgue{
-	name = "airlock-'Chapel Office'";
-	req_access_txt = "22"
+/obj/machinery/conveyor_switch{
+	id = "chapel"
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/specialroom/chapel{
-	dir = 1
+	dir = 8
 	},
-/area/station/chapel/office)
+/area/station/chapel/sanctuary)
 "aHf" = (
 /obj/decal/tile_edge/stripe{
 	dir = 6;
@@ -9080,12 +9084,11 @@
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "aJB" = (
-/obj/disposalpipe/segment,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
@@ -15599,9 +15602,6 @@
 /area/station/engine/core)
 "btw" = (
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/specialroom/chapel{
@@ -18083,9 +18083,14 @@
 /turf/simulated/floor/black,
 /area/station/ai_monitored/storage/eva)
 "bHk" = (
-/obj/player_piano,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/specialroom/chapel{
-	dir = 4
+	dir = 1
 	},
 /area/station/chapel/sanctuary)
 "bHI" = (
@@ -18692,8 +18697,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "bZL" = (
-/turf/simulated/floor/black,
-/area/station/hydroponics/bay)
+/obj/item/instrument/large/organ,
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "bZX" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
@@ -19450,12 +19456,11 @@
 	},
 /area/station/turret_protected/Zeta)
 "cpo" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
@@ -20210,19 +20215,8 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "cJG" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/door/airlock/gannets/morgue/alt{
-	name = "airlock-'Crematorium'";
-	req_access_txt = "27"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/medical/crematorium)
+/turf/simulated/floor/carpet/grime,
+/area/station/chapel/office)
 "cJZ" = (
 /obj/lattice{
 	dir = 5;
@@ -20735,9 +20729,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "cUL" = (
-/obj/machinery/launcher_loader/east,
-/turf/simulated/floor/plating,
-/area/station/chapel/sanctuary)
+/obj/cable{
+	icon_state = "2-5"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/west{
+	name = "West Central Maintenance"
+	})
 "cUO" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -24064,13 +24065,6 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
 /obj/submachine/chicken_incubator,
 /obj/item/reagent_containers/food/snacks/ingredient/egg,
 /obj/machinery/light/incandescent/netural{
@@ -24078,6 +24072,10 @@
 	},
 /obj/machinery/camera/ranch{
 	dir = 1
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
@@ -25135,6 +25133,16 @@
 /obj/item/device/radio/intercom/security,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
+"eQn" = (
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/bar)
 "eQp" = (
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-M"
@@ -25773,6 +25781,9 @@
 	icon_state = "1-2"
 	},
 /obj/stool/chair/pew/fancy/left,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
@@ -26067,7 +26078,11 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/turf/simulated/floor,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	location = "QM #1"
+	},
+/turf/simulated/floor/bot,
 /area/station/quartermaster/office)
 "fkF" = (
 /obj/submachine/chicken_feed_grinder,
@@ -27802,6 +27817,9 @@
 	dir = 9;
 	icon_state = "xtra_bigstripe-corner2"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "gaP" = (
@@ -28398,6 +28416,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/gannets/glass{
 	name = "glass airlock-'Bar'"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
@@ -29603,7 +29624,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
-/area/station/hydroponics/bay)
+/area/station/hallway/primary/central)
 "gVT" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 4;
@@ -29657,14 +29678,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "gXg" = (
-/obj/rack,
-/obj/item/clothing/suit/fire,
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/head/helmet/hardhat,
-/obj/item/tank/air,
-/obj/item/extinguisher,
-/obj/item/crowbar,
-/obj/item/device/light/flashlight,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -29749,16 +29762,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "gZc" = (
-/obj/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/conveyor_switch{
-	id = "chapel"
-	},
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1
-	},
+/obj/player_piano,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
@@ -31749,15 +31753,12 @@
 	},
 /area/station/medical/medbay/treatment)
 "ifL" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/specialroom/chapel{
-	dir = 8
+	dir = 4
 	},
 /area/station/chapel/sanctuary)
 "igc" = (
@@ -32921,6 +32922,10 @@
 	},
 /area/station/crew_quarters/lounge/starboard)
 "iUK" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "fpurple5"
@@ -33286,17 +33291,20 @@
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "jgq" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "chapel"
+/obj/machinery/firealarm{
+	layer = 3.5;
+	pixel_y = 28
 	},
-/obj/machinery/door/window/westleft{
-	dir = 2;
-	name = "Chapel Mass Driver";
-	req_access_txt = "22"
+/obj/cable{
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/east{
+	name = "East Central Maintenance"
+	})
 "jgy" = (
 /obj/machinery/light{
 	dir = 8
@@ -35805,7 +35813,7 @@
 /area/station/hallway/secondary/entry)
 "kDO" = (
 /obj/disposalpipe/trunk{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/disposal/small{
 	dir = 8
@@ -38095,11 +38103,12 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
 "lRK" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "2-8"
 	},
-/turf/simulated/wall/auto/gannets,
-/area/station/crew_quarters/bar)
+/turf/simulated/floor/specialroom/chapel,
+/area/station/chapel/sanctuary)
 "lSk" = (
 /obj/submachine/ATM{
 	pixel_x = -32
@@ -42320,13 +42329,19 @@
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "oik" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/gannets/maintenance{
+	name = "airlock-'Chapel'"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/chapel/sanctuary)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
+	},
+/area/station/maintenance/inner/east{
+	name = "East Central Maintenance"
+	})
 "oiC" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -44699,17 +44714,6 @@
 	},
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
-"pAo" = (
-/obj/disposalpipe/trunk/mail{
-	dir = 1
-	},
-/obj/machinery/disposal/mail/small{
-	dir = 4;
-	mail_tag = "chapel";
-	name = "mail chute-'Chapel'"
-	},
-/turf/simulated/floor/carpet/grime,
-/area/station/chapel/office)
 "pBg" = (
 /turf/simulated/floor/yellow,
 /area/station/hallway/secondary/construction)
@@ -45847,9 +45851,6 @@
 /turf/simulated/floor/yellow,
 /area/station/hallway/secondary/construction)
 "qhZ" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/navbeacon/tour/destiny/tour2,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
@@ -46852,14 +46853,19 @@
 	},
 /area/station/crew_quarters/sauna)
 "qJg" = (
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1
+/obj/machinery/door/firedoor/border_only,
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/table/wood/round/auto,
-/obj/item/decoration/flower_vase,
-/turf/simulated/floor/specialroom/chapel,
-/area/station/chapel/sanctuary)
+/obj/machinery/door/airlock/gannets/morgue{
+	name = "airlock-'Chapel Office'";
+	req_access_txt = "22"
+	},
+/turf/simulated/floor/specialroom/chapel{
+	dir = 1
+	},
+/area/station/chapel/office)
 "qJu" = (
 /obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
@@ -47041,6 +47047,10 @@
 	},
 /obj/submachine/chem_extractor{
 	dir = 8
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
@@ -47872,9 +47882,13 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
+/obj/item/decoration/flower_vase,
+/obj/machinery/light/incandescent/cool{
+	dir = 1;
+	nostick = 1
+	},
+/obj/noticeboard{
+	pixel_y = 32
 	},
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
@@ -48057,15 +48071,15 @@
 	},
 /area/station/bridge)
 "ruj" = (
-/obj/disposalpipe/segment{
+/obj/machinery/light_switch/west{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
+/turf/simulated/floor/carpet/grime,
+/area/station/chapel/office)
 "ruC" = (
 /obj/item/storage/wall/fire{
 	pixel_y = 32
@@ -48171,8 +48185,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment,
 /obj/railing/orange/reinforced,
+/obj/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-y"
+	},
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "rxw" = (
@@ -48528,6 +48545,10 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "rGK" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "rGW" = (
@@ -48755,17 +48776,6 @@
 "rMl" = (
 /turf/simulated/wall/auto/reinforced/gannets,
 /area/station/engine/core)
-"rMt" = (
-/obj/morgue{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13"
-	},
-/turf/simulated/floor/black,
-/area/station/medical/crematorium)
 "rMN" = (
 /obj/lattice{
 	dir = 4;
@@ -48948,13 +48958,12 @@
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "rSR" = (
-/obj/stool/chair/wooden{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
 	},
-/turf/simulated/floor/specialroom/chapel{
-	dir = 8
-	},
-/area/station/chapel/sanctuary)
+/turf/simulated/floor/carpet/grime,
+/area/station/chapel/office)
 "rTc" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
@@ -49551,13 +49560,25 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge)
+"sjE" = (
+/obj/disposalpipe/trunk/mail{
+	dir = 1
+	},
+/obj/machinery/disposal/mail/small{
+	dir = 4;
+	mail_tag = "chapel";
+	name = "mail chute-'Chapel'"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/chapel/office)
 "skl" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/disposalpipe/segment,
-/obj/disposalpipe/segment/mail,
 /obj/machinery/door/airlock/gannets{
 	name = "airlock-'Ranch'";
 	req_access_txt = "83"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/ranch)
@@ -49629,7 +49650,7 @@
 	dir = 8
 	},
 /obj/disposalpipe/trunk{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
@@ -51862,7 +51883,7 @@
 "tBE" = (
 /obj/disposalpipe/segment/food,
 /turf/simulated/wall/auto/gannets,
-/area/station/hydroponics/bay)
+/area/station/hallway/primary/central)
 "tBK" = (
 /obj/decal/tile_edge/stripe,
 /obj/mic_stand,
@@ -53214,6 +53235,11 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	location = "Refinery"
+	},
+/obj/decal/mule/beacon,
 /turf/simulated/floor/grey,
 /area/station/mining/refinery)
 "ukc" = (
@@ -55391,16 +55417,15 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "vnG" = (
-/obj/cable{
-	icon_state = "1-8"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/gannets/glass/morgue/alt{
+	name = "glass airlock-'Mass Driver'";
+	req_access_txt = ""
 	},
-/obj/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/specialroom/chapel{
+	dir = 4
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/inner/east{
-	name = "East Central Maintenance"
-	})
+/area/station/chapel/sanctuary)
 "vnY" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -56725,15 +56750,19 @@
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "wfj" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/door/firedoor/border_only,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/door/airlock/gannets/morgue/alt{
+	name = "airlock-'Crematorium'";
+	req_access_txt = "27"
 	},
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/chapel/sanctuary)
+/turf/simulated/floor/black,
+/area/station/medical/crematorium)
 "wfk" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -57388,17 +57417,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "wwR" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Chapel'"
-	},
+/obj/wingrille_spawn/reinforced_crystal/full,
+/obj/cable,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/inner/east{
-	name = "East Central Maintenance"
-	})
+/area/station/chapel/sanctuary)
 "wxa" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -57677,16 +57702,16 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-y"
-	},
 /obj/machinery/light/incandescent/cool{
 	dir = 8;
 	nostick = 1
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
@@ -57726,11 +57751,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "wEA" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/morgue{
+	dir = 8
 	},
-/turf/simulated/wall/auto/gannets,
-/area/station/ranch)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
+	},
+/turf/simulated/floor/black,
+/area/station/medical/crematorium)
 "wEI" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -58133,7 +58163,7 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/delivery,
 /area/station/quartermaster/office)
 "wQT" = (
 /turf/simulated/wall/auto/reinforced/gannets,
@@ -59115,6 +59145,7 @@
 /obj/machinery/disposal/small{
 	dir = 4
 	},
+/obj/decal/mule/dropoff,
 /turf/simulated/floor/yellow,
 /area/station/mining/refinery)
 "xrW" = (
@@ -60195,6 +60226,7 @@
 "xVS" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "xVU" = (
@@ -60637,10 +60669,6 @@
 "yia" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	location = "QM #1"
 	},
 /turf/simulated/floor/bot,
 /area/station/quartermaster/cargobay)
@@ -100597,7 +100625,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aag
 aag
 aag
@@ -100898,9 +100926,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
-aaa
+aag
+aag
 aaa
 aaa
 aaa
@@ -101197,15 +101225,15 @@ alw
 alw
 fhk
 aaa
+aag
+aag
+aag
+aag
 aaa
 aaa
-aag
-aag
-aag
 aaa
 bkt
 aqq
-bkt
 bkt
 aGs
 xqm
@@ -101500,15 +101528,15 @@ alw
 fhk
 aaa
 aag
-aag
-aag
+aaa
 aaa
 aaa
 aaa
 bkt
-azZ
+bkt
+bkt
 aCu
-aDj
+ayV
 azi
 aMm
 aMm
@@ -101803,13 +101831,13 @@ aag
 aag
 aag
 aaa
-aaa
-aaa
+bkt
+aqq
 bkt
 bkt
-bkt
+aMm
 vEX
-auZ
+cUL
 azi
 aMm
 aMm
@@ -102106,8 +102134,8 @@ aaa
 aaa
 aaa
 bkt
-aqq
-bkt
+azZ
+aGq
 aMm
 ayV
 aJD
@@ -102408,7 +102436,7 @@ aaa
 bkt
 bkt
 bkt
-auv
+fEO
 aMm
 auZ
 azi
@@ -104849,7 +104877,7 @@ oWh
 lpP
 lut
 hjE
-awm
+eQn
 xVS
 qOm
 lPP
@@ -105449,11 +105477,11 @@ hqQ
 mTi
 erC
 goT
-lRK
+lbp
 rZZ
 aey
 eFI
-lRK
+lbp
 xNX
 axG
 ayu
@@ -105750,14 +105778,14 @@ vry
 qXK
 aDq
 aAx
-uSJ
+vry
 qhZ
 muN
 dGt
 apb
-ruj
-aox
 uSJ
+aox
+vry
 uSJ
 vmC
 wjb
@@ -106052,14 +106080,14 @@ arZ
 anI
 uSJ
 uSJ
-uSJ
 rVd
+arY
 wuX
 xWf
 mom
-vry
-xHw
 uSJ
+xHw
+vry
 uSJ
 uSJ
 wjb
@@ -106359,9 +106387,9 @@ anM
 awp
 aql
 tsT
-awp
-nuF
 arY
+nuF
+awp
 rsh
 tHD
 azR
@@ -109072,8 +109100,8 @@ kll
 kll
 bBQ
 atu
-bZL
-aus
+uSJ
+aup
 vtx
 dPn
 cue
@@ -109676,7 +109704,7 @@ efB
 asT
 iCk
 bDQ
-cor
+xeC
 gVO
 gVu
 sGK
@@ -109957,11 +109985,11 @@ xXH
 asY
 sok
 gXg
-qmN
-qJg
+aqc
+jfC
 wox
 jfC
-aou
+wox
 jfC
 aCQ
 rec
@@ -109970,7 +109998,7 @@ jcO
 wXU
 aMB
 ylC
-rMt
+wEA
 csz
 qPF
 kll
@@ -110259,19 +110287,19 @@ ast
 myX
 kbg
 dgv
-aAp
-aAp
+asj
+aCo
 wwR
-qmN
+aoV
 azw
-rSR
+aoV
 lsU
 aoW
 qQc
 cec
 wXU
 wXU
-cJG
+wfj
 wXU
 csz
 pLl
@@ -110561,20 +110589,20 @@ asF
 aAM
 aAM
 atY
-xXH
-xXH
+aus
+aCr
 vnG
-aAp
-bHk
 jfC
-aCQ
-rec
-qQc
+wox
+bZL
+ifL
+lRK
+qJg
 rGK
-aqc
-asj
+ruj
+rSR
 nsV
-pAo
+sjE
 csz
 sey
 wNu
@@ -110863,20 +110891,20 @@ aaa
 aaa
 aAM
 aAM
-aAM
+auv
 auy
 auO
-aAp
-qmN
+aGX
+bHk
 gZc
 aCU
-ifL
-aGX
+aoV
+qQc
 aJB
 cpo
 csb
 cyj
-rGK
+cJG
 csz
 dAT
 wNu
@@ -111165,14 +111193,14 @@ aag
 aaa
 aaa
 aaa
+auv
+aDj
+auO
 aAM
-aAM
-auV
-xXH
 oik
-jgq
-aou
-rec
+aAp
+aAp
+aAp
 qQc
 aJC
 aKx
@@ -111467,14 +111495,14 @@ aag
 aag
 aag
 aaa
-aaa
-aAM
-aAM
-aAM
-wfj
-cUL
-aAp
+azX
 aFe
+auO
+aAM
+auV
+xXH
+dgv
+aAO
 qQc
 qQc
 csL
@@ -111768,15 +111796,15 @@ alL
 ptc
 aaa
 aag
-aag
 aaa
 aaa
 aaa
 aaa
-wfj
-aCo
 aAM
-aGq
+aAM
+aAM
+jgq
+xXH
 dgv
 aAp
 aAp
@@ -112069,15 +112097,15 @@ alL
 alL
 ptc
 aaa
-aaa
 aag
 aag
 aag
 aag
 aaa
-azX
-aCr
+aaa
+aaa
 aAM
+asF
 aAM
 aJz
 xXH
@@ -112374,9 +112402,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
-aaa
+aag
+aag
 aaa
 aaa
 aaa
@@ -112677,7 +112705,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aag
 aag
 aag
@@ -114819,7 +114847,7 @@ aQM
 skl
 aQM
 aQM
-wEA
+aQM
 aQM
 tFQ
 tbc

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -4142,14 +4142,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northeast)
 "aqc" = (
-/obj/storage/closet/coffin,
-/obj/item/device/radio/intercom/security,
-/obj/machinery/light{
+/obj/machinery/light_switch/west{
 	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/bottle/hobo_wine,
-/turf/simulated/floor/black,
-/area/station/medical/crematorium)
+/turf/simulated/floor/carpet/grime,
+/area/station/chapel/office)
 "aqd" = (
 /obj/stool/chair/wooden,
 /turf/simulated/floor/grass/random/alt,
@@ -4789,16 +4786,12 @@
 	name = "Crew Quarters M03"
 	})
 "asj" = (
-/obj/morgue{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
+/obj/machinery/firealarm{
 	dir = 8;
-	name = "autoname  - SS13"
+	pixel_x = -28
 	},
-/turf/simulated/floor/black,
-/area/station/medical/crematorium)
+/turf/simulated/floor/carpet/grime,
+/area/station/chapel/office)
 "asl" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 1;
@@ -7230,6 +7223,11 @@
 	dir = 4;
 	id = "chapelgun";
 	name = "Chapel Mass Driver"
+	},
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 100;
+	id = "chapelgun"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/chapel/sanctuary)
@@ -10072,6 +10070,10 @@
 	})
 "aMB" = (
 /obj/storage/closet/coffin/wood,
+/obj/item/device/radio/intercom/security,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aMC" = (
@@ -19455,9 +19457,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light_switch/west{
-	dir = 4
-	},
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "cpv" = (
@@ -19639,10 +19638,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "csb" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -19872,10 +19867,6 @@
 /turf/simulated/floor/red,
 /area/station/science/lab)
 "cyj" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -20219,16 +20210,19 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "cJG" = (
-/obj/machinery/disposal/mail/small{
-	dir = 4;
-	mail_tag = "chapel";
-	name = "mail chute-'Chapel'"
+/obj/machinery/door/firedoor/border_only,
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/obj/disposalpipe/trunk/mail{
-	dir = 1
+/obj/machinery/door/airlock/gannets/morgue/alt{
+	name = "airlock-'Crematorium'";
+	req_access_txt = "27"
 	},
-/turf/simulated/floor/carpet/grime,
-/area/station/chapel/office)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/medical/crematorium)
 "cJZ" = (
 /obj/lattice{
 	dir = 5;
@@ -20904,6 +20898,10 @@
 /obj/decal/tile_edge/line/purple{
 	dir = 10;
 	icon_state = "line2"
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1;
+	name = "Mixing West"
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
@@ -23211,11 +23209,6 @@
 /turf/simulated/floor/purple,
 /area/station/science/research_director)
 "dZk" = (
-/obj/machinery/atmospherics/binary/pump{
-	icon_state = "intact_on";
-	on = 1;
-	target_pressure = 250
-	},
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
@@ -34668,6 +34661,7 @@
 /area/station/medical/medbay)
 "jUr" = (
 /obj/storage/closet/coffin,
+/obj/item/reagent_containers/food/drinks/bottle/hobo_wine,
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "jUN" = (
@@ -34995,6 +34989,9 @@
 	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/machinery/dispenser{
+	pltanks = 0
+	},
 /turf/simulated/floor,
 /area/station/science/lab)
 "kgw" = (
@@ -40835,19 +40832,15 @@
 	name = "Genetic Research"
 	})
 "nsV" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/door/airlock/gannets/morgue/alt{
-	name = "airlock-'Crematorium'";
-	req_access_txt = "27"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/medical/crematorium)
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/chapel/office)
 "ntz" = (
 /obj/stool/bar,
 /obj/landmark/start{
@@ -44706,6 +44699,17 @@
 	},
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
+"pAo" = (
+/obj/disposalpipe/trunk/mail{
+	dir = 1
+	},
+/obj/machinery/disposal/mail/small{
+	dir = 4;
+	mail_tag = "chapel";
+	name = "mail chute-'Chapel'"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/chapel/office)
 "pBg" = (
 /turf/simulated/floor/yellow,
 /area/station/hallway/secondary/construction)
@@ -48751,6 +48755,17 @@
 "rMl" = (
 /turf/simulated/wall/auto/reinforced/gannets,
 /area/station/engine/core)
+"rMt" = (
+/obj/morgue{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
+	},
+/turf/simulated/floor/black,
+/area/station/medical/crematorium)
 "rMN" = (
 /obj/lattice{
 	dir = 4;
@@ -109955,7 +109970,7 @@ jcO
 wXU
 aMB
 ylC
-eeV
+rMt
 csz
 qPF
 kll
@@ -110255,9 +110270,9 @@ aoW
 qQc
 cec
 wXU
-aqc
-ylC
-asj
+wXU
+cJG
+wXU
 csz
 pLl
 aZS
@@ -110556,10 +110571,10 @@ aCQ
 rec
 qQc
 rGK
-wXU
-wXU
+aqc
+asj
 nsV
-wXU
+pAo
 csz
 sey
 wNu
@@ -110861,7 +110876,7 @@ aJB
 cpo
 csb
 cyj
-cJG
+rGK
 csz
 dAT
 wNu


### PR DESCRIPTION
[mapping]

## About the PR 
Yup.
Fixes connector port in toxins
Revises chapel a little to make the space more usable.
Re-routes disposal pipes to be in-round fixable.
Extra MULE drop offs in Refinery and QM front office.

## Why's this needed?
No precision toxins mixing allowed currently. Scientists can have little a precision toxins mixing, as a treat.
Chapel revisions based on player feedback.