### PR TITLE
Adds blue lab coat as a Medical Doctor job reward, Docs now start with the doctor labcoat equipped at roundstart

### DIFF
--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -591,7 +591,7 @@ mob/verb/checkrewards()
 /datum/jobXpReward/medical_doctor/blue_labcoat
 	name = "Blue Labcoat"
 	desc = "Woops. Looks like you put too much detergent into the washing machine when you put your work clothes in. Let's hope the Medical Director doesn't enforce a dress code."
-	required_levels = list("Medical Doctor"=5)
+	required_levels = list("Medical Doctor"=10)
 	icon_state = "?"
 	claimable = 1
 	claimPerRound = 1

--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -586,3 +586,25 @@ mob/verb/checkrewards()
 		C.mob.put_in_hand_or_drop(I)
 		boutput(C.mob, "You look away for a second and the shaker turns into golden from top to bottom!")
 
+/////////////Medical Doctor////////////////
+
+/datum/jobXpReward/medical_doctor/blue_labcoat
+	name = "Blue Labcoat"
+	desc = "Woops. Looks like you put too much detergent into the washing machine when you put your work clothes in. Let's hope the Medical Director doesn't enforce a dress code."
+	required_levels = list("Medical Doctor"=5)
+	icon_state = "?"
+	claimable = 1
+	claimPerRound = 1
+	var/path_to_spawn = /obj/item/clothing/suit/labcoat/medical/blue
+
+	activate(var/client/C)
+		var/obj/item/clothing/suit/labcoat/medical/labcoat = locate(/obj/item/clothing/suit/labcoat/medical/) in C.mob.contents
+
+		if(!istype(labcoat))
+			return
+		C.mob.remove_item(labcoat)
+		qdel(labcoat)
+		var/obj/item/I = new path_to_spawn()
+		I.set_loc(get_turf(C.mob))
+		C.mob.put_in_hand_or_drop(I)
+		boutput(C.mob, "You sneeze and suddenly your labcoat changes color. Wierd.")

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -666,7 +666,7 @@ ABSTRACT_TYPE(/datum/job/research)
 	slot_back = /obj/item/storage/backpack/medic
 	slot_belt = /obj/item/storage/belt/medical
 	slot_jump = /obj/item/clothing/under/rank/medical
-	slot_suit = /obj/item/clothing/suit/labcoat
+	slot_suit = /obj/item/clothing/suit/labcoat/medical
 	slot_foot = /obj/item/clothing/shoes/red
 	slot_lhan = /obj/item/storage/firstaid/regular/doctor_spawn
 	slot_ears = /obj/item/device/radio/headset/medical

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -466,7 +466,7 @@
 	item_state = "MDlabcoat"
 	coat_style = "MDlabcoat"
 
-	april_fools
+	blue
 		icon_state = "MDlabcoat-alt"
 		item_state = "MDlabcoat-alt"
 		coat_style = "MDlabcoat-alt"

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -9948,7 +9948,7 @@
 "cEO" = (
 /obj/displaycase{
 	displayed = new /obj/item/captaingun
-},
+	},
 /obj/machinery/light/incandescent/greenish{
 	dir = 1
 	},
@@ -23952,19 +23952,13 @@
 /area/listeningpost)
 "gQV" = (
 /obj/rack,
-/obj/item/clothing/suit/labcoat/medical/april_fools{
-	pixel_x = 4;
-	pixel_y = 5
+/obj/item/sponge{
+	pixel_x = -5;
+	pixel_y = 1
 	},
-/obj/item/clothing/suit/labcoat/medical{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/clothing/suit/labcoat/medical{
-	pixel_x = -3
-	},
-/obj/item/clothing/suit/labcoat/medical/april_fools{
-	pixel_x = 9
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 6;
+	pixel_y = -5
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/breakroom)
@@ -42759,7 +42753,9 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
 "mCO" = (
-/obj/stool/chair/comfy,
+/obj/stool/chair/comfy{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/breakroom)
 "mCZ" = (

--- a/maps/donut3_xmas.dmm
+++ b/maps/donut3_xmas.dmm
@@ -24386,7 +24386,7 @@
 /area/space)
 "gQV" = (
 /obj/rack,
-/obj/item/clothing/suit/labcoat/medical/april_fools{
+/obj/item/clothing/suit/labcoat/medical/blue{
 	pixel_x = 4;
 	pixel_y = 5
 	},
@@ -24397,7 +24397,7 @@
 /obj/item/clothing/suit/labcoat/medical{
 	pixel_x = -3
 	},
-/obj/item/clothing/suit/labcoat/medical/april_fools{
+/obj/item/clothing/suit/labcoat/medical/blue{
 	pixel_x = 9
 	},
 /turf/simulated/floor/carpet/arcade,

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -67659,7 +67659,7 @@
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/darkchis)
 "dwd" = (
-/obj/item/clothing/suit/labcoat/medical/april_fools,
+/obj/item/clothing/suit/labcoat/medical/blue,
 /obj/machinery/light{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the blue lab coat as a Medical Doctor job reward
Docs now start with the doctor labcoat equipped at roundstart
Rename item patch from labcoat/medical/april_fools to labcoat/medical/blue
Removed red and blue lab coats from Donut 3


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Feature request and to expand Job XP rewards


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Carbadox
(*)Added a blue variant of the medical lab coat as a Medical Doctor job reward
(+)Doctors now start with the red medical labcoat equipped at roundstart
```
