### PR TITLE
Horizon HoS door fix

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -35227,7 +35227,8 @@
 /area/station/maintenance/southeast)
 "bHF" = (
 /obj/machinery/door/airlock/pyro/security{
-	dir = 4
+	dir = 4;
+	req_access = null
 	},
 /obj/cable{
 	d1 = 4;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
sets the "req_access" on the HoS's door to null, it wasn't null before and it caused the access spawner on it to not work.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Door should open for HoS only, like it does on almost every other map.