### PR TITLE
Renames inappropriate Grones soda

### DIFF
--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -91,7 +91,7 @@
 	New()
 		switch(rand(1,12))
 			if (1)
-				src.name += "At Least It's Not Discount Dan's flavor"
+				src.name += "Crunchy Kidney Stone Lemonade flavor"
 				src.initial_reagents["urine"] = 10
 			if (2)
 				src.name += "Radical Roadkill Rampage flavor"

--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -91,7 +91,7 @@
 	New()
 		switch(rand(1,12))
 			if (1)
-				src.name += "Ballin' Banana Testicular Torsion flavor"
+				src.name += "At Least It's Not Discount Dan's flavor"
 				src.initial_reagents["urine"] = 10
 			if (2)
 				src.name += "Radical Roadkill Rampage flavor"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Renames the "Ballin' Banana Testicular Torsion" Grones drink to "Crunchy Kidney Stone Lemonade" (credit goes to Camryn Buttes for that name), keeping in line with the general naming scheme of other Grones sodas. (Personally, I also think it's plain better than my initial suggestion of "At Least It's Not Discount Dan's"). Contents are still urine, same as before.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
"Ballin' Banana Testicular Torsion" runs afoul of our "no sexual content" rule, given the references to genitalia ("testicular" references the testicles, and in that context, "banana" refers to the penis rather than the fruit).  Personally, I think it's kinda funny, but it's also a name that's inappropriate for our servers and so should be changed.

Also, I think "Crunchy Kidney Stone Lemonade" is simply funnier than the previous, regardless of whether it breaks the rules. 