### PR TITLE
adds call to parent to 50 attackby children

### DIFF
--- a/code/datums/gauntlet/podcolosseum.dm
+++ b/code/datums/gauntlet/podcolosseum.dm
@@ -1483,6 +1483,8 @@ proc/get_colosseum_message(var/name, var/message)
 				visible_message("<span class='notice'><b>[user]</b> repairs some dents on [src]!</span>")
 				message_pilot("<b>[user]</b> repairs some dents on [src]!")
 				repair_by(10)
+		else
+			..()
 
 	proc/add_armor(var/value)
 		armor += value

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2378,3 +2378,4 @@ proc/get_mobs_trackable_by_AI()
 				still_needed += "a pane of glass"
 			boutput(user, "\The [src] needs [still_needed.len ? english_list(still_needed) : "bugfixing (please call a coder)"] before you can activate it.")
 			return
+	else ..()

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -1185,3 +1185,5 @@ Frequency:
 				still_needed += "an AI interface board"
 			boutput(user, "\The [src] needs [still_needed.len ? english_list(still_needed) : "bugfixing (please call a coder)"] before you can activate it.")
 			return
+	else
+		..()

--- a/code/modules/antagonists/floor_goblin/floor_goblin.dm
+++ b/code/modules/antagonists/floor_goblin/floor_goblin.dm
@@ -45,6 +45,7 @@
 	attackby(obj/item/W as obj, mob/user as mob)
 		if(!istype(W, /obj/item/clothing/shoes))
 			boutput(user, "<span class='alert'>\The [W] doesn't seem to fit in the bag. Weird!</span>")
+			..()
 			return
 		user.u_equip(W)
 		W.set_loc(src)

--- a/code/modules/atmospherics/machinery/binary/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/binary/passive_gate.dm
@@ -61,6 +61,8 @@ obj/machinery/atmospherics/binary/passive_gate
 obj/machinery/atmospherics/binary/passive_gate/attackby(obj/item/W, mob/user)
 	if(ispulsingtool(W))
 		ui.show_ui(user)
+	else
+		..()
 
 datum/pump_ui/passive_gate_ui
 	value_name = "Release Pressure"

--- a/code/modules/atmospherics/machinery/binary/pump.dm
+++ b/code/modules/atmospherics/machinery/binary/pump.dm
@@ -143,6 +143,7 @@ obj/machinery/atmospherics/binary/pump
 obj/machinery/atmospherics/binary/pump/attackby(obj/item/W as obj, mob/user as mob)
 	if(ispulsingtool(W) || iswrenchingtool(W))
 		ui.show_ui(user)
+	else ..()
 
 datum/pump_ui/basic_pump_ui
 	value_name = "Target Pressure"

--- a/code/modules/atmospherics/machinery/binary/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/binary/volume_pump.dm
@@ -119,6 +119,8 @@ obj/machinery/atmospherics/binary/volume_pump
 obj/machinery/atmospherics/binary/volume_pump/attackby(obj/item/W, mob/user)
 	if(ispulsingtool(W))
 		ui.show_ui(user)
+	else
+		..()
 
 datum/pump_ui/volume_pump_ui
 	value_name = "Flow Rate"

--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -81,6 +81,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 	attackby(obj/item/I as obj, mob/user as mob)
 		if (reagents)
 			reagents.physical_shock(I.force)
+		..()
 		return
 	afterattack(obj/target, mob/user , flag)
 		return

--- a/code/modules/chemistry/tools/bombs.dm
+++ b/code/modules/chemistry/tools/bombs.dm
@@ -108,6 +108,8 @@
 		qdel(src)
 		return
 
+	else
+		..()
 	src.add_fingerprint(user)
 	return
 

--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -20,6 +20,8 @@
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/cargotele))
 			W:cargoteleport(src, user)
+		else
+			..()
 		return
 
 	New()
@@ -178,6 +180,8 @@
 				playsound(src.loc, "sound/items/Screwdriver.ogg", 100, 1)
 				src.anchored = 0
 			return
+		else
+			..()
 
 	New()
 		..()

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -112,6 +112,8 @@
 			S:part2 = null
 			//S = null
 			qdel(S)
+		else
+			..()
 
 // warcrimes: Why the fuck is autothrow a feature why would this ever be a feature WHY. Now it wont do it unless it's primed i think.
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -97,6 +97,7 @@
 			return 1
 
 	attackby(obj/item/W as obj, mob/user as mob)
+		..()
 		return
 
 	attack_self(mob/user as mob)

--- a/code/modules/chemistry/tools/pills.dm
+++ b/code/modules/chemistry/tools/pills.dm
@@ -102,6 +102,8 @@
 			if (istype(I, /obj/item/clothing/mask/cigarette)) //Apparently you can smush a lit cigarette into a pill and destroy both
 				return
 			afterattack(I, user)	//Probably weird but afterattack contains the dissolving code
+		else
+			..()
 		return
 
 	proc/create_random_icon()

--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -70,6 +70,7 @@
 		update_icon()
 
 	attackby(obj/item/I as obj, mob/user as mob)
+		..()
 		return
 
 	afterattack(var/atom/target, mob/user, flag)

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -110,6 +110,8 @@
 			else
 				boutput(usr, "<span class='alert'>No bank account associated with this ID found.</span>")
 				src.scan = null
+		else
+			..()
 
 	attack_hand(var/mob/user as mob)
 		if(..())

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -690,6 +690,8 @@
 			user.put_in_hand_or_drop(D)
 			qdel(W)
 			qdel(src)
+		else
+			..()
 
 	on_bite(obj/item/I, mob/M, mob/user)
 		boutput(M, "<span class='alert'>The noodles taste terrible uncooked...</span>")
@@ -738,6 +740,8 @@ obj/item/reagent_containers/food/snacks/ingredient/pepperoni_log
 			for (var/i in 1 to 4)
 				new /obj/item/reagent_containers/food/snacks/ingredient/pepperoni(T)
 			qdel (src)
+		else
+		 ..()
 
 /obj/item/reagent_containers/food/snacks/ingredient/seaweed
 	name = "seaweed sheets"

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -919,6 +919,8 @@
 			var/obj/item/clothing/head/pumpkin/P = new /obj/item/clothing/head/pumpkin(user.loc)
 			P.name = "carved [src.name]"
 			pool (src)
+		else
+			..()
 
 /obj/item/reagent_containers/food/snacks/plant/pumpkin/summon
 	New()

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -110,6 +110,8 @@
 			if (src.name == "cheese keyzza")
 				boutput(user, "<i>You feel as though something of value has been lost...</i>")
 			src.make_slices()
+		else
+			..()
 
 	proc/make_slices()
 		var/makeslices = src.amount
@@ -787,6 +789,8 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/reagent_containers/food/snacks/condiment/)) src.amount += 1
+		else
+			..()
 
 /obj/item/reagent_containers/food/snacks/donkpocket_w
 	name = "donk-pocket"
@@ -2233,6 +2237,7 @@
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/reagent_containers/food/snacks/condiment/)) src.amount += 1
+		else ..()
 
 /obj/item/reagent_containers/food/snacks/rice_ball
 	name = "rice ball"
@@ -2272,6 +2277,8 @@
 			else
 				nigiri.set_loc(spawnloc)
 			qdel(src)
+		else
+			..()
 
 /obj/item/reagent_containers/food/snacks/rice_ball/onigiri
 	name = "onigiri"
@@ -2307,6 +2314,8 @@
 				S.pixel_y = rand(-6, 6)
 				makepieces--
 			qdel (src)
+		else
+			..()
 
 	attack(mob/M as mob, mob/user as mob, def_zone)
 		if (!src.cut)

--- a/code/modules/items/gimmick/figurine.dm
+++ b/code/modules/items/gimmick/figurine.dm
@@ -112,6 +112,8 @@
 			if (src.icon_state != "fig-shelterfrog-dead")
 				make_cleanable(/obj/decal/cleanable/blood,get_turf(src))
 				src.icon_state = "fig-shelterfrog-dead"
+		else
+			..()
 		user.lastattacked = src
 		return 0
 

--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -648,6 +648,8 @@
 			else
 				boutput(user, "<span class='alert'>The smelter can only use metals or minerals in raw form.</span>")
 				return
+		else
+			..()
 		return
 
 	ex_act(severity) // bloo bloo we blew it up and nobody gets to have fun

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -350,6 +350,7 @@
 
 		if (letgo_hp <= 0)
 			src.eject_occupant(add_power = 0)
+		..()
 
 //next :
 	//sound effects

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -686,6 +686,8 @@ CONTAINS:
 		user.lastattacked = src
 		if (W == src.defib)
 			src.defib.move_callback(user,get_turf(user),get_turf(src))
+		else
+			..()
 
 	proc/put_back_defib(var/mob/living/M)
 		if (src.defib)

--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -76,7 +76,7 @@
 					boutput(user, "<span class='notice'>You wrench the frame into place.</span>")
 					src.anchored = 1
 					src.state = 1
-			if(isweldingtool(P))
+			else if (isweldingtool(P))
 				playsound(src.loc, "sound/items/Welder.ogg", 50, 1)
 				if(do_after(user, 2 SECONDS))
 					boutput(user, "<span class='notice'>You deconstruct the frame.</span>")
@@ -88,6 +88,8 @@
 						A.setMaterial(M)
 					A.amount = src.metal_given
 					qdel(src)
+			else
+				..()
 		if(1)
 			if (iswrenchingtool(P))
 				playsound(src.loc, "sound/items/Ratchet.ogg", 50, 1)
@@ -95,36 +97,39 @@
 					boutput(user, "<span class='notice'>You unfasten the frame.</span>")
 					src.anchored = 0
 					src.state = 0
-			if (istype(P, /obj/item/motherboard) && !mainboard)
+			else if (istype(P, /obj/item/motherboard) && !mainboard)
 				playsound(src.loc, "sound/items/Deconstruct.ogg", 50, 1)
 				boutput(user, "<span class='notice'>You place the mainboard inside the frame.</span>")
 				src.icon_state = "1"
 				src.mainboard = P
 				user.drop_item()
 				P.set_loc(src)
-			if (isscrewingtool(P) && mainboard)
+			else if (isscrewingtool(P) && mainboard)
 				playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
 				boutput(user, "<span class='notice'>You screw the mainboard into place.</span>")
 				src.state = 2
 				src.icon_state = "2"
-			if (ispryingtool(P) && mainboard)
+			else if (ispryingtool(P) && mainboard)
 				playsound(src.loc, "sound/items/Crowbar.ogg", 50, 1)
 				boutput(user, "<span class='notice'>You remove the mainboard.</span>")
 				src.state = 1
 				src.icon_state = "0"
 				mainboard.set_loc(src.loc)
 				src.mainboard = null
-			if (istype(P, /obj/item/circuitboard))
+			else if (istype(P, /obj/item/circuitboard))
 				boutput(user, "<span class='alert'>This is the wrong type of frame, it won't fit!</span>")
+			else
+				..()
 
 		if(2)
+			var/obj/item/cable_coil/C = P
 			if (isscrewingtool(P) && mainboard && (!peripherals.len))
 				playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
 				boutput(user, "<span class='notice'>You unfasten the mainboard.</span>")
 				src.state = 1
 				src.icon_state = "1"
 
-			if (istype(P, /obj/item/peripheral))
+			else if (istype(P, /obj/item/peripheral))
 				if(src.peripherals.len < src.max_peripherals)
 					user.drop_item()
 					src.peripherals.Add(P)
@@ -133,7 +138,7 @@
 				else
 					boutput(user, "<span class='alert'>There is no more room for peripheral cards.</span>")
 
-			if (ispryingtool(P) && length(src.peripherals))
+			else if (ispryingtool(P) && length(src.peripherals))
 				playsound(src.loc, "sound/items/Crowbar.ogg", 50, 1)
 				boutput(user, "<span class='notice'>You remove the peripheral boards.</span>")
 				for(var/obj/item/peripheral/W in src.peripherals)
@@ -141,14 +146,15 @@
 					src.peripherals.Remove(W)
 					W.uninstalled()
 
-			var/obj/item/cable_coil/C = P
-			if (istype(C))
+			else if (istype(C))
 				if (C.amount >= 5)
 					playsound(src.loc, "sound/items/Deconstruct.ogg", 50, 1)
 					if (do_after(user, 2 SECONDS) && C?.use(5))
 						boutput(user, "<span class='notice'>You add cables to the frame.</span>")
 						src.state = 3
 						src.icon_state = "3"
+			else
+				..()
 		if(3)
 			if (issnippingtool(P))
 				playsound(src.loc, "sound/items/Wirecutter.ogg", 50, 1)
@@ -161,19 +167,19 @@
 					src.hd.set_loc(src.loc)
 					src.hd = null
 
-			if (istype(P, /obj/item/disk/data/fixed_disk) && !src.hd)
+			else if (istype(P, /obj/item/disk/data/fixed_disk) && !src.hd)
 				user.drop_item()
 				src.hd = P
 				P.set_loc(src)
 				boutput(user, "<span class='notice'>You connect the drive to the cabling.</span>")
 
-			if (ispryingtool(P) && src.hd)
+			else if (ispryingtool(P) && src.hd)
 				playsound(src.loc, "sound/items/Crowbar.ogg", 50, 1)
 				boutput(user, "<span class='notice'>You remove the hard drive.</span>")
 				src.hd.set_loc(src.loc)
 				src.hd = null
 
-			if (istype(P, /obj/item/sheet))
+			else if (istype(P, /obj/item/sheet))
 				var/obj/item/sheet/S = P
 				if (S.material && S.material.material_flags & MATERIAL_CRYSTAL)
 					if (S.amount >= src.glass_needed)
@@ -186,6 +192,8 @@
 						boutput(user, "<span class='alert'>There's not enough sheets on the stack.</span>")
 				else
 					boutput(user, "<span class='alert'>You need sheets of some kind of crystal or glass for this.</span>")
+			else
+				..()
 		if(4)
 			if (ispryingtool(P))
 				playsound(src.loc, "sound/items/Crowbar.ogg", 50, 1)
@@ -195,7 +203,7 @@
 				var/obj/item/sheet/glass/A = new /obj/item/sheet/glass(src.loc)
 				A.amount = src.glass_needed
 
-			if (isscrewingtool(P))
+			else if (isscrewingtool(P))
 				playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
 				boutput(user, "<span class='notice'>You connect the monitor.</span>")
 				var/obj/machinery/computer3/C= new /obj/machinery/computer3( src.loc )
@@ -215,3 +223,5 @@
 					W.installed(C) //Set C as their host, etc
 				//dispose()
 				src.dispose()
+			else
+				..()

--- a/code/modules/networks/computer3/disks.dm
+++ b/code/modules/networks/computer3/disks.dm
@@ -121,6 +121,8 @@
 				src.root = new /datum/computer/folder
 				src.root.holder = src
 				src.root.name = "root"
+		else
+			..()
 
 /obj/item/disk/data/tape
 	name = "ThinkTape"

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -424,6 +424,8 @@ var/zapLimiter = 0
 				else
 					boutput(user, "<span class='alert'>You need to repair and tune the autotransformer before resetting the control board.</span>")
 			return
+		else
+			..()
 
 		return
 	if (ispryingtool(W))	// crowbar means open or close the cover
@@ -512,6 +514,8 @@ var/zapLimiter = 0
 				updateicon()
 			else
 				boutput(user, "<span class='alert'>Access denied.</span>")
+	else
+		..()
 
 
 /obj/machinery/power/apc/attack_ai(mob/user)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -249,6 +249,7 @@
 
 	else
 		shock(user, 10)
+		..()
 
 	src.add_fingerprint(user)
 

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -40,6 +40,8 @@
 				updateicon()
 			else
 				boutput(user, "<span class='notice'>A fuel pellet has already been inserted.</span>")
+		else
+			..()
 
 	Topic(href, href_list)
 		if (..())

--- a/code/modules/power/sword_engine.dm
+++ b/code/modules/power/sword_engine.dm
@@ -93,7 +93,7 @@
 				//		qdel(temp_term)
 				//		terminal = null
 		updateicon()
-	
+
 	else if (integrity_state == 2 && ispryingtool(W) && core_inserted)
 		if (user.hasStatus(list("weakened", "paralysis", "stunned")) || !isalive(user))
 			user.show_text("Not when you're incapacitated.", "red")
@@ -114,6 +114,8 @@
 		online = 0
 		charging = 0
 		updateicon()
+	else
+		..()
 
 
 /obj/machinery/power/sword_engine/emp_act()

--- a/code/modules/robotics/bot/buttbot.dm
+++ b/code/modules/robotics/bot/buttbot.dm
@@ -172,7 +172,7 @@
 	if(istype(W, /obj/item/card/emag))
 		//Do not hit the buttbot with the emag tia
 	else
-		src.visible_message("<span class='alert'>[user] hits [src] with [W]!</span>")
+		..()
 		src.health -= W.force * 0.5
 		if(src.health <= 0)
 			src.explode()

--- a/code/modules/robotics/bot/chefbot.dm
+++ b/code/modules/robotics/bot/chefbot.dm
@@ -173,7 +173,7 @@
 	if (istype(W, /obj/item/card/emag))
 		emag_act(user, W)
 	else
-		src.visible_message("<span class='alert'>[user] hits [src] with [W]!</span>")
+		..()
 		src.health -= W.force * 0.5
 		if (src.health <= 0)
 			src.explode()

--- a/code/modules/robotics/bot/duckbot.dm
+++ b/code/modules/robotics/bot/duckbot.dm
@@ -259,7 +259,7 @@
 	if (istype(W, /obj/item/card/emag))
 		emag_act(user, W)
 	else
-		src.visible_message("<span class='alert'>[user] hits [src] with [W]!</span>")
+		..()
 		src.health -= W.force * 0.5
 		if (src.health <= 0)
 			src.explode()

--- a/code/modules/robotics/bot/firebot.dm
+++ b/code/modules/robotics/bot/firebot.dm
@@ -425,5 +425,7 @@
 			return
 
 		src.created_name = t
+	else
+		..()
 
 #undef FIREBOT_MOVE_SPEED

--- a/code/modules/robotics/bot/goosebot.dm
+++ b/code/modules/robotics/bot/goosebot.dm
@@ -60,7 +60,7 @@
 	return
 
 /obj/machinery/bot/goosebot/attackby(obj/item/W as obj, mob/user as mob)
-	src.visible_message("<span class='combat'>[user] hits [src] with [W]!</span>")
+	..()
 	src.health -= W.force * 0.5
 	if (src.health <= 0)
 		src.explode()

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -5017,6 +5017,9 @@
 
 			qdel(src)
 			return
+		else
+			spawn(0)
+				..()
 
 /obj/item/guardbot_core/old
 	name = "Robuddy mainboard"
@@ -5093,6 +5096,8 @@
 				tohug.hug_target = user
 				buddy.add_task(tohug, 1, 0)
 				buddy.navigate_to(get_turf(user))
+		else
+			..()
 
 /obj/item/token/hug_token
 	name = "Hug Token"

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -877,5 +877,7 @@
 			return
 
 		src.created_name = t
+	else
+		..()
 
 #undef MEDBOT_MOVE_SPEED

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -1526,6 +1526,8 @@
 			return
 
 		src.created_name = t
+	else
+		..()
 
 #undef IS_NOT_BEEPSKY_AND_HAS_SOME_GENERIC_BATON
 #undef IS_BEEPSKY_AND_HAS_HIS_SPECIAL_BATON

--- a/code/modules/robotics/bot/skullbot.dm
+++ b/code/modules/robotics/bot/skullbot.dm
@@ -46,7 +46,7 @@
 
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		src.visible_message("<span class='combat'>[user] hits [src] with [W]!</span>")
+		..()
 		src.health -= W.force * 0.5
 		if (src.health <= 0)
 			src.explode()

--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -517,6 +517,8 @@ ABSTRACT_TYPE(/obj/item/record/random/chronoquest)
 		boutput(user, "<span class='notice'>You examine the record with the magnifying glass.</span>")
 		sleep(2 SECONDS)
 		boutput(user, "The scratch on the record, upon close examination, is actually tiny lettering. It says, <i>Fuck Discount Dan's. I hope more of your factories go under and you all drown in your toxic sewage.</i>")
+	else
+		..()
 
 /obj/item/record/atlas
 	desc = "Ode to a space ship."
@@ -663,6 +665,8 @@ ABSTRACT_TYPE(/obj/item/record/random/chronoquest)
 			//////
 			sleep(6000)
 			is_playing = 0
+	else
+		..()
 
 /obj/submachine/tape_deck/attack_hand(mob/user as mob)
 	if(has_tape)

--- a/code/modules/transport/cruisers/cruisers.dm
+++ b/code/modules/transport/cruisers/cruisers.dm
@@ -945,6 +945,7 @@
 			var/repair_time_adj = round(repair_time * health_adj)
 			actions.start(new/datum/action/bar/icon/cruiser_repair(src, W, repair_time_adj), user)
 			return 1
+		..()
 		return 0
 
 	proc/reboot() //Called when the device is rebooted / in override mode.

--- a/code/modules/transport/pods/MainWeapon.dm
+++ b/code/modules/transport/pods/MainWeapon.dm
@@ -434,7 +434,7 @@
 							purge_sps(destruction_point_x, destruction_point_y)
 							destruction_point_y = ship.loc.y + 1
 						purge_sps(destruction_point_x, destruction_point_y)
-				
+
 				else boutput(ship.pilot, "<span class='alert'><B>Shooting diagonally is unsupported.</B></span>")
 
 
@@ -460,6 +460,8 @@
 			desc = "After a delay, fires a destructive beam capable of penetrating walls. The core is installed."
 			tooltip_rebuild = 1
 			return
+		else
+			..()
 
 	proc/purge_sps(var/point_x, var/point_y)
 		for (var/mob/M in locate(point_x,point_y,ship.loc.z))

--- a/code/modules/transport/pods/secondary_system.dm
+++ b/code/modules/transport/pods/secondary_system.dm
@@ -960,7 +960,7 @@
 					boutput(ship.pilot, "<span class='alert'><B>Snapshot discarded!</B></span>")
 				return
 		return
-	
+
 	attackby(obj/item/W, mob/user)
 		if (isscrewingtool(W) && core_inserted)
 			core_inserted = false
@@ -978,3 +978,5 @@
 			desc = "After a delay, rewinds the ship's integrity to the state it was in at the moment of activation. The core is installed."
 			tooltip_rebuild = 1
 			return
+		else
+			..()

--- a/code/modules/vending/clothingbooth.dm
+++ b/code/modules/vending/clothingbooth.dm
@@ -149,6 +149,8 @@ var/list/clothingbooth_items = list()
 					logTheThing("combat", user, GM, "places [constructTarget(GM,"combat")] into [src] at [log_loc(src)].")
 					actions.interrupt(G.affecting, INTERRUPT_MOVE)
 					actions.interrupt(user, INTERRUPT_ACT)
+		else
+			..()
 
 /obj/machinery/clothingbooth/proc/set_open(var/new_open)
 	if(new_open == src.open)

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -277,6 +277,8 @@
 		if (istype(W, /obj/item/clothing/suit/bedsheet))
 			qdel(W)
 			src.amount++
+		else
+			..()
 		return
 
 	attack_hand(mob/user as mob)
@@ -304,6 +306,8 @@
 		if (istype(W, /obj/item/clothing/under/towel))
 			qdel(W)
 			src.amount++
+		else
+			..()
 		return
 
 	attack_hand(mob/user as mob)
@@ -365,13 +369,15 @@
 			boutput(user, "<span class='notice'>Slicing lattice joints ...</span>")
 			new /obj/item/rods/steel(src.loc)
 			qdel(src)
+			return
 		if (istype(C, /obj/item/rods))
 			var/obj/item/rods/R = C
 			if (R.consume_rods(2))
 				boutput(user, "<span class='notice'>You assemble a barricade from the lattice and rods.</span>")
 				new /obj/lattice/barricade(src.loc)
 				qdel(src)
-		return
+			return
+		..()
 
 /obj/lattice/barricade
 	name = "barricade"

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -772,30 +772,32 @@ obj/decoration/ceilingfan
 				src.lit = 1
 				update_icon()
 
-			if (istype(W, /obj/item/clothing/head/cakehat) && W:on)
+			else if (istype(W, /obj/item/clothing/head/cakehat) && W:on)
 				boutput(user, "<span class='alert'>Did [user] just light \his [src] with [W]? Holy Shit.</span>")
 				src.lit = 1
 				update_icon()
 
-			if (istype(W, /obj/item/device/igniter))
+			else if (istype(W, /obj/item/device/igniter))
 				boutput(user, "<span class='alert'><b>[user]</b> fumbles around with [W]; a small flame erupts from [src].</span>")
 				src.lit = 1
 				update_icon()
 
-			if (istype(W, /obj/item/device/light/zippo) && W:on)
+			else if (istype(W, /obj/item/device/light/zippo) && W:on)
 				boutput(user, "<span class='alert'>With a single flick of their wrist, [user] smoothly lights [src] with [W]. Damn they're cool.</span>")
 				src.lit = 1
 				update_icon()
 
-			if ((istype(W, /obj/item/match) || istype(W, /obj/item/device/light/candle)) && W:on)
+			else if ((istype(W, /obj/item/match) || istype(W, /obj/item/device/light/candle)) && W:on)
 				boutput(user, "<span class='alert'><b>[user] lights [src] with [W].</span>")
 				src.lit = 1
 				update_icon()
 
-			if (W.burning)
+			else if (W.burning)
 				boutput(user, "<span class='alert'><b>[user]</b> lights [src] with [W]. Goddamn.</span>")
 				src.lit = 1
 				update_icon ()
+			else
+				..()
 
 	attack_hand(mob/user as mob)
 		if (src.lit)

--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -404,7 +404,7 @@
 		else
 			user.lastattacked = src
 			attack_particle(user,src)
-			src.visible_message("<span class='alert'><b>[usr]</b> attacks [src] with [W].</span>")
+			..()
 			playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Light_1.ogg', 80, 1)
 
 			switch(W.hit_type)

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -223,6 +223,8 @@
 			loaded = 1
 			boutput(user, "<span class='notice'>You charge the magnetizer with the plasmastone.</span>")
 			pool(W)
+		else
+			..()
 
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 		if (!magnet)
@@ -1148,6 +1150,7 @@
 			boutput(user, message)
 
 		else
+			..()
 			boutput(user, "<span class='alert'>You hit the [src.name] with [W], but nothing happens!</span>")
 		return
 
@@ -1423,6 +1426,8 @@
 	attackby(obj/item/W as obj, mob/user as mob)
 		if(ispryingtool(W))
 			src.ReplaceWithSpace()
+		else
+			..()
 
 	update_icon()
 		src.overlays = list()

--- a/code/obj/neon_lining.dm
+++ b/code/obj/neon_lining.dm
@@ -100,21 +100,21 @@
 			new /obj/item/neon_lining(get_turf(user))
 			qdel(src)
 			return
-		if (iswrenchingtool(W))
+		else if (iswrenchingtool(W))
 			if (lining_shape > 0 && lining_shape < 6)
 				lining_shape++
 			else
 				lining_shape = 1
 			lining_update_icon()
 			return
-		if (isscrewingtool(W))
+		else if (isscrewingtool(W))
 			if (lining_rotation >-1 && lining_rotation <3)
 				lining_rotation++
 			else
 				lining_rotation = 0
 			lining_update_icon()
 			return
-		if (issnippingtool(W))
+		else if (issnippingtool(W))
 			if (lining_neOn == 0)
 				lining_neOn++
 				glow.icon_state = "off"
@@ -125,11 +125,13 @@
 				light.set_brightness(0.1)
 				lining_update_icon()
 			return
-		if (ispulsingtool(W))
+		else if (ispulsingtool(W))
 			if (lining_pattern > -1 && lining_pattern < 7)
 				lining_pattern++
 			else
 				lining_pattern = 0
 			lining_update_icon()
 			return
+		else
+			..()
 		return

--- a/code/obj/railing.dm
+++ b/code/obj/railing.dm
@@ -142,6 +142,8 @@
 					src.icon_state = "railing-reinforced"
 			else
 				user.show_text("[src] is already reinforced!", "red")
+		else
+			..()
 
 	attack_hand(mob/user)
 		src.try_vault(user)

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1308,6 +1308,7 @@
 				src.part1 = null
 			qdel(src)
 			return
+		else ..()
 
 	verb/controls()
 		set src in oview(1)

--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -109,6 +109,8 @@ ABSTRACT_TYPE(/obj/vehicle)
 			if (attacks_fast_eject || rider.hasStatus(list("weakened", "paralysis", "stunned")))
 				eject_rider()
 			W.visible_message("<span class='alert'>[user] swings at [rider] with [W]!</span>")
+		else
+			..()
 		return
 
 	Exited(atom/movable/thing, atom/newloc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes 50 files containing children of the attackby() proc call parent. Would be more, but my reason for doing this went away.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
any changes to parents such as atom, object, or item currently would not apply to the attackby() proc of these 50, and that's not really good.