### PR TITLE
nerf some artifacts and stuff

### DIFF
--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -49,9 +49,10 @@
 		attack_type = pick("lightning","fire","ice","sonic")
 		if(prob(10))
 			attack_type = "all"
-		cooldown = rand(25,900)
-		if (prob(5))
-			cooldown = 0
+		// cooldown
+		cooldown = rand(3 SECONDS, 70 SECONDS)
+		if(attack_type == "lightning")
+			cooldown = max(30 SECONDS, cooldown)
 		// fire
 		powerVars["fireTemp"] = rand(1000,10000)
 		if(prob(10))

--- a/code/obj/artifacts/artifact_items/attack_wand.dm
+++ b/code/obj/artifacts/artifact_items/attack_wand.dm
@@ -22,7 +22,6 @@
 			user.lastattacked = src
 			var/turf/U = (istype(target, /atom/movable) ? target.loc : target)
 			A.effect_click_tile(src,user,U)
-			src.ArtifactFaultUsed(user)
 
 /datum/artifact/attack_wand
 	associated_object = /obj/item/artifact/attack_wand
@@ -146,4 +145,6 @@
 
 				if (R.total_volume)
 					R.clear_reagents()
+
+		O.ArtifactFaultUsed(user)
 		return

--- a/code/obj/artifacts/artifact_items/melee_weapon.dm
+++ b/code/obj/artifacts/artifact_items/melee_weapon.dm
@@ -25,7 +25,6 @@
 	var/damtype = "brute"
 	var/dmg_amount = 5
 	var/stamina_dmg = 0
-	var/deadly = 0
 	var/sound/hitsound = null
 	examine_hint = "It seems to have a handle you're supposed to hold it by."
 	module_research = list("weapons" = 8, "miniaturization" = 8)
@@ -36,12 +35,8 @@
 		src.damtype = pick("brute", "fire", "toxin")
 		src.dmg_amount = rand(3,6)
 		src.dmg_amount *= rand(1,5)
-		if (prob(5))
-			src.dmg_amount *= rand(1,5)
 		if (prob(45))
 			src.stamina_dmg = rand(50,120)
-		if (prob(1))
-			src.deadly = 1
 		src.hitsound = pick('sound/impact_sounds/Metal_Hit_Heavy_1.ogg','sound/impact_sounds/Wood_Hit_1.ogg','sound/effects/exlow.ogg','sound/effects/mag_magmisimpact.ogg','sound/impact_sounds/Energy_Hit_1.ogg',
 		'sound/impact_sounds/Generic_Snap_1.ogg','sound/machines/mixer.ogg','sound/impact_sounds/Generic_Hit_Heavy_1.ogg','sound/weapons/ACgun2.ogg','sound/impact_sounds/Energy_Hit_3.ogg','sound/weapons/flashbang.ogg',
 		'sound/weapons/grenade.ogg','sound/weapons/railgun.ogg')
@@ -54,16 +49,12 @@
 		user.visible_message("<span class='alert'><b>[user.name]</b> attacks [target.name] with [O]!</span>")
 		var/turf/T = get_turf(user)
 		playsound(T, hitsound, 50, 1, -1)
-		if (src.deadly)
-			user.visible_message("<span class='alert'><b>[target] is utterly destroyed!</b></span>")
-			target.gib()
-		else
-			switch(damtype)
-				if ("brute")
-					random_brute_damage(target, dmg_amount,1)
-				if ("fire")
-					random_burn_damage(target, dmg_amount)
-				if ("toxin")
-					target.take_toxin_damage(rand(1, dmg_amount))
-			if (src.stamina_dmg)
-				target.do_disorient(stamina_damage = src.stamina_dmg, weakened = src.stamina_dmg - 20, disorient = src.stamina_dmg - 40)
+		switch(damtype)
+			if ("brute")
+				random_brute_damage(target, dmg_amount,1)
+			if ("fire")
+				random_burn_damage(target, dmg_amount)
+			if ("toxin")
+				target.take_toxin_damage(rand(1, dmg_amount))
+		if (src.stamina_dmg)
+			target.do_disorient(stamina_damage = src.stamina_dmg, weakened = src.stamina_dmg - 20, disorient = src.stamina_dmg - 40)

--- a/code/obj/artifacts/artifact_items/teleport_wand.dm
+++ b/code/obj/artifacts/artifact_items/teleport_wand.dm
@@ -24,7 +24,6 @@
 				A.effect_click_tile(src,user,U)
 			else
 				boutput(user, "<b>[src]</b> [A.error_phrase]")
-			src.ArtifactFaultUsed(user)
 
 /datum/artifact/telewand
 	associated_object = /obj/item/artifact/teleport_wand
@@ -72,6 +71,7 @@
 		var/turf/start_loc = get_turf(user)
 		playsound(start_loc, wand_sound, 50, 1, -1)
 		particleMaster.SpawnSystem(new /datum/particleSystem/tele_wand(T,particle_sprite,particle_color))
+		O.ArtifactFaultUsed(user)
 		return
 
 	proc/can_teleport_here(var/turf/T)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
*Removes the chance for melee artifacts to have huge damage rarely. Their damage should now vary from 3 to 30.
*Removes the chance for melee artifacts to rarely have the ability to instantly gib hit target.

*Attack Wands now have their cooldowns range from 3 seconds to 70 seconds. (Before: 2.5 seconds to 90 seconds)
*They no longer have a small chance to have no cooldown at all.
*Lightning type wands will always have a cooldown of at least 30 seconds.

*Fixed a bug where attack wands and teleport wands could trigger their faults even when on cooldown.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As the complaint thread in the forum says, (strong) lightning artifacts with no cooldown are really pretty unfair.
Melee artifacts that kill you in one or two hits seem a little unneeded as well.
Since ice, fire, sonic wands don't really stack their effects very well, I think low cooldowns are alright on those.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+)Reduced the maximum power level of melee and magic wand artifacts.
```
