### PR TITLE
Upgrades Atlas, Cog2 and Horizon ranches to two pens

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1868,15 +1868,9 @@
 /turf/simulated/floor/stairs/wide/other,
 /area/station/mining/refinery)
 "eG" = (
-/obj/machinery/vending/cola/red,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
+/turf/simulated/floor/stairs/wide{
+	dir = 1
 	},
-/turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "eH" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -5307,13 +5301,6 @@
 /obj/disposalpipe/junction/middle/east,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"na" = (
-/obj/stool/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/south)
 "nb" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -5481,9 +5468,13 @@
 /turf/simulated/floor/caution/south,
 /area/station/engine/core)
 "nu" = (
-/obj/submachine/ATM,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ranch)
+/obj/potted_plant{
+	dir = 4
+	},
+/turf/simulated/floor/stairs/wide{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
 "nv" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -5510,6 +5501,11 @@
 /obj/landmark/halloween,
 /obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
 /turf/simulated/floor/green/side{
 	dir = 1
@@ -9063,6 +9059,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/stool/chair/office/purple{
+	dir = 1
+	},
+/obj/landmark/start{
+	name = "Scientist"
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
@@ -9294,7 +9296,14 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
 "vQ" = (
-/turf/simulated/floor,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
 /area/station/hallway/primary/east)
 "vR" = (
 /obj/storage/secure/closet/medical/medicine,
@@ -9573,16 +9582,6 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
-"wG" = (
-/obj/table/auto,
-/obj/item/card_group/plain,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/south)
 "wH" = (
 /obj/table/auto,
 /obj/item/aiModule/protectStation,
@@ -9653,6 +9652,27 @@
 	dir = 9
 	},
 /area/station/engine/elect)
+"wS" = (
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
+/area/station/ranch)
+"wT" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/plantpot,
+/obj/railing/orange/reinforced,
+/obj/railing/orange/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "wV" = (
 /obj/machinery/clonegrinder,
 /obj/cable{
@@ -9882,12 +9902,6 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
-"xv" = (
-/obj/landmark/spawner{
-	name = "monkeyspawn_mrsmuggles"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/east)
 "xw" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -9967,7 +9981,7 @@
 "xI" = (
 /obj/displaycase{
 	displayed = new /obj/item/captaingun
-},
+	},
 /turf/simulated/floor/blue,
 /area/station/bridge/captain)
 "xL" = (
@@ -10316,13 +10330,16 @@
 /turf/simulated/floor/caution/corner/sw,
 /area/station/engine/core)
 "yA" = (
-/obj/stool/chair,
+/obj/shrub{
+	dir = 4;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
 /turf/simulated/floor/black,
-/area/station/hallway/primary/south)
+/area/station/hallway/primary/east)
 "yB" = (
 /obj/machinery/light,
-/obj/submachine/chicken_incubator,
-/obj/item/reagent_containers/food/snacks/ingredient/egg,
+/obj/machinery/plantpot,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "yD" = (
@@ -10487,6 +10504,10 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/security/main)
+"yV" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/east)
 "yW" = (
 /turf/space,
 /area/shuttle/escape/station/cogmap2)
@@ -10586,19 +10607,13 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "zq" = (
-/obj/stool/chair/green{
-	dir = 8
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/submachine/chef_sink/chem_sink{
-	pixel_y = 16
-	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "zr" = (
 /obj/machinery/door/unpowered/wood/stall,
 /turf/simulated/floor/sanitary,
@@ -10964,6 +10979,11 @@
 /obj/creepy_sound_trigger,
 /turf/simulated/wall/false_wall/reinforced,
 /area/station/quartermaster/office)
+"As" = (
+/turf/simulated/floor/stairs/wide/other{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
 "Ax" = (
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/engine,
@@ -11016,7 +11036,7 @@
 "AC" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/station/hallway/primary/east)
+/area/station/ranch)
 "AD" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/east)
@@ -11209,6 +11229,17 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
 /area/station/storage/tools)
+"Bb" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	layer = 3
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "Bd" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
@@ -11279,23 +11310,22 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "Bp" = (
-/obj/machinery/light{
+/obj/potted_plant{
 	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+	pixel_y = 28
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/green/side{
-	dir = 1
-	},
-/area/station/hallway/primary/east)
+/turf/space,
+/area/station/shield_zone)
 "Bq" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light_switch/auto,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "Br" = (
@@ -11345,6 +11375,20 @@
 "Bx" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay)
+"By" = (
+/obj/shrub{
+	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
+	dir = 1;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "Bz" = (
 /turf/simulated/floor/bluewhite{
 	dir = 1
@@ -11479,6 +11523,14 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/light{
+	layer = 3
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -11700,30 +11752,22 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
-"CB" = (
-/turf/simulated/floor/stairs/wide,
-/area/station/hallway/primary/east)
 "CC" = (
-/turf/simulated/floor/stairs/wide/middle,
-/area/station/hallway/primary/east)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/ranch)
 "CD" = (
 /obj/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/stairs/wide/other,
-/area/station/hallway/primary/east)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/ranch)
 "CE" = (
-/obj/machinery/power/apc/autoname_west,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/bluewhite{
-	dir = 8
-	},
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/white,
 /area/station/medical/medbay)
 "CF" = (
 /obj/cable{
@@ -11811,6 +11855,13 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/hangar/arrivals)
+"CR" = (
+/obj/machinery/camera/ranch,
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
+/area/station/ranch)
 "CU" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -11901,22 +11952,24 @@
 	},
 /area/station/science/chemistry)
 "Dh" = (
-/turf/simulated/floor/purple/side{
-	dir = 6
-	},
-/area/station/hallway/primary/east)
-"Di" = (
-/turf/simulated/floor/caution/south,
-/area/station/hallway/primary/east)
-"Dj" = (
-/obj/machinery/disposal/small{
+/obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 8
 	},
-/obj/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/cashreg,
+/obj/machinery/light{
+	layer = 3
 	},
-/turf/simulated/floor/caution/south,
-/area/station/hallway/primary/east)
+/obj/railing/orange/reinforced{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/rancher,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
+"Di" = (
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "Dk" = (
 /obj/table/auto,
 /obj/machinery/light{
@@ -12211,24 +12264,37 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/artifact)
 "DV" = (
-/obj/potted_plant{
-	dir = 8
+/turf/simulated/floor/purple/side{
+	dir = 6
 	},
-/turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "DW" = (
-/turf/simulated/floor/black,
-/area/station/hallway/primary/east)
+/obj/disposalpipe/segment,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "DX" = (
-/obj/potted_plant{
+/obj/disposalpipe/segment,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
+"DY" = (
+/obj/table/reinforced/auto,
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/airlock/pyro/glass/windoor{
 	dir = 4
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/east)
-"DY" = (
-/obj/machinery/vending/medical,
-/turf/simulated/floor/blue,
-/area/station/medical/medbay)
+/obj/firedoor_spawn,
+/obj/access_spawn/rancher,
+/turf/simulated/floor/bluewhite{
+	dir = 8
+	},
+/area/station/ranch)
 "DZ" = (
 /obj/machinery/light{
 	light_type = /obj/item/light/tube/blueish
@@ -12499,11 +12565,14 @@
 	},
 /area/station/science/artifact)
 "EI" = (
-/obj/stool/chair/office/purple{
-	dir = 1
+/obj/machinery/computer3/terminal/zeta{
+	dir = 8;
+	setup_os_string = "ZETA_MAINFRAME"
 	},
-/obj/landmark/start{
-	name = "Scientist"
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
@@ -12517,16 +12586,19 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southwest)
 "EK" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/east)
-"EL" = (
-/obj/stool/chair,
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/submachine/chef_sink/chem_sink{
+	desc = "A water-filled unit intended for hand-washing purposes.";
+	dir = 4;
+	pixel_x = -4
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
+"EL" = (
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "EM" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -12740,56 +12812,66 @@
 "Fn" = (
 /turf/simulated/floor/white,
 /area/station/science/artifact)
-"Fq" = (
-/obj/stool/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/east)
 "Fr" = (
-/obj/table/auto,
-/obj/item/paper_bin,
-/obj/item/pen/pencil,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/east)
+/obj/submachine/chicken_feed_grinder,
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/snacks/plant/corn{
+	doants = 0
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
+/area/station/ranch)
 "Fs" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/machinery/plantpot,
+/obj/railing/orange/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/caution/south,
-/area/station/hallway/primary/east)
+/obj/railing/orange/reinforced,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "Ft" = (
-/obj/table/auto,
-/obj/item/game_kit,
-/obj/item/card_group/plain,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/east)
+/obj/railing/orange/reinforced{
+	dir = 4
+	},
+/obj/table/reinforced/auto,
+/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
+	rand_pos = 1
+	},
+/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
+	rand_pos = 1
+	},
+/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
+	rand_pos = 1
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
+/area/station/ranch)
 "Fu" = (
-/obj/table/auto,
-/obj/machinery/light,
-/obj/item/reagent_containers/food/drinks/cola/random{
-	pixel_x = 1;
-	pixel_y = -2
+/obj/machinery/light{
+	layer = 3
 	},
-/obj/item/reagent_containers/food/drinks/cola/random{
-	pixel_x = -13;
-	pixel_y = -4
+/obj/storage/closet{
+	name = "rancher's supply closet"
 	},
-/obj/item/reagent_containers/food/drinks/cola/random{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/east)
+/obj/item/device/camera_viewer/ranch,
+/obj/item/paper/ranch_guide,
+/obj/item/storage/box/clothing/rancher,
+/obj/item/fishing_rod,
+/obj/item/chicken_carrier,
+/obj/item/clothing/mask/chicken,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "Fv" = (
 /obj/machinery/door/airlock/pyro/alt{
 	dir = 4;
 	tag = "icon-generic2_closed (EAST)"
 	},
-/obj/access_spawn/maint,
+/obj/access_spawn/rancher,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "Fw" = (
@@ -13172,6 +13254,9 @@
 "Gj" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/east)
+"Gk" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/ranch)
 "Gl" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5;
@@ -13444,6 +13529,13 @@
 /obj/machinery/computer/robot_module_rewriter,
 /turf/simulated/floor,
 /area/station/medical/robotics)
+"GZ" = (
+/obj/chicken_nesting_box,
+/obj/machinery/light{
+	layer = 3
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "Ha" = (
 /obj/machinery/computer/operating{
 	id = "robotics"
@@ -13953,6 +14045,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"Id" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "Ie" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -14417,6 +14513,9 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
+"Js" = (
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "Jt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -14714,6 +14813,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/storage)
+"Kf" = (
+/obj/shrub{
+	dir = 1
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/southwest)
 "Kh" = (
 /obj/machinery/atmospherics/portables_connector/north,
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -15736,6 +15841,15 @@
 	icon_state = "floor4"
 	},
 /area/listeningpost/power)
+"Na" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/ranch)
 "Nb" = (
 /obj/cable{
 	d1 = 1;
@@ -16588,11 +16702,12 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "Pc" = (
-/obj/stool/chair{
-	dir = 8
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg{
+	rand_pos = 0
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "Pd" = (
 /obj/table/auto,
 /obj/machinery/phone,
@@ -16630,15 +16745,23 @@
 	},
 /area/station/science/teleporter)
 "Pg" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
 	},
-/turf/simulated/floor/purple/side{
-	dir = 4
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
+"Ph" = (
+/obj/potted_plant{
+	dir = 1;
+	pixel_y = 28
 	},
-/area/station/hallway/primary/east)
+/turf/space,
+/area/space)
 "Pi" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light{
@@ -16915,6 +17038,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom/medical,
+/obj/machinery/vending/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -17047,10 +17171,16 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "Qa" = (
-/obj/submachine/chicken_feed_grinder,
-/obj/item/reagent_containers/food/snacks/plant/corn,
+/obj/machinery/plantpot,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics)
+"Qb" = (
+/obj/stool/chair/green,
+/obj/railing/orange/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "Qc" = (
 /obj/machinery/networked/storage/bomb_tester,
 /obj/cable,
@@ -17143,6 +17273,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/storage/tools)
+"Qr" = (
+/obj/machinery/disposal/small{
+	dir = 8
+	},
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "Qs" = (
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 4
@@ -17356,6 +17495,14 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
+"Rc" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Arrivals"
+	},
+/obj/access_spawn/rancher,
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/ranch)
 "Re" = (
 /obj/storage/secure/closet/command/hop,
 /turf/simulated/floor/carpet{
@@ -17410,13 +17557,19 @@
 	icon_state = "fblue2"
 	},
 /area/station/bridge)
-"Ro" = (
-/obj/submachine/chicken_feed_grinder,
-/obj/item/reagent_containers/food/snacks/plant/corn{
-	doants = 0
-	},
-/turf/simulated/floor/dirt,
+"Rn" = (
+/turf/simulated/wall/auto/supernorn,
 /area/station/ranch)
+"Ro" = (
+/obj/machinery/vending/cola/red,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13";
+	pixel_x = 10
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "Rp" = (
 /obj/cable{
 	d1 = 4;
@@ -17454,9 +17607,6 @@
 	icon_state = "engine_caution_we"
 	},
 /area/station/engine/combustion_chamber)
-"Rx" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ranch)
 "RA" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -17477,20 +17627,28 @@
 /turf/simulated/floor/caution/west,
 /area/station/engine/core)
 "RC" = (
+/obj/table/auto,
+/obj/item/card_group/plain,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
+"RD" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
-/turf/simulated/floor/dirt,
+/turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "RE" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/ranch)
+/obj/stool/chair{
+	dir = 4;
+	tag = "icon-chair (EAST)"
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "RG" = (
 /obj/cable{
 	d1 = 4;
@@ -17508,16 +17666,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "RJ" = (
-/obj/decal/tile_edge/line/green{
-	icon_state = "line1"
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 1
 	},
-/obj/table/reinforced/auto,
-/obj/machinery/cashreg,
-/obj/machinery/door/airlock/pyro/glass/windoor,
-/obj/access_spawn/rancher,
-/obj/firedoor_spawn,
-/turf/simulated/floor/dirt,
-/area/station/ranch)
+/area/station/hallway/primary/east)
 "RK" = (
 /obj/machinery/atmospherics/binary/pump{
 	frequency = 1229;
@@ -17572,14 +17724,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
-"RV" = (
-/obj/railing/orange/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/grasstodirt{
-	dir = 8
-	},
-/area/station/ranch)
 "RW" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Burn Chamber";
@@ -17822,6 +17966,12 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/storage/eva)
+"SN" = (
+/obj/shrub{
+	dir = 8
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "SP" = (
 /obj/landmark/start{
 	name = "Medical Doctor"
@@ -17905,10 +18055,23 @@
 	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
+"Tg" = (
+/obj/disposalpipe/segment,
+/obj/machinery/vending/cola/blue,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "Th" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
 /area/station/medical/head)
+"Tj" = (
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "Tk" = (
 /obj/cable{
 	d1 = 4;
@@ -17959,14 +18122,11 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "Tu" = (
-/obj/chicken_nesting_box,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
+/obj/table/auto,
+/obj/item/game_kit,
+/obj/item/card_group/plain,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "Tv" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -17985,13 +18145,21 @@
 	},
 /area/station/engine/combustion_chamber)
 "TA" = (
-/obj/submachine/chicken_incubator,
-/obj/item/reagent_containers/food/snacks/ingredient/egg{
-	rand_pos = 0
+/obj/table/auto,
+/obj/item/reagent_containers/food/drinks/cola/random{
+	pixel_x = 1;
+	pixel_y = -2
 	},
-/obj/machinery/camera/ranch,
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
+/obj/item/reagent_containers/food/drinks/cola/random{
+	pixel_x = -13;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/food/drinks/cola/random{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "TD" = (
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
@@ -18029,18 +18197,14 @@
 /turf/unsimulated/floor/caution/north,
 /area/station/crewquarters/cryotron)
 "TK" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/stool/chair{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/landmark/spawner{
+	name = "monkeyspawn_mrsmuggles"
 	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "TL" = (
 /obj/machinery/door/airlock/pyro/sci_alt,
 /obj/cable{
@@ -18089,6 +18253,12 @@
 /obj/machinery/networked/radio,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
+"TX" = (
+/obj/landmark/start{
+	name = "Rancher"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "TY" = (
 /obj/firedoor_spawn,
 /obj/access_spawn/engineering,
@@ -18161,11 +18331,6 @@
 	dir = 4;
 	level = -1
 	},
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -18225,13 +18390,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"Uy" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "Uz" = (
 /obj/table/reinforced/bar/auto,
 /obj/machinery/camera{
@@ -18322,16 +18480,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/clown)
 "UT" = (
-/obj/machinery/computer3/terminal/zeta{
-	dir = 8;
-	setup_os_string = "ZETA_MAINFRAME"
-	},
-/obj/machinery/power/data_terminal,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/purple,
+/turf/simulated/wall/auto/supernorn,
 /area/station/science/artifact)
 "UU" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -18643,8 +18797,14 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/heads)
 "VZ" = (
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
+/obj/stool/chair{
+	dir = 1
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "Wb" = (
 /obj/table/auto,
 /obj/item/kitchen/rollingpin,
@@ -18787,14 +18947,12 @@
 	},
 /area/station/medical/medbay)
 "Wy" = (
-/obj/railing/orange/reinforced{
-	dir = 8
+/obj/stool/chair{
+	dir = 4;
+	tag = "icon-chair (EAST)"
 	},
-/obj/machinery/light_switch/auto,
-/turf/simulated/floor/grasstodirt{
-	dir = 8
-	},
-/area/station/ranch)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "Wz" = (
 /obj/stool/chair/office/blue,
 /obj/machinery/camera{
@@ -19005,6 +19163,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -19024,6 +19187,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hangar/science)
+"Xm" = (
+/obj/railing/orange/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "Xn" = (
 /obj/rack,
 /obj/item/spacecash/bag,
@@ -19111,6 +19280,14 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/power)
+"Xx" = (
+/obj/potted_plant{
+	dir = 8
+	},
+/turf/simulated/floor/stairs/wide/other{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
 "Xz" = (
 /obj/table/round/auto,
 /obj/machinery/computer/tour_console,
@@ -19127,11 +19304,11 @@
 /turf/simulated/floor/white,
 /area/station/science/lab)
 "XB" = (
-/obj/shrub{
-	dir = 8
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
+/obj/table/auto,
+/obj/item/paper_bin,
+/obj/item/pen/pencil,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "XC" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -19221,17 +19398,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "XL" = (
-/obj/decal/tile_edge/line/green{
-	icon_state = "line1"
-	},
+/obj/submachine/ATM,
 /obj/cable{
-	icon_state = "1-2"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/door/airlock/pyro/alt,
-/obj/access_spawn/rancher,
-/obj/firedoor_spawn,
-/turf/simulated/floor/dirt,
-/area/station/ranch)
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/primary/east)
 "XM" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating/random,
@@ -19394,9 +19567,10 @@
 	},
 /area/station/science/lab)
 "Yl" = (
+/obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/primary/east)
+/turf/simulated/floor/plating/random,
+/area/station/ranch)
 "Ym" = (
 /obj/machinery/disposal/small{
 	dir = 8
@@ -19419,6 +19593,12 @@
 	},
 /turf/simulated/floor/circuit/purple,
 /area/station/science/artifact)
+"Yo" = (
+/obj/shrub{
+	dir = 1
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "Ys" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
@@ -19742,25 +19922,9 @@
 	},
 /area/station/mining/staff_room)
 "Zl" = (
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/table/reinforced/auto,
-/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
-	rand_pos = 1
-	},
-/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
-	rand_pos = 1
-	},
-/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
-	rand_pos = 1
-	},
-/turf/simulated/floor/grasstodirt{
-	dir = 1
-	},
-/area/station/ranch)
+/obj/machinery/vending/snack,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "Zn" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -19825,8 +19989,8 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "Zy" = (
-/turf/simulated/floor/dirt,
-/area/station/ranch)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "Zz" = (
 /obj/disposalpipe/segment,
 /obj/critter/dog/george/orwell,
@@ -53920,7 +54084,7 @@ PS
 PS
 PS
 PS
-PS
+Bp
 aa
 aa
 aa
@@ -54222,7 +54386,7 @@ PS
 aa
 aa
 aa
-aa
+Ph
 iW
 iW
 iW
@@ -54524,7 +54688,7 @@ aa
 iW
 iW
 iW
-ii
+Kf
 iX
 jW
 jY
@@ -60576,9 +60740,9 @@ xT
 qD
 oF
 lx
-mM
-kZ
-xF
+mL
+mL
+mL
 xr
 Zg
 nP
@@ -60877,11 +61041,11 @@ qD
 VM
 qD
 aa
-oF
+yV
 yA
-wG
-na
-mL
+Zy
+Zy
+Xx
 nv
 QX
 jP
@@ -61179,11 +61343,11 @@ vO
 lO
 ZK
 yf
-Rx
+AD
 RE
-RE
-RE
-Rx
+Zy
+Zy
+RJ
 nx
 nM
 BM
@@ -61484,8 +61648,8 @@ qD
 qD
 XB
 VZ
-VZ
-RE
+Zy
+eG
 RZ
 Rp
 Cz
@@ -61786,8 +61950,8 @@ vG
 qD
 TA
 VZ
-VZ
-RE
+Zy
+zM
 ny
 Rp
 CA
@@ -62085,11 +62249,11 @@ ss
 tE
 uM
 vH
-qD
+Gk
 Tu
 VZ
-VZ
-RE
+Zy
+Xx
 RZ
 Rp
 CA
@@ -62387,11 +62551,11 @@ rw
 tF
 rw
 rw
+Gk
 qD
-qD
-VZ
-VZ
-Rx
+By
+Zy
+RJ
 Ui
 Rp
 Cz
@@ -62692,7 +62856,7 @@ vI
 qj
 qD
 Wy
-RV
+Zy
 nu
 RZ
 Rp
@@ -62994,7 +63158,7 @@ vJ
 wH
 qD
 RC
-Uy
+Zy
 XL
 Xk
 XF
@@ -63297,7 +63461,7 @@ wI
 qD
 TK
 Zy
-RE
+As
 RZ
 Rp
 Cz
@@ -63901,8 +64065,8 @@ qj
 qD
 Zl
 Ro
-RE
-Bp
+nu
+RZ
 Rp
 oq
 pq
@@ -64201,9 +64365,9 @@ qD
 qD
 qD
 qD
-Rx
-Rx
-Rx
+AD
+AD
+AD
 Bq
 nO
 hN
@@ -64509,7 +64673,7 @@ AD
 Bo
 Rp
 vQ
-pq
+DV
 DT
 EI
 Fn
@@ -64810,7 +64974,7 @@ tW
 AE
 Br
 Vl
-Pg
+zM
 Dh
 DU
 UT
@@ -65113,8 +65277,8 @@ AD
 lP
 RG
 Yl
-Yl
-ZQ
+DW
+Pg
 ZQ
 ZQ
 Gi
@@ -65414,11 +65578,11 @@ zN
 tl
 XX
 BV
-CB
-Fs
-DV
+CC
+Di
+Di
 EK
-eG
+GZ
 AC
 ax
 aa
@@ -65715,12 +65879,12 @@ qK
 zO
 AF
 Bo
-BW
+Bb
 CC
+Fs
 Di
-DW
-DW
-Fq
+Yo
+Pc
 AC
 ax
 aa
@@ -66018,9 +66182,9 @@ zP
 Si
 Bo
 BW
-CC
-Di
-DW
+Rn
+wS
+EL
 EL
 Fr
 AC
@@ -66320,12 +66484,12 @@ Sa
 zR
 Bo
 BW
-CC
-Di
-DW
-EL
+Rc
+TX
+Id
+Js
 Fu
-AD
+Gk
 ax
 aa
 ax
@@ -66622,10 +66786,10 @@ zR
 sI
 Bo
 BW
-CC
-Di
-DW
-EL
+Rn
+CR
+Xm
+Qb
 Ft
 AC
 ax
@@ -66924,10 +67088,10 @@ tX
 tX
 XX
 BX
-CC
-Di
-DW
-xv
+Na
+wT
+RD
+SN
 Pc
 AC
 ax
@@ -67225,12 +67389,12 @@ at
 zS
 zS
 Bu
-zS
+Tg
 CD
-Dj
+DW
 DX
-DW
-DW
+Qr
+GZ
 AC
 ax
 aa
@@ -67528,9 +67692,9 @@ zT
 yg
 yg
 yg
-Bx
-Bx
-Bx
+Rn
+Di
+Tj
 Bx
 Fv
 Gj
@@ -67830,9 +67994,9 @@ zU
 AG
 Wx
 Bv
-CE
-Dm
+Bx
 DY
+Bx
 Bx
 XT
 Sw
@@ -68132,7 +68296,7 @@ zV
 AH
 TS
 yF
-CF
+CE
 yF
 DZ
 Bx

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -12587,13 +12587,11 @@
 	},
 /area/station/hydroponics/bay)
 "aCc" = (
-/obj/stool/chair/green,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
+/obj/shrub,
+/turf/simulated/floor/grass{
+	name = "astroturf"
 	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
+/area/station/hydroponics/bay)
 "aCd" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /turf/simulated/floor/grass{
@@ -13116,13 +13114,15 @@
 	},
 /area/station/hydroponics/bay)
 "aDm" = (
-/obj/railing/orange/reinforced{
-	dir = 8
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
-/turf/simulated/floor/grasstodirt{
-	dir = 8
+/turf/simulated/floor/grass{
+	name = "astroturf"
 	},
-/area/station/ranch)
+/area/station/hydroponics/bay)
 "aDn" = (
 /turf/simulated/floor/stairs{
 	dir = 1;
@@ -13719,22 +13719,14 @@
 	},
 /area/shuttle/arrival/station)
 "aED" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "aEE" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/rancher,
-/turf/simulated/floor/delivery,
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/turf/simulated/floor,
 /area/station/ranch)
 "aEF" = (
 /turf/simulated/floor,
@@ -14879,9 +14871,13 @@
 	},
 /area/station/hydroponics/bay)
 "aHr" = (
-/obj/shrub,
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "aHs" = (
 /obj/submachine/seed_manipulator{
 	dir = 8
@@ -15995,20 +15991,25 @@
 	},
 /area/shuttle/arrival/station)
 "aKt" = (
-/obj/railing/orange/reinforced{
-	dir = 1
+/obj/reagent_dispensers/watertank/big,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
-/turf/simulated/floor/grasstodirt{
-	dir = 1
+/turf/simulated/floor/grass{
+	name = "astroturf"
 	},
-/area/station/ranch)
+/area/station/hydroponics/bay)
 "aKu" = (
-/obj/submachine/chicken_incubator,
-/obj/item/reagent_containers/food/snacks/ingredient/egg{
-	rand_pos = 0
+/obj/window/auto/reinforced,
+/obj/grille/steel,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
+/turf/simulated/floor/plating,
+/area/station/hydroponics/bay)
 "aKv" = (
 /obj/machinery/disposal/mail/autoname/hydroponics,
 /obj/disposalpipe/trunk/mail/north,
@@ -17114,9 +17115,6 @@
 	dir = 0;
 	name = "autoname - SS13";
 	pixel_y = 20
-	},
-/obj/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/green/side{
 	dir = 10
@@ -18596,7 +18594,11 @@
 /turf/simulated/floor/grass/random,
 /area/station/crew_quarters/garden)
 "aQx" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/reagent_dispensers/watertank/fountain,
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "blue1"
+	},
 /area/station/crew_quarters/arcade/dungeon)
 "aQy" = (
 /obj/window/auto/reinforced,
@@ -18730,12 +18732,6 @@
 	},
 /area/shuttle/arrival/station)
 "aQT" = (
-/obj/reagent_dispensers/watertank/big,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/hydroponics/bay)
-"aQU" = (
 /obj/table/wood/auto,
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/sandwich/meat_m{
@@ -18744,6 +18740,16 @@
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
+/area/station/hydroponics/bay)
+"aQU" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 1
+	},
+/obj/access_spawn/rancher,
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment/mail/vertical,
+/obj/decal/tile_edge/stripe,
+/turf/simulated/floor/wood,
 /area/station/hydroponics/bay)
 "aQV" = (
 /obj/shrub{
@@ -18781,11 +18787,6 @@
 /obj/item/paper/book/hydroponicsguide,
 /obj/item/storage/firstaid/regular,
 /obj/item/device/light/zippo,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -19318,7 +19319,7 @@
 /obj/window/auto/reinforced,
 /obj/grille/steel,
 /turf/simulated/floor/black,
-/area/station/hydroponics/bay)
+/area/station/crew_quarters/arcade)
 "aSl" = (
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -19697,102 +19698,62 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/checkpoint/arrivals)
 "aTk" = (
-/obj/disposalpipe/trunk/mail/east,
-/obj/machinery/disposal/mail/autoname/public/arcade,
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "blue6"
-	},
-/area/station/crew_quarters/arcade/dungeon)
-"aTl" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "blue5"
-	},
-/area/station/crew_quarters/arcade/dungeon)
-"aTm" = (
-/obj/stool/chair/couch{
-	dir = 8
-	},
-/obj/item/reagent_containers/food/snacks/chips,
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "blue5"
-	},
-/area/station/crew_quarters/arcade/dungeon)
-"aTn" = (
-/obj/stool/chair/couch{
-	dir = 4
-	},
-/obj/item/storage/goodybag,
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "blue5"
-	},
-/area/station/crew_quarters/arcade/dungeon)
-"aTo" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/vending/cola/red,
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "blue5"
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/green/side{
+	dir = 9
 	},
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/crew_quarters/arcade)
+"aTl" = (
+/obj/shrub{
+	dir = 1
+	},
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/crew_quarters/arcade)
+"aTn" = (
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/crew_quarters/arcade)
+"aTo" = (
+/obj/decal/poster/wallsign/poster_mining{
+	pixel_y = 30
+	},
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/crew_quarters/arcade)
 "aTp" = (
-/obj/decal/poster/wallsign/poster_rand{
-	pixel_y = 28
+/obj/disposalpipe/segment/mail/bent/east,
+/turf/simulated/floor/green/side{
+	dir = 1
 	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "blue6"
-	},
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/crew_quarters/arcade)
 "aTq" = (
-/obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/light_switch/north,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
+/obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/stairs{
+	dir = 4;
+	icon_state = "Stairs_wide"
+	},
+/area/station/crew_quarters/arcade)
+"aTr" = (
+/obj/noticeboard{
+	pixel_x = -32
+	},
+/turf/simulated/floor/green/side{
 	dir = 8
 	},
-/area/station/crew_quarters/arcade/dungeon)
-"aTr" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8;
-	tag = ""
-	},
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "blue5"
-	},
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/crew_quarters/arcade)
 "aTs" = (
 /obj/machinery/light{
 	dir = 1;
@@ -19809,6 +19770,11 @@
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -20390,87 +20356,25 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/arrivals)
 "aUI" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "blue1"
-	},
-/area/station/crew_quarters/arcade/dungeon)
-"aUJ" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "blue1"
-	},
-/area/station/crew_quarters/arcade/dungeon)
-"aUK" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "blue1"
-	},
-/area/station/crew_quarters/arcade/dungeon)
+/turf/simulated/floor/green/corner,
+/area/station/crew_quarters/arcade)
 "aUL" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/switch_junction/left/east{
+	mail_tag = ranch
 	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "blue1"
-	},
-/area/station/crew_quarters/arcade/dungeon)
+/turf/simulated/floor/green/side,
+/area/station/hydroponics/lobby)
 "aUM" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "blue5"
-	},
-/area/station/crew_quarters/arcade/dungeon)
+/obj/potted_plant,
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/green/side,
+/area/station/crew_quarters/arcade)
 "aUN" = (
-/obj/window/auto/reinforced,
-/obj/grille/steel,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/arcade/dungeon)
-"aUO" = (
-/obj/machinery/power/data_terminal,
-/obj/table/wood/auto,
-/obj/machinery/networked/printer{
-	name = "Printer - Arcade";
-	pixel_y = 5;
-	print_id = "Arcade"
+/turf/simulated/floor/stairs{
+	dir = 4;
+	icon_state = "Stairs2_wide"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "blue5"
-	},
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/crew_quarters/arcade)
 "aUP" = (
 /obj/machinery/sim/vr_bed{
 	dir = 4;
@@ -21009,66 +20913,15 @@
 /turf/space,
 /area/space)
 "aWd" = (
-/obj/stool/chair{
+/turf/simulated/floor/green/side{
 	dir = 4
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "blue1"
-	},
-/area/station/crew_quarters/arcade/dungeon)
-"aWe" = (
-/obj/table/wood/auto,
-/obj/item/decoration/ashtray,
-/obj/machinery/light/lamp/green{
-	pixel_x = 7;
-	pixel_y = 12
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "blue1"
-	},
-/area/station/crew_quarters/arcade/dungeon)
-"aWf" = (
-/obj/table/wood/auto,
-/obj/disposalpipe/segment,
-/obj/item/paper/book/monster_manual_revised{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/paper/book/DNDrulebook{
-	pixel_x = 3;
-	pixel_y = 1
-	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "blue1"
-	},
-/area/station/crew_quarters/arcade/dungeon)
-"aWg" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "blue1"
-	},
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/crew_quarters/arcade)
 "aWh" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/carpet{
-	dir = 4;
-	icon_state = "blue5"
-	},
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade/dungeon)
 "aWi" = (
 /turf/simulated/wall/auto/supernorn,
@@ -21077,7 +20930,7 @@
 /obj/grille/steel,
 /obj/window/auto,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade)
+/area/station/crew_quarters/arcade/dungeon)
 "aWk" = (
 /obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -21666,81 +21519,59 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
 "aXB" = (
-/obj/storage/closet/office,
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "blue5"
+/turf/simulated/floor/green/side{
+	dir = 8
 	},
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/crew_quarters/arcade)
 "aXC" = (
-/obj/stool/chair{
+/obj/potted_plant{
 	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "blue1"
+/turf/simulated/floor/green/side{
+	dir = 4
 	},
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/crew_quarters/arcade)
 "aXD" = (
-/obj/table/wood/auto,
-/obj/item/paper_bin{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/clipboard{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/clipboard{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/clipboard{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/clipboard{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "blue1"
-	},
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade/dungeon)
 "aXE" = (
-/obj/table/wood/auto,
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/item/storage/box/nerd_kit{
-	pixel_y = 5
-	},
+/obj/storage/closet/office,
 /turf/simulated/floor/carpet{
 	dir = 9;
-	icon_state = "blue1"
+	icon_state = "blue2"
 	},
 /area/station/crew_quarters/arcade/dungeon)
 "aXF" = (
-/obj/stool/chair{
+/obj/stool/chair/couch{
 	dir = 8
+	},
+/obj/item/storage/goodybag,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"aXG" = (
+/obj/machinery/disposal/mail/autoname/public/arcade,
+/obj/machinery/light_switch/north,
+/obj/disposalpipe/trunk/mail/north{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"aXH" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
@@ -21750,31 +21581,6 @@
 	icon_state = "blue1"
 	},
 /area/station/crew_quarters/arcade/dungeon)
-"aXG" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade)
-"aXH" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	areastring = "Arcade";
-	dir = 8;
-	name = "Arcade APC";
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/northwest)
 "aXI" = (
 /obj/cable{
 	d1 = 4;
@@ -22609,52 +22415,62 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/arrivals)
 "aZm" = (
-/obj/disposalpipe/segment{
+/obj/stool/chair/couch{
 	dir = 4
 	},
+/obj/item/reagent_containers/food/snacks/chips,
+/obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/carpet{
-	dir = 5;
+	dir = 10;
 	icon_state = "blue5"
 	},
 /area/station/crew_quarters/arcade/dungeon)
 "aZn" = (
-/obj/shrub{
-	dir = 1
-	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/arcade/dungeon)
-"aZo" = (
 /obj/stool/chair{
+	dir = 8
+	},
+/turf/simulated/floor/green/side{
+	dir = 8
+	},
+/area/station/crew_quarters/arcade)
+"aZo" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/green/corner{
 	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "blue1"
-	},
-/area/station/crew_quarters/arcade/dungeon)
+/area/station/crew_quarters/arcade)
 "aZp" = (
-/obj/table/wood/auto,
-/obj/item/dice/magic8ball{
-	pixel_x = 4;
-	pixel_y = 6
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/item/reagent_containers/food/drinks/cola{
-	pixel_x = -3;
-	pixel_y = 4
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "blue1"
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/stairs{
+	dir = 8;
+	icon_state = "Stairs2_wide"
 	},
 /area/station/crew_quarters/arcade/dungeon)
 "aZq" = (
-/obj/table/wood/auto,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "blue1"
+	dir = 9;
+	icon_state = "blue5"
 	},
 /area/station/crew_quarters/arcade/dungeon)
 "aZr" = (
@@ -23263,68 +23079,55 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/arrivals)
 "baI" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/camera/television{
-	c_tag = "game room";
-	dir = 8;
-	name = "camera - game room"
+/obj/disposalpipe/junction{
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
-	dir = 4;
-	icon_state = "blue5"
+	dir = 9;
+	icon_state = "blue1"
 	},
 /area/station/crew_quarters/arcade/dungeon)
 "baJ" = (
-/obj/window/auto/reinforced,
-/obj/grille/steel,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade/dungeon)
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
+/area/station/crew_quarters/arcade)
 "baK" = (
-/obj/stool/chair{
-	dir = 4
+/turf/simulated/floor/green/side,
+/area/station/crew_quarters/arcade)
+"baL" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/stairs{
+	dir = 8;
+	icon_state = "Stairs_wide"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"baM" = (
+/obj/shrub{
+	dir = 1
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "blue2"
 	},
 /area/station/crew_quarters/arcade/dungeon)
-"baL" = (
-/obj/table/wood/auto,
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "blue5"
-	},
-/area/station/crew_quarters/arcade/dungeon)
-"baM" = (
-/obj/table/wood/auto,
-/obj/item/clothing/suit/cultist/nerd{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/apprentice{
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/obj/item/clothing/mask/skull{
-	pixel_x = -4
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "blue5"
-	},
-/area/station/crew_quarters/arcade/dungeon)
 "baN" = (
-/obj/stool/chair{
-	dir = 8
+/obj/table/wood/auto,
+/obj/machinery/networked/printer{
+	name = "Printer - Arcade";
+	pixel_y = 5;
+	print_id = "Arcade"
 	},
-/obj/machinery/light,
+/obj/machinery/power/data_terminal,
+/obj/cable,
 /turf/simulated/floor/carpet{
-	dir = 6;
 	icon_state = "blue5"
 	},
 /area/station/crew_quarters/arcade/dungeon)
@@ -23520,10 +23323,13 @@
 /turf/simulated/floor/caution/northsouth,
 /area/station/maintenance/northeast)
 "bbt" = (
-/obj/reagent_dispensers/watertank/fountain,
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/carpet{
 	dir = 6;
-	icon_state = "blue6"
+	icon_state = "blue5"
 	},
 /area/station/crew_quarters/arcade/dungeon)
 "bbu" = (
@@ -38949,7 +38755,6 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "bHM" = (
@@ -41293,10 +41098,6 @@
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engine/inner)
@@ -47411,7 +47212,7 @@
 "bXI" = (
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingun
+	displayed = new /obj/item/captaingun;
 	pixel_y = 6
 	},
 /obj/cable{
@@ -78974,11 +78775,10 @@
 	},
 /area/space)
 "dpq" = (
-/obj/shrub,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/hydroponics/bay)
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/ranch)
 "dpC" = (
 /obj/table/auto,
 /obj/item/disk/data/cartridge/captain,
@@ -79004,6 +78804,10 @@
 	icon_state = "fgreen4"
 	},
 /area/station/hydroponics/bay)
+"duT" = (
+/obj/item/reagent_containers/food/drinks/chickensoup,
+/turf/simulated/floor/plating/airless,
+/area/space)
 "dJs" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -79024,35 +78828,90 @@
 	},
 /turf/simulated/floor,
 /area/station/science/teleporter)
-"eQI" = (
-/obj/machinery/light,
-/turf/simulated/floor/grass/leafy,
+"dSl" = (
+/obj/decal/tile_edge/stripe{
+	dir = 5
+	},
+/turf/simulated/floor/wood,
 /area/station/ranch)
-"fHh" = (
+"etE" = (
+/obj/machinery/sim/vr_bed{
+	dir = 4;
+	name = "VR simulation pod";
+	network = "arcadevr"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
+"eQI" = (
+/obj/item/device/radio/intercom/catering{
+	dir = 8
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
+"eZn" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"fji" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 1;
+	dir = 4;
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/potted_plant{
+	dir = 8
+	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"fVc" = (
-/obj/stool/chair/green{
-	dir = 4
+"fHh" = (
+/obj/machinery/light_switch/west,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/grasstodirt{
-	dir = 1
-	},
+/turf/simulated/floor/dirt,
 /area/station/ranch)
-"gor" = (
+"fHY" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/plating,
+/area/station/maintenance/northwest)
+"gcY" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
-/obj/stool/chair/green{
-	dir = 1
+/obj/railing/orange/reinforced,
+/turf/simulated/floor/grasstodirt{
+	dir = 6
+	},
+/area/station/ranch)
+"gtQ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -79060,9 +78919,76 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/ai_monitored/storage/eva)
+"hlQ" = (
+/obj/stool/chair,
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "blue1"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"hoU" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/arcade)
+"hFn" = (
+/turf/simulated/wall/auto/supernorn{
+	icon_state = "12"
+	},
+/area/station/crew_quarters/arcade)
+"hJC" = (
+/obj/table/wood/auto,
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/clipboard{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clipboard{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clipboard{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clipboard{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "blue1"
+	},
+/area/station/crew_quarters/arcade/dungeon)
 "hRi" = (
 /turf/space,
 /area/shuttle/arrival/station)
+"hRE" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/green/side,
+/area/station/crew_quarters/arcade)
 "iaz" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/vertical,
 /turf/simulated/floor/carpet{
@@ -79071,10 +78997,7 @@
 	},
 /area/station/hydroponics/bay)
 "idv" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 4
-	},
-/obj/machinery/camera/ranch{
+/obj/shrub{
 	dir = 1
 	},
 /turf/simulated/floor/grass/leafy,
@@ -79086,6 +79009,28 @@
 	},
 /turf/simulated/floor/bot,
 /area/station/hydroponics/bay)
+"ilw" = (
+/obj/machinery/vending/cola/red,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"ism" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "iFq" = (
 /obj/cable{
 	d1 = 1;
@@ -79095,29 +79040,71 @@
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/caution/west,
 /area/station/science/teleporter)
-"iHK" = (
-/obj/landmark/halloween,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/hydroponics/bay)
 "iRa" = (
-/obj/table/wood/auto,
-/obj/item/plate,
-/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget,
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 8
+	},
+/obj/machinery/camera/ranch,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
+"iYX" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/arcade/dungeon)
+"jcc" = (
+/obj/item/device/radio/intercom/catering,
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
-"jdA" = (
-/obj/cable{
-	icon_state = "4-8"
+"jcR" = (
+/obj/machinery/light,
+/obj/submachine/chicken_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn{
+	doants = 0
 	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
+/turf/simulated/floor/wood,
+/area/station/ranch)
+"jqe" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = -1
 	},
-/area/station/hydroponics/bay)
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/decal/tile_edge/stripe{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/ranch)
+"jsm" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/disposal/small{
+	dir = 1;
+	layer = 32;
+	pixel_y = 32
+	},
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "jJK" = (
 /obj/window/auto/reinforced,
 /obj/grille/steel,
@@ -79127,13 +79114,68 @@
 /obj/item/paper/book/monster_manual_revised,
 /turf/simulated/wall/asteroid,
 /area/space)
-"lAy" = (
-/obj/machinery/light_switch/east,
-/obj/submachine/chicken_feed_grinder,
-/obj/item/reagent_containers/food/snacks/plant/corn{
-	doants = 0
+"jRr" = (
+/obj/stool/chair,
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"kBU" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "blue1"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"kSZ" = (
+/obj/table/wood/auto,
+/obj/item/clothing/head/apprentice{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/clothing/mask/skull{
+	pixel_x = -4
+	},
+/obj/item/clothing/suit/cultist/nerd{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"luy" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/potted_plant{
+	dir = 1;
+	pixel_y = 28
 	},
 /turf/simulated/floor/dirt,
+/area/station/ranch)
+"lAy" = (
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/obj/table/wood/auto,
+/obj/item/reagent_containers/food/snacks/chicken_feed_bag,
+/obj/item/reagent_containers/food/snacks/chicken_feed_bag,
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
 /area/station/ranch)
 "lBA" = (
 /obj/machinery/arc_electroplater,
@@ -79141,6 +79183,12 @@
 	name = "reinforced plating"
 	},
 /area/station/quartermaster/refinery)
+"maP" = (
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "blue1"
+	},
+/area/station/crew_quarters/arcade/dungeon)
 "mgV" = (
 /obj/submachine/seed_manipulator{
 	dir = 4
@@ -79157,6 +79205,11 @@
 	icon_state = "fgreen2"
 	},
 /area/station/hydroponics/bay)
+"mhq" = (
+/obj/chicken_nesting_box,
+/obj/machinery/light,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "miG" = (
 /obj/window/auto/reinforced,
 /obj/grille/steel,
@@ -79166,7 +79219,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/hydroponics/bay)
+/area/station/crew_quarters/arcade)
 "mqm" = (
 /obj/landmark/start{
 	name = "Botanist"
@@ -79184,8 +79237,26 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"mBI" = (
-/turf/simulated/floor/dirt,
+"mtI" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/pyro{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/arcade/dungeon)
+"mBW" = (
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/decal/tile_edge/stripe{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/station/ranch)
 "mDn" = (
 /obj/cable{
@@ -79206,6 +79277,14 @@
 /obj/window/auto/reinforced,
 /obj/grille/steel,
 /turf/simulated/floor/plating,
+/area/station/ranch)
+"nnj" = (
+/obj/railing/orange/reinforced,
+/obj/machinery/light_switch/east,
+/obj/table/wood/auto,
+/obj/item/reagent_containers/food/snacks/chicken_feed_bag,
+/obj/item/reagent_containers/food/snacks/chicken_feed_bag,
+/turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "nqk" = (
 /obj/machinery/photocopier,
@@ -79252,8 +79331,13 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "nMJ" = (
+/obj/table/reinforced/auto,
+/obj/machinery/cashreg,
+/obj/machinery/door/window/eastright,
+/obj/access_spawn/rancher,
+/obj/firedoor_spawn,
 /turf/simulated/floor/grasstodirt{
-	dir = 10
+	dir = 4
 	},
 /area/station/ranch)
 "ojq" = (
@@ -79266,14 +79350,28 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "oxp" = (
-/turf/simulated/floor/grasstodirt{
-	dir = 9
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg{
+	rand_pos = 0
 	},
+/obj/machinery/light{
+	dir = 8;
+	tag = ""
+	},
+/turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "oHZ" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
+"oKC" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
 "pdE" = (
 /obj/machinery/chem_master{
 	dir = 4
@@ -79286,25 +79384,68 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai_upload)
+"ptb" = (
+/obj/table/wood/auto,
+/obj/item/decoration/ashtray,
+/obj/machinery/light/lamp/green{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "blue1"
+	},
+/area/station/crew_quarters/arcade/dungeon)
 "pFA" = (
 /obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/chapel)
+"pJZ" = (
+/obj/machinery/camera/television{
+	c_tag = "game room";
+	dir = 4;
+	name = "camera - game room"
+	},
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/arcade/dungeon)
 "pTS" = (
 /obj/item/storage/wall/random,
 /obj/machinery/vending/janitor,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
-"qfX" = (
-/obj/machinery/light{
-	dir = 8;
-	tag = ""
+"pVe" = (
+/obj/decal/poster/wallsign/poster_rand{
+	pixel_y = 28
 	},
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"qfX" = (
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"qmv" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/arcade/dungeon)
+"qvI" = (
+/obj/window/auto/reinforced,
+/obj/grille/steel,
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "blue2"
+	},
+/area/station/hydroponics/bay)
 "qBq" = (
-/obj/machinery/light,
-/turf/simulated/floor/dirt,
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
 /area/station/ranch)
 "qKy" = (
 /obj/machinery/atmospherics/valve{
@@ -79313,12 +79454,30 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/science/lab)
-"rsz" = (
-/obj/cable{
-	icon_state = "2-8"
+"qLi" = (
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg{
+	rand_pos = 0
 	},
-/turf/simulated/floor/green/side,
-/area/station/hydroponics/bay)
+/obj/machinery/light,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
+"qXj" = (
+/obj/stool/chair,
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "blue1"
+	},
+/area/station/crew_quarters/arcade/dungeon)
 "rsO" = (
 /obj/table/auto,
 /obj/item/kitchen/rollingpin,
@@ -79327,15 +79486,35 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
 "rBI" = (
-/obj/railing/orange/reinforced,
 /obj/stool/chair/green{
 	dir = 4
 	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
+"rOo" = (
+/obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "saK" = (
-/turf/simulated/floor/grass/leafy,
+/obj/table/reinforced/auto,
+/obj/machinery/door/window/eastright,
+/obj/access_spawn/rancher,
+/obj/firedoor_spawn,
+/obj/item/plate,
+/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget,
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
 /area/station/ranch)
+"snI" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
 "svu" = (
 /obj/indestructible/shuttle_corner{
 	dir = 8
@@ -79362,6 +79541,71 @@
 	icon_state = "fpurple2"
 	},
 /area/station/crew_quarters/hor)
+"sGY" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"sLX" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "blue6"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"tat" = (
+/obj/storage/closet{
+	name = "rancher's supply closet"
+	},
+/obj/item/paper/ranch_guide,
+/obj/item/storage/box/clothing/rancher,
+/obj/item/fishing_rod,
+/obj/item/chicken_carrier,
+/obj/item/device/camera_viewer/ranch{
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/chicken,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
+"thz" = (
+/obj/railing/orange/reinforced,
+/obj/landmark/start{
+	name = "Rancher"
+	},
+/turf/simulated/floor/grasstodirt,
+/area/station/ranch)
+"tlM" = (
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "blue1"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"trh" = (
+/obj/submachine/chef_sink/chem_sink{
+	desc = "A water-filled unit intended for hand-washing purposes.";
+	dir = 8;
+	pixel_x = 2
+	},
+/obj/machinery/camera/ranch{
+	dir = 8
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "trr" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -79407,38 +79651,96 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/purple,
 /area/station/teleporter)
+"tGv" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "tJa" = (
 /obj/machinery/flasher/portable,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/chapel)
-"tPC" = (
-/obj/machinery/door/airlock/pyro/glass{
+"tTd" = (
+/turf/simulated/floor/dirt,
+/area/station/ranch)
+"tWh" = (
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"ucI" = (
+/obj/table/wood/auto,
+/obj/item/paper/book/monster_manual_revised{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/paper/book/DNDrulebook{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "blue1"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"uUh" = (
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 9
+	},
+/area/station/ranch)
+"vdM" = (
+/obj/shrub{
+	dir = 6
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
+"viA" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/window/eastright,
+/obj/item/satchel/hydro,
+/obj/access_spawn/rancher,
+/obj/firedoor_spawn,
+/turf/simulated/floor/grasstodirt{
 	dir = 4
 	},
-/obj/firedoor_spawn,
-/obj/access_spawn/rancher,
+/area/station/ranch)
+"vlg" = (
+/obj/table/wood/auto,
+/obj/item/dice/magic8ball{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/cola{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "blue1"
+	},
+/area/station/crew_quarters/arcade/dungeon)
+"vlP" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/delivery,
-/area/station/ranch)
-"tTd" = (
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/snacks/chicken_feed_bag,
-/obj/item/reagent_containers/food/snacks/chicken_feed_bag,
-/turf/simulated/floor/dirt,
-/area/station/ranch)
-"viA" = (
-/obj/chicken_nesting_box,
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
-"vlP" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = -1
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "blue1"
+	},
+/area/station/crew_quarters/arcade/dungeon)
 "vrU" = (
 /obj/table/wood/auto,
 /obj/item/plantanalyzer,
@@ -79460,10 +79762,11 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "vNO" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 4
+/obj/chicken_nesting_box,
+/obj/machinery/light{
+	dir = 8;
+	tag = ""
 	},
-/obj/machinery/camera/ranch,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "vRi" = (
@@ -79475,37 +79778,42 @@
 	},
 /area/station/hydroponics/bay)
 "wcj" = (
-/obj/railing/orange/reinforced,
-/turf/simulated/floor/grasstodirt,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/potted_plant{
+	dir = 4
+	},
+/turf/simulated/floor/dirt,
 /area/station/ranch)
+"wmO" = (
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "Arcade";
+	dir = 8;
+	name = "Arcade APC";
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/northwest)
 "wSb" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
+	dir = 1;
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/potted_plant,
 /turf/simulated/floor/grass/leafy,
-/area/station/ranch)
-"wWm" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = -1
-	},
-/turf/simulated/floor/dirt,
 /area/station/ranch)
 "xfw" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ranch)
-"xiP" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/hydroponics/bay)
 "xBG" = (
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -79547,6 +79855,21 @@
 /obj/random_item_spawner/desk_stuff,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/ce)
+"xRj" = (
+/obj/table/wood/auto,
+/obj/item/storage/box/nerd_kit{
+	pixel_y = 5
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
 "xRN" = (
 /obj/table/wood/auto,
 /obj/machinery/light{
@@ -79562,30 +79885,34 @@
 	icon_state = "fgreen4"
 	},
 /area/station/hydroponics/bay)
-"xTc" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/ranch)
 "xZx" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 1
 	},
-/turf/simulated/floor/dirt,
+/obj/access_spawn/rancher,
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment,
+/obj/decal/tile_edge/stripe,
+/turf/simulated/floor/wood,
 /area/station/ranch)
+"xZN" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "blue5"
+	},
+/area/station/crew_quarters/arcade/dungeon)
 "ybe" = (
-/obj/shrub{
-	dir = 6
+/obj/window/auto/reinforced,
+/obj/grille/steel,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
-"ydl" = (
-/obj/landmark/start{
-	name = "Rancher"
-	},
-/turf/simulated/floor/dirt,
+/turf/simulated/floor/plating,
 /area/station/ranch)
 "yfA" = (
 /obj/machinery/disposal/mail/small{
@@ -98736,9 +99063,9 @@ aaa
 aaa
 aaa
 aaa
-acq
 aaa
-acq
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99038,9 +99365,9 @@ aaa
 aaa
 aaa
 aaa
-aam
-aaS
-aaI
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99340,9 +99667,9 @@ aaa
 aaa
 aaa
 aaa
-aam
-aan
-aaI
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99642,9 +99969,9 @@ aaa
 aaa
 aaa
 aaa
-aam
-aaB
-aaI
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99941,15 +100268,15 @@ aaa
 aaa
 aaa
 aaa
-acq
 aaa
 aaa
-aao
-aaa
-aao
 aaa
 aaa
-acq
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100242,17 +100569,17 @@ aaa
 aaa
 aaa
 aaa
-xfw
-xTc
-xTc
-xfw
-xTc
-xTc
-xTc
-xfw
-xTc
-xTc
-xfw
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100543,19 +100870,19 @@ aaa
 aaa
 aaa
 aaa
-xfw
-xfw
-wSb
-aHr
-qfX
-fVc
-iRa
-rBI
-qfX
-ybe
-fHh
-xfw
-xfw
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100845,19 +101172,19 @@ aaa
 aaa
 aaa
 aaa
-xfw
-vNO
-saK
-saK
-saK
-aKt
-ydl
-wcj
-saK
-saK
-saK
-idv
-xfw
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101147,19 +101474,19 @@ aaa
 aaa
 aaa
 aaa
-xTc
-vlP
-saK
-saK
-saK
-aKt
-mBI
-wcj
-saK
-saK
-saK
-eQI
-xTc
+aaa
+aaa
+aaa
+aaa
+aaa
+acq
+aaa
+acq
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101447,29 +101774,29 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aam
+aaS
+aaI
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 acq
 aaa
-xTc
-aKu
-viA
-saK
-saK
-aKt
-mBI
-wcj
-saK
-saK
-viA
-aKu
-xTc
-aaa
 acq
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -101749,22 +102076,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aam
-axt
-xTc
-aDm
-aDm
-aDm
-aDm
-oxp
-mBI
-nMJ
-aDm
-aDm
-aDm
-aDm
-xTc
-abB
+aan
 aaI
 aaa
 aaa
@@ -101772,6 +102092,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aam
+aaS
+aaI
 aaa
 aaa
 aaa
@@ -102051,22 +102378,15 @@ aaa
 aaa
 aaa
 aaa
+acq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aam
-aaF
-xTc
-wWm
-mBI
-mBI
-mBI
-mBI
-mBI
-mBI
-mBI
-mBI
-mBI
-qBq
-xTc
-aaF
+aaB
 aaI
 aaa
 aaa
@@ -102074,6 +102394,13 @@ aaa
 aaa
 aaa
 aaa
+acq
+aaa
+aaa
+aaa
+aam
+duT
+aaI
 aaa
 aaa
 aaa
@@ -102354,28 +102681,28 @@ aaa
 aaa
 aaa
 aam
-aaF
-xfw
-aCc
-mBI
-mBI
-mBI
-tTd
-lAy
-tTd
-mBI
-mBI
-xZx
-gor
-xfw
-aaF
+axt
+aaa
+aaa
+aaa
+aaa
+aaa
+aao
+aaa
+aao
+aaa
+aaa
+aaa
+aaa
+aaa
+abB
 aaI
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aam
+aaB
+aaI
 aaa
 aaa
 aaa
@@ -102656,28 +102983,28 @@ aaa
 aaa
 aaa
 aam
-xfw
-xfw
+aaI
+aaa
+aaa
+acq
 nbd
+xfw
+jJK
 aEE
-nbd
-xfw
-jJK
-xfw
 jJK
 xfw
 nbd
-tPC
-nbd
-xfw
-xfw
+acq
+aaa
+aaa
+aam
 aaI
 aaa
 aaa
 aaa
+aao
 aaa
-aaa
-aaa
+aao
 aaa
 aaa
 aaa
@@ -102958,29 +103285,29 @@ aaa
 aaa
 aaa
 aam
+aaF
 awc
-dpq
 aED
-azn
+aED
 awc
 aLI
 aIT
 mgV
 vrU
 xGk
-awc
-jdA
+aHr
 aED
-dpq
+aED
 awc
+aaF
 aaI
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dpq
+dpq
+dpq
+dpq
+dpq
 aaa
 aaa
 aaa
@@ -103261,9 +103588,9 @@ aaa
 aaa
 aam
 awc
-azn
-azn
-azn
+awc
+aCc
+aDm
 azn
 azn
 aFD
@@ -103271,19 +103598,19 @@ aHq
 aIU
 azn
 azn
-jdA
-azn
-azn
+aKt
+aCc
+aKu
 awc
 aaI
 aaa
-aaa
-acq
-aaa
-acq
-aaa
-aaa
-aaa
+dpq
+dpq
+oxp
+qfX
+vNO
+dpq
+dpq
 aaa
 aaa
 aaa
@@ -103572,22 +103899,22 @@ azn
 azn
 azn
 azn
-aAH
-jdA
+azn
+azn
 azn
 azn
 awc
 aaI
 aaa
-aaa
-aam
-aaS
-aaI
-aaa
-aaa
-aaa
-aaa
-aaa
+dpq
+idv
+qfX
+qfX
+qfX
+qfX
+dpq
+xfw
+xfw
 aaa
 aaa
 aaa
@@ -103875,22 +104202,22 @@ azn
 vRi
 azn
 aAH
-jdA
+azn
 aAH
 aPA
 awc
-awc
+qvI
 aaa
-aaa
-aam
-aan
-aaI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xfw
+iRa
+qfX
+qfX
+qfX
+wSb
+xfw
+jqe
+jcR
+xfw
 aaa
 aaa
 aaa
@@ -104177,25 +104504,25 @@ azn
 aIW
 azn
 aAH
-iHK
+aCb
 aAH
 azn
 aQT
-awc
-aaa
-aaa
-aam
-aaB
-aaI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+awd
+dpq
+xfw
+lAy
+qBq
+qBq
+qBq
+qBq
+uUh
+dSl
+mBW
+xfw
+aah
+aah
+arR
 aaa
 aaa
 aaa
@@ -104479,23 +104806,23 @@ azn
 azn
 azn
 aAH
-jdA
+azn
 aAH
 azn
+azn
 aQU
-awd
-afk
-aaa
-aao
-aaa
-aao
-aaa
-acq
-aaa
-aaa
-aaa
-aaa
-aaa
+eQI
+fHh
+tTd
+rBI
+tTd
+wcj
+tTd
+ism
+gcY
+xfw
+dpq
+dpq
 aaa
 aaa
 aaa
@@ -104781,24 +105108,24 @@ mqm
 xBG
 azn
 azn
-jdA
+azn
 aAH
 azn
 aQV
 awd
-aQx
-aQx
-aUN
-aUN
-aUN
-baJ
-aaI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xfw
+xfw
+nMJ
+saK
+viA
+xfw
+xfw
+tGv
+rOo
+fji
+vdM
+dpq
+dpq
 aaa
 aaa
 aaa
@@ -105083,24 +105410,24 @@ aHs
 aIY
 xRN
 axz
-jdA
 azn
 azn
 azn
-awe
+azn
+hFn
 aTk
 aTr
-aUO
+aXB
 aXB
 aZn
 baJ
-baJ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xfw
+luy
+rOo
+qfX
+qfX
+mhq
+dpq
 aaa
 aaa
 aaa
@@ -105385,24 +105712,24 @@ awf
 awf
 awc
 axr
-jdA
+azn
 azn
 azn
 aQW
-awe
+hFn
 aTl
 aUI
 aWd
 aXC
 aZo
-baK
-baJ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hRE
+xZx
+gtQ
+thz
+qfX
+qfX
+qfX
+dpq
 aaa
 aaa
 aaa
@@ -105692,19 +106019,19 @@ azn
 azn
 aQX
 aSk
-aTm
-aUJ
-aWe
+aTn
+baK
+aXD
 aXD
 aZp
 baL
-baJ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ybe
+jcc
+rOo
+qfX
+qfX
+qLi
+dpq
 aaa
 aaa
 aaa
@@ -105989,24 +106316,24 @@ aEF
 aEF
 aEF
 nCq
-rsz
-xiP
-xiP
+aJa
+azn
+azn
 aQY
 miG
 aTn
-aUK
-aWf
+baK
+aXD
 aXE
 aZq
 baM
-baJ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nbd
+jsm
+nnj
+trh
+qfX
+dpq
+dpq
 abB
 aaS
 aaS
@@ -106295,19 +106622,19 @@ aJa
 azn
 azn
 aPA
-awh
+aKy
 aTo
-aUL
-aWg
+baK
+aXD
 aXF
-aWg
+vlP
 baN
-aQx
-aaa
-aaa
-aaa
-aaa
-aaa
+xfw
+tat
+xfw
+xfw
+dpq
+dpq
 aaa
 aam
 bdU
@@ -106597,16 +106924,16 @@ aNa
 aOo
 aPB
 aQZ
-awh
+aKy
 aTp
 aUM
 aWh
 aZm
 baI
 bbt
-aQx
-aah
-aah
+xfw
+xfw
+xfw
 aah
 aah
 aah
@@ -106899,16 +107226,16 @@ aLK
 aLK
 aLK
 aLK
-aLK
+hoU
 aTq
 aUN
 aWi
 aXG
-aKy
+aXH
 aQx
-aQx
-aaa
-aaa
+ilw
+pJZ
+aXD
 aaa
 aaa
 aaa
@@ -107204,13 +107531,13 @@ aRa
 aKy
 aTs
 aUP
-aKy
-bah
-aXH
-akw
-aaI
-aaa
-aaa
+aWi
+pVe
+kBU
+tlM
+maP
+tWh
+aXD
 aaa
 aaa
 aaa
@@ -107505,14 +107832,14 @@ aPD
 aOq
 aSl
 aTt
-aUP
-aKy
-bah
-aYI
-akw
-aaI
-aaa
-aaa
+etE
+iYX
+sGY
+qXj
+ptb
+hJC
+oKC
+aXD
 aaa
 aaa
 bfD
@@ -107809,12 +108136,12 @@ aOr
 aTu
 aWO
 aWj
-bah
-aYI
-auh
-aaI
-aaa
-aaa
+xZN
+hlQ
+ucI
+vlg
+snI
+aXD
 aaa
 aaa
 aao
@@ -108111,12 +108438,12 @@ aSm
 aTv
 aUR
 aWj
-bah
-aYI
-auh
-aaI
-aaa
-aaa
+eZn
+jRr
+xRj
+kSZ
+sLX
+aXD
 aaa
 aaa
 afB
@@ -108412,13 +108739,13 @@ aOt
 aOt
 aTw
 aUS
-aKy
-bah
-aYI
-akw
-aaI
-aaa
-aaa
+aWi
+mtI
+aWi
+qmv
+aXD
+aXD
+aXD
 aaa
 abB
 aaF
@@ -108716,7 +109043,7 @@ aTx
 aRc
 aKy
 bah
-aYI
+wmO
 akw
 aaI
 aaa
@@ -109924,7 +110251,7 @@ aTB
 aUV
 aKC
 bah
-aYI
+fHY
 akw
 aaI
 aaa
@@ -110818,7 +111145,7 @@ vyj
 ase
 aFV
 aHD
-aJj
+aUL
 aKE
 aLT
 aNn

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -20358,12 +20358,6 @@
 "aUI" = (
 /turf/simulated/floor/green/corner,
 /area/station/crew_quarters/arcade)
-"aUL" = (
-/obj/disposalpipe/switch_junction/left/east{
-	mail_tag = ranch
-	},
-/turf/simulated/floor/green/side,
-/area/station/hydroponics/lobby)
 "aUM" = (
 /obj/potted_plant,
 /obj/disposalpipe/segment/mail/vertical,
@@ -78804,10 +78798,6 @@
 	icon_state = "fgreen4"
 	},
 /area/station/hydroponics/bay)
-"duT" = (
-/obj/item/reagent_containers/food/drinks/chickensoup,
-/turf/simulated/floor/plating/airless,
-/area/space)
 "dJs" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -102399,7 +102389,7 @@ aaa
 aaa
 aaa
 aam
-duT
+aan
 aaI
 aaa
 aaa
@@ -111145,7 +111135,7 @@ vyj
 ase
 aFV
 aHD
-aUL
+aJj
 aKE
 aLT
 aNn

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -58780,6 +58780,11 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/chapel/sanctuary)
+"gqE" = (
+/obj/chicken_nesting_box,
+/obj/item/device/radio/intercom/catering,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "gug" = (
 /turf/simulated/shuttle/wall{
 	dir = 8;
@@ -59357,8 +59362,8 @@
 	anchored = 1
 	},
 /obj/railing/orange/reinforced,
-/turf/simulated/floor/grasstodirt,
 /turf/unsimulated/grasstodirt,
+/turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "rGC" = (
 /obj/cable{
@@ -59488,10 +59493,10 @@
 /obj/machinery/plantpot{
 	anchored = 1
 	},
-/turf/simulated/floor/grasstodirt{
+/turf/unsimulated/grasstodirt{
 	dir = 1
 	},
-/turf/unsimulated/grasstodirt{
+/turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
 /area/station/ranch)
@@ -93131,7 +93136,7 @@ bUY
 bUL
 aaa
 qfu
-lkp
+gqE
 rxZ
 vpa
 viZ

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -12545,8 +12545,18 @@
 	},
 /area/station/hallway/secondary/east)
 "aFt" = (
-/obj/decal/poster/wallsign/stencil/left/r,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	layer = 3.5;
+	pixel_y = -24
+	},
+/turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "aFu" = (
 /turf/simulated/floor,
@@ -14131,8 +14141,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/mining/refinery)
 "aJb" = (
-/obj/disposalpipe/segment/produce,
 /obj/item/raw_material/rock,
+/obj/disposalpipe/junction/left,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "aJc" = (
@@ -19336,7 +19346,7 @@
 /obj/table/wood/auto,
 /obj/displaycase{
 	displayed = new /obj/item/captaingun
-},
+	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/south,
 /area/station/bridge/captain)
 "aTY" = (
@@ -32389,6 +32399,9 @@
 	pixel_x = -10
 	},
 /obj/decal/cleanable/dirt/dirt4,
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
 /turf/simulated/floor/escape{
 	dir = 8
 	},
@@ -45091,6 +45104,9 @@
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
 	},
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "bXo" = (
@@ -45099,6 +45115,9 @@
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
 	},
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "bXp" = (
@@ -45106,6 +45125,9 @@
 /obj/reagent_dispensers/watertank/big,
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
+	},
+/obj/disposalpipe/segment/produce{
+	dir = 4
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
@@ -45117,6 +45139,9 @@
 	icon_state = "line1"
 	},
 /obj/machinery/light,
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "bXr" = (
@@ -58569,6 +58594,13 @@
 	icon_state = "floorscorched1"
 	},
 /area/space)
+"cGc" = (
+/obj/landmark/start{
+	name = "Rancher"
+	},
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "cPK" = (
 /obj/cable{
 	d1 = 4;
@@ -58614,17 +58646,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/produce,
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/station/ranch)
 "doh" = (
-/obj/submachine/chicken_incubator,
-/obj/item/reagent_containers/food/snacks/ingredient/egg{
-	rand_pos = 0
+/obj/disposalpipe/segment/produce{
+	dir = 4
 	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hydroponics/bay)
 "dzg" = (
 /obj/lattice{
 	dir = 4;
@@ -58659,8 +58691,16 @@
 	layer = 3.5;
 	pixel_y = -24
 	},
+/obj/disposalpipe/segment/produce{
+	dir = 4
+	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"eam" = (
+/obj/decal/poster/wallsign/stencil/left/n,
+/obj/decal/poster/wallsign/stencil/right/c,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/ranch)
 "ecc" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -58668,6 +58708,11 @@
 /obj/reagent_dispensers/compostbin,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
+"epE" = (
+/turf/simulated/floor/grasstodirt{
+	dir = 10
+	},
+/area/station/ranch)
 "fgx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -58736,19 +58781,28 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/chapel/sanctuary)
 "gug" = (
-/obj/chicken_nesting_box,
-/turf/simulated/floor/grass/leafy,
+/turf/simulated/shuttle/wall{
+	dir = 8;
+	icon_state = "wall_space"
+	},
 /area/station/ranch)
 "gyU" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
 "gBU" = (
-/obj/decal/poster/wallsign/stencil/left/c{
-	pixel_x = -20
+/obj/table/glass/auto,
+/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
+	rand_pos = 1
 	},
-/obj/decal/poster/wallsign/stencil/left/h,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
+	rand_pos = 1
+	},
+/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
+	rand_pos = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/dirt,
 /area/station/ranch)
 "gDr" = (
 /obj/cable{
@@ -58770,11 +58824,23 @@
 /turf/space,
 /area/space)
 "hhi" = (
-/obj/decal/poster/wallsign/stencil{
-	pixel_x = -20
+/obj/railing/orange/reinforced{
+	dir = 8
 	},
-/obj/decal/poster/wallsign/stencil/left/n,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/storage/closet{
+	name = "rancher supply closet"
+	},
+/obj/item/paper/ranch_guide,
+/obj/item/storage/box/clothing/rancher,
+/obj/item/fishing_rod,
+/obj/item/chicken_carrier,
+/obj/item/device/camera_viewer/ranch{
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/chicken,
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
 /area/station/ranch)
 "hDj" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
@@ -58792,13 +58858,15 @@
 /area/station/science/chemistry)
 "igR" = (
 /obj/machinery/door/airlock/pyro/glass,
+/obj/disposalpipe/segment/produce,
 /obj/access_spawn/rancher,
+/obj/machinery/door/firedoor/pyro,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/ranch)
 "itZ" = (
 /turf/simulated/floor/escape{
@@ -58817,6 +58885,13 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
+"iNY" = (
+/turf/simulated/shuttle/wall/cockpit/window{
+	dir = 4;
+	icon_state = "wall_space";
+	name = "window"
+	},
+/area/station/ranch)
 "iQj" = (
 /obj/cable{
 	d1 = 4;
@@ -58856,14 +58931,9 @@
 	},
 /area/station/janitor/office)
 "jxd" = (
-/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
-	rand_pos = 1
-	},
-/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
-	rand_pos = 1
-	},
-/obj/item/reagent_containers/food/snacks/chicken_feed_bag{
-	rand_pos = 1
+/obj/decal/fakeobjects/console_radar{
+	desc = "The control panel for a mark 1 rancher minishuttle. It is currently deactivated.";
+	name = "Rancher Shuttle Controls"
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -58875,19 +58945,26 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/produce,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "jUq" = (
-/obj/shrub,
-/turf/simulated/floor/grass/leafy,
+/turf/simulated/shuttle/wall/cockpit/window{
+	dir = 1;
+	icon_state = "wall_space";
+	name = "window"
+	},
 /area/station/ranch)
 "kdU" = (
-/obj/machinery/power/apc/autoname_north/nopoweralert,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/table/reinforced/auto,
+/obj/railing/orange/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/grass/leafy,
+/obj/item/satchel/hydro,
+/obj/item/satchel/hydro,
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
 /area/station/ranch)
 "kgQ" = (
 /obj/disposalpipe/segment/transport{
@@ -58897,11 +58974,11 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/storage)
 "klE" = (
-/turf/simulated/shuttle/wall/cockpit/window{
-	dir = 4;
-	icon_state = "wall_space";
-	name = "window"
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg{
+	rand_pos = 0
 	},
+/turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "kyZ" = (
 /obj/overlay{
@@ -58932,9 +59009,6 @@
 /area/station/crew_quarters/info{
 	name = "Net Cafe"
 	})
-"kYx" = (
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "lja" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /obj/cable{
@@ -58945,28 +59019,22 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "lkp" = (
-/obj/shrub{
-	dir = 6
-	},
+/obj/chicken_nesting_box,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "lsK" = (
-/obj/submachine/chef_sink/chem_sink{
-	pixel_y = 15
+/obj/shrub{
+	dir = 6
 	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
-"lwg" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "lDx" = (
-/obj/railing/orange/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/grasstodirt{
-	dir = 8
-	},
+/turf/simulated/floor/dirt,
 /area/station/ranch)
 "lPw" = (
 /obj/machinery/light/emergency{
@@ -59044,6 +59112,11 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet/red/standard/edge/se,
 /area/station/crew_quarters/fitness)
+"nhJ" = (
+/obj/decal/poster/wallsign/stencil/left/r,
+/obj/decal/poster/wallsign/stencil/right/a,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/ranch)
 "nii" = (
 /obj/cable{
 	d1 = 4;
@@ -59115,25 +59188,40 @@
 /turf/simulated/floor/blue,
 /area/station/medical/robotics)
 "nAW" = (
-/obj/railing/orange/reinforced{
-	dir = 8
+/obj/machinery/disposal{
+	icon_state = "mailchute";
+	icon_style = "mail";
+	name = "Produce Chute - Kitchen"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grasstodirt{
-	dir = 8
-	},
-/area/station/ranch)
-"nTp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/disposalpipe/trunk/east,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 22
 	},
 /turf/simulated/floor/dirt,
+/area/station/ranch)
+"nFM" = (
+/obj/stool/chair/green{
+	dir = 8
+	},
+/obj/machinery/power/apc/autoname_east,
+/obj/cable,
+/turf/simulated/floor/dirt,
+/area/station/ranch)
+"nTp" = (
+/obj/machinery/light_switch/east,
+/obj/disposalpipe/segment/bent/west,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
+"ore" = (
+/obj/decal/poster/wallsign/stencil/left/h,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ranch)
 "ozO" = (
 /obj/cable{
@@ -59175,6 +59263,11 @@
 /obj/storage/secure/closet/civilian/chaplain,
 /turf/simulated/floor/black,
 /area/station/chapel/office)
+"pEL" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "wall_space"
+	},
+/area/station/ranch)
 "pVw" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -59183,16 +59276,11 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
 "qam" = (
-/obj/submachine/chicken_feed_grinder,
-/obj/item/reagent_containers/food/snacks/plant/corn{
-	doants = 0
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/machinery/light_switch/east,
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = -1
-	},
-/turf/simulated/floor/dirt,
 /area/station/ranch)
 "qfu" = (
 /obj/grille/steel,
@@ -59226,13 +59314,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "rfP" = (
-/obj/stool/chair/green{
-	dir = 8
+/obj/submachine/chicken_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn{
+	doants = 0
 	},
-/obj/machinery/light,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "rnI" = (
@@ -59255,14 +59344,21 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "rvR" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = -1
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 15
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "rxZ" = (
 /turf/simulated/floor/grass/leafy,
+/area/station/ranch)
+"rAd" = (
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/railing/orange/reinforced,
+/turf/simulated/floor/grasstodirt,
+/turf/unsimulated/grasstodirt,
 /area/station/ranch)
 "rGC" = (
 /obj/cable{
@@ -59278,9 +59374,11 @@
 /turf/simulated/floor/white,
 /area/station/medical/dome)
 "rHh" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall_space"
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "alt_propulsion"
 	},
+/turf/space,
 /area/station/ranch)
 "rJe" = (
 /obj/item/device/radio/beacon,
@@ -59299,11 +59397,10 @@
 	},
 /area/station/hallway/secondary/exit)
 "rWE" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "alt_propulsion"
-	},
-/turf/space,
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/obj/lattice,
+/turf/simulated/floor/plating,
 /area/station/ranch)
 "sdX" = (
 /obj/table/auto,
@@ -59345,6 +59442,10 @@
 /obj/disposalpipe/segment/bent/east,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
+"sQL" = (
+/turf/simulated/floor/airless/plating/catwalk,
+/turf/space,
+/area/space)
 "tnv" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -59376,14 +59477,23 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "tVk" = (
-/obj/decal/fakeobjects/console_radar{
+/obj/grille/catwalk,
+/turf/simulated/floor/airless/plating/catwalk,
+/turf/space,
+/area/space)
+"ucf" = (
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
+/obj/machinery/plantpot{
 	anchored = 1
 	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
-"ucf" = (
-/turf/space,
-/turf/simulated/floor/grass/leafy,
+/turf/simulated/floor/grasstodirt{
+	dir = 1
+	},
+/turf/unsimulated/grasstodirt{
+	dir = 1
+	},
 /area/station/ranch)
 "upX" = (
 /obj/disposalpipe/segment/bent/north,
@@ -59441,28 +59551,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "viZ" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 10;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/machinery/camera/ranch{
-	dir = 1
-	},
-/turf/simulated/floor/grass/leafy,
+/obj/railing/orange/reinforced,
+/turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "vpa" = (
-/turf/simulated/shuttle/wall{
-	dir = 8;
-	icon_state = "wall_space"
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 1
 	},
 /area/station/ranch)
 "vvy" = (
-/turf/simulated/shuttle/wall/cockpit/window{
-	dir = 1;
-	icon_state = "wall_space";
-	name = "window"
+/turf/unsimulated/grasstodirt{
+	dir = 9
 	},
 /area/station/ranch)
 "vRD" = (
@@ -59498,6 +59600,11 @@
 "wds" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ranch)
+"wht" = (
+/obj/shrub,
+/obj/machinery/light,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "wwH" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /obj/cable{
@@ -59532,10 +59639,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "wWj" = (
-/obj/landmark/start{
-	name = "Rancher"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/landmark/gps_waypoint,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "xqH" = (
@@ -59577,6 +59685,18 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"xTu" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = -1
+	},
+/obj/decal/fakeobjects/shuttleweapon/base{
+	desc = "A futuristic system that collects residual power from chicken alchemy.";
+	dir = 8;
+	name = "Chicken Power Generator"
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "xXL" = (
 /obj/cable{
 	d1 = 4;
@@ -59611,9 +59731,14 @@
 /turf/simulated/floor/engine,
 /area/station/mining/refinery)
 "yjt" = (
-/obj/machinery/light{
+/obj/machinery/camera/ranch{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/decal/fakeobjects/shuttleweapon/base{
+	desc = "A futuristic system that collects residual power from chicken alchemy.";
 	dir = 8;
-	tag = ""
+	name = "Chicken Power Generator"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
@@ -91196,9 +91321,9 @@ bmb
 bmb
 ala
 adk
-adk
-ala
-ala
+tVk
+tVk
+sQL
 aaa
 adk
 adk
@@ -91496,14 +91621,14 @@ bUU
 bUL
 aaa
 aaa
-vpa
-rWE
-rWE
-rWE
-rHh
 aaa
 aaa
-aGl
+aaa
+aad
+aaa
+aaa
+aaa
+cjp
 ciC
 ckt
 ckZ
@@ -91797,12 +91922,12 @@ bSn
 bUV
 bUL
 aaa
-vpa
-wds
-qfu
-qfu
-qfu
-wds
+aaa
+rHh
+rHh
+aaa
+aad
+rHh
 rHh
 aaa
 cjp
@@ -92099,14 +92224,14 @@ bSo
 bUV
 bUL
 aaa
-wds
-wds
-rxZ
 gug
-doh
 wds
 wds
-aaa
+qfu
+qfu
+wds
+wds
+pEL
 aGl
 ciY
 adk
@@ -92401,14 +92526,14 @@ bSp
 aYq
 bUL
 aaa
-qfu
-yjt
-rxZ
+wds
+wds
+xTu
 ucf
-ucf
+rAd
 yjt
-qfu
-aaa
+wds
+wds
 cjp
 ciO
 aaa
@@ -92704,13 +92829,13 @@ bUX
 bUL
 aaa
 qfu
+klE
 rxZ
+vpa
+viZ
 rxZ
-rxZ
-rxZ
-rxZ
+klE
 qfu
-aaa
 aGl
 ciO
 cku
@@ -93005,15 +93130,15 @@ bSr
 bUY
 bUL
 aaa
-wds
+qfu
 lkp
 rxZ
+vpa
+viZ
 rxZ
-rxZ
-jUq
-wds
-aaa
-cjp
+lkp
+qfu
+aGl
 ciO
 ckv
 cle
@@ -93307,14 +93432,14 @@ bSs
 bUZ
 bUL
 aaa
-wds
-wds
+qfu
 lsK
 rxZ
+vpa
 viZ
-wds
-wds
-aaa
+rxZ
+wht
+qfu
 aGl
 ciO
 ckw
@@ -93609,14 +93734,14 @@ lja
 bVa
 bXl
 aaa
-vvy
+wds
 wds
 rvR
-rxZ
-lwg
+vpa
+viZ
 aFt
-klE
-aaa
+wds
+wds
 cjp
 cjO
 ckx
@@ -93911,14 +94036,14 @@ lja
 bVb
 bXl
 bXl
-aaa
+jUq
 wds
 kdU
-rxZ
-rxZ
+vvy
+epE
 hhi
-aaa
-kFI
+wds
+iNY
 cjp
 cjP
 cky
@@ -94214,12 +94339,12 @@ bVb
 bkq
 bXl
 psi
-qfu
+qam
 nAW
 lDx
-lDx
+cGc
 gBU
-aaa
+nhJ
 aaa
 cjp
 cjP
@@ -94519,9 +94644,9 @@ dmx
 igR
 nTp
 wWj
-kYx
-qfu
-aaa
+wWj
+nFM
+eam
 aaa
 cjp
 cjP
@@ -94818,12 +94943,12 @@ bVb
 bXn
 bXl
 psi
-qfu
-qam
+wds
+wds
 jxd
 rfP
-qfu
-aaa
+wds
+ore
 aaa
 cjp
 cjP
@@ -95120,12 +95245,12 @@ bVb
 bXo
 bXl
 aaa
+jUq
 wds
+rWE
+qfu
 wds
-tVk
-wds
-wds
-aaa
+iNY
 aaa
 cjp
 cjP
@@ -95422,11 +95547,11 @@ bVb
 dKQ
 bXl
 aaa
-vvy
-wds
-qfu
-wds
-klE
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 cjp
@@ -95725,9 +95850,9 @@ bXn
 bGy
 aaa
 aaa
-vvy
-wds
-klE
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97835,7 +97960,7 @@ bMI
 bPB
 bSx
 aJm
-bXl
+doh
 bXl
 cbm
 aEL


### PR DESCRIPTION
[MAPPING]
## About the PR

Updates Atlas and Horizon so that their ranches have two pens, hydro trays, an equipment locker, and other amenities like windows/kitchen chutes. The lockers also have chicken masks, because I think they're fun.

Atlas:
![image](https://user-images.githubusercontent.com/58895092/112826523-f5708c80-9041-11eb-9aea-fafddf9a66bf.png)
Horizon:
![image](https://user-images.githubusercontent.com/58895092/112826558-01f4e500-9042-11eb-865f-a4f1b5319f6f.png)
Cogmap2:
![fineal](https://user-images.githubusercontent.com/58895092/112856545-bf90cf80-9064-11eb-9082-8d85ad5c161f.PNG)

## Why's this needed?

- More pens and hydro trays = More parallel projects = Good
- More public desks and chutes = More places to send your eggs = Higher chance your eggs are used by other people = Good
- Adds ranching equipment lockers which makes it easier for non-ranchers to get a job change into the profession
- Chicken masks let you empathize with your roosters and grow closer to them ~~before you chuck them into a disposal chute~~
- Warc already said he feels strongly that the ranch in cog1 shouldn't mess with the silhouette of the Botany glass dome thing so 
this applies the same logic to cog2

## Changelog

```changelog
(u)Gremy
(*) Revamps the Atlas, Cog2 and Horizon ranches to include two pens, more access to other departments and extra amenities. Also chicken masks. Bok!
```

