### PR TITLE
Allows security personnel to baton-fry dough into donuts

### DIFF
--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -404,7 +404,7 @@
 				if (user.a_intent != "harm")
 					if (user.traitHolder.hasTrait("training_security"))
 						playsound(get_turf(src), "sound/impact_sounds/Energy_Hit_3.ogg", 30, 1, -1) //bit quieter than a baton hit
-						user.visible_message("<span class='notice'>[user] [pick("expertly", "deftly", "casually", "smoothly")] baton-fries the dough, yielding a tasty donut.</span>")
+						user.visible_message("<span class='notice'>[user] [pick("expertly", "deftly", "casually", "smoothly")] baton-fries the dough, yielding a tasty donut.</span>", group = "batonfry")
 						var/obj/item/reagent_containers/food/snacks/donut/result = new /obj/item/reagent_containers/food/snacks/donut(src.loc)
 						user.u_equip(src)
 						user.put_in_hand_or_drop(result)

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -409,7 +409,7 @@
 			var/obj/item/baton/baton = W
 			if (!baton.uses_electricity)
 				..()
-			if (baton.status = 1) //baton is on
+			if (baton.status == 1) //baton is on
 				if (user.a_intent != "harm")
 					if (user.traitHolder.hasTrait("training_security"))
 						playsound(get_turf(src), "sound/impact_sounds/Energy_Hit_3.ogg", 30, 1, -1) //bit quieter than a baton hit

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -397,15 +397,6 @@
 			user.put_in_hand_or_drop(F)
 			qdel(src)
 		else if (istype(W, /obj/item/baton))
-			/*TODO testing
-			mobcritters- traitholder runtime?
-			all cases-
-				on/nonharm/trained
-				on/nonharm/untrained
-				on/harm
-				off/nonharm
-				off/harm
-			*/
 			var/obj/item/baton/baton = W
 			if (!baton.uses_electricity)
 				..()
@@ -427,8 +418,6 @@
 					user.emote("scream")
 			else
 				boutput(user, "<span class='notice'>You [user.a_intent == "harm" ? "beat" : "prod"] the dough. The dough doesn't react.</span>")
-
-
 		else ..()
 
 /obj/item/reagent_containers/food/snacks/ingredient/dough/semolina

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -419,13 +419,12 @@
 						user.put_in_hand_or_drop(result)
 						qdel(src)
 					else
-						boutput(user, "<span class='notice'>You just aren't experienced enough to baton-fry.</span>")
+						boutput(user, "<span class='alert'>You just aren't experienced enough to baton-fry.</span>")
 				else
 					user.visible_message("<b class='alert'>[user] tries to baton fry the dough, but fries [his_or_her(user)] hand instead!</b>")
 					playsound(get_turf(src), "sound/impact_sounds/Energy_Hit_3.ogg", 30, 1, -1)
 					user.do_disorient(baton.stamina_damage, weakened = baton.stun_normal_weakened * 10, disorient = 80) //cut from batoncode to bypass all the logging stuff
 					user.emote("scream")
-					user.u_equip(baton)
 					ThrowRandom(baton, 5)
 			else
 				boutput(user, "<span class='notice'>You [user.a_intent == "harm" ? "beat" : "prod"] the dough. The dough doesn't react.</span>")

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -425,7 +425,7 @@
 					playsound(get_turf(src), "sound/impact_sounds/Energy_Hit_3.ogg", 30, 1, -1)
 					user.do_disorient(baton.stamina_damage, weakened = baton.stun_normal_weakened * 10, disorient = 80) //cut from batoncode to bypass all the logging stuff
 					user.emote("scream")
-					ThrowRandom(baton, 5)
+					ThrowRandom(baton, 3)
 			else
 				boutput(user, "<span class='notice'>You [user.a_intent == "harm" ? "beat" : "prod"] the dough. The dough doesn't react.</span>")
 

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -425,7 +425,6 @@
 					playsound(get_turf(src), "sound/impact_sounds/Energy_Hit_3.ogg", 30, 1, -1)
 					user.do_disorient(baton.stamina_damage, weakened = baton.stun_normal_weakened * 10, disorient = 80) //cut from batoncode to bypass all the logging stuff
 					user.emote("scream")
-					ThrowRandom(baton, 3)
 			else
 				boutput(user, "<span class='notice'>You [user.a_intent == "harm" ? "beat" : "prod"] the dough. The dough doesn't react.</span>")
 

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -396,6 +396,41 @@
 			user.u_equip(src)
 			user.put_in_hand_or_drop(F)
 			qdel(src)
+		else if (istype(W, /obj/item/baton))
+			/*TODO testing
+			mobcritters- traitholder runtime?
+			all cases-
+				on/nonharm/trained
+				on/nonharm/untrained
+				on/harm
+				off/nonharm
+				off/harm
+			*/
+			var/obj/item/baton/baton = W
+			if (!baton.uses_electricity)
+				..()
+			if (baton.status = 1) //baton is on
+				if (user.a_intent != "harm")
+					if (user.traitHolder.hasTrait("training_security"))
+						playsound(get_turf(src), "sound/impact_sounds/Energy_Hit_3.ogg", 30, 1, -1) //bit quieter than a baton hit
+						user.visible_message("<span class='notice'>[user] [pick("expertly", "deftly", "casually", "smoothly")] baton-fries the dough, yielding a tasty donut.</span>")
+						var/obj/item/reagent_containers/food/snacks/donut/result = new /obj/item/reagent_containers/food/snacks/donut(src.loc)
+						user.u_equip(src)
+						user.put_in_hand_or_drop(result)
+						qdel(src)
+					else
+						boutput(user, "<span class='notice'>You just aren't experienced enough to baton-fry.</span>")
+				else
+					user.visible_message("<b class='alert'>[user] tries to baton fry the dough, but fries [his_or_her(user)] hand instead!</b>")
+					playsound(get_turf(src), "sound/impact_sounds/Energy_Hit_3.ogg", 30, 1, -1)
+					user.do_disorient(baton.stamina_damage, weakened = baton.stun_normal_weakened * 10, disorient = 80) //cut from batoncode to bypass all the logging stuff
+					user.emote("scream")
+					user.u_equip(baton)
+					ThrowRandom(baton, 5)
+			else
+				boutput(user, "<span class='notice'>You [user.a_intent == "harm" ? "beat" : "prod"] the dough. The dough doesn't react.</span>")
+
+
 		else ..()
 
 /obj/item/reagent_containers/food/snacks/ingredient/dough/semolina


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
(creds to Danger Noodle#9588 on discord for the idea)
This allows security personnel (anyone with the training_security trait) to fry dough into donuts by smacking it with their baton, similar to how you can defib dough into pancakes. People without the trait won't be able to, as they simply don't have the raw security energy required. You can harmbatonfry. It doesn't go well.

This does make it pretty easy to mass-produce donuts as it doesn't deduct any charge from the baton, so I can add a charge requirement if there's any balance concerns.

Was also considering adding special interactions for NTSO and riot batons, but that's for another time.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a neat way for security to replenish their donuts which are so often stolen. Also a great way for those security personnel who REALLY want to smack something with their baton to blow off steam. I don't play sec so I can't comment too much, but I thought the idea sounded fun.
[feature]
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Asche
(+)Security personnel can now baton-fry dough into donuts. Remember to hold the baton the right way.
```
