### PR TITLE
tiny typo with afterlife slot machine

### DIFF
--- a/code/obj/submachine/slots.dm
+++ b/code/obj/submachine/slots.dm
@@ -462,7 +462,7 @@
 						//src.money = 0
 					else if (roll > 1 && roll <= 5)
 						for(var/mob/O in hearers(src, null))
-							O.show_message(text("<span class='subtle'><b>[]</b> says, 'Big Winner! You have has won a hundred thousand credits!'</span>", src), 1)
+							O.show_message(text("<span class='subtle'><b>[]</b> says, 'Big Winner! You have won a hundred thousand credits!'</span>", src), 1)
 						playsound(src.loc, "sound/misc/klaxon.ogg", 55, 1)
 						src.play_money += 100000
 						//src.money -= 100000


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

fixes a miniscule typo with the winner declaration string for 100k credits in the afterlife slot machine

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

typofix
