### PR TITLE
Avoid merging spliced genes in genebooth

### DIFF
--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -627,7 +627,7 @@
 			for_by_tcl(GB, /obj/machinery/genetics_booth)
 				var/already_has = 0
 				for (var/datum/geneboothproduct/P as anything in GB.offered_genes)
-					if (P.id == E.id)
+					if (P.id == E.id && P.name == E.name)
 						already_has = P
 						P.uses += 5
 						P.desc = booth_effect_desc


### PR DESCRIPTION
[bug][balance]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Spliced and Normal gene variants are treated as unique so will show up as separate items in the Gene Booth, allows them to be offered for different costs as well.
Increases value of stored genes as base versions can **not** be used to increase number of uses in genebooths (especially if it is spliced).
Overall increases value of spliced mutations.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows better management of spliced genes by treating them as unique items.
Current behavior requires geneticists have some understanding of this behavior or get stuck added uses to initial mutation.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(+)Spliced and normal mutations can now coexist in the Gene Booth.  Charge the crew accordingly.
```
