### PR TITLE
Kondaru upgrade "Lambda" - mix and match QoL tuneup

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -344,14 +344,12 @@
 	},
 /area/space)
 "aaX" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/engine/caution/westeast,
-/area/station/hallway/primary/west)
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "aaY" = (
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -402,9 +400,12 @@
 /area/space)
 "abg" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "abh" = (
 /obj/lattice{
@@ -4429,6 +4430,9 @@
 	name = "Staff Assistant"
 	},
 /obj/blind_switch/north,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood/seven,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
@@ -4919,6 +4923,9 @@
 	pixel_y = 10
 	},
 /obj/machinery/light_switch/east,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood/seven,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
@@ -5888,18 +5895,15 @@
 /area/station/security/checkpoint/podbay)
 "apG" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/red/side{
-	dir = 8
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/west)
 "apH" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/grey/side{
 	dir = 4
 	},
@@ -5917,7 +5921,6 @@
 /obj/submachine/ATM{
 	pixel_y = 32
 	},
-/obj/machinery/light/small/floor,
 /turf/simulated/floor/darkblue/checker,
 /area/station/hallway/primary/west)
 "apK" = (
@@ -6302,13 +6305,14 @@
 	},
 /area/station/hallway/primary/west)
 "aqM" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/glass/windoor{
+/turf/simulated/floor/red/side{
 	dir = 8
 	},
-/turf/simulated/floor/darkblue/checker,
 /area/station/hallway/primary/west)
 "aqN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -6734,10 +6738,13 @@
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "arQ" = (
-/obj/machinery/light_switch/east,
-/turf/simulated/floor/grey/corner{
+/obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/turf/simulated/floor/darkblue/checker,
 /area/station/hallway/primary/west)
 "arR" = (
 /obj/decal/garland/ephemeral{
@@ -7106,12 +7113,15 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
 "asX" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/info{
-	name = "Book Nook"
-	})
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/grey/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
 "asZ" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -7480,21 +7490,21 @@
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/west)
 "auc" = (
-/obj/machinery/light,
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/yellow/side,
-/area/station/hallway/primary/west)
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "aud" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/west)
 "aue" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/info{
-	name = "Book Nook"
-	})
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light,
+/turf/simulated/floor/yellow/side,
+/area/station/hallway/primary/west)
 "auf" = (
 /obj/decal/garland/ephemeral{
 	dir = 8;
@@ -7688,16 +7698,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "auM" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "auN" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -7722,13 +7728,16 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/power)
 "auR" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/radio/news_office)
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "auS" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -8022,21 +8031,19 @@
 	},
 /area/station/hallway/primary/west)
 "avJ" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
 	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/radio/news_office)
+"avK" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine/caution/corner{
 	dir = 4
-	},
-/area/station/hallway/primary/west)
-"avK" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 8
 	},
 /area/station/hallway/primary/west)
 "avL" = (
@@ -8068,17 +8075,6 @@
 	dir = 1
 	},
 /area/station/engine/core)
-"avN" = (
-/obj/stool/bench/yellow/auto,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/engine/core)
 "avO" = (
 /obj/stool/bench/yellow/auto,
 /obj/cable{
@@ -8090,6 +8086,9 @@
 /area/station/engine/core)
 "avP" = (
 /obj/stool/bench/yellow/auto,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -8098,11 +8097,6 @@
 /obj/table/reinforced/auto,
 /obj/item/clothing/suit/fire/heavy,
 /obj/item/clothing/head/helmet/welding,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
 /obj/item/clothing/suit/fire/heavy,
 /obj/item/clothing/head/helmet/welding,
 /turf/simulated/floor/yellow/side{
@@ -8111,9 +8105,9 @@
 /area/station/engine/core)
 "avR" = (
 /turf/simulated/floor/stairs/wide/middle{
-	dir = 4
+	dir = 8
 	},
-/area/station/hallway/primary/north)
+/area/station/hallway/primary/west)
 "avS" = (
 /obj/machinery/power/monitor{
 	dir = 4;
@@ -8125,6 +8119,9 @@
 	},
 /obj/machinery/power/apc/autoname_west,
 /obj/machinery/power/data_terminal,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -8146,17 +8143,17 @@
 "avV" = (
 /obj/storage/crate/furnacefuel,
 /obj/machinery/light_switch/north,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
 /area/station/engine/power)
 "avW" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 4
 	},
-/turf/simulated/floor,
 /area/station/hallway/primary/north)
 "avX" = (
 /obj/lattice{
@@ -8897,6 +8894,7 @@
 	},
 /obj/access_spawn/engineering_power,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
 "aya" = (
@@ -9220,9 +9218,10 @@
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -9321,6 +9320,11 @@
 "aza" = (
 /obj/table/reinforced/auto,
 /obj/machinery/phone,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -10298,6 +10302,7 @@
 	pixel_x = -14
 	},
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/light,
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/north)
 "aBn" = (
@@ -10518,7 +10523,7 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "aBS" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "aBT" = (
@@ -11798,6 +11803,7 @@
 	on = 1;
 	transfer_rate = 1000
 	},
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -12936,18 +12942,15 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aIj" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/obj/disposalpipe/segment/brig{
-	dir = 1
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/hallway/primary/west)
+/turf/space,
+/area/space)
 "aIk" = (
 /obj/stool/bench/yellow/auto,
 /obj/item/device/radio/intercom/engineering,
@@ -12956,9 +12959,7 @@
 	},
 /area/station/engine/core)
 "aIl" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/lattice{
 	dir = 8;
 	icon_state = "lattice-dir"
@@ -12978,22 +12979,23 @@
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aIo" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aIp" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/lattice{
-	dir = 8;
-	icon_state = "lattice-dir"
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	frequency = 1225;
+	icon_state = "intact_on";
+	id = "Hot Loop Gas Supply 1";
+	on = 1;
+	target_pressure = 1000
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "aIq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -13060,16 +13062,16 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aIw" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	frequency = 1225;
-	icon_state = "intact_on";
-	id = "Hot Loop Gas Supply 1";
-	on = 1;
-	target_pressure = 1000
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
 	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-9"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "aIx" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5
@@ -13792,21 +13794,19 @@
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aKv" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 8;
+	level = 2
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-9"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/turf/simulated/floor/blueblack,
+/area/station/engine/coldloop)
 "aKw" = (
-/obj/item/device/radio/intercom/engineering{
-	dir = 4
-	},
 /obj/storage/closet/fire,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "aKx" = (
@@ -13823,17 +13823,6 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "aKz" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 8;
-	level = 2
-	},
-/turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
-"aKA" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
-"aKB" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/lattice{
 	dir = 10;
@@ -13841,6 +13830,18 @@
 	},
 /turf/space,
 /area/space)
+"aKA" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
+"aKB" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/engine/coldloop)
 "aKC" = (
 /obj/machinery/light{
 	dir = 4;
@@ -14094,7 +14095,11 @@
 	pixel_x = -10;
 	tag = ""
 	},
-/obj/machinery/light_switch/west,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aLF" = (
@@ -14115,13 +14120,14 @@
 /turf/simulated/floor/caution/south,
 /area/station/engine/gas)
 "aLH" = (
-/obj/machinery/light,
-/obj/machinery/light_switch/west,
 /obj/table/reinforced/auto,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /obj/item/device/transfer_valve,
 /obj/item/device/transfer_valve,
+/obj/item/device/radio/intercom/engineering{
+	dir = 4
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "aLI" = (
@@ -14138,11 +14144,9 @@
 /area/station/engine/combustion_chamber)
 "aLK" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
+/turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
 "aLL" = (
 /obj/machinery/door/airlock/pyro/maintenance,
@@ -14384,10 +14388,15 @@
 /area/station/engine/gas)
 "aMF" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "2-5"
 	},
-/turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "aMI" = (
 /obj/stool/chair/couch{
 	dir = 4
@@ -14420,16 +14429,26 @@
 /turf/space,
 /area/space)
 "aMN" = (
-/obj/cable{
-	icon_state = "2-5"
+/obj/table/reinforced/auto,
+/obj/item/device/analyzer/atmospheric{
+	pixel_x = 7;
+	pixel_y = 2
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "5-8"
+/obj/item/device/analyzer/atmosanalyzer_upgrade,
+/obj/machinery/door_control{
+	id = "fireshield";
+	name = "Heat Shield";
+	pixel_x = -24;
+	pixel_y = 8
 	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
+/obj/machinery/door_control{
+	id = "combustion";
+	name = "Chamber Exhaust";
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "aMO" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/decal/tile_edge/stripe/extra_big,
@@ -14717,23 +14736,20 @@
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aNM" = (
-/obj/table/reinforced/auto,
-/obj/item/device/analyzer/atmospheric{
-	pixel_x = 7;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 5
 	},
-/obj/item/device/analyzer/atmosanalyzer_upgrade,
-/obj/machinery/door_control{
-	id = "fireshield";
-	name = "Heat Shield";
-	pixel_x = -24;
-	pixel_y = 8
+/obj/machinery/power/stats_meter{
+	name = "Cold Loop Outlet Meter";
+	tag = "Cold Loop Outlet Meter"
 	},
-/obj/machinery/door_control{
-	id = "combustion";
-	name = "Chamber Exhaust";
-	pixel_x = -24;
-	pixel_y = -8
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -14963,23 +14979,18 @@
 	},
 /area/station/security/checkpoint/escape)
 "aOK" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 5
+/obj/machinery/atmospherics/unary/cold_sink/freezer{
+	dir = 8
 	},
-/obj/machinery/power/stats_meter{
-	name = "Cold Loop Outlet Meter";
-	tag = "Cold Loop Outlet Meter"
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/area/station/engine/coldloop)
 "aOL" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -20126,17 +20137,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/podbay)
 "bec" = (
-/obj/machinery/atmospherics/unary/cold_sink/freezer{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/coldloop)
 "bef" = (
 /obj/stool/chair{
@@ -20457,8 +20458,12 @@
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "bfe" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/coldloop)
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "bff" = (
 /obj/lattice{
 	dir = 1;
@@ -21156,10 +21161,10 @@
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "bhG" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 1;
-	level = 2
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
+/obj/machinery/light/emergency,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bhI" = (
@@ -21169,12 +21174,15 @@
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "bhJ" = (
-/obj/machinery/atmospherics/valve{
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
 	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "bhK" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -21683,11 +21691,11 @@
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
 "biW" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 4
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 8
 	},
 /obj/lattice{
-	dir = 4;
+	dir = 5;
 	icon_state = "lattice-dir"
 	},
 /turf/space,
@@ -43312,10 +43320,6 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
-"cOV" = (
-/turf/space,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/west)
 "cPy" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
@@ -43552,13 +43556,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
-"dct" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "dcK" = (
 /obj/machinery/atmospherics/portables_connector/east,
 /obj/machinery/portable_atmospherics/canister/air/large,
@@ -43772,15 +43769,14 @@
 	},
 /area/station/turret_protected/Zeta)
 "dlP" = (
-/obj/machinery/atmospherics/pipe/vent{
-	dir = 8
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	name = "Auxiliary Purge"
 	},
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir"
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
 	},
-/turf/space,
-/area/space)
+/area/station/engine/hotloop)
 "dma" = (
 /obj/storage/secure/closet/brig,
 /obj/disposalpipe/segment/transport{
@@ -43863,6 +43859,16 @@
 /obj/item/device/light/glowstick,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"dpL" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 8
+	},
+/turf/space,
+/area/space)
 "dqu" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -44617,14 +44623,13 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "ejI" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	name = "Auxiliary Purge"
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 10
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/engine/hotloop)
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "ejP" = (
 /obj/stool/bench/red,
 /obj/disposalpipe/segment/brig{
@@ -44673,15 +44678,6 @@
 	icon_state = "engine_caution_south"
 	},
 /area/station/hangar/sec)
-"emQ" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/space)
 "enu" = (
 /obj/railing/orange/reinforced{
 	dir = 4
@@ -44781,16 +44777,6 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"erg" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "esb" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -44823,13 +44809,11 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "etO" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 10
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "euW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -44892,15 +44876,6 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"eyT" = (
-/obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
-/area/space)
 "ezj" = (
 /obj/machinery/bot/duckbot,
 /turf/simulated/floor/wood,
@@ -45295,6 +45270,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
+"fbF" = (
+/obj/grille/catwalk{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/area/space)
 "fbU" = (
 /obj/stool/bar,
 /obj/cable{
@@ -45338,6 +45323,18 @@
 	},
 /turf/simulated/floor/red,
 /area/station/routing/security)
+"feE" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "fgr" = (
 /obj/shrub{
 	dir = 10
@@ -45575,15 +45572,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
-/area/station/engine/core)
-"fom" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Core Access";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/turf/simulated/floor/engine/vacuum,
 /area/station/engine/core)
 "fpv" = (
 /obj/disposalpipe/segment/horizontal,
@@ -46064,11 +46052,6 @@
 	dir = 1
 	},
 /area/station/bridge)
-"fSc" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "fSI" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -46440,6 +46423,13 @@
 	},
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
+"gmi" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "gmO" = (
 /obj/machinery/floorflusher/solitary2,
 /obj/disposalpipe/trunk/south,
@@ -46476,8 +46466,13 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/east)
 "goX" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/one{
+	layer = 2;
+	pixel_x = 15;
+	pixel_y = 12
 	},
 /turf/simulated/floor/caution/north,
 /area/station/engine/coldloop)
@@ -47025,16 +47020,15 @@
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
 "gSM" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/decal/poster/wallsign/stencil/right/one{
-	layer = 2;
-	pixel_x = 15;
-	pixel_y = 12
-	},
-/turf/simulated/floor/caution/north,
-/area/station/engine/coldloop)
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "gTx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -47248,6 +47242,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/south)
+"hbs" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
 "hbu" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -47308,6 +47314,10 @@
 	dir = 4
 	},
 /area/station/routing/security)
+"hdj" = (
+/obj/decal/poster/wallsign/warning1,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/gas)
 "hdT" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -47445,6 +47455,12 @@
 /obj/decal/garland/ephemeral,
 /turf/simulated/floor/black,
 /area/station/bridge)
+"hlS" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "hmG" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -47778,16 +47794,6 @@
 "hHF" = (
 /obj/disposalpipe/segment/food,
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
-"hHH" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/decal/tile_edge/floorguide/arrow_s{
-	dir = 4
-	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "hJP" = (
@@ -48374,13 +48380,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/secwing)
-"iEf" = (
-/obj/machinery/door/poddoor/pyro{
-	id = "combustion";
-	name = "Combustion Chamber Vent"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "iEB" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/plating,
@@ -48708,12 +48707,15 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "iRP" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/machinery/atmospherics/mixer{
+	dir = 4;
+	frequency = 1225;
+	id_tag = "engine_combust";
+	master_id = "engine_combust_control";
+	name = "Gas Mixer (Combustion Chamber)"
 	},
-/turf/simulated/floor/black,
-/area/station/engine/gas)
+/turf/simulated/floor/caution/corner/ne,
+/area/station/engine/hotloop)
 "iSr" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -48803,6 +48805,9 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
+"iYU" = (
+/turf/simulated/floor/caution/east,
+/area/station/engine/gas)
 "iZd" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "General Population"
@@ -48832,6 +48837,10 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/maintenance/southeast)
+"jaV" = (
+/turf/space,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/inner/west)
 "jcj" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -48955,6 +48964,13 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"jmx" = (
+/obj/machinery/door/poddoor/pyro{
+	id = "combustion";
+	name = "Combustion Chamber Vent"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "jna" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/food,
@@ -48972,16 +48988,6 @@
 /obj/decal/garland/ephemeral,
 /turf/simulated/floor/dirt,
 /area/station/ranch)
-"jnr" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/decal/cleanable/oil,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "jnz" = (
 /obj/table/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -49060,12 +49066,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "jrg" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = -12
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core)
 "jrn" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -49297,6 +49302,18 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"jML" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "jNl" = (
 /obj/table/reinforced/auto,
 /obj/item/hand_labeler{
@@ -50041,18 +50058,6 @@
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
-"kDw" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/hotloop)
 "kDV" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/black,
@@ -50342,18 +50347,6 @@
 	},
 /turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
-"kZN" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
 "kZX" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -50489,6 +50482,12 @@
 /obj/machinery/light,
 /turf/simulated/floor/red/side,
 /area/station/security/secwing)
+"lhi" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "lhD" = (
 /obj/machinery/light{
 	dir = 1;
@@ -51174,6 +51173,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"lVd" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "lVB" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/brig{
@@ -51855,16 +51859,6 @@
 	},
 /turf/simulated/floor/caution/east,
 /area/station/hangar/sec)
-"mSL" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/atmospherics/pipe/vent{
-	dir = 8
-	},
-/turf/space,
-/area/space)
 "mSM" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/middle{
@@ -51917,6 +51911,16 @@
 	dir = 8
 	},
 /area/station/mining/magnet)
+"mUN" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/decal/tile_edge/floorguide/arrow_s{
+	dir = 4
+	},
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "mVi" = (
 /obj/fluid_spawner{
 	amount = 2100
@@ -52025,15 +52029,11 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
 "nbW" = (
-/obj/machinery/atmospherics/mixer{
-	dir = 4;
-	frequency = 1225;
-	id_tag = "engine_combust";
-	master_id = "engine_combust_control";
-	name = "Gas Mixer (Combustion Chamber)"
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/turf/simulated/floor/caution/corner/ne,
-/area/station/engine/hotloop)
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "ncc" = (
 /obj/rack,
 /obj/machinery/light/small{
@@ -52046,17 +52046,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"ncM" = (
-/obj/machinery/atmospherics/pipe/simple/junction,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "ncP" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -52680,11 +52669,16 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "nRo" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/core)
+/obj/decal/poster/wallsign/stencil/right/two{
+	layer = 2;
+	pixel_x = 17;
+	pixel_y = 12
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "nSc" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -52913,6 +52907,11 @@
 	dir = 6
 	},
 /area/station/security/interrogation)
+"ogc" = (
+/obj/wingrille_spawn/auto,
+/turf/space,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "ogf" = (
 /obj/item/device/radio/intercom{
 	dir = 4
@@ -53554,13 +53553,6 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
-"oWz" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/obj/lattice,
-/turf/space,
-/area/space)
 "oWV" = (
 /obj/machinery/disposal/brig{
 	name = "escape checkpoint chute"
@@ -53785,6 +53777,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
+"poJ" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/tile_edge/floorguide/hop{
+	dir = 4
+	},
+/obj/decal/tile_edge/floorguide/arrow_w,
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "poX" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
@@ -53801,16 +53801,6 @@
 /obj/item/device/light/flashlight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
-"pqS" = (
-/obj/grille/catwalk{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/space)
 "prs" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -54042,6 +54032,13 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space)
+"pCH" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "pCV" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
@@ -54177,6 +54174,18 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
+"pLo" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Engine Core";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "pLp" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -54453,6 +54462,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"qaF" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "qaK" = (
 /obj/rack,
 /obj/item/clothing/suit/fire,
@@ -54866,6 +54879,16 @@
 /obj/stool/chair,
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/crew_quarters/arcade/dungeon)
+"qzP" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "qAR" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/neutral/side{
@@ -54909,6 +54932,13 @@
 "qGc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
+"qGG" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/lattice,
+/turf/space,
+/area/space)
 "qHq" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -54937,11 +54967,10 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
-"qJJ" = (
-/obj/wingrille_spawn/auto,
-/turf/space,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "qJN" = (
@@ -55023,11 +55052,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "qRd" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/caution/south,
-/area/station/engine/coldloop)
+/turf/simulated/floor/plating,
+/area/station/engine/gas)
 "qRn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55438,6 +55470,14 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
+"rlE" = (
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "rlK" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -55608,13 +55648,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
-"rzK" = (
-/obj/decal/poster/wallsign/hazard_coldloop,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/coldloop)
-"rzP" = (
-/turf/simulated/floor/caution/east,
-/area/station/engine/gas)
 "rAa" = (
 /obj/table/reinforced/auto,
 /obj/item/gun/kinetic/riot40mm{
@@ -55664,14 +55697,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/ce)
-"rBd" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/decal/tile_edge/floorguide/hop{
-	dir = 4
-	},
-/obj/decal/tile_edge/floorguide/arrow_w,
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
 "rBy" = (
 /obj/machinery/atmospherics/pipe/manifold/south,
 /turf/simulated/wall/auto/supernorn,
@@ -56107,6 +56132,11 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"sdL" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "set" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/wood,
@@ -57315,6 +57345,15 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/routing/depot)
+"tym" = (
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
+/area/space)
 "tzu" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -57328,14 +57367,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/magnet)
-"tzY" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
-"tAF" = (
-/obj/decal/poster/wallsign/warning1,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/gas)
 "tBq" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -57557,21 +57588,12 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
-"tLP" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "tMp" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/obj/decal/poster/wallsign/stencil/right/two{
-	layer = 2;
-	pixel_x = 17;
-	pixel_y = 12
-	},
-/turf/simulated/floor/caution/south,
-/area/station/engine/coldloop)
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "tNc" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/book/space_law,
@@ -57787,12 +57809,6 @@
 	},
 /turf/simulated/floor/yellow/corner,
 /area/station/hallway/primary/west)
-"ucG" = (
-/obj/cable{
-	icon_state = "2-5"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
 "ucN" = (
 /obj/table/wood/auto,
 /obj/item/item_box/gold_star{
@@ -58520,12 +58536,6 @@
 /area/station/routing/medsci{
 	name = "Research Router"
 	})
-"uXt" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "uZQ" = (
 /obj/cable{
 	icon_state = "2-5"
@@ -58895,13 +58905,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/southeast)
-"vzH" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "vAR" = (
 /obj/stool/bed,
 /obj/item/storage/secure/ssafe{
@@ -59219,18 +59222,6 @@
 "vTk" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge/hos)
-"vTz" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engine Core";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
 "vTK" = (
 /turf/simulated/floor/escape/corner{
 	dir = 1
@@ -59436,6 +59427,18 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig/solitary)
+"weA" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "wfc" = (
 /obj/cable{
 	d1 = 1;
@@ -60001,13 +60004,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"wKN" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
 "wLh" = (
 /obj/machinery/computer3/generic/secure_data,
 /obj/machinery/power/data_terminal,
@@ -60337,10 +60333,18 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
 	})
+"xen" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "xew" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -60519,25 +60523,22 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"xmA" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "xmF" = (
 /obj/disposalpipe/segment/vertical,
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "xnb" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/junction,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
 	},
-/turf/simulated/floor/plating,
-/area/station/engine/gas)
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "xnq" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport,
@@ -60603,11 +60604,9 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "xqF" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
+/obj/decal/poster/wallsign/hazard_coldloop,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/coldloop)
 "xqR" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -60927,6 +60926,15 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"xIn" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/space)
 "xJq" = (
 /obj/lattice{
 	dir = 8;
@@ -61434,6 +61442,15 @@
 	dir = 8
 	},
 /area/station/security/secwing)
+"yfH" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Core Access";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core)
 "yfK" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
@@ -97963,7 +97980,7 @@ aof
 inc
 ait
 aro
-auR
+avJ
 atJ
 ait
 avz
@@ -101304,7 +101321,7 @@ aGe
 aGe
 aKo
 aLC
-bld
+aOG
 aNI
 aOG
 aPy
@@ -101903,12 +101920,12 @@ ayP
 aEa
 aEZ
 aGg
+ayO
 aHp
-aIj
 aJf
 aHp
 ayO
-aHp
+hbs
 vBz
 aHp
 aPA
@@ -102207,7 +102224,7 @@ aFa
 aGh
 aHq
 aJh
-xnb
+qRd
 aKq
 aHq
 aHq
@@ -102514,7 +102531,7 @@ aKr
 aLE
 aHq
 aNJ
-xmA
+sdL
 aHq
 hgU
 qwl
@@ -103414,9 +103431,9 @@ aCV
 aGk
 aGk
 aHq
-iRP
+gSM
 aJj
-rzP
+iYU
 sJY
 bfi
 aNL
@@ -103719,8 +103736,8 @@ aHq
 aIo
 aJk
 aKu
-tzY
-tAF
+rlE
+hdj
 aNL
 aNK
 aHq
@@ -104023,17 +104040,17 @@ aJl
 aHq
 aHq
 aHq
-aNL
+pCH
 aNL
 aHq
-jnr
+qzP
 qwl
-jrg
+uIC
 uIC
 rTU
 uIC
 odP
-tLP
+qaF
 iwq
 iPr
 cRL
@@ -104315,9 +104332,9 @@ aaa
 ach
 aCV
 aHr
-aIw
+aIp
 aEe
-aMN
+aMF
 aGn
 aHt
 aIq
@@ -104621,16 +104638,16 @@ aCY
 aEf
 aFf
 aGo
-ejI
+dlP
 aIr
 aJn
 aKx
-ucG
-vTz
+lhi
+pLo
 sWO
-erg
-vzH
-uXt
+sWO
+gmi
+hlS
 gxC
 gxC
 gxC
@@ -104923,7 +104940,7 @@ auN
 aEg
 auL
 wLi
-etO
+ejI
 aIs
 aJo
 aKy
@@ -104932,8 +104949,8 @@ aGk
 vHU
 ftA
 gxC
-qJJ
-cOV
+ogc
+jaV
 bfj
 abh
 abh
@@ -105223,13 +105240,13 @@ aAX
 aHs
 aDf
 dTh
-aNM
+aMN
 aGp
 auN
-nbW
+iRP
 aJp
 aKx
-wKN
+jML
 aMK
 abf
 aaf
@@ -105530,10 +105547,10 @@ aDb
 auN
 aIt
 aJq
-kDw
+weA
 aGk
 aGk
-mSL
+dpL
 ceD
 abn
 aaa
@@ -105832,7 +105849,7 @@ aGq
 auL
 auL
 aJr
-kZN
+feE
 auL
 aML
 aaa
@@ -106118,9 +106135,9 @@ apD
 bfk
 arM
 asO
-atX
+atY
 aDT
-avN
+avP
 awW
 axV
 ayW
@@ -106130,9 +106147,9 @@ aBV
 aDd
 aEj
 aFh
-bhG
+bfe
 aHv
-nRo
+jrg
 aJs
 aKA
 aLI
@@ -106438,7 +106455,7 @@ gMO
 aJt
 aKA
 aLJ
-iEf
+jmx
 aaa
 ach
 aba
@@ -106737,10 +106754,10 @@ aGr
 nQL
 gMO
 gMO
-xqF
+tMp
 aKA
 aLI
-iEf
+jmx
 aaa
 ach
 aba
@@ -107024,7 +107041,7 @@ aWM
 beb
 arL
 asR
-auc
+aud
 axX
 aza
 awZ
@@ -107035,11 +107052,11 @@ aBc
 aBZ
 aDg
 aEm
-aOK
+aNM
 aGs
 aHw
 aIu
-ncM
+xnb
 aaV
 aLJ
 aaY
@@ -107335,17 +107352,17 @@ ayZ
 aaY
 aGu
 aFj
-aKv
+aIw
 aEn
 nQL
-bhJ
+bhG
 auL
 auL
 auL
 auL
-fom
+yfH
 auL
-eyT
+tym
 aaf
 aba
 aQJ
@@ -107624,9 +107641,9 @@ alr
 amv
 anA
 aoB
-apG
+aqM
 aqL
-auM
+auR
 asS
 aud
 auL
@@ -107644,10 +107661,10 @@ aGt
 aJu
 aIv
 aJu
-pqS
-fSc
-dct
-emQ
+fbF
+lVd
+xen
+xIn
 aaf
 aba
 aQJ
@@ -107925,12 +107942,12 @@ ahE
 ahE
 ahE
 ahE
-aaX
+abg
 ahE
 ahE
 arP
 asT
-aud
+aue
 auP
 avS
 aAW
@@ -107948,7 +107965,7 @@ auL
 auL
 aaQ
 aaf
-oWz
+qGG
 aad
 aaf
 aba
@@ -108227,7 +108244,7 @@ akG
 ajG
 amw
 ajG
-abg
+apG
 aGf
 aHo
 aKp
@@ -108242,15 +108259,15 @@ aDX
 aBf
 qfl
 aDj
-aLK
+aKB
 aFl
 aGv
 aHz
 aIx
-rzK
+xqF
 aaQ
 acO
-dlP
+biW
 aaa
 aaO
 aba
@@ -108531,9 +108548,9 @@ amx
 akH
 akH
 apH
-arQ
+asX
 arR
-avJ
+avK
 auf
 axZ
 axd
@@ -108544,7 +108561,7 @@ aEb
 aBg
 kbj
 aCe
-aMF
+aLK
 aFm
 aGw
 aHA
@@ -108832,7 +108849,7 @@ als
 amy
 anB
 aoC
-aqM
+arQ
 aqN
 arS
 asV
@@ -108845,12 +108862,12 @@ aCU
 auQ
 aBh
 aHy
-aKz
-aKz
+aKv
+aKv
 aFn
 tVy
-goX
-qRd
+etO
+nbW
 aCf
 aaQ
 acO
@@ -109149,10 +109166,10 @@ aHm
 ylQ
 aNr
 aNr
-bec
+aOK
 dlp
-gSM
-tMp
+goX
+nRo
 aCf
 aaQ
 aaf
@@ -109439,7 +109456,7 @@ aoC
 apI
 aqN
 arU
-avK
+avR
 yjd
 auQ
 auQ
@@ -109451,11 +109468,11 @@ mHX
 mHX
 aCf
 aCf
-bfe
+bec
 aBj
 aCf
 aCf
-bfe
+bec
 aaQ
 acO
 aaa
@@ -109750,11 +109767,11 @@ aBU
 pCp
 pCp
 aBi
-aIl
-aKB
+aIj
+aKz
 pCp
 hbu
-biW
+bhJ
 aaa
 aaa
 ach
@@ -110052,11 +110069,11 @@ chj
 aBU
 hbu
 aBU
-aIp
-aKB
+aIl
+aKz
 pCp
 aBi
-dlP
+biW
 aaa
 aaa
 ach
@@ -113667,7 +113684,7 @@ aFv
 cCG
 aFv
 xQm
-avR
+avW
 rDI
 aFv
 aFv
@@ -114265,7 +114282,7 @@ aaa
 aaa
 axl
 azp
-azp
+aaX
 axl
 avq
 atC
@@ -114571,9 +114588,9 @@ amJ
 axl
 aHP
 apU
-asX
+auc
 asa
-avW
+uzL
 aBm
 auT
 awi
@@ -114873,7 +114890,7 @@ amJ
 axi
 aKD
 uIf
-aue
+auM
 uzL
 uzL
 aum
@@ -118859,7 +118876,7 @@ rOU
 boq
 bCI
 uKA
-hHH
+mUN
 vPj
 bGX
 bIv
@@ -122181,7 +122198,7 @@ bAL
 kli
 udY
 ygw
-rBd
+poJ
 chs
 maH
 ftU

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -325,15 +325,15 @@
 /turf/space,
 /area/station/solar/west)
 "aaV" = (
-/obj/grille/catwalk{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/machinery/sparker{
+	id = "eng_ignition";
+	layer = 7;
+	name = "Mounted Igniter";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/space)
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "aaW" = (
 /obj/grille/catwalk{
 	dir = 5;
@@ -344,17 +344,18 @@
 	},
 /area/space)
 "aaX" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
-"aaY" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine/caution/westeast,
+/area/station/hallway/primary/west)
+"aaY" = (
+/obj/decal/poster/wallsign/fire,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core)
 "aaZ" = (
 /obj/grille/catwalk{
 	dir = 9
@@ -393,21 +394,18 @@
 /turf/space,
 /area/mining/magnet)
 "abf" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
-	},
 /obj/lattice,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
+	},
 /turf/space,
 /area/space)
 "abg" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
+/obj/cable{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/space)
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "abh" = (
 /obj/lattice{
 	dir = 1;
@@ -1420,9 +1418,7 @@
 	},
 /obj/access_spawn/engineering_power,
 /obj/firedoor_spawn,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/ptl)
 "adH" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -1589,9 +1585,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/maintenance/north)
 "aej" = (
 /obj/machinery/light/small{
@@ -1895,9 +1889,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/maintenance/north)
 "aeU" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -2464,9 +2456,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/maintenance/north)
 "agG" = (
 /turf/simulated/wall/auto/supernorn,
@@ -2840,9 +2830,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "ahF" = (
 /obj/machinery/vending/cola/red,
@@ -3224,9 +3212,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon9,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "aiC" = (
 /obj/cable{
@@ -5513,6 +5499,9 @@
 	},
 /area/station/security/checkpoint/podbay)
 "aoB" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
@@ -5898,27 +5887,22 @@
 	},
 /area/station/security/checkpoint/podbay)
 "apG" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/red/side{
+	dir = 8
+	},
 /area/station/hallway/primary/west)
 "apH" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/submachine/ATM{
-	pixel_x = 32
+/turf/simulated/floor/grey/side{
+	dir = 4
 	},
-/obj/machinery/door/window/westright,
-/obj/machinery/light/small/floor,
-/turf/simulated/floor/darkblue/checker,
 /area/station/hallway/primary/west)
 "apI" = (
 /obj/disposalpipe/segment/morgue{
@@ -5927,11 +5911,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/west)
 "apJ" = (
-/obj/grille/steel,
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/submachine/ATM{
+	pixel_y = 32
+	},
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/darkblue/checker,
 /area/station/hallway/primary/west)
 "apK" = (
 /obj/lattice{
@@ -6305,21 +6292,23 @@
 	},
 /area/station/hallway/primary/west)
 "aqL" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red/corner{
 	dir = 1
 	},
 /area/station/hallway/primary/west)
 "aqM" = (
 /obj/disposalpipe/segment/morgue{
-	dir = 1
+	dir = 4
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
 	},
-/obj/machinery/light_switch/east,
-/turf/simulated/floor,
+/turf/simulated/floor/darkblue/checker,
 /area/station/hallway/primary/west)
 "aqN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -6481,14 +6470,19 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/radio/news_office)
 "aro" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
-	},
 /obj/machinery/light_switch/north,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
+	},
+/obj/table/wood/round,
+/obj/item/device/audio_log{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/storage/fanny,
+/obj/item/audio_tape{
+	pixel_x = 3;
+	pixel_y = 4
 	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/radio/news_office)
@@ -6737,56 +6731,41 @@
 	dir = 4
 	},
 /obj/landmark/halloween,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "arQ" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/grey/corner{
+	dir = 4
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/area/station/hallway/primary/west)
+"arR" = (
 /obj/decal/garland/ephemeral{
 	dir = 8;
 	pixel_x = 14
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"arR" = (
+"arS" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"arS" = (
+"arT" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"arT" = (
+"arU" = (
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
 /turf/simulated/floor/stairs/wide/other{
 	dir = 8
 	},
-/area/station/hallway/primary/west)
-"arU" = (
-/obj/machinery/computer/airbr{
-	density = 0;
-	icon = 'icons/obj/airtunnel.dmi';
-	id = "northconnector";
-	pixel_y = 32;
-	starts_established = 1
-	},
-/turf/simulated/floor/grey,
 /area/station/hallway/primary/west)
 "arV" = (
 /obj/decal/poster/wallsign/space,
@@ -6806,10 +6785,10 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
 "asa" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
-/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "asb" = (
@@ -6908,7 +6887,8 @@
 /area/station/crew_quarters/radio/news_office)
 "asx" = (
 /obj/table/wood/auto,
-/obj/item/reagent_containers/food/drinks/mug/random_color,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/carpet/red/standard/edge/north,
 /area/station/crew_quarters/radio/news_office)
 "asy" = (
@@ -7100,50 +7080,38 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "asS" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon8,
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "asT" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
+/turf/simulated/floor/engine/caution/corner,
+/area/station/hallway/primary/west)
+"asU" = (
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon10,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
-/area/station/hallway/primary/west)
-"asU" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon10,
-/turf/simulated/floor,
+/turf/simulated/floor/engine/caution/northsouth,
 /area/station/hallway/primary/west)
 "asV" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/west)
 "asX" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 8
-	},
-/area/station/hallway/primary/west)
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "asZ" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -7373,9 +7341,16 @@
 /area/station/crew_quarters/radio/news_office)
 "atL" = (
 /obj/table/wood/auto,
-/obj/item/device/audio_log,
-/obj/item/audio_tape,
-/obj/item/audio_tape,
+/obj/item/decoration/ashtray{
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/food/drinks/mug/random_color{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/mug/random_color{
+	pixel_x = -6
+	},
 /turf/simulated/floor/carpet/red/standard/edge/south,
 /area/station/crew_quarters/radio/news_office)
 "atM" = (
@@ -7514,33 +7489,37 @@
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/west)
 "aue" = (
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
+"auf" = (
+/obj/decal/garland/ephemeral{
+	dir = 8;
+	pixel_x = 14
+	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
-/area/station/hallway/primary/west)
-"auf" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/firedoor_spawn,
-/turf/simulated/floor/yellow/corner{
-	dir = 8
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "aug" = (
+/obj/machinery/computer/airbr{
+	density = 0;
+	icon = 'icons/obj/airtunnel.dmi';
+	id = "northconnector";
+	pixel_y = 32;
+	starts_established = 1
+	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/west)
 "auh" = (
-/obj/disposalpipe/segment/mail/bent/south,
 /obj/machinery/light/emergency,
-/turf/simulated/floor/stairs/wide{
-	dir = 8
-	},
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aui" = (
 /obj/disposalpipe/segment/morgue{
@@ -7709,18 +7688,16 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "auM" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
 /obj/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engine Core";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/yellow,
-/area/station/engine/core)
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "auN" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -7734,26 +7711,24 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/podbay)
 "auP" = (
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Power Room";
-	req_access = null
-	},
-/obj/access_spawn/engineering_power,
-/obj/firedoor_spawn,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/plating,
 /area/station/engine/power)
 "auQ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/power)
 "auR" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/west)
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/radio/news_office)
 "auS" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -7798,12 +7773,17 @@
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "auX" = (
-/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Engine Core";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/yellow,
 /area/station/engine/core)
 "auY" = (
 /obj/table/wood/auto,
@@ -8042,6 +8022,24 @@
 	},
 /area/station/hallway/primary/west)
 "avJ" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/engine/caution/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
+"avK" = (
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 8
+	},
+/area/station/hallway/primary/west)
+"avL" = (
 /obj/rack,
 /obj/item/clothing/suit/fire,
 /obj/item/clothing/mask/gas/emergency,
@@ -8062,7 +8060,7 @@
 	dir = 9
 	},
 /area/station/engine/core)
-"avK" = (
+"avM" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -8070,14 +8068,7 @@
 	dir = 1
 	},
 /area/station/engine/core)
-"avL" = (
-/obj/stool/bench/yellow/auto,
-/obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/engine/core)
-"avM" = (
+"avN" = (
 /obj/stool/bench/yellow/auto,
 /obj/machinery/light{
 	dir = 1;
@@ -8088,20 +8079,22 @@
 	dir = 1
 	},
 /area/station/engine/core)
-"avN" = (
-/obj/stool/bench/yellow/auto,
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/engine/core)
 "avO" = (
-/obj/table/reinforced/auto,
-/obj/machinery/phone,
+/obj/stool/bench/yellow/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
 /area/station/engine/core)
 "avP" = (
+/obj/stool/bench/yellow/auto,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/engine/core)
+"avQ" = (
 /obj/table/reinforced/auto,
 /obj/item/clothing/suit/fire/heavy,
 /obj/item/clothing/head/helmet/welding,
@@ -8116,7 +8109,12 @@
 	dir = 5
 	},
 /area/station/engine/core)
-"avQ" = (
+"avR" = (
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 4
+	},
+/area/station/hallway/primary/north)
+"avS" = (
 /obj/machinery/power/monitor{
 	dir = 4;
 	name = "Station Power Grid Monitoring"
@@ -8129,30 +8127,6 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side{
 	dir = 8
-	},
-/area/station/engine/power)
-"avR" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
-"avS" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
 	},
 /area/station/engine/power)
 "avT" = (
@@ -8169,22 +8143,21 @@
 	},
 /turf/space,
 /area/space)
-"avU" = (
+"avV" = (
 /obj/storage/crate/furnacefuel,
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
 /area/station/engine/power)
-"avV" = (
-/obj/grille/steel,
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/west)
 "avW" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/west)
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/north)
 "avX" = (
 /obj/lattice{
 	dir = 4;
@@ -8262,6 +8235,9 @@
 /obj/item/device/radio/intercom/engineering{
 	dir = 4
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "awj" = (
@@ -8284,6 +8260,9 @@
 	amount = 50
 	},
 /obj/item/storage/box/cablesbox,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "awl" = (
@@ -8536,6 +8515,20 @@
 /turf/space,
 /area/space)
 "awT" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/firedoor_spawn,
+/turf/simulated/floor/yellow/corner{
+	dir = 8
+	},
+/area/station/hallway/primary/west)
+"awU" = (
+/obj/disposalpipe/segment/mail/bent/south,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/west)
+"awV" = (
 /obj/rack,
 /obj/item/clothing/suit/fire,
 /obj/item/clothing/mask/gas/emergency,
@@ -8552,29 +8545,6 @@
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/engine/core)
-"awU" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/engine/core)
-"awV" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor,
 /area/station/engine/core)
 "awW" = (
 /obj/cable{
@@ -8595,9 +8565,31 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/core)
 "awY" = (
+/obj/disposalpipe/segment/mail/bent/east,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
+"awZ" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/engine/core)
+"axa" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8607,7 +8599,7 @@
 	dir = 4
 	},
 /area/station/engine/core)
-"awZ" = (
+"axb" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8622,17 +8614,7 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/core)
-"axa" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/engine/power)
-"axb" = (
+"axc" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -8643,26 +8625,11 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
-"axc" = (
-/turf/simulated/floor,
-/area/station/engine/power)
 "axd" = (
-/obj/storage/crate/furnacefuel,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/item/device/radio/intercom/engineering{
-	dir = 8;
-	pixel_x = 21;
-	pixel_y = -3
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
 "axe" = (
 /obj/table/wood/round/auto,
@@ -8877,6 +8844,24 @@
 	},
 /area/station/hallway/primary/west)
 "axU" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
+"axV" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/engine/core)
+"axW" = (
 /obj/storage/secure/closet/engineering/engineer,
 /obj/machinery/light{
 	dir = 8;
@@ -8887,27 +8872,34 @@
 	dir = 8
 	},
 /area/station/engine/core)
-"axV" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/engine/core)
-"axW" = (
-/turf/simulated/floor,
-/area/station/engine/core)
 "axX" = (
-/obj/stool/chair/office/yellow,
+/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/engine/core)
 "axY" = (
 /obj/stool/chair/office/yellow,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/engine/core)
 "axZ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Power Room";
+	req_access = null
+	},
+/obj/access_spawn/engineering_power,
+/obj/firedoor_spawn,
+/turf/simulated/floor/engine/caution/westeast,
+/area/station/engine/power)
+"aya" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/alarm{
@@ -8919,7 +8911,11 @@
 	dir = 4
 	},
 /area/station/engine/core)
-"aya" = (
+"ayb" = (
+/obj/decal/poster/wallsign/danger_highvolt,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/power)
+"ayc" = (
 /obj/machinery/power/smes{
 	charge = 1e+006;
 	chargelevel = 15000;
@@ -8938,7 +8934,7 @@
 	dir = 8
 	},
 /area/station/engine/power)
-"ayb" = (
+"ayd" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
@@ -8952,7 +8948,7 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
-"ayc" = (
+"aye" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -8961,36 +8957,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
-/area/station/engine/power)
-"ayd" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/engine/power)
-"aye" = (
-/obj/machinery/power/smes{
-	charge = 1e+006;
-	chargelevel = 15000;
-	output = 10000
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
 "ayg" = (
 /obj/machinery/door/airlock/pyro/command{
@@ -9077,7 +9044,7 @@
 	name = "Engineer"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -9283,6 +9250,14 @@
 	},
 /area/station/hallway/primary/west)
 "ayR" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/west)
+"ayS" = (
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/north)
+"ayT" = (
 /obj/storage/secure/closet/engineering/electrical,
 /obj/item/clothing/suit/rad,
 /obj/item/clothing/head/rad_hood,
@@ -9295,17 +9270,19 @@
 	dir = 10
 	},
 /area/station/engine/core)
-"ayS" = (
+"ayU" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/core)
-"ayT" = (
-/obj/reagent_dispensers/foamtank,
+"ayV" = (
+/obj/machinery/power/reactor_stats,
+/obj/cable,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/core)
-"ayU" = (
+"ayW" = (
 /obj/machinery/computer3/terminal/zeta{
 	setup_os_string = "ZETA_MAINFRAME"
 	},
@@ -9313,13 +9290,13 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/core)
-"ayV" = (
+"ayX" = (
 /obj/machinery/computer/atmosphere/pumpcontrol,
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/core)
-"ayW" = (
+"ayY" = (
 /obj/machinery/computer/atmosphere/mixercontrol{
 	frequency = 1225;
 	id = "engine_combust_control";
@@ -9330,17 +9307,7 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/core)
-"ayX" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/firstaid/fire{
-	pixel_x = -4
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 4
-	},
-/turf/simulated/floor/yellow/side,
-/area/station/engine/core)
-"ayY" = (
+"ayZ" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/emergency,
 /obj/item/wrench,
@@ -9351,7 +9318,14 @@
 	dir = 6
 	},
 /area/station/engine/core)
-"ayZ" = (
+"aza" = (
+/obj/table/reinforced/auto,
+/obj/machinery/phone,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/engine/core)
+"azb" = (
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -9368,7 +9342,7 @@
 	icon_state = "engine_caution_misc"
 	},
 /area/station/engine/power)
-"aza" = (
+"azc" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -9384,7 +9358,7 @@
 	icon_state = "engine_caution_ns"
 	},
 /area/station/engine/power)
-"azb" = (
+"azd" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -9398,44 +9372,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
-/area/station/engine/power)
-"azc" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/stool/chair/office/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_ns"
-	},
-/area/station/engine/power)
-"azd" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/machinery/power/monitor/smes{
-	dir = 8;
-	name = "Engine Output Monitoring"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
-	},
-/turf/simulated/floor/engine{
-	dir = 4;
-	icon_state = "engine_caution_misc"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/engine/power)
 "aze" = (
 /obj/storage/closet/wardrobe/black,
@@ -9781,55 +9718,63 @@
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "azU" = (
-/obj/decal/poster/wallsign/hazard_caution,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/core)
+/obj/decal/tile_edge/floorguide/engineering{
+	desc = "The power transmission laser is in this direction.";
+	name = "PTL Navigation Guide";
+	pixel_y = 16
+	},
+/obj/decal/tile_edge/floorguide/arrow_n,
+/turf/simulated/floor,
+/area/station/engine/power)
 "azV" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engine Core";
-	req_access = null
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/access_spawn/engineering_engine,
-/obj/firedoor_spawn,
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/engine/core)
-"azW" = (
-/obj/decal/poster/wallsign/fire,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/core)
-"azX" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/poster/wallsign/hazard_coldloop,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/power)
-"azY" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Power Room";
-	req_access = null
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/access_spawn/engineering_power,
-/obj/access_spawn/engineering_engine,
-/obj/firedoor_spawn,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_misc"
-	},
-/area/station/engine/power)
-"azZ" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
+/obj/disposalpipe/segment/mail/bent/north,
 /turf/space,
 /area/space)
+"azX" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/obj/disposalpipe/segment/mail/bent/west,
+/turf/space,
+/area/space)
+"azY" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/engine/core)
+"azZ" = (
+/obj/machinery/power/smes{
+	charge = 1e+006;
+	chargelevel = 15000;
+	output = 10000
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/engine/power)
 "aAa" = (
 /obj/stool/chair/couch{
 	dir = 4;
@@ -10200,38 +10145,23 @@
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "aAS" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/hotloop)
-"aAT" = (
-/obj/decal/poster/wallsign/hazard_hotloop,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/hotloop)
-"aAU" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/engine/hotloop)
-"aAV" = (
-/obj/machinery/atmospherics/pipe/tank,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -20
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
 	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "aAW" = (
 /obj/cable{
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/stairs,
-/area/station/engine/core)
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
+/area/station/engine/power)
 "aAX" = (
-/obj/machinery/atmospherics/unary/furnace_connector,
-/obj/machinery/power/furnace/thermo{
-	fuel = 100
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
+/obj/machinery/atmospherics/pipe/tank,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aAY" = (
@@ -10242,6 +10172,16 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aAZ" = (
+/obj/machinery/atmospherics/unary/furnace_connector,
+/obj/machinery/power/furnace/thermo{
+	fuel = 100
+	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"aBa" = (
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -10253,33 +10193,41 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aBa" = (
+"aBb" = (
+/turf/simulated/floor,
+/area/station/engine/power)
+"aBc" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aBb" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
-"aBc" = (
+"aBd" = (
 /obj/machinery/atmospherics/pipe/tank{
 	dir = 8
 	},
 /obj/item/device/radio/intercom/engineering,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aBd" = (
+"aBe" = (
+/obj/storage/crate/furnacefuel,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/item/device/radio/intercom/engineering{
+	dir = 8;
+	pixel_x = 21;
+	pixel_y = -3
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/engine/power)
+"aBf" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -10290,7 +10238,7 @@
 	dir = 8
 	},
 /area/station/engine/coldloop)
-"aBe" = (
+"aBg" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -10300,7 +10248,7 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
-"aBf" = (
+"aBh" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -10314,28 +10262,6 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
-"aBg" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 8;
-	on = 1;
-	transfer_rate = 1000
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/engine/coldloop)
-"aBh" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/junction{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/coldloop)
 "aBi" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -10343,15 +10269,13 @@
 /turf/space,
 /area/space)
 "aBj" = (
-/obj/machinery/atmospherics/pipe/vent{
-	dir = 8
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0;
+	dir = 4
 	},
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "aBl" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -10369,12 +10293,12 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "aBm" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
+/obj/decal/garland/ephemeral{
+	dir = 4;
+	pixel_x = -14
 	},
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/firedoor_spawn,
-/turf/simulated/floor/yellow/corner,
+/turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/north)
 "aBn" = (
 /obj/storage/secure/closet/engineering/engineer,
@@ -10388,13 +10312,9 @@
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "aBo" = (
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
-	},
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/yellow/side,
-/area/station/hallway/primary/north)
+/obj/stool/chair/office/yellow,
+/turf/simulated/floor,
+/area/station/engine/core)
 "aBp" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -10590,49 +10510,32 @@
 	},
 /area/station/hallway/primary/west)
 "aBQ" = (
-/obj/reagent_dispensers/foamtank,
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
-/area/station/engine/hotloop)
-"aBR" = (
-/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor,
+/area/station/engine/power)
+"aBS" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
-"aBS" = (
-/obj/machinery/power/reactor_stats,
-/obj/cable{
-	icon_state = "0-2"
+"aBT" = (
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/machinery/power/data_terminal,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
 /area/station/engine/hotloop)
-"aBT" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/machinery/atmospherics/valve,
-/turf/simulated/floor/engine,
-/area/station/engine/core)
 "aBU" = (
-/obj/machinery/meter,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/turf/space,
+/area/space)
 "aBV" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -10640,39 +10543,35 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aBW" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/space,
+/area/space)
+"aBX" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -4
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 4
+	},
+/turf/simulated/floor/yellow/side,
+/area/station/engine/core)
+"aBY" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
 	level = 2
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aBX" = (
+"aBZ" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 8;
 	level = 2
 	},
 /obj/cable{
 	icon_state = "6-10"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
-"aBY" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 8;
-	on = 1;
-	pixel_y = 1;
-	target_pressure = 1e+031
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
-"aBZ" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -10686,34 +10585,41 @@
 /turf/simulated/floor/grey,
 /area/station/maintenance/west)
 "aCb" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"aCc" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0;
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
+"aCd" = (
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 4;
+	on = 1;
+	pixel_y = 1;
+	target_pressure = 1e+031
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core)
+"aCe" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 9
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
-/area/station/engine/coldloop)
-"aCc" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/valve,
 /turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
-"aCd" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 1;
-	level = 2
-	},
-/turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
-"aCe" = (
-/obj/machinery/atmospherics/unary/cold_sink/freezer{
-	dir = 8
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
 /area/station/engine/coldloop)
 "aCf" = (
 /obj/wingrille_spawn/auto/crystal,
@@ -10958,6 +10864,23 @@
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "aCU" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/stool/chair/office/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/engine{
+	icon_state = "engine_caution_ns"
+	},
+/area/station/engine/power)
+"aCV" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
+"aCW" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
 	layer = 2.9
@@ -10967,77 +10890,73 @@
 	pixel_x = 18;
 	pixel_y = 18
 	},
-/obj/machinery/alarm{
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/engine/hotloop)
+"aCY" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 10
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/engine/hotloop)
+"aCZ" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/power/monitor/smes{
+	dir = 8;
+	name = "Engine Output Monitoring"
+	},
+/obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -20
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/engine{
+	dir = 4;
+	icon_state = "engine_caution_misc"
+	},
+/area/station/engine/power)
+"aDa" = (
+/obj/reagent_dispensers/foamtank,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
 /area/station/engine/hotloop)
-"aCV" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
-"aCW" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	frequency = 1225;
-	icon_state = "intact_on";
-	id = "Hot Loop Gas Supply 1";
-	on = 1;
-	target_pressure = 1000
-	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
-"aCX" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 10
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/stool/chair/office/yellow{
-	dir = 1
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/engine/hotloop)
-"aCY" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
-	},
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
-"aCZ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold{
-	level = 2
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
-"aDa" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
 "aDb" = (
+/obj/machinery/light/emergency,
 /obj/machinery/atmospherics/pipe/manifold{
-	dir = 1;
 	level = 2
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"aDd" = (
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 4;
+	on = 1;
+	pixel_y = 1;
+	target_pressure = 1e+031
+	},
+/obj/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aDc" = (
+"aDe" = (
 /obj/machinery/meter{
 	pixel_x = -10;
 	pixel_y = -8
@@ -11061,17 +10980,17 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aDd" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/cable{
-	icon_state = "2-5"
+"aDf" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
 	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -10
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aDe" = (
+"aDg" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/machinery/power/stats_meter{
 	name = "Cold Loop Inlet Meter";
@@ -11089,13 +11008,7 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aDf" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
-"aDg" = (
+"aDh" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -11105,29 +11018,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aDh" = (
+"aDi" = (
+/obj/decal/poster/wallsign/hazard_caution,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core)
+"aDj" = (
 /obj/machinery/atmospherics/pipe/tank{
 	dir = 4
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/engine/coldloop)
-"aDi" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 9
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
-"aDj" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 8;
-	level = 2
-	},
-/turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
 "aDk" = (
 /obj/machinery/mass_driver{
@@ -11226,12 +11127,19 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "aDt" = (
-/obj/decal/garland/ephemeral{
-	dir = 4;
-	pixel_x = -14
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Engine Core";
+	req_access = null
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/engine/core)
 "aDu" = (
 /obj/machinery/light{
 	dir = 1;
@@ -11408,10 +11316,6 @@
 "aDT" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -11431,18 +11335,25 @@
 "aDW" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
-"aDX" = (
-/obj/wingrille_spawn/auto/crystal,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
+/area/station/engine/core)
+"aDX" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/decal/poster/wallsign/hazard_coldloop,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/power)
 "aDY" = (
 /obj/machinery/light/small{
@@ -11467,6 +11378,19 @@
 	},
 /area/station/hallway/primary/west)
 "aEb" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Power Room";
+	req_access = null
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/access_spawn/engineering_power,
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/turf/simulated/floor/engine/caution/misc,
+/area/station/engine/power)
+"aEc" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
 	layer = 2.9
@@ -11476,14 +11400,17 @@
 	pixel_x = 18;
 	pixel_y = 18
 	},
-/obj/item/device/radio/intercom/engineering{
-	dir = 4
-	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
 /area/station/engine/hotloop)
-"aEc" = (
+"aEd" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
+"aEe" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
 	frequency = 1225;
@@ -11497,7 +11424,7 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
-"aEd" = (
+"aEf" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
 	level = 2
@@ -11508,14 +11435,11 @@
 	d2 = 4;
 	icon_state = "4-10"
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
 /area/station/engine/hotloop)
-"aEe" = (
+"aEg" = (
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	dir = 4;
 	name = "Hot Loop";
@@ -11530,17 +11454,7 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/caution/westeast,
 /area/station/engine/core)
-"aEf" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/stairs{
-	dir = 8
-	},
-/area/station/engine/core)
-"aEg" = (
+"aEh" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
@@ -11556,7 +11470,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aEh" = (
+"aEi" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"aEj" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
 	},
@@ -11568,11 +11493,11 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aEi" = (
+"aEk" = (
 /obj/machinery/atmospherics/binary/circulatorTemp,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aEj" = (
+"aEl" = (
 /obj/machinery/power/generatorTemp,
 /obj/cable,
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -11581,18 +11506,18 @@
 /obj/item/paper/engine,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aEk" = (
+"aEm" = (
 /obj/machinery/atmospherics/binary/circulatorTemp/right,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aEl" = (
+"aEn" = (
 /obj/machinery/atmospherics/valve,
 /obj/cable{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aEm" = (
+"aEo" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -11600,7 +11525,7 @@
 	dir = 4
 	},
 /area/station/engine/core)
-"aEn" = (
+"aEp" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -11613,20 +11538,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/caution/westeast,
 /area/station/engine/core)
-"aEo" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
-/area/station/engine/coldloop)
-"aEp" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
 "aEq" = (
 /obj/grille/catwalk{
 	dir = 9
@@ -11857,6 +11768,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aFb" = (
+/obj/decal/poster/wallsign/hazard_hotloop,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/hotloop)
+"aFd" = (
 /obj/table/reinforced/auto,
 /obj/cable{
 	d2 = 8;
@@ -11870,7 +11785,7 @@
 	dir = 8
 	},
 /area/station/engine/hotloop)
-"aFc" = (
+"aFe" = (
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11878,18 +11793,7 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
-"aFd" = (
-/obj/cable{
-	icon_state = "2-5"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "5-8"
-	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
-"aFe" = (
+"aFf" = (
 /obj/machinery/atmospherics/binary/volume_pump{
 	on = 1;
 	transfer_rate = 1000
@@ -11898,28 +11802,17 @@
 	dir = 4
 	},
 /area/station/engine/hotloop)
-"aFf" = (
-/obj/table/reinforced/auto,
-/obj/item/device/analyzer/atmospheric{
-	pixel_x = 7;
-	pixel_y = 2
+"aFh" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
 	},
-/obj/item/device/analyzer/atmosanalyzer_upgrade,
-/obj/machinery/door_control{
-	id = "fireshield";
-	name = "Heat Shield";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/machinery/door_control{
-	id = "combustion";
-	name = "Chamber Exhaust";
-	pixel_x = -24;
-	pixel_y = -8
+/obj/machinery/meter,
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aFg" = (
+"aFi" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
 	},
@@ -11938,40 +11831,22 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aFh" = (
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
-"aFi" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 5
-	},
-/obj/machinery/power/stats_meter{
-	name = "Cold Loop Outlet Meter";
-	tag = "Cold Loop Outlet Meter"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
 "aFj" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	can_rupture = 0;
-	dir = 4
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 8;
+	on = 1;
+	pixel_y = 1;
+	target_pressure = 1e+031
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/engine,
 /area/station/engine/core)
 "aFk" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"aFl" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 1;
 	level = 2
@@ -11980,27 +11855,18 @@
 	dir = 8
 	},
 /area/station/engine/coldloop)
-"aFl" = (
+"aFm" = (
 /obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
 	level = 2
 	},
 /turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
-"aFm" = (
-/obj/machinery/atmospherics/unary/cold_sink/freezer{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/engine/coldloop)
 "aFn" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
+	},
+/turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
 "aFo" = (
 /obj/stool/chair/yellow{
@@ -12320,6 +12186,15 @@
 	},
 /area/station/hallway/primary/west)
 "aGj" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/stairs,
+/area/station/engine/core)
+"aGk" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/hotloop)
+"aGl" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/extinguisher,
@@ -12332,7 +12207,7 @@
 	dir = 8
 	},
 /area/station/engine/hotloop)
-"aGk" = (
+"aGm" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
 	layer = 2.9
@@ -12344,7 +12219,7 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
-"aGl" = (
+"aGn" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -12353,7 +12228,7 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
-"aGm" = (
+"aGo" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
 	},
@@ -12361,15 +12236,7 @@
 	dir = 4
 	},
 /area/station/engine/hotloop)
-"aGn" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
-"aGo" = (
+"aGp" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
 	},
@@ -12380,7 +12247,7 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aGp" = (
+"aGq" = (
 /obj/machinery/ignition_switch{
 	id = "eng_ignition";
 	name = "Burn Chamber Ignition";
@@ -12396,21 +12263,24 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aGq" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/engine,
-/area/station/engine/core)
 "aGr" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	level = 2
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/meter,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aGs" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
+	level = 2
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"aGt" = (
 /obj/machinery/light{
 	dir = 4;
 	layer = 9.1;
@@ -12421,36 +12291,30 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aGt" = (
+"aGu" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"aGv" = (
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
 /area/station/engine/coldloop)
-"aGu" = (
+"aGw" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5
 	},
 /turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
-"aGv" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
-"aGw" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	frequency = 1225;
-	icon_state = "intact_on";
-	id = "Cold Loop Purge Pump";
-	on = 1;
-	target_pressure = 2000
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
 /area/station/engine/coldloop)
 "aGx" = (
 /obj/machinery/light{
@@ -12556,9 +12420,9 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/t_scanner,
 /obj/item/wrench,
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
@@ -12726,17 +12590,20 @@
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "aHm" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8;
+	on = 1;
+	transfer_rate = 1000
 	},
-/turf/simulated/floor/plating,
-/area/station/engine/power)
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/engine/coldloop)
 "aHn" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Detective's Room";
@@ -12768,6 +12635,19 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
 "aHr" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
+"aHs" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/machinery/atmospherics/valve,
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"aHt" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -12787,45 +12667,34 @@
 	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
-"aHs" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	name = "Auxiliary Purge"
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/engine/hotloop)
-"aHt" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
 "aHu" = (
+/obj/machinery/meter,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"aHv" = (
 /obj/machinery/atmospherics/valve,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
-"aHv" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
 "aHw" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/access_spawn/engineering_engine,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/engine,
+/obj/machinery/atmospherics/valve,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
-"aHx" = (
+"aHy" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
+	},
+/turf/simulated/floor/blueblack,
+/area/station/engine/coldloop)
+"aHz" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 8;
 	level = 2
@@ -12844,7 +12713,7 @@
 	},
 /turf/simulated/floor/caution/north,
 /area/station/engine/coldloop)
-"aHy" = (
+"aHA" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
 	frequency = 1225;
@@ -12852,23 +12721,6 @@
 	id = "Cold Loop Gas Supply 1";
 	on = 1;
 	target_pressure = 1000
-	},
-/turf/simulated/floor/caution/north,
-/area/station/engine/coldloop)
-"aHz" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/caution/north,
-/area/station/engine/coldloop)
-"aHA" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/decal/poster/wallsign/stencil/right/one{
-	layer = 2;
-	pixel_x = 15;
-	pixel_y = 12
 	},
 /turf/simulated/floor/caution/north,
 /area/station/engine/coldloop)
@@ -13098,38 +12950,27 @@
 /area/station/hallway/primary/west)
 "aIk" = (
 /obj/stool/bench/yellow/auto,
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/item/device/radio/intercom/engineering,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
 /area/station/engine/core)
 "aIl" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/obj/stool/chair/office/yellow{
-	dir = 8
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/engine/power)
+/turf/space,
+/area/space)
 "aIm" = (
 /obj/machinery/manufacturer/gas,
 /obj/item/device/radio/intercom/engineering,
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aIn" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -13137,6 +12978,23 @@
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aIo" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
+"aIp" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
+"aIq" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -13159,43 +13017,39 @@
 	},
 /turf/simulated/floor/caution/corner/nw,
 /area/station/engine/hotloop)
-"aIp" = (
+"aIr" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
 	},
 /turf/simulated/floor/caution/north,
 /area/station/engine/hotloop)
-"aIq" = (
+"aIs" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/caution/north,
 /area/station/engine/hotloop)
-"aIr" = (
-/obj/machinery/atmospherics/mixer{
-	dir = 4;
-	frequency = 1225;
-	id_tag = "engine_combust";
-	master_id = "engine_combust_control";
-	name = "Gas Mixer (Combustion Chamber)"
-	},
-/turf/simulated/floor/caution/corner/ne,
-/area/station/engine/hotloop)
-"aIs" = (
+"aIt" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 10
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
-"aIt" = (
+"aIu" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
 	},
+/obj/machinery/power/stats_meter{
+	name = "Hot Loop Combustion Chamber Meter";
+	tag = "Hot Loop Combustion Chamber Meter"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
-"aIu" = (
+"aIv" = (
 /obj/machinery/atmospherics/binary/pump{
 	frequency = 1225;
 	icon_state = "intact_on";
@@ -13205,7 +13059,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aIv" = (
+"aIw" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	frequency = 1225;
+	icon_state = "intact_on";
+	id = "Hot Loop Gas Supply 1";
+	on = 1;
+	target_pressure = 1000
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
+"aIx" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5
 	},
@@ -13215,7 +13080,7 @@
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/coldloop)
-"aIw" = (
+"aIy" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
 	frequency = 1225;
@@ -13225,23 +13090,6 @@
 	target_pressure = 1000
 	},
 /obj/machinery/light,
-/turf/simulated/floor/caution/south,
-/area/station/engine/coldloop)
-"aIx" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/caution/south,
-/area/station/engine/coldloop)
-"aIy" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/decal/poster/wallsign/stencil/right/two{
-	layer = 2;
-	pixel_x = 17;
-	pixel_y = 12
-	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/coldloop)
 "aIz" = (
@@ -13485,19 +13333,38 @@
 "aJh" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/gas)
 "aJi" = (
 /obj/machinery/dispenser,
-/obj/cable{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aJj" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8;
+	name = "Mixing Port"
+	},
+/turf/simulated/floor/caution/corner/ne,
+/area/station/engine/gas)
+"aJk" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
+"aJl" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Engine Gas Storage";
@@ -13512,13 +13379,13 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
 /area/station/engine/gas)
-"aJk" = (
+"aJm" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/caution/corner/sw,
 /area/station/engine/hotloop)
-"aJl" = (
+"aJn" = (
 /obj/machinery/atmospherics/valve,
 /obj/decal/poster/wallsign/stencil/right/two{
 	layer = 2;
@@ -13532,7 +13399,7 @@
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/hotloop)
-"aJm" = (
+"aJo" = (
 /obj/machinery/atmospherics/binary/pump{
 	frequency = 1225;
 	icon_state = "intact_on";
@@ -13542,7 +13409,7 @@
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/hotloop)
-"aJn" = (
+"aJp" = (
 /obj/machinery/atmospherics/valve/vertical,
 /obj/decal/poster/wallsign/stencil/right/one{
 	layer = 2;
@@ -13551,7 +13418,7 @@
 	},
 /turf/simulated/floor/caution/corner/se,
 /area/station/engine/hotloop)
-"aJo" = (
+"aJq" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 5
@@ -13559,14 +13426,14 @@
 /obj/machinery/meter,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
-"aJp" = (
+"aJr" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
-"aJq" = (
+"aJs" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 4
@@ -13574,7 +13441,7 @@
 /obj/machinery/atmospherics/pipe/simple/junction,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
-"aJr" = (
+"aJt" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
@@ -13586,27 +13453,12 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
-"aJs" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
-"aJt" = (
-/obj/machinery/atmospherics/pipe/simple/junction,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "aJu" = (
-/obj/decal/poster/wallsign/hazard_coldloop,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/coldloop)
+/obj/machinery/door/airlock/pyro/external,
+/obj/access_spawn/engineering_engine,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "aJv" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -13749,19 +13601,10 @@
 	},
 /area/station/solar/west)
 "aJZ" = (
-/obj/machinery/atmospherics/portables_connector{
-	name = "Mixing Port"
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -20
-	},
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/caution/corner/nw,
+/turf/simulated/floor/black,
 /area/station/engine/gas)
 "aKa" = (
 /obj/cable{
@@ -13925,54 +13768,45 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/gas)
 "aKr" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 8;
-	level = 2
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/caution/west,
+/turf/simulated/floor/black,
 /area/station/engine/gas)
 "aKs" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/caution/north,
-/area/station/engine/gas)
-"aKt" = (
 /obj/machinery/atmospherics/portables_connector{
-	dir = 8;
+	dir = 4;
 	name = "Mixing Port"
 	},
-/obj/machinery/power/apc/autoname_east,
-/obj/cable,
-/turf/simulated/floor/caution/east,
+/turf/simulated/floor/caution/corner/nw,
+/area/station/engine/gas)
+"aKt" = (
+/obj/machinery/atmospherics/valve{
+	name = "Intermix Valve"
+	},
+/turf/simulated/floor,
 /area/station/engine/gas)
 "aKu" = (
-/obj/table/reinforced/auto,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/machinery/light_switch/west,
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
+/obj/machinery/power/apc/autoname_east,
+/obj/cable,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "aKv" = (
-/obj/machinery/atmospherics/portables_connector/north,
-/obj/machinery/light,
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
-"aKw" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
+	},
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-9"
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"aKw" = (
+/obj/item/device/radio/intercom/engineering{
+	dir = 4
+	},
+/obj/storage/closet/fire,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "aKx" = (
@@ -13980,43 +13814,33 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "aKy" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "9-10"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "aKz" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 8;
+	level = 2
 	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
+/turf/simulated/floor/blueblack,
+/area/station/engine/coldloop)
 "aKA" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
 "aKB" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/machinery/sparker{
-	id = "eng_ignition";
-	layer = 7;
-	name = "Mounted Igniter";
-	pixel_x = 24
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
+/turf/space,
+/area/space)
 "aKC" = (
 /obj/machinery/light{
 	dir = 4;
@@ -14263,10 +14087,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aLE" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1;
-	name = "Mixing Port"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -14275,36 +14095,34 @@
 	tag = ""
 	},
 /obj/machinery/light_switch/west,
-/turf/simulated/floor/caution/west,
+/turf/simulated/floor/black,
 /area/station/engine/gas)
 "aLF" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/caution/corner/ne,
+/obj/machinery/atmospherics/pipe/manifold/overfloor/north,
+/obj/machinery/meter,
+/turf/simulated/floor/caution/north,
 /area/station/engine/gas)
 "aLG" = (
-/turf/simulated/floor/caution/east,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1;
+	name = "Mixing Port"
+	},
+/turf/simulated/floor/caution/south,
 /area/station/engine/gas)
 "aLH" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engine Core";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/firedoor_spawn,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/redblack,
+/obj/machinery/light,
+/obj/machinery/light_switch/west,
+/obj/table/reinforced/auto,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/device/transfer_valve,
+/obj/item/device/transfer_valve,
+/turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "aLI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -14319,14 +14137,13 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
 "aLK" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Core Access";
-	req_access = null
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/access_spawn/engineering_engine,
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/core)
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/engine/coldloop)
 "aLL" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment/vertical,
@@ -14554,37 +14371,23 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/landmark/gps_waypoint,
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor,
 /area/station/engine/core)
 "aME" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	name = "Intermix Valve"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/caution/west,
 /area/station/engine/gas)
 "aMF" = (
-/turf/simulated/floor/caution/corner/se,
-/area/station/engine/gas)
-"aMG" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/blueblack,
+/area/station/engine/coldloop)
 "aMI" = (
 /obj/stool/chair/couch{
 	dir = 4
@@ -14598,16 +14401,17 @@
 /turf/simulated/floor/carpet/red/fancy/edge/se,
 /area/station/crew_quarters/quarters_north)
 "aMK" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
+"aML" = (
 /obj/decal/poster/wallsign/hazard_exheat,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
-"aML" = (
-/obj/machinery/door/poddoor/pyro{
-	id = "combustion";
-	name = "Combustion Chamber Vent"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "aMM" = (
 /obj/lattice{
 	icon_state = "lattice-dir-b"
@@ -14616,12 +14420,16 @@
 /turf/space,
 /area/space)
 "aMN" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
+/obj/cable{
+	icon_state = "2-5"
 	},
-/obj/lattice,
-/turf/space,
-/area/space)
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "5-8"
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "aMO" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/decal/tile_edge/stripe/extra_big,
@@ -14778,13 +14586,13 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/supply)
 "aNr" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
+/obj/machinery/atmospherics/unary/cold_sink/freezer{
+	dir = 8
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/engine/coldloop)
 "aNt" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -14896,11 +14704,12 @@
 	},
 /area/station/hallway/primary/west)
 "aNJ" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aNK" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/small,
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aNL" = (
@@ -14908,14 +14717,26 @@
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aNM" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/table/reinforced/auto,
+/obj/item/device/analyzer/atmospheric{
+	pixel_x = 7;
+	pixel_y = 2
 	},
-/turf/simulated/floor/black,
-/area/station/engine/gas)
+/obj/item/device/analyzer/atmosanalyzer_upgrade,
+/obj/machinery/door_control{
+	id = "fireshield";
+	name = "Heat Shield";
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/obj/machinery/door_control{
+	id = "combustion";
+	name = "Chamber Exhaust";
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "aNQ" = (
 /obj/lattice{
 	dir = 9;
@@ -15142,12 +14963,23 @@
 	},
 /area/station/security/checkpoint/escape)
 "aOK" = (
-/obj/machinery/atmospherics/pipe/vent{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 5
 	},
-/obj/lattice,
-/turf/space,
-/area/space)
+/obj/machinery/power/stats_meter{
+	name = "Cold Loop Outlet Meter";
+	tag = "Cold Loop Outlet Meter"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "aOL" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -16053,10 +15885,10 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "aRr" = (
@@ -17416,9 +17248,6 @@
 "aVc" = (
 /obj/stool/chair/office{
 	dir = 8
-	},
-/obj/landmark/start{
-	name = "Medical Doctor"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 5
@@ -18948,17 +18777,21 @@
 	},
 /area/station/medical/medbay)
 "aZq" = (
-/obj/machinery/sleep_console{
-	dir = 4
-	},
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
+	},
+/obj/machinery/sleep_console{
+	dir = 4
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
 /area/station/medical/medbay)
 "aZr" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
 /obj/machinery/sleeper{
 	dir = 4
 	},
@@ -20281,12 +20114,7 @@
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "bea" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/caution/corner/sw,
 /area/station/engine/gas)
 "beb" = (
 /obj/wingrille_spawn/auto,
@@ -20298,16 +20126,18 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/podbay)
 "bec" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/atmospherics/unary/cold_sink/freezer{
+	dir = 8
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
-/turf/simulated/floor/plating,
-/area/station/engine/gas)
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/engine/coldloop)
 "bef" = (
 /obj/stool/chair{
 	dir = 1
@@ -20627,18 +20457,8 @@
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "bfe" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/caution/corner/sw,
-/area/station/engine/gas)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/coldloop)
 "bff" = (
 /obj/lattice{
 	dir = 1;
@@ -20650,12 +20470,13 @@
 /turf/space,
 /area/station/mining/refinery)
 "bfi" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Gas Storage";
+	req_access = null
 	},
-/turf/simulated/floor/caution/south,
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
 /area/station/engine/gas)
 "bfj" = (
 /obj/lattice,
@@ -21335,13 +21156,12 @@
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "bhG" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
+	level = 2
 	},
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/engine/gas)
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "bhI" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -21349,11 +21169,12 @@
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "bhJ" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/turf/space,
-/area/space)
+/obj/machinery/light/emergency,
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "bhK" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -21862,10 +21683,15 @@
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
 "biW" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable,
-/turf/simulated/floor/plating,
-/area/station/engine/gas)
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
+	},
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "biX" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/specialroom/arcade,
@@ -23623,6 +23449,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/redwhite,
 /area/station/medical/medbay)
 "boO" = (
@@ -24173,7 +24002,7 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "bqm" = (
-/obj/reagent_dispensers/watertank/fountain,
+/obj/storage/secure/closet/medical/uniforms,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "bqn" = (
@@ -24433,6 +24262,9 @@
 	dir = 4
 	},
 /obj/machinery/light/small/floor/netural,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "brn" = (
@@ -27308,17 +27140,9 @@
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/south)
 "bBs" = (
-/obj/decal/tile_edge/line/green{
-	icon_state = "line1"
-	},
-/obj/machinery/door/airlock/pyro{
-	name = "Ranch Division"
-	},
-/obj/access_spawn/rancher,
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/dirt,
+/obj/wingrille_spawn/auto,
+/obj/decal/wreath/ephemeral,
+/turf/simulated/floor/plating,
 /area/station/ranch)
 "bBt" = (
 /obj/wingrille_spawn/auto,
@@ -27568,7 +27392,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/decal/xmas_lights/ephemeral{
+/obj/machinery/phone/wall{
 	pixel_y = 32
 	},
 /turf/simulated/floor/purple,
@@ -27582,6 +27406,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "bBZ" = (
@@ -27590,14 +27417,14 @@
 /area/station/science/chemistry)
 "bCa" = (
 /obj/machinery/chem_heater,
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
-	},
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/chemistry)
 "bCb" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/light_switch/north,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/purpleblack,
 /area/station/science/chemistry)
 "bCc" = (
@@ -27931,7 +27758,7 @@
 "bCR" = (
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingun
+	displayed = new /obj/item/captaingun;
 	pixel_y = 6
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -28743,6 +28570,9 @@
 /obj/stool/chair{
 	dir = 8
 	},
+/obj/decal/tile_edge/floorguide/command{
+	dir = 1
+	},
 /turf/simulated/floor/black/side{
 	dir = 1
 	},
@@ -29433,11 +29263,6 @@
 	},
 /area/station/security/main)
 "bGH" = (
-/obj/stool/chair/comfy{
-	desc = "This old armchair has been pretty well mangled by owls.";
-	name = "hooty's throne"
-	},
-/obj/machinery/portableowl/judgementowl,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -29608,6 +29433,7 @@
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
+/obj/machinery/portableowl/judgementowl,
 /turf/simulated/floor/stairs/wood/wide{
 	dir = 9
 	},
@@ -31442,6 +31268,9 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/blind_switch/area/west{
+	pixel_y = -10
+	},
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/bridge/hos)
 "bLt" = (
@@ -33068,11 +32897,16 @@
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
 /obj/item/clothing/head/emerg,
-/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath{
+	pixel_y = 1
+	},
 /obj/item/tank/air,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility,
 /obj/machinery/light_switch/east,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 6
+	},
+/obj/item/storage/belt/utility,
 /turf/simulated/floor/white,
 /area/station/hangar/science)
 "bPx" = (
@@ -35221,13 +35055,17 @@
 /area/station/science/teleporter)
 "bWe" = (
 /obj/table/auto,
+/obj/machinery/phone,
 /obj/item/reagent_containers/food/snacks/sandwich/pbh{
 	desc = "A good luck charm from one of Heisenbee's relatives.";
-	name = "nice peanut butter and honey sandwich"
+	name = "nice peanut butter and honey sandwich";
+	pixel_x = -11;
+	pixel_y = -1
 	},
 /turf/simulated/floor/purplewhite,
 /area/station/science/teleporter)
 "bWf" = (
+/obj/storage/secure/closet/research/uniform,
 /turf/simulated/floor/purplewhite,
 /area/station/science/teleporter)
 "bWg" = (
@@ -37977,6 +37815,10 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
+/obj/item/robodefibrillator{
+	pixel_x = 4;
+	pixel_y = 15
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -39408,11 +39250,21 @@
 /area/space)
 "cgY" = (
 /obj/table/auto,
-/obj/item/reagent_containers/glass/oilcan,
-/obj/item/storage/toolbox/emergency,
-/obj/item/reagent_containers/glass/oilcan,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/glass/oilcan{
+	pixel_x = 7;
+	pixel_y = 2
+	},
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
+	},
+/obj/item/reagent_containers/glass/oilcan{
+	pixel_x = 1
 	},
 /turf/simulated/floor/caution/east,
 /area/station/medical/robotics)
@@ -40965,7 +40817,6 @@
 /area/research_outpost/indigo_rye)
 "cle" = (
 /obj/table/wood/auto,
-/obj/item/reagent_containers/food/snacks/snack_cake,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
@@ -40979,6 +40830,7 @@
 	name = "mysterious computer";
 	pixel_y = 30
 	},
+/obj/item/storage/fanny,
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/research_outpost/indigo_rye)
 "clf" = (
@@ -41231,15 +41083,20 @@
 /area/research_outpost/indigo_rye)
 "clJ" = (
 /obj/table/wood/auto,
-/obj/machinery/light/lamp,
 /obj/machinery/light/small,
+/obj/item/reagent_containers/food/snacks/snack_cake{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/obj/machinery/light/lamp,
 /turf/simulated/floor/purpleblack,
 /area/research_outpost/indigo_rye)
 "clK" = (
 /obj/table/wood/auto,
 /obj/deskclutter,
 /obj/item/paper{
-	info = "delta oblique seneca toreador neptune"
+	info = "delta oblique seneca toreador neptune";
+	name = "stale paper"
 	},
 /obj/item/pen,
 /turf/simulated/floor/purpleblack,
@@ -43336,13 +43193,6 @@
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"cIl" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor/engine,
-/area/station/engine/core)
 "cIR" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/disposalpipe/segment/transport{
@@ -43462,6 +43312,10 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
+"cOV" = (
+/turf/space,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/inner/west)
 "cPy" = (
 /obj/decal/tile_edge/stripe/big{
 	dir = 8
@@ -43698,6 +43552,13 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
+"dct" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "dcK" = (
 /obj/machinery/atmospherics/portables_connector/east,
 /obj/machinery/portable_atmospherics/canister/air/large,
@@ -43783,6 +43644,9 @@
 	},
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/light/small/floor/netural,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "dha" = (
@@ -43886,15 +43750,18 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "dlp" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	frequency = 1225;
+	icon_state = "intact_on";
+	id = "Cold Loop Purge Pump";
+	on = 1;
+	target_pressure = 2000
+	},
+/turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/space)
+/area/station/engine/coldloop)
 "dlL" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/robotics{
@@ -43905,13 +43772,15 @@
 	},
 /area/station/turret_protected/Zeta)
 "dlP" = (
-/obj/decal/xmas_lights/ephemeral{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 8
 	},
-/turf/simulated/floor/stairs/wide{
-	dir = 4
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
 	},
-/area/station/hallway/primary/north)
+/turf/space,
+/area/space)
 "dma" = (
 /obj/storage/secure/closet/brig,
 /obj/disposalpipe/segment/transport{
@@ -44432,15 +44301,14 @@
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "dTh" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/stairs{
+	dir = 8
+	},
 /area/station/engine/core)
 "dTK" = (
 /obj/table/wood/auto,
@@ -44502,7 +44370,6 @@
 /obj/item/furniture_parts/wheelchair,
 /obj/item/furniture_parts/surgery_tray,
 /obj/item/furniture_parts/IVstand,
-/obj/item/robodefibrillator,
 /turf/simulated/floor/white/grime,
 /area/station/hangar/medical)
 "dWT" = (
@@ -44750,13 +44617,14 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "ejI" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	name = "Auxiliary Purge"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/engine/hotloop)
 "ejP" = (
 /obj/stool/bench/red,
 /obj/disposalpipe/segment/brig{
@@ -44805,6 +44673,15 @@
 	icon_state = "engine_caution_south"
 	},
 /area/station/hangar/sec)
+"emQ" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/space)
 "enu" = (
 /obj/railing/orange/reinforced{
 	dir = 4
@@ -44904,6 +44781,16 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
+"erg" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "esb" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -44936,14 +44823,13 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "etO" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
+/area/station/engine/core)
 "euW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -45006,6 +44892,15 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"eyT" = (
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
+/area/space)
 "ezj" = (
 /obj/machinery/bot/duckbot,
 /turf/simulated/floor/wood,
@@ -45672,15 +45567,23 @@
 /turf/simulated/floor/plating,
 /area/station/routing/security)
 "foi" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/cable{
+	icon_state = "2-5"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-9"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
+/area/station/engine/core)
+"fom" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Core Access";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/turf/simulated/floor/engine/vacuum,
 /area/station/engine/core)
 "fpv" = (
 /obj/disposalpipe/segment/horizontal,
@@ -46161,6 +46064,11 @@
 	dir = 1
 	},
 /area/station/bridge)
+"fSc" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "fSI" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -46233,13 +46141,6 @@
 /obj/item/hand_labeler,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/south)
-"fWk" = (
-/obj/machinery/atmospherics/valve,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/core)
 "fWx" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet,
@@ -46575,13 +46476,11 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/east)
 "goX" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/decal/garland/ephemeral{
-	dir = 8;
-	pixel_x = 14
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/turf/simulated/floor/yellow/side,
-/area/station/hallway/primary/west)
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "gpc" = (
 /obj/cable{
 	d2 = 8;
@@ -46677,6 +46576,10 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/chem_grenade/metalfoam,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "guN" = (
@@ -46842,6 +46745,18 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"gBs" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/disposalpipe/segment/vertical,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/hallway/primary/south)
 "gBY" = (
 /obj/machinery/light{
 	dir = 8;
@@ -46931,6 +46846,9 @@
 	dir = 4;
 	pixel_x = 8
 	},
+/obj/decal/tile_edge/floorguide/command{
+	dir = 4
+	},
 /turf/simulated/floor/black/side,
 /area/station/hallway/primary/south)
 "gKo" = (
@@ -46966,16 +46884,15 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "gMO" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
 	},
-/obj/machinery/power/stats_meter{
-	name = "Hot Loop Combustion Chamber Meter";
-	tag = "Hot Loop Combustion Chamber Meter"
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/floor/plating,
 /area/station/engine/core)
 "gNp" = (
 /obj/machinery/disposal,
@@ -47108,11 +47025,16 @@
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
 "gSM" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 6
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/obj/decal/poster/wallsign/stencil/right/one{
+	layer = 2;
+	pixel_x = 15;
+	pixel_y = 12
+	},
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "gTx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -47503,6 +47425,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "hly" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
@@ -47851,6 +47778,16 @@
 "hHF" = (
 /obj/disposalpipe/segment/food,
 /obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
+"hHH" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/decal/tile_edge/floorguide/arrow_s{
+	dir = 4
+	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "hJP" = (
@@ -48266,7 +48203,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "iwq" = (
-/obj/machinery/space_heater,
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "ixo" = (
@@ -48437,6 +48374,13 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/secwing)
+"iEf" = (
+/obj/machinery/door/poddoor/pyro{
+	id = "combustion";
+	name = "Combustion Chamber Vent"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "iEB" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/plating,
@@ -48717,7 +48661,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/machinery/portable_atmospherics/pump,
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "iPv" = (
@@ -48764,9 +48708,12 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "iRP" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "iSr" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -48874,7 +48821,6 @@
 /area/station/security/brig)
 "iZx" = (
 /obj/grille/steel,
-/obj/disposalpipe/segment/mail/bent/west,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/north)
 "jal" = (
@@ -48897,8 +48843,16 @@
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
 "jdV" = (
-/obj/decal/poster/wallsign/danger_highvolt,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
 /area/station/engine/power)
 "jed" = (
 /obj/landmark{
@@ -49007,10 +48961,27 @@
 /turf/simulated/floor/plating,
 /area/station/hydroponics/bay)
 "jnb" = (
-/obj/wingrille_spawn/auto,
-/obj/decal/wreath/ephemeral,
-/turf/simulated/floor/plating,
+/obj/decal/tile_edge/line/green{
+	icon_state = "line1"
+	},
+/obj/machinery/door/airlock/pyro{
+	name = "Ranch Division"
+	},
+/obj/access_spawn/rancher,
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/dirt,
 /area/station/ranch)
+"jnr" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "jnz" = (
 /obj/table/auto,
 /obj/machinery/computer/security/wooden_tv/small{
@@ -49599,14 +49570,11 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "kbj" = (
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 4;
-	on = 1;
-	transfer_rate = 1000
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
+/obj/machinery/atmospherics/valve,
+/turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
 "kbP" = (
 /obj/wingrille_spawn/auto/crystal,
@@ -49893,7 +49861,6 @@
 /obj/item/storage/toilet{
 	dir = 4
 	},
-/obj/blind_switch/area/south,
 /obj/decal/tile_edge/line/black{
 	dir = 1;
 	icon_state = "line1"
@@ -50074,6 +50041,18 @@
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
+"kDw" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "kDV" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/black,
@@ -50278,12 +50257,8 @@
 /turf/simulated/floor/orangeblack/side,
 /area/station/quartermaster/office)
 "kTo" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	level = 2
-	},
-/obj/machinery/meter,
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -50367,6 +50342,18 @@
 	},
 /turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
+"kZN" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "kZX" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -50626,14 +50613,12 @@
 "lpu" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
@@ -50676,13 +50661,10 @@
 /turf/simulated/floor/red,
 /area/station/security/hos)
 "lrq" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 1;
-	level = 2
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "lrT" = (
@@ -51165,8 +51147,12 @@
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/west)
 "lRA" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor,
+/obj/firedoor_spawn,
+/turf/simulated/floor/yellow/corner,
 /area/station/hallway/primary/north)
 "lSk" = (
 /turf/simulated/floor/black,
@@ -51688,13 +51674,12 @@
 /turf/simulated/floor,
 /area/station/mining/magnet)
 "mHX" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/lattice{
-	dir = 8;
-	icon_state = "lattice-dir"
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/junction{
+	dir = 4
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/plating,
+/area/station/engine/coldloop)
 "mJy" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51870,6 +51855,16 @@
 	},
 /turf/simulated/floor/caution/east,
 /area/station/hangar/sec)
+"mSL" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 8
+	},
+/turf/space,
+/area/space)
 "mSM" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/middle{
@@ -52030,9 +52025,15 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
 "nbW" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
+/obj/machinery/atmospherics/mixer{
+	dir = 4;
+	frequency = 1225;
+	id_tag = "engine_combust";
+	master_id = "engine_combust_control";
+	name = "Gas Mixer (Combustion Chamber)"
+	},
+/turf/simulated/floor/caution/corner/ne,
+/area/station/engine/hotloop)
 "ncc" = (
 /obj/rack,
 /obj/machinery/light/small{
@@ -52045,6 +52046,17 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"ncM" = (
+/obj/machinery/atmospherics/pipe/simple/junction,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "ncP" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -52600,11 +52612,9 @@
 	},
 /area/station/chapel/sanctuary)
 "nNQ" = (
-/obj/disposalpipe/segment/mail/bent/east,
 /obj/machinery/light/emergency,
-/turf/simulated/floor/stairs/wide/other{
-	dir = 4
-	},
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor,
 /area/station/hallway/primary/north)
 "nNY" = (
 /obj/storage/secure/closet/brig,
@@ -52663,23 +52673,18 @@
 	},
 /area/station/routing/security)
 "nQL" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 4;
-	on = 1;
-	pixel_y = 1;
-	target_pressure = 1e+031
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/engine,
+/area/station/engine/core)
+"nRo" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
-"nRo" = (
-/obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
-/area/space)
 "nSc" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -53549,6 +53554,13 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
+"oWz" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/lattice,
+/turf/space,
+/area/space)
 "oWV" = (
 /obj/machinery/disposal/brig{
 	name = "escape checkpoint chute"
@@ -53789,6 +53801,16 @@
 /obj/item/device/light/flashlight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"pqS" = (
+/obj/grille/catwalk{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/area/space)
 "prs" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -54492,9 +54514,11 @@
 /area/station/hydroponics/bay)
 "qfl" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 6
+	dir = 9
 	},
-/turf/simulated/floor/blueblack,
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
 /area/station/engine/coldloop)
 "qha" = (
 /obj/machinery/weapon_stand/rifle_rack/recharger,
@@ -54911,17 +54935,13 @@
 /area/station/crew_quarters/quarters_south)
 "qJq" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
+"qJJ" = (
+/obj/wingrille_spawn/auto,
+/turf/space,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "qJN" = (
@@ -55003,14 +55023,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "qRd" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "qRn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55591,6 +55608,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
+"rzK" = (
+/obj/decal/poster/wallsign/hazard_coldloop,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/coldloop)
+"rzP" = (
+/turf/simulated/floor/caution/east,
+/area/station/engine/gas)
 "rAa" = (
 /obj/table/reinforced/auto,
 /obj/item/gun/kinetic/riot40mm{
@@ -55640,6 +55664,14 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/ce)
+"rBd" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/tile_edge/floorguide/hop{
+	dir = 4
+	},
+/obj/decal/tile_edge/floorguide/arrow_w,
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "rBy" = (
 /obj/machinery/atmospherics/pipe/manifold/south,
 /turf/simulated/wall/auto/supernorn,
@@ -55664,7 +55696,10 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/simulated/floor/grey,
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/stairs/wide/other{
+	dir = 4
+	},
 /area/station/hallway/primary/north)
 "rFf" = (
 /obj/machinery/atmospherics/valve{
@@ -56459,10 +56494,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/sw)
 "sJY" = (
-/obj/decal/poster/wallsign/warning1{
-	pixel_x = 6
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/floor/caution/corner/se,
 /area/station/engine/gas)
 "sKk" = (
 /obj/machinery/camera{
@@ -56776,8 +56808,8 @@
 	},
 /area/station/hallway/primary/east)
 "sWO" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
@@ -57296,6 +57328,14 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/magnet)
+"tzY" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
+"tAF" = (
+/obj/decal/poster/wallsign/warning1,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/gas)
 "tBq" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -57517,15 +57557,21 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/security/main)
-"tMp" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/decal/cleanable/oil,
+"tLP" = (
+/obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
+"tMp" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/two{
+	layer = 2;
+	pixel_x = 17;
+	pixel_y = 12
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "tNc" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/book/space_law,
@@ -57640,12 +57686,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "tVy" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	can_rupture = 0;
+/obj/machinery/atmospherics/valve{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
 "tWL" = (
 /obj/grille/catwalk,
@@ -57743,6 +57787,12 @@
 	},
 /turf/simulated/floor/yellow/corner,
 /area/station/hallway/primary/west)
+"ucG" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "ucN" = (
 /obj/table/wood/auto,
 /obj/item/item_box/gold_star{
@@ -58081,6 +58131,10 @@
 /obj/random_item_spawner/tools,
 /obj/item/device/light/glowstick,
 /obj/item/device/light/glowstick,
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 15;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "uvK" = (
@@ -58335,14 +58389,11 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "uMJ" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 4;
-	on = 1;
-	pixel_y = 1;
-	target_pressure = 1e+031
-	},
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -58392,9 +58443,7 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/halloween,
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_we"
-	},
+/turf/simulated/floor/engine/caution/westeast,
 /area/station/hallway/primary/west)
 "uQH" = (
 /obj/disposalpipe/segment/food,
@@ -58471,6 +58520,12 @@
 /area/station/routing/medsci{
 	name = "Research Router"
 	})
+"uXt" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "uZQ" = (
 /obj/cable{
 	icon_state = "2-5"
@@ -58840,6 +58895,13 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/southeast)
+"vzH" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "vAR" = (
 /obj/stool/bed,
 /obj/item/storage/secure/ssafe{
@@ -59019,9 +59081,6 @@
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "vIY" = (
@@ -59160,6 +59219,18 @@
 "vTk" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge/hos)
+"vTz" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Engine Core";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "vTK" = (
 /turf/simulated/floor/escape/corner{
 	dir = 1
@@ -59703,6 +59774,7 @@
 "wyb" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/disposalpipe/segment/vertical,
+/obj/decal/tile_edge/floorguide/hop,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "wyj" = (
@@ -59894,6 +59966,9 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/ranch)
 "wHG" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/north)
 "wHZ" = (
@@ -59926,6 +60001,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"wKN" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "wLh" = (
 /obj/machinery/computer3/generic/secure_data,
 /obj/machinery/power/data_terminal,
@@ -59944,12 +60026,12 @@
 	},
 /area/station/bridge)
 "wLi" = (
-/obj/machinery/light/emergency,
-/obj/machinery/atmospherics/pipe/manifold{
-	level = 2
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 4
 	},
-/obj/machinery/meter,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/plating,
 /area/station/engine/core)
 "wMb" = (
 /obj/table/reinforced/auto,
@@ -60437,16 +60519,25 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"xmA" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "xmF" = (
 /obj/disposalpipe/segment/vertical,
 /obj/landmark/halloween,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "xnb" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 4
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/area/station/hallway/primary/north)
+/turf/simulated/floor/plating,
+/area/station/engine/gas)
 "xnq" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport,
@@ -60512,16 +60603,11 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "xqF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "xqR" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -60835,9 +60921,10 @@
 /turf/simulated/floor,
 /area/station/security/secwing)
 "xIe" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "xJq" = (
@@ -60999,12 +61086,17 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/hangar/engine)
 "xQl" = (
-/obj/decal/tile_edge/floorguide/engineering{
-	desc = "The power transmission laser is in this direction.";
-	name = "PTL Navigation Guide";
-	pixel_y = 16
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/decal/tile_edge/floorguide/arrow_n,
+/obj/stool/chair/office/yellow{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/engine/power)
 "xQm" = (
@@ -61014,7 +61106,9 @@
 	id = "northconnector";
 	pixel_y = 32
 	},
-/turf/simulated/floor/grey,
+/turf/simulated/floor/stairs/wide{
+	dir = 4
+	},
 /area/station/hallway/primary/north)
 "xQB" = (
 /obj/grille/catwalk{
@@ -61450,7 +61544,10 @@
 	dir = 1;
 	name = "autoname - SS13"
 	},
-/turf/simulated/floor/grey,
+/obj/disposalpipe/segment/mail/horizontal,
+/turf/simulated/floor/stairs/wide{
+	dir = 8
+	},
 /area/station/hallway/primary/west)
 "ykc" = (
 /obj/wingrille_spawn/auto/crystal,
@@ -61471,15 +61568,15 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "ylQ" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 4;
+	on = 1;
+	transfer_rate = 1000
 	},
-/obj/lattice{
-	dir = 8;
-	icon_state = "lattice-dir"
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
 	},
-/turf/space,
-/area/space)
+/area/station/engine/coldloop)
 "ymh" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
@@ -97866,7 +97963,7 @@ aof
 inc
 ait
 aro
-arq
+auR
 atJ
 ait
 avz
@@ -102110,12 +102207,12 @@ aFa
 aGh
 aHq
 aJh
-aHq
+xnb
 aKq
 aHq
-bec
-bhG
-biW
+aHq
+aHq
+aHq
 aHq
 agE
 cQJ
@@ -102415,9 +102512,9 @@ aJi
 aJZ
 aKr
 aLE
-bfe
+aHq
 aNJ
-aNJ
+xmA
 aHq
 hgU
 qwl
@@ -102706,20 +102803,20 @@ asV
 asV
 asV
 asV
-aAS
-aAS
-aAS
-aAS
-aAS
-aAS
+aqN
+asV
+asV
+asV
+asV
+asV
 aHq
 aIm
 aKs
 aME
 bea
 bfi
-aNL
-aNL
+aNJ
+aNJ
 aHq
 hqM
 qwl
@@ -103008,20 +103105,20 @@ aaf
 aad
 aad
 aaf
-aAT
-aBQ
-aCU
-aEb
-aFb
-aGj
+aaf
+acO
+aaa
+aaa
+ach
+aaf
 aHq
 aIn
 aLF
 aKt
 aLG
-aMF
-aNL
-aNL
+aHq
+aHq
+aHq
 aHq
 fjf
 xrF
@@ -103310,19 +103407,19 @@ awS
 aaa
 aaa
 ach
-aAU
-aBR
+aGk
+aGk
 aCV
 aCV
-aFc
+aGk
 aGk
 aHq
-aHq
+iRP
 aJj
-aHq
+rzP
 sJY
-aMG
-aMG
+bfi
+aNL
 aNL
 aHq
 rTU
@@ -103612,19 +103709,19 @@ aaa
 aaa
 aaa
 ach
-aAU
+aFb
 aDa
 aCW
 aEc
 aFd
 aGl
-aHr
+aHq
 aIo
 aJk
 aKu
-aHq
-aMG
-aNM
+tzY
+tAF
+aNL
 aNK
 aHq
 eIB
@@ -103909,34 +104006,34 @@ arH
 arA
 ucz
 asV
-aaf
-aay
-aay
-aay
-aaf
-aAT
+acO
+aaa
+aaa
+aaa
+ach
+aCV
 aBS
-aCX
+aEd
 aEd
 aFe
 aGm
-aHs
-aIp
+aHq
+aHq
 aJl
-aKv
 aHq
 aHq
 aHq
+aNL
+aNL
 aHq
-aHq
-uIC
+jnr
 qwl
 jrg
 uIC
 rTU
 uIC
 odP
-rTU
+tLP
 iwq
 iPr
 cRL
@@ -104210,27 +104307,27 @@ ack
 arG
 arA
 lRp
-auL
-auL
-auL
-auL
-auL
-auL
-auL
-auN
-auN
+asV
+acO
+aaa
+aaa
+aaa
+ach
+aCV
+aHr
+aIw
 aEe
-auL
+aMN
 aGn
 aHt
 aIq
 aJm
 aKw
 aLH
-qRd
-xqF
-etO
-tMp
+aHq
+aHq
+aHq
+aHq
 qJq
 lpu
 duY
@@ -104512,29 +104609,29 @@ aqH
 arI
 asK
 atY
-auL
-avJ
-awT
-axU
-ayR
-azU
-aAV
+asV
+aaf
+aay
+aay
+aay
+aaf
+aGk
 aBT
 aCY
 aEf
 aFf
 aGo
-auN
+ejI
 aIr
 aJn
 aKx
-aAT
-uIC
+ucG
+vTz
 sWO
+erg
+vzH
+uXt
 gxC
-gxC
-gxC
-oDR
 gxC
 gxC
 gxC
@@ -104814,29 +104911,29 @@ ack
 arG
 asL
 atZ
-auM
-avK
-awU
-axV
-ayS
-azV
-aAW
-aBU
-aCZ
-aEg
-gSM
-wLi
+auL
+auL
+auL
+auL
+auL
+auL
+auL
 auN
+auN
+aEg
+auL
+wLi
+etO
 aIs
 aJo
 aKy
 aAS
-cRL
+aGk
 vHU
 ftA
-aaf
-abh
-abh
+gxC
+qJJ
+cOV
 bfj
 abh
 abh
@@ -105121,21 +105218,21 @@ avL
 awV
 axW
 ayT
-auL
+aDi
 aAX
-aBV
+aHs
 aDf
 dTh
-aBY
+aNM
 aGp
-auL
-auL
+auN
+nbW
 aJp
-aKz
-auL
+aKx
+wKN
 aMK
 abf
-aOK
+aaf
 abn
 aaa
 aaa
@@ -105420,23 +105517,23 @@ asN
 atX
 auX
 avM
-awW
+azY
 axV
 ayU
-auN
-aAY
-aBV
+aDt
+aGj
+aHu
 uMJ
 aEh
 kTo
 aDb
-aHu
+auN
 aIt
 aJq
-aKA
-aLI
-azW
-aad
+kDw
+aGk
+aGk
+mSL
 ceD
 abn
 aaa
@@ -105720,23 +105817,23 @@ aAE
 arL
 asM
 atX
-avR
+auL
 aIk
 aMD
-axX
+axV
 ayV
-auN
+auL
 aAZ
 aBV
-aDc
+aFk
 aEi
-aFg
+aFj
 aGq
-aHv
-aHv
+auL
+auL
 aJr
-aKA
-aLJ
+kZN
+auL
 aML
 aaa
 ach
@@ -106029,19 +106126,19 @@ axV
 ayW
 auN
 aAY
-aBW
+aBV
 aDd
 aEj
 aFh
-aGr
+bhG
 aHv
-aHv
+nRo
 aJs
 aKA
 aLI
-aML
-aaa
-ach
+aaY
+abZ
+aaf
 aba
 aQJ
 aQJ
@@ -106331,19 +106428,19 @@ axY
 ayX
 auN
 aBa
-aBX
+aBV
 aDe
 aEk
 aFi
 lrq
-fWk
+gMO
 gMO
 aJt
-aKB
+aKA
 aLJ
-azW
-aay
-aaf
+iEf
+aaa
+ach
 aba
 aQJ
 aQJ
@@ -106626,26 +106723,26 @@ bhN
 tIp
 asQ
 aub
-auL
+axU
 avP
-awY
-axZ
+awW
+axV
 ayY
-azW
-aBb
+auN
+aAY
 aBY
 foi
 aEl
 aGr
-cIl
-auL
-auL
-auL
-auL
-aLK
-auL
-nRo
-aaf
+nQL
+gMO
+gMO
+xqF
+aKA
+aLI
+iEf
+aaa
+ach
 aba
 aQJ
 aQJ
@@ -106928,25 +107025,25 @@ beb
 arL
 asR
 auc
-auL
-auL
+axX
+aza
 awZ
-auL
-auL
-auL
+aBo
+aBX
+auN
 aBc
 aBZ
 aDg
 aEm
-aDf
+aOK
 aGs
 aHw
 aIu
-aHw
+ncM
 aaV
-aaX
+aLJ
 aaY
-abg
+aay
 aaf
 aba
 aQJ
@@ -107230,25 +107327,25 @@ aqK
 arO
 asR
 aud
-aDX
+auL
 avQ
 axa
 aya
 ayZ
-auQ
-auL
+aaY
+aGu
 aFj
-auN
+aKv
 aEn
 nQL
-auN
+bhJ
 auL
 auL
 auL
-aaQ
-aaf
-aMN
-aad
+auL
+fom
+auL
+eyT
 aaf
 aba
 aQJ
@@ -107527,31 +107624,31 @@ alr
 amv
 anA
 aoB
-aoB
+apG
 aqL
-arE
+auM
 asS
 aud
-aHm
-aIl
+auL
+auL
 axb
-ayb
-aza
-azX
+auL
+auL
+auL
 aBd
 aCb
 aDh
 aEo
 aFk
 aGt
-aHx
+aJu
 aIv
 aJu
-aaQ
-acO
-aBj
-aaa
-aaO
+pqS
+fSc
+dct
+emQ
+aaf
 aba
 aQJ
 aQJ
@@ -107828,32 +107925,32 @@ ahE
 ahE
 ahE
 ahE
-ahE
+aaX
 ahE
 ahE
 arP
 asT
-aue
+aud
 auP
 avS
-avS
+aAW
 ayc
 azb
-azY
-aBe
+auQ
+auL
 aCc
-aDi
+auN
 aEp
 aCd
-aGu
-aHy
-aIw
-aCf
+auN
+auL
+auL
+auL
 aaQ
-acO
-aaa
-aaa
-acb
+aaf
+oWz
+aad
+aaf
 aba
 aQJ
 aQJ
@@ -108130,32 +108227,32 @@ akG
 ajG
 amw
 ajG
-ajG
-apG
-aqM
-arQ
+abg
+aGf
+aHo
+aKp
 asU
-goX
+aud
 jdV
 xQl
 axc
 ayd
 azc
-auQ
+aDX
 aBf
 qfl
 aDj
-aDj
+aLK
 aFl
 aGv
 aHz
 aIx
-aCf
+rzK
 aaQ
-aaf
-aay
-aay
-aaf
+acO
+dlP
+aaa
+aaO
 aba
 aQJ
 aQJ
@@ -108434,30 +108531,30 @@ amx
 akH
 akH
 apH
-aqN
+arQ
 arR
-asV
+avJ
 auf
-auQ
-avU
+axZ
+axd
 axd
 aye
 azd
-auQ
+aEb
 aBg
 kbj
 aCe
-aCe
+aMF
 aFm
 aGw
 aHA
 aIy
 aCf
 aaQ
-aaf
-aad
-aad
-aaf
+acO
+aaa
+aaa
+acb
 aba
 aQJ
 aQJ
@@ -108735,26 +108832,26 @@ als
 amy
 anB
 aoC
-apI
+aqM
 aqN
 arS
-awR
-arA
-auQ
-auQ
-auQ
-auQ
-auQ
+asV
+awT
+ayb
+azU
+aBb
+aBQ
+aCU
 auQ
 aBh
-aBh
-aCf
-aCf
+aHy
+aKz
+aKz
 aFn
 tVy
+goX
+qRd
 aCf
-aCf
-aFn
 aaQ
 acO
 aaa
@@ -109040,28 +109137,28 @@ aoC
 apJ
 aqN
 arT
-asX
+awR
 auh
-auR
+auQ
 avV
-aqN
+aBe
 azZ
-pCp
-pCp
-aBi
+aCZ
+auQ
+aHm
 ylQ
 aNr
-pCp
-hbu
+aNr
+bec
 dlp
-aaa
-aaa
-ach
+gSM
+tMp
+aCf
 aaQ
-acO
-aaa
-aaa
-ach
+aaf
+aad
+aad
+aaf
 aba
 abe
 abe
@@ -109342,23 +109439,23 @@ aoC
 apI
 aqN
 arU
-aug
+avK
 yjd
-aqN
-avW
-aqN
-chj
-azZ
-hbu
-azZ
+auQ
+auQ
+auQ
+auQ
+auQ
+auQ
 mHX
-aNr
-pCp
-aBi
+mHX
+aCf
+aCf
+bfe
 aBj
-aaa
-aaa
-ach
+aCf
+aCf
+bfe
 aaQ
 acO
 aaa
@@ -109645,19 +109742,19 @@ apK
 aqN
 aug
 vVG
-aug
-aqN
-avX
+awU
+ayR
+azV
 aaT
-chj
-chj
-chj
-chj
-ach
-acO
-aaa
-aaa
-aaa
+aBU
+pCp
+pCp
+aBi
+aIl
+aKB
+pCp
+hbu
+biW
 aaa
 aaa
 ach
@@ -109952,17 +110049,17 @@ aqN
 avX
 aaa
 chj
-chj
-chj
-chj
+aBU
+hbu
+aBU
+aIp
+aKB
+pCp
+aBi
+dlP
+aaa
+aaa
 ach
-aaf
-abZ
-abZ
-abZ
-abZ
-abZ
-aaf
 aaQ
 acO
 aaa
@@ -110555,18 +110652,18 @@ aaa
 aaa
 avX
 aaa
-bhJ
-aBi
-bhJ
-aBi
+chj
+chj
+chj
+chj
 ach
-acO
-aaa
-aaa
-aaa
-aaa
-aaa
-ach
+aaf
+abZ
+abZ
+abZ
+abZ
+abZ
+aaf
 aaW
 aaS
 aaZ
@@ -110857,10 +110954,10 @@ aaa
 aaa
 avX
 aaa
-aaa
-aaa
-aaa
-aaa
+chj
+chj
+chj
+chj
 ach
 acO
 aaa
@@ -111159,10 +111256,10 @@ aaa
 aaa
 avX
 aaa
-aaa
-aaa
-aaa
-aaa
+aBW
+aBi
+aBW
+aBi
 ach
 acO
 aaa
@@ -113269,9 +113366,9 @@ apK
 aFv
 wHG
 gBY
-wHG
-aFv
-avX
+awY
+ayS
+azX
 abX
 aaa
 aaa
@@ -113323,8 +113420,8 @@ etm
 emI
 bzs
 eaI
-bBs
-mwI
+rSW
+gBs
 bDF
 tQL
 bGD
@@ -113570,10 +113667,10 @@ aFv
 cCG
 aFv
 xQm
-wHG
+avR
 rDI
 aFv
-nbW
+aFv
 aFv
 abZ
 abZ
@@ -113625,8 +113722,8 @@ bxc
 gjq
 ltn
 bAz
-tah
-tZz
+bBs
+tvw
 bDA
 bEB
 dYo
@@ -113871,10 +113968,10 @@ aaa
 aFv
 ezu
 aFv
-dlP
-xnb
+bDr
+uzL
 nNQ
-iRP
+aFv
 iZx
 aFv
 aaa
@@ -114174,7 +114271,7 @@ avq
 atC
 avq
 xIe
-uzL
+aGL
 lRA
 auT
 auT
@@ -114474,9 +114571,9 @@ amJ
 axl
 aHP
 apU
-avq
+asX
 asa
-aGL
+avW
 aBm
 auT
 awi
@@ -114776,10 +114873,10 @@ amJ
 axi
 aKD
 uIf
-oIc
-aDt
-ejI
-aBo
+aue
+uzL
+uzL
+aum
 auT
 guJ
 hly
@@ -118762,7 +118859,7 @@ rOU
 boq
 bCI
 uKA
-bEL
+hHH
 vPj
 bGX
 bIv
@@ -122084,7 +122181,7 @@ bAL
 kli
 udY
 ygw
-bEv
+rBd
 chs
 maH
 ftU

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -7697,13 +7697,6 @@
 "auL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
-"auM" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/info{
-	name = "Book Nook"
-	})
 "auN" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -7716,28 +7709,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/podbay)
-"auP" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/power)
 "auQ" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/power)
-"auR" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Power Room";
+	req_access = null
+	},
+/obj/access_spawn/engineering_power,
+/obj/firedoor_spawn,
+/obj/decal/garland/ephemeral,
+/turf/simulated/floor/engine/caution/westeast,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "auS" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -7793,7 +7779,9 @@
 /obj/firedoor_spawn,
 /obj/decal/garland/ephemeral,
 /turf/simulated/floor/yellow,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "auY" = (
 /obj/table/wood/auto,
 /obj/loudspeaker,
@@ -8031,21 +8019,12 @@
 	},
 /area/station/hallway/primary/west)
 "avJ" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
-	},
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/radio/news_office)
-"avK" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/engine/caution/corner{
-	dir = 4
-	},
-/area/station/hallway/primary/west)
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/right,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "avL" = (
 /obj/rack,
 /obj/item/clothing/suit/fire,
@@ -8066,7 +8045,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "avM" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8074,7 +8055,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "avO" = (
 /obj/stool/bench/yellow/auto,
 /obj/cable{
@@ -8083,7 +8066,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "avP" = (
 /obj/stool/bench/yellow/auto,
 /obj/decal/xmas_lights/ephemeral{
@@ -8092,7 +8077,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "avQ" = (
 /obj/table/reinforced/auto,
 /obj/item/clothing/suit/fire/heavy,
@@ -8102,22 +8089,14 @@
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
-/area/station/engine/core)
-"avR" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 8
-	},
-/area/station/hallway/primary/west)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "avS" = (
 /obj/machinery/power/monitor{
 	dir = 4;
 	name = "Station Power Grid Monitoring"
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_west,
 /obj/machinery/power/data_terminal,
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
@@ -8125,7 +8104,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "avT" = (
 /obj/lattice{
 	dir = 1;
@@ -8149,12 +8130,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
-/area/station/engine/power)
-"avW" = (
-/turf/simulated/floor/stairs/wide/middle{
-	dir = 4
-	},
-/area/station/hallway/primary/north)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "avX" = (
 /obj/lattice{
 	dir = 4;
@@ -8512,18 +8490,15 @@
 /turf/space,
 /area/space)
 "awT" = (
-/obj/machinery/door/airlock/pyro/external{
+/obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/firedoor_spawn,
-/turf/simulated/floor/yellow/corner{
-	dir = 8
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/hallway/primary/west)
-"awU" = (
-/obj/disposalpipe/segment/mail/bent/south,
-/turf/simulated/floor/grey,
+/turf/simulated/floor,
 /area/station/hallway/primary/west)
 "awV" = (
 /obj/rack,
@@ -8534,28 +8509,32 @@
 /obj/item/chem_grenade/firefighting,
 /obj/item/chem_grenade/firefighting,
 /obj/item/extinguisher,
+/obj/machinery/power/apc/autoname_west,
 /obj/cable{
-	d2 = 8;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "awW" = (
 /obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "awX" = (
 /obj/cable{
 	d1 = 4;
@@ -8573,11 +8552,24 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "awY" = (
-/obj/disposalpipe/segment/mail/bent/east,
-/turf/simulated/floor/grey,
-/area/station/hallway/primary/north)
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "awZ" = (
 /obj/cable{
 	d1 = 4;
@@ -8585,7 +8577,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "axa" = (
 /obj/cable{
 	d1 = 4;
@@ -8595,7 +8589,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "axb" = (
 /obj/cable{
 	d1 = 4;
@@ -8610,7 +8606,9 @@
 /obj/access_spawn/engineering_engine,
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "axc" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8621,13 +8619,17 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "axd" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine/caution/westeast,
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "axe" = (
 /obj/table/wood/round/auto,
 /obj/item/pen,
@@ -8841,23 +8843,13 @@
 	},
 /area/station/hallway/primary/west)
 "axU" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
-"axV" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/engine/core)
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/radio/news_office)
 "axW" = (
 /obj/storage/secure/closet/engineering/engineer,
 /obj/machinery/light{
@@ -8868,35 +8860,26 @@
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/engine/core)
-"axX" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "axY" = (
 /obj/stool/chair/office/yellow,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "axZ" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Power Room";
-	req_access = null
-	},
-/obj/access_spawn/engineering_power,
-/obj/firedoor_spawn,
-/obj/decal/garland/ephemeral,
-/turf/simulated/floor/engine/caution/westeast,
-/area/station/engine/power)
+/turf/simulated/floor,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aya" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -8908,11 +8891,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
-/area/station/engine/core)
-"ayb" = (
-/obj/decal/poster/wallsign/danger_highvolt,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "ayc" = (
 /obj/machinery/power/smes{
 	charge = 1e+006;
@@ -8931,7 +8912,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "ayd" = (
 /obj/cable{
 	d1 = 1;
@@ -8945,7 +8928,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aye" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8956,7 +8941,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine/caution/westeast,
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "ayg" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -9249,13 +9236,13 @@
 	},
 /area/station/hallway/primary/west)
 "ayR" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/engine/caution/corner{
+	dir = 4
+	},
 /area/station/hallway/primary/west)
-"ayS" = (
-/obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/primary/north)
 "ayT" = (
 /obj/storage/secure/closet/engineering/electrical,
 /obj/item/clothing/suit/rad,
@@ -9268,19 +9255,25 @@
 /turf/simulated/floor/yellow/side{
 	dir = 10
 	},
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "ayU" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "ayV" = (
 /obj/machinery/power/reactor_stats,
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "ayW" = (
 /obj/machinery/computer3/terminal/zeta{
 	setup_os_string = "ZETA_MAINFRAME"
@@ -9288,13 +9281,17 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "ayX" = (
 /obj/machinery/computer/atmosphere/pumpcontrol,
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "ayY" = (
 /obj/machinery/computer/atmosphere/mixercontrol{
 	frequency = 1225;
@@ -9305,7 +9302,9 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/yellow/side,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "ayZ" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/emergency,
@@ -9316,19 +9315,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
-/area/station/engine/core)
-"aza" = (
-/obj/table/reinforced/auto,
-/obj/machinery/phone,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "azb" = (
 /obj/cable{
 	d2 = 4;
@@ -9345,7 +9334,9 @@
 	dir = 8;
 	icon_state = "engine_caution_misc"
 	},
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "azc" = (
 /obj/cable{
 	d1 = 4;
@@ -9361,7 +9352,9 @@
 /turf/simulated/floor/engine{
 	icon_state = "engine_caution_ns"
 	},
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "azd" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -9377,7 +9370,9 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine/caution/westeast,
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aze" = (
 /obj/storage/closet/wardrobe/black,
 /turf/simulated/floor/plating,
@@ -9722,44 +9717,29 @@
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "azU" = (
-/obj/decal/tile_edge/floorguide/engineering{
-	desc = "The power transmission laser is in this direction.";
-	name = "PTL Navigation Guide";
-	pixel_y = 16
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 8
 	},
-/obj/decal/tile_edge/floorguide/arrow_n,
-/turf/simulated/floor,
-/area/station/engine/power)
+/area/station/hallway/primary/west)
 "azV" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 4
 	},
-/obj/disposalpipe/segment/mail/bent/north,
-/turf/space,
-/area/space)
+/area/station/hallway/primary/north)
 "azX" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
 	},
-/obj/disposalpipe/segment/mail/bent/west,
-/turf/space,
-/area/space)
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/firedoor_spawn,
+/turf/simulated/floor/yellow/corner{
+	dir = 8
+	},
+/area/station/hallway/primary/west)
 "azY" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/engine/core)
+/obj/disposalpipe/segment/mail/bent/south,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/west)
 "azZ" = (
 /obj/machinery/power/smes{
 	charge = 1e+006;
@@ -9778,7 +9758,9 @@
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aAa" = (
 /obj/stool/chair/couch{
 	dir = 4;
@@ -10155,15 +10137,9 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "aAW" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 8
-	},
-/area/station/engine/power)
+/obj/disposalpipe/segment/mail/bent/east,
+/turf/simulated/floor/grey,
+/area/station/hallway/primary/north)
 "aAX" = (
 /obj/machinery/atmospherics/pipe/tank,
 /turf/simulated/floor/engine,
@@ -10198,11 +10174,31 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aBb" = (
-/turf/simulated/floor,
-/area/station/engine/power)
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aBc" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/cable{
+	icon_state = "6-10"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -10214,30 +10210,28 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aBe" = (
-/obj/storage/crate/furnacefuel,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/item/device/radio/intercom/engineering{
-	dir = 8;
-	pixel_x = 21;
-	pixel_y = -3
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/engine/power)
+/turf/simulated/floor/plating,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aBf" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
 	},
-/obj/machinery/portable_atmospherics/pump,
+/obj/table/auto,
+/obj/item/device/analyzer/atmospheric{
+	pixel_x = -4
+	},
+/obj/item/device/t_scanner{
+	pixel_x = 7
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -10317,9 +10311,11 @@
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "aBo" = (
-/obj/stool/chair/office/yellow,
-/turf/simulated/floor,
-/area/station/engine/core)
+/obj/decal/poster/wallsign/danger_highvolt,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aBp" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -10515,32 +10511,26 @@
 	},
 /area/station/hallway/primary/west)
 "aBQ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/engine/power)
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/west)
 "aBS" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "aBT" = (
+/obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
 /area/station/engine/hotloop)
 "aBU" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/turf/space,
-/area/space)
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/north)
 "aBV" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -10548,25 +10538,35 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aBW" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/turf/space,
-/area/space)
-"aBX" = (
 /obj/table/reinforced/auto,
-/obj/item/storage/firstaid/fire{
-	pixel_x = -4
+/obj/machinery/phone,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 4
+/turf/simulated/floor/yellow/side{
+	dir = 1
 	},
-/turf/simulated/floor/yellow/side,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
+"aBX" = (
+/obj/machinery/atmospherics/pipe/manifold{
+	level = 2
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/engine,
 /area/station/engine/core)
 "aBY" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
 	level = 2
+	},
+/obj/cable{
+	icon_state = "5-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -10869,18 +10869,16 @@
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "aCU" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/decal/tile_edge/floorguide/engineering{
+	desc = "The power transmission laser is in this direction.";
+	name = "PTL Navigation Guide";
+	pixel_y = 16
 	},
-/obj/stool/chair/office/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_ns"
-	},
-/area/station/engine/power)
+/obj/decal/tile_edge/floorguide/arrow_n,
+/turf/simulated/floor,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aCV" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -10909,27 +10907,13 @@
 	},
 /area/station/engine/hotloop)
 "aCZ" = (
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/machinery/power/monitor/smes{
-	dir = 8;
-	name = "Engine Output Monitoring"
-	},
-/obj/machinery/firealarm{
+/obj/lattice{
 	dir = 4;
-	pixel_x = 26;
-	pixel_y = 1
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/engine{
-	dir = 4;
-	icon_state = "engine_caution_misc"
-	},
-/area/station/engine/power)
+/obj/disposalpipe/segment/mail/bent/north,
+/turf/space,
+/area/space)
 "aDa" = (
 /obj/reagent_dispensers/foamtank,
 /obj/machinery/light{
@@ -10983,6 +10967,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/data_terminal,
+/obj/cable,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aDf" = (
@@ -11024,9 +11009,13 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aDi" = (
-/obj/decal/poster/wallsign/hazard_caution,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/core)
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/obj/disposalpipe/segment/mail/bent/west,
+/turf/space,
+/area/space)
 "aDj" = (
 /obj/machinery/atmospherics/pipe/tank{
 	dir = 4
@@ -11132,19 +11121,17 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
 "aDt" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engine Core";
-	req_access = null
-	},
 /obj/cable{
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/access_spawn/engineering_engine,
-/obj/firedoor_spawn,
 /turf/simulated/floor/yellow/side{
-	dir = 1
+	dir = 8
 	},
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aDu" = (
 /obj/machinery/light{
 	dir = 1;
@@ -11325,7 +11312,9 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aDU" = (
 /obj/table/wood/auto,
 /obj/item/paper_bin,
@@ -11352,14 +11341,9 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/core)
-"aDX" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/poster/wallsign/hazard_coldloop,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aDY" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -11383,18 +11367,10 @@
 	},
 /area/station/hallway/primary/west)
 "aEb" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Power Room";
-	req_access = null
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/access_spawn/engineering_power,
-/obj/access_spawn/engineering_engine,
-/obj/firedoor_spawn,
-/turf/simulated/floor/engine/caution/misc,
-/area/station/engine/power)
+/turf/simulated/floor,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aEc" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
@@ -11508,11 +11484,14 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
 	},
-/obj/item/paper/engine,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aEm" = (
 /obj/machinery/atmospherics/binary/circulatorTemp/right,
+/obj/item/paper/engine{
+	pixel_x = -8;
+	pixel_y = 5
+	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aEn" = (
@@ -11773,9 +11752,25 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aFb" = (
-/obj/decal/poster/wallsign/hazard_hotloop,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/hotloop)
+/obj/storage/crate/furnacefuel,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/item/device/radio/intercom/engineering{
+	dir = 8;
+	pixel_x = 21;
+	pixel_y = -3
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aFd" = (
 /obj/table/reinforced/auto,
 /obj/cable{
@@ -11783,9 +11778,18 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
-/obj/item/storage/firstaid/toxin,
 /obj/item/device/analyzer/atmospheric,
-/obj/item/wrench,
+/obj/item/wrench{
+	pixel_y = -6
+	},
+/obj/item/device/analyzer/atmosanalyzer_upgrade{
+	pixel_x = 6;
+	pixel_y = -16
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -5;
+	pixel_y = 6
+	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -11808,6 +11812,15 @@
 	dir = 4
 	},
 /area/station/engine/hotloop)
+"aFg" = (
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 8;
+	on = 1;
+	pixel_y = 1;
+	target_pressure = 1e+031
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "aFh" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -11843,6 +11856,11 @@
 	on = 1;
 	pixel_y = 1;
 	target_pressure = 1e+031
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-9"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -12192,11 +12210,11 @@
 	},
 /area/station/hallway/primary/west)
 "aGj" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/stairs,
-/area/station/engine/core)
+/obj/stool/chair/office/yellow,
+/turf/simulated/floor,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aGk" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/hotloop)
@@ -12221,7 +12239,7 @@
 /obj/decal/poster/wallsign/space{
 	layer = 2;
 	name = "DIRECT VENTING";
-	pixel_y = 22
+	pixel_y = -15
 	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
@@ -12298,18 +12316,11 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aGu" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/turf/space,
+/area/space)
 "aGv" = (
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/orangeblack/side{
@@ -12595,21 +12606,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
-"aHm" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 8;
-	on = 1;
-	transfer_rate = 1000
-	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/engine/coldloop)
 "aHn" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Detective's Room";
@@ -12641,28 +12637,26 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
 "aHr" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
-"aHs" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 9.1;
-	pixel_x = -10
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/obj/machinery/atmospherics/valve,
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/turf/space,
+/area/space)
+"aHs" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -4
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 4
+	},
+/turf/simulated/floor/yellow/side,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aHt" = (
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -12671,18 +12665,30 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
 /turf/simulated/floor/redblack,
 /area/station/engine/hotloop)
 "aHu" = (
-/obj/machinery/meter,
 /obj/cable{
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 6
+/obj/stool/chair/office/yellow{
+	dir = 4
 	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/turf/simulated/floor/engine{
+	icon_state = "engine_caution_ns"
+	},
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aHv" = (
 /obj/machinery/atmospherics/valve,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -12695,11 +12701,29 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "aHy" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 6
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/power/monitor/smes{
+	dir = 8;
+	name = "Engine Output Monitoring"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/turf/simulated/floor/engine{
+	dir = 4;
+	icon_state = "engine_caution_misc"
+	},
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aHz" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 8;
@@ -12942,30 +12966,23 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aIj" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/obj/lattice{
-	dir = 8;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/space)
+/obj/decal/poster/wallsign/hazard_caution,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core)
 "aIk" = (
 /obj/stool/bench/yellow/auto,
 /obj/item/device/radio/intercom/engineering,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aIl" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/lattice{
-	dir = 8;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/space)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aIm" = (
 /obj/machinery/manufacturer/gas,
 /obj/item/device/radio/intercom/engineering,
@@ -12986,16 +13003,19 @@
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aIp" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	frequency = 1225;
-	icon_state = "intact_on";
-	id = "Hot Loop Gas Supply 1";
-	on = 1;
-	target_pressure = 1000
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Engine Core";
+	req_access = null
 	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/engine/core)
 "aIq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -13062,16 +13082,14 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aIw" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 6
-	},
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-9"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/obj/decal/poster/wallsign/hazard_coldloop,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aIx" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 5
@@ -13794,12 +13812,20 @@
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aKv" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 8;
-	level = 2
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Power Room";
+	req_access = null
 	},
-/turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/access_spawn/engineering_power,
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/turf/simulated/floor/engine/caution/misc,
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aKw" = (
 /obj/storage/closet/fire,
 /obj/machinery/light{
@@ -13823,25 +13849,19 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "aKz" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/space)
+/obj/decal/poster/wallsign/hazard_hotloop,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/hotloop)
 "aKA" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
 "aKB" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
-/area/station/engine/coldloop)
+/turf/simulated/floor/stairs,
+/area/station/engine/core)
 "aKC" = (
 /obj/machinery/light{
 	dir = 4;
@@ -14143,11 +14163,15 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
 "aLK" = (
-/obj/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/turf/simulated/floor/blueblack,
-/area/station/engine/coldloop)
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "aLL" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/disposalpipe/segment/vertical,
@@ -14382,21 +14406,27 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
-/area/station/engine/core)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "aME" = (
 /turf/simulated/floor/caution/west,
 /area/station/engine/gas)
 "aMF" = (
-/obj/cable{
-	icon_state = "2-5"
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "5-8"
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8;
+	on = 1;
+	transfer_rate = 1000
 	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/engine/coldloop)
 "aMI" = (
 /obj/stool/chair/couch{
 	dir = 4
@@ -14429,26 +14459,9 @@
 /turf/space,
 /area/space)
 "aMN" = (
-/obj/table/reinforced/auto,
-/obj/item/device/analyzer/atmospheric{
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/obj/item/device/analyzer/atmosanalyzer_upgrade,
-/obj/machinery/door_control{
-	id = "fireshield";
-	name = "Heat Shield";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/machinery/door_control{
-	id = "combustion";
-	name = "Chamber Exhaust";
-	pixel_x = -24;
-	pixel_y = -8
-	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "aMO" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/decal/tile_edge/stripe/extra_big,
@@ -14736,21 +14749,12 @@
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aNM" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 5
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
 	},
-/obj/machinery/power/stats_meter{
-	name = "Cold Loop Outlet Meter";
-	tag = "Cold Loop Outlet Meter"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
-	},
+/obj/machinery/atmospherics/valve,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aNQ" = (
@@ -14979,18 +14983,15 @@
 	},
 /area/station/security/checkpoint/escape)
 "aOK" = (
-/obj/machinery/atmospherics/unary/cold_sink/freezer{
-	dir = 8
+/obj/machinery/meter,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 6
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/engine/coldloop)
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "aOL" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -16363,6 +16364,16 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_north)
+"aSv" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/decal/tile_edge/floorguide/arrow_s{
+	dir = 4
+	},
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "aSw" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -20137,7 +20148,10 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/podbay)
 "bec" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
+	},
+/turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
 "bef" = (
 /obj/stool/chair{
@@ -20458,12 +20472,15 @@
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "bfe" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 1;
-	level = 2
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "bff" = (
 /obj/lattice{
 	dir = 1;
@@ -21161,12 +21178,13 @@
 /turf/simulated/floor/darkblue,
 /area/station/storage/eva)
 "bhG" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
 	},
-/obj/machinery/light/emergency,
-/turf/simulated/floor/engine,
-/area/station/engine/core)
+/turf/space,
+/area/space)
 "bhI" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -21174,15 +21192,16 @@
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "bhJ" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	dir = 4
-	},
-/obj/lattice{
+/obj/machinery/atmospherics/binary/pump{
 	dir = 4;
-	icon_state = "lattice-dir"
+	frequency = 1225;
+	icon_state = "intact_on";
+	id = "Hot Loop Gas Supply 1";
+	on = 1;
+	target_pressure = 1000
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "bhK" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -21691,15 +21710,16 @@
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
 "biW" = (
-/obj/machinery/atmospherics/pipe/vent{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 6
 	},
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir"
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-9"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "biX" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/specialroom/arcade,
@@ -22221,12 +22241,12 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "bkO" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 8;
+	level = 2
 	},
-/obj/warp_beacon/engineering,
-/turf/space,
-/area/space)
+/turf/simulated/floor/blueblack,
+/area/station/engine/coldloop)
 "bkP" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/food/drinks/bottle/champagne{
@@ -42933,6 +42953,15 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
+"crg" = (
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
+/area/space)
 "crn" = (
 /obj/table/round/auto,
 /obj/item/gobowl/w,
@@ -43552,6 +43581,13 @@
 	dir = 1
 	},
 /area/station/storage/emergency)
+"daI" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "dcb" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit/green,
@@ -43769,14 +43805,13 @@
 	},
 /area/station/turret_protected/Zeta)
 "dlP" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4;
-	name = "Auxiliary Purge"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 4
-	},
-/area/station/engine/hotloop)
+/turf/space,
+/area/space)
 "dma" = (
 /obj/storage/secure/closet/brig,
 /obj/disposalpipe/segment/transport{
@@ -43859,16 +43894,6 @@
 /obj/item/device/light/glowstick,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
-"dpL" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/atmospherics/pipe/vent{
-	dir = 8
-	},
-/turf/space,
-/area/space)
 "dqu" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -44623,13 +44648,13 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "ejI" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 10
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/engine/coldloop)
 "ejP" = (
 /obj/stool/bench/red,
 /obj/disposalpipe/segment/brig{
@@ -44809,10 +44834,10 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/quarters_east)
 "etO" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
+/obj/cable{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/caution/north,
+/turf/simulated/floor/blueblack,
 /area/station/engine/coldloop)
 "euW" = (
 /obj/cable{
@@ -44963,6 +44988,15 @@
 	},
 /turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
+"eGu" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/space)
 "eGO" = (
 /obj/railing/orange/reinforced{
 	dir = 4
@@ -45270,16 +45304,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
-"fbF" = (
-/obj/grille/catwalk{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/space)
 "fbU" = (
 /obj/stool/bar,
 /obj/cable{
@@ -45323,18 +45347,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/routing/security)
-"feE" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
 "fgr" = (
 /obj/shrub{
 	dir = 10
@@ -45351,6 +45363,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"fgQ" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "fhx" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -45657,8 +45675,10 @@
 /turf/simulated/floor/escape,
 /area/station/hallway/secondary/exit)
 "ftA" = (
-/obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/supernorn,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "ftT" = (
 /obj/machinery/vehicle/pod_smooth/heavy,
@@ -45882,6 +45902,16 @@
 /area/station/maintenance/storage{
 	name = "Secure Atmospherics"
 	})
+"fGT" = (
+/obj/machinery/atmospherics/mixer{
+	dir = 4;
+	frequency = 1225;
+	id_tag = "engine_combust";
+	master_id = "engine_combust_control";
+	name = "Gas Mixer (Combustion Chamber)"
+	},
+/turf/simulated/floor/caution/corner/ne,
+/area/station/engine/hotloop)
 "fIi" = (
 /obj/machinery/power/apc/autoname_west/noaicontrol,
 /obj/cable{
@@ -46423,18 +46453,21 @@
 	},
 /turf/simulated/floor/white/checker,
 /area/station/crew_quarters/pool)
-"gmi" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "gmO" = (
 /obj/machinery/floorflusher/solitary2,
 /obj/disposalpipe/trunk/south,
 /turf/simulated/floor/black,
 /area/station/security/brig/solitary)
+"gnr" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "gnU" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/unsimulated/floor/circuit/vintage,
@@ -46466,16 +46499,16 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/east)
 "goX" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/cable{
+	icon_state = "2-5"
 	},
-/obj/decal/poster/wallsign/stencil/right/one{
-	layer = 2;
-	pixel_x = 15;
-	pixel_y = 12
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "5-8"
 	},
-/turf/simulated/floor/caution/north,
-/area/station/engine/coldloop)
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "gpc" = (
 /obj/cable{
 	d2 = 8;
@@ -46597,6 +46630,16 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/ai_monitored/armory)
+"gvD" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "gvH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -46631,6 +46674,10 @@
 /obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"gwz" = (
+/obj/decal/poster/wallsign/hazard_coldloop,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/coldloop)
 "gwF" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -47020,15 +47067,22 @@
 /turf/simulated/floor/black/grime,
 /area/station/routing/depot)
 "gSM" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/table/reinforced/auto,
+/obj/machinery/door_control{
+	id = "fireshield";
+	name = "Heat Shield";
+	pixel_x = -24;
+	pixel_y = 8
 	},
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
+/obj/machinery/door_control{
+	id = "combustion";
+	name = "Chamber Exhaust";
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/obj/machinery/phone,
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "gTx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -47055,6 +47109,18 @@
 	icon_state = "platingdmg3"
 	},
 /area/station/maintenance/southeast)
+"gVb" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
 "gVh" = (
 /obj/cable{
 	d1 = 1;
@@ -47242,18 +47308,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/south)
-"hbs" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/hallway/primary/west)
 "hbu" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -47314,10 +47368,6 @@
 	dir = 4
 	},
 /area/station/routing/security)
-"hdj" = (
-/obj/decal/poster/wallsign/warning1,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/gas)
 "hdT" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -47350,6 +47400,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
+"hfy" = (
+/obj/decal/poster/wallsign/warning1,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/gas)
 "hgw" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
@@ -47455,12 +47509,6 @@
 /obj/decal/garland/ephemeral,
 /turf/simulated/floor/black,
 /area/station/bridge)
-"hlS" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "hmG" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -48128,6 +48176,19 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/courtroom)
+"iqt" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
+"iqv" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/lattice,
+/turf/space,
+/area/space)
 "iro" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -48707,15 +48768,23 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "iRP" = (
-/obj/machinery/atmospherics/mixer{
-	dir = 4;
-	frequency = 1225;
-	id_tag = "engine_combust";
-	master_id = "engine_combust_control";
-	name = "Gas Mixer (Combustion Chamber)"
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 5
 	},
-/turf/simulated/floor/caution/corner/ne,
-/area/station/engine/hotloop)
+/obj/machinery/power/stats_meter{
+	name = "Cold Loop Outlet Meter";
+	tag = "Cold Loop Outlet Meter"
+	},
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "iSr" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -48727,6 +48796,10 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/bridge)
+"iSF" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "iSH" = (
 /obj/table/auto,
 /obj/machinery/coffeemaker/botany,
@@ -48790,6 +48863,13 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
+"iXA" = (
+/obj/machinery/door/poddoor/pyro{
+	id = "combustion";
+	name = "Combustion Chamber Vent"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "iXW" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/alarm{
@@ -48805,9 +48885,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
-"iYU" = (
-/turf/simulated/floor/caution/east,
-/area/station/engine/gas)
 "iZd" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "General Population"
@@ -48837,10 +48914,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/maintenance/southeast)
-"jaV" = (
-/turf/space,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/west)
 "jcj" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -48862,7 +48935,9 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "jed" = (
 /obj/landmark{
 	name = "Observer-Start"
@@ -48964,13 +49039,6 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"jmx" = (
-/obj/machinery/door/poddoor/pyro{
-	id = "combustion";
-	name = "Combustion Chamber Vent"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "jna" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/food,
@@ -49066,11 +49134,18 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "jrg" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0
+/obj/machinery/atmospherics/unary/cold_sink/freezer{
+	dir = 8
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/core)
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/engine/coldloop)
 "jrn" = (
 /obj/machinery/door/airlock/pyro/command{
 	dir = 4;
@@ -49302,18 +49377,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"jML" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
 "jNl" = (
 /obj/table/reinforced/auto,
 /obj/item/hand_labeler{
@@ -50062,6 +50125,15 @@
 /obj/machinery/chem_master,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
+"kFk" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/gas)
 "kGp" = (
 /obj/stool/chair{
 	dir = 1
@@ -50482,12 +50554,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/red/side,
 /area/station/security/secwing)
-"lhi" = (
-/obj/cable{
-	icon_state = "2-5"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
 "lhD" = (
 /obj/machinery/light{
 	dir = 1;
@@ -50802,6 +50868,11 @@
 	dir = 4
 	},
 /area/station/security/secwing)
+"lwE" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "lwM" = (
 /obj/decal/poster/wallsign/stencil/left/e{
 	pixel_x = -1
@@ -51173,11 +51244,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"lVd" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "lVB" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/brig{
@@ -51729,6 +51795,11 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"mKW" = (
+/obj/wingrille_spawn/auto,
+/turf/space,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "mLb" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/magnet)
@@ -51894,6 +51965,13 @@
 /obj/machinery/turret,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"mTN" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "mTQ" = (
 /obj/table/reinforced/auto,
 /obj/item/wrench,
@@ -51911,16 +51989,6 @@
 	dir = 8
 	},
 /area/station/mining/magnet)
-"mUN" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/decal/tile_edge/floorguide/arrow_s{
-	dir = 4
-	},
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
 "mVi" = (
 /obj/fluid_spawner{
 	amount = 2100
@@ -52029,10 +52097,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
 "nbW" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/caution/south,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/coldloop)
 "ncc" = (
 /obj/rack,
@@ -52170,6 +52235,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
+"nma" = (
+/turf/space,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/inner/west)
 "nmf" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -52669,16 +52738,12 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "nRo" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 1;
+	level = 2
 	},
-/obj/decal/poster/wallsign/stencil/right/two{
-	layer = 2;
-	pixel_x = 17;
-	pixel_y = 12
-	},
-/turf/simulated/floor/caution/south,
-/area/station/engine/coldloop)
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "nSc" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -52907,11 +52972,6 @@
 	dir = 6
 	},
 /area/station/security/interrogation)
-"ogc" = (
-/obj/wingrille_spawn/auto,
-/turf/space,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "ogf" = (
 /obj/item/device/radio/intercom{
 	dir = 4
@@ -53777,14 +53837,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
-"poJ" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/decal/tile_edge/floorguide/hop{
-	dir = 4
-	},
-/obj/decal/tile_edge/floorguide/arrow_w,
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
 "poX" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
@@ -54032,13 +54084,6 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space)
-"pCH" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "pCV" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/cable{
@@ -54174,18 +54219,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
-"pLo" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engine Core";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
 "pLp" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -54462,10 +54495,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"qaF" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "qaK" = (
 /obj/rack,
 /obj/item/clothing/suit/fire,
@@ -54487,6 +54516,18 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
+"qcu" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "qdv" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -54529,6 +54570,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 9
 	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -54879,16 +54921,6 @@
 /obj/stool/chair,
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
 /area/station/crew_quarters/arcade/dungeon)
-"qzP" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/decal/cleanable/oil,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "qAR" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/neutral/side{
@@ -54932,13 +54964,6 @@
 "qGc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
-"qGG" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/obj/lattice,
-/turf/space,
-/area/space)
 "qHq" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -55052,14 +55077,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
 "qRd" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/engine/gas)
+/obj/machinery/light/emergency,
+/turf/simulated/floor/engine,
+/area/station/engine/core)
 "qRn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55118,6 +55141,18 @@
 /obj/access_spawn/mining,
 /turf/simulated/floor/grey,
 /area/station/mining/magnet)
+"qTm" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Engine Core";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "qTA" = (
 /obj/stool/chair{
 	dir = 1
@@ -55127,6 +55162,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"qTR" = (
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "qUf" = (
 /obj/cable{
 	d1 = 1;
@@ -55303,6 +55346,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
+"rdW" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "ree" = (
 /turf/space,
 /area/station/mining/magnet)
@@ -55397,6 +55446,17 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
+"rhS" = (
+/obj/machinery/atmospherics/pipe/simple/junction,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "riw" = (
 /obj/grille/catwalk{
 	dir = 6
@@ -55470,14 +55530,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
-"rlE" = (
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "rlK" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -56132,11 +56184,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
-"sdL" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "set" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/wood,
@@ -56247,6 +56294,11 @@
 /obj/machinery/r_door_control/podbay/security/new_walls/east,
 /turf/simulated/floor/engine,
 /area/station/hangar/sec)
+"snS" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "soA" = (
 /obj/stool,
 /obj/decal/xmas_lights/ephemeral{
@@ -56258,6 +56310,17 @@
 /obj/machinery/turret,
 /turf/simulated/floor/greenblack,
 /area/station/turret_protected/Zeta)
+"soX" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/one{
+	layer = 2;
+	pixel_x = 15;
+	pixel_y = 12
+	},
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "spB" = (
 /obj/disposalpipe/segment/brig{
 	dir = 2;
@@ -56614,6 +56677,18 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
+"sPd" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "sPt" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -56631,6 +56706,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"sPL" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core)
 "sQa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56647,6 +56728,14 @@
 	dir = 8
 	},
 /area/station/medical/medbooth)
+"sQX" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/tile_edge/floorguide/hop{
+	dir = 4
+	},
+/obj/decal/tile_edge/floorguide/arrow_w,
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "sRn" = (
 /obj/machinery/computer3/generic/communications,
 /obj/machinery/power/data_terminal,
@@ -56671,6 +56760,15 @@
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"sSF" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Core Access";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core)
 "sSO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -56851,6 +56949,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"sYb" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "sYq" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -57345,15 +57449,6 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/routing/depot)
-"tym" = (
-/obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
-/area/space)
 "tzu" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -57473,6 +57568,17 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
+"tEU" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/two{
+	layer = 2;
+	pixel_x = 17;
+	pixel_y = 12
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "tEZ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -57589,11 +57695,15 @@
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "tMp" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	dir = 4
 	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "tNc" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/book/space_law,
@@ -58440,6 +58550,9 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"uOy" = (
+/turf/simulated/floor/caution/east,
+/area/station/engine/gas)
 "uPl" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/cargo_router/kd_med_left,
@@ -58634,6 +58747,16 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"vgo" = (
+/obj/grille/catwalk{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/area/space)
 "vgI" = (
 /obj/cable{
 	d1 = 1;
@@ -58673,6 +58796,14 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
+"viz" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "viJ" = (
 /obj/storage/crate,
 /obj/item/reagent_containers/food/snacks/ingredient/flour,
@@ -59081,10 +59212,8 @@
 	},
 /area/station/mining/magnet)
 "vHU" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/obj/decal/poster/wallsign/space,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/west)
 "vIY" = (
 /obj/wingrille_spawn/auto,
@@ -59312,6 +59441,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"vYg" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "vZp" = (
 /obj/machinery/door/airlock/pyro/security,
 /obj/cable{
@@ -59427,18 +59562,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig/solitary)
-"weA" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/hotloop)
 "wfc" = (
 /obj/cable{
 	d1 = 1;
@@ -59649,6 +59772,15 @@
 "wrE" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
+"wrM" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/warp_beacon{
+	name = "inner hangars beacon"
+	},
+/turf/space,
+/area/space)
 "wsb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -60144,6 +60276,16 @@
 /obj/item/tile/steel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"wQH" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 8
+	},
+/turf/space,
+/area/space)
 "wQJ" = (
 /obj/rack,
 /obj/item/clothing/suit/armor/heavy,
@@ -60338,13 +60480,6 @@
 /area/station/crew_quarters/info{
 	name = "Book Nook"
 	})
-"xen" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "xew" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -60529,16 +60664,15 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "xnb" = (
-/obj/machinery/atmospherics/pipe/simple/junction,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 8
 	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "xnq" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/transport,
@@ -60604,9 +60738,14 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "xqF" = (
-/obj/decal/poster/wallsign/hazard_coldloop,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/coldloop)
+/obj/machinery/atmospherics/valve{
+	dir = 4;
+	name = "Auxiliary Purge"
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/engine/hotloop)
 "xqR" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -60829,6 +60968,13 @@
 /obj/machinery/cashreg,
 /turf/simulated/floor/carpet/green/standard/narrow/northsouth,
 /area/station/crew_quarters/cafeteria)
+"xCX" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "xDz" = (
 /obj/disposalpipe/junction/right/west,
 /obj/machinery/atmospherics/pipe/simple{
@@ -60926,15 +61072,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"xIn" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/space)
 "xJq" = (
 /obj/lattice{
 	dir = 8;
@@ -61094,11 +61231,6 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/hangar/engine)
 "xQl" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/stool/chair/office/yellow{
 	dir = 8
 	},
@@ -61106,7 +61238,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/engine/power)
+/area/station/engine/power{
+	name = "Engineering Control Room"
+	})
 "xQm" = (
 /obj/machinery/computer/airbr{
 	density = 0;
@@ -61346,6 +61480,18 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/southwest)
+"xYw" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "xYH" = (
 /obj/lattice{
 	dir = 4;
@@ -61442,15 +61588,6 @@
 	dir = 8
 	},
 /area/station/security/secwing)
-"yfH" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Core Access";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/core)
 "yfK" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 10
@@ -97980,7 +98117,7 @@ aof
 inc
 ait
 aro
-avJ
+axU
 atJ
 ait
 avz
@@ -101925,7 +102062,7 @@ aHp
 aJf
 aHp
 ayO
-hbs
+gVb
 vBz
 aHp
 aPA
@@ -102224,7 +102361,7 @@ aFa
 aGh
 aHq
 aJh
-qRd
+kFk
 aKq
 aHq
 aHq
@@ -102531,7 +102668,7 @@ aKr
 aLE
 aHq
 aNJ
-sdL
+lwE
 aHq
 hgU
 qwl
@@ -103431,9 +103568,9 @@ aCV
 aGk
 aGk
 aHq
-gSM
+gvD
 aJj
-iYU
+uOy
 sJY
 bfi
 aNL
@@ -103726,7 +103863,7 @@ aaa
 aaa
 aaa
 ach
-aFb
+aKz
 aDa
 aCW
 aEc
@@ -103736,8 +103873,8 @@ aHq
 aIo
 aJk
 aKu
-rlE
-hdj
+qTR
+hfy
 aNL
 aNK
 aHq
@@ -104040,17 +104177,17 @@ aJl
 aHq
 aHq
 aHq
-pCH
+xCX
 aNL
 aHq
-qzP
+gnr
 qwl
 uIC
 uIC
 rTU
 uIC
 odP
-qaF
+iSF
 iwq
 iPr
 cRL
@@ -104331,10 +104468,10 @@ aaa
 aaa
 ach
 aCV
-aHr
-aIp
+aMN
+bhJ
 aEe
-aMF
+goX
 aGn
 aHt
 aIq
@@ -104638,16 +104775,16 @@ aCY
 aEf
 aFf
 aGo
-dlP
+xqF
 aIr
 aJn
 aKx
-lhi
-pLo
+iqt
+qTm
 sWO
 sWO
-gmi
-hlS
+daI
+vYg
 gxC
 gxC
 gxC
@@ -104928,11 +105065,11 @@ ack
 arG
 asL
 atZ
-auL
-auL
-auL
-auL
-auL
+aIl
+aIl
+aIl
+aIl
+aIl
 auL
 auL
 auN
@@ -104940,7 +105077,7 @@ auN
 aEg
 auL
 wLi
-ejI
+viz
 aIs
 aJo
 aKy
@@ -104949,8 +105086,8 @@ aGk
 vHU
 ftA
 gxC
-ogc
-jaV
+mKW
+nma
 bfj
 abh
 abh
@@ -105230,23 +105367,23 @@ ack
 arJ
 cIc
 atX
-auL
+aIl
 avL
 awV
 axW
 ayT
-aDi
+aIj
 aAX
-aHs
+aNM
 aDf
 dTh
-aMN
+gSM
 aGp
 auN
-iRP
+fGT
 aJp
 aKx
-jML
+sPd
 aMK
 abf
 aaf
@@ -105534,12 +105671,12 @@ asN
 atX
 auX
 avM
-azY
-axV
+awW
+axZ
 ayU
-aDt
-aGj
-aHu
+aIp
+aKB
+aOK
 uMJ
 aEh
 kTo
@@ -105547,10 +105684,10 @@ aDb
 auN
 aIt
 aJq
-weA
+qcu
 aGk
 aGk
-dpL
+wQH
 ceD
 abn
 aaa
@@ -105834,22 +105971,22 @@ aAE
 arL
 asM
 atX
-auL
+aIl
 aIk
 aMD
-axV
+axZ
 ayV
 auL
 aAZ
 aBV
 aFk
 aEi
-aFj
+aFg
 aGq
 auL
 auL
 aJr
-feE
+xYw
 auL
 aML
 aaa
@@ -106138,8 +106275,8 @@ asO
 atY
 aDT
 avP
-awW
-axV
+awY
+axZ
 ayW
 auN
 aAY
@@ -106147,9 +106284,9 @@ aBV
 aDd
 aEj
 aFh
-bfe
+nRo
 aHv
-jrg
+sPL
 aJs
 aKA
 aLI
@@ -106445,7 +106582,7 @@ axY
 ayX
 auN
 aBa
-aBV
+aBX
 aDe
 aEk
 aFi
@@ -106455,7 +106592,7 @@ gMO
 aJt
 aKA
 aLJ
-jmx
+iXA
 aaa
 ach
 aba
@@ -106740,10 +106877,10 @@ bhN
 tIp
 asQ
 aub
-axU
+aBb
 avP
-awW
-axV
+awY
+axZ
 ayY
 auN
 aAY
@@ -106754,10 +106891,10 @@ aGr
 nQL
 gMO
 gMO
-tMp
+rdW
 aKA
 aLI
-jmx
+iXA
 aaa
 ach
 aba
@@ -107042,21 +107179,21 @@ beb
 arL
 asR
 aud
-axX
-aza
+aBe
+aBW
 awZ
-aBo
-aBX
+aGj
+aHs
 auN
 aBc
 aBZ
 aDg
 aEm
-aNM
+iRP
 aGs
 aHw
 aIu
-xnb
+rhS
 aaV
 aLJ
 aaY
@@ -107344,25 +107481,25 @@ aqK
 arO
 asR
 aud
-auL
+aIl
 avQ
 axa
 aya
 ayZ
-aaY
-aGu
+auL
+aLK
 aFj
-aIw
+biW
 aEn
 nQL
-bhG
+qRd
 auL
 auL
 auL
 auL
-yfH
+sSF
 auL
-tym
+crg
 aaf
 aba
 aQJ
@@ -107643,14 +107780,14 @@ anA
 aoB
 aqM
 aqL
-auR
+awT
 asS
 aud
-auL
-auL
+aIl
+aIl
 axb
-auL
-auL
+aIl
+aIl
 auL
 aBd
 aCb
@@ -107661,10 +107798,10 @@ aGt
 aJu
 aIv
 aJu
-fbF
-lVd
-xen
-xIn
+vgo
+snS
+mTN
+eGu
 aaf
 aba
 aQJ
@@ -107948,12 +108085,12 @@ ahE
 arP
 asT
 aue
-auP
+aDT
 avS
-aAW
+aDt
 ayc
 azb
-auQ
+auL
 auL
 aCc
 auN
@@ -107965,7 +108102,7 @@ auL
 auL
 aaQ
 aaf
-qGG
+iqv
 aad
 aaf
 aba
@@ -108255,19 +108392,19 @@ xQl
 axc
 ayd
 azc
-aDX
+aIw
 aBf
 qfl
 aDj
-aKB
+ejI
 aFl
 aGv
 aHz
 aIx
-xqF
+gwz
 aaQ
 acO
-biW
+xnb
 aaa
 aaO
 aba
@@ -108550,18 +108687,18 @@ akH
 apH
 asX
 arR
-avK
+ayR
 auf
-axZ
+auQ
 axd
 axd
 aye
 azd
-aEb
+aKv
 aBg
 kbj
 aCe
-aLK
+etO
 aFm
 aGw
 aHA
@@ -108853,21 +108990,21 @@ arQ
 aqN
 arS
 asV
-awT
-ayb
-azU
-aBb
-aBQ
+azX
+aBo
 aCU
-auQ
+aEb
+awZ
+aHu
+aIl
 aBh
-aHy
-aKv
-aKv
+bec
+bkO
+bkO
 aFn
 tVy
-etO
-nbW
+sYb
+fgQ
 aCf
 aaQ
 acO
@@ -109156,25 +109293,25 @@ aqN
 arT
 awR
 auh
-auQ
+aIl
 avV
-aBe
+aFb
 azZ
-aCZ
-auQ
-aHm
+aHy
+aIl
+aMF
 ylQ
 aNr
 aNr
-aOK
+jrg
 dlp
-goX
-nRo
+soX
+tEU
 aCf
 aaQ
 aaf
-aad
-aad
+abZ
+abZ
 aaf
 aba
 abe
@@ -109456,23 +109593,23 @@ aoC
 apI
 aqN
 arU
-avR
+azU
 yjd
-auQ
-auQ
-auQ
-auQ
-auQ
-auQ
+aIl
+aIl
+aIl
+aIl
+aIl
+aIl
 mHX
 mHX
 aCf
 aCf
-bec
+nbW
 aBj
 aCf
 aCf
-bec
+nbW
 aaQ
 acO
 aaa
@@ -109759,19 +109896,19 @@ apK
 aqN
 aug
 vVG
-awU
-ayR
-azV
+azY
+aBQ
+aCZ
 aaT
-aBU
+aGu
 pCp
 pCp
 aBi
-aIj
-aKz
+bfe
+dlP
 pCp
 hbu
-bhJ
+tMp
 aaa
 aaa
 ach
@@ -110066,14 +110203,14 @@ aqN
 avX
 aaa
 chj
-aBU
+aGu
 hbu
-aBU
-aIl
-aKz
+aGu
+bhG
+dlP
 pCp
 aBi
-biW
+xnb
 aaa
 aaa
 ach
@@ -111273,9 +111410,9 @@ aaa
 aaa
 avX
 aaa
-aBW
+aHr
 aBi
-aBW
+aHr
 aBi
 ach
 acO
@@ -111901,12 +112038,12 @@ aaa
 aci
 aaa
 aaa
-aci
-aaa
-aaa
-aaa
-aaa
-aaa
+ach
+aay
+abZ
+abZ
+abZ
+abZ
 abl
 abZ
 abZ
@@ -112205,7 +112342,7 @@ aaa
 aaa
 ieG
 gvH
-aci
+aaa
 aaa
 aaa
 aaa
@@ -112507,9 +112644,9 @@ aaa
 aaa
 ach
 ooE
-acO
-aaa
-aaa
+aay
+aay
+aay
 tuN
 riw
 aaa
@@ -112798,13 +112935,13 @@ aci
 aaa
 ach
 aaQ
+aaf
+abZ
+abZ
+wrM
+abZ
+abZ
 acO
-aaa
-aaa
-aaa
-aaa
-aaa
-aci
 aaa
 aaa
 ach
@@ -113383,9 +113520,9 @@ apK
 aFv
 wHG
 gBY
-awY
-ayS
-azX
+aAW
+aBU
+aDi
 abX
 aaa
 aaa
@@ -113402,13 +113539,13 @@ bwp
 aXM
 aCh
 aaQ
-aad
-abZ
-abZ
-abZ
-abZ
-abZ
-acO
+awS
+aaa
+aaa
+aaa
+aaa
+aaa
+aci
 aaa
 aaa
 ach
@@ -113684,7 +113821,7 @@ aFv
 cCG
 aFv
 xQm
-avW
+azV
 rDI
 aFv
 aFv
@@ -114310,7 +114447,7 @@ aCh
 aaQ
 aaf
 abZ
-bkO
+abZ
 abZ
 abZ
 abZ
@@ -114890,7 +115027,7 @@ amJ
 axi
 aKD
 uIf
-auM
+avJ
 uzL
 uzL
 aum
@@ -118876,7 +119013,7 @@ rOU
 boq
 bCI
 uKA
-mUN
+aSv
 vPj
 bGX
 bIv
@@ -122198,7 +122335,7 @@ bAL
 kli
 udY
 ygw
-poJ
+sQX
 chs
 maH
 ftU

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -16364,16 +16364,6 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_north)
-"aSv" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/decal/tile_edge/floorguide/arrow_s{
-	dir = 4
-	},
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
 "aSw" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -29567,6 +29557,7 @@
 	pixel_x = 5
 	},
 /obj/item/device/radio/intercom/bridge,
+/obj/blind_switch/area/west,
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
 /area/station/bridge/hos)
 "bHi" = (
@@ -31295,9 +31286,6 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
-	},
-/obj/blind_switch/area/west{
-	pixel_y = -10
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/sw,
 /area/station/bridge/hos)
@@ -42953,15 +42941,6 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
-"crg" = (
-/obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
-/area/space)
 "crn" = (
 /obj/table/round/auto,
 /obj/item/gobowl/w,
@@ -43047,6 +43026,12 @@
 /obj/machinery/light_switch/east,
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
+"cyk" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "cyl" = (
 /obj/grille/steel,
 /turf/simulated/floor/black/grime,
@@ -43581,13 +43566,6 @@
 	dir = 1
 	},
 /area/station/storage/emergency)
-"daI" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "dcb" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit/green,
@@ -43863,6 +43841,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"dpt" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "dpu" = (
 /obj/storage/secure/closet/fridge/kitchen,
 /obj/item/reagent_containers/food/drinks/milk,
@@ -44297,6 +44282,16 @@
 	dir = 9
 	},
 /area/station/security/secwing)
+"dQR" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 8
+	},
+/turf/space,
+/area/space)
 "dRk" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/grime,
@@ -44988,15 +44983,6 @@
 	},
 /turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
-"eGu" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/space)
 "eGO" = (
 /obj/railing/orange/reinforced{
 	dir = 4
@@ -45148,6 +45134,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"ePG" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "eQE" = (
 /obj/grille/catwalk,
 /obj/machinery/oreaccumulator,
@@ -45363,12 +45359,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"fgQ" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/caution/south,
-/area/station/engine/coldloop)
 "fhx" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -45902,16 +45892,6 @@
 /area/station/maintenance/storage{
 	name = "Secure Atmospherics"
 	})
-"fGT" = (
-/obj/machinery/atmospherics/mixer{
-	dir = 4;
-	frequency = 1225;
-	id_tag = "engine_combust";
-	master_id = "engine_combust_control";
-	name = "Gas Mixer (Combustion Chamber)"
-	},
-/turf/simulated/floor/caution/corner/ne,
-/area/station/engine/hotloop)
 "fIi" = (
 /obj/machinery/power/apc/autoname_west/noaicontrol,
 /obj/cable{
@@ -46177,6 +46157,12 @@
 	dir = 10
 	},
 /area/station/mining/magnet)
+"fYh" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "fYk" = (
 /obj/disposalpipe/junction/right/north,
 /turf/simulated/floor,
@@ -46259,6 +46245,11 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
+"geP" = (
+/obj/wingrille_spawn/auto,
+/turf/space,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "geV" = (
 /obj/lattice{
 	dir = 10;
@@ -46458,16 +46449,6 @@
 /obj/disposalpipe/trunk/south,
 /turf/simulated/floor/black,
 /area/station/security/brig/solitary)
-"gnr" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/decal/cleanable/oil,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "gnU" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/unsimulated/floor/circuit/vintage,
@@ -46630,16 +46611,6 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/ai_monitored/armory)
-"gvD" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "gvH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -46674,10 +46645,6 @@
 /obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"gwz" = (
-/obj/decal/poster/wallsign/hazard_coldloop,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/coldloop)
 "gwF" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -47096,6 +47063,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
+"gTA" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "gTZ" = (
 /obj/decal/poster/wallsign/security_right,
 /turf/simulated/wall/auto/supernorn,
@@ -47109,18 +47082,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/station/maintenance/southeast)
-"gVb" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/hallway/primary/west)
 "gVh" = (
 /obj/cable{
 	d1 = 1;
@@ -47158,6 +47119,10 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -20
+	},
+/obj/item/device/radio/intercom/engineering{
+	pixel_x = 4;
+	pixel_y = 24
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
@@ -47263,6 +47228,13 @@
 /obj/decal/tile_edge/floorguide/arrow_s,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"haf" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/warp_beacon/engineering,
+/turf/space,
+/area/space)
 "hal" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Holding Cell One"
@@ -47400,10 +47372,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
-"hfy" = (
-/obj/decal/poster/wallsign/warning1,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/gas)
 "hgw" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
@@ -47802,6 +47770,22 @@
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"hEA" = (
+/obj/decal/poster/wallsign/hazard_coldloop,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/coldloop)
+"hEG" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "hFc" = (
 /obj/table/wood/round/auto,
 /obj/item/storage/toolbox{
@@ -48176,19 +48160,12 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/courtroom)
-"iqt" = (
+"iqZ" = (
 /obj/cable{
-	icon_state = "2-5"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
-"iqv" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/obj/lattice,
-/turf/space,
-/area/space)
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "iro" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -48796,10 +48773,6 @@
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/bridge)
-"iSF" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "iSH" = (
 /obj/table/auto,
 /obj/machinery/coffeemaker/botany,
@@ -48839,6 +48812,12 @@
 	dir = 1
 	},
 /area/station/security/secwing)
+"iVi" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core)
 "iVC" = (
 /obj/stool,
 /obj/item/device/radio/intercom{
@@ -48863,13 +48842,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
-"iXA" = (
-/obj/machinery/door/poddoor/pyro{
-	id = "combustion";
-	name = "Combustion Chamber Vent"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "iXW" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/alarm{
@@ -48924,6 +48896,18 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
+"jdp" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Engine Core";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "jdV" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -49371,12 +49355,36 @@
 /obj/machinery/hydro_growlamp,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"jHZ" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/space)
 "jJP" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"jMP" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
+"jNg" = (
+/obj/machinery/door/poddoor/pyro{
+	id = "combustion";
+	name = "Combustion Chamber Vent"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "jNl" = (
 /obj/table/reinforced/auto,
 /obj/item/hand_labeler{
@@ -49878,6 +49886,10 @@
 	dir = 1
 	},
 /area/station/mining/magnet)
+"kpt" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "kpw" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating{
@@ -50125,15 +50137,6 @@
 /obj/machinery/chem_master,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"kFk" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/gas)
 "kGp" = (
 /obj/stool/chair{
 	dir = 1
@@ -50378,6 +50381,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"kVG" = (
+/turf/space,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/inner/west)
 "kWb" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/electrical,
@@ -50868,11 +50875,6 @@
 	dir = 4
 	},
 /area/station/security/secwing)
-"lwE" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "lwM" = (
 /obj/decal/poster/wallsign/stencil/left/e{
 	pixel_x = -1
@@ -51093,6 +51095,13 @@
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
+"lKI" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "lMa" = (
 /obj/machinery/light{
 	dir = 4;
@@ -51335,6 +51344,16 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/simulated/floor/plating/damaged1,
 /area/station/security/beepsky)
+"mem" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/decal/tile_edge/floorguide/arrow_s{
+	dir = 4
+	},
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "mep" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -51423,6 +51442,17 @@
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hangar/engine)
+"mmg" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/two{
+	layer = 2;
+	pixel_x = 17;
+	pixel_y = 12
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "mmn" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8;
@@ -51795,11 +51825,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"mKW" = (
-/obj/wingrille_spawn/auto,
-/turf/space,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "mLb" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/magnet)
@@ -51916,6 +51941,13 @@
 	dir = 8
 	},
 /area/station/hallway/primary/east)
+"mRV" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "mSv" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -51965,13 +51997,6 @@
 /obj/machinery/turret,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"mTN" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "mTQ" = (
 /obj/table/reinforced/auto,
 /obj/item/wrench,
@@ -52235,10 +52260,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
-"nma" = (
-/turf/space,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/west)
 "nmf" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -52396,6 +52417,18 @@
 	dir = 8
 	},
 /area/station/routing/security)
+"nvE" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
 "nwI" = (
 /obj/stool/chair/office/red,
 /obj/disposalpipe/segment/brig{
@@ -53259,6 +53292,16 @@
 	dir = 8
 	},
 /area/station/science/testchamber)
+"owm" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "owG" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/landmark/halloween,
@@ -53292,6 +53335,17 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/east)
+"owO" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/one{
+	layer = 2;
+	pixel_x = 15;
+	pixel_y = 12
+	},
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "owU" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -53482,6 +53536,16 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
+"oMv" = (
+/obj/grille/catwalk{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/area/space)
 "oNK" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/disposalpipe/junction/right/north,
@@ -54516,18 +54580,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
-"qcu" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/hotloop)
 "qdv" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -55076,6 +55128,9 @@
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"qPm" = (
+/turf/simulated/floor/caution/east,
+/area/station/engine/gas)
 "qRd" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -55141,18 +55196,6 @@
 /obj/access_spawn/mining,
 /turf/simulated/floor/grey,
 /area/station/mining/magnet)
-"qTm" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engine Core";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
 "qTA" = (
 /obj/stool/chair{
 	dir = 1
@@ -55162,14 +55205,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"qTR" = (
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "qUf" = (
 /obj/cable{
 	d1 = 1;
@@ -55346,12 +55381,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/com_dish/comdish)
-"rdW" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "ree" = (
 /turf/space,
 /area/station/mining/magnet)
@@ -55446,17 +55475,6 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
-"rhS" = (
-/obj/machinery/atmospherics/pipe/simple/junction,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "riw" = (
 /obj/grille/catwalk{
 	dir = 6
@@ -55569,6 +55587,14 @@
 "rnN" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
+/area/station/hallway/primary/south)
+"rox" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/tile_edge/floorguide/hop{
+	dir = 4
+	},
+/obj/decal/tile_edge/floorguide/arrow_w,
+/turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "rrc" = (
 /obj/machinery/door/airlock/pyro/security{
@@ -55749,6 +55775,13 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/ce)
+"rBd" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/lattice,
+/turf/space,
+/area/space)
 "rBy" = (
 /obj/machinery/atmospherics/pipe/manifold/south,
 /turf/simulated/wall/auto/supernorn,
@@ -56294,11 +56327,6 @@
 /obj/machinery/r_door_control/podbay/security/new_walls/east,
 /turf/simulated/floor/engine,
 /area/station/hangar/sec)
-"snS" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "soA" = (
 /obj/stool,
 /obj/decal/xmas_lights/ephemeral{
@@ -56310,17 +56338,6 @@
 /obj/machinery/turret,
 /turf/simulated/floor/greenblack,
 /area/station/turret_protected/Zeta)
-"soX" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/decal/poster/wallsign/stencil/right/one{
-	layer = 2;
-	pixel_x = 15;
-	pixel_y = 12
-	},
-/turf/simulated/floor/caution/north,
-/area/station/engine/coldloop)
 "spB" = (
 /obj/disposalpipe/segment/brig{
 	dir = 2;
@@ -56427,6 +56444,15 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/station/crew_quarters/quarters_north)
+"swR" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Core Access";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core)
 "swT" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -56656,6 +56682,16 @@
 /obj/critter/cat/jones,
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/bridge)
+"sNK" = (
+/obj/machinery/atmospherics/mixer{
+	dir = 4;
+	frequency = 1225;
+	id_tag = "engine_combust";
+	master_id = "engine_combust_control";
+	name = "Gas Mixer (Combustion Chamber)"
+	},
+/turf/simulated/floor/caution/corner/ne,
+/area/station/engine/hotloop)
 "sNP" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/hazard_bio,
@@ -56677,18 +56713,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
-"sPd" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
 "sPt" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -56706,12 +56730,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
-"sPL" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/core)
 "sQa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56728,14 +56746,6 @@
 	dir = 8
 	},
 /area/station/medical/medbooth)
-"sQX" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/decal/tile_edge/floorguide/hop{
-	dir = 4
-	},
-/obj/decal/tile_edge/floorguide/arrow_w,
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
 "sRn" = (
 /obj/machinery/computer3/generic/communications,
 /obj/machinery/power/data_terminal,
@@ -56760,15 +56770,6 @@
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"sSF" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Core Access";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/core)
 "sSO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -56869,6 +56870,10 @@
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
+"sUM" = (
+/obj/decal/poster/wallsign/warning1,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/gas)
 "sVu" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -56949,12 +56954,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"sYb" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/caution/north,
-/area/station/engine/coldloop)
 "sYq" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -57568,17 +57567,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
-"tEU" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/decal/poster/wallsign/stencil/right/two{
-	layer = 2;
-	pixel_x = 17;
-	pixel_y = 12
-	},
-/turf/simulated/floor/caution/south,
-/area/station/engine/coldloop)
 "tEZ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -57894,6 +57882,11 @@
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"ubB" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "ubE" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
@@ -57935,7 +57928,6 @@
 	pixel_y = 21
 	},
 /obj/item/deconstructor,
-/obj/item/device/radio/intercom/engineering,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -58063,6 +58055,15 @@
 	dir = 5
 	},
 /area/station/hallway/primary/east)
+"ukT" = (
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
+/area/space)
 "ule" = (
 /turf/simulated/floor/caution/east,
 /area/station/hangar/sec)
@@ -58550,9 +58551,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"uOy" = (
-/turf/simulated/floor/caution/east,
-/area/station/engine/gas)
 "uPl" = (
 /obj/disposalpipe/segment/horizontal,
 /obj/machinery/cargo_router/kd_med_left,
@@ -58747,16 +58745,11 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
-"vgo" = (
-/obj/grille/catwalk{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/space)
+"vgv" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "vgI" = (
 /obj/cable{
 	d1 = 1;
@@ -58796,14 +58789,6 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
-"viz" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
 "viJ" = (
 /obj/storage/crate,
 /obj/item/reagent_containers/food/snacks/ingredient/flour,
@@ -59292,6 +59277,18 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
+"vPO" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "vRn" = (
 /obj/disposaloutlet/south,
 /obj/disposalpipe/trunk/east,
@@ -59441,12 +59438,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"vYg" = (
+"vZk" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "2-5"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "vZp" = (
 /obj/machinery/door/airlock/pyro/security,
 /obj/cable{
@@ -59772,15 +59769,6 @@
 "wrE" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
-"wrM" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/warp_beacon{
-	name = "inner hangars beacon"
-	},
-/turf/space,
-/area/space)
 "wsb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -59827,6 +59815,17 @@
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/south)
+"wuh" = (
+/obj/machinery/atmospherics/pipe/simple/junction,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "wwg" = (
 /obj/cable{
 	d1 = 4;
@@ -60276,16 +60275,15 @@
 /obj/item/tile/steel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"wQH" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
+"wQy" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/vent{
-	dir = 8
-	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/plating,
+/area/station/engine/gas)
 "wQJ" = (
 /obj/rack,
 /obj/item/clothing/suit/armor/heavy,
@@ -60803,6 +60801,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
+"xrM" = (
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "xtO" = (
 /obj/rack,
 /obj/item/clothing/suit/space/captain,
@@ -60968,13 +60974,6 @@
 /obj/machinery/cashreg,
 /turf/simulated/floor/carpet/green/standard/narrow/northsouth,
 /area/station/crew_quarters/cafeteria)
-"xCX" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "xDz" = (
 /obj/disposalpipe/junction/right/west,
 /obj/machinery/atmospherics/pipe/simple{
@@ -61480,18 +61479,6 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/station/maintenance/southwest)
-"xYw" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
 "xYH" = (
 /obj/lattice{
 	dir = 4;
@@ -61635,6 +61622,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"yhg" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "yhi" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -102062,7 +102061,7 @@ aHp
 aJf
 aHp
 ayO
-gVb
+nvE
 vBz
 aHp
 aPA
@@ -102361,7 +102360,7 @@ aFa
 aGh
 aHq
 aJh
-kFk
+wQy
 aKq
 aHq
 aHq
@@ -102668,7 +102667,7 @@ aKr
 aLE
 aHq
 aNJ
-lwE
+vgv
 aHq
 hgU
 qwl
@@ -103568,9 +103567,9 @@ aCV
 aGk
 aGk
 aHq
-gvD
+ePG
 aJj
-uOy
+qPm
 sJY
 bfi
 aNL
@@ -103873,8 +103872,8 @@ aHq
 aIo
 aJk
 aKu
-qTR
-hfy
+xrM
+sUM
 aNL
 aNK
 aHq
@@ -104177,17 +104176,17 @@ aJl
 aHq
 aHq
 aHq
-xCX
+dpt
 aNL
 aHq
-gnr
+owm
 qwl
 uIC
 uIC
 rTU
 uIC
 odP
-iSF
+kpt
 iwq
 iPr
 cRL
@@ -104779,12 +104778,12 @@ xqF
 aIr
 aJn
 aKx
-iqt
-qTm
+vZk
+jdp
 sWO
 sWO
-daI
-vYg
+mRV
+iqZ
 gxC
 gxC
 gxC
@@ -105077,7 +105076,7 @@ auN
 aEg
 auL
 wLi
-viz
+jMP
 aIs
 aJo
 aKy
@@ -105086,8 +105085,8 @@ aGk
 vHU
 ftA
 gxC
-mKW
-nma
+geP
+kVG
 bfj
 abh
 abh
@@ -105380,10 +105379,10 @@ dTh
 gSM
 aGp
 auN
-fGT
+sNK
 aJp
 aKx
-sPd
+hEG
 aMK
 abf
 aaf
@@ -105684,10 +105683,10 @@ aDb
 auN
 aIt
 aJq
-qcu
+yhg
 aGk
 aGk
-wQH
+dQR
 ceD
 abn
 aaa
@@ -105986,7 +105985,7 @@ aGq
 auL
 auL
 aJr
-xYw
+vPO
 auL
 aML
 aaa
@@ -106286,7 +106285,7 @@ aEj
 aFh
 nRo
 aHv
-sPL
+iVi
 aJs
 aKA
 aLI
@@ -106592,7 +106591,7 @@ gMO
 aJt
 aKA
 aLJ
-iXA
+jNg
 aaa
 ach
 aba
@@ -106891,10 +106890,10 @@ aGr
 nQL
 gMO
 gMO
-rdW
+gTA
 aKA
 aLI
-iXA
+jNg
 aaa
 ach
 aba
@@ -107193,7 +107192,7 @@ iRP
 aGs
 aHw
 aIu
-rhS
+wuh
 aaV
 aLJ
 aaY
@@ -107497,9 +107496,9 @@ auL
 auL
 auL
 auL
-sSF
+swR
 auL
-crg
+ukT
 aaf
 aba
 aQJ
@@ -107798,10 +107797,10 @@ aGt
 aJu
 aIv
 aJu
-vgo
-snS
-mTN
-eGu
+oMv
+ubB
+lKI
+jHZ
 aaf
 aba
 aQJ
@@ -108102,7 +108101,7 @@ auL
 auL
 aaQ
 aaf
-iqv
+rBd
 aad
 aaf
 aba
@@ -108401,7 +108400,7 @@ aFl
 aGv
 aHz
 aIx
-gwz
+hEA
 aaQ
 acO
 xnb
@@ -109003,8 +109002,8 @@ bkO
 bkO
 aFn
 tVy
-sYb
-fgQ
+fYh
+cyk
 aCf
 aaQ
 acO
@@ -109305,8 +109304,8 @@ aNr
 aNr
 jrg
 dlp
-soX
-tEU
+owO
+mmg
 aCf
 aaQ
 aaf
@@ -112938,7 +112937,7 @@ aaQ
 aaf
 abZ
 abZ
-wrM
+haf
 abZ
 abZ
 acO
@@ -119013,7 +119012,7 @@ rOU
 boq
 bCI
 uKA
-aSv
+mem
 vPj
 bGX
 bIv
@@ -122335,7 +122334,7 @@ bAL
 kli
 udY
 ygw
-sQX
+rox
 chs
 maH
 ftU

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -29473,7 +29473,6 @@
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
-/obj/machinery/portableowl/judgementowl,
 /turf/simulated/floor/stairs/wood/wide{
 	dir = 9
 	},
@@ -32212,6 +32211,7 @@
 /area/station/security/brig)
 "bNA" = (
 /obj/machinery/light,
+/obj/machinery/portableowl/judgementowl,
 /turf/simulated/floor/stairs/wood/wide{
 	dir = 8
 	},
@@ -113843,7 +113843,7 @@ abZ
 abZ
 abZ
 abZ
-aCo
+aCh
 aDw
 aCh
 aFx
@@ -115966,7 +115966,7 @@ xEt
 xEt
 xEt
 xEt
-aCo
+aCh
 mAq
 mEy
 mEy
@@ -116268,7 +116268,7 @@ xPz
 xPz
 xPz
 bEN
-aCh
+aCo
 bUy
 mEy
 dDe

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -8888,12 +8888,21 @@
 	})
 "aya" = (
 /obj/table/reinforced/auto,
-/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = -10
+	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/item/paper/engine,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 4;
+	pixel_y = 6
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -12656,11 +12665,8 @@
 /area/space)
 "aHs" = (
 /obj/table/reinforced/auto,
-/obj/item/storage/firstaid/fire{
-	pixel_x = -4
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 4
+/obj/machinery/computer/security/wooden_tv/small{
+	pixel_y = 8
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/power{
@@ -51297,11 +51303,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
 	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
+/obj/machinery/light,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/hotloop)
 "lSk" = (
@@ -53036,6 +53038,18 @@
 	dir = 6
 	},
 /area/station/security/interrogation)
+"ofV" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "TEG Monitoring";
+	dir = 1;
+	name = "TEG Monitoring";
+	network = "Zeta"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "ogf" = (
 /obj/item/device/radio/intercom{
 	dir = 4
@@ -105698,7 +105712,7 @@ auN
 aIt
 aJq
 jkC
-aGk
+jkC
 aGk
 gtY
 ceD
@@ -106000,7 +106014,7 @@ auL
 auL
 aJr
 izD
-auL
+izD
 aML
 aaa
 ach
@@ -106302,7 +106316,7 @@ aHv
 xMr
 aJs
 aKA
-aLI
+ofV
 aaY
 abZ
 aaf

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -8722,7 +8722,9 @@
 /area/station/engine/engineering)
 "axu" = (
 /obj/table/auto,
-/obj/machinery/phone,
+/obj/machinery/computer/security/wooden_tv/small{
+	pixel_y = 8
+	},
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "axv" = (
@@ -10099,14 +10101,15 @@
 	desc = "Smells a bit funny, but gets the job done.";
 	name = "mending patch";
 	pixel_x = -1;
-	pixel_y = 4
+	pixel_y = 6
 	},
 /obj/item/reagent_containers/food/snacks/chips{
-	pixel_y = 2
+	pixel_x = 5;
+	pixel_y = 2;
+	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/drinks/mug/random_color{
-	pixel_x = 4;
-	pixel_y = 1
+	pixel_x = -7
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -12564,6 +12567,10 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)
 "aHf" = (
+/obj/machinery/phone/wall{
+	pixel_x = 24;
+	pixel_y = 8
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -18626,7 +18633,7 @@
 /area/station/hallway/primary/north)
 "aYX" = (
 /obj/machinery/camera/television{
-	c_tag = "boxing";
+	c_tag = "Boxing Ring";
 	dir = 1;
 	name = "camera - boxing"
 	},
@@ -33043,6 +33050,9 @@
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-4"
+	},
+/obj/landmark/spawner{
+	name = "monkeyspawn_albert"
 	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
@@ -50348,7 +50358,7 @@
 /area/station/crew_quarters/md)
 "kQR" = (
 /obj/machinery/camera/television{
-	c_tag = "test chamber";
+	c_tag = "Test Chamber";
 	dir = 1;
 	name = "camera - test chamber"
 	},
@@ -55923,12 +55933,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"rPP" = (
-/obj/landmark/spawner{
-	name = "monkeyspawn_albert"
-	},
-/turf/simulated/floor/white,
-/area/station/science/teleporter)
 "rQB" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -98499,7 +98503,7 @@ bOp
 bRa
 bSA
 bSA
-rPP
+bSA
 bWe
 bLL
 bzR

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -9324,6 +9324,18 @@
 /obj/item/device/analyzer/atmospheric,
 /obj/item/device/analyzer/atmosanalyzer_upgrade,
 /obj/machinery/light/emergency,
+/obj/machinery/door_control{
+	id = "combustion";
+	name = "Chamber Exhaust";
+	pixel_x = 24;
+	pixel_y = -8
+	},
+/obj/machinery/door_control{
+	id = "fireshield";
+	name = "Heat Shield";
+	pixel_x = 24;
+	pixel_y = 8
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
@@ -50165,6 +50177,18 @@
 	},
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
+"kCB" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "TEG Monitoring";
+	dir = 1;
+	name = "TEG Monitoring";
+	network = "Zeta"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "kCR" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -53038,18 +53062,6 @@
 	dir = 6
 	},
 /area/station/security/interrogation)
-"ofV" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "TEG Monitoring";
-	dir = 1;
-	name = "TEG Monitoring";
-	network = "Zeta"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "ogf" = (
 /obj/item/device/radio/intercom{
 	dir = 4
@@ -106316,7 +106328,7 @@ aHv
 xMr
 aJs
 aKA
-ofV
+kCB
 aaY
 abZ
 aaf

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -8046,6 +8046,9 @@
 	tag = ""
 	},
 /obj/machinery/light_switch/north,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 9
 	},
@@ -8090,6 +8093,9 @@
 /obj/item/clothing/head/helmet/welding,
 /obj/item/clothing/suit/fire/heavy,
 /obj/item/clothing/head/helmet/welding,
+/obj/decal/xmas_lights/ephemeral{
+	pixel_y = 32
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -7003,20 +7003,17 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "asL" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour15;desc=The Engineering department's power division is located here. In the event they're not good at their jobs, the Pod Bay is directly opposite.";
 	freq = 1443;
 	location = "tour14";
 	name = "tour 14 - north"
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -7040,6 +7037,11 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
@@ -7465,14 +7467,12 @@
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/west)
 "atZ" = (
-/obj/disposalpipe/segment/brig{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/yellow/side,
-/area/station/hallway/primary/west)
+/obj/wingrille_spawn/auto,
+/obj/window_blinds/cog2/left,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/info{
+	name = "Book Nook"
+	})
 "aua" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8;
@@ -7491,7 +7491,7 @@
 /area/station/hallway/primary/west)
 "auc" = (
 /obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/left,
+/obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/info{
 	name = "Book Nook"
@@ -8019,12 +8019,16 @@
 	},
 /area/station/hallway/primary/west)
 "avJ" = (
-/obj/wingrille_spawn/auto,
-/obj/window_blinds/cog2/right,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/info{
-	name = "Book Nook"
-	})
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/west)
 "avL" = (
 /obj/rack,
 /obj/item/clothing/suit/fire,
@@ -8321,6 +8325,15 @@
 /obj/item/device/multitool,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
+"awt" = (
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
+/area/space)
 "awy" = (
 /obj/table/reinforced/auto,
 /obj/item/wrestlingbell,
@@ -8490,16 +8503,13 @@
 /turf/space,
 /area/space)
 "awT" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/west)
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/radio/news_office)
 "awV" = (
 /obj/rack,
 /obj/item/clothing/suit/fire,
@@ -8843,13 +8853,13 @@
 	},
 /area/station/hallway/primary/west)
 "axU" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
+/obj/cable{
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood/two,
-/area/station/crew_quarters/radio/news_office)
+/turf/simulated/floor/engine/caution/corner{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
 "axW" = (
 /obj/storage/secure/closet/engineering/engineer,
 /obj/machinery/light{
@@ -9236,11 +9246,8 @@
 	},
 /area/station/hallway/primary/west)
 "ayR" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/engine/caution/corner{
-	dir = 4
+/turf/simulated/floor/stairs/wide/middle{
+	dir = 8
 	},
 /area/station/hallway/primary/west)
 "ayT" = (
@@ -9718,14 +9725,18 @@
 /area/station/security/detectives_office)
 "azU" = (
 /turf/simulated/floor/stairs/wide/middle{
-	dir = 8
-	},
-/area/station/hallway/primary/west)
-"azV" = (
-/turf/simulated/floor/stairs/wide/middle{
 	dir = 4
 	},
 /area/station/hallway/primary/north)
+"azV" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/side,
+/area/station/hallway/primary/west)
 "azX" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -43026,12 +43037,6 @@
 /obj/machinery/light_switch/east,
 /turf/simulated/floor,
 /area/station/hallway/secondary/south)
-"cyk" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/caution/south,
-/area/station/engine/coldloop)
 "cyl" = (
 /obj/grille/steel,
 /turf/simulated/floor/black/grime,
@@ -43809,6 +43814,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
+"dmI" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/tile_edge/floorguide/hop{
+	dir = 4
+	},
+/obj/decal/tile_edge/floorguide/arrow_w,
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "dog" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Chef's Quarters"
@@ -43841,13 +43854,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
-"dpt" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "dpu" = (
 /obj/storage/secure/closet/fridge/kitchen,
 /obj/item/reagent_containers/food/drinks/milk,
@@ -44282,16 +44288,6 @@
 	dir = 9
 	},
 /area/station/security/secwing)
-"dQR" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/atmospherics/pipe/vent{
-	dir = 8
-	},
-/turf/space,
-/area/space)
 "dRk" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/grime,
@@ -44638,6 +44634,16 @@
 /obj/machinery/atmospherics/pipe/simple/southeast,
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
+"eis" = (
+/obj/grille/catwalk{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/area/space)
 "ejB" = (
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/sanitary,
@@ -44797,6 +44803,17 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
+"erT" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/two{
+	layer = 2;
+	pixel_x = 17;
+	pixel_y = 12
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "esb" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -44950,6 +44967,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"eEy" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "eEA" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -45134,16 +45155,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"ePG" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "eQE" = (
 /obj/grille/catwalk,
 /obj/machinery/oreaccumulator,
@@ -45686,6 +45697,10 @@
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
+"ftX" = (
+/obj/decal/poster/wallsign/warning1,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/gas)
 "fvy" = (
 /obj/shrub{
 	dir = 8
@@ -45892,6 +45907,16 @@
 /area/station/maintenance/storage{
 	name = "Secure Atmospherics"
 	})
+"fHE" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 8
+	},
+/turf/space,
+/area/space)
 "fIi" = (
 /obj/machinery/power/apc/autoname_west/noaicontrol,
 /obj/cable{
@@ -46157,12 +46182,6 @@
 	dir = 10
 	},
 /area/station/mining/magnet)
-"fYh" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/caution/north,
-/area/station/engine/coldloop)
 "fYk" = (
 /obj/disposalpipe/junction/right/north,
 /turf/simulated/floor,
@@ -46245,11 +46264,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
-"geP" = (
-/obj/wingrille_spawn/auto,
-/turf/space,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "geV" = (
 /obj/lattice{
 	dir = 10;
@@ -46317,6 +46331,9 @@
 /obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
+"ggk" = (
+/turf/simulated/floor/caution/east,
+/area/station/engine/gas)
 "ggG" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -47063,12 +47080,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
-"gTA" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "gTZ" = (
 /obj/decal/poster/wallsign/security_right,
 /turf/simulated/wall/auto/supernorn,
@@ -47210,6 +47221,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
+"gZf" = (
+/obj/machinery/atmospherics/mixer{
+	dir = 4;
+	frequency = 1225;
+	id_tag = "engine_combust";
+	master_id = "engine_combust_control";
+	name = "Gas Mixer (Combustion Chamber)"
+	},
+/turf/simulated/floor/caution/corner/ne,
+/area/station/engine/hotloop)
 "gZm" = (
 /obj/table/reinforced/auto,
 /obj/machinery/phone,
@@ -47228,13 +47249,6 @@
 /obj/decal/tile_edge/floorguide/arrow_s,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"haf" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/warp_beacon/engineering,
-/turf/space,
-/area/space)
 "hal" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Holding Cell One"
@@ -47445,6 +47459,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"hji" = (
+/obj/wingrille_spawn/auto,
+/turf/space,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "hkw" = (
 /obj/machinery/light{
 	dir = 4;
@@ -47770,22 +47789,6 @@
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"hEA" = (
-/obj/decal/poster/wallsign/hazard_coldloop,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/coldloop)
-"hEG" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
 "hFc" = (
 /obj/table/wood/round/auto,
 /obj/item/storage/toolbox{
@@ -47925,6 +47928,16 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/sw)
+"hSb" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/decal/tile_edge/floorguide/arrow_s{
+	dir = 4
+	},
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "hSz" = (
 /obj/machinery/drainage,
 /obj/disposalpipe/junction/right/north,
@@ -48012,6 +48025,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"idO" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "iee" = (
 /obj/table/auto,
 /obj/item/storage/box/evidence,
@@ -48094,6 +48113,18 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/green/side,
 /area/station/garden/aviary)
+"ikI" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
 "ill" = (
 /obj/machinery/light{
 	dir = 4;
@@ -48160,12 +48191,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet/green/fancy/edge/se,
 /area/station/crew_quarters/courtroom)
-"iqZ" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "iro" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -48195,6 +48220,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"isM" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "itX" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -48212,6 +48244,12 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"iuo" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "iut" = (
 /obj/machinery/light,
 /turf/simulated/floor/grey,
@@ -48236,6 +48274,12 @@
 /obj/machinery/cargo_router/kd_depot_south,
 /turf/simulated/floor/caution/westeast,
 /area/station/routing/depot)
+"ivm" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "ivn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -48812,12 +48856,6 @@
 	dir = 1
 	},
 /area/station/security/secwing)
-"iVi" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/core)
 "iVC" = (
 /obj/stool,
 /obj/item/device/radio/intercom{
@@ -48834,6 +48872,13 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
+"iWx" = (
+/obj/machinery/door/poddoor/pyro{
+	id = "combustion";
+	name = "Combustion Chamber Vent"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "iWG" = (
 /obj/table/wood/round/auto,
 /obj/item/device/light/candle{
@@ -48896,18 +48941,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/medical/robotics)
-"jdp" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engine Core";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
 "jdV" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -49051,6 +49084,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"jnF" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "jnP" = (
 /obj/machinery/atmospherics/valve{
 	name = "Brig Repressurization"
@@ -49269,6 +49308,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/ce)
+"jAL" = (
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "jAR" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -49355,36 +49402,12 @@
 /obj/machinery/hydro_growlamp,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
-"jHZ" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/space)
 "jJP" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
 /area/station/hallway/primary/south)
-"jMP" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
-"jNg" = (
-/obj/machinery/door/poddoor/pyro{
-	id = "combustion";
-	name = "Combustion Chamber Vent"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "jNl" = (
 /obj/table/reinforced/auto,
 /obj/item/hand_labeler{
@@ -49886,10 +49909,6 @@
 	dir = 1
 	},
 /area/station/mining/magnet)
-"kpt" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "kpw" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating{
@@ -50224,6 +50243,17 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/news_office)
+"kKs" = (
+/obj/machinery/atmospherics/pipe/simple/junction,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "kKG" = (
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
@@ -50244,6 +50274,15 @@
 /obj/machinery/gibber/output_south,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
+"kLV" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/gas)
 "kMi" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50381,10 +50420,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"kVG" = (
-/turf/space,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/west)
 "kWb" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/electrical,
@@ -51095,13 +51130,6 @@
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
-"lKI" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "lMa" = (
 /obj/machinery/light{
 	dir = 4;
@@ -51245,6 +51273,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
+"lUC" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "lUL" = (
 /obj/cable{
 	d1 = 1;
@@ -51317,6 +51353,15 @@
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
+"mco" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Core Access";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core)
 "mcp" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
@@ -51344,16 +51389,6 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/simulated/floor/plating/damaged1,
 /area/station/security/beepsky)
-"mem" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/decal/tile_edge/floorguide/arrow_s{
-	dir = 4
-	},
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
 "mep" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -51442,17 +51477,6 @@
 	},
 /turf/simulated/floor/caution/northsouth,
 /area/station/hangar/engine)
-"mmg" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/decal/poster/wallsign/stencil/right/two{
-	layer = 2;
-	pixel_x = 17;
-	pixel_y = 12
-	},
-/turf/simulated/floor/caution/south,
-/area/station/engine/coldloop)
 "mmn" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8;
@@ -51941,13 +51965,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/east)
-"mRV" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "mSv" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -52074,6 +52091,12 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
+"mYp" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "mZB" = (
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -52375,6 +52398,12 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_south)
+"nsU" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core)
 "ntn" = (
 /obj/decal/tile_edge/stripe{
 	dir = 10;
@@ -52417,18 +52446,6 @@
 	dir = 8
 	},
 /area/station/routing/security)
-"nvE" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/hallway/primary/west)
 "nwI" = (
 /obj/stool/chair/office/red,
 /obj/disposalpipe/segment/brig{
@@ -53124,6 +53141,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/sw)
+"omY" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "onB" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
@@ -53228,6 +53257,11 @@
 "osY" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner/east)
+"ouo" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "oup" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -53292,16 +53326,6 @@
 	dir = 8
 	},
 /area/station/science/testchamber)
-"owm" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/decal/cleanable/oil,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "owG" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/landmark/halloween,
@@ -53335,17 +53359,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/primary/east)
-"owO" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/decal/poster/wallsign/stencil/right/one{
-	layer = 2;
-	pixel_x = 15;
-	pixel_y = 12
-	},
-/turf/simulated/floor/caution/north,
-/area/station/engine/coldloop)
 "owU" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -53536,16 +53549,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
-"oMv" = (
-/obj/grille/catwalk{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/space)
 "oNK" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/disposalpipe/junction/right/north,
@@ -53616,6 +53619,10 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/magnet)
+"oUc" = (
+/turf/space,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/inner/west)
 "oUk" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -53810,6 +53817,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"pgh" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "pgz" = (
 /obj/lattice{
 	dir = 9;
@@ -54331,6 +54348,22 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/south)
+"pMZ" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/space)
+"pNp" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "pPf" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
@@ -54702,6 +54735,17 @@
 /obj/machinery/vending/standard,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"qmV" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/one{
+	layer = 2;
+	pixel_x = 15;
+	pixel_y = 12
+	},
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "qnB" = (
 /obj/table/auto,
 /obj/machinery/networked/storage/scanner{
@@ -55128,9 +55172,6 @@
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
-"qPm" = (
-/turf/simulated/floor/caution/east,
-/area/station/engine/gas)
 "qRd" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -55588,14 +55629,13 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"rox" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/decal/tile_edge/floorguide/hop{
+"rqF" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
-/obj/decal/tile_edge/floorguide/arrow_w,
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
+/obj/lattice,
+/turf/space,
+/area/space)
 "rrc" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Courtroom"
@@ -55775,13 +55815,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/ce)
-"rBd" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/obj/lattice,
-/turf/space,
-/area/space)
 "rBy" = (
 /obj/machinery/atmospherics/pipe/manifold/south,
 /turf/simulated/wall/auto/supernorn,
@@ -56444,15 +56477,6 @@
 	},
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/station/crew_quarters/quarters_north)
-"swR" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Core Access";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/core)
 "swT" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -56682,16 +56706,6 @@
 /obj/critter/cat/jones,
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/station/bridge)
-"sNK" = (
-/obj/machinery/atmospherics/mixer{
-	dir = 4;
-	frequency = 1225;
-	id_tag = "engine_combust";
-	master_id = "engine_combust_control";
-	name = "Gas Mixer (Combustion Chamber)"
-	},
-/turf/simulated/floor/caution/corner/ne,
-/area/station/engine/hotloop)
 "sNP" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/hazard_bio,
@@ -56814,6 +56828,18 @@
 	},
 /turf/simulated/floor/red,
 /area/station/routing/security)
+"sTr" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "sTA" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Mining Hangar"
@@ -56870,10 +56896,6 @@
 	dir = 1
 	},
 /area/station/turret_protected/Zeta)
-"sUM" = (
-/obj/decal/poster/wallsign/warning1,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/gas)
 "sVu" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -57071,6 +57093,11 @@
 	dir = 5
 	},
 /area/station/hallway/primary/east)
+"tfb" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "tfv" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -57882,11 +57909,6 @@
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"ubB" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "ubE" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2{
@@ -57895,6 +57917,13 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/ce)
+"ubF" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "ubR" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -58055,15 +58084,6 @@
 	dir = 5
 	},
 /area/station/hallway/primary/east)
-"ukT" = (
-/obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
-/area/space)
 "ule" = (
 /turf/simulated/floor/caution/east,
 /area/station/hangar/sec)
@@ -58607,6 +58627,13 @@
 /obj/machinery/light/runway_light/delay4,
 /turf/space,
 /area/station/ai_monitored/armory)
+"uVl" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/warp_beacon/engineering,
+/turf/space,
+/area/space)
 "uWq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -58745,11 +58772,6 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
-"vgv" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "vgI" = (
 /obj/cable{
 	d1 = 1;
@@ -58917,6 +58939,18 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"voA" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "vpD" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/sw)
@@ -59277,18 +59311,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/garden/aviary)
-"vPO" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
 "vRn" = (
 /obj/disposaloutlet/south,
 /obj/disposalpipe/trunk/east,
@@ -59438,12 +59460,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"vZk" = (
-/obj/cable{
-	icon_state = "2-5"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
 "vZp" = (
 /obj/machinery/door/airlock/pyro/security,
 /obj/cable{
@@ -59815,17 +59831,6 @@
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/south)
-"wuh" = (
-/obj/machinery/atmospherics/pipe/simple/junction,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "wwg" = (
 /obj/cable{
 	d1 = 4;
@@ -60275,15 +60280,6 @@
 /obj/item/tile/steel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"wQy" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/gas)
 "wQJ" = (
 /obj/rack,
 /obj/item/clothing/suit/armor/heavy,
@@ -60502,6 +60498,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"xgf" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Engine Core";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "xgg" = (
 /obj/disposaloutlet/east,
 /obj/disposalpipe/trunk/east,
@@ -60801,14 +60809,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
-"xrM" = (
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "xtO" = (
 /obj/rack,
 /obj/item/clothing/suit/space/captain,
@@ -61071,6 +61071,16 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"xIQ" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "xJq" = (
 /obj/lattice{
 	dir = 8;
@@ -61443,6 +61453,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
+"xXN" = (
+/obj/decal/poster/wallsign/hazard_coldloop,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/coldloop)
 "xYi" = (
 /obj/machinery/disposal/transport{
 	desc = "A pneumatic delivery chute for transporting people from one section of maintenance to another.";
@@ -61622,18 +61636,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"yhg" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/hotloop)
 "yhi" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -98116,7 +98118,7 @@ aof
 inc
 ait
 aro
-axU
+awT
 atJ
 ait
 avz
@@ -102061,7 +102063,7 @@ aHp
 aJf
 aHp
 ayO
-nvE
+ikI
 vBz
 aHp
 aPA
@@ -102360,7 +102362,7 @@ aFa
 aGh
 aHq
 aJh
-wQy
+kLV
 aKq
 aHq
 aHq
@@ -102667,7 +102669,7 @@ aKr
 aLE
 aHq
 aNJ
-vgv
+tfb
 aHq
 hgU
 qwl
@@ -103567,9 +103569,9 @@ aCV
 aGk
 aGk
 aHq
-ePG
+xIQ
 aJj
-qPm
+ggk
 sJY
 bfi
 aNL
@@ -103872,8 +103874,8 @@ aHq
 aIo
 aJk
 aKu
-xrM
-sUM
+jAL
+ftX
 aNL
 aNK
 aHq
@@ -104176,17 +104178,17 @@ aJl
 aHq
 aHq
 aHq
-dpt
+pNp
 aNL
 aHq
-owm
+pgh
 qwl
 uIC
 uIC
 rTU
 uIC
 odP
-kpt
+eEy
 iwq
 iPr
 cRL
@@ -104778,12 +104780,12 @@ xqF
 aIr
 aJn
 aKx
-vZk
-jdp
+jnF
+xgf
 sWO
 sWO
-mRV
-iqZ
+isM
+mYp
 gxC
 gxC
 gxC
@@ -105063,7 +105065,7 @@ apA
 ack
 arG
 asL
-atZ
+atX
 aIl
 aIl
 aIl
@@ -105076,7 +105078,7 @@ auN
 aEg
 auL
 wLi
-jMP
+lUC
 aIs
 aJo
 aKy
@@ -105085,8 +105087,8 @@ aGk
 vHU
 ftA
 gxC
-geP
-kVG
+hji
+oUc
 bfj
 abh
 abh
@@ -105379,10 +105381,10 @@ dTh
 gSM
 aGp
 auN
-sNK
+gZf
 aJp
 aKx
-hEG
+voA
 aMK
 abf
 aaf
@@ -105667,7 +105669,7 @@ agD
 agD
 arK
 asN
-atX
+azV
 auX
 avM
 awW
@@ -105683,10 +105685,10 @@ aDb
 auN
 aIt
 aJq
-yhg
+omY
 aGk
 aGk
-dQR
+fHE
 ceD
 abn
 aaa
@@ -105985,7 +105987,7 @@ aGq
 auL
 auL
 aJr
-vPO
+sTr
 auL
 aML
 aaa
@@ -106285,7 +106287,7 @@ aEj
 aFh
 nRo
 aHv
-iVi
+nsU
 aJs
 aKA
 aLI
@@ -106591,7 +106593,7 @@ gMO
 aJt
 aKA
 aLJ
-jNg
+iWx
 aaa
 ach
 aba
@@ -106890,10 +106892,10 @@ aGr
 nQL
 gMO
 gMO
-gTA
+idO
 aKA
 aLI
-jNg
+iWx
 aaa
 ach
 aba
@@ -107192,7 +107194,7 @@ iRP
 aGs
 aHw
 aIu
-wuh
+kKs
 aaV
 aLJ
 aaY
@@ -107496,9 +107498,9 @@ auL
 auL
 auL
 auL
-swR
+mco
 auL
-ukT
+awt
 aaf
 aba
 aQJ
@@ -107779,7 +107781,7 @@ anA
 aoB
 aqM
 aqL
-awT
+avJ
 asS
 aud
 aIl
@@ -107797,10 +107799,10 @@ aGt
 aJu
 aIv
 aJu
-oMv
-ubB
-lKI
-jHZ
+eis
+ouo
+ubF
+pMZ
 aaf
 aba
 aQJ
@@ -108101,7 +108103,7 @@ auL
 auL
 aaQ
 aaf
-rBd
+rqF
 aad
 aaf
 aba
@@ -108400,7 +108402,7 @@ aFl
 aGv
 aHz
 aIx
-hEA
+xXN
 aaQ
 acO
 xnb
@@ -108686,7 +108688,7 @@ akH
 apH
 asX
 arR
-ayR
+axU
 auf
 auQ
 axd
@@ -109002,8 +109004,8 @@ bkO
 bkO
 aFn
 tVy
-fYh
-cyk
+ivm
+iuo
 aCf
 aaQ
 acO
@@ -109304,8 +109306,8 @@ aNr
 aNr
 jrg
 dlp
-owO
-mmg
+qmV
+erT
 aCf
 aaQ
 aaf
@@ -109592,7 +109594,7 @@ aoC
 apI
 aqN
 arU
-azU
+ayR
 yjd
 aIl
 aIl
@@ -112937,7 +112939,7 @@ aaQ
 aaf
 abZ
 abZ
-haf
+uVl
 abZ
 abZ
 acO
@@ -113820,7 +113822,7 @@ aFv
 cCG
 aFv
 xQm
-azV
+azU
 rDI
 aFv
 aFv
@@ -114724,7 +114726,7 @@ amJ
 axl
 aHP
 apU
-auc
+atZ
 asa
 uzL
 aBm
@@ -115026,7 +115028,7 @@ amJ
 axi
 aKD
 uIf
-avJ
+auc
 uzL
 uzL
 aum
@@ -119012,7 +119014,7 @@ rOU
 boq
 bCI
 uKA
-mem
+hSb
 vPj
 bGX
 bIv
@@ -122334,7 +122336,7 @@ bAL
 kli
 udY
 ygw
-rox
+dmI
 chs
 maH
 ftU

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -8105,6 +8105,9 @@
 /obj/decal/xmas_lights/ephemeral{
 	pixel_y = 32
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -8325,15 +8328,6 @@
 /obj/item/device/multitool,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
-"awt" = (
-/obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
-/area/space)
 "awy" = (
 /obj/table/reinforced/auto,
 /obj/item/wrestlingbell,
@@ -27307,6 +27301,16 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/black,
 /area/station/bridge)
+"bBO" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "bBP" = (
 /obj/stool/chair{
 	dir = 4
@@ -33890,6 +33894,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"bSr" = (
+/obj/cable{
+	icon_state = "2-5"
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "bSs" = (
 /obj/disposalpipe/segment/transport{
 	icon_state = "pipe-c"
@@ -43814,14 +43824,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"dmI" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/decal/tile_edge/floorguide/hop{
-	dir = 4
-	},
-/obj/decal/tile_edge/floorguide/arrow_w,
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
 "dog" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Chef's Quarters"
@@ -43982,6 +43984,11 @@
 	name = "landing pad plating"
 	},
 /area/station/maintenance/southeast)
+"dsH" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "duY" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -44047,6 +44054,13 @@
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/caution/northsouth,
 /area/station/hallway/secondary/exit)
+"dAY" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "dCL" = (
 /obj/machinery/light/runway_light/delay5,
 /obj/lattice,
@@ -44142,6 +44156,10 @@
 "dHl" = (
 /turf/simulated/floor/orange/side,
 /area/station/crew_quarters/catering)
+"dHw" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "dHS" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -44223,6 +44241,13 @@
 /obj/item/storage/box/cutlery,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"dMR" = (
+/obj/machinery/door/poddoor/pyro{
+	id = "combustion";
+	name = "Combustion Chamber Vent"
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "dNQ" = (
 /obj/stool/chair/red{
 	dir = 4
@@ -44634,16 +44659,6 @@
 /obj/machinery/atmospherics/pipe/simple/southeast,
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
-"eis" = (
-/obj/grille/catwalk{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
-	},
-/area/space)
 "ejB" = (
 /obj/stool/bench/blue/auto,
 /turf/simulated/floor/sanitary,
@@ -44682,6 +44697,11 @@
 	dir = 8
 	},
 /area/station/mining/magnet)
+"emm" = (
+/obj/wingrille_spawn/auto,
+/turf/space,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "emB" = (
 /obj/cable{
 	d1 = 2;
@@ -44715,6 +44735,16 @@
 	dir = 4
 	},
 /area/station/ranch)
+"eoI" = (
+/obj/machinery/atmospherics/mixer{
+	dir = 4;
+	frequency = 1225;
+	id_tag = "engine_combust";
+	master_id = "engine_combust_control";
+	name = "Gas Mixer (Combustion Chamber)"
+	},
+/turf/simulated/floor/caution/corner/ne,
+/area/station/engine/hotloop)
 "eoO" = (
 /obj/table/round/auto,
 /obj/item/reagent_containers/food/drinks/bottle/bottledwater{
@@ -44803,17 +44833,6 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"erT" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/decal/poster/wallsign/stencil/right/two{
-	layer = 2;
-	pixel_x = 17;
-	pixel_y = 12
-	},
-/turf/simulated/floor/caution/south,
-/area/station/engine/coldloop)
 "esb" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -44967,10 +44986,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
-"eEy" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "eEA" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -45697,10 +45712,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
-"ftX" = (
-/obj/decal/poster/wallsign/warning1,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/gas)
 "fvy" = (
 /obj/shrub{
 	dir = 8
@@ -45840,6 +45851,9 @@
 	dir = 1
 	},
 /area/station/security/secwing)
+"fDe" = (
+/turf/simulated/floor/caution/east,
+/area/station/engine/gas)
 "fDq" = (
 /obj/stool/bar,
 /turf/simulated/floor/carpet/green/fancy/edge/nw,
@@ -45907,16 +45921,6 @@
 /area/station/maintenance/storage{
 	name = "Secure Atmospherics"
 	})
-"fHE" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/atmospherics/pipe/vent{
-	dir = 8
-	},
-/turf/space,
-/area/space)
 "fIi" = (
 /obj/machinery/power/apc/autoname_west/noaicontrol,
 /obj/cable{
@@ -46331,9 +46335,6 @@
 /obj/decal/wreath/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/south)
-"ggk" = (
-/turf/simulated/floor/caution/east,
-/area/station/engine/gas)
 "ggG" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -46574,6 +46575,16 @@
 /obj/machinery/light/small/floor,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
+"gtY" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/atmospherics/pipe/vent{
+	dir = 8
+	},
+/turf/space,
+/area/space)
 "gut" = (
 /obj/machinery/atmospherics/pipe/tank/air_repressurization/south,
 /turf/simulated/floor/plating,
@@ -46771,6 +46782,17 @@
 	dir = 1
 	},
 /area/station/hallway/primary/south)
+"gAY" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/one{
+	layer = 2;
+	pixel_x = 15;
+	pixel_y = 12
+	},
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "gBs" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8
@@ -46847,6 +46869,17 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/caution/north,
 /area/research_outpost/indigo_rye)
+"gGA" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/decal/poster/wallsign/stencil/right/two{
+	layer = 2;
+	pixel_x = 17;
+	pixel_y = 12
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "gGT" = (
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -47221,16 +47254,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
-"gZf" = (
-/obj/machinery/atmospherics/mixer{
-	dir = 4;
-	frequency = 1225;
-	id_tag = "engine_combust";
-	master_id = "engine_combust_control";
-	name = "Gas Mixer (Combustion Chamber)"
-	},
-/turf/simulated/floor/caution/corner/ne,
-/area/station/engine/hotloop)
 "gZm" = (
 /obj/table/reinforced/auto,
 /obj/machinery/phone,
@@ -47459,11 +47482,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
-"hji" = (
-/obj/wingrille_spawn/auto,
-/turf/space,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "hkw" = (
 /obj/machinery/light{
 	dir = 4;
@@ -47652,6 +47670,14 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/hallway/primary/north)
+"huy" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/decal/tile_edge/floorguide/hop{
+	dir = 4
+	},
+/obj/decal/tile_edge/floorguide/arrow_w,
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "hvr" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right,
@@ -47928,16 +47954,6 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/sw)
-"hSb" = (
-/obj/disposalpipe/segment/mail/horizontal,
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/decal/tile_edge/floorguide/arrow_s{
-	dir = 4
-	},
-/turf/simulated/floor/red/side,
-/area/station/hallway/primary/south)
 "hSz" = (
 /obj/machinery/drainage,
 /obj/disposalpipe/junction/right/north,
@@ -48025,12 +48041,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"idO" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "iee" = (
 /obj/table/auto,
 /obj/item/storage/box/evidence,
@@ -48113,18 +48123,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/green/side,
 /area/station/garden/aviary)
-"ikI" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
-/area/station/hallway/primary/west)
 "ill" = (
 /obj/machinery/light{
 	dir = 4;
@@ -48220,13 +48218,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"isM" = (
-/obj/machinery/door/airlock/pyro/external,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "itX" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -48244,12 +48235,6 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"iuo" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/caution/south,
-/area/station/engine/coldloop)
 "iut" = (
 /obj/machinery/light,
 /turf/simulated/floor/grey,
@@ -48274,12 +48259,6 @@
 /obj/machinery/cargo_router/kd_depot_south,
 /turf/simulated/floor/caution/westeast,
 /area/station/routing/depot)
-"ivm" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
-/turf/simulated/floor/caution/north,
-/area/station/engine/coldloop)
 "ivn" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -48331,6 +48310,18 @@
 	dir = 1
 	},
 /area/station/security/secwing)
+"izD" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "izH" = (
 /obj/shrub{
 	dir = 6
@@ -48667,6 +48658,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"iLZ" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "iMJ" = (
 /obj/cable{
 	d1 = 4;
@@ -48872,13 +48869,6 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/routing/depot)
-"iWx" = (
-/obj/machinery/door/poddoor/pyro{
-	id = "combustion";
-	name = "Combustion Chamber Vent"
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "iWG" = (
 /obj/table/wood/round/auto,
 /obj/item/device/light/candle{
@@ -49039,6 +49029,18 @@
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"jkC" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/poddoor/pyro{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "fireshield";
+	name = "Combustion Chamber Heat Shield";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/hotloop)
 "jmu" = (
 /obj/machinery/light{
 	dir = 1;
@@ -49056,6 +49058,10 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"jmF" = (
+/turf/space,
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/inner/west)
 "jna" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/food,
@@ -49084,12 +49090,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"jnF" = (
-/obj/cable{
-	icon_state = "2-5"
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
 "jnP" = (
 /obj/machinery/atmospherics/valve{
 	name = "Brig Repressurization"
@@ -49256,6 +49256,14 @@
 	},
 /turf/space,
 /area/station/mining/magnet)
+"juR" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0;
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/core)
 "jvb" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/black/side{
@@ -49308,14 +49316,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/ce)
-"jAL" = (
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = 12
-	},
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "jAR" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -49375,6 +49375,15 @@
 	dir = 4
 	},
 /area/station/maintenance/southeast)
+"jET" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/space)
 "jFS" = (
 /obj/storage/crate{
 	desc = "A private crate that isn't yours.";
@@ -49398,6 +49407,14 @@
 	},
 /turf/simulated/floor/plating/damaged3,
 /area/station/security/beepsky)
+"jGH" = (
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "jHF" = (
 /obj/machinery/hydro_growlamp,
 /turf/simulated/floor/grass,
@@ -49582,6 +49599,10 @@
 "jUy" = (
 /turf/simulated/floor/delivery,
 /area/station/mining/magnet)
+"jVS" = (
+/obj/decal/poster/wallsign/warning1,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/gas)
 "jVX" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -49701,6 +49722,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
+"kdP" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Core Access";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core)
 "kfn" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable,
@@ -50243,17 +50273,6 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/news_office)
-"kKs" = (
-/obj/machinery/atmospherics/pipe/simple/junction,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/combustion_chamber)
 "kKG" = (
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
@@ -50274,15 +50293,6 @@
 /obj/machinery/gibber/output_south,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
-"kLV" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/gas)
 "kMi" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50461,6 +50471,17 @@
 	},
 /turf/simulated/floor/escape,
 /area/station/hallway/primary/east)
+"kZR" = (
+/obj/machinery/atmospherics/pipe/simple/junction,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "kZX" = (
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -51261,6 +51282,18 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/yellow/corner,
 /area/station/hallway/primary/north)
+"lSe" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/orangeblack,
+/area/station/engine/hotloop)
 "lSk" = (
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
@@ -51273,14 +51306,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
-"lUC" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0;
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
 "lUL" = (
 /obj/cable{
 	d1 = 1;
@@ -51353,15 +51378,6 @@
 	dir = 8
 	},
 /area/station/crew_quarters/courtroom)
-"mco" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Core Access";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/turf/simulated/floor/engine/vacuum,
-/area/station/engine/core)
 "mcp" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
@@ -52091,12 +52107,6 @@
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
-"mYp" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "mZB" = (
 /turf/simulated/floor/redblack{
 	dir = 1
@@ -52398,12 +52408,6 @@
 	dir = 4
 	},
 /area/station/crew_quarters/quarters_south)
-"nsU" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/core)
 "ntn" = (
 /obj/decal/tile_edge/stripe{
 	dir = 10;
@@ -53141,18 +53145,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/sw)
-"omY" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/hotloop)
 "onB" = (
 /obj/machinery/door/airlock/pyro/maintenance,
 /obj/cable{
@@ -53257,11 +53249,6 @@
 "osY" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner/east)
-"ouo" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "oup" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -53619,10 +53606,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/magnet)
-"oUc" = (
-/turf/space,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/west)
 "oUk" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -53749,6 +53732,13 @@
 /obj/disposalpipe/trunk/east,
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/west)
+"paH" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 4
+	},
+/obj/lattice,
+/turf/space,
+/area/space)
 "paR" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/emergency)
@@ -53817,16 +53807,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"pgh" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/decal/cleanable/oil,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/west)
 "pgz" = (
 /obj/lattice{
 	dir = 9;
@@ -54323,6 +54303,13 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/grime,
 /area/station/routing/depot)
+"pMm" = (
+/obj/grille/catwalk,
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	dir = 5
+	},
+/turf/simulated/floor/airless/plating/catwalk,
+/area/space)
 "pMI" = (
 /obj/storage/crate/rcd/CE,
 /obj/cable{
@@ -54348,22 +54335,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/south)
-"pMZ" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/space)
-"pNp" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "pPf" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
@@ -54735,17 +54706,6 @@
 /obj/machinery/vending/standard,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"qmV" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/decal/poster/wallsign/stencil/right/one{
-	layer = 2;
-	pixel_x = 15;
-	pixel_y = 12
-	},
-/turf/simulated/floor/caution/north,
-/area/station/engine/coldloop)
 "qnB" = (
 /obj/table/auto,
 /obj/machinery/networked/storage/scanner{
@@ -55172,6 +55132,15 @@
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"qOU" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/gas)
 "qRd" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -55629,13 +55598,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"rqF" = (
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 4
-	},
-/obj/lattice,
-/turf/space,
-/area/space)
 "rrc" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Courtroom"
@@ -56828,18 +56790,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/routing/security)
-"sTr" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/machinery/door/poddoor/pyro{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "fireshield";
-	name = "Combustion Chamber Heat Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/engine/core)
 "sTA" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Mining Hangar"
@@ -57093,11 +57043,6 @@
 	dir = 5
 	},
 /area/station/hallway/primary/east)
-"tfb" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "tfv" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -57446,6 +57391,16 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
+"tve" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/decal/tile_edge/floorguide/arrow_s{
+	dir = 4
+	},
+/turf/simulated/floor/red/side,
+/area/station/hallway/primary/south)
 "tvp" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Chef's Quarters"
@@ -57917,13 +57872,6 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/ce)
-"ubF" = (
-/obj/grille/catwalk,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 5
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "ubR" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -58087,6 +58035,18 @@
 "ule" = (
 /turf/simulated/floor/caution/east,
 /area/station/hangar/sec)
+"ulO" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Engine Core";
+	req_access = null
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/redblack,
+/area/station/engine/hotloop)
 "umn" = (
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/station/mining/magnet)
@@ -58418,6 +58378,15 @@
 	},
 /turf/space,
 /area/station/ai_monitored/armory)
+"uEI" = (
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
+/area/space)
 "uFl" = (
 /obj/item/storage/wall/random{
 	dir = 8;
@@ -58627,13 +58596,6 @@
 /obj/machinery/light/runway_light/delay4,
 /turf/space,
 /area/station/ai_monitored/armory)
-"uVl" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/warp_beacon/engineering,
-/turf/space,
-/area/space)
 "uWq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -58939,18 +58901,6 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
-"voA" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/orangeblack,
-/area/station/engine/hotloop)
 "vpD" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/sw)
@@ -58963,6 +58913,13 @@
 	dir = 9
 	},
 /area/station/hangar/main)
+"vqF" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/warp_beacon/engineering,
+/turf/space,
+/area/space)
 "vrp" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -59493,6 +59450,13 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters_east)
+"vZO" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "wam" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -60091,6 +60055,16 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/hallway/secondary/exit)
+"wGq" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13";
+	pixel_y = 20
+	},
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/west)
 "wGt" = (
 /obj/cable{
 	d1 = 2;
@@ -60104,6 +60078,16 @@
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/supernorn,
 /area/station/ranch)
+"wGL" = (
+/obj/grille/catwalk{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/insulated,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	icon_state = "catwalk_cross"
+	},
+/area/space)
 "wHG" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -60140,6 +60124,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"wKJ" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/caution/south,
+/area/station/engine/coldloop)
 "wLh" = (
 /obj/machinery/computer3/generic/secure_data,
 /obj/machinery/power/data_terminal,
@@ -60273,6 +60263,12 @@
 	dir = 4
 	},
 /area/station/security/main)
+"wPH" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/combustion_chamber)
 "wQk" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -60430,6 +60426,12 @@
 "xcv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/ce)
+"xcC" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/caution/north,
+/area/station/engine/coldloop)
 "xcP" = (
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
@@ -60498,18 +60500,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"xgf" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Engine Core";
-	req_access = null
-	},
-/obj/access_spawn/engineering_engine,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/redblack,
-/area/station/engine/hotloop)
 "xgg" = (
 /obj/disposaloutlet/east,
 /obj/disposalpipe/trunk/east,
@@ -60539,6 +60529,11 @@
 	dir = 4
 	},
 /area/station/mining/magnet)
+"xgy" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small,
+/turf/simulated/floor/black,
+/area/station/engine/gas)
 "xgL" = (
 /obj/machinery/light{
 	dir = 4;
@@ -61071,16 +61066,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
-"xIQ" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/black,
-/area/station/engine/gas)
 "xJq" = (
 /obj/lattice{
 	dir = 8;
@@ -61097,6 +61082,18 @@
 	},
 /turf/simulated/floor,
 /area/station/security/secwing)
+"xJE" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/station/hallway/primary/west)
 "xKr" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -61174,6 +61171,12 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters_south)
+"xMr" = (
+/obj/machinery/atmospherics/pipe/simple/insulated{
+	can_rupture = 0
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/core)
 "xMD" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -61245,6 +61248,11 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/power{
@@ -61453,10 +61461,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/east)
-"xXN" = (
-/obj/decal/poster/wallsign/hazard_coldloop,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/coldloop)
 "xYi" = (
 /obj/machinery/disposal/transport{
 	desc = "A pneumatic delivery chute for transporting people from one section of maintenance to another.";
@@ -61682,6 +61686,10 @@
 	dir = 8
 	},
 /area/station/hallway/primary/east)
+"yim" = (
+/obj/decal/poster/wallsign/hazard_coldloop,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/coldloop)
 "yiL" = (
 /obj/cable{
 	d1 = 1;
@@ -102063,7 +102071,7 @@ aHp
 aJf
 aHp
 ayO
-ikI
+xJE
 vBz
 aHp
 aPA
@@ -102362,7 +102370,7 @@ aFa
 aGh
 aHq
 aJh
-kLV
+qOU
 aKq
 aHq
 aHq
@@ -102669,7 +102677,7 @@ aKr
 aLE
 aHq
 aNJ
-tfb
+xgy
 aHq
 hgU
 qwl
@@ -103569,9 +103577,9 @@ aCV
 aGk
 aGk
 aHq
-xIQ
+bBO
 aJj
-ggk
+fDe
 sJY
 bfi
 aNL
@@ -103874,8 +103882,8 @@ aHq
 aIo
 aJk
 aKu
-jAL
-ftX
+jGH
+jVS
 aNL
 aNK
 aHq
@@ -104178,17 +104186,17 @@ aJl
 aHq
 aHq
 aHq
-pNp
+dAY
 aNL
 aHq
-pgh
+wGq
 qwl
 uIC
 uIC
 rTU
 uIC
 odP
-eEy
+dHw
 iwq
 iPr
 cRL
@@ -104780,12 +104788,12 @@ xqF
 aIr
 aJn
 aKx
-jnF
-xgf
+bSr
+ulO
 sWO
 sWO
-isM
-mYp
+vZO
+iLZ
 gxC
 gxC
 gxC
@@ -105078,7 +105086,7 @@ auN
 aEg
 auL
 wLi
-lUC
+juR
 aIs
 aJo
 aKy
@@ -105087,8 +105095,8 @@ aGk
 vHU
 ftA
 gxC
-hji
-oUc
+emm
+jmF
 bfj
 abh
 abh
@@ -105381,10 +105389,10 @@ dTh
 gSM
 aGp
 auN
-gZf
+eoI
 aJp
 aKx
-voA
+lSe
 aMK
 abf
 aaf
@@ -105685,10 +105693,10 @@ aDb
 auN
 aIt
 aJq
-omY
+jkC
 aGk
 aGk
-fHE
+gtY
 ceD
 abn
 aaa
@@ -105987,7 +105995,7 @@ aGq
 auL
 auL
 aJr
-sTr
+izD
 auL
 aML
 aaa
@@ -106287,7 +106295,7 @@ aEj
 aFh
 nRo
 aHv
-nsU
+xMr
 aJs
 aKA
 aLI
@@ -106593,7 +106601,7 @@ gMO
 aJt
 aKA
 aLJ
-iWx
+dMR
 aaa
 ach
 aba
@@ -106892,10 +106900,10 @@ aGr
 nQL
 gMO
 gMO
-idO
+wPH
 aKA
 aLI
-iWx
+dMR
 aaa
 ach
 aba
@@ -107194,7 +107202,7 @@ iRP
 aGs
 aHw
 aIu
-kKs
+kZR
 aaV
 aLJ
 aaY
@@ -107498,9 +107506,9 @@ auL
 auL
 auL
 auL
-mco
+kdP
 auL
-awt
+uEI
 aaf
 aba
 aQJ
@@ -107799,10 +107807,10 @@ aGt
 aJu
 aIv
 aJu
-eis
-ouo
-ubF
-pMZ
+wGL
+dsH
+pMm
+jET
 aaf
 aba
 aQJ
@@ -108103,7 +108111,7 @@ auL
 auL
 aaQ
 aaf
-rqF
+paH
 aad
 aaf
 aba
@@ -108402,7 +108410,7 @@ aFl
 aGv
 aHz
 aIx
-xXN
+yim
 aaQ
 acO
 xnb
@@ -109004,8 +109012,8 @@ bkO
 bkO
 aFn
 tVy
-ivm
-iuo
+xcC
+wKJ
 aCf
 aaQ
 acO
@@ -109306,8 +109314,8 @@ aNr
 aNr
 jrg
 dlp
-qmV
-erT
+gAY
+gGA
 aCf
 aaQ
 aaf
@@ -112939,7 +112947,7 @@ aaQ
 aaf
 abZ
 abZ
-uVl
+vqF
 abZ
 abZ
 acO
@@ -119014,7 +119022,7 @@ rOU
 boq
 bCI
 uKA
-hSb
+tve
 vPj
 bGX
 bIv
@@ -122336,7 +122344,7 @@ bAL
 kli
 udY
 ygw
-dmI
+huy
 chs
 maH
 ftU


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Mid-size change batch for Kondaru, most prominently including engine layout tinkering.

Engine core:
- Core has been shifted two tiles east and received a slight layout adjustment.
- Engineering Gas Storage is the primary target and beneficiary of this change; stores of sensitive tanks are now sequestered within sub-chambers that are surrounded by R-walls on all sides, making it significantly more secure, and there is a slightly greater canister selection.
- The burn chamber now has a camera for viewing of the burn, allowing it to be monitored even if heat shields are closed. Its west viewport is also much wider.
- The engine control room now has a television and burn chamber controls, and shares an area with the SMES room instead of the TEG chamber, permitting the chamber to have a discrete phone.

General changes:
- Added an item fuel tank to the research hangar, Robotics, and outer southeast maintenance.
- Added two phones to the Research department, one at the inner hall computer desk and one within Telescience.
- Added two additional fanny packs to station Z-level - one in the news office, and one at IR53. This brings the count to two on station and three total.
- Added an additional science and medical uniform locker, respectively added to an open space in Telescience and replacing a redundant water cooler.
- Added a defibrillator to the central Medbay table (removed from its prior home in the supplementary crate in Medbay's hangar).
- Added a few select floor guides near the Bridge and Courtroom to (hopefully) make navigation a bit more intuitive.
- Slightly reorganized Engineering Storage, the Head of Personnel's quarters, and the Ranch. No change in room dimensions or equipment complement.
- Engineering hangar beacon has been relocated a bit west of its prior location to better utilize the space now that it's more open.
- North airbridge and Book Nook adjusted a bit to maintain an extent of symmetry after the engine changes.
- Adjusted layout of table contents in News Office private room and Detective's Office lobby.
- Added a television to Engineering staff room. Phone has been moved to a wall.
- Television cameras now have their c_tag strings capitalized.
- Ephemeral ornamentation touchup, primarily in adjusted areas.
- Albert now starts directly in the Telescience pad room, instead of the embarkation room.
- Hooty has departed from Security's front office and now watches over court proceedings.
- Relocated a few oddball objects that didn't line up on walls right (east Engineering space signs, CE intercom). 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Further improves the usability and feature set of Kondaru.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(*)Kondaru upgrade Lambda - engineering gas storage rework, improved equipment complement, small tuneups and an owl migration.
```
