### PR TITLE
Add ref input to list edit and advanced proc call

### DIFF
--- a/code/modules/admin/debug.dm
+++ b/code/modules/admin/debug.dm
@@ -343,7 +343,7 @@ var/global/debug_messages = 0
 	if (!argnum)
 		return listargs
 	for (var/i=0, i<argnum, i++)
-		var/class = input("Type of Argument #[i]","Variable Type", null) as null|anything in list("text","num","type","reference","mob reference","reference atom at current turf","icon","color","file","the turf of which you are on top of right now")
+		var/class = input("Type of Argument #[i]","Variable Type", null) as null|anything in list("text","num","type","ref","reference","mob reference","reference atom at current turf","icon","color","file","the turf of which you are on top of right now")
 		if(!class)
 			break
 		switch(class)
@@ -362,6 +362,12 @@ var/global/debug_messages = 0
 					var/match = get_one_match(typename, /datum, use_concrete_types = FALSE)
 					if (match)
 						listargs += match
+
+			if ("ref")
+				var/input = input("Enter ref:") as null|text
+				var/target = locate(input)
+				if (!target) target = locate("\[[input]\]")
+				listargs += target
 
 			if ("reference")
 				listargs += input("Select reference:","Reference", null) as null|mob|obj|turf|area in world

--- a/code/modules/admin/modifyvariables.dm
+++ b/code/modules/admin/modifyvariables.dm
@@ -557,7 +557,7 @@
 			boutput(usr, "If a direction, direction is: [dir]")
 
 	var/class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-		"num","num adjust","type","reference","mob reference","turf by coordinates","reference picker","new instance of a type","icon","file","color","list","json","edit referenced object","create new list","restore to default")
+		"num","num adjust","type","ref","reference","mob reference","turf by coordinates","reference picker","new instance of a type","icon","file","color","list","json","edit referenced object","create new list","restore to default")
 
 	if(!class)
 		return
@@ -607,6 +607,12 @@
 		if("type")
 			O.vars[variable] = input("Enter type:","Type",O.vars[variable]) \
 				in typesof(/obj,/mob,/area,/turf)
+
+		if("ref")
+			var/input = input("Enter ref:") as null|text
+			var/target = locate(input)
+			if (!target) target = locate("\[[input]\]")
+			O.vars[variable] = target
 
 		if("reference")
 			O.vars[variable] = input("Select reference:","Reference",\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds ref input to list edit and advanced proc call
* Accepts both `0x12345678` and `[0x12345678]` formatted ref strings

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* These currently don't allow a ref string to be input as text for locating an object in world. Instead they only have the reference tool which lists every object in world an a giant list of apparent uselessness