### PR TITLE
Adds a secondary janitor's locker to Oshan

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -37732,6 +37732,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/mopbucket,
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
@@ -38101,10 +38102,6 @@
 	},
 /area/station/janitor/supply)
 "bPO" = (
-/obj/mopbucket,
-/turf/simulated/floor/purple/side,
-/area/station/janitor/supply)
-"bPP" = (
 /obj/storage/crate,
 /obj/item/storage/box/mousetraps,
 /obj/item/sponge,
@@ -38113,6 +38110,10 @@
 /obj/item/reagent_containers/glass/bottle/cleaner,
 /obj/item/spraybottle/cleaner,
 /obj/item/chem_grenade/cleaner,
+/turf/simulated/floor/purple/side,
+/area/station/janitor/supply)
+"bPP" = (
+/obj/storage/secure/closet/civilian/janitor,
 /turf/simulated/floor/purple/side{
 	dir = 6
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a secondary janitor's locker to the supply closet near arrivals.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I was very sad when I recently realised there is only one vacuum on oshan. Every janitor deserves a vacuum.


