### PR TITLE
Map file display case semicolon fix

### DIFF
--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -14620,7 +14620,7 @@
 "CL" = (
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingun
+	displayed = new /obj/item/captaingun;
 	pixel_y = 6
 	},
 /turf/simulated/floor/black,

--- a/maps/icarus.dmm
+++ b/maps/icarus.dmm
@@ -17365,7 +17365,7 @@
 	},
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingun
+	displayed = new /obj/item/captaingun;
 	pixel_y = 6
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -27931,7 +27931,7 @@
 "bCR" = (
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingun
+	displayed = new /obj/item/captaingun;
 	pixel_y = 6
 	},
 /turf/simulated/floor/carpet/arcade,

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -6176,7 +6176,7 @@
 "bRA" = (
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingun
+	displayed = new /obj/item/captaingun;
 	pixel_y = 6
 	},
 /obj/machinery/light/small{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds absent semicolons to "displayed" var (added after display case rework) in Kondaru, Ozymandias, Fleet and Icarus.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Semicolons are cool and good, especially for map diff.