### PR TITLE
Makes intercoms constructable/deconstructable

### DIFF
--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -7,7 +7,8 @@
 #endif
 	anchored = 1.0
 	plane = PLANE_NOSHADOW_ABOVE
-	mats = 0
+	mats = 3
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WIRECUTTERS | DECON_MULTITOOL
 	chat_class = RADIOCL_INTERCOM
 	var/number = 0
 	rand_pos = 0
@@ -43,8 +44,6 @@
 		src.UpdateOverlays(screen_image, "screen")
 		if(src.pixel_x == 0 && src.pixel_y == 0)
 			change_dir(src,null,src.dir)
-	mats = 3
-	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WIRECUTTERS | DECON_MULTITOOL
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -13,6 +13,19 @@
 	rand_pos = 0
 	desc = "A wall-mounted radio intercom, used to communicate with the specified frequency. Usually turned off except during emergencies."
 	hardened = 0
+/obj/item/device/radio/intercom/set_dir(new_dir)
+	. = ..()
+	src.pixel_x = 0
+	src.pixel_y = 0
+	switch(src.dir)
+		if(NORTH)
+			pixel_y = -21
+		if(SOUTH)
+			pixel_y = 24
+		if(EAST)
+			pixel_x = -21
+		if(WEST)
+			pixel_x = 21
 
 /obj/item/device/radio/intercom/New()
 	. = ..()
@@ -25,19 +38,11 @@
 				screen_image.color = new_color
 		screen_image.alpha = 180
 		src.UpdateOverlays(screen_image, "screen")
-		SPAWN_DBG(0.1) // OH GOD WHY
 		if(src.pixel_x == 0 && src.pixel_y == 0)
-			switch(src.dir)
-				if(NORTH)
-					pixel_y = -21
-				if(SOUTH)
-					pixel_y = 24
-				if(EAST)
-					pixel_x = -21
-				if(WEST)
-					pixel_x = 21
+			set_dir(src.dir)
 	mats = 3
 	deconstruct_flags = 102
+
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -13,21 +13,24 @@
 	rand_pos = 0
 	desc = "A wall-mounted radio intercom, used to communicate with the specified frequency. Usually turned off except during emergencies."
 	hardened = 0
-/obj/item/device/radio/intercom/set_dir(new_dir)
-	. = ..()
+
+/obj/item/device/radio/intercom/proc/change_dir(obj/item/AM, old_dir, new_dir)
 	src.pixel_x = 0
 	src.pixel_y = 0
-	switch(src.dir)
+	switch(new_dir)
 		if(NORTH)
-			pixel_y = -21
+			src.pixel_y = -21
 		if(SOUTH)
-			pixel_y = 24
+			src.pixel_y = 24
 		if(EAST)
-			pixel_x = -21
+			src.pixel_x = -21
 		if(WEST)
-			pixel_x = 21
+			src.pixel_x = 21
 
 /obj/item/device/radio/intercom/New()
+	//Register before calling our parent
+	//There's a possible race condition in assembly from a frame if you don't
+	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGED, .proc/change_dir)
 	. = ..()
 	if(src.icon_state == "intercom") // if something overrides the icon we don't want this
 		var/image/screen_image = image(src.icon, "intercom-screen")
@@ -39,10 +42,9 @@
 		screen_image.alpha = 180
 		src.UpdateOverlays(screen_image, "screen")
 		if(src.pixel_x == 0 && src.pixel_y == 0)
-			set_dir(src.dir)
+			change_dir(src,null,src.dir)
 	mats = 3
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WIRECUTTERS | DECON_MULTITOOL
-
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -41,7 +41,7 @@
 		if(src.pixel_x == 0 && src.pixel_y == 0)
 			set_dir(src.dir)
 	mats = 3
-	deconstruct_flags = 102
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WIRECUTTERS | DECON_MULTITOOL
 
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -15,7 +15,7 @@
 	desc = "A wall-mounted radio intercom, used to communicate with the specified frequency. Usually turned off except during emergencies."
 	hardened = 0
 
-/obj/item/device/radio/intercom/proc/change_dir(obj/item/AM, old_dir, new_dir)
+/obj/item/device/radio/intercom/proc/update_pixel_offset_dir(obj/item/AM, old_dir, new_dir)
 	src.pixel_x = 0
 	src.pixel_y = 0
 	switch(new_dir)
@@ -29,10 +29,8 @@
 			src.pixel_x = 21
 
 /obj/item/device/radio/intercom/New()
-	//Register before calling our parent
-	//There's a possible race condition in assembly from a frame if you don't
-	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGED, .proc/change_dir)
 	. = ..()
+	RegisterSignal(src, COMSIG_ATOM_DIR_CHANGED, .proc/update_pixel_offset_dir)
 	if(src.icon_state == "intercom") // if something overrides the icon we don't want this
 		var/image/screen_image = image(src.icon, "intercom-screen")
 		screen_image.color = src.device_color
@@ -43,7 +41,7 @@
 		screen_image.alpha = 180
 		src.UpdateOverlays(screen_image, "screen")
 		if(src.pixel_x == 0 && src.pixel_y == 0)
-			change_dir(src,null,src.dir)
+			update_pixel_offset_dir(src,null,src.dir)
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -25,6 +25,7 @@
 				screen_image.color = new_color
 		screen_image.alpha = 180
 		src.UpdateOverlays(screen_image, "screen")
+		SPAWN_DBG(0.1) // OH GOD WHY
 		if(src.pixel_x == 0 && src.pixel_y == 0)
 			switch(src.dir)
 				if(NORTH)

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -35,6 +35,8 @@
 					pixel_x = -21
 				if(WEST)
 					pixel_x = 21
+	mats = 3
+	deconstruct_flags = 102
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

You can now scan intercoms as well as deconstruct them with screwdriver + wrench + cutting tool + pulse

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Both changes are to help with construction and building them helps with station rebuild efforts, it also makes it consistent with other radios which are all already scannable.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Penny
(+)Intercoms may now be fabricated by mechanics as well as deconstructed.
```
