### PR TITLE
Removes the cyalumes saber ability to deflect projectiles

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -102,7 +102,6 @@
 		light_c = src.AddComponent(/datum/component/holdertargeting/simple_light, r, g, b, 150)
 		light_c.update(0)
 		src.setItemSpecial(/datum/item_special/swipe/csaber)
-		AddComponent(/datum/component/itemblock/saberblock)
 		BLOCK_SETUP(BLOCK_SWORD)
 
 /obj/item/sword/attack(mob/target, mob/user, def_zone, is_special = 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the cyalumes saber ability to deflect projectiles


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The current version of the deflect ability is as such -

Only prerequisite is to be holding a c-saber, no special (Sith/Jedi) clothing required
100% chance of deflect from every direction, even behind
No required timing, only need to toggle blocking by pressing Z
No stamina drain on a successful block

None of the above points are balanced in any way, and this is all top of an already strong item.

To me, this feature only makes sense to be tied to the Cyalume Knight thats in the code. Otherwise I see no reason for this to just be readily available to anyone holding it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Carbadox
(*)Removed the cyalumes saber ability to deflect projectiles
```
