### PR TITLE
Use enviroment for bodytemp calculation in non-sealed vehicles

### DIFF
--- a/code/mob/living/life/bodytemp.dm
+++ b/code/mob/living/life/bodytemp.dm
@@ -22,6 +22,8 @@
 			var/obj/vehicle/V = owner.loc
 			if (V.sealed_cabin)
 				loc_temp = T20C // hardcoded honkytonk nonsense
+			else
+				loc_temp = environment.temperature
 		else if (istype(owner.loc, /obj/machinery/atmospherics/unary/cryo_cell))
 			var/obj/machinery/atmospherics/unary/cryo_cell/C = owner.loc
 			loc_temp = C.air_contents.temperature


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use turf air to calculate temperature experienced by player/mob when in a vehicle that is not sealed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #2642 or at least a major aspect.
