### PR TITLE
Clarion Sec revamp

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -22583,7 +22583,8 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/pyro/glass/security{
-	name = "Security"
+	name = "Security";
+	req_access = null
 	},
 /obj/access_spawn/security,
 /obj/firedoor_spawn,
@@ -25711,7 +25712,8 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/pyro/glass/security{
-	name = "Locker Room"
+	name = "Locker Room";
+	req_access = null
 	},
 /obj/access_spawn/sec_lockers,
 /obj/firedoor_spawn,
@@ -27651,7 +27653,8 @@
 "bam" = (
 /obj/disposalpipe/segment/ejection,
 /obj/machinery/door/airlock/pyro/glass/security{
-	name = "Processing room"
+	name = "Processing room";
+	req_access = null
 	},
 /obj/access_spawn/security,
 /obj/firedoor_spawn,
@@ -27692,10 +27695,6 @@
 	},
 /area/station/security/main)
 "bar" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -28402,6 +28401,11 @@
 	dir = 6;
 	name = "autoname  - SS13";
 	pixel_y = 21
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 28;
+	text = "NF"
 	},
 /turf/simulated/floor/caution/north,
 /area/station/security/main)
@@ -29693,7 +29697,8 @@
 "bdZ" = (
 /obj/machinery/door/airlock/pyro/glass/security{
 	dir = 4;
-	name = "Interrogation Room"
+	name = "Interrogation Room";
+	req_access = null
 	},
 /obj/access_spawn/security,
 /obj/firedoor_spawn,
@@ -29746,7 +29751,8 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/security{
 	dir = 4;
-	name = "Interrogation Room"
+	name = "Interrogation Room";
+	req_access = null
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/security,
@@ -30205,7 +30211,8 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/security{
 	dir = 8;
-	name = "Solitary Brig"
+	name = "Solitary Brig";
+	req_access = null
 	},
 /obj/access_spawn/brig,
 /obj/firedoor_spawn,
@@ -31341,7 +31348,8 @@
 	},
 /obj/disposalpipe/segment/ejection,
 /obj/machinery/door/airlock/pyro/glass/security{
-	name = "Brig"
+	name = "Brig";
+	req_access = null
 	},
 /obj/access_spawn/brig,
 /obj/firedoor_spawn,
@@ -47619,8 +47627,9 @@
 /area/station/security/armory)
 "bMR" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/machinery/recharger/wall{
-	pixel_y = -21
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -19
 	},
 /turf/simulated/floor/redblack,
 /area/station/security/armory)
@@ -49956,7 +49965,8 @@
 "lOY" = (
 /obj/machinery/door/airlock/pyro/glass/security{
 	dir = 8;
-	name = "Armory"
+	name = "Armory";
+	req_access = null
 	},
 /obj/access_spawn/security,
 /obj/firedoor_spawn,
@@ -51513,6 +51523,10 @@
 	print_id = "Security"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -51547,7 +51561,8 @@
 "vxc" = (
 /obj/machinery/door/airlock/pyro/glass/security{
 	dir = 8;
-	name = "Security"
+	name = "Security";
+	req_access = null
 	},
 /obj/access_spawn/security,
 /obj/firedoor_spawn,

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -22593,19 +22593,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
-"aQV" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	dir = 0;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "aQW" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail,
@@ -22619,7 +22606,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/security/main)
 "aQX" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -22627,7 +22614,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/security/main)
 "aQY" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
@@ -30856,6 +30843,11 @@
 /obj/table/reinforced/auto,
 /obj/machinery/computer3/generic/personal,
 /obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/redblack{
 	dir = 10
 	},
@@ -30864,6 +30856,11 @@
 /obj/stool/bed/brig,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/redblack{
 	dir = 6
@@ -48640,6 +48637,10 @@
 	},
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
@@ -82093,7 +82094,7 @@ aMd
 aNs
 aOu
 aPH
-aQV
+aWB
 aSt
 aTT
 aVq

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -6182,6 +6182,9 @@
 	icon_state = "bedsheet-red"
 	},
 /obj/item/device/radio/intercom/security,
+/obj/decal/poster/wallsign/medal{
+	pixel_y = 25
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fred2"
@@ -22553,20 +22556,15 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "aQS" = (
-/obj/disposaloutlet{
-	dir = 1;
-	mailgroup = "security";
-	message = "Automated parole chute activated.";
-	name = "automated parole chute"
-	},
-/obj/window/reinforced/east,
-/obj/window/reinforced/west,
-/obj/window/reinforced/south,
 /obj/decal/poster/wallsign/poster_y4nt{
 	pixel_x = -32
 	},
-/obj/disposalpipe/trunk/ejection,
-/turf/simulated/floor/black,
+/obj/disposalpipe/segment/ejection,
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
 /area/station/security/main)
 "aQT" = (
 /obj/decal/fakeobjects/airmonitor_broken{
@@ -23345,35 +23343,60 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/central)
 "aSj" = (
-/obj/table/reinforced/auto,
-/obj/machinery/networked/printer{
-	print_id = "Security"
+/obj/storage/closet/wardrobe/red/security_gimmick,
+/obj/item/clothing/head/beret/random_color,
+/obj/item/clothing/head/beret/random_color,
+/turf/simulated/floor/redblack{
+	dir = 9
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor,
 /area/station/security/main)
 "aSk" = (
-/obj/table/reinforced/auto,
-/obj/machinery/networked/storage/scanner{
-	bank_id = "security"
+/turf/simulated/floor/redblack{
+	dir = 1
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor,
 /area/station/security/main)
 "aSl" = (
-/obj/machinery/computer/security,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/item/device/radio/intercom/security,
-/turf/simulated/floor,
+/obj/rack,
+/obj/item/gun/kinetic/riot40mm{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/gun/kinetic/riot40mm{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/gun/kinetic/riot40mm{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/ammo/bullets/smoke{
+	pixel_x = 6;
+	pixel_y = -9
+	},
+/obj/item/ammo/bullets/smoke{
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/obj/item/wrench{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/wrench{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/gun/implanter{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/turf/simulated/floor/redblack{
+	dir = 1
+	},
 /area/station/security/main)
 "aSm" = (
 /obj/machinery/firealarm{
@@ -23382,7 +23405,9 @@
 	text = "NF"
 	},
 /obj/submachine/weapon_vendor/security,
-/turf/simulated/floor,
+/turf/simulated/floor/redblack{
+	dir = 1
+	},
 /area/station/security/main)
 "aSn" = (
 /obj/machinery/disposal/small{
@@ -23391,14 +23416,9 @@
 	pixel_y = 32
 	},
 /obj/disposalpipe/trunk,
-/obj/storage/crate{
-	desc = "A crate of confiscated items.";
-	name = "Contraband"
+/turf/simulated/floor/redblack{
+	dir = 1
 	},
-/obj/item/instrument/vuvuzela,
-/obj/item/bananapeel,
-/obj/item/storage/pill_bottle/cyberpunk,
-/turf/simulated/floor,
 /area/station/security/main)
 "aSo" = (
 /obj/machinery/light{
@@ -23411,7 +23431,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/redblack{
+	dir = 5
+	},
 /area/station/security/main)
 "aSp" = (
 /obj/wingrille_spawn/auto,
@@ -23437,6 +23459,9 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/red/side{
 	dir = 9
@@ -23480,10 +23505,11 @@
 /area/station/security/main)
 "aSu" = (
 /obj/disposalpipe/segment/mail,
-/obj/stool/chair/couch{
-	dir = 8
-	},
 /obj/item/device/radio/intercom/brig,
+/obj/stool/chair/comfy/red,
+/obj/landmark/start{
+	name = "Security Assistant"
+	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "red2"
@@ -23493,9 +23519,6 @@
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 10
-	},
-/obj/stool/chair/couch{
-	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
@@ -23522,6 +23545,7 @@
 	pixel_x = -10;
 	pixel_y = -5
 	},
+/obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "blue2"
@@ -23995,10 +24019,15 @@
 /obj/machinery/cashreg{
 	name = "bail payment device"
 	},
-/obj/window/reinforced/east,
-/obj/window/reinforced/west,
+/obj/window/reinforced{
+	dir = 4
+	},
+/obj/window/reinforced{
+	dir = 8
+	},
 /obj/machinery/door/window/northleft{
-	req_access = list(1)
+	req_access = list(1);
+	req_access_txt = 1
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
@@ -24258,42 +24287,25 @@
 /turf/simulated/floor/purple,
 /area/station/hallway/secondary/central)
 "aTK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = -10
 	},
-/obj/storage/closet/office,
-/turf/simulated/floor,
-/area/station/security/main)
-"aTL" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/storage/secure/closet/security/equipment,
+/turf/simulated/floor/redblack{
+	dir = 8
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
 /area/station/security/main)
 "aTN" = (
 /obj/disposalpipe/segment,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/black,
 /area/station/security/main)
 "aTO" = (
 /obj/storage/secure/closet/security/equipment,
 /obj/disposalpipe/segment/ejection,
-/turf/simulated/floor,
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
 /area/station/security/main)
 "aTP" = (
 /obj/wingrille_spawn/auto,
@@ -24987,29 +24999,27 @@
 	name = "autoname  - SS13";
 	pixel_x = -10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/redblack{
+	dir = 10
+	},
 /area/station/security/main)
 "aVh" = (
-/obj/machinery/light/emergency,
-/obj/storage/secure/closet/security/equipment,
-/turf/simulated/floor,
+/obj/machinery/recharger/wall{
+	dir = 1;
+	pixel_y = -18
+	},
+/turf/simulated/floor/redblack,
 /area/station/security/main)
 "aVi" = (
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
-/turf/simulated/floor,
+/obj/machinery/vending/security,
+/turf/simulated/floor/redblack,
 /area/station/security/main)
 "aVj" = (
 /turf/simulated/floor,
 /area/station/security/main)
 "aVk" = (
 /obj/disposalpipe/segment,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/redblack,
 /area/station/security/main)
 "aVl" = (
 /obj/storage/secure/closet/security/equipment,
@@ -25017,7 +25027,9 @@
 	icon_state = "2-4"
 	},
 /obj/disposalpipe/segment/ejection,
-/turf/simulated/floor,
+/turf/simulated/floor/redblack{
+	dir = 6
+	},
 /area/station/security/main)
 "aVm" = (
 /obj/wingrille_spawn/auto,
@@ -25699,7 +25711,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/pyro/glass/security{
-	name = "Security"
+	name = "Locker Room"
 	},
 /obj/access_spawn/sec_lockers,
 /obj/firedoor_spawn,
@@ -25760,6 +25772,12 @@
 	},
 /obj/random_item_spawner/med_kit,
 /obj/item/storage/firstaid/regular,
+/obj/item/clothing/mask/muzzle{
+	pixel_y = -8
+	},
+/obj/item/clothing/mask/muzzle{
+	pixel_y = 11
+	},
 /turf/simulated/floor/carpet{
 	icon_state = "fred1"
 	},
@@ -25799,6 +25817,9 @@
 	name = "Head of Personnel"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aWL" = (
@@ -25807,6 +25828,12 @@
 	name = "table"
 	},
 /obj/item/storage/toolbox/emergency,
+/obj/machinery/computer3/generic/personal,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fblue2"
@@ -26191,44 +26218,11 @@
 	},
 /area/station/solar/west)
 "aXL" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/pyro/security{
-	dir = 4
-	},
-/obj/access_spawn/security,
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/security/main)
-"aXM" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red/side{
-	dir = 9
-	},
-/area/station/security/main)
-"aXN" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/main)
 "aXO" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -26339,6 +26333,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/submachine/poster_creator,
 /turf/simulated/floor/carpet{
 	icon_state = "red2"
 	},
@@ -26381,12 +26376,23 @@
 	broadcasting = 0;
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/bridge)
 "aXZ" = (
 /obj/disposalpipe/segment/food,
 /obj/table/reinforced/bar/auto{
 	name = "table"
+	},
+/obj/machinery/networked/printer{
+	print_id = "Bridge"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
@@ -26841,7 +26847,10 @@
 /obj/landmark/start{
 	name = "Security Officer"
 	},
-/obj/machinery/recharger/wall/sticky,
+/obj/machinery/recharger/wall/sticky{
+	dir = 4;
+	pixel_x = 17
+	},
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "red2"
@@ -26986,35 +26995,9 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
-"aYZ" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
-	},
-/obj/shrub{
-	dir = 6
-	},
-/turf/simulated/floor/redblack{
-	dir = 4
-	},
-/area/station/hallway/primary/west)
-"aZa" = (
-/obj/item/storage/toilet/random{
-	dir = 4;
-	pixel_x = -8
-	},
-/turf/simulated/floor/white/checker{
-	dir = 5
-	},
-/area/station/security/main)
 "aZb" = (
 /obj/machinery/light,
-/obj/submachine/poster_creator{
-	dir = 4
-	},
-/turf/simulated/floor/red/side{
-	dir = 10
-	},
+/turf/simulated/floor/red/side,
 /area/station/security/main)
 "aZc" = (
 /obj/disposalpipe/segment/ejection{
@@ -27029,16 +27012,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/table/reinforced/auto,
-/obj/item/paper/Port_A_Brig,
-/obj/item/remote/porter/port_a_brig,
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "aZe" = (
-/obj/machinery/port_a_brig,
 /obj/disposalpipe/segment/ejection{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -27195,6 +27174,10 @@
 "aZs" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
+	},
+/obj/machinery/power/apc{
+	name = "E APC";
+	pixel_x = 20
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -27665,21 +27648,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
-"bal" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/redblack{
-	dir = 4
-	},
-/area/station/hallway/primary/west)
 "bam" = (
 /obj/disposalpipe/segment/ejection,
 /obj/machinery/door/airlock/pyro/glass/security{
-	name = "Brig"
+	name = "Processing room"
 	},
 /obj/access_spawn/security,
 /obj/firedoor_spawn,
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/main)
 "ban" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -27692,7 +27669,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/main)
 "bao" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -27703,21 +27680,16 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/main)
 "bap" = (
-/obj/storage/closet/wardrobe/red/security_gimmick,
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = -11
+	},
+/obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
-/area/station/security/main)
-"baq" = (
-/obj/table/reinforced/auto,
-/obj/item/paper/book/space_law,
-/obj/item/clipboard,
-/obj/item/paper_bin,
-/obj/item/stamp,
-/obj/item/pen,
-/turf/simulated/floor,
 /area/station/security/main)
 "bar" = (
 /obj/machinery/firealarm{
@@ -27735,6 +27707,7 @@
 	name = "autoname  - SS13";
 	pixel_x = 10
 	},
+/obj/storage/closet/office,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -28181,18 +28154,22 @@
 /turf/space,
 /area/space)
 "bbc" = (
-/obj/submachine/chef_sink/chem_sink{
-	desc = "A water-filled unit intended for hand-washing purposes.";
-	dir = 4;
-	pixel_x = -4
-	},
 /obj/machinery/light{
 	dir = 1;
-	pixel_x = -1;
-	pixel_y = 21
+	pixel_y = 10
 	},
-/turf/simulated/floor/white/checker{
-	dir = 5
+/obj/shrub{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname  - SS13";
+	pixel_x = -10;
+	pixel_y = 15
+	},
+/turf/simulated/floor/red/side{
+	dir = 9
 	},
 /area/station/security/main)
 "bbd" = (
@@ -28417,54 +28394,33 @@
 	dir = 8;
 	pixel_x = -10
 	},
-/obj/table/reinforced/auto,
-/obj/machinery/computer3/generic/personal,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/redblack{
-	dir = 9
-	},
-/area/station/security/brig)
+/turf/simulated/floor/caution/corner/nw,
+/area/station/security/main)
 "bbv" = (
-/obj/stool/bed/brig,
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
 	name = "autoname  - SS13";
 	pixel_y = 21
 	},
-/turf/simulated/floor/redblack{
-	dir = 5
-	},
-/area/station/security/brig)
+/turf/simulated/floor/caution/north,
+/area/station/security/main)
 "bbw" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment/ejection,
-/turf/simulated/floor/caution/corner/nw{
-	dir = 1
-	},
-/area/station/security/brig)
+/turf/simulated/floor/caution/north,
+/area/station/security/main)
 "bbx" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/storage/closet/wardrobe/orange,
+/obj/machinery/flasher/portable,
 /turf/simulated/floor/caution/corner/ne,
-/area/station/security/brig)
+/area/station/security/main)
 "bby" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/main)
 "bbz" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/stma_kit,
@@ -28472,10 +28428,12 @@
 /obj/item/storage/box/handcuff_kit,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/multitool,
-/obj/item/crowbar,
 /obj/machinery/light{
 	dir = 8;
 	tag = ""
+	},
+/obj/item/clothing/gloves/yellow{
+	pixel_y = 12
 	},
 /turf/simulated/floor/red/side{
 	dir = 10
@@ -28493,29 +28451,22 @@
 /obj/item/kitchen/food_box/donut_box{
 	pixel_y = 11
 	},
+/obj/disposalpipe/segment/brig,
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "bbB" = (
 /obj/machinery/vending/security,
 /turf/simulated/floor/red/side,
 /area/station/security/main)
-"bbD" = (
-/obj/machinery/light,
-/obj/table/reinforced/auto,
-/obj/machinery/coffeemaker/security,
-/turf/simulated/floor/red/side,
-/area/station/security/main)
-"bbE" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/red/corner{
-	dir = 8
-	},
-/area/station/security/main)
 "bbF" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 10
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -29090,15 +29041,19 @@
 	},
 /area/station/hallway/primary/west)
 "bcK" = (
-/obj/decal/cleanable/dirt,
-/obj/item/storage/toilet/random{
-	dir = 4;
-	pixel_x = -8
+/obj/storage/crate{
+	desc = "A crate of confiscated items.";
+	name = "Contraband"
 	},
-/turf/simulated/floor/redblack{
-	dir = 10
+/obj/item/storage/pill_bottle/cyberpunk,
+/obj/item/instrument/vuvuzela,
+/obj/item/bananapeel,
+/obj/item/item_box/no{
+	pixel_x = 8;
+	pixel_y = -5
 	},
-/area/station/security/brig)
+/turf/simulated/floor/caution/corner/sw,
+/area/station/security/main)
 "bcL" = (
 /obj/submachine/chef_sink/chem_sink{
 	desc = "A water-filled unit intended for hand-washing purposes.";
@@ -29114,24 +29069,15 @@
 /turf/simulated/floor/sanitary/blue,
 /area/station/crew_quarters/captain)
 "bcM" = (
-/obj/machinery/floorflusher/solitary2,
-/obj/machinery/door/window/eastleft{
-	name = "interior door-'Solitary Cell Two'";
-	req_access_txt = "1"
-	},
-/obj/disposalpipe/trunk/ejection{
-	dir = 4
-	},
-/turf/simulated/floor/red,
-/area/station/security/brig)
+/obj/storage/secure/closet/brig,
+/turf/simulated/floor/caution/south,
+/area/station/security/main)
 "bcN" = (
-/obj/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2";
-	name = "ejection pipe"
+/obj/disposalpipe/segment/ejection,
+/turf/simulated/floor/caution/corner/misc{
+	dir = 10
 	},
-/turf/simulated/floor/caution/west,
-/area/station/security/brig)
+/area/station/security/main)
 "bcO" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -29141,41 +29087,28 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door_timer/genpop/new_walls/north{
-	pixel_x = 24;
-	pixel_y = 8
+/obj/landmark/start{
+	name = "Security Assistant"
 	},
 /turf/simulated/floor/caution/east{
 	dir = 8
 	},
-/area/station/security/brig)
-"bcS" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/window_blinds/cog2/right,
-/turf/simulated/floor/plating,
-/area/station/security/main)
-"bcT" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/red/side{
-	dir = 8
-	},
 /area/station/security/main)
 "bcU" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/table/reinforced/auto,
+/obj/item/device/ticket_writer{
+	pixel_x = 1;
+	pixel_y = 18
+	},
+/obj/machinery/coffeemaker/security,
+/obj/mug_rack{
+	pixel_x = 24;
+	pixel_y = 5
 	},
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -29205,7 +29138,6 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/window/reinforced/south,
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -29215,7 +29147,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/window/reinforced/south,
 /obj/machinery/light,
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -29248,7 +29179,6 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bcZ" = (
-/obj/window/reinforced/south,
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -29278,24 +29208,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/command{
-	dir = 4;
-	name = "Bridge"
-	},
-/obj/access_spawn/heads,
-/obj/firedoor_spawn,
-/obj/machinery/door/poddoor/blast{
-	density = 0;
-	dir = 1;
-	icon_state = "bdoormid0";
-	id = "lockdown";
-	layer = 4;
-	name = "Bridge Lockdown Door";
-	opacity = 0
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
+/turf/simulated/floor/black,
 /area/station/bridge)
 "bdd" = (
 /obj/disposalpipe/segment{
@@ -29766,13 +29679,9 @@
 	pixel_x = -24;
 	pixel_y = -8
 	},
-/obj/machinery/door_timer/solitary2{
-	pixel_x = -24;
-	pixel_y = 8
-	},
 /obj/disposalpipe/segment/ejection,
 /turf/simulated/floor/caution/west,
-/area/station/security/brig)
+/area/station/security/main)
 "bdY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -29780,7 +29689,7 @@
 /turf/simulated/floor/caution/east{
 	dir = 8
 	},
-/area/station/security/brig)
+/area/station/security/main)
 "bdZ" = (
 /obj/machinery/door/airlock/pyro/glass/security{
 	dir = 4;
@@ -29789,7 +29698,7 @@
 /obj/access_spawn/security,
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/security/brig)
+/area/station/security/main)
 "bea" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -29797,33 +29706,36 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "beb" = (
-/obj/stool,
+/obj/table/reinforced/auto,
 /obj/disposalpipe/segment/brig,
+/obj/window/reinforced{
+	dir = 4
+	},
+/obj/window/reinforced{
+	dir = 2
+	},
+/obj/item/paper_bin,
+/obj/item/device/detective_scanner{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/item/storage/box/evidence{
+	pixel_x = 5;
+	pixel_y = 7
+	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "bec" = (
-/obj/table/reinforced/auto,
-/obj/item/device/audio_log,
-/obj/item/audio_tape{
-	pixel_y = 5
-	},
-/obj/item/device/radio/intercom/security{
-	layer = 6.02
-	},
-/turf/simulated/floor/carpet,
-/area/station/security/main)
-"bed" = (
-/obj/storage/closet/office,
 /obj/cable{
 	icon_state = "1-4"
 	},
 /obj/blind_switch/area/north{
 	pixel_y = 28
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/black,
 /area/station/security/main)
-"bee" = (
-/obj/wingrille_spawn/auto,
+"bed" = (
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -29832,65 +29744,66 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/window_blinds/cog2/left{
+/obj/machinery/door/airlock/pyro/glass/security{
+	dir = 4;
+	name = "Interrogation Room"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
+/turf/simulated/floor/black,
+/area/station/security/main)
+"bee" = (
+/turf/simulated/floor/red/side{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
 /area/station/security/main)
 "bef" = (
 /obj/disposalpipe/segment,
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "2-4"
+/obj/machinery/door/airlock/pyro/command{
+	name = "Armory";
+	req_access = null
 	},
+/obj/firedoor_spawn,
+/obj/machinery/door/poddoor/blast{
+	density = 0;
+	dir = 4;
+	icon_state = "bdoormid0";
+	id = "lockdown";
+	layer = 4;
+	name = "Bridge Lockdown Door";
+	opacity = 0
+	},
+/obj/access_spawn/heads,
 /turf/simulated/floor/black,
-/area/station/bridge)
+/area/station/security/main)
 "beg" = (
 /obj/disposalpipe/segment/food,
-/obj/window/reinforced/east,
-/obj/table/wood/round/auto,
-/obj/machinery/power/data_terminal,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/main)
+"beh" = (
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/networked/printer{
-	print_id = "Bridge"
+	d2 = 4;
+	dir = 0;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge)
-"beh" = (
-/obj/window/reinforced/north,
-/obj/window/reinforced/west,
-/turf/space,
-/area/station/com_dish/comdish)
+/area/station/security/main)
 "bei" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/window/reinforced/north,
-/turf/space,
-/area/station/com_dish/comdish)
-"bej" = (
-/obj/window/reinforced/north,
-/obj/window/reinforced/east,
-/turf/space,
-/area/station/com_dish/comdish)
+/turf/simulated/floor/black,
+/area/station/security/main)
 "bek" = (
-/obj/window/reinforced/west,
 /obj/machinery/computer3/terminal/network{
 	dir = 4;
 	name = "CENTCOM Terminal";
@@ -29902,21 +29815,6 @@
 	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
-	},
-/turf/simulated/floor/black,
-/area/station/bridge)
-"bel" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -30278,6 +30176,11 @@
 	dir = 4;
 	pixel_x = -8
 	},
+/obj/machinery/drainage,
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = 6
+	},
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
@@ -30297,13 +30200,17 @@
 	},
 /area/station/medical/cdc)
 "bfa" = (
-/obj/machinery/floorflusher/solitary,
-/obj/machinery/door/window/eastright{
-	name = "interior door-'Solitary Cell One'";
-	req_access_txt = "1"
-	},
-/obj/disposalpipe/trunk/ejection{
+/obj/disposalpipe/segment/ejection{
 	dir = 4
+	},
+/obj/machinery/door/airlock/pyro/glass/security{
+	dir = 8;
+	name = "Solitary Brig"
+	},
+/obj/access_spawn/brig,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/red,
 /area/station/security/brig)
@@ -30320,17 +30227,20 @@
 	name = "ejection pipe"
 	},
 /turf/simulated/floor/caution/west,
-/area/station/security/brig)
+/area/station/security/main)
 "bfc" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/landmark/start{
+	name = "Security Assistant"
+	},
 /turf/simulated/floor/caution/east{
 	dir = 8
 	},
-/area/station/security/brig)
+/area/station/security/main)
 "bfd" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -30346,7 +30256,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/main)
 "bfe" = (
 /obj/machinery/light{
 	dir = 8;
@@ -30358,30 +30268,40 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/table/reinforced/auto,
+/obj/item/paper/Port_A_Brig,
+/obj/item/device/audio_log,
+/obj/item/audio_tape{
+	pixel_y = 5
+	},
+/obj/item/remote/porter/port_a_brig{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/window/reinforced{
+	dir = 2
+	},
+/obj/item/device/detective_scanner{
+	pixel_x = 10;
+	pixel_y = 10
+	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "bff" = (
-/obj/table/reinforced/auto,
-/obj/item/clipboard,
-/obj/item/paper_bin,
-/obj/item/stamp,
-/obj/item/pen,
-/turf/simulated/floor/carpet,
+/obj/machinery/door/airlock/pyro/glass/security{
+	name = "Interrogation Room"
+	},
+/obj/access_spawn/security,
+/turf/simulated/floor/black,
 /area/station/security/main)
 "bfi" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/red/side{
-	dir = 8
-	},
+/turf/simulated/floor,
 /area/station/security/main)
 "bfj" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 10
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -30402,52 +30322,52 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-4"
+	d2 = 4;
+	dir = 0;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge)
+/area/station/security/main)
 "bfl" = (
 /obj/disposalpipe/segment/food,
-/obj/window/reinforced/east,
-/obj/table/wood/round/auto,
-/obj/machinery/computer3/generic/personal,
-/obj/machinery/power/data_terminal,
+/obj/machinery/computer/riotgear{
+	pixel_y = 28
+	},
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/bridge)
+/area/station/security/main)
 "bfm" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/window/reinforced/west,
-/turf/space,
-/area/station/com_dish/comdish)
+/turf/simulated/floor/black,
+/area/station/security/main)
 "bfn" = (
-/obj/machinery/communications_dish,
-/obj/machinery/power/data_terminal,
-/obj/cable,
-/turf/simulated/floor/plating/airless,
-/area/station/com_dish/comdish)
-"bfo" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/window/reinforced/east,
+/turf/simulated/floor/black,
+/area/station/security/main)
+"bfo" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/space,
-/area/station/com_dish/comdish)
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	dir = 0;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/black,
+/area/station/security/main)
 "bfp" = (
-/obj/window/reinforced/west,
 /obj/machinery/computer3/generic/communications{
 	dir = 4
 	},
@@ -30456,6 +30376,10 @@
 	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
@@ -30471,28 +30395,13 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bfr" = (
+/obj/access_spawn/ai_upload,
 /obj/machinery/turretid{
-	pixel_x = -8;
-	req_access_txt = "19"
+	pixel_x = 24;
+	req_access_txt = null
 	},
-/turf/simulated/wall/auto/reinforced/supernorn{
-	explosion_resistance = 15;
-	name = "very reinforced wall"
-	},
-/area/station/turret_protected/ai)
-"bfs" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/table/reinforced/auto,
-/obj/item/aiModule/oneHuman,
-/obj/item/aiModule/notHuman,
-/obj/item/aiModule/freeform,
-/turf/simulated/floor/blueblack{
-	dir = 9
-	},
-/area/station/turret_protected/ai)
+/turf/simulated/floor/black,
+/area/station/bridge)
 "bft" = (
 /obj/machinery/light_switch/north{
 	pixel_y = 28
@@ -30521,13 +30430,8 @@
 	dir = 1
 	},
 /area/station/turret_protected/ai)
-"bfw" = (
-/obj/machinery/computer/aiupload,
-/turf/simulated/floor/blueblack{
-	dir = 1
-	},
-/area/station/turret_protected/ai)
 "bfx" = (
+/obj/machinery/computer/aiupload,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/blueblack{
 	dir = 1
@@ -30931,6 +30835,8 @@
 	name = "autoname  - SS13";
 	pixel_x = 10
 	},
+/obj/table/auto,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -30971,19 +30877,21 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/caution/corner/sw,
-/area/station/security/brig)
+/area/station/security/main)
 "bgn" = (
 /obj/machinery/disposal/brig,
 /obj/disposalpipe/trunk/brig,
 /obj/item/device/radio/intercom/brig{
-	broadcasting = 1;
-	layer = 5
+	dir = 8
+	},
+/obj/machinery/door_timer/genpop/new_walls/north{
+	pixel_y = -16
 	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "corner_east"
 	},
-/area/station/security/brig)
+/area/station/security/main)
 "bgo" = (
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -30991,38 +30899,37 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/main)
 "bgp" = (
 /turf/simulated/floor/black,
 /area/station/security/main)
 "bgq" = (
+/obj/stool/chair/red{
+	anchored = 0;
+	dir = 1
+	},
 /obj/disposalpipe/segment/brig,
+/obj/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/black,
 /area/station/security/main)
-"bgr" = (
-/obj/machinery/door/window/westright{
-	dir = 4;
-	tag = "icon-right (EAST)"
-	},
-/turf/simulated/floor/carpet,
-/area/station/security/main)
 "bgs" = (
-/turf/simulated/floor/carpet,
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/black,
 /area/station/security/main)
 "bgt" = (
-/obj/machinery/door/airlock/pyro/glass/security{
-	dir = 4;
-	name = "Security"
-	},
-/obj/access_spawn/security,
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/security/main)
-"bgu" = (
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
+/area/station/security/main)
+"bgu" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/red/side,
 /area/station/security/main)
 "bgv" = (
 /obj/cable{
@@ -31030,23 +30937,30 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/cable{
+	d2 = 4;
+	dir = 0;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/red/side{
 	dir = 6
 	},
 /area/station/security/main)
 "bgw" = (
 /obj/disposalpipe/segment,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24
-	},
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
+	},
 /turf/simulated/floor/black,
-/area/station/bridge)
+/area/station/security/main)
 "bgx" = (
 /obj/disposalpipe/segment/food{
 	dir = 1;
@@ -31065,18 +30979,15 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/armory)
 "bgA" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	dir = 0;
-	icon_state = "2-4"
-	},
 /obj/item/device/radio/intercom/AI{
 	dir = 4
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "bgB" = (
@@ -31416,6 +31327,7 @@
 	pixel_x = 10
 	},
 /obj/disposalpipe/segment/mail,
+/obj/machinery/vending/snack,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -31454,10 +31366,12 @@
 	dir = 0;
 	icon_state = "0-4"
 	},
-/obj/disposalpipe/trunk/mail,
-/obj/submachine/slot_machine,
-/obj/window/reinforced/north,
-/turf/simulated/floor,
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right{
+	layer = 2.9;
+	pixel_y = 13
+	},
+/turf/simulated/floor/plating,
 /area/station/security/brig)
 "bhp" = (
 /obj/cable{
@@ -31469,10 +31383,13 @@
 	dir = 0;
 	icon_state = "0-4"
 	},
-/obj/machinery/computer/arcade,
-/obj/window/reinforced/north,
 /obj/disposalpipe/segment/brig,
-/turf/simulated/floor/neutral/corner,
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right{
+	layer = 2.9;
+	pixel_y = 13
+	},
+/turf/simulated/floor/plating,
 /area/station/security/brig)
 "bhq" = (
 /obj/cable{
@@ -31480,34 +31397,14 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	d2 = 4;
-	dir = 0;
-	icon_state = "0-4"
-	},
-/obj/disposalpipe/trunk/brig,
-/obj/disposaloutlet{
-	name = "brig delivery chute"
-	},
-/obj/window/reinforced/north,
-/turf/simulated/floor,
-/area/station/security/brig)
-"bhr" = (
-/obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right{
+	layer = 2.9;
+	pixel_y = 13
 	},
-/obj/machinery/disposal/mail{
-	mail_tag = "brig";
-	mailgroup = "security";
-	message = "1";
-	name = "mail chute-'Brig'"
-	},
-/obj/window/reinforced/north,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/plating,
 /area/station/security/brig)
 "bhs" = (
 /obj/window_blinds/cog2,
@@ -31561,72 +31458,46 @@
 	name = "Bridge Lockdown Door";
 	opacity = 0
 	},
-/turf/simulated/floor/red,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/hos)
 "bhv" = (
 /obj/disposalpipe/segment/food,
-/obj/decal/tile_edge/line/red{
-	dir = 9;
-	icon_state = "line2"
-	},
 /obj/storage/secure/closet/security/armory,
-/turf/simulated/floor/black,
+/turf/simulated/floor/redblack{
+	dir = 9
+	},
 /area/station/security/armory)
 "bhw" = (
-/obj/machinery/computer3/generic/communications,
-/obj/decal/tile_edge/line/red{
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/machinery/power/data_terminal,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/black,
-/area/station/security/armory)
-"bhx" = (
-/obj/decal/tile_edge/line/red{
-	dir = 5;
-	icon_state = "line2"
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/vending/security_ammo,
-/turf/simulated/floor/black,
-/area/station/security/armory)
-"bhy" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/command{
-	name = "Bridge";
-	req_access = null
+/turf/simulated/floor/redblack{
+	dir = 1
 	},
-/obj/access_spawn/heads,
-/obj/firedoor_spawn,
-/obj/machinery/door/poddoor/blast{
-	density = 0;
-	dir = 4;
-	icon_state = "bdoormid0";
-	id = "lockdown";
-	layer = 4;
-	name = "Bridge Lockdown Door";
-	opacity = 0
+/area/station/security/armory)
+"bhx" = (
+/obj/machinery/vending/security_ammo,
+/turf/simulated/floor/redblack{
+	dir = 5
 	},
-/turf/simulated/floor/plating,
-/area/station/bridge)
-"bhz" = (
-/obj/item/device/radio/intercom/AI{
-	dir = 4
-	},
-/turf/simulated/floor/blueblack{
-	dir = 8
-	},
-/area/station/turret_protected/ai)
+/area/station/security/armory)
 "bhA" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -10
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -32136,19 +32007,19 @@
 	mail_tag = "engineering";
 	name = "engineering mail router"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "bit" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
 /obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -32157,21 +32028,22 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
 /area/station/security/brig)
 "biv" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/item/storage/toilet/random{
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -10
-	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/floor/white/grime,
+/obj/stool/bed/brig,
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/turf/simulated/floor/grime,
 /area/station/security/brig)
 "biw" = (
 /obj/machinery/firealarm{
@@ -32180,13 +32052,6 @@
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
-	},
-/obj/window/cubicle{
-	dir = 8
-	},
-/obj/stool/bed/brig,
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -32199,10 +32064,6 @@
 /obj/disposalpipe/segment/mail{
 	dir = 2;
 	icon_state = "pipe-c"
-	},
-/obj/stool/bed/brig,
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
 	},
 /obj/machinery/power/apc{
 	areastring = "Brig";
@@ -32243,38 +32104,55 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "biB" = (
-/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/trunk/mail,
+/obj/machinery/disposal/mail{
+	mail_tag = "brig";
+	mailgroup = "security";
+	message = "1";
+	name = "mail chute-'Brig'"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "biC" = (
-/obj/disposalpipe/segment/brig,
-/turf/simulated/floor,
-/area/station/security/brig)
-"biD" = (
-/obj/stool/bench/red/auto,
 /obj/disposalpipe/segment/brig{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/neutral/corner{
-	dir = 4
-	},
+/turf/simulated/floor,
 /area/station/security/brig)
-"biE" = (
+"biD" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/table/reinforced/auto,
-/obj/disposalpipe/segment/brig{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/storage/secure/closet/brig/automatic/genpop,
+/turf/simulated/floor/neutral/corner{
+	dir = 4
 	},
+/area/station/security/brig)
+"biE" = (
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 10
 	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	dir = 0;
+	icon_state = "0-4"
+	},
+/obj/disposaloutlet{
+	name = "brig delivery chute"
+	},
+/obj/disposalpipe/trunk/brig,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "biF" = (
@@ -32293,7 +32171,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hos)
 "biG" = (
-/obj/storage/closet/office,
 /obj/disposalpipe/segment/mail,
 /obj/machinery/firealarm{
 	dir = 8;
@@ -32340,7 +32217,6 @@
 	},
 /area/station/crew_quarters/hos)
 "biK" = (
-/obj/wingrille_spawn/auto,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -32352,11 +32228,12 @@
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/hos)
+/area/station/security/armory)
 "biL" = (
 /obj/machinery/weapon_stand/taser_rack/recharger/empty,
-/turf/simulated/floor,
+/turf/simulated/floor/redblack,
 /area/station/security/main)
 "biM" = (
 /obj/cable{
@@ -32366,41 +32243,11 @@
 /area/station/security/armory)
 "biN" = (
 /obj/disposalpipe/segment/food,
-/obj/decal/tile_edge/line/red{
-	dir = 8;
-	icon_state = "line1"
-	},
 /obj/machinery/weapon_stand/shotgun_rack,
-/turf/simulated/floor/black,
-/area/station/security/armory)
-"biO" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Armory APC";
-	noalerts = 1;
-	pixel_x = -24
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13";
-	pixel_x = 10
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"biP" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/blueblack{
+/turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/turret_protected/ai)
+/area/station/security/armory)
 "biR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -32896,8 +32743,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -32906,19 +32751,22 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/submachine/chef_sink/chem_sink{
-	desc = "A water-filled unit intended for hand-washing purposes.";
-	dir = 4;
-	pixel_x = -4
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/decal/cleanable/generic,
-/turf/simulated/floor/white/grime,
+/obj/stool/bed/brig,
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/turf/simulated/floor/grime,
 /area/station/security/brig)
 "bjL" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/window/westleft,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bjM" = (
@@ -32929,6 +32777,9 @@
 /obj/decal/cleanable/dirt,
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -32941,6 +32792,10 @@
 	},
 /obj/landmark/spawner{
 	name = "monkeyspawn_stirstir"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -32978,10 +32833,9 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bjS" = (
-/obj/table/reinforced/auto,
 /obj/decal/cleanable/dirt,
-/obj/item/card_box/plain,
 /obj/disposalpipe/segment/brig,
+/obj/disposalpipe/junction/right/north,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bjT" = (
@@ -32997,9 +32851,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hos)
 "bjU" = (
-/obj/table/wood/auto,
-/obj/machinery/computer3/generic/personal,
-/obj/item/paper/book/space_law,
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	d2 = 4;
@@ -33011,6 +32862,9 @@
 	broadcasting = 0;
 	dir = 4;
 	layer = 6.02
+	},
+/obj/machinery/computer3/generic/communications{
+	dir = 4
 	},
 /turf/simulated/floor/escape{
 	dir = 8
@@ -33068,13 +32922,13 @@
 	},
 /area/station/crew_quarters/hos)
 "bjY" = (
-/obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/window_blinds/cog2{
 	dir = 8
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/hos)
+/area/station/security/armory)
 "bjZ" = (
 /obj/machinery/disposal/mail/small{
 	dir = 8;
@@ -33095,21 +32949,6 @@
 /obj/item/device/microphone,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/fitness)
-"bkb" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
-"bkc" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/blueblack{
-	dir = 8
-	},
-/area/station/turret_protected/ai)
 "bkd" = (
 /obj/cable,
 /obj/cable{
@@ -33649,35 +33488,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
-"bkW" = (
-/obj/stool/chair{
-	dir = 8
+"bkZ" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/redblack{
+/obj/item/device/radio/intercom/brig{
 	dir = 4
 	},
-/area/station/hallway/primary/west)
-"bkX" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = 6
-	},
-/obj/machinery/door/window/northleft,
-/obj/machinery/drainage,
-/turf/simulated/floor/white/grime,
-/area/station/security/brig)
-"bkY" = (
-/obj/window/cubicle{
-	dir = 8
-	},
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
-/area/station/security/brig)
-"bkZ" = (
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bla" = (
@@ -33688,13 +33505,10 @@
 	},
 /area/station/security/brig)
 "blb" = (
-/turf/simulated/floor/neutral/side{
-	dir = 8
-	},
+/turf/simulated/floor,
 /area/station/security/brig)
 "blc" = (
 /obj/decal/cleanable/dirt,
-/obj/disposalpipe/segment/brig,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bld" = (
@@ -33790,25 +33604,53 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/door/airlock/pyro/glass/command{
-	dir = 4;
-	name = "Armory";
-	req_access = null
+/obj/wingrille_spawn/auto/crystal,
+/obj/window_blinds/cog2/right{
+	dir = 8
 	},
-/obj/access_spawn/hos,
-/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/armory)
 "blk" = (
-/obj/disposalpipe/segment/food,
-/obj/decal/tile_edge/line/red{
-	dir = 8;
-	icon_state = "line1"
+/obj/rack,
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -13;
+	pixel_y = -1
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/clothing/suit/armor/heavy{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/clothing/suit/armor/EOD{
+	pixel_x = 9;
+	pixel_y = -1
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -15;
+	pixel_y = 12
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -7;
+	pixel_y = 12
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/item/clothing/head/helmet/EOD{
+	pixel_x = 12;
+	pixel_y = 8
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
+/obj/disposalpipe/segment/food,
+/turf/simulated/floor/redblack{
+	dir = 8
+	},
 /area/station/security/armory)
 "bll" = (
 /obj/cable{
@@ -33823,22 +33665,10 @@
 /obj/loudspeaker,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/fitness)
-"bln" = (
-/obj/cable{
-	d2 = 4;
-	dir = 0;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/blueblack{
-	dir = 8
-	},
-/area/station/turret_protected/ai)
 "blo" = (
+/obj/machinery/power/data_terminal,
 /obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	dir = null
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -34357,17 +34187,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/cloner)
-"bmi" = (
-/obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/west)
 "bmj" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/shrub{
 	dir = 10
 	},
@@ -34381,58 +34201,44 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
-"bmk" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/brig)
 "bml" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/shower{
 	dir = 8;
 	pixel_y = 6
 	},
-/obj/decal/cleanable/dirt,
-/obj/machinery/drainage,
+/obj/item/storage/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -10
+	},
 /turf/simulated/floor/white/grime,
 /area/station/security/brig)
 "bmm" = (
-/obj/machinery/light/emergency,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/window/cubicle{
-	dir = 8
-	},
 /obj/decal/cleanable/dirt,
-/obj/stool/bed/brig,
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = 6
 	},
-/turf/simulated/floor/grime,
+/obj/machinery/drainage,
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1;
+	pixel_y = -3
+	},
+/turf/simulated/floor/white/grime,
 /area/station/security/brig)
 "bmn" = (
 /obj/machinery/light,
 /obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/stool/bed/brig,
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
+/obj/machinery/door/airlock/pyro{
+	dir = 4
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bmo" = (
 /obj/cable{
-	icon_state = "4-8"
-	},
-/obj/stool/bed/brig,
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -34456,7 +34262,9 @@
 	},
 /obj/table/reinforced/auto,
 /obj/decal/cleanable/dirt,
-/obj/item/card_box/plain,
+/obj/item/card_box/plain{
+	pixel_x = -15
+	},
 /obj/machinery/power/data_terminal,
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -34476,15 +34284,13 @@
 /area/station/security/brig)
 "bms" = (
 /obj/machinery/light/emergency,
-/obj/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2";
-	name = "brig pipe"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/fitness/speedbag,
+/obj/disposalpipe/segment/brig{
+	dir = 4
+	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bmt" = (
@@ -34492,14 +34298,17 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/stool/bench/red/auto,
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
+/obj/storage/closet/office,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bmu" = (
-/obj/table/reinforced/auto,
+/obj/disposalpipe/segment/brig{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	d2 = 4;
@@ -34510,14 +34319,9 @@
 	dir = 0;
 	icon_state = "0-4"
 	},
-/obj/item/decoration/ashtray{
-	butts = 5;
-	name = "grubby old ashtray"
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/table/reinforced/auto,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bmv" = (
@@ -34572,11 +34376,13 @@
 	dir = 4
 	},
 /obj/table/wood/auto,
-/obj/item/device/camera_viewer,
-/obj/item/device/prisoner_scanner,
-/obj/item/device/detective_scanner,
-/obj/item/device/radio/headset/security,
-/obj/item/device/radio/headset/security,
+/obj/item/device/prisoner_scanner{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/device/detective_scanner{
+	pixel_x = 12
+	},
 /obj/disposalpipe/segment/food,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -34584,6 +34390,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/machinery/recharger,
 /turf/simulated/floor/escape,
 /area/station/crew_quarters/hos)
 "bmz" = (
@@ -34609,17 +34416,21 @@
 /turf/simulated/wall/auto/supernorn,
 /area/space)
 "bmB" = (
-/obj/decal/tile_edge/line/red{
-	icon_state = "line1"
-	},
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/simulated/floor/black,
+/obj/machinery/recharger/wall{
+	pixel_y = -21
+	},
+/obj/deployable_turret/riot{
+	active = 1;
+	anchored = 1;
+	dir = 1
+	},
+/turf/simulated/floor/redblack,
 /area/station/security/armory)
 "bmC" = (
 /obj/machinery/optable,
@@ -34629,12 +34440,6 @@
 /obj/item/paper/book/medical_surgery_guide,
 /turf/simulated/floor/bot/white,
 /area/station/medical/medbay/surgery)
-"bmD" = (
-/obj/machinery/turret,
-/turf/simulated/floor/blueblack{
-	dir = 8
-	},
-/area/station/turret_protected/ai)
 "bmE" = (
 /obj/machinery/light,
 /turf/simulated/floor/circuit,
@@ -35095,17 +34900,6 @@
 /obj/disposalpipe/segment/food,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/armory)
-"bnF" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/pyro/command{
-	req_access = null
-	},
-/obj/access_spawn/heads,
-/obj/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/maintenance/central)
 "bnG" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/Zeta)
@@ -35560,6 +35354,12 @@
 	dir = 0;
 	icon_state = "0-4"
 	},
+/obj/item/reagent_containers/food/snacks/donut/custom/frosted{
+	desc = "the best officer's donut, goes great with coffee";
+	name = "beepsky's donut";
+	pixel_x = -7;
+	pixel_y = -4
+	},
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
@@ -35728,9 +35528,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "boT" = (
@@ -36527,9 +36325,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
@@ -40938,12 +40733,11 @@
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
 "byf" = (
-/obj/machinery/light/emergency,
-/obj/machinery/drainage,
-/turf/simulated/floor/redblack{
-	dir = 6
-	},
-/area/station/security/brig)
+/obj/machinery/light,
+/obj/storage/closet/wardrobe/orange,
+/obj/item/clothing/head/beret/prisoner,
+/turf/simulated/floor/caution/south,
+/area/station/security/main)
 "byg" = (
 /obj/window/auto/reinforced,
 /obj/grille/steel{
@@ -47642,7 +47436,10 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/machinery/drainage,
+/obj/machinery/floorflusher/solitary,
+/obj/disposalpipe/trunk/ejection{
+	dir = 4
+	},
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
@@ -47789,88 +47586,67 @@
 /area/ghostdrone_factory)
 "bMM" = (
 /obj/disposalpipe/segment/food,
-/obj/decal/tile_edge/line/red{
-	dir = 8;
-	icon_state = "line1"
+/obj/machinery/weapon_stand/rifle_rack/recharger,
+/turf/simulated/floor/redblack{
+	dir = 8
 	},
-/obj/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/tank/air,
-/obj/item/tank/air,
-/obj/item/chem_grenade/pepper,
-/obj/item/chem_grenade/pepper,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/thermal,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/nightvision,
-/turf/simulated/floor/black,
-/area/station/security/armory)
-"bMO" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/decal/tile_edge/line/red{
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/storage/secure/crate/weapon/armory/tranquilizer,
-/turf/simulated/floor/black,
 /area/station/security/armory)
 "bMP" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 10
-	},
-/obj/decal/tile_edge/line/red{
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/storage/secure/crate/gear/armory/grenades,
 /turf/simulated/floor/black,
 /area/station/security/armory)
 "bMQ" = (
-/obj/disposalpipe/segment/food,
-/obj/decal/tile_edge/line/red{
-	dir = 10;
-	icon_state = "line2"
+/obj/rack,
+/obj/item/breaching_charge{
+	pixel_x = 10;
+	pixel_y = 1
 	},
-/obj/table/reinforced/auto,
-/obj/machinery/recharger,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/electropack,
-/obj/item/device/radio/signaler,
-/obj/item/device/radio/signaler,
-/obj/item/storage/box/revimp_kit,
-/obj/item/storage/box/flashbang_kit,
-/obj/item/storage/box/stinger_kit,
-/turf/simulated/floor/black,
+/obj/item/breaching_charge{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/breaching_charge{
+	pixel_x = -2;
+	pixel_y = -5
+	},
+/obj/item/breaching_hammer{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/disposalpipe/segment/food,
+/turf/simulated/floor/redblack{
+	dir = 10
+	},
 /area/station/security/armory)
 "bMR" = (
-/obj/decal/tile_edge/line/red{
-	dir = 6;
-	icon_state = "line2"
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/machinery/recharger/wall{
+	pixel_y = -21
 	},
-/obj/storage/secure/crate/weapon/armory/pod_weapons,
-/obj/machinery/light_switch/south{
-	dir = 4;
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/redblack,
 /area/station/security/armory)
 "bMS" = (
 /obj/machinery/drainage/big,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "bMT" = (
-/obj/decal/poster/wallsign/medal{
+/obj/machinery/door/airlock/pyro/glass/command{
+	aiControlDisabled = 1;
+	name = "Armory";
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/hos,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/secscanner{
 	pixel_y = -10
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/floor/black,
 /area/station/security/armory)
 "bMU" = (
 /obj/grille/catwalk{
@@ -48635,6 +48411,17 @@
 	icon_state = "fgreen1"
 	},
 /area/station/garden/aviary)
+"bWX" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/central)
 "bXY" = (
 /obj/machinery/plantpot,
 /obj/decal/tile_edge/line/green{
@@ -48680,6 +48467,19 @@
 	icon_state = "corner_east"
 	},
 /area/station/science/lab)
+"cie" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/disposaloutlet{
+	dir = 1;
+	mailgroup = "security";
+	message = "Automated parole chute activated.";
+	name = "automated parole chute"
+	},
+/obj/disposalpipe/trunk/ejection,
+/turf/simulated/floor/redblack,
+/area/station/hallway/secondary/central)
 "cmJ" = (
 /obj/machinery/computer/tanning{
 	pixel_y = 32
@@ -48778,6 +48578,13 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"dmU" = (
+/obj/stool/bench/red/auto,
+/obj/disposalpipe/segment/brig{
+	dir = 4
+	},
+/turf/simulated/floor/grime,
+/area/station/security/brig)
 "dnX" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -48799,23 +48606,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
-"dwl" = (
-/obj/stool/chair/office/red{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/landmark/start{
-	name = "Security Assistant"
-	},
-/turf/simulated/floor,
-/area/station/security/main)
 "dxC" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -48828,13 +48618,8 @@
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "dyB" = (
-/obj/stool/chair/red{
-	anchored = 0;
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Security Assistant"
-	},
+/obj/machinery/light,
+/obj/machinery/flasher/portable,
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "dAH" = (
@@ -48843,6 +48628,9 @@
 	d2 = 4;
 	dir = 0;
 	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
@@ -48862,6 +48650,13 @@
 /area/station/crew_quarters/bathroom{
 	name = "Locker Room"
 	})
+"dFK" = (
+/obj/machinery/port_a_brig,
+/obj/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/security/main)
 "dPK" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -48887,6 +48682,16 @@
 	dir = 8
 	},
 /area/station/science/lobby)
+"efM" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/black,
+/area/station/maintenance/central)
 "ejx" = (
 /obj/pool_springboard,
 /obj/pool/perspective{
@@ -49077,6 +48882,18 @@
 	},
 /turf/simulated/floor/damaged2,
 /area/station/quartermaster/storage)
+"fkT" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "fmc" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -49128,6 +48945,13 @@
 /obj/machinery/portable_reclaimer,
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
+"fsv" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 10
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
 "fwR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -49240,6 +49064,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
+"gAX" = (
+/turf/simulated/floor/red/side,
+/area/station/security/main)
 "gMH" = (
 /obj/cable{
 	d2 = 4;
@@ -49385,16 +49212,13 @@
 	},
 /obj/disposalpipe/segment/mail,
 /obj/table/reinforced/auto,
-/obj/machinery/recharger,
-/obj/item/ammo/bullets/smoke,
-/obj/item/ammo/bullets/smoke,
-/obj/item/gun/kinetic/riot40mm,
-/obj/item/wrench,
-/obj/item/clothing/head/helmet/camera/security,
-/obj/item/device/detective_scanner,
 /obj/item/device/ticket_writer{
 	pixel_y = 20
 	},
+/obj/machinery/networked/storage/scanner{
+	bank_id = "security"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet{
 	icon_state = "fred1"
 	},
@@ -49471,6 +49295,19 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"hLU" = (
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/table/reinforced/auto,
+/obj/item/aiModule/oneHuman,
+/obj/item/aiModule/notHuman,
+/obj/item/aiModule/freeform,
+/turf/simulated/floor/blueblack{
+	dir = 1
+	},
+/area/station/turret_protected/ai)
 "hSR" = (
 /obj/decal/tile_edge/line/green{
 	dir = 4;
@@ -49605,13 +49442,22 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "iIr" = (
-/obj/stool/chair/red{
+/obj/window_blinds/cog2/right{
 	dir = 8
 	},
-/obj/landmark/start{
-	name = "Security Assistant"
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/carpet,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	dir = 0;
+	icon_state = "2-4"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/black,
 /area/station/security/main)
 "iMu" = (
 /obj/decal/tile_edge/line/green{
@@ -49745,6 +49591,14 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
+"jGY" = (
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
 "jIw" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -49758,6 +49612,14 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/central)
+"jIV" = (
+/obj/item/device/radio/intercom/security{
+	layer = 6.02
+	},
+/obj/disposalpipe/segment/brig,
+/obj/stool/chair/red,
+/turf/simulated/floor/black,
+/area/station/security/main)
 "jKb" = (
 /obj/window/reinforced/north,
 /obj/table/reinforced/auto,
@@ -49864,17 +49726,9 @@
 	},
 /area/station/crew_quarters/hos)
 "kFh" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
+/turf/simulated/floor/redblack/corner{
+	dir = 8
 	},
-/obj/decal/tile_edge/line/red{
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/storage/secure/crate/plasma/armory/anti_biological,
-/obj/item/gun/flamethrower/assembled/loaded,
-/turf/simulated/floor/black,
 /area/station/security/armory)
 "kIg" = (
 /obj/decal/tile_edge/line/yellow{
@@ -50088,6 +49942,26 @@
 /obj/access_spawn/pathology,
 /turf/simulated/floor/green,
 /area/station/medical/cdc)
+"lLS" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/device/radio/intercom/AI{
+	dir = 4
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
+"lOY" = (
+/obj/machinery/door/airlock/pyro/glass/security{
+	dir = 8;
+	name = "Armory"
+	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/security/main)
 "lUk" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -50187,6 +50061,20 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"mEw" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	dir = 0;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/black,
+/area/station/bridge)
 "mEH" = (
 /obj/machinery/drainage/big,
 /obj/landmark/gps_waypoint,
@@ -50214,17 +50102,11 @@
 	dir = 1
 	},
 /area/station/science/artifact)
-"mWj" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/blueblack{
-	dir = 8
-	},
-/area/station/turret_protected/ai)
+"mYD" = (
+/obj/disposalpipe/segment/brig,
+/obj/machinery/computer/arcade,
+/turf/simulated/floor,
+/area/station/security/brig)
 "nfL" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
@@ -50350,16 +50232,12 @@
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "nOq" = (
-/obj/wingrille_spawn/auto,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/window_blinds/cog2/right{
+/turf/simulated/floor/red/side{
 	dir = 8
 	},
-/obj/cable,
-/turf/simulated/floor/plating,
 /area/station/security/main)
 "nQs" = (
 /obj/wingrille_spawn/auto,
@@ -50385,13 +50263,13 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "nXg" = (
-/obj/wingrille_spawn/auto,
 /obj/cable,
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/hos)
+/area/station/security/armory)
 "ohJ" = (
 /obj/machinery/door/airlock/pyro/glass/med,
 /obj/firedoor_spawn,
@@ -50495,12 +50373,6 @@
 	icon_state = "fgreen1"
 	},
 /area/station/garden/aviary)
-"oCF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/security/main)
 "oJG" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
@@ -50543,6 +50415,10 @@
 /obj/window/reinforced/south,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
+"oWM" = (
+/obj/item/storage/wall/fire,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/main)
 "oXa" = (
 /obj/stool,
 /obj/landmark/gps_waypoint,
@@ -50674,6 +50550,12 @@
 	dir = 5
 	},
 /area/station/hydroponics/bay)
+"pLq" = (
+/obj/machinery/recharger/wall{
+	pixel_y = -11
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/main)
 "pNt" = (
 /obj/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -50681,6 +50563,17 @@
 /obj/machinery/drone_recharger,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"pRQ" = (
+/obj/machinery/light_switch/south{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/storage/secure/crate/weapon/armory/pod_weapons,
+/turf/simulated/floor/redblack{
+	dir = 6
+	},
+/area/station/security/armory)
 "pSe" = (
 /obj/stool/bench/auto,
 /obj/item/storage/wall/medical{
@@ -50814,8 +50707,20 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/noticeboard{
-	pixel_y = 32
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Bridge"
+	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
+/obj/machinery/door/poddoor/blast{
+	density = 0;
+	dir = 1;
+	icon_state = "bdoormid0";
+	id = "lockdown";
+	layer = 4;
+	name = "Bridge Lockdown Door";
+	opacity = 0
 	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
@@ -50865,6 +50770,18 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
+"qxH" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai)
 "qCZ" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -50899,6 +50816,38 @@
 	dir = 8
 	},
 /area/station/hydroponics/bay)
+"qLv" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/storage/secure/crate/weapon/armory/tranquilizer,
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/station/security/armory)
+"qMv" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/middle,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/main)
+"qMO" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 10
+	},
+/obj/storage/secure/crate/plasma/armory/anti_biological,
+/obj/item/gun/flamethrower/assembled/loaded,
+/turf/simulated/floor/redblack{
+	dir = 5
+	},
+/area/station/security/armory)
 "qUi" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -50922,6 +50871,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/disposalpipe/segment/brig,
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "qZL" = (
@@ -50943,10 +50893,38 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/caution/corner/ne,
 /area/station/medical/cdc)
+"rqP" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/command{
+	name = "Bridge"
+	},
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
+/obj/machinery/door/poddoor/blast{
+	density = 0;
+	dir = 4;
+	icon_state = "bdoormid0";
+	id = "lockdown";
+	layer = 4;
+	name = "Bridge Lockdown Door";
+	opacity = 0
+	},
+/obj/cable,
+/turf/simulated/floor/black,
+/area/station/bridge)
 "rsw" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/engine/substation/west)
+"rvp" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/security/main)
 "ryf" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -51169,6 +51147,12 @@
 /obj/crematorium/tanning,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
+"sTY" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/maintenance/central)
 "tdg" = (
 /obj/decal/tile_edge/line/green{
 	dir = 6;
@@ -51184,6 +51168,10 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
+"thg" = (
+/obj/item/storage/wall/emergency,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/brig)
 "tlS" = (
 /obj/window/reinforced/south,
 /turf/simulated/floor/blue/checker,
@@ -51256,6 +51244,42 @@
 	icon_state = "fblue2"
 	},
 /area/station/bridge)
+"tSB" = (
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 10
+	},
+/obj/storage/secure/crate/gear/armory/grenades{
+	name = "special equipment crate"
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/thermal{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/nightvision{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/turf/simulated/floor/redblack{
+	dir = 4
+	},
+/area/station/security/armory)
 "ubD" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -51267,6 +51291,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
+"uju" = (
+/turf/simulated/floor/caution/north,
+/area/station/security/main)
 "umm" = (
 /obj/disposalpipe/segment/morgue,
 /obj/decal/tile_edge/line/red{
@@ -51444,6 +51471,15 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
+"vaf" = (
+/obj/machinery/recharger/wall{
+	dir = 8;
+	pixel_x = -19
+	},
+/turf/simulated/floor/red/side{
+	dir = 8
+	},
+/area/station/security/main)
 "vfn" = (
 /obj/overlay{
 	anchored = 1;
@@ -51466,6 +51502,21 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"vfo" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/table/reinforced/auto,
+/obj/machinery/networked/printer{
+	print_id = "Security"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/station/security/main)
 "vgE" = (
 /obj/towelbin,
 /obj/table/glass/reinforced/auto,
@@ -51493,6 +51544,19 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
+"vxc" = (
+/obj/machinery/door/airlock/pyro/glass/security{
+	dir = 8;
+	name = "Security"
+	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
+/obj/machinery/secscanner{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/black,
+/area/station/security/main)
 "vGP" = (
 /obj/cable{
 	d2 = 8;
@@ -51513,15 +51577,6 @@
 "vHe" = (
 /turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
-"vHg" = (
-/obj/disposalpipe/segment/mail,
-/obj/mug_rack{
-	pixel_x = -24
-	},
-/turf/simulated/floor/red/side{
-	dir = 8
-	},
-/area/station/security/main)
 "vLx" = (
 /obj/landmark{
 	icon_state = "x3";
@@ -51686,6 +51741,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
+"xyq" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/command,
+/obj/access_spawn/heads,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/maintenance/central)
 "xyV" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/carpet{
@@ -51754,6 +51818,25 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
+"ydC" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Armory APC";
+	noalerts = 1;
+	pixel_x = -24
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13";
+	pixel_x = 10
+	},
+/turf/simulated/floor/black,
+/area/station/maintenance/central)
 "yeI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -78411,10 +78494,10 @@ aQO
 bak
 bak
 bak
-bak
+aNn
 bak
 aOs
-aNn
+bak
 aOs
 bow
 bak
@@ -78671,7 +78754,7 @@ aPq
 bis
 aPq
 bkV
-bmi
+aPq
 bnA
 box
 bpW
@@ -78917,17 +79000,17 @@ aWz
 bMt
 bIn
 bsI
-aYZ
-bal
+aXJ
+aXJ
 bbt
 bcJ
 bdW
-aXJ
+jGY
 bgj
 bhk
 bit
 bjJ
-bkW
+aXJ
 bmj
 bnB
 boy
@@ -79174,18 +79257,18 @@ aQR
 aQR
 aQR
 aQR
+vxc
+aQR
+aQR
 aQR
 bhl
 bhl
 bhl
 bhl
-bhl
-bhl
-bhl
-biu
+fkT
 biu
 bhl
-bmk
+bhl
 bhl
 boz
 boz
@@ -79431,8 +79514,8 @@ aTK
 aVg
 aQR
 bbc
-aZa
-bhl
+bgt
+oWM
 bbu
 bcK
 bhl
@@ -79441,7 +79524,7 @@ bgk
 bhl
 biv
 bjK
-bkX
+bhl
 bml
 bhl
 boA
@@ -79682,14 +79765,14 @@ aLW
 aNu
 aOu
 aPz
-aQR
+pLq
 aSk
-aTL
+bgp
 aVh
-aQR
+oWM
 aXL
+gAX
 aQR
-bhl
 bbv
 byf
 bhl
@@ -79698,7 +79781,7 @@ bgl
 bhl
 biw
 bjL
-bkY
+bhl
 bmm
 bhl
 boB
@@ -79941,13 +80024,13 @@ aOu
 aPA
 aQR
 aSl
-dwl
+bgp
 aVi
 aWA
-aXM
+aXL
 aZb
-bhl
-dAH
+thg
+uju
 bcM
 bhl
 bfa
@@ -79955,7 +80038,7 @@ dAH
 bhl
 bix
 bjM
-biB
+bnC
 bmn
 bnC
 boC
@@ -80198,10 +80281,10 @@ aOu
 aPB
 aQR
 aSm
-oCF
+bgp
 biL
 aWB
-aXN
+aXL
 aZc
 bam
 bbw
@@ -80719,7 +80802,7 @@ aXP
 aZe
 bao
 bby
-bhl
+aQR
 bdZ
 bfd
 bgo
@@ -80979,7 +81062,7 @@ bbz
 jVa
 bea
 bfe
-bgp
+dFK
 bho
 biB
 bjQ
@@ -81223,7 +81306,7 @@ fNN
 aMb
 aNs
 aOu
-aPE
+cie
 aQS
 aSq
 aTQ
@@ -81234,11 +81317,11 @@ aZg
 aZg
 bbA
 qXK
-beb
+jIV
 beb
 bgq
 bhp
-biC
+mYD
 biC
 blc
 bms
@@ -81490,13 +81573,13 @@ aXS
 aZh
 aVj
 bbB
-qXK
+qMv
 bec
 bff
-bgr
+bgp
 bhq
 biD
-bjR
+dmU
 bjR
 bmt
 bhl
@@ -81747,11 +81830,11 @@ aXT
 aZi
 aVj
 dyB
-bcS
+aQR
 bed
 iIr
 bgs
-bhr
+bhl
 biE
 bjS
 bld
@@ -82002,9 +82085,9 @@ aVq
 aWG
 aXU
 aZj
-baq
-bbD
-aQR
+aVj
+aZf
+vaf
 bee
 nOq
 bgt
@@ -82260,9 +82343,9 @@ aWH
 aXV
 aZk
 aVo
-bbE
-vHg
-bcT
+aVo
+aVo
+aVo
 bfi
 bgu
 bhs
@@ -82517,7 +82600,7 @@ aWI
 aXW
 aZl
 bar
-bbF
+vfo
 bcU
 bbF
 bfj
@@ -82776,9 +82859,9 @@ aQY
 aQY
 aQY
 aQY
-aQY
-aQY
-aQY
+aQR
+lOY
+rvp
 ajE
 kAn
 bjW
@@ -83293,12 +83376,12 @@ bcW
 beg
 bfl
 bgx
-ajE
+bgz
 biK
 nXg
 blj
 bjY
-ajE
+bgz
 boO
 bqh
 brk
@@ -84061,12 +84144,12 @@ aZq
 baw
 bbK
 bcZ
-bej
+aQR
 bfo
 bgz
 bhx
 kFh
-bMO
+bMP
 bMP
 bMR
 bgz
@@ -84322,10 +84405,10 @@ bek
 bfp
 bgz
 bgz
-bgz
-bgz
-bgz
-bgz
+qMO
+qLv
+tSB
+pRQ
 bgz
 boR
 bqm
@@ -84575,15 +84658,15 @@ aZs
 bay
 bbM
 bdb
-bel
+bfq
 bfq
 bgA
-bhy
-biO
-bkb
-bkb
-bkb
-bnF
+bgz
+bgz
+bgz
+bgz
+bgz
+bgz
 boS
 bqn
 brn
@@ -84832,17 +84915,17 @@ aZt
 aQY
 aQY
 bdc
-bem
+fsv
 bfr
-bgB
-bem
-bem
-bem
-bem
-bem
-bem
-boG
-bqe
+mEw
+rqP
+ydC
+efM
+sTY
+sTY
+xyq
+brm
+bWX
 bro
 bso
 bso
@@ -85090,13 +85173,13 @@ baz
 aWQ
 qro
 bem
-bfs
-mWj
-bhz
-biP
-bkc
-bln
-bmD
+bem
+bgB
+bem
+bem
+bem
+bem
+bem
 bem
 boT
 bqo
@@ -85347,13 +85430,13 @@ baA
 aWQ
 bde
 bem
-bft
+hLU
 bgD
-bhA
-bhA
+lLS
+qxH
 bhA
 blo
-bhB
+bmF
 bem
 boU
 bqp
@@ -85604,7 +85687,7 @@ baB
 bbN
 bdd
 bem
-bfu
+bft
 bgE
 bhB
 blp
@@ -85861,7 +85944,7 @@ baC
 aWQ
 bdd
 bem
-bfv
+bfu
 bgE
 bhC
 biR
@@ -86118,7 +86201,7 @@ bpn
 aWQ
 bdf
 bem
-bfw
+bfv
 bgE
 bhD
 biS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] --> [WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes a lot of stuff on Clarion security, the bigger ones are:

  - Makes the armory use a computer to open it so sec can open it without an HoS and adds some extra stuff to it like pulse rifles.
  - Add flashers, it didn't have any before.
  - a new entrance to sec by the west side.
  - Remove the comms dish in the bridge to make space for the armory.
![Captura de Tela (213)](https://user-images.githubusercontent.com/74429191/114254498-26c45300-9986-11eb-8a00-2e260170fd27.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes Clarion more up to date with the other maps and changes some stuff people complained about like the locker room.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Arthur Holiday
(*)Revamped the security department on Clarion.
```
