### PR TITLE
jobprocs.dm, 296: Cannot modify null.assigned_role.

### DIFF
--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -292,6 +292,7 @@
 		// we really need to fix this or it'll be some kinda weird inf loop shit
 		low_priority_jobs += "Staff Assistant"
 	for (var/mob/new_player/player in unassigned)
+		if(isnull(player.mind)) continue
 		logTheThing("debug", null, null, "<b>I Said No/Jobs:</b> [player] given a low priority role")
 		player.mind.assigned_role = pick(low_priority_jobs)
 		logTheThing("debug", player, null, "assigned job: [player.mind.assigned_role]")

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -292,7 +292,7 @@
 		// we really need to fix this or it'll be some kinda weird inf loop shit
 		low_priority_jobs += "Staff Assistant"
 	for (var/mob/new_player/player in unassigned)
-		if(isnull(player.mind)) continue
+		if(!player?.mind) continue
 		logTheThing("debug", null, null, "<b>I Said No/Jobs:</b> [player] given a low priority role")
 		player.mind.assigned_role = pick(low_priority_jobs)
 		logTheThing("debug", player, null, "assigned job: [player.mind.assigned_role]")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Check for null minds during job distribution of low priority roles
* If a `mob/new_player/player` manages to lose its mind while the the job distribution is querying the job bans API then it will cause a runtime

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

File | jobprocs.dm
-- | --
Line | 296
Error | Cannot modify null.assigned_role.
```dm
proc name: DivideOccupations (/proc/DivideOccupations)
  source file: jobprocs.dm,296
  usr: (src)
  src: null
  call stack:
DivideOccupations()
/datum/controller/gameticker (/datum/controller/gameticker): distribute jobs()
/datum/controller/gameticker (/datum/controller/gameticker): setup()
/datum/controller/gameticker (/datum/controller/gameticker): pregame()
```