### PR TITLE
Small vehicles will no longer save you from burning alive

### DIFF
--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -207,6 +207,12 @@ ABSTRACT_TYPE(/obj/vehicle)
 	blob_act(var/power)
 		qdel(src)
 
+	temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+		..()
+		// Simulate hotspot Crossed/Process so turfs engulfed in flames aren't simply ignored in vehicles
+		if (src.rider_visible && !src.sealed_cabin && ismob(src.rider) && exposed_volume > (CELL_VOLUME * 0.8) && exposed_temperature > FIRE_MINIMUM_TEMPERATURE_TO_SPREAD)
+			src.rider.update_burning(clamp(exposed_temperature / 60, 0, 10))
+
 //////////////////////////////////////////////////////////// Segway ///////////////////////////////////////////
 
 /obj/vehicle/segway


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature][balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a temperature exposure check to `obj/vehicles` modeled on hotspot Crossed/Process to determine if the rider should be burning.
Current behavior giving immunity is not very intuitive. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolved an expected aspect of #2642
Removed simple means of simply ignoring station hazards.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(+)Riding through fires on segways, forklifts, and cats may catch you on fire.
```
