### PR TITLE
Clown name change update in security records

### DIFF
--- a/code/datums/powernet_data.dm
+++ b/code/datums/powernet_data.dm
@@ -8,10 +8,10 @@
 	/// associated list of various data fields
 	var/list/fields = list(  )
 
-proc/FindRecordByField(var/list/datum/data/record/L, var/F, var/V)
-	if (!V) return
+proc/FindRecordByField(var/list/datum/data/record/L, var/field, var/value)
+	if (!value) return
 	for(var/datum/data/record/R in L)
-		if(R.fields[F] == V)
+		if(R.fields[field] == value)
 			return R
 	return
 

--- a/code/datums/powernet_data.dm
+++ b/code/datums/powernet_data.dm
@@ -8,6 +8,13 @@
 	/// associated list of various data fields
 	var/list/fields = list(  )
 
+proc/FindRecordByField(var/list/datum/data/record/L, var/F, var/V)
+	if (!V) return
+	for(var/datum/data/record/R in L)
+		if(R.fields[F] == V)
+			return R
+	return
+
 /datum/powernet
 	/// all cables & junctions
 	var/list/obj/cable/cables = list()

--- a/code/datums/powernet_data.dm
+++ b/code/datums/powernet_data.dm
@@ -8,7 +8,7 @@
 	/// associated list of various data fields
 	var/list/fields = list(  )
 
-proc/FindRecordByField(var/list/datum/data/record/L, var/field, var/value)
+proc/FindRecordByFieldValue(var/list/datum/data/record/L, var/field, var/value)
 	if (!value) return
 	for(var/datum/data/record/R in L)
 		if(R.fields[field] == value)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2658,9 +2658,16 @@
 			else
 				if (force_instead || alert(src, "Use the name [newname]?", newname, "Yes", "No") == "Yes")
 					if(!src.traitHolder.hasTrait("immigrant"))// stowaway entertainers shouldn't be on the manifest
-						var/datum/data/record/B = FindBankAccountByName(src.real_name)
-						if (B?.fields["name"])
-							B.fields["name"] = newname
+						for (var/L in list(data_core.bank, data_core.security, data_core.general, data_core.medical))
+							if (L)
+								var/datum/data/record/R = FindRecordByField(L, "name", src.real_name)
+								if (R)
+									R.fields["name"] = newname
+									if (R.fields["full_name"])
+										R.fields["full_name"] = newname
+						// var/datum/data/record/B = FindBankAccountByName(src.real_name)
+						// if (B?.fields["name"])
+						// 	B.fields["name"] = newname
 						for (var/obj/item/card/id/ID in src.contents)
 							ID.registered = newname
 							ID.update_name()

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2660,7 +2660,7 @@
 					if(!src.traitHolder.hasTrait("immigrant"))// stowaway entertainers shouldn't be on the manifest
 						for (var/L in list(data_core.bank, data_core.security, data_core.general, data_core.medical))
 							if (L)
-								var/datum/data/record/R = FindRecordByField(L, "name", src.real_name)
+								var/datum/data/record/R = FindRecordByFieldValue(L, "name", src.real_name)
 								if (R)
 									R.fields["name"] = newname
 									if (R.fields["full_name"])

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2665,9 +2665,6 @@
 									R.fields["name"] = newname
 									if (R.fields["full_name"])
 										R.fields["full_name"] = newname
-						// var/datum/data/record/B = FindBankAccountByName(src.real_name)
-						// if (B?.fields["name"])
-						// 	B.fields["name"] = newname
 						for (var/obj/item/card/id/ID in src.contents)
 							ID.registered = newname
 							ID.update_name()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Clown names are now properly updated in security and medical records. Other jobs should be updated properly when changing names on spawn as well.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Clowns used to be able to change their name when they joined. This name change would get updated in the bank records, but not the security records. Now you can more easily set the clown to arrest for heinous crimes against the public!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Jawns
(+)Clown names are now properly updated in security records.
```
