### PR TITLE
Removes unused matsci recipes from the refining nanofab

### DIFF
--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -8,9 +8,9 @@
 	/datum/matfab_recipe/bow,
 	/datum/matfab_recipe/quiver,
 	/datum/matfab_recipe/lens,
-	/datum/matfab_recipe/gears,
+	//datum/matfab_recipe/gears,
 	/datum/matfab_recipe/tripod,
-	/datum/matfab_recipe/aplates,
+	//datum/matfab_recipe/aplates,
 	/datum/matfab_recipe/glasses,
 	/datum/matfab_recipe/jumpsuit,
 	/datum/matfab_recipe/glovesins,
@@ -30,8 +30,8 @@
 	/datum/matfab_recipe/simple/insbag,
 	/datum/matfab_recipe/simple/insrod,
 	/datum/matfab_recipe/infusion,
-	/datum/matfab_recipe/fuel_rod,
-	/datum/matfab_recipe/fuel_rod_4,
+	//datum/matfab_recipe/fuel_rod,
+	//datum/matfab_recipe/fuel_rod_4,
 	/datum/matfab_recipe/spacesuit)
 
 /obj/machinery/nanofab/mining

--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -8,9 +8,7 @@
 	/datum/matfab_recipe/bow,
 	/datum/matfab_recipe/quiver,
 	/datum/matfab_recipe/lens,
-	//datum/matfab_recipe/gears,
 	/datum/matfab_recipe/tripod,
-	//datum/matfab_recipe/aplates,
 	/datum/matfab_recipe/glasses,
 	/datum/matfab_recipe/jumpsuit,
 	/datum/matfab_recipe/glovesins,
@@ -30,9 +28,14 @@
 	/datum/matfab_recipe/simple/insbag,
 	/datum/matfab_recipe/simple/insrod,
 	/datum/matfab_recipe/infusion,
-	//datum/matfab_recipe/fuel_rod,
-	//datum/matfab_recipe/fuel_rod_4,
 	/datum/matfab_recipe/spacesuit)
+	/*
+	Note: the following items were removed from the refining nanofab due to the unfinished state of matsci and the resulting lack of any use for those:
+	/datum/matfab_recipe/fuel_rod,
+	/datum/matfab_recipe/fuel_rod_4,
+	/datum/matfab_recipe/gears,
+	/datum/matfab_recipe/aplates
+	*/
 
 /obj/machinery/nanofab/mining
 	name = "Nano-fabricator (Mining)"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[clean][removal][wiki]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR comments out matsci recipes for armor plates, gears and fuel rods from the refining nanofab list. I'm not removing them from the code entirely to not mess with a potential future matsci rework (if it ever happens)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

People keep getting confused by the existence of those recipes all the time. We don't really need them to be accessible

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Removed unused matsci recipes from the refining nanofab.
```
