### PR TITLE
Catperson Roundstart Trait

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1064,6 +1064,17 @@ obj/trait/pilot
 	category = "species"
 	mutantRace = /datum/mutantrace/roach
 
+/obj/trait/cat
+	name = "Felinid (-5) \[Species\]"
+	cleanName = "cat"
+	icon_state = "catseyeG"
+	desc = "Wait, this isnt a felinid..."
+	id = "cat"
+	points = -5
+	isPositive = TRUE
+	category = "species"
+	mutantRace = /datum/mutantrace/cat
+
 //Infernal Contract Traits
 /obj/trait/hair
 	name = "Wickedly Good Hair"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a trait that unlocks the hidden catperson race found deep within gooncode, at the low-low cost of 5 trait points!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No longer shall we be oppressed. We have been stockpiling Meowitzers for years. Catmandu was merely a setback. We shall rise again.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kapu1178
(*)Felinid is now a selectable round start race via traits.
```
