### PR TITLE
Adds access spawner to the MD's room on horizon 

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -20525,6 +20525,7 @@
 /obj/machinery/door/airlock/pyro/glass/command{
 	name = "Director's Office"
 	},
+/obj/access_spawn/medical_director,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/md)
 "aXu" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds an access spawner that was previously missing to the MDir's door on Horizon, wich caused people without access to it to be able to open it. Now they won't be able to.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bug bad.