### PR TITLE
adds o2 and XL air mixcanisters to QM purchase list

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -951,23 +951,23 @@
 	containertype = /obj/storage/crate/wooden
 	containername = "EVA Equipment Crate"
 
+/datum/supply_packs/XL_air_canister
+	name = "Extra Large Air Mix Canister"
+	desc = "Spare canister filled with a mix of nitrogen, oxygen and minimal amounts of carbon dioxide. Used for emergency re-pressurisation efforts."
+	category = "Engineering Department"
+	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
+	cost = 8000
+	containertype = /obj/storage/crate/wooden
+	containername = "Spare Oxygen Canister Crate"
 /datum/supply_packs/oxygen_canister
 	name = "Spare Oxygen Canister"
-	desc = "Spare oxygen canister, for Engineering gas resupplies or emergency re-pressurisation efforts."
+	desc = "Spare oxygen canister, for resupplying Engineering's fuel or refilling oxygen tanks."
 	category = "Engineering Department"
 	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
 	cost = 10000
 	containertype = /obj/storage/crate/wooden
 	containername = "Spare Oxygen Canister Crate"
 
-/datum/supply_packs/plasma_canister
-	name = "Spare Plasma Canister"
-	desc = "Spare Plasma canister, for Engineering gas resupplies or impromptu gas lit campfires."
-	category = "Engineering Department"
-	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
-	cost = 80000
-	containertype = /obj/storage/crate/wooden
-	containername = "Spare Plasma Canister Crate"
 /datum/supply_packs/abcu
 	name = "ABCU Unit Crate"
 	desc = "An additional ABCU Unit, for large construction projects."

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -958,7 +958,7 @@
 	contains = list(/obj/machinery/portable_atmospherics/canister/air/large)
 	cost = 8000
 	containertype = /obj/storage/crate/wooden
-	containername = "Spare Oxygen Canister Crate"
+	containername = "Spare XL Air Mix Canister Crate"
 /datum/supply_packs/oxygen_canister
 	name = "Spare Oxygen Canister"
 	desc = "Spare oxygen canister, for resupplying Engineering's fuel or refilling oxygen tanks."

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -956,7 +956,7 @@
 	desc = "Spare canister filled with a mix of nitrogen, oxygen and minimal amounts of carbon dioxide. Used for emergency re-pressurisation efforts."
 	category = "Engineering Department"
 	contains = list(/obj/machinery/portable_atmospherics/canister/air/large)
-	cost = 8000
+	cost = 5000
 	containertype = /obj/storage/crate/wooden
 	containername = "Spare XL Air Mix Canister Crate"
 /datum/supply_packs/oxygen_canister

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -955,7 +955,7 @@
 	name = "Extra Large Air Mix Canister"
 	desc = "Spare canister filled with a mix of nitrogen, oxygen and minimal amounts of carbon dioxide. Used for emergency re-pressurisation efforts."
 	category = "Engineering Department"
-	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
+	contains = list(/obj/machinery/portable_atmospherics/canister/air/large)
 	cost = 8000
 	containertype = /obj/storage/crate/wooden
 	containername = "Spare Oxygen Canister Crate"

--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -951,6 +951,23 @@
 	containertype = /obj/storage/crate/wooden
 	containername = "EVA Equipment Crate"
 
+/datum/supply_packs/oxygen_canister
+	name = "Spare Oxygen Canister"
+	desc = "Spare oxygen canister, for Engineering gas resupplies or emergency re-pressurisation efforts."
+	category = "Engineering Department"
+	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
+	cost = 10000
+	containertype = /obj/storage/crate/wooden
+	containername = "Spare Oxygen Canister Crate"
+
+/datum/supply_packs/plasma_canister
+	name = "Spare Plasma Canister"
+	desc = "Spare Plasma canister, for Engineering gas resupplies or impromptu gas lit campfires."
+	category = "Engineering Department"
+	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
+	cost = 80000
+	containertype = /obj/storage/crate/wooden
+	containername = "Spare Plasma Canister Crate"
 /datum/supply_packs/abcu
 	name = "ABCU Unit Crate"
 	desc = "An additional ABCU Unit, for large construction projects."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds o2 and plasma canisters to QM purchase list


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Feature request from the Discord server. Current values are up for debate.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Carbadox
(+)Additional large air mix and oxygen canisters can now be purchased through the Quartermaster console
```
