### PR TITLE
Minor Destiny tidiness update

### DIFF
--- a/code/WorkInProgress/ZeWakasStuff.dm
+++ b/code/WorkInProgress/ZeWakasStuff.dm
@@ -17,6 +17,7 @@
 	particle abuse
 */
 
+// cat
 
 // Greek Adventurezone Thingy
 

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -2602,9 +2602,6 @@
 	icon_state = "2-8"
 	},
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
 	icon_state = "2-4"
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon8,
@@ -12451,7 +12448,6 @@
 /obj/item/device/radio,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/chem_grenade/firefighting,
-/obj/machinery/phone,
 /obj/item/device/transfer_valve{
 	pixel_x = 14;
 	pixel_y = 4
@@ -12801,6 +12797,21 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/table/glass/reinforced/auto,
+/obj/item/clothing/shoes/flippers,
+/obj/item/clothing/shoes/flippers,
+/obj/item/inner_tube/random{
+	pixel_y = 8
+	},
+/obj/item/inner_tube/random{
+	pixel_y = 8
+	},
+/obj/item/clothing/gloves/water_wings{
+	pixel_y = 8
+	},
+/obj/item/clothing/gloves/water_wings{
+	pixel_y = 8
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 9
@@ -20636,9 +20647,6 @@
 /obj/decal/tile_edge/line/blue{
 	icon_state = "line1"
 	},
-/obj/table/glass/reinforced/auto,
-/obj/item/decoration/flower_vase,
-/obj/item/reagent_containers/food/drinks/peach,
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -21837,6 +21845,7 @@
 /area/station/science/artifact)
 "dtd" = (
 /obj/table/reinforced/industrial,
+/obj/machinery/phone,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "dtg" = (
@@ -50691,6 +50700,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/lobby)
 "sXf" = (
@@ -53796,7 +53808,6 @@
 /obj/machinery/light/emergency{
 	dir = 1
 	},
-/obj/machinery/phone,
 /obj/item/instrument/harmonica,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -57191,21 +57202,6 @@
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "wsb" = (
-/obj/item/clothing/shoes/flippers,
-/obj/item/clothing/shoes/flippers,
-/obj/item/inner_tube/random{
-	pixel_y = 8
-	},
-/obj/item/inner_tube/random{
-	pixel_y = 8
-	},
-/obj/item/clothing/gloves/water_wings{
-	pixel_y = 8
-	},
-/obj/item/clothing/gloves/water_wings{
-	pixel_y = 8
-	},
-/obj/table/glass/reinforced/auto,
 /obj/decal/tile_edge/line/blue{
 	color = "#485e81";
 	icon_state = "line1"
@@ -60603,6 +60599,9 @@
 	dir = 4;
 	pixel_x = -32
 	},
+/obj/table/glass/reinforced/auto,
+/obj/item/decoration/flower_vase,
+/obj/item/reagent_containers/food/drinks/peach,
 /turf/simulated/floor/darkblue,
 /area/station/crew_quarters/pool)
 "yhz" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -10481,6 +10481,12 @@
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
+"aOK" = (
+/obj/machinery/atmospherics/valve{
+	name = "Purge Valve"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/outer/sw)
 "aON" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -26574,9 +26580,7 @@
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/supply)
 "fvT" = (
-/obj/landmark{
-	name = "blobstart"
-	},
+/obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/overfloor/southwest,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "fvV" = (
@@ -28977,6 +28981,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
+"gEl" = (
+/obj/machinery/atmospherics/pipe/vent,
+/turf/simulated/floor/plating/airless,
+/area/space)
 "gEo" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -29291,6 +29299,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
+"gNL" = (
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "gOd" = (
 /obj/machinery/computer/airbr/emergency_shuttle{
 	density = 0;
@@ -40130,6 +40144,15 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/west)
+"mXn" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/central)
 "mXO" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools,
@@ -41208,6 +41231,12 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/medical/cdc)
+"nBO" = (
+/obj/machinery/atmospherics/valve{
+	name = "Purge Valve"
+	},
+/turf/simulated/wall/auto/reinforced/gannets,
+/area/station/maintenance/central)
 "nCG" = (
 /obj/machinery/computer/pathology{
 	dir = 4
@@ -48732,6 +48761,10 @@
 	dir = 4
 	},
 /area/station/crew_quarters/fitness)
+"rKX" = (
+/obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/overfloor/vertical,
+/turf/simulated/wall/auto/reinforced/gannets,
+/area/station/maintenance/central)
 "rKY" = (
 /obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
@@ -49895,6 +49928,10 @@
 /obj/machinery/light/small/floor/purpleish,
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
+"swo" = (
+/obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/overfloor/vertical,
+/turf/simulated/wall/auto/reinforced/gannets,
+/area/station/maintenance/outer/sw)
 "swv" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
@@ -54671,6 +54708,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/courtroom)
+"uUV" = (
+/obj/landmark{
+	name = "blobstart"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/outer/sw)
 "uVl" = (
 /obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/right{
@@ -56003,6 +56046,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/science/research_director)
+"vDL" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/outer/sw)
 "vDY" = (
 /obj/machinery/disposal/small{
 	dir = 4
@@ -58841,6 +58890,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
+"xjY" = (
+/obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/overfloor/northeast,
+/turf/simulated/wall/auto/reinforced/gannets,
+/area/station/maintenance/central)
 "xjZ" = (
 /turf/simulated/wall/auto/gannets,
 /area/station/maintenance/southwest)
@@ -86180,7 +86233,7 @@ tRI
 lwH
 vrH
 vpo
-usV
+uUV
 usV
 lwH
 lwH
@@ -86484,7 +86537,7 @@ eIo
 toY
 usV
 usV
-usV
+vDL
 lwH
 lwH
 aaa
@@ -86787,9 +86840,9 @@ vpo
 usV
 usV
 fvT
-usV
-lwH
-lwH
+aOK
+swo
+gNL
 aaa
 aaa
 aag
@@ -87090,7 +87143,7 @@ usV
 usV
 usV
 usV
-usV
+lwH
 oQW
 oQW
 aaa
@@ -103618,11 +103671,11 @@ aaa
 oTy
 aaa
 aaa
-aaa
-apR
-apR
-apR
-apR
+gEl
+rKX
+rKX
+nBO
+xjY
 apR
 apR
 arm
@@ -103924,7 +103977,7 @@ eRv
 apR
 kbO
 aMa
-aNQ
+mXn
 axZ
 aNQ
 gJb

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -15197,7 +15197,7 @@
 	},
 /obj/decal/mule/beacon,
 /obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
+	codes_txt = "delivery;dir=8";
 	location = "Kitchen"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
@@ -32747,7 +32747,7 @@
 	},
 /obj/decal/mule/beacon,
 /obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
+	codes_txt = "delivery;dir=8";
 	location = "Arcade"
 	},
 /turf/simulated/floor/black,
@@ -53248,7 +53248,7 @@
 	dir = 4
 	},
 /obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
+	codes_txt = "delivery;dir=8";
 	location = "Refinery"
 	},
 /obj/decal/mule/beacon,


### PR DESCRIPTION
[mapping]

## About the PR 
Removes duplicate wiring and phones, adds a phone to Research. 
Adds two atmos scrubber/can purge stations.
Other behind-the-scenes fun.

## Why's this needed? 
People requested phones, which I added in an earlier update. Little did I know that the map was already pretty heavily covered in phones. 
Moved some things for visibility and aesthetics.
Zamu said morespots to clean out scrubbers on all maps would be cool and I agree. Could provide easier time for rebuilding/cleaning.
Always finding spare wires. Always.

Holding as draft for now to see if there's any other things that come up today that I can fix as a part of this PR.