### PR TITLE
Allow critters to bind abilities to key combos

### DIFF
--- a/code/datums/abilities/critter.dm
+++ b/code/datums/abilities/critter.dm
@@ -1,25 +1,12 @@
 /atom/movable/screen/ability/topBar/critter
 	clicked(params)
-		var/datum/targetable/critter/spell = owner
-		if (!istype(spell))
+		if (!istype(owner, /datum/targetable/critter))
 			return
-		if (!spell.holder)
+		if (!owner.holder)
 			return
 		if (!isturf(usr.loc))
 			return
-		if (spell.targeted && usr.targeting_ability == owner)
-			usr.targeting_ability = null
-			usr.update_cursor()
-			return
-		if (spell.targeted)
-			if (world.time < spell.last_cast)
-				return
-			usr.targeting_ability = owner
-			usr.update_cursor()
-		else
-			SPAWN_DBG(0)
-				spell.handleCast()
-		return
+		..()
 
 /datum/abilityHolder/critter
 	usesPoints = 0

--- a/code/modules/interface/mob_input.dm
+++ b/code/modules/interface/mob_input.dm
@@ -23,12 +23,12 @@
 				src.targeting_ability = S
 				update_cursor()
 			return 100
-		if (S.target_in_inventory && ( get_dist(src, target) > 1 && !isturf(target) && !isturf(target.loc)))
+		if (S.target_in_inventory && (!IN_RANGE(src, target, 1) && !isturf(target) && !isturf(target.loc)))
 			if(S.sticky)
 				src.targeting_ability = S
 				update_cursor()
 			return 100
-		if (S.check_range && (get_dist(src, target) > S.max_range))
+		if (S.check_range && !IN_RANGE(src, target, S.max_range))
 			src.show_text("You are too far away from the target.", "red") // At least tell them why it failed.
 			if(S.sticky)
 				src.targeting_ability = S
@@ -131,11 +131,12 @@
   */
 /mob/proc/get_ability_hotkey(mob/user, parameters)
 	if(!parameters["left"]) return
-	if (parameters["ctrl"] && user?.abilityHolder?.ctrlPower)
+	if(!user?.abilityHolder) return
+	if(parameters["ctrl"] && user.abilityHolder.ctrlPower)
 		return user.abilityHolder.ctrlPower
-	if (parameters["alt"] && user?.abilityHolder?.altPower)
+	if(parameters["alt"] && user.abilityHolder.altPower)
 		return user.abilityHolder.altPower
-	if (parameters["shift"] && user?.abilityHolder?.shiftPower)
+	if(parameters["shift"] && user.abilityHolder.shiftPower)
 		return user.abilityHolder.shiftPower
 
 /**

--- a/code/modules/interface/mob_input.dm
+++ b/code/modules/interface/mob_input.dm
@@ -127,9 +127,7 @@
 			src.pulling = null
 
 /**
-  *
 	* Return the ability bound to the pressed ability hotkey combination
-	*
   */
 /mob/proc/get_ability_hotkey(mob/user, parameters)
 	if(!parameters["left"]) return

--- a/code/modules/interface/mob_input.dm
+++ b/code/modules/interface/mob_input.dm
@@ -4,80 +4,81 @@
 
 /mob/proc/click(atom/target, params)
 	//moved the 'actions.interrupt(src, INTERRUPT_ACT)' here to on mob/living
+	var/used_ability = src.targeting_ability
+	if (!used_ability) used_ability = get_ability_hotkey(src, params)
 
-	if (src.targeting_ability)
-		if (istype(src.targeting_ability, /datum/targetable))
-			var/datum/targetable/S = src.targeting_ability
+	if (istype(used_ability, /datum/targetable))
+		var/datum/targetable/S = used_ability
+		src.targeting_ability = null
+		update_cursor()
+
+		if (!S.target_anything && !ismob(target))
+			src.show_text("You have to target a person.", "red")
+			if(S.sticky)
+				src.targeting_ability = S
+				update_cursor()
+			return 100
+		if (!S.target_in_inventory && !isturf(target.loc) && !isturf(target))
+			if(S.sticky)
+				src.targeting_ability = S
+				update_cursor()
+			return 100
+		if (S.target_in_inventory && ( get_dist(src, target) > 1 && !isturf(target) && !isturf(target.loc)))
+			if(S.sticky)
+				src.targeting_ability = S
+				update_cursor()
+			return 100
+		if (S.check_range && (get_dist(src, target) > S.max_range))
+			src.show_text("You are too far away from the target.", "red") // At least tell them why it failed.
+			if(S.sticky)
+				src.targeting_ability = S
+				update_cursor()
+			return 100
+		if (!S.can_target_ghosts && ismob(target) && (!isliving(target) || iswraith(target) || isintangible(target)))
+			src.show_text("It would have no effect on this target.", "red")
+			if(S.sticky)
+				src.targeting_ability = S
+				update_cursor()
+			return 100
+		if (!S.castcheck(src))
+			if(S.sticky)
+				src.targeting_ability = S
+				update_cursor()
+			return 100
+		actions.interrupt(src, INTERRUPT_ACTION)
+		SPAWN_DBG(0)
+			S.handleCast(target)
+			if(S)
+				if((S.ignore_sticky_cooldown && !S.cooldowncheck()) || (S.sticky && S.cooldowncheck()))
+					if(src)
+						src.targeting_ability = S
+						src.update_cursor()
+		return 100
+
+	else if (istype(src.targeting_ability, /obj/ability_button))
+		var/obj/ability_button/B = src.targeting_ability
+
+		if (!B.target_anything && !ismob(target) && !istype(target, B))
+			src.show_text("You have to target a person.", "red")
 			src.targeting_ability = null
-			update_cursor()
-
-			if (!S.target_anything && !ismob(target))
-				src.show_text("You have to target a person.", "red")
-				if(S.sticky)
-					src.targeting_ability = S
-					update_cursor()
-				return 100
-			if (!S.target_in_inventory && !isturf(target.loc) && !isturf(target))
-				if(S.sticky)
-					src.targeting_ability = S
-					update_cursor()
-				return 100
-			if (S.target_in_inventory && ( get_dist(src, target) > 1 && !isturf(target) && !isturf(target.loc)))
-				if(S.sticky)
-					src.targeting_ability = S
-					update_cursor()
-				return 100
-			if (S.check_range && (get_dist(src, target) > S.max_range))
-				src.show_text("You are too far away from the target.", "red") // At least tell them why it failed.
-				if(S.sticky)
-					src.targeting_ability = S
-					update_cursor()
-				return 100
-			if (!S.can_target_ghosts && ismob(target) && (!isliving(target) || iswraith(target) || isintangible(target)))
-				src.show_text("It would have no effect on this target.", "red")
-				if(S.sticky)
-					src.targeting_ability = S
-					update_cursor()
-				return 100
-			if (!S.castcheck(src))
-				if(S.sticky)
-					src.targeting_ability = S
-					update_cursor()
-				return 100
-			actions.interrupt(src, INTERRUPT_ACTION)
-			SPAWN_DBG(0)
-				S.handleCast(target)
-				if(S)
-					if((S.ignore_sticky_cooldown && !S.cooldowncheck()) || (S.sticky && S.cooldowncheck()))
-						if(src)
-							src.targeting_ability = S
-							src.update_cursor()
+			src.update_cursor()
 			return 100
-
-		else if (istype(src.targeting_ability, /obj/ability_button))
-			var/obj/ability_button/B = src.targeting_ability
-
-			if (!B.target_anything && !ismob(target) && !istype(target, B))
-				src.show_text("You have to target a person.", "red")
-				src.targeting_ability = null
-				src.update_cursor()
-				return 100
-			if (!isturf(target.loc) && !isturf(target) && !istype(target, B))
-				src.targeting_ability = null
-				src.update_cursor()
-				return 100
-			if (!B.ability_allowed())
-				src.targeting_ability = null
-				src.update_cursor()
-				return 100
-			if (istype(target, B))
-				return 100
-			actions.interrupt(src, INTERRUPT_ACTION)
-			SPAWN_DBG(0)
-				B.execute_ability(target)
-				src.targeting_ability = null
-				src.update_cursor()
+		if (!isturf(target.loc) && !isturf(target) && !istype(target, B))
+			src.targeting_ability = null
+			src.update_cursor()
 			return 100
+		if (!B.ability_allowed())
+			src.targeting_ability = null
+			src.update_cursor()
+			return 100
+		if (istype(target, B))
+			return 100
+		actions.interrupt(src, INTERRUPT_ACTION)
+		SPAWN_DBG(0)
+			B.execute_ability(target)
+			src.targeting_ability = null
+			src.update_cursor()
+		return 100
 
 	if (abilityHolder)
 		if (abilityHolder.topBarRendered)
@@ -124,6 +125,20 @@
 			if (src.pulling)
 				unpull_particle(src,pulling)
 			src.pulling = null
+
+/**
+  *
+	* Return the ability bound to the pressed ability hotkey combination
+	*
+  */
+/mob/proc/get_ability_hotkey(mob/user, parameters)
+	if(!parameters["left"]) return
+	if (parameters["ctrl"] && user?.abilityHolder?.ctrlPower)
+		return user.abilityHolder.ctrlPower
+	if (parameters["alt"] && user?.abilityHolder?.altPower)
+		return user.abilityHolder.altPower
+	if (parameters["shift"] && user?.abilityHolder?.shiftPower)
+		return user.abilityHolder.shiftPower
 
 /**
 	* Additiviely applies keybind styles onto the client's keymap.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE][BUG][BALANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Allows critters to bind abilities to ctrl/shift/alt+left click
* ties the hotkey abilities into the cast checks for range, target, etc that they were bypassing before


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* hotkeys make it easier to use abilities
* abilities that previously benefit from hotkeys may not have been properly doing range checks, or checking for targets, unless they had special code to do so.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(*)Critter abilities can now be bound to ctrl/alt/shift+left click
```
