### PR TITLE
Removing finger snapping off chance from *snap and removes nipple tweaking

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1213,24 +1213,11 @@
 						if (src.bioHolder.HasEffect("chime_snaps"))
 							src.sound_fingersnap = 'sound/musical_instruments/WeirdChime_5.ogg'
 							src.sound_snap = 'sound/impact_sounds/Glass_Shards_Hit_1.ogg'
-						if (prob(5))
-							message = "<font color=red><B>[src]</B> snaps [his_or_her(src)] fingers RIGHT OFF!</font>"
-							/*
-							if (src.bioHolder)
-								src.bioHolder.AddEffect("[src.hand ? "left" : "right"]_arm")
-							else
-							*/
-							random_brute_damage(src, 20)
-							if (narrator_mode)
-								playsound(src.loc, 'sound/vox/break.ogg', 100, 1, channel=VOLUME_CHANNEL_EMOTE)
-							else
-								playsound(src.loc, src.sound_snap, 100, 1, channel=VOLUME_CHANNEL_EMOTE)
-						else
-							message = "<B>[src]</B> snaps [his_or_her(src)] fingers."
 							if (narrator_mode)
 								playsound(src.loc, 'sound/vox/deeoo.ogg', 50, 1, channel=VOLUME_CHANNEL_EMOTE)
 							else
 								playsound(src.loc, src.sound_fingersnap, 50, 1, channel=VOLUME_CHANNEL_EMOTE)
+								message = "<B>[src]</B> snaps [his_or_her(src)] fingers."
 
 			if ("airquote","airquotes")
 				if (param)

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1033,11 +1033,6 @@
 
 			// targeted emotes
 
-			if ("tweak","tweaknipples","tweaknips","nippletweak")
-				if (!src.restrained())
-					message = "<B>[src]</b> tweaks [his_or_her(src)] nipples."
-				m_type = 1
-
 			if ("flipoff","flipbird","middlefinger")
 				m_type = 1
 				if (!src.restrained())
@@ -1213,11 +1208,11 @@
 						if (src.bioHolder.HasEffect("chime_snaps"))
 							src.sound_fingersnap = 'sound/musical_instruments/WeirdChime_5.ogg'
 							src.sound_snap = 'sound/impact_sounds/Glass_Shards_Hit_1.ogg'
-							if (narrator_mode)
-								playsound(src.loc, 'sound/vox/deeoo.ogg', 50, 1, channel=VOLUME_CHANNEL_EMOTE)
-							else
-								playsound(src.loc, src.sound_fingersnap, 50, 1, channel=VOLUME_CHANNEL_EMOTE)
-								message = "<B>[src]</B> snaps [his_or_her(src)] fingers."
+						if (narrator_mode)
+							playsound(src.loc, 'sound/vox/deeoo.ogg', 50, 1, channel=VOLUME_CHANNEL_EMOTE)
+						else
+							playsound(src.loc, src.sound_fingersnap, 50, 1, channel=VOLUME_CHANNEL_EMOTE)
+							message = "<B>[src]</B> snaps [his_or_her(src)] fingers."
 
 			if ("airquote","airquotes")
 				if (param)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR removes the 1/20 (5%) chance of having your finger snap off when you used the *snap emote. This gave 20 brute. 
I also removed the nippletweaking emote


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This is needed as the 5% chance of receiving 20 brute for using a hotkey emote completely nuked any use of the emote for its purpose other than to deal massive amounts of damage to themselves.

Also nippletweaking is gross

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Yellow-Mushroom
(*)Removed the chance to have your finger snapping off
(*)Removed nipple tweaking emotes
```
