### PR TITLE
Re-Colours several of the Cables on Cogmap1

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -9685,8 +9685,6 @@
 	dir = 8
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/landmark/gps_waypoint,
@@ -9717,8 +9715,6 @@
 /area/station/hydroponics/bay)
 "axV" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/grass{
@@ -14114,7 +14110,6 @@
 "aHv" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/shrub{
@@ -62480,8 +62475,6 @@
 	dir = 4
 	},
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -11867,7 +11867,7 @@
 /turf/simulated/floor/stairs{
 	icon_state = "Stairs2_wide"
 	},
-/area/station/security/brig)
+/area/station/security/main)
 "aCG" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -12555,7 +12555,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/bot,
-/area/station/security/brig)
+/area/station/security/main)
 "aEa" = (
 /obj/table/reinforced/auto,
 /obj/machinery/power/data_terminal,
@@ -60403,24 +60403,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/coldloop)
-"gmO" = (
-/obj/grille/catwalk{
-	dir = 8
-	},
-/obj/cable/yellow,
-/obj/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/station/solar/north)
 "gom" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -60841,30 +60823,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"iwO" = (
-/obj/cable/brown{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
-"izm" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/obj/cable/yellow,
-/obj/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/station/solar/south)
 "iAg" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -61145,14 +61103,6 @@
 /obj/item/gun/flamethrower/assembled/loaded,
 /turf/simulated/floor/bot,
 /area/station/security/main)
-"jMS" = (
-/obj/disposalpipe/segment,
-/obj/grille/catwalk,
-/obj/cable/brown{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "jMV" = (
 /obj/table/auto,
 /obj/item/hand_labeler{
@@ -61996,6 +61946,12 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/bridge)
+"nzv" = (
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "nAl" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/stairs{
@@ -62303,6 +62259,12 @@
 	icon_state = "Stairs2_wide"
 	},
 /area/station/hydroponics/bay)
+"oOI" = (
+/obj/cable/brown{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "oOM" = (
 /obj/table/auto,
 /obj/item/bandage{
@@ -62759,6 +62721,24 @@
 	icon_state = "swampgrass_edge"
 	},
 /area/station/ranch)
+"qXd" = (
+/obj/grille/catwalk{
+	dir = 8
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/solar/north)
 "rae" = (
 /obj/machinery/light{
 	dir = 4
@@ -63750,6 +63730,14 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/medical/cdc)
+"wQU" = (
+/obj/disposalpipe/segment,
+/obj/grille/catwalk,
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "wSv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -63807,6 +63795,24 @@
 	},
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
+"xfn" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/solar/south)
 "xfX" = (
 /obj/table/wood/auto,
 /obj/item/storage/box/nerd_kit{
@@ -63885,12 +63891,6 @@
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
-"xJB" = (
-/obj/cable/brown{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/airless,
-/area/space)
 "xKG" = (
 /obj/machinery/light{
 	dir = 8
@@ -107073,7 +107073,7 @@ adC
 aah
 adC
 aag
-xJB
+oOI
 aaG
 adC
 aah
@@ -107375,7 +107375,7 @@ adC
 aah
 adC
 aag
-xJB
+oOI
 aaG
 adC
 aah
@@ -111880,7 +111880,7 @@ bdv
 bjI
 bfi
 boI
-jMS
+wQU
 bqu
 btm
 btH
@@ -111901,7 +111901,7 @@ bsP
 bsP
 bsP
 bvg
-iwO
+nzv
 bwV
 bCn
 byJ
@@ -116054,7 +116054,7 @@ adC
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -116356,7 +116356,7 @@ adC
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -116658,7 +116658,7 @@ adC
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -116960,7 +116960,7 @@ adC
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -117262,7 +117262,7 @@ adC
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -117866,7 +117866,7 @@ adC
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -118168,7 +118168,7 @@ abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -118470,7 +118470,7 @@ abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -118772,7 +118772,7 @@ abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -119074,7 +119074,7 @@ abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -120107,12 +120107,12 @@ adC
 adC
 adC
 csh
-izm
+xfn
 cCd
 adC
 adC
 csh
-izm
+xfn
 cCd
 adC
 aal
@@ -120409,12 +120409,12 @@ adC
 adC
 adC
 csh
-izm
+xfn
 cCd
 adC
 adC
 csh
-izm
+xfn
 cCd
 aar
 aap
@@ -120711,12 +120711,12 @@ adC
 adC
 adC
 csh
-izm
+xfn
 cCd
 adC
 adC
 csh
-izm
+xfn
 cCd
 adC
 aai
@@ -120881,17 +120881,17 @@ aaq
 aaq
 aaq
 aaY
-gmO
+qXd
 abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 aaq
 agz
@@ -121013,12 +121013,12 @@ adC
 adC
 adC
 csh
-izm
+xfn
 cCd
 adC
 adC
 csh
-izm
+xfn
 cCd
 aar
 aap
@@ -121183,17 +121183,17 @@ adC
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 aaj
@@ -121315,12 +121315,12 @@ adC
 adC
 adC
 csh
-izm
+xfn
 cCd
 adC
 adC
 csh
-izm
+xfn
 cCd
 adC
 aah
@@ -121485,17 +121485,17 @@ adC
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -121617,7 +121617,7 @@ adC
 adC
 adC
 csh
-izm
+xfn
 cCd
 adC
 adC
@@ -121787,17 +121787,17 @@ adC
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -122089,17 +122089,17 @@ adC
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC
@@ -122396,7 +122396,7 @@ abl
 adC
 adC
 aaY
-gmO
+qXd
 abl
 adC
 adC

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -347,13 +347,6 @@
 /obj/stool/chair/comfy/shuttle,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
-"abd" = (
-/obj/grille/catwalk,
-/obj/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/station/solar/west)
 "abe" = (
 /obj/grille/catwalk{
 	dir = 8
@@ -397,7 +390,8 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 1
+	dir = 1;
+	icon_state = "catwalk_cross"
 	},
 /area/station/solar/north)
 "abi" = (
@@ -610,7 +604,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/tracker/west,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/airless/solar,
 /area/station/solar/north)
 "abR" = (
 /obj/machinery/firealarm{
@@ -1819,7 +1813,7 @@
 	},
 /obj/cable/yellow,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 1
+	icon_state = "catwalk_cross"
 	},
 /area/station/solar/north)
 "aeY" = (
@@ -2447,7 +2441,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "agv" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -3294,15 +3288,15 @@
 /turf/simulated/floor,
 /area/station/security/armory)
 "aio" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/grille/catwalk{
 	dir = 9
+	},
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
@@ -7449,14 +7443,11 @@
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/east)
 "asF" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/solar/alt,
-/turf/simulated/floor/airless{
-	icon_state = "solarbase";
-	name = "solar paneling"
-	},
+/obj/machinery/power/tracker/west,
+/turf/simulated/floor/airless/solar,
 /area/station/solar/west)
 "asG" = (
 /obj/table/auto,
@@ -8570,18 +8561,18 @@
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "avp" = (
-/obj/cable,
-/obj/cable{
+/obj/grille/catwalk{
+	dir = 8
+	},
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
+/obj/cable/yellow,
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/grille/catwalk{
-	dir = 4
+/obj/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
@@ -9019,11 +9010,11 @@
 	name = "Tool Storage"
 	})
 "awr" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/grille/catwalk/cross{
 	dir = 5
+	},
+/obj/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
@@ -9710,12 +9701,9 @@
 	},
 /area/station/hydroponics/bay)
 "axX" = (
-/obj/cable,
-/obj/machinery/power/solar/alt,
-/turf/simulated/floor/airless{
-	icon_state = "solarbase";
-	name = "solar paneling"
-	},
+/obj/cable/yellow,
+/obj/machinery/power/tracker/west,
+/turf/simulated/floor/airless/solar,
 /area/station/solar/west)
 "axY" = (
 /obj/disposalpipe/segment/ejection{
@@ -9740,23 +9728,21 @@
 	},
 /area/station/medical/medbooth)
 "ayb" = (
-/obj/cable{
+/obj/wingrille_spawn/auto,
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "ayc" = (
-/obj/cable{
+/obj/grille/catwalk,
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1
-	},
+/turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west)
 "ayd" = (
 /obj/cable{
@@ -10406,11 +10392,11 @@
 	},
 /area/station/hallway/primary/east)
 "azy" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/tracker/alt,
-/turf/simulated/floor/plating/airless,
+/obj/machinery/power/solar/west,
+/turf/simulated/floor/airless/solar,
 /area/station/solar/west)
 "azz" = (
 /obj/disposalpipe/segment/produce{
@@ -10423,7 +10409,7 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "azB" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -11132,11 +11118,11 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aBf" = (
-/obj/cable{
+/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto,
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aBg" = (
@@ -11144,33 +11130,33 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/solar/west)
 "aBh" = (
-/obj/cable{
+/obj/decal/cleanable/cobweb,
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/decal/cleanable/cobweb,
-/obj/machinery/power/solar_control/alt{
+/obj/machinery/power/solar_control/west{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aBi" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/stool/chair{
 	dir = 8
+	},
+/obj/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aBj" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/terminal{
 	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
@@ -11207,26 +11193,26 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "aBo" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/grille/catwalk{
 	dir = 4
+	},
+/obj/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
 /area/station/solar/west)
 "aBp" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "External Access";
 	req_access_txt = null
 	},
 /obj/access_spawn/engineering,
+/obj/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aBq" = (
@@ -11712,21 +11698,18 @@
 	},
 /area/station/hydroponics/bay)
 "aCo" = (
-/obj/cable{
+/obj/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aCp" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "External Access";
@@ -11734,6 +11717,9 @@
 	},
 /obj/access_spawn/engineering,
 /obj/firedoor_spawn,
+/obj/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aCq" = (
@@ -11781,8 +11767,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "aCw" = (
-/obj/cable,
 /obj/wingrille_spawn/auto,
+/obj/cable/yellow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aCx" = (
@@ -13063,11 +13049,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aFc" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/grille/catwalk/cross{
 	dir = 6
+	},
+/obj/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
@@ -14114,14 +14100,12 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aHy" = (
-/obj/cable{
+/obj/grille/catwalk,
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-8"
-	},
-/obj/grille/catwalk{
-	dir = 5
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
@@ -14213,11 +14197,11 @@
 /obj/grille/catwalk{
 	dir = 9
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
@@ -36610,11 +36594,11 @@
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bEW" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/grille/catwalk/cross{
 	dir = 1
+	},
+/obj/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
@@ -36639,15 +36623,15 @@
 	},
 /area/station/solar/south)
 "bFc" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/grille/catwalk{
 	dir = 9
+	},
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
@@ -36664,29 +36648,29 @@
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "bFf" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/grille/catwalk{
 	dir = 4
+	},
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
 /area/station/solar/south)
 "bFg" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/grille/catwalk{
 	dir = 4
+	},
+/obj/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
@@ -36782,22 +36766,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"bFq" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/grille/catwalk{
-	dir = 5
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
-	},
-/area/station/solar/south)
 "bFr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/qm)
@@ -36937,13 +36905,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/inner)
-"bFH" = (
-/obj/grille/catwalk,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/station/solar/south)
 "bFI" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1;
@@ -36957,22 +36918,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
-"bFM" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/grille/catwalk{
-	dir = 5
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
-	},
-/area/station/solar/south)
 "bFN" = (
 /obj/disposalpipe/segment,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -37002,10 +36947,10 @@
 /turf/simulated/floor/grime,
 /area/station/engine/coldloop)
 "bFR" = (
-/obj/cable{
+/obj/grille/catwalk,
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/south)
 "bFS" = (
@@ -37150,22 +37095,21 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "bGg" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/grille/catwalk/cross{
 	dir = 1
 	},
+/obj/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
+	dir = 1
 	},
 /area/station/solar/south)
 "bGh" = (
@@ -37347,30 +37291,30 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/power)
 "bGA" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/grille/catwalk{
 	dir = 6
 	},
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/cable/yellow,
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
 /area/station/solar/south)
 "bGB" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/grille/catwalk{
 	dir = 5
+	},
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
@@ -51403,11 +51347,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "cle" = (
-/obj/cable,
-/obj/cable{
+/obj/wingrille_spawn/auto,
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto,
+/obj/cable/yellow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "clf" = (
@@ -51543,10 +51487,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "clt" = (
-/obj/cable{
+/obj/wingrille_spawn/auto,
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "clu" = (
@@ -54302,7 +54246,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
@@ -54412,9 +54356,6 @@
 /turf/simulated/floor,
 /area/station/science/chemistry)
 "cry" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
 	name = "External Access";
@@ -54422,6 +54363,9 @@
 	},
 /obj/access_spawn/engineering,
 /obj/firedoor_spawn,
+/obj/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "crC" = (
@@ -54670,7 +54614,7 @@
 	},
 /area/station/hangar/engine)
 "crX" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -54698,14 +54642,14 @@
 /turf/simulated/floor/delivery,
 /area/station/hallway/secondary/exit)
 "csb" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/external{
 	name = "External Access";
 	req_access_txt = null
 	},
 /obj/access_spawn/engineering,
+/obj/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "csd" = (
@@ -54727,9 +54671,6 @@
 "csf" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -54738,6 +54679,9 @@
 	},
 /obj/item/cell/supercell/charged{
 	pixel_x = 2
+	},
+/obj/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
@@ -54751,14 +54695,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
 "csh" = (
-/obj/cable{
+/obj/machinery/power/solar/east,
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/solar/east,
-/turf/simulated/floor/airless{
-	icon_state = "solarbase";
-	name = "solar paneling"
-	},
+/turf/simulated/floor/airless/solar,
 /area/station/solar/south)
 "csj" = (
 /obj/machinery/light{
@@ -55381,14 +55322,14 @@
 	},
 /area/station/medical/research)
 "ctF" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/power/solar_control/east{
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
@@ -55396,7 +55337,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -59029,12 +58970,9 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "cCd" = (
-/obj/cable,
 /obj/machinery/power/solar/east,
-/turf/simulated/floor/airless{
-	icon_state = "solarbase";
-	name = "solar paneling"
-	},
+/obj/cable/yellow,
+/turf/simulated/floor/airless/solar,
 /area/station/solar/south)
 "cCe" = (
 /obj/landmark/gps_waypoint,
@@ -59117,11 +59055,11 @@
 /turf/simulated/floor/wood,
 /area/station/medical/medbay/lobby)
 "cCm" = (
-/obj/cable{
+/obj/machinery/power/tracker/east,
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/tracker/east,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/airless/solar,
 /area/station/solar/south)
 "cCo" = (
 /obj/decal/poster/wallsign/teaparty{
@@ -60465,6 +60403,24 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/coldloop)
+"gmO" = (
+/obj/grille/catwalk{
+	dir = 8
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/solar/north)
 "gom" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -60793,24 +60749,6 @@
 /obj/lattice,
 /turf/space,
 /area/space)
-"ibs" = (
-/obj/grille/catwalk{
-	dir = 8
-	},
-/obj/cable/yellow,
-/obj/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/station/solar/north)
 "icC" = (
 /obj/stool/chair/office/red{
 	dir = 1
@@ -60903,6 +60841,30 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"iwO" = (
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"izm" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/solar/south)
 "iAg" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -61183,6 +61145,14 @@
 /obj/item/gun/flamethrower/assembled/loaded,
 /turf/simulated/floor/bot,
 /area/station/security/main)
+"jMS" = (
+/obj/disposalpipe/segment,
+/obj/grille/catwalk,
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "jMV" = (
 /obj/table/auto,
 /obj/item/hand_labeler{
@@ -61302,14 +61272,6 @@
 	dir = 9
 	},
 /area/station/medical/medbay)
-"kke" = (
-/obj/disposalpipe/segment,
-/obj/grille/catwalk,
-/obj/cable/brown{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "kkk" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -62877,12 +62839,6 @@
 	icon_state = "fred5"
 	},
 /area/station/crew_quarters/hor)
-"rLK" = (
-/obj/cable/brown{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
 "rMQ" = (
 /obj/stool/chair{
 	dir = 8
@@ -63467,12 +63423,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/security/checkpoint/cargo)
-"uHV" = (
-/obj/cable/brown{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/airless,
-/area/space)
 "uKI" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -63935,6 +63885,12 @@
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
+"xJB" = (
+/obj/cable/brown{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "xKG" = (
 /obj/machinery/light{
 	dir = 8
@@ -107117,7 +107073,7 @@ adC
 aah
 adC
 aag
-uHV
+xJB
 aaG
 adC
 aah
@@ -107419,7 +107375,7 @@ adC
 aah
 adC
 aag
-uHV
+xJB
 aaG
 adC
 aah
@@ -111924,7 +111880,7 @@ bdv
 bjI
 bfi
 boI
-kke
+jMS
 bqu
 btm
 btH
@@ -111945,7 +111901,7 @@ bsP
 bsP
 bsP
 bvg
-rLK
+iwO
 bwV
 bCn
 byJ
@@ -116098,7 +116054,7 @@ adC
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -116400,7 +116356,7 @@ adC
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -116702,7 +116658,7 @@ adC
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -117004,7 +116960,7 @@ adC
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -117306,7 +117262,7 @@ adC
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -117910,7 +117866,7 @@ adC
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -118212,7 +118168,7 @@ abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -118514,7 +118470,7 @@ abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -118816,7 +118772,7 @@ abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -119118,7 +119074,7 @@ abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -119538,11 +119494,11 @@ crf
 cri
 csb
 bEW
-bFq
-bFH
-bFH
-bFH
-bFM
+bGB
+bFR
+bFR
+bFR
+bGB
 bFR
 bFR
 bFR
@@ -120151,12 +120107,12 @@ adC
 adC
 adC
 csh
-bFf
+izm
 cCd
 adC
 adC
 csh
-bFf
+izm
 cCd
 adC
 aal
@@ -120322,15 +120278,15 @@ aay
 aap
 aaZ
 abg
-abd
-abd
-abd
-abd
+ayc
+ayc
+ayc
+ayc
 abO
-abd
-abd
-abd
-abd
+ayc
+ayc
+ayc
+ayc
 aeX
 aaZ
 aap
@@ -120453,12 +120409,12 @@ adC
 adC
 adC
 csh
-bFf
+izm
 cCd
 adC
 adC
 csh
-bFf
+izm
 cCd
 aar
 aap
@@ -120755,12 +120711,12 @@ adC
 adC
 adC
 csh
-bFf
+izm
 cCd
 adC
 adC
 csh
-bFf
+izm
 cCd
 adC
 aai
@@ -120925,17 +120881,17 @@ aaq
 aaq
 aaq
 aaY
-ibs
+gmO
 abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 aaq
 agz
@@ -121057,12 +121013,12 @@ adC
 adC
 adC
 csh
-bFf
+izm
 cCd
 adC
 adC
 csh
-bFf
+izm
 cCd
 aar
 aap
@@ -121227,17 +121183,17 @@ adC
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 aaj
@@ -121359,12 +121315,12 @@ adC
 adC
 adC
 csh
-bFf
+izm
 cCd
 adC
 adC
 csh
-bFf
+izm
 cCd
 adC
 aah
@@ -121529,17 +121485,17 @@ adC
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -121661,7 +121617,7 @@ adC
 adC
 adC
 csh
-bFf
+izm
 cCd
 adC
 adC
@@ -121831,17 +121787,17 @@ adC
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -122133,17 +122089,17 @@ adC
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC
@@ -122440,7 +122396,7 @@ abl
 adC
 adC
 aaY
-ibs
+gmO
 abl
 adC
 adC

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -95,15 +95,15 @@
 /turf/space,
 /area/space)
 "aas" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/grille/catwalk{
 	dir = 9
+	},
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
@@ -310,14 +310,11 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aaY" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/solar/west,
-/turf/simulated/floor/airless{
-	icon_state = "solarbase";
-	name = "solar paneling"
-	},
+/turf/simulated/floor/airless/solar,
 /area/station/solar/north)
 "aaZ" = (
 /obj/lattice,
@@ -351,73 +348,56 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "abd" = (
-/obj/cable{
+/obj/grille/catwalk,
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/west)
 "abe" = (
-/obj/cable,
-/obj/cable{
+/obj/grille/catwalk{
+	dir = 8
+	},
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
+/obj/cable/yellow,
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/grille/catwalk{
-	dir = 4
+/obj/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
 /area/station/solar/north)
 "abf" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/grille/catwalk{
 	dir = 4
+	},
+/obj/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
 	},
 /area/station/solar/north)
 "abg" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/grille/catwalk{
 	dir = 10
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
-/area/station/solar/north)
-"abh" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/grille/catwalk{
-	dir = 5
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
+	dir = 1
 	},
 /area/station/solar/north)
 "abi" = (
@@ -428,12 +408,9 @@
 /turf/simulated/floor,
 /area/station/routing/security)
 "abl" = (
-/obj/cable,
+/obj/cable/yellow,
 /obj/machinery/power/solar/west,
-/turf/simulated/floor/airless{
-	icon_state = "solarbase";
-	name = "solar paneling"
-	},
+/turf/simulated/floor/airless/solar,
 /area/station/solar/north)
 "abn" = (
 /turf/simulated/floor/black,
@@ -592,29 +569,29 @@
 	},
 /area/shuttle/arrival/station)
 "abN" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/grille/catwalk/cross{
 	dir = 9
+	},
+/obj/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
 /area/station/solar/north)
 "abO" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/grille/catwalk/cross{
 	dir = 1
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
@@ -622,14 +599,14 @@
 	},
 /area/station/solar/north)
 "abP" = (
-/obj/cable{
+/obj/grille/catwalk,
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/solar/north)
 "abQ" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/tracker/west,
@@ -1514,7 +1491,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/solar/west)
 "aen" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
@@ -1767,11 +1744,11 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction)
 "aeP" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/grille/catwalk{
 	dir = 9
+	},
+/obj/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
@@ -1814,7 +1791,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "aeU" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
@@ -1831,18 +1808,18 @@
 /turf/simulated/floor,
 /area/station/security/armory)
 "aeX" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/grille/catwalk{
 	dir = 6
 	},
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/cable/yellow,
 /turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
+	dir = 1
 	},
 /area/station/solar/north)
 "aeY" = (
@@ -1896,18 +1873,15 @@
 	},
 /area/station/crew_quarters/quarters)
 "aff" = (
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/grille/catwalk{
 	dir = 5
+	},
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
@@ -2140,14 +2114,14 @@
 /turf/simulated/floor/plating/damaged1,
 /area/station/crew_quarters/clown)
 "afH" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/power/solar_control/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)
 "afI" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal{
@@ -2483,7 +2457,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/solar/north)
 "agx" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/external{
@@ -2764,7 +2738,7 @@
 	},
 /area/station/hallway/secondary/entry)
 "ahc" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -2795,7 +2769,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)
 "ahj" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
@@ -3199,13 +3173,13 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "ahX" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)
 "ahY" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -60819,6 +60793,24 @@
 /obj/lattice,
 /turf/space,
 /area/space)
+"ibs" = (
+/obj/grille/catwalk{
+	dir = 8
+	},
+/obj/cable/yellow,
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/solar/north)
 "icC" = (
 /obj/stool/chair/office/red{
 	dir = 1
@@ -61263,14 +61255,6 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
-"jUI" = (
-/obj/disposalpipe/segment,
-/obj/grille/catwalk,
-/obj/cable/brown{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "jUM" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/item/device/radio/intercom/cargo{
@@ -61318,6 +61302,14 @@
 	dir = 9
 	},
 /area/station/medical/medbay)
+"kke" = (
+/obj/disposalpipe/segment,
+/obj/grille/catwalk,
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "kkk" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -61909,12 +61901,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
-"mZH" = (
-/obj/cable/brown{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
 "naz" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor,
@@ -62891,6 +62877,12 @@
 	icon_state = "fred5"
 	},
 /area/station/crew_quarters/hor)
+"rLK" = (
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "rMQ" = (
 /obj/stool/chair{
 	dir = 8
@@ -63458,12 +63450,6 @@
 /obj/critter/mouse/remy,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"uCQ" = (
-/obj/cable/brown{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/airless,
-/area/space)
 "uDR" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -63481,6 +63467,12 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/security/checkpoint/cargo)
+"uHV" = (
+/obj/cable/brown{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "uKI" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -107125,7 +107117,7 @@ adC
 aah
 adC
 aag
-uCQ
+uHV
 aaG
 adC
 aah
@@ -107427,7 +107419,7 @@ adC
 aah
 adC
 aag
-uCQ
+uHV
 aaG
 adC
 aah
@@ -111932,7 +111924,7 @@ bdv
 bjI
 bfi
 boI
-jUI
+kke
 bqu
 btm
 btH
@@ -111953,7 +111945,7 @@ bsP
 bsP
 bsP
 bvg
-mZH
+rLK
 bwV
 bCn
 byJ
@@ -116106,7 +116098,7 @@ adC
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -116408,7 +116400,7 @@ adC
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -116710,7 +116702,7 @@ adC
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -117012,7 +117004,7 @@ adC
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -117314,7 +117306,7 @@ adC
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -117918,7 +117910,7 @@ adC
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -118220,7 +118212,7 @@ abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -118522,7 +118514,7 @@ abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -118824,7 +118816,7 @@ abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -119126,7 +119118,7 @@ abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -120933,17 +120925,17 @@ aaq
 aaq
 aaq
 aaY
-abe
+ibs
 abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 aaq
 agz
@@ -121235,17 +121227,17 @@ adC
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 aaj
@@ -121537,17 +121529,17 @@ adC
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -121839,17 +121831,17 @@ adC
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -122141,17 +122133,17 @@ adC
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC
@@ -122443,12 +122435,12 @@ adC
 adC
 adC
 aaY
-abh
+aff
 abl
 adC
 adC
 aaY
-abe
+ibs
 abl
 adC
 adC

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -11328,11 +11328,11 @@
 	dir = 4;
 	name = "Electrical Substation"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/access_spawn/engineering_power,
 /obj/firedoor_spawn,
+/obj/cable/brown{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "aBC" = (
@@ -23468,7 +23468,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -23986,11 +23986,11 @@
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Electrical Substation"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/access_spawn/engineering_power,
 /obj/firedoor_spawn,
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/pylon)
 "bdw" = (
@@ -25592,7 +25592,7 @@
 "bgH" = (
 /obj/displaycase{
 	displayed = new /obj/item/captaingun
-},
+	},
 /obj/window/reinforced{
 	dir = 2
 	},
@@ -26949,9 +26949,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/grille/catwalk{
 	dir = 6
 	},
@@ -26960,6 +26957,9 @@
 	dir = 1;
 	name = "autoname - SS13";
 	tag = ""
+	},
+/obj/cable/brown{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
@@ -27291,12 +27291,12 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/grille/catwalk/cross{
 	dir = 5;
 	tag = "icon-catwalk_cross (NORTHEAST)"
+	},
+/obj/cable/brown{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
@@ -29199,11 +29199,11 @@
 /turf/space,
 /area/space)
 "boo" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment,
 /obj/grille/catwalk,
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
@@ -29416,15 +29416,15 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "boI" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
 /obj/grille/catwalk{
 	dir = 10
+	},
+/obj/cable/brown{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
@@ -29438,9 +29438,6 @@
 /turf/simulated/floor/plating,
 /area/station/hangar/main)
 "boK" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -29448,6 +29445,9 @@
 /obj/grille/catwalk/cross{
 	dir = 6;
 	tag = "icon-catwalk_cross (SOUTHEAST)"
+	},
+/obj/cable/brown{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
@@ -30150,7 +30150,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
 "bql" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -30198,13 +30198,13 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/engine)
 "bqr" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/external{
 	req_access_txt = null
 	},
 /obj/access_spawn/engineering_storage,
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/engine)
 "bqs" = (
@@ -30218,15 +30218,15 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/engine)
 "bqu" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /obj/grille/catwalk{
 	dir = 9
+	},
+/obj/cable/brown{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
@@ -30462,7 +30462,7 @@
 /turf/simulated/floor,
 /area/station/hangar/engine)
 "bqT" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -30675,7 +30675,7 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "brs" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-4"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -31024,13 +31024,13 @@
 /turf/simulated/floor/delivery,
 /area/station/routing/engine)
 "bsh" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	req_access = null
 	},
 /obj/access_spawn/engineering_engine,
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/engine)
 "bsj" = (
@@ -31343,7 +31343,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/inner)
 "bsP" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -31373,12 +31373,12 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/decal/tile_edge/stripe/big{
 	dir = 4;
 	icon_state = "xtra_bigstripe-edge"
+	},
+/obj/cable/brown{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/ptl)
@@ -31512,11 +31512,11 @@
 	},
 /area/station/crew_quarters/info)
 "btm" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/grille/catwalk{
 	dir = 5
+	},
+/obj/cable/brown{
+	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -31675,10 +31675,10 @@
 /turf/simulated/floor/plating,
 /area/station/engine/inner)
 "btH" = (
-/obj/cable{
+/obj/grille/catwalk,
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
-/obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "btI" = (
@@ -31714,9 +31714,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
 "btM" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -31726,6 +31723,9 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 4;
 	icon_state = "xtra_bigstripe-edge"
+	},
+/obj/cable/brown{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/ptl)
@@ -31825,11 +31825,11 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai_upload)
 "bud" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/grille/catwalk{
 	dir = 6
+	},
+/obj/cable/brown{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
@@ -31915,12 +31915,12 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
 "bun" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/grille/catwalk/cross{
 	dir = 5;
 	tag = "icon-catwalk_cross (NORTHEAST)"
+	},
+/obj/cable/brown{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
@@ -32054,11 +32054,11 @@
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
 "buE" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 5
+	},
+/obj/cable/brown{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/ptl)
@@ -32269,15 +32269,15 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "bvg" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/engineering{
 	name = "Generator Core";
 	req_access = null
 	},
 /obj/access_spawn/engineering_engine,
 /obj/firedoor_spawn,
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/core)
 "bvh" = (
@@ -32349,30 +32349,30 @@
 	name = "Power Transmission Laser";
 	req_access = null
 	},
-/obj/cable{
+/obj/access_spawn/engineering_engine,
+/obj/cable/brown{
 	icon_state = "4-8"
 	},
-/obj/access_spawn/engineering_engine,
 /turf/simulated/floor,
 /area/station/engine/gas)
 "bvo" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "4-8"
+	},
+/obj/cable/brown{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/ptl)
 "bvp" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/ptl)
 "bvq" = (
 /obj/machinery/light,
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -32382,10 +32382,10 @@
 	dir = 8;
 	name = "Engine Output Monitoring"
 	},
-/obj/cable{
+/obj/machinery/power/data_terminal,
+/obj/cable/brown{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor,
 /area/station/engine/ptl)
 "bvs" = (
@@ -32696,14 +32696,14 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bwe" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/grille/catwalk{
 	dir = 9
+	},
+/obj/cable/brown{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
@@ -32766,21 +32766,21 @@
 	dir = 8;
 	tag = ""
 	},
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/bot,
 /area/station/engine/gas)
 "bwm" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/decal/tile_edge/stripe/big{
 	dir = 4;
 	icon_state = "xtra_bigstripe-edge"
+	},
+/obj/cable/brown{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/gas)
@@ -33019,11 +33019,11 @@
 	},
 /area/space)
 "bwO" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/grille/catwalk{
 	dir = 10
+	},
+/obj/cable/brown{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
@@ -33054,12 +33054,12 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bwS" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/grille/catwalk/cross{
 	dir = 6;
 	tag = "icon-catwalk_cross (SOUTHEAST)"
+	},
+/obj/cable/brown{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
@@ -33078,11 +33078,11 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
 "bwV" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "0-2"
 	},
-/obj/cable,
-/obj/cable{
+/obj/cable/brown,
+/obj/cable/brown{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/engine,
@@ -33101,7 +33101,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "6-8"
 	},
 /turf/simulated/floor/engine,
@@ -33133,7 +33133,7 @@
 /area/space)
 "bxb" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/bot,
@@ -33311,24 +33311,24 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bxA" = (
 /obj/grille/steel,
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/window/reinforced{
 	dir = 2
+	},
+/obj/cable/brown{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "bxB" = (
 /obj/grille/steel,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/window/reinforced{
 	dir = 2
+	},
+/obj/cable/brown{
+	icon_state = "0-8"
+	},
+/obj/cable/brown{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
@@ -33430,10 +33430,10 @@
 /area/station/engine/core)
 "bxO" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/cable{
+/obj/wingrille_spawn/auto,
+/obj/cable/brown{
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/engine/core)
 "bxP" = (
@@ -33445,15 +33445,15 @@
 	},
 /area/space)
 "bxQ" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/wingrille_spawn/auto,
+/obj/cable/brown{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/engine/core)
 "bxS" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "4-9"
 	},
 /obj/cable{
@@ -33498,7 +33498,7 @@
 /area/station/engine/core)
 "bxW" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/grime,
@@ -33745,25 +33745,22 @@
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "byy" = (
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/cable,
 /obj/securearea{
 	desc = "";
 	icon_state = "shock";
 	name = "Danger: High Voltage";
 	pixel_x = 32
 	},
+/obj/cable/brown,
+/obj/cable/brown{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "byz" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 8;
 	level = 2
@@ -33771,6 +33768,9 @@
 /obj/machinery/power/stats_meter{
 	name = "Cold Loop Inlet Meter";
 	tag = "Cold Loop Inlet Meter"
+	},
+/obj/cable/brown{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -33838,16 +33838,16 @@
 /area/station/engine/core)
 "byJ" = (
 /obj/machinery/power/generatorTemp,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
 /obj/item/paper/engine,
 /obj/decal/tile_edge/stripe/big{
 	dir = 1;
 	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/cable/brown{
+	icon_state = "0-2"
+	},
+/obj/cable/brown,
 /turf/simulated/floor,
 /area/station/engine/core)
 "byK" = (
@@ -34242,16 +34242,16 @@
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "bzF" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
+	},
+/obj/cable/brown{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "bzG" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -34302,7 +34302,7 @@
 /turf/simulated/floor/delivery,
 /area/station/engine/core)
 "bzN" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/delivery,
@@ -34676,9 +34676,6 @@
 	dir = 4
 	},
 /obj/table/auto,
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/item/cell/supercell/charged{
 	pixel_x = -7;
 	pixel_y = 12
@@ -34690,6 +34687,9 @@
 /obj/machinery/cell_charger,
 /obj/item/cell/supercell/charged{
 	pixel_x = 2
+	},
+/obj/cable/brown{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
@@ -34780,7 +34780,7 @@
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
 "bAI" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs,
@@ -35103,28 +35103,28 @@
 /area/station/turret_protected/ai_upload_foyer)
 "bBt" = (
 /obj/grille/steel,
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/window/reinforced{
 	dir = 1
+	},
+/obj/cable/brown{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "bBu" = (
 /obj/grille/steel,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable,
 /obj/window/reinforced{
 	dir = 1
 	},
+/obj/cable/brown{
+	icon_state = "0-8"
+	},
+/obj/cable/brown,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload_foyer)
 "bBv" = (
 /obj/grille/steel,
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
@@ -35465,24 +35465,22 @@
 /turf/simulated/floor,
 /area/station/engine/hotloop)
 "bCn" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/wingrille_spawn/auto,
 /obj/securearea{
 	desc = "";
 	icon_state = "shock";
 	name = "Danger: High Voltage"
 	},
+/obj/cable/brown{
+	icon_state = "0-8"
+	},
+/obj/cable/brown{
+	icon_state = "0-4"
+	},
+/obj/cable/brown{
+	icon_state = "0-2"
+	},
+/obj/cable/brown,
 /turf/simulated/floor/plating,
 /area/station/engine/core)
 "bCo" = (
@@ -35493,7 +35491,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
 "bCq" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -35537,10 +35535,10 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bCv" = (
-/obj/cable{
+/obj/machinery/light/small,
+/obj/cable/brown{
 	icon_state = "1-4"
 	},
-/obj/machinery/light/small,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bCw" = (
@@ -35548,7 +35546,7 @@
 	dir = 8;
 	level = 2
 	},
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine,
@@ -35923,7 +35921,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless,
@@ -36049,15 +36047,15 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	name = "Core Access";
 	req_access = null
 	},
 /obj/access_spawn/engineering_engine,
 /obj/firedoor_spawn,
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/delivery,
 /area/station/engine/core)
 "bDB" = (
@@ -36917,40 +36915,28 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
-"bFA" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/hotloop)
 "bFB" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "4-8"
 	},
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "2-4"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
 "bFC" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
 "bFD" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/delivery,
 /area/station/engine/hotloop)
 "bFE" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/table/auto,
 /obj/item/clothing/mask/gas/emergency{
 	pixel_x = -6;
@@ -36960,16 +36946,19 @@
 	pixel_x = 6;
 	pixel_y = 2
 	},
+/obj/cable/brown{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
 "bFF" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/inner)
 "bFG" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -37364,8 +37353,8 @@
 /area/station/engine/power)
 "bGx" = (
 /obj/machinery/power/terminal,
-/obj/cable,
 /obj/grille/steel,
+/obj/cable/brown,
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "bGy" = (
@@ -37378,7 +37367,7 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "bGz" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -37416,14 +37405,14 @@
 /area/station/solar/south)
 "bGC" = (
 /obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/monitor/smes{
 	name = "Engine Output Monitoring"
+	},
+/obj/cable/brown{
+	icon_state = "0-4"
+	},
+/obj/cable/brown{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -37442,20 +37431,20 @@
 /turf/simulated/floor/airless/plating/damaged2,
 /area/abandonedship)
 "bGF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/light/emergency{
 	dir = 1
+	},
+/obj/cable/brown{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/delivery,
 /area/station/engine/engineering)
 "bGI" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/atmosphere/pumpcontrol,
+/obj/cable/brown{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -37741,10 +37730,10 @@
 /area/station/engine/power)
 "bHn" = (
 /obj/machinery/power/data_terminal,
-/obj/cable,
 /obj/machinery/power/monitor/smes{
 	name = "Engine Output Monitoring"
 	},
+/obj/cable/brown,
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "bHo" = (
@@ -37761,9 +37750,6 @@
 /obj/deskclutter{
 	pixel_x = 1
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/item/paper_bin{
 	pixel_x = -7;
 	pixel_y = 7
@@ -37779,6 +37765,9 @@
 /obj/item/pen{
 	pixel_x = -7;
 	pixel_y = 8
+	},
+/obj/cable/brown{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 9
@@ -38202,13 +38191,13 @@
 	mixerid = "engine_combust";
 	name = "Gas Mixer Control (Combustion Chamber)"
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
+/obj/machinery/power/data_terminal,
+/obj/cable/brown{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/data_terminal,
+/obj/cable/brown{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -48859,10 +48848,10 @@
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "cfr" = (
-/obj/cable{
+/obj/landmark/gps_waypoint,
+/obj/cable/brown{
 	icon_state = "4-8"
 	},
-/obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/engine/ptl)
 "cfs" = (
@@ -59780,7 +59769,7 @@
 /area/station/hallway/primary/central)
 "dIa" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/bot,
@@ -60615,14 +60604,14 @@
 	},
 /area/station/ranch)
 "gVk" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/decal/tile_edge/stripe/big{
 	dir = 1;
 	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/cable/brown{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/grime,
 /area/station/engine/gas)
 "gZd" = (
@@ -60647,9 +60636,6 @@
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "hhs" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/disposal/mail{
 	mail_tag = "engineering";
 	mailgroup = "engineer";
@@ -60666,6 +60652,9 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0;
 	dir = 10
+	},
+/obj/cable/brown{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -60948,9 +60937,6 @@
 	},
 /area/station/medical/medbay)
 "iLA" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/decal/tile_edge/stripe/big{
 	dir = 1;
 	icon_state = "xtra_bigstripe-edge"
@@ -60958,6 +60944,9 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 9
+	},
+/obj/cable/brown{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -61254,7 +61243,7 @@
 /obj/machinery/atmospherics/valve{
 	name = "outlet purge valve"
 	},
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/delivery,
@@ -61274,6 +61263,14 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
+"jUI" = (
+/obj/disposalpipe/segment,
+/obj/grille/catwalk,
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "jUM" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/item/device/radio/intercom/cargo{
@@ -61335,15 +61332,15 @@
 /turf/simulated/floor/yellow/side,
 /area/station/science/lobby)
 "kqm" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/binary/pump{
 	frequency = 1225;
 	icon_state = "intact_on";
 	id = "Cold Loop Purge Pump";
 	on = 1;
 	target_pressure = 2000
+	},
+/obj/cable/brown{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
@@ -61674,12 +61671,12 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "lNm" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
 	level = 2
+	},
+/obj/cable/brown{
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
@@ -61846,15 +61843,9 @@
 /turf/simulated/floor/delivery,
 /area/station/security/main)
 "mCU" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-c"
-	},
-/obj/cable{
-	icon_state = "1-8"
 	},
 /obj/decal/tile_edge/stripe/big{
 	dir = 1;
@@ -61863,6 +61854,12 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0;
 	dir = 5
+	},
+/obj/cable/brown{
+	icon_state = "4-8"
+	},
+/obj/cable/brown{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
@@ -61912,6 +61909,12 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
+"mZH" = (
+/obj/cable/brown{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "naz" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor,
@@ -62494,11 +62497,11 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "pDV" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
 	dir = 4
+	},
+/obj/cable/brown{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -63039,7 +63042,7 @@
 	dir = 4;
 	level = 2
 	},
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -63178,9 +63181,6 @@
 	},
 /area/station/security/main)
 "tpI" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
@@ -63189,6 +63189,9 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 6
+	},
+/obj/cable/brown{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -63455,6 +63458,12 @@
 /obj/critter/mouse/remy,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"uCQ" = (
+/obj/cable/brown{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space)
 "uDR" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -63558,7 +63567,7 @@
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/armory_outside)
 "vli" = (
-/obj/cable{
+/obj/cable/brown{
 	icon_state = "1-2"
 	},
 /obj/cable{
@@ -63842,9 +63851,6 @@
 	},
 /area/station/hydroponics/bay)
 "xee" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	name = "Core Access";
 	req_access = null
@@ -63853,6 +63859,9 @@
 /obj/access_spawn/engineering_engine,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0
+	},
+/obj/cable/brown{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
@@ -107116,7 +107125,7 @@ adC
 aah
 adC
 aag
-btR
+uCQ
 aaG
 adC
 aah
@@ -107418,7 +107427,7 @@ adC
 aah
 adC
 aag
-btR
+uCQ
 aaG
 adC
 aah
@@ -108029,7 +108038,7 @@ bqk
 bDo
 bqk
 bqk
-bFA
+bFB
 bGx
 bHi
 bIg
@@ -111923,7 +111932,7 @@ bdv
 bjI
 bfi
 boI
-boL
+jUI
 bqu
 btm
 btH
@@ -111944,7 +111953,7 @@ bsP
 bsP
 bsP
 bvg
-bwk
+mZH
 bwV
 bCn
 byJ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes parts of Cogmap 1 to use the Coloured Cabling not seen on most maps!
-Solar Arrays now use Yellow cabling
-HotWired TEG cabling now uses Brown cabling

Additionally:
-Fixes some odd tiles of the Brig area that jutted out into the hallway for some reason
-Purges some of the D1&D2 Vars i forgot to purge earlier
-Makes the West solar array actually use the objects for a West solar array, instead of Alt
-Changed tiles under Solar Trackers to be solar tiles as they (imo) look better

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Looks better in these areas which have overlapping wiregrids, and makes it less likely for a player to unknowingly hotwire the wrong wires


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Comradef191
(*)You can now tell which cables on Cogmap 1 are directly connected to the Engine thanks to their Brown colour!
(+)You can also now tell which cables are connected to the Solar Arrays on Cogmap 1, as they are now Yellow.
```
