### PR TITLE
De-RNG blocking

### DIFF
--- a/_std/defines/blocking.dm
+++ b/_std/defines/blocking.dm
@@ -10,7 +10,8 @@
 //#define BLOCK_BOOK		BLOCK_SETUP; src.c_flags |= (BLOCK_CUT | BLOCK_STAB)
 //#define BLOCK_ROPE		BLOCK_BOOK
 
-#define DEFAULT_BLOCK_PROTECTION_BONUS 2 //blocking to match damage type correctly gives you a -2 bonus on protection (unless this item grants Even More protection, that overrides this)
+#define DEFAULT_BLOCK_PROTECTION_BONUS 4 //blocking to match damage type correctly gives you a +3 bonus on protection (unless this item grants Even More protection, that overrides this)
+#define UNARMED_BLOCK_PROTECTION_BONUS 2 //Unarmed blocks don't need to match damage type, but generally block less damage
 
 
 #define BLOCK_SETUP(blocktypes)	RegisterSignal(src, COMSIG_ITEM_BLOCK_BEGIN, .proc/block_prop_setup, TRUE); src.c_flags |= BLOCK_TOOLTIP; ADD_BLOCKS(blocktypes)

--- a/_std/defines/component_defines.dm
+++ b/_std/defines/component_defines.dm
@@ -123,7 +123,8 @@
 #define COMSIG_UNARMED_BLOCK_BEGIN "unarmed_block_begin"
 /// When an item block is created
 #define COMSIG_UNARMED_BLOCK_END "unarmed_block_end"
-
+/// When a block blocks damage at all
+#define COMSIG_BLOCK_BLOCKED "blockblock"
 // ---- human signals ----
 
 // ---- mob signals ----

--- a/code/WorkInProgress/ObjectProperties.dm
+++ b/code/WorkInProgress/ObjectProperties.dm
@@ -196,11 +196,11 @@ var/list/globalPropList = null
 	deflection
 		name = "Deflection"
 		id = "deflection"
-		desc = "Improves chance to deflect attacks while unarmed." //Value is extra block chance.
+		desc = "Improves chance to resist being disarmed." //Value is extra block chance.
 		tooltipImg = "block.png"
 		defaultValue = 10
 		getTooltipDesc(var/obj/propOwner, var/propVal)
-			return "+[propVal]% additional chance to deflect attacks while blocking"
+			return "+[propVal]% additional chance to deflect disarm attempts"
 	pierceprot
 		name = "Piercing Resistance"
 		id = "pierceprot"

--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -284,7 +284,7 @@
 			"<br><img style=\"display:inline;margin:0\" width=\"12\" height=\"12\" /><img style=\"display:inline;margin:0\" src=\"[resource("images/tooltips/stabprot.png")]\" width=\"12\" height=\"12\" /> Increased armor vs stabbing attacks"+\
 			"<br><img style=\"display:inline;margin:0\" width=\"12\" height=\"12\" /><img style=\"display:inline;margin:0\" src=\"[resource("images/tooltips/burnprot.png")]\" width=\"12\" height=\"12\" /> Increased armor vs burning attacks"+\
 			"<br><img style=\"display:inline;margin:0\" width=\"12\" height=\"12\" /><img style=\"display:inline;margin:0\" src=\"[resource("images/tooltips/bluntprot.png")]\" width=\"12\" height=\"12\" /> Increased armor vs blunt attacks"+\
-			"<br><img style=\"display:inline;margin:0\" width=\"12\" height=\"12\" /><img style=\"display:inline;margin:0\" src=\"[resource("images/tooltips/protdisorient.png")]\" width=\"12\" height=\"12\" /> Body Insulation (Disorient Resist): 15%"
+			"<br><img style=\"display:inline;margin:0\" width=\"12\" height=\"12\" /><img style=\"display:inline;margin:0\" src=\"[resource("images/tooltips/protdisorient.png")]\" width=\"12\" height=\"12\" /> Body Insulation (Disorient Resist): 20%"
 
 			sel = create_screen("sel", "sel", src.icon_hud, "sel", null, HUD_LAYER+1.2)
 			sel.mouse_opacity = 0

--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -759,8 +759,8 @@
 		newDesc += "<div><img src='[resource("images/tooltips/disease.png")]' alt='' class='icon' /><span>Total Resistance (Disease): [master.get_disease_protection()]%</span></div>"
 		newDesc += "<div><img src='[resource("images/tooltips/explosion.png")]' alt='' class='icon' /><span>Total Resistance (Explosion): [master.get_explosion_resistance() * 100]%</span></div>"
 		newDesc += "<div><img src='[resource("images/tooltips/bullet.png")]' alt='' class='icon' /><span>Total Ranged Protection: [master.get_ranged_protection()]</span></div>"
-		newDesc += "<div><img src='[resource("images/tooltips/melee.png")]' alt='' class='icon' /><span>Total Melee Armor (Body): [master.get_melee_protection("chest", DAMAGE_CRUSH)]</span></div>"
-		newDesc += "<div><img src='[resource("images/tooltips/melee.png")]' alt='' class='icon' /><span>Total Melee Armor (Head): [master.get_melee_protection("head", DAMAGE_CRUSH)]</span></div>"
+		newDesc += "<div><img src='[resource("images/tooltips/melee.png")]' alt='' class='icon' /><span>Total Melee Armor (Body): [master.get_melee_protection("chest")]</span></div>"
+		newDesc += "<div><img src='[resource("images/tooltips/melee.png")]' alt='' class='icon' /><span>Total Melee Armor (Head): [master.get_melee_protection("head")]</span></div>"
 
 		var/block = master.get_passive_block()
 		if (block)

--- a/code/mob/living/life/Life.dm
+++ b/code/mob/living/life/Life.dm
@@ -704,23 +704,18 @@
 		var/a_zone = zone
 		if (a_zone in list("l_leg", "r_arm", "l_leg", "r_leg"))
 			a_zone = "chest"
-		if(a_zone=="All")
-			protection=(5*get_melee_protection("chest",damage_type)+get_melee_protection("head",damage_type))/6
-
-		else
-
 			//protection from clothing
-			if (a_zone == "chest")
-				protection = GET_MOB_PROPERTY(src, PROP_MELEEPROT_BODY)
-			else //can only be head
-				protection = GET_MOB_PROPERTY(src, PROP_MELEEPROT_HEAD)
-			protection += GET_MOB_PROPERTY(src, PROP_ENCHANT_ARMOR)/2
-			//protection from blocks
-			var/obj/item/grab/block/G = src.check_block()
-			if (G)
-				protection += 1
-				if (G != src.equipped()) // bare handed block is less protective
-					protection += G.can_block(damage_type)
+		if(a_zone == "All")
+			protection = (5 * GET_MOB_PROPERTY(src, PROP_MELEEPROT_BODY) + GET_MOB_PROPERTY(src, PROP_MELEEPROT_HEAD))/6
+		if (a_zone == "chest")
+			protection = GET_MOB_PROPERTY(src, PROP_MELEEPROT_BODY)
+		else //can only be head
+			protection = GET_MOB_PROPERTY(src, PROP_MELEEPROT_HEAD)
+		protection += GET_MOB_PROPERTY(src, PROP_ENCHANT_ARMOR)/2
+		//protection from blocks
+		var/obj/item/grab/block/G = src.check_block()
+		if (G && damage_type)
+			protection += G.can_block(damage_type)
 
 		if (isnull(protection)) //due to GET_MOB_PROPERTY returning null if it doesnt exist
 			protection = 0

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -344,7 +344,7 @@
 
 	if(prob(target.get_deflection())) //chance to deflect disarm attempts entirely
 		msgs.played_sound = 'sound/impact_sounds/Generic_Swing_1.ogg'
-		msgs.base_attack_message = "<span class='alert'><B>[target] deflects [src]'s attempt to shove [him_or_her(target)] around!</B></span>"
+		msgs.base_attack_message = "<span class='alert'><B>[src] shoves at [target][DISARM_WITH_ITEM_TEXT]!</B></span>"
 		fuckup_attack_particle(src)
 		return msgs
 
@@ -424,7 +424,7 @@
 	if (I)
 		var/disarm_item_prob = 37
 		if (target.check_block() && !(HAS_MOB_PROPERTY(target, PROP_CANTMOVE)))
-			disarm_item_prob = 8
+			disarm_item_prob = 5
 
 		if (I.temp_flags & IS_LIMB_ITEM)
 			if (prob(disarm_item_prob * mult))

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -266,10 +266,15 @@
 			playsound(target.loc, 'sound/impact_sounds/Generic_Swing_1.ogg', 25, 1, 1)
 			return
 		else
-			if (target.do_block(src, null, show_msg = 0))
+			var/obj/item/grab/block/B = target.check_block()
+			if (target.do_dodge(src, null, show_msg = 0))
+				src.visible_message("<span class='alert'><B>[target] dodges [src]'s attempt to grab [him_or_her(target)]!</span>")
+				playsound(target.loc, 'sound/impact_sounds/Generic_Swing_1.ogg', 25, 1, 1)
+				return
+			else if(B)
 				src.visible_message("<span class='alert'><B>[target] blocks [src]'s attempt to grab [him_or_her(target)]!</span>")
 				playsound(target.loc, 'sound/impact_sounds/Generic_Swing_1.ogg', 25, 1, 1)
-
+				qdel(B)
 				target.remove_stamina(STAMINA_DEFAULT_BLOCK_COST)
 				return
 
@@ -336,6 +341,12 @@
 	else
 		def_zone = "All"
 		msgs.affecting = def_zone
+
+	if(prob(target.get_deflection())) //chance to deflect disarm attempts entirely
+		msgs.played_sound = 'sound/impact_sounds/Generic_Swing_1.ogg'
+		msgs.base_attack_message = "<span class='alert'><B>[target] deflects [src]'s attempt to shove [him_or_her(target)] around!</B></span>"
+		fuckup_attack_particle(src)
+		return msgs
 
 	if (target.lying == 1) //roll lying bodies
 		msgs.played_sound = 'sound/impact_sounds/Generic_Shove_1.ogg'
@@ -454,6 +465,7 @@
 #undef DISARM_WITH_ITEM_TEXT
 
 /mob/proc/check_block(ignoreStuns = 0) //am i blocking?
+	RETURN_TYPE(/obj/item/grab/block)
 	if (ignoreStuns || (isalive(src) && !getStatusDuration("paralysis")))
 		var/obj/item/I = src.equipped()
 		if (I)
@@ -462,28 +474,12 @@
 			else if (I.c_flags & HAS_GRAB_EQUIP)
 				for (var/obj/item/grab/block/G in I)
 					return G
+	return null
+
+/mob/proc/do_dodge(var/mob/attacker, var/obj/item/W, var/show_msg = 1)
 	return 0
 
-/mob/proc/do_block(var/mob/attacker, var/obj/item/W, var/show_msg = 1)
-	var/obj/item/grab/block/G = check_block()
-	if (G)
-		if (G.can_block(W?.hit_type))
-			if (prob(STAMINA_BLOCK_CHANCE + get_deflection()))
-				if (show_msg)
-					if (G != src.equipped())
-						visible_message("<span class='alert'><B>[src] blocks [attacker]'s attack with [G.loc]!</span>")
-					else
-						visible_message("<span class='alert'><B>[src] blocks [attacker]'s attack!</span>")
-
-				playsound(loc, 'sound/impact_sounds/Generic_Swing_1.ogg', 50, 1, 1)
-				remove_stamina(STAMINA_DEFAULT_BLOCK_COST)
-				fuckup_attack_particle(attacker)
-				return 1
-			block_spark(src)
-			fuckup_attack_particle(attacker)
-	return 0
-
-/mob/living/do_block(var/mob/attacker, var/obj/item/W, var/show_msg = 1)
+/mob/living/do_dodge(var/mob/attacker, var/obj/item/W, var/show_msg = 1)
 	if (stance == "dodge")
 		if (show_msg)
 			visible_message("<span class='alert'><B>[src] narrowly dodges [attacker]'s attack!</span>")
@@ -694,7 +690,7 @@
 
 		msgs.stamina_target -= max(stam_power, 0)
 
-		if (can_crit && prob(crit_chance))
+		if (can_crit && prob(crit_chance) && !target.check_block()?.can_block(DAMAGE_BLUNT, 0))
 			msgs.stamina_crit = 1
 			msgs.played_sound = pick(sounds_punch)
 			//msgs.visible_message_target("<span class='alert'><B><I>... and lands a devastating hit!</B></I></span>")
@@ -1091,7 +1087,7 @@
 	if (!..())
 		return 0
 
-	if (src.do_block(attacker, I))
+	if (src.do_dodge(attacker, I))
 		return 0
 
 	return 1

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1169,7 +1169,7 @@
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_PRE, M, user) & ATTACK_PRE_DONT_ATTACK)
 		return
 	var/stam_crit_pow = src.stamina_crit_chance
-	if (prob(stam_crit_pow))
+	if (prob(stam_crit_pow) && !M.check_block()?.can_block(src.hit_type, 0))
 		msgs.stamina_crit = 1
 		msgs.played_sound = pick(sounds_punch)
 		//moved to item_attack_message

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -789,16 +789,21 @@
 		if(istype(P))
 			P.removeFromMob(src, src.assailant, propVal)
 
-	proc/can_block(var/hit_type = null)
-		.= DEFAULT_BLOCK_PROTECTION_BONUS
+	proc/can_block(var/hit_type = null, real_hit = 1)
+		.= UNARMED_BLOCK_PROTECTION_BONUS
 		if (isitem(src.loc) && hit_type)
 			.= 0
 			var/obj/item/I = src.loc
 
 			var/prop = DAMAGE_TYPE_TO_STRING(hit_type)
-			if(prop == "burn" && I?.reagents)
+			if(real_hit && prop == "burn" && I?.reagents)
 				I.reagents.temperature_reagents(2000,10)
 			.= src.getProperty("I_block_[prop]")
+		if(. && real_hit)
+			SEND_SIGNAL(src, COMSIG_BLOCK_BLOCKED)
+			block_spark(src.assailant)
+			fuckup_attack_particle()
+
 
 	proc/play_block_sound(var/hit_type = DAMAGE_BLUNT)
 		switch(hit_type)

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -741,7 +741,7 @@
 			var/obj/item/I = src.loc
 			I.c_flags |= HAS_GRAB_EQUIP
 			I.tooltip_rebuild = 1
-		setProperty("I_disorient_resist", 15)
+		setProperty("I_disorient_resist", 20)
 
 	disposing()
 		for(var/datum/objectProperty/equipment/P in src.properties)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
random block chance removed
blocking blocks 1 more point of damage
blocking prevents stamina crits ('devastating hit')
deflection property (of swat gloves and armored gloves) changed to be a percent chance of ignoring a disarm attempt entirely

Added signal for a blocked hit (for future use)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reduce painful combat RNG -> having c-saber/etc hits no-sold 40% of the time while blocking felt weird.
Changing the effect to preventing stamina criticals will make blocking feel more consistent in a fight/

Deflection property change was due to the removal of random dodging while blocking

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Tarmunora
(*)Random dodge chance from blocking removed.
(*)Blocking armor bonus and disorient resist buffed, and blocking now prevent stamina criticals ("devastating hit")
(+)Deflection object property now provides passive block chance against disarm attempts
```
