### PR TITLE
Increases price of CSaber from 18 to 35 materials.

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -36,6 +36,8 @@
 	throw_range = 5
 	w_class = 2.0
 	flags = FPRINT | TABLEPASS | NOSHIELD | USEDELAY
+	is_syndicate = 1
+	mats = 18
 	tool_flags = TOOL_CUTTING
 	contraband = 5
 	desc = "An illegal weapon that, when activated, uses cyalume to create an extremely dangerous saber. Can be concealed when deactivated."

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -36,9 +36,9 @@
 	throw_range = 5
 	w_class = 2.0
 	flags = FPRINT | TABLEPASS | NOSHIELD | USEDELAY
+	tool_flags - TOOL_CUTTING
 	is_syndicate = 1
 	mats = 35
-	tool_flags = TOOL_CUTTING
 	contraband = 5
 	desc = "An illegal weapon that, when activated, uses cyalume to create an extremely dangerous saber. Can be concealed when deactivated."
 	stamina_damage = 35 // This gets applied by obj/item/attack, regardless of if the saber is active.

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -37,8 +37,6 @@
 	w_class = 2.0
 	flags = FPRINT | TABLEPASS | NOSHIELD | USEDELAY
 	tool_flags = TOOL_CUTTING
-	is_syndicate = 1
-	mats = 18
 	contraband = 5
 	desc = "An illegal weapon that, when activated, uses cyalume to create an extremely dangerous saber. Can be concealed when deactivated."
 	stamina_damage = 35 // This gets applied by obj/item/attack, regardless of if the saber is active.

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -37,7 +37,7 @@
 	w_class = 2.0
 	flags = FPRINT | TABLEPASS | NOSHIELD | USEDELAY
 	tool_flags = TOOL_CUTTING
-	is_syndicate = 1
+	is_syndicate = TRUE
 	mats = 35
 	contraband = 5
 	desc = "An illegal weapon that, when activated, uses cyalume to create an extremely dangerous saber. Can be concealed when deactivated."

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -37,7 +37,7 @@
 	w_class = 2.0
 	flags = FPRINT | TABLEPASS | NOSHIELD | USEDELAY
 	is_syndicate = 1
-	mats = 18
+	mats = 35
 	tool_flags = TOOL_CUTTING
 	contraband = 5
 	desc = "An illegal weapon that, when activated, uses cyalume to create an extremely dangerous saber. Can be concealed when deactivated."

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -36,7 +36,7 @@
 	throw_range = 5
 	w_class = 2.0
 	flags = FPRINT | TABLEPASS | NOSHIELD | USEDELAY
-	tool_flags - TOOL_CUTTING
+	tool_flags = TOOL_CUTTING
 	is_syndicate = 1
 	mats = 35
 	contraband = 5


### PR DESCRIPTION
[BALANCE]
**PLEASE DO NOT SHANK ME. I WAS BRIBED BY `Mystic Midgit#6020` TO DO THIS, I HAVE NO OPINIONS ON THIS MATTER.**
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the materials price of the Cyalume caber to 35, as opposed to 18.
For comparison, the crusher is set to 20, and industrial mining armour is set to 45.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
"To hopefully make it harder to mass produce c sabers and hold off the greytide that normally follows after said c sabers are mass produced"


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Mystic_Midgit
(*)The Cyalume Saber now costs 35 materials, as opposed to its usual 18.
```
