### PR TITLE
makes NTSO, Sec Assistants, and part-time VOs heal more from donuts

### DIFF
--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -1188,7 +1188,7 @@
 	var/style_step = 1
 
 	heal(var/mob/M)
-		if(ishuman(M) && (M.job in list("Security Officer", "Head of Security", "Detective")))
+		if(ishuman(M) && (M.job in list("Security Officer", "Head of Security", "Detective", "Nanotrasen Security Operative", "Security Assistant", "Part-time Vice Officer")))
 			src.heal_amt *= 2
 			..()
 			src.heal_amt /= 2


### PR DESCRIPTION
[Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As the title says, makes these roles get the increased healing from donuts. Scrumptious

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These are part of the sec department, so they should meet the one real qualifier.

## Changelog
```changelog
(u)DimWhat
(+)NTSO, Security Assistants, and Part-time Vice Officers now heal more from donuts
```