### PR TITLE
Adds a hidden entrance to the debris hat trader's asteroid

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -78096,7 +78096,7 @@ aac
 aac
 aac
 aac
-aac
+oNB
 oNB
 aaa
 aaa

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -25295,6 +25295,12 @@
 /obj/item/reagent_containers/food/snacks/breakfast,
 /turf/simulated/floor/caution/west,
 /area/mining/quarters)
+"oNB" = (
+/turf/simulated/wall/asteroid{
+	name = "weak compacted stone";
+	stone_color = "#575A5E"
+	},
+/area/space)
 "qBE" = (
 /obj/lattice{
 	dir = 1;
@@ -78090,8 +78096,8 @@ aac
 aac
 aac
 aac
-aHr
-aHr
+aac
+oNB
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR replaces two of the compacted stone walls on the Clack Hat's asteroid with regular asteroid walls, reskinned to match the compacted stone colour and a fitting name.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently the Clack Hat's asteroid is completely surrounded with compacted stone, so getting there requires you to get actual good mining tools. Which is a little bit weird in my opinion, debris traders with much more powerful gear to buy are much easier to get to than the trader that sells just hats.

