### PR TITLE
Gives the stoners more XP

### DIFF
--- a/code/WorkInProgress/JobXP.dm
+++ b/code/WorkInProgress/JobXP.dm
@@ -110,6 +110,7 @@ var/list/xp_cache = list()
 	if(!key) return null
 	var/actual = round(amount * XP_GLOBAL_MOD)
 
+	command_announcement("YOU JUST GOT [amount] JOB XP! CONGRATS!", "good job")
 	if(is_eligible_xp(key, amount) || (amount >= XP_THROTTLE_AMT) || ignore_caps)
 		if(xp_earned[key] && !ignore_caps)
 			if(xp_earned[key] + (amount * XP_GLOBAL_MOD) > XP_ROUND_CAP)

--- a/code/WorkInProgress/JobXP.dm
+++ b/code/WorkInProgress/JobXP.dm
@@ -110,7 +110,6 @@ var/list/xp_cache = list()
 	if(!key) return null
 	var/actual = round(amount * XP_GLOBAL_MOD)
 
-	command_announcement("YOU JUST GOT [amount] JOB XP! CONGRATS!", "good job")
 	if(is_eligible_xp(key, amount) || (amount >= XP_THROTTLE_AMT) || ignore_caps)
 		if(xp_earned[key] && !ignore_caps)
 			if(xp_earned[key] + (amount * XP_GLOBAL_MOD) > XP_ROUND_CAP)

--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -53,8 +53,7 @@
 			pool (W)
 			pool (src)
 			user.put_in_hand_or_drop(P)
-			if (prob(20))
-				JOB_XP(user, "Botanist", 2)
+			JOB_XP(user, "Botanist", 1)
 
 		else if (istype(W, /obj/item/bluntwrap))
 			boutput(user, "<span class='alert'>You roll [src] up in [W] and make a fat doink.</span>")
@@ -72,8 +71,7 @@
 			qdel(W)
 			pool(src)
 			user.put_in_hand_or_drop(doink)
-			if (prob(20))
-				JOB_XP(user, "Botanist", 3)
+			JOB_XP(user, "Botanist", 2)
 
 	combust_ended()
 		smoke_reaction(src.reagents, 1, get_turf(src), do_sfx = 0)

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1252,8 +1252,10 @@
 			// +10: if HP >= 400% w/ 30% chance
 			// Mutations can add or remove this, of course
 			// @TODO adjust this later, this is just to fix runtimes and make it slightly consistent
-			if (base_quality_score >= 1 && prob(10))
+			if (base_quality_score >= 1 && prob(30))
 				if (base_quality_score >= 11)
+					JOB_XP(user, "Botanist", 4)
+				else if (base_quality_score >= 6)
 					JOB_XP(user, "Botanist", 2)
 				else
 					JOB_XP(user, "Botanist", 1)

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -593,7 +593,7 @@
 
 				boutput(usr, "<span class='notice'>Splice successful.</span>")
 				//0 xp for a 100% splice, 4 xp for a 10% splice
-				JOB_XP(usr, "Botanist", round((100 - splice_chance) / 20))
+				JOB_XP(usr, "Botanist", clamp(round((100 - splice_chance) / 20), 0, 4))
 				if (!src.seedoutput) src.seeds.Add(S)
 				else S.set_loc(src.loc)
 

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -592,6 +592,8 @@
 				DNA.endurance = SpliceMK2(P1DNA.alleles[7],P2DNA.alleles[7],P1DNA.vars["endurance"],P2DNA.vars["endurance"])
 
 				boutput(usr, "<span class='notice'>Splice successful.</span>")
+				//0 xp for a 100% splice, 4 xp for a 10% splice
+				JOB_XP(usr, "Botanist", round((100 - splice_chance) / 20))
 				if (!src.seedoutput) src.seeds.Add(S)
 				else S.set_loc(src.loc)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
(Inspired by #2976 and the feedback given there)
Increases the amount of XP botanists can earn in a few ways:

1. Currently, healthy plants have a chance to get +5 quality on harvest, and REALLY healthy plants have a chance to get +10 quality. Botanists currently have a 10% chance to get 1 xp for 1 quality, or 2 xp for 11 quality. This adds in the middle option and bumps up the higher quality XP- 1 for 1 quality, 2 for 6 quality , 4 for 11 quality. Additionally, the chance for XP is raised to 30%.
2. Currently you have a 20% chance to get 2 xp for rolling a joint with paper, and a 20% chance to get 3 xp for rolling a blunt with a wrap. This makes joints a flat 1 xp, and blunts a flat 2; this makes XP more consistent, and increases the expected amount. Rolling with credits/paper is pretty spammable, but I feel that the XP cap should deal with that.
3. Adds XP for splicing, inversely proportional to the chance of a successful splice. Easy splices (>=80%) award no XP, while hard splices (<=20%) award 4. This grants some XP while you're screwing with plant genes, which is a pretty crucial part of botany.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Current botany XP is just way too low for the amount of higher-level rewards available. Additionally, it's all random, so you can do the exact same things 2 rounds in a row and get wildly different amounts of XP. I tried to increase the amount of XP botanists get on average, and make gaining XP more consistent.