### PR TITLE
Maximum nuke ops raised to 10 + utility knife buff

### DIFF
--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -38,7 +38,7 @@
 
 		if (player.ready)
 			num_players++
-	var/num_synds = max(1, min(round(num_players / 4), agents_possible))
+	var/num_synds = clamp( round(num_players / 6 ), 1, agents_possible)
 
 	possible_syndicates = get_possible_syndicates(num_synds)
 

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -11,7 +11,7 @@
 	var/agent_radiofreq = 0 //:h for syndies, randomized per round
 	var/obj/machinery/nuclearbomb/the_bomb = null
 	var/bomb_check_timestamp = 0 // See check_finished().
-	var/const/agents_possible = 8 //If we ever need more syndicate agents. cogwerks - raised from 5
+	var/const/agents_possible = 10 //If we ever need more syndicate agents. cogwerks - raised from 5
 
 
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -506,13 +506,17 @@
 	desc = "An ornamental dagger for syndicate higher-ups. It sounds fancy, but it's basically the munitions company equivalent of those glass cubes with the company logo frosted on."
 
 /obj/item/dagger/syndicate/specialist //Infiltrator class knife
-	name = "syndicate combat knife"
+	name = "syndicate fighting utiltiy knife"
 	desc = "A light but robust combat knife that allows you to move faster in fights."
 	icon_state = "combat_knife"
+	force = 15
+	throwforce = 20
+	stamina_cost = 5
 
 	setupProperties()
 		..()
 		setProperty("movespeed", -0.5)
+		setProperty("frenzy")
 
 /obj/item/dagger/throwing_knife
 	name = "cheap throwing knife"

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -516,7 +516,6 @@
 	setupProperties()
 		..()
 		setProperty("movespeed", -0.5)
-		setProperty("frenzy")
 
 /obj/item/dagger/throwing_knife
 	name = "cheap throwing knife"

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -506,7 +506,7 @@
 	desc = "An ornamental dagger for syndicate higher-ups. It sounds fancy, but it's basically the munitions company equivalent of those glass cubes with the company logo frosted on."
 
 /obj/item/dagger/syndicate/specialist //Infiltrator class knife
-	name = "syndicate fighting utiltiy knife"
+	name = "syndicate fighting utility knife"
 	desc = "A light but robust combat knife that allows you to move faster in fights."
 	icon_state = "combat_knife"
 	force = 15

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -12876,10 +12876,15 @@
 /turf/unsimulated/wall/setpieces/leadwall,
 /area/crater/biodome/research)
 "aQz" = (
-/obj/storage/cart,
-/obj/random_item_spawner/furniture_parts/few,
-/turf/unsimulated/floor/black/grime,
-/area/syndicate_station/battlecruiser)
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/turf/simulated/wall/target,
+/turf/unsimulated/floor/plating/random,
+/area/syndicate_station/firing_range)
 "aQA" = (
 /obj/table/wood/auto,
 /turf/unsimulated/floor/carpet/grime,
@@ -14564,15 +14569,12 @@
 /turf/unsimulated/floor/specialroom/medbay,
 /area/marsoutpost)
 "aVd" = (
-/obj/table/auto,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
-/turf/unsimulated/floor/darkblue,
-/area/syndicate_station/battlecruiser)
+/obj/indestructible/shuttle_corner{
+	dir = 8;
+	icon_state = "wall3_trans"
+	},
+/turf/space,
+/area/space)
 "aVe" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8
@@ -24603,11 +24605,9 @@
 /turf/unsimulated/floor,
 /area/iomoon/base)
 "btp" = (
-/obj/item/sea_ladder,
-/obj/item/sea_ladder,
-/obj/item/sea_ladder,
-/obj/item/sea_ladder,
-/obj/item/sea_ladder,
+/obj/storage/crate/packing,
+/obj/item/paint_can/random,
+/obj/item/pen/crayon/random,
 /turf/unsimulated/floor/black/grime,
 /area/syndicate_station/battlecruiser)
 "btq" = (
@@ -45833,23 +45833,20 @@
 /turf/unsimulated/floor/circuit/red,
 /area/syndicate_station/battlecruiser)
 "cvX" = (
-/obj/machinery/door/airlock/pyro/syndicate{
-	dir = 8;
-	name = "launch bay";
-	opacity = 0
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	id = "medbay_door";
+	name = "launch bay"
 	},
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "cvY" = (
-/obj/table/auto,
-/obj/item/pinpointer/nuke,
-/obj/item/pinpointer/nuke,
-/obj/item/pinpointer/nuke,
-/obj/item/pinpointer/nuke,
-/obj/item/pinpointer/nuke,
-/obj/item/pinpointer/nuke,
-/turf/unsimulated/floor/darkblue,
-/area/syndicate_station/battlecruiser)
+/obj/indestructible/shuttle_corner{
+	dir = 1;
+	icon_state = "wall3_trans"
+	},
+/turf/space,
+/area/space)
 "cvZ" = (
 /obj/rack,
 /obj/item/tank/jetpack/syndicate,
@@ -45858,13 +45855,11 @@
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "cwa" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "delivery2"
 	},
-/obj/submachine/weapon_vendor/syndicate,
-/turf/unsimulated/floor/red,
+/turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "cwc" = (
 /obj/decal/stalagtite{
@@ -45899,12 +45894,10 @@
 /turf/unsimulated/floor/red,
 /area/syndicate_station/battlecruiser)
 "cwh" = (
-/obj/decal/tile_edge/stripe{
-	dir = 6;
-	icon_state = "delivery2"
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
 	},
-/turf/unsimulated/floor/darkblue,
-/area/syndicate_station/battlecruiser)
+/area/space)
 "cwi" = (
 /obj/decal/boxingrope{
 	dir = 4
@@ -61375,9 +61368,14 @@
 /area/sim/racing_track)
 "dff" = (
 /obj/table/auto,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/nightvision,
-/obj/item/clothing/glasses/nightvision,
+/obj/machinery/light,
+/obj/item/remote/syndicate_teleporter,
+/obj/item/remote/syndicate_teleporter,
+/obj/item/remote/syndicate_teleporter,
+/obj/item/remote/syndicate_teleporter,
+/obj/item/remote/syndicate_teleporter,
+/obj/item/remote/syndicate_teleporter,
+/obj/item/remote/syndicate_teleporter,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "dfg" = (
@@ -61448,12 +61446,9 @@
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/sim/gunsim)
 "dfn" = (
-/obj/table/auto,
-/obj/item/shipcomponent/secondary_system/crash,
-/obj/item/shipcomponent/secondary_system/crash,
-/obj/item/crowbar,
-/turf/unsimulated/floor/darkpurple,
-/area/syndicate_station/battlecruiser)
+/obj/wingrille_spawn/auto/crystal,
+/turf/unsimulated/floor/plating/random,
+/area/space)
 "dfo" = (
 /obj/decal/tile_edge/stripe{
 	dir = 6;
@@ -61825,10 +61820,9 @@
 /area/iomoon/caves)
 "dfP" = (
 /obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/shipcomponent/mainweapon/gun,
-/obj/item/shipcomponent/mainweapon/gun,
-/obj/item/shipcomponent/mainweapon/gun,
+/obj/item/shipcomponent/secondary_system/crash,
+/obj/item/shipcomponent/secondary_system/crash,
+/obj/item/crowbar,
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "dfQ" = (
@@ -62003,16 +61997,14 @@
 	},
 /area/iomoon)
 "dgk" = (
-/obj/rack,
-/obj/item/tank/emergency_oxygen,
-/obj/item/tank/emergency_oxygen,
-/obj/item/tank/emergency_oxygen,
-/obj/item/tank/emergency_oxygen,
-/obj/item/tank/emergency_oxygen,
-/obj/item/tank/emergency_oxygen,
-/obj/item/tank/emergency_oxygen,
-/obj/item/tank/emergency_oxygen,
-/turf/unsimulated/floor/bot/darkpurple,
+/obj/table/auto,
+/obj/item/pinpointer/nuke,
+/obj/item/pinpointer/nuke,
+/obj/item/pinpointer/nuke,
+/obj/item/pinpointer/nuke,
+/obj/item/pinpointer/nuke,
+/obj/item/pinpointer/nuke,
+/turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "dgl" = (
 /obj/cable{
@@ -62050,30 +62042,22 @@
 /area/syndicate_station/battlecruiser)
 "dgq" = (
 /obj/table/auto,
-/obj/item/gun/kinetic/rpg7,
-/obj/decal/tile_edge/stripe{
-	dir = 6;
-	icon_state = "delivery2"
-	},
-/turf/unsimulated/floor/darkblue,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/shipcomponent/mainweapon/gun,
+/obj/item/shipcomponent/mainweapon/gun,
+/turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "dgr" = (
-/obj/table/auto,
-/obj/item/ammo/bullets/rpg,
-/obj/item/ammo/bullets/rpg,
-/obj/item/ammo/bullets/rpg,
 /obj/decal/tile_edge/stripe{
 	dir = 6;
 	icon_state = "delivery2"
 	},
+/obj/table/auto,
+/obj/item/gun/kinetic/rpg7,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "dgs" = (
 /obj/table/auto,
-/obj/item/old_grenade/stinger/frag,
-/obj/item/old_grenade/stinger/frag,
-/obj/item/old_grenade/stinger/frag,
-/obj/item/old_grenade/stinger/frag,
 /obj/decal/tile_edge/stripe{
 	dir = 6;
 	icon_state = "delivery2"
@@ -62082,20 +62066,26 @@
 /area/syndicate_station/battlecruiser)
 "dgt" = (
 /obj/table/auto,
+/obj/item/ammo/bullets/rpg,
+/obj/item/ammo/bullets/rpg,
+/obj/item/ammo/bullets/rpg,
 /obj/decal/tile_edge/stripe{
 	dir = 6;
 	icon_state = "delivery2"
 	},
-/obj/item/old_grenade/stinger,
-/obj/item/old_grenade/stinger,
-/obj/item/old_grenade/stinger,
-/obj/item/old_grenade/stinger,
-/obj/machinery/light/small/floor,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "dgu" = (
-/obj/machinery/dispenser,
-/turf/unsimulated/floor/darkpurple,
+/obj/table/auto,
+/obj/item/old_grenade/stinger/frag,
+/obj/item/old_grenade/stinger/frag,
+/obj/item/old_grenade/stinger/frag,
+/obj/item/old_grenade/stinger/frag,
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "delivery2"
+	},
+/turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "dgv" = (
 /obj/machinery/light,
@@ -62226,37 +62216,50 @@
 	dir = 6;
 	icon_state = "delivery2"
 	},
-/obj/landmark{
-	name = "Breaching-Charges"
-	},
+/obj/item/old_grenade/stinger,
+/obj/item/old_grenade/stinger,
+/obj/item/old_grenade/stinger,
+/obj/item/old_grenade/stinger,
+/obj/machinery/light/small/floor,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "dgM" = (
 /obj/table/auto,
-/obj/decal/tile_edge/stripe{
-	dir = 6;
-	icon_state = "delivery2"
-	},
-/obj/item/mine/blast,
-/obj/item/mine/blast,
-/obj/item/mine/blast,
-/obj/item/mine/blast,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "dgN" = (
-/obj/table/auto,
-/obj/decal/tile_edge/stripe{
-	dir = 6;
-	icon_state = "delivery2"
-	},
-/obj/item/device/flash/turbo,
-/obj/machinery/light/small/floor,
-/turf/unsimulated/floor/darkblue,
+/obj/rack,
+/obj/item/tank/emergency_oxygen,
+/obj/item/tank/emergency_oxygen,
+/obj/item/tank/emergency_oxygen,
+/obj/item/tank/emergency_oxygen,
+/obj/item/tank/emergency_oxygen,
+/obj/item/tank/emergency_oxygen,
+/obj/item/tank/emergency_oxygen,
+/obj/item/tank/emergency_oxygen,
+/turf/unsimulated/floor/bot/darkpurple,
 /area/syndicate_station/battlecruiser)
 "dgO" = (
-/obj/storage/crate/wooden,
-/obj/random_item_spawner/furniture_parts/few,
-/turf/unsimulated/floor/black/grime,
+/obj/table/auto,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/tool/omnitool/syndicate{
+	icon_state = "syndicate-omnitool-screwing"
+	},
+/obj/item/tool/omnitool/syndicate{
+	icon_state = "syndicate-omnitool-screwing"
+	},
+/obj/item/tool/omnitool/syndicate{
+	icon_state = "syndicate-omnitool-screwing"
+	},
+/turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "dgP" = (
 /obj/machinery/light{
@@ -62312,9 +62315,8 @@
 	},
 /area/iomoon)
 "dgW" = (
-/obj/storage/crate/packing,
-/obj/item/paint_can/random,
-/obj/item/pen/crayon/random,
+/obj/storage/cart,
+/obj/random_item_spawner/furniture_parts/few,
 /turf/unsimulated/floor/black/grime,
 /area/syndicate_station/battlecruiser)
 "dgX" = (
@@ -62324,15 +62326,18 @@
 /turf/unsimulated/outdoors/grass,
 /area/shuttle/merchant_shuttle/left_centcom/donut2)
 "dgY" = (
-/obj/storage/crate/wooden,
-/obj/random_item_spawner/junk/some,
-/turf/unsimulated/floor/black,
-/area/syndicate_station/battlecruiser)
-"dgZ" = (
 /obj/machinery/light,
 /obj/random_item_spawner/tools,
 /obj/rack,
 /turf/unsimulated/floor/black,
+/area/syndicate_station/battlecruiser)
+"dgZ" = (
+/obj/item/sea_ladder,
+/obj/item/sea_ladder,
+/obj/item/sea_ladder,
+/obj/item/sea_ladder,
+/obj/item/sea_ladder,
+/turf/unsimulated/floor/black/grime,
 /area/syndicate_station/battlecruiser)
 "dha" = (
 /obj/storage/crate/packing,
@@ -62389,30 +62394,18 @@
 	},
 /area/iomoon)
 "dhg" = (
-/obj/table/auto,
-/obj/item/clothing/gloves/yellow,
-/obj/item/clothing/gloves/yellow,
-/obj/item/clothing/gloves/yellow,
-/obj/item/clothing/gloves/yellow,
-/obj/item/clothing/gloves/yellow,
-/obj/item/clothing/gloves/yellow,
-/obj/machinery/light,
-/turf/unsimulated/floor/darkblue,
+/obj/machinery/dispenser,
+/turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "dhh" = (
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "delivery2"
+	},
 /obj/table/auto,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/tool/omnitool/syndicate{
-	icon_state = "syndicate-omnitool-screwing"
-	},
-/obj/item/tool/omnitool/syndicate{
-	icon_state = "syndicate-omnitool-screwing"
-	},
-/obj/item/tool/omnitool/syndicate{
-	icon_state = "syndicate-omnitool-screwing"
-	},
+/obj/item/clothing/glasses/nightvision,
+/obj/item/clothing/glasses/nightvision,
+/obj/item/clothing/glasses/nightvision,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "dhi" = (
@@ -62447,14 +62440,13 @@
 /area/iomoon/caves)
 "dhk" = (
 /obj/table/auto,
-/obj/machinery/light,
-/obj/item/remote/syndicate_teleporter,
-/obj/item/remote/syndicate_teleporter,
-/obj/item/remote/syndicate_teleporter,
-/obj/item/remote/syndicate_teleporter,
-/obj/item/remote/syndicate_teleporter,
-/obj/item/remote/syndicate_teleporter,
-/obj/item/remote/syndicate_teleporter,
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "delivery2"
+	},
+/obj/landmark{
+	name = "Breaching-Charges"
+	},
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "dhl" = (
@@ -77267,6 +77259,17 @@
 /obj/machinery/door/airlock/pyro/security,
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom/donut3)
+"eaP" = (
+/obj/table/auto,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/machinery/light,
+/turf/unsimulated/floor/darkblue,
+/area/syndicate_station/battlecruiser)
 "ecr" = (
 /obj/machinery/light{
 	dir = 1
@@ -79249,6 +79252,18 @@
 	dir = 4
 	},
 /area/ship_interior/cruisertest2)
+"kQr" = (
+/obj/table/auto,
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "delivery2"
+	},
+/obj/item/mine/blast,
+/obj/item/mine/blast,
+/obj/item/mine/blast,
+/obj/item/mine/blast,
+/turf/unsimulated/floor/darkblue,
+/area/syndicate_station/battlecruiser)
 "kRQ" = (
 /obj/grille/steel,
 /obj/window/reinforced{
@@ -80600,6 +80615,16 @@
 /obj/item/paper/postcard/mushroom,
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/efrem)
+"pbO" = (
+/obj/table/auto,
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "delivery2"
+	},
+/obj/item/device/flash/turbo,
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/darkblue,
+/area/syndicate_station/battlecruiser)
 "peF" = (
 /obj/stool/chair{
 	dir = 1
@@ -80635,6 +80660,11 @@
 /turf/space,
 /turf/unsimulated/floor/caution/south,
 /area/hospital/samostrel)
+"phn" = (
+/obj/storage/crate/wooden,
+/obj/random_item_spawner/furniture_parts/few,
+/turf/unsimulated/floor/black/grime,
+/area/syndicate_station/battlecruiser)
 "pkO" = (
 /obj/fakeobjects{
 	icon = 'icons/misc/critter.dmi';
@@ -83103,6 +83133,11 @@
 	icon_state = "floor3"
 	},
 /area/hospital/samostrel)
+"xQV" = (
+/obj/storage/crate/wooden,
+/obj/random_item_spawner/junk/some,
+/turf/unsimulated/floor/black,
+/area/syndicate_station/battlecruiser)
 "xUe" = (
 /turf/unsimulated/floor/dream/beach{
 	icon_state = "shore-21"
@@ -107450,16 +107485,16 @@ cnw
 cnw
 cnw
 cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+aVd
+cwh
+dfn
+dfn
+dfn
+cwh
+cwh
+cwh
+cwh
+cwh
 cnw
 cnw
 cnw
@@ -107752,15 +107787,15 @@ cnw
 cnw
 cnw
 cnw
-aJC
 aKf
-aKz
-aKz
-aKz
+dey
+dfP
+dgq
+dgN
+dhg
 aKf
-aKf
-aKf
-aKf
+phn
+btp
 aKf
 cnw
 cnw
@@ -108055,13 +108090,13 @@ aKf
 aKf
 aKf
 aKf
-dey
-dfn
-dfP
-dgk
-dgu
+bqV
+bqV
+bqV
+bqV
+dgv
 aKf
-dgO
+dgP
 dgW
 aKf
 bCy
@@ -108361,10 +108396,10 @@ bqV
 bqV
 bqV
 bqV
-dgv
-aKf
-dgP
-aQz
+bqV
+dgD
+bqW
+bqW
 aKf
 aKf
 aKz
@@ -108664,9 +108699,9 @@ dfo
 dfQ
 dfQ
 bqV
-dgD
-bqW
-bqW
+aKf
+dgQ
+xQV
 aKf
 dhp
 dhB
@@ -109269,7 +109304,7 @@ dfQ
 dfQ
 sdh
 aKf
-dgQ
+bqW
 dgZ
 aKf
 dhr
@@ -113497,8 +113532,8 @@ btf
 btf
 btf
 dgK
-btf
-dff
+cwa
+cwg
 aKf
 dhv
 bvI
@@ -113799,8 +113834,8 @@ btf
 btf
 btf
 btf
-btf
-dhg
+dgi
+cwg
 aKf
 dhw
 bqW
@@ -114090,19 +114125,19 @@ bEP
 aKf
 cIe
 cKR
-acn
+aQz
 cKR
 cIe
 deq
 dex
 dfa
 btf
-dgi
-dgq
-dgi
-dgL
-dgi
+dgr
+btf
 dhh
+btf
+cwa
+cwg
 aKf
 dhx
 bqW
@@ -114399,12 +114434,12 @@ dep
 dex
 deG
 btf
+dgs
+btf
+dhk
+btf
 dgi
-dgr
-dgi
-dgL
-dgi
-aVd
+cwg
 aKf
 dhy
 bqW
@@ -114701,12 +114736,12 @@ dep
 nWL
 dfa
 btf
-dgi
-dgs
-dgi
-dgM
-dgi
-cvY
+dgt
+btf
+dhk
+btf
+cwa
+cwg
 aKf
 dhz
 bqW
@@ -115003,12 +115038,12 @@ dep
 dex
 deG
 btf
+dgu
+btf
+kQr
+btf
 dgi
-dgt
-dgi
-dgN
-dgi
-dhk
+cwg
 aKf
 dhw
 bqW
@@ -115305,12 +115340,12 @@ deq
 dex
 dfa
 btf
+dgL
 btf
+pbO
 btf
-btf
-btf
-btf
-btf
+cwa
+cwg
 aKf
 cwk
 dhN
@@ -115606,13 +115641,13 @@ cIe
 dep
 dex
 deG
+btf
+btf
+btf
+btf
+btf
 dgi
-cwh
-dgi
-cwh
-dgi
-cwh
-dgi
+cwg
 aKf
 aKz
 aKz
@@ -115907,12 +115942,12 @@ aKf
 aKf
 aKf
 aKf
-cwg
-cwa
-cwg
-cwg
-cwg
-cwg
+btf
+btf
+btf
+btf
+btf
+btf
 cwa
 cwg
 aKf
@@ -116208,15 +116243,15 @@ cnw
 cnw
 cnw
 cnw
-aKA
 aKf
-aKf
-aKf
-aKf
-aKf
-aKf
-aKf
-aKf
+dff
+dgk
+dgM
+dgO
+eaP
+btf
+dgi
+cwg
 aKf
 cnw
 cnw
@@ -116510,16 +116545,16 @@ cnw
 cnw
 cnw
 cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
-cnw
+cvY
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
 cnw
 cnw
 cnw


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Raises the total nuclear operatives possible in a round from 8 to 10 and adjusts the Cairngorm to fit 10 weapons vendors.
Also, improves the damage, throw damage and stamina cost of the nuke ops utility knife. I also gave it frenzy, that's probably good, right?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Players are encountering populations of 100 or more and 8 operatives doesn't feel like enough to really fight against those overwhelming odds. I'm cautious to raise it further without compromisnig teamwork but 10 is probably good.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gannets
(*)Raised the total nuclear operatives possible in a round from 8 to 10. Scaling is also adjusted to account for higher population, for example, 48 players ready at round-start will result in 8 operatives. Any fewer players will mean less operatives.
(*)Renamed the syndicate combat knife to syndicate fighting utility knife, increased it's damage, throwing damage & reduced it's stamina cost.
```
