### PR TITLE
Fixes "Leave pod" button for /tg/ HUD layout

### DIFF
--- a/code/datums/hud/pod.dm
+++ b/code/datums/hud/pod.dm
@@ -75,7 +75,7 @@
 
 	proc/check_hud_layout(mob/user)
 		if (user.client.tg_layout)
-			leave.screen_loc = "SOUTH,EAST-5"
+			leave.screen_loc = "SOUTH,EAST-6"
 		else
 			leave.screen_loc = "SOUTH, EAST"
 

--- a/code/datums/hud/pod.dm
+++ b/code/datums/hud/pod.dm
@@ -77,7 +77,7 @@
 		if (user.client.tg_layout)
 			leave.screen_loc = "SOUTH,EAST-6"
 		else
-			leave.screen_loc = "SOUTH, EAST"
+			leave.screen_loc = "SOUTH,EAST"
 
 	proc/update_health()
 		check_clients()

--- a/code/datums/hud/pod.dm
+++ b/code/datums/hud/pod.dm
@@ -73,6 +73,12 @@
 				if (C.tooltipHolder)
 					C.tooltipHolder.inPod = 0
 
+	proc/check_hud_layout(mob/user)
+		if (user.client.tg_layout)
+			leave.screen_loc = "SOUTH,EAST-5"
+		else
+			leave.screen_loc = "SOUTH, EAST"
+
 	proc/update_health()
 		check_clients()
 		health_bar.update_health_overlay(master.health, master.maxhealth, 0, 0)

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -1007,6 +1007,7 @@
 	src.find_pilot()
 	if (M.client)
 		M.attach_hud(myhud)
+		myhud.check_hud_layout(M)
 		if (M.client.tooltipHolder)
 			M.client.tooltipHolder.inPod = 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR moves the "Leave pod" button a little bit to the left, if the player is using /tg/ HUD layout:

![0](https://user-images.githubusercontent.com/62990808/112897840-649cbe00-90e0-11eb-9b55-31aca00e9f28.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugfix. Currently the button is quite inaccessible if you're on /tg/ HUD, hidden behind limb targetting buttons.

