### PR TITLE
jobban.dm, 53: Cannot execute null.Find().

### DIFF
--- a/code/modules/admin/jobban.dm
+++ b/code/modules/admin/jobban.dm
@@ -35,7 +35,7 @@
 		var/datum/player/player = make_player(M2.ckey) // Get the player so we can use their bancache.
 		if(player.cached_jobbans == null) // Shit they aren't cached.
 			var/api_response = apiHandler.queryAPI("jobbans/get/player", list("ckey"=M2.ckey), 1)
-			if(!length(api_response)) // API unavailable or something
+			if(!length(api_response) || !api_response[M2.ckey]) // API unavailable or something
 				return FALSE
 			player.cached_jobbans = api_response[M2.ckey]
 		cache = player.cached_jobbans

--- a/code/modules/admin/jobban.dm
+++ b/code/modules/admin/jobban.dm
@@ -33,12 +33,13 @@
 		//if(isnull(M2.client))
 			//return FALSE
 		var/datum/player/player = make_player(M2.ckey) // Get the player so we can use their bancache.
-		var/mob_ckey = M2.ckey
 		if(player.cached_jobbans == null) // Shit they aren't cached.
-			var/api_response = apiHandler.queryAPI("jobbans/get/player", list("ckey"=mob_ckey), 1)
+			var/api_response = apiHandler.queryAPI("jobbans/get/player", list("ckey"=M2.ckey), 1)
 			if(!length(api_response)) // API unavailable or something
 				return FALSE
-			player.cached_jobbans = api_response[mob_ckey]
+			if(!M2?.ckey)
+				return FALSE // new_player was disposed during api call
+			player.cached_jobbans = api_response[M2.ckey]
 		cache = player.cached_jobbans
 	else if(islist(M))
 		cache = M

--- a/code/modules/admin/jobban.dm
+++ b/code/modules/admin/jobban.dm
@@ -33,11 +33,12 @@
 		//if(isnull(M2.client))
 			//return FALSE
 		var/datum/player/player = make_player(M2.ckey) // Get the player so we can use their bancache.
+		var/mob_ckey = M2.ckey
 		if(player.cached_jobbans == null) // Shit they aren't cached.
-			var/api_response = apiHandler.queryAPI("jobbans/get/player", list("ckey"=M2.ckey), 1)
-			if(!length(api_response) || !api_response[M2.ckey]) // API unavailable or something
+			var/api_response = apiHandler.queryAPI("jobbans/get/player", list("ckey"=mob_ckey), 1)
+			if(!length(api_response)) // API unavailable or something
 				return FALSE
-			player.cached_jobbans = api_response[M2.ckey]
+			player.cached_jobbans = api_response[mob_ckey]
 		cache = player.cached_jobbans
 	else if(islist(M))
 		cache = M


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* `return FALSE` if `M2?.ckey` evaluates to null
* if a `new_player` disconnects and is disposed of during the api call sleep their key is set to null and the `cache` var ends up empty causing a runtime

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
File | jobban.dm
-- | --
Line | 53
Error | Cannot execute null.Find().

```dm
proc name: jobban isbanned (/proc/jobban_isbanned)
  source file: jobban.dm,53
  usr: Mr Siz (/mob/new_player)
  src: null
  usr.loc: null
  call stack:
jobban isbanned(Mr Siz (/mob/new_player), "Head of Personnel")
Mr Siz (/mob/new_player): IsJobAvailable(Head of Personnel (/datum/job/command/head_of_personnel))
Mr Siz (/mob/new_player): LateJoinLink(Head of Personnel (/datum/job/command/head_of_personnel))
Mr Siz (/mob/new_player): LateChoices()
Mr Siz (/mob/new_player): .ready()
```
