### PR TITLE
Makes glass recycler code prettier, makes a bunch of things unrecyclable

### DIFF
--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -434,6 +434,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 	initial_volume = 50
 	flags = FPRINT | OPENCONTAINER | SUPPRESSATTACK
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
+	can_recycle = 0
 	var/helmet_bucket_type = /obj/item/clothing/head/helmet/bucket
 	var/hat_bucket_type = /obj/item/clothing/head/helmet/bucket/hat
 	var/bucket_sensor_type = /obj/item/bucket_sensor

--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -139,7 +139,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 	icon_state = "null"
 	item_state = "null"
 	amount_per_transfer_from_this = 10
-	var/can_recycle = 1 //can this be put in a glass recycler?
+	var/can_recycle = TRUE //can this be put in a glass recycler?
 	var/splash_all_contents = 1
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | SUPPRESSATTACK
 
@@ -434,7 +434,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 	initial_volume = 50
 	flags = FPRINT | OPENCONTAINER | SUPPRESSATTACK
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
-	can_recycle = 0
+	can_recycle = FALSE
 	var/helmet_bucket_type = /obj/item/clothing/head/helmet/bucket
 	var/hat_bucket_type = /obj/item/clothing/head/helmet/bucket/hat
 	var/bucket_sensor_type = /obj/item/bucket_sensor

--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -139,6 +139,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 	icon_state = "null"
 	item_state = "null"
 	amount_per_transfer_from_this = 10
+	var/can_recycle = 1 //can this be put in a glass recycler?
 	var/splash_all_contents = 1
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | SUPPRESSATTACK
 

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1260,7 +1260,7 @@
 	icon_state = "icing_tube"
 	initial_volume = 50
 	amount_per_transfer_from_this = 5
-	can_recycle = 0
+	can_recycle = FALSE
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	var/image/chem = new /image('icons/obj/foodNdrink/food.dmi',"icing_tube_chem")
 
@@ -1394,7 +1394,7 @@
 	icon_state = "duo"
 	item_state = "duo"
 	initial_volume = 30
-	can_recycle = 0
+	can_recycle = FALSE
 	var/image/fluid_image
 
 	New()
@@ -1427,7 +1427,7 @@
 	icon_state = "skullchalice"
 	item_state = "skullchalice"
 	rc_flags = RC_SPECTRO
-	can_recycle = 0
+	can_recycle = FALSE
 
 /obj/item/reagent_containers/food/drinks/mug
 	name = "mug"
@@ -1602,7 +1602,7 @@
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	g_amt = 30
 	initial_volume = 50
-	can_recycle = 0
+	can_recycle = FALSE
 	initial_reagents = list("coconut_milk"=20)
 
 /obj/item/reagent_containers/food/drinks/energyshake
@@ -1628,7 +1628,7 @@
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	g_amt = 5
 	initial_volume = 40
-	can_recycle = 0
+	can_recycle = FALSE
 	initial_reagents = list("bojack"=40)
 
 /obj/item/reagent_containers/food/drinks/cocktailshaker

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1260,6 +1260,7 @@
 	icon_state = "icing_tube"
 	initial_volume = 50
 	amount_per_transfer_from_this = 5
+	can_recycle = 0
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	var/image/chem = new /image('icons/obj/foodNdrink/food.dmi',"icing_tube_chem")
 
@@ -1393,6 +1394,7 @@
 	icon_state = "duo"
 	item_state = "duo"
 	initial_volume = 30
+	can_recycle = 0
 	var/image/fluid_image
 
 	New()
@@ -1425,6 +1427,7 @@
 	icon_state = "skullchalice"
 	item_state = "skullchalice"
 	rc_flags = RC_SPECTRO
+	can_recycle = 0
 
 /obj/item/reagent_containers/food/drinks/mug
 	name = "mug"
@@ -1599,6 +1602,7 @@
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	g_amt = 30
 	initial_volume = 50
+	can_recycle = 0
 	initial_reagents = list("coconut_milk"=20)
 
 /obj/item/reagent_containers/food/drinks/energyshake
@@ -1624,6 +1628,7 @@
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	g_amt = 5
 	initial_volume = 40
+	can_recycle = 0
 	initial_reagents = list("bojack"=40)
 
 /obj/item/reagent_containers/food/drinks/cocktailshaker

--- a/code/modules/chemistry/tools/fuel_tanks.dm
+++ b/code/modules/chemistry/tools/fuel_tanks.dm
@@ -18,6 +18,7 @@
 	rc_flags = RC_SCALE
 	module_research = list("science" = 2, "engineering" = 2, "fuels" = 10)
 	initial_volume = 400
+	can_recycle = 0
 	initial_reagents = "fuel"
 
 /obj/item/reagent_containers/food/drinks/fueltank/empty

--- a/code/modules/chemistry/tools/fuel_tanks.dm
+++ b/code/modules/chemistry/tools/fuel_tanks.dm
@@ -18,7 +18,7 @@
 	rc_flags = RC_SCALE
 	module_research = list("science" = 2, "engineering" = 2, "fuels" = 10)
 	initial_volume = 400
-	can_recycle = 0
+	can_recycle = FALSE
 	initial_reagents = "fuel"
 
 /obj/item/reagent_containers/food/drinks/fueltank/empty

--- a/code/modules/food_and_drink/discount_dans.dm
+++ b/code/modules/food_and_drink/discount_dans.dm
@@ -7,6 +7,7 @@
 	heal_amt = 1
 	var/activated = 0
 	initial_volume = 60
+	can_recycle = 0
 	initial_reagents = list("chickensoup"=10,"msg"=9,"salt"=10,"nicotine"=8)
 
 	New()

--- a/code/modules/food_and_drink/discount_dans.dm
+++ b/code/modules/food_and_drink/discount_dans.dm
@@ -7,7 +7,7 @@
 	heal_amt = 1
 	var/activated = 0
 	initial_volume = 60
-	can_recycle = 0
+	can_recycle = FALSE
 	initial_reagents = list("chickensoup"=10,"msg"=9,"salt"=10,"nicotine"=8)
 
 	New()

--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -207,6 +207,7 @@
 	heal_amt = 1
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	initial_volume = 50
+	can_recycle = 0
 	initial_reagents = list("chickensoup"=30)
 
 /obj/item/reagent_containers/food/drinks/weightloss_shake

--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -207,7 +207,7 @@
 	heal_amt = 1
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	initial_volume = 50
-	can_recycle = 0
+	can_recycle = FALSE
 	initial_reagents = list("chickensoup"=30)
 
 /obj/item/reagent_containers/food/drinks/weightloss_shake

--- a/code/obj/artifacts/artifact_items/watering_can.dm
+++ b/code/obj/artifacts/artifact_items/watering_can.dm
@@ -6,7 +6,6 @@
 	module_research_no_diminish = 1
 	mat_changename = 0
 	mat_changedesc = 0
-	can_recycle = 0
 
 	New(var/loc, var/forceartiorigin)
 		..()

--- a/code/obj/artifacts/artifact_items/watering_can.dm
+++ b/code/obj/artifacts/artifact_items/watering_can.dm
@@ -6,7 +6,7 @@
 	module_research_no_diminish = 1
 	mat_changename = 0
 	mat_changedesc = 0
-	can_recycle = 0
+	can_recycle = FALSE
 
 	New(var/loc, var/forceartiorigin)
 		..()

--- a/code/obj/artifacts/artifact_items/watering_can.dm
+++ b/code/obj/artifacts/artifact_items/watering_can.dm
@@ -6,6 +6,7 @@
 	module_research_no_diminish = 1
 	mat_changename = 0
 	mat_changedesc = 0
+	can_recycle = 0
 
 	New(var/loc, var/forceartiorigin)
 		..()

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -461,6 +461,7 @@
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	module_research = list("tools" = 2, "hydroponics" = 4)
 	initial_volume = 120
+	can_recycle = 0
 
 	New()
 		..()

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -461,7 +461,7 @@
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	module_research = list("tools" = 2, "hydroponics" = 4)
 	initial_volume = 120
-	can_recycle = 0
+	can_recycle = FALSE
 
 	New()
 		..()

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -24,7 +24,7 @@
 			return
 
 		var/success = 0 //did we successfully recycle a thing?
-		if(istype(W, /obj/reagent_containers/glass))
+		if(istype(W, /obj/item/reagent_containers/glass))
 			if (istype(W, /obj/item/reagent_containers/glass/beaker))
 				success = 1
 				if (istype(W, /obj/item/reagent_containers/glass/beaker/large))
@@ -44,7 +44,6 @@
 					var/obj/item/reagent_containers/food/drinks/drinkingglass/DG = W
 					glass_amt += DG.shard_amt
 				else
-					var/obj/item/reagent_containers/food/drinks/D = W
 					if (istype(W,/obj/item/reagent_containers/food/drinks/bottle))
 						var/obj/item/reagent_containers/food/drinks/bottle/B = W
 						if (!B.broken) glass_amt += 1

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -23,74 +23,64 @@
 			boutput(user, "<span class='alert'>You cannot put [W] into [src]!</span>")
 			return
 
-		if (istype(W, /obj/item/reagent_containers/glass/beaker))
-			if (istype(W, /obj/item/reagent_containers/glass/beaker/large))
-				glass_amt += 2
-			else
-				glass_amt += 1
-			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
-			user.u_equip(W)
-			qdel(W)
-			return 1
-		else if (istype(W, /obj/item/reagent_containers/food/drinks/drinkingglass))
-			if (istype(W, /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher))
-				glass_amt += 2
-			else
-				glass_amt += 1
-			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
-			user.u_equip(W)
-			qdel(W)
-			return 1
-		else if (istype(W, /obj/item/material_piece) && W.material?.material_flags & MATERIAL_CRYSTAL && W.material?.alpha <= 180)
-			glass_amt += W.amount * 10
-			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
-			user.u_equip(W)
-			qdel(W)
-			return 1
-		else if (istype(W, /obj/item/raw_material/shard) || istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food/drinks))
-			if (istype(W,/obj/item/reagent_containers/food/drinks))
-				var/obj/item/reagent_containers/food/drinks/D = W
-				if (!D.can_recycle)
-					boutput(user, "<span class='alert'>[src] only accepts crystals, glass shards or glassware!</span>")
-					return
-				if (istype(W,/obj/item/reagent_containers/food/drinks/bottle))
-					var/obj/item/reagent_containers/food/drinks/bottle/B = W
-					if (!B.broken) glass_amt += 1
+		var/success = 0 //did we successfully recycle a thing?
+		if(istype(W, /obj/reagent_containers/glass))
+			if (istype(W, /obj/item/reagent_containers/glass/beaker))
+				success = 1
+				if (istype(W, /obj/item/reagent_containers/glass/beaker/large))
+					glass_amt += 2
 				else
-					glass_amt += W.amount
+					glass_amt += 1
 			else
-				glass_amt += W.amount
-			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
-			user.u_equip(W)
-
-			if (istype(W, /obj/item/raw_material))
-				pool(W)
-			else
-				qdel(W)
-			return 1
+				var/obj/item/reagent_containers/glass/G = W
+				if (G.can_recycle)
+					success = 1
+					glass_amt += 1
+		else if (istype(W, /obj/item/reagent_containers/food/drinks/))
+			var/obj/item/reagent_containers/food/drinks/D = W
+			if (D.can_recycle)
+				success = 1
+				if (istype(W,/obj/item/reagent_containers/food/drinks/drinkingglass))
+					var/obj/item/reagent_containers/food/drinks/drinkingglass/DG = W
+					glass_amt += DG.shard_amt
+				else
+					var/obj/item/reagent_containers/food/drinks/D = W
+					if (istype(W,/obj/item/reagent_containers/food/drinks/bottle))
+						var/obj/item/reagent_containers/food/drinks/bottle/B = W
+						if (!B.broken) glass_amt += 1
+					else
+						glass_amt += W.amount
+		else if (istype(W, /obj/item/material_piece) && W.material?.material_flags & MATERIAL_CRYSTAL && W.material?.alpha <= 180)
+			success = 1
+			glass_amt += W.amount * 10
+		else if (istype(W, /obj/item/raw_material/shard))
+			success = 1
+			glass_amt += W.amount
 		else if (istype(W, /obj/item/plate))
+			success = 1
 			glass_amt += PLATE_COST
-			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
-			user.u_equip(W)
-			qdel(W)
-			return 1
 		else if (istype(W, /obj/item/platestack))
+			success = 1
 			var/obj/item/platestack/PS = W
 			var/plateCount = PS.platenum + 1
 			glass_amt += plateCount * PLATE_COST
-			user.visible_message("<span class='notice'>[user] inserts [plateCount] plates into [src].</span>")
-			user.u_equip(W)
-			qdel(W)
-			return 1
-
 		else if (istype(W, /obj/item/storage/box))
 			var/obj/item/storage/S = W
 			for (var/obj/item/I in S.get_contents())
 				if (!.(I, user))
 					break
+
+		if (success)
+			user.visible_message("<span class='notice'>[user] inserts [W] into [src].</span>")
+			user.u_equip(W)
+			if (istype(W, /obj/item/raw_material/shard))
+				pool(W)
+			else
+				qdel(W)
+			return 1
 		else
-			boutput(user, "<span class='alert'>[src] only accepts glass shards or glassware!</span>")
-			return
+			boutput(user, "<span class='alert'>You cannot put [W] into [src]!</span>")
+			return 0
 
 	attack_hand(mob/user as mob)
 		var/dat = {"<b>Glass Left</b>: [glass_amt]<br>

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -23,10 +23,10 @@
 			boutput(user, "<span class='alert'>You cannot put [W] into [src]!</span>")
 			return
 
-		var/success = 0 //did we successfully recycle a thing?
+		var/success = FALSE //did we successfully recycle a thing?
 		if(istype(W, /obj/item/reagent_containers/glass))
 			if (istype(W, /obj/item/reagent_containers/glass/beaker))
-				success = 1
+				success = TRUE
 				if (istype(W, /obj/item/reagent_containers/glass/beaker/large))
 					glass_amt += 2
 				else
@@ -34,12 +34,12 @@
 			else
 				var/obj/item/reagent_containers/glass/G = W
 				if (G.can_recycle)
-					success = 1
+					success = TRUE
 					glass_amt += 1
 		else if (istype(W, /obj/item/reagent_containers/food/drinks/))
 			var/obj/item/reagent_containers/food/drinks/D = W
 			if (D.can_recycle)
-				success = 1
+				success = TRUE
 				if (istype(W,/obj/item/reagent_containers/food/drinks/drinkingglass))
 					var/obj/item/reagent_containers/food/drinks/drinkingglass/DG = W
 					glass_amt += DG.shard_amt
@@ -50,16 +50,16 @@
 					else
 						glass_amt += W.amount
 		else if (istype(W, /obj/item/material_piece) && W.material?.material_flags & MATERIAL_CRYSTAL && W.material?.alpha <= 180)
-			success = 1
+			success = TRUE
 			glass_amt += W.amount * 10
 		else if (istype(W, /obj/item/raw_material/shard))
-			success = 1
+			success = TRUE
 			glass_amt += W.amount
 		else if (istype(W, /obj/item/plate))
-			success = 1
+			success = TRUE
 			glass_amt += PLATE_COST
 		else if (istype(W, /obj/item/platestack))
-			success = 1
+			success = TRUE
 			var/obj/item/platestack/PS = W
 			var/plateCount = PS.platenum + 1
 			glass_amt += plateCount * PLATE_COST


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[cleanliness]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Firstly, cleans up glass recycler code for less copy-pasted qdel/message stuff. It probably performs every so slightly worse now, but unless you're somehow nesting boxes in boxes in boxes and recycling from them, I don't see that being an issue. The glass recycler code is tested fairly extensively, and I couldn't find any real issues.

Secondly, makes a bunch of things unrecyclable. Turns out so many children of /reagent_containers/glass are non-glass that it necessitates a can_recycle var, basically what /reagent_containers/food/drinks/ has. Notable new exclusions:

- Coconut shells
- Chicken soup cans
- Skull chalices
- Buckets
- Artbeakers (and other watering cans)
- Styrofoam soup cups
- Fueltanks (the lil ones)

Glass is still readily availible in the form of shards, material blocks, and plan ol' chemmaster bottle production, so I don't foresee this having a balance impact.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prettier code is good.
Closes #4098, prevents people from recycling their precious artbeakers, common sense?
(I'm not too attached to most of the recycling exclusions- mostly made this for artbeakers and buckets, and the rest were just for consistency.)