### PR TITLE
Adds health pop-up overhead to upgraded ProDocs and floor health scanners

### DIFF
--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -347,63 +347,15 @@
 			var/obj/item/clothing/glasses/healthgoggles/G = H.glasses
 			if (G.scan_upgrade && G.health_scan)
 				. += "<br><span class='alert'>Your ProDocs analyze [src]'s vitals.</span><br>[scan_health(src, 0, 0)]"
-				if (usr.client && !usr.client.preferences?.flying_chat_hidden)
-
-					var/image/chat_maptext/chat_text = null
-					var/h_pct = src.max_health ? round(100 * src.health / src.max_health) : src.health
-					var/oxy = round(src.get_oxygen_deprivation())
-					var/tox = round(src.get_toxin_damage())
-					var/burn = round(src.get_burn_damage())
-					var/brute = round(src.get_brute_damage())
-
-					var/popup_text = "<span class='ol c pixel'><span class='vga'>[h_pct]%</span>\n<span style='color: #40b0ff;'>[oxy]</span> - <span style='color: #33ff33;'>[tox]</span> - <span style='color: #ffee00;'>[burn]</span> - <span style='color: #ff6666;'>[brute]</span></span>"
-					chat_text = make_chat_maptext(src, popup_text, force = 1)
-					if(chat_text)
-						chat_text.measure(usr.client)
-						for(var/image/chat_maptext/I in usr.chat_text.lines)
-							if(I != chat_text)
-								I.bump_up(chat_text.measured_height)
-						chat_text.show_to(usr.client)
+				scan_health_overhead(src, usr)
 			update_medical_record(src)
 		else if (H.organ_istype("left_eye", /obj/item/organ/eye/cyber/prodoc) && H.organ_istype("right_eye", /obj/item/organ/eye/cyber/prodoc)) // two prodoc eyes = scan upgrade because that's cool
 			. += "<br><span class='alert'>Your ProDocs analyze [src]'s vitals.</span><br>[scan_health(src, 0, 0)]"
-			if (usr.client && !usr.client.preferences?.flying_chat_hidden)
-
-				var/image/chat_maptext/chat_text = null
-				var/h_pct = src.max_health ? round(100 * src.health / src.max_health) : src.health
-				var/oxy = round(src.get_oxygen_deprivation())
-				var/tox = round(src.get_toxin_damage())
-				var/burn = round(src.get_burn_damage())
-				var/brute = round(src.get_brute_damage())
-
-				var/popup_text = "<span class='ol c pixel'><span class='vga'>[h_pct]%</span>\n<span style='color: #40b0ff;'>[oxy]</span> - <span style='color: #33ff33;'>[tox]</span> - <span style='color: #ffee00;'>[burn]</span> - <span style='color: #ff6666;'>[brute]</span></span>"
-				chat_text = make_chat_maptext(src, popup_text, force = 1)
-				if(chat_text)
-					chat_text.measure(usr.client)
-					for(var/image/chat_maptext/I in usr.chat_text.lines)
-						if(I != chat_text)
-							I.bump_up(chat_text.measured_height)
-					chat_text.show_to(usr.client)
+			scan_health_overhead(src, usr)
 			update_medical_record(src)
 		else if (istype(H.head, /obj/item/clothing/head/helmet/space/syndicate/specialist/medic))
 			. += "<br><span class='alert'>Your health monitor analyzes [src]'s vitals.</span><br>[scan_health(src, 0, 0)]"
-			if (usr.client && !usr.client.preferences?.flying_chat_hidden)
-
-				var/image/chat_maptext/chat_text = null
-				var/h_pct = src.max_health ? round(100 * src.health / src.max_health) : src.health
-				var/oxy = round(src.get_oxygen_deprivation())
-				var/tox = round(src.get_toxin_damage())
-				var/burn = round(src.get_burn_damage())
-				var/brute = round(src.get_brute_damage())
-
-				var/popup_text = "<span class='ol c pixel'><span class='vga'>[h_pct]%</span>\n<span style='color: #40b0ff;'>[oxy]</span> - <span style='color: #33ff33;'>[tox]</span> - <span style='color: #ffee00;'>[burn]</span> - <span style='color: #ff6666;'>[brute]</span></span>"
-				chat_text = make_chat_maptext(src, popup_text, force = 1)
-				if(chat_text)
-					chat_text.measure(usr.client)
-					for(var/image/chat_maptext/I in usr.chat_text.lines)
-						if(I != chat_text)
-							I.bump_up(chat_text.measured_height)
-					chat_text.show_to(usr.client)
+			scan_health_overhead(src, usr)
 			update_medical_record(src)
 
 	return jointext(., "")

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -347,12 +347,63 @@
 			var/obj/item/clothing/glasses/healthgoggles/G = H.glasses
 			if (G.scan_upgrade && G.health_scan)
 				. += "<br><span class='alert'>Your ProDocs analyze [src]'s vitals.</span><br>[scan_health(src, 0, 0)]"
+				if (usr.client && !usr.client.preferences?.flying_chat_hidden)
+
+					var/image/chat_maptext/chat_text = null
+					var/h_pct = src.max_health ? round(100 * src.health / src.max_health) : src.health
+					var/oxy = round(src.get_oxygen_deprivation())
+					var/tox = round(src.get_toxin_damage())
+					var/burn = round(src.get_burn_damage())
+					var/brute = round(src.get_brute_damage())
+
+					var/popup_text = "<span class='ol c pixel'><span class='vga'>[h_pct]%</span>\n<span style='color: #40b0ff;'>[oxy]</span> - <span style='color: #33ff33;'>[tox]</span> - <span style='color: #ffee00;'>[burn]</span> - <span style='color: #ff6666;'>[brute]</span></span>"
+					chat_text = make_chat_maptext(src, popup_text, force = 1)
+					if(chat_text)
+						chat_text.measure(usr.client)
+						for(var/image/chat_maptext/I in usr.chat_text.lines)
+							if(I != chat_text)
+								I.bump_up(chat_text.measured_height)
+						chat_text.show_to(usr.client)
 			update_medical_record(src)
 		else if (H.organ_istype("left_eye", /obj/item/organ/eye/cyber/prodoc) && H.organ_istype("right_eye", /obj/item/organ/eye/cyber/prodoc)) // two prodoc eyes = scan upgrade because that's cool
 			. += "<br><span class='alert'>Your ProDocs analyze [src]'s vitals.</span><br>[scan_health(src, 0, 0)]"
+			if (usr.client && !usr.client.preferences?.flying_chat_hidden)
+
+				var/image/chat_maptext/chat_text = null
+				var/h_pct = src.max_health ? round(100 * src.health / src.max_health) : src.health
+				var/oxy = round(src.get_oxygen_deprivation())
+				var/tox = round(src.get_toxin_damage())
+				var/burn = round(src.get_burn_damage())
+				var/brute = round(src.get_brute_damage())
+
+				var/popup_text = "<span class='ol c pixel'><span class='vga'>[h_pct]%</span>\n<span style='color: #40b0ff;'>[oxy]</span> - <span style='color: #33ff33;'>[tox]</span> - <span style='color: #ffee00;'>[burn]</span> - <span style='color: #ff6666;'>[brute]</span></span>"
+				chat_text = make_chat_maptext(src, popup_text, force = 1)
+				if(chat_text)
+					chat_text.measure(usr.client)
+					for(var/image/chat_maptext/I in usr.chat_text.lines)
+						if(I != chat_text)
+							I.bump_up(chat_text.measured_height)
+					chat_text.show_to(usr.client)
 			update_medical_record(src)
 		else if (istype(H.head, /obj/item/clothing/head/helmet/space/syndicate/specialist/medic))
 			. += "<br><span class='alert'>Your health monitor analyzes [src]'s vitals.</span><br>[scan_health(src, 0, 0)]"
+			if (usr.client && !usr.client.preferences?.flying_chat_hidden)
+
+				var/image/chat_maptext/chat_text = null
+				var/h_pct = src.max_health ? round(100 * src.health / src.max_health) : src.health
+				var/oxy = round(src.get_oxygen_deprivation())
+				var/tox = round(src.get_toxin_damage())
+				var/burn = round(src.get_burn_damage())
+				var/brute = round(src.get_brute_damage())
+
+				var/popup_text = "<span class='ol c pixel'><span class='vga'>[h_pct]%</span>\n<span style='color: #40b0ff;'>[oxy]</span> - <span style='color: #33ff33;'>[tox]</span> - <span style='color: #ffee00;'>[burn]</span> - <span style='color: #ff6666;'>[brute]</span></span>"
+				chat_text = make_chat_maptext(src, popup_text, force = 1)
+				if(chat_text)
+					chat_text.measure(usr.client)
+					for(var/image/chat_maptext/I in usr.chat_text.lines)
+						if(I != chat_text)
+							I.bump_up(chat_text.measured_height)
+					chat_text.show_to(usr.client)
 			update_medical_record(src)
 
 	return jointext(., "")

--- a/code/obj/health_scanner.dm
+++ b/code/obj/health_scanner.dm
@@ -103,23 +103,7 @@
 			on_cooldown = TRUE
 			for (var/mob/living/carbon/human/H in get_turf(src))
 				data += "[scan_health(H, 1, 1, 1, 1)]"
-				if (H.client && !H.client.preferences?.flying_chat_hidden)
-
-					var/image/chat_maptext/chat_text = null
-					var/h_pct = H.max_health ? round(100 * H.health / H.max_health) : H.health
-					var/oxy = round(H.get_oxygen_deprivation())
-					var/tox = round(H.get_toxin_damage())
-					var/burn = round(H.get_burn_damage())
-					var/brute = round(H.get_brute_damage())
-
-					var/popup_text = "<span class='ol c pixel'><span class='vga'>[h_pct]%</span>\n<span style='color: #40b0ff;'>[oxy]</span> - <span style='color: #33ff33;'>[tox]</span> - <span style='color: #ffee00;'>[burn]</span> - <span style='color: #ff6666;'>[brute]</span></span>"
-					chat_text = make_chat_maptext(H, popup_text, force = 1)
-					if(chat_text)
-						chat_text.measure(H.client)
-						for(var/image/chat_maptext/I in H.chat_text.lines)
-							if(I != chat_text)
-								I.bump_up(chat_text.measured_height)
-						chat_text.show_to(H.client)
+				scan_health_overhead(H, H)
 				if (alert && H.health < 0)
 					src.crit_alert(H)
 			playsound(src.loc, "sound/machines/scan2.ogg", 30, 0)

--- a/code/obj/health_scanner.dm
+++ b/code/obj/health_scanner.dm
@@ -103,6 +103,23 @@
 			on_cooldown = TRUE
 			for (var/mob/living/carbon/human/H in get_turf(src))
 				data += "[scan_health(H, 1, 1, 1, 1)]"
+				if (H.client && !H.client.preferences?.flying_chat_hidden)
+
+					var/image/chat_maptext/chat_text = null
+					var/h_pct = H.max_health ? round(100 * H.health / H.max_health) : H.health
+					var/oxy = round(H.get_oxygen_deprivation())
+					var/tox = round(H.get_toxin_damage())
+					var/burn = round(H.get_burn_damage())
+					var/brute = round(H.get_brute_damage())
+
+					var/popup_text = "<span class='ol c pixel'><span class='vga'>[h_pct]%</span>\n<span style='color: #40b0ff;'>[oxy]</span> - <span style='color: #33ff33;'>[tox]</span> - <span style='color: #ffee00;'>[burn]</span> - <span style='color: #ff6666;'>[brute]</span></span>"
+					chat_text = make_chat_maptext(H, popup_text, force = 1)
+					if(chat_text)
+						chat_text.measure(H.client)
+						for(var/image/chat_maptext/I in H.chat_text.lines)
+							if(I != chat_text)
+								I.bump_up(chat_text.measured_height)
+						chat_text.show_to(H.client)
 				if (alert && H.health < 0)
 					src.crit_alert(H)
 			playsound(src.loc, "sound/machines/scan2.ogg", 30, 0)

--- a/code/obj/item/device/pda2/scanners.dm
+++ b/code/obj/item/device/pda2/scanners.dm
@@ -37,6 +37,7 @@
 				var/obj/machinery/clonepod/P = A
 				if(P.occupant)
 					scan_health(P.occupant, 0, 1)
+					scan_health_overhead(P.occupant, usr)
 					update_medical_record(P.occupant)
 
 			if (!iscarbon(A))
@@ -44,6 +45,7 @@
 			var/mob/living/carbon/C = A
 
 			. = scan_health(C, 0, 1, visible = 1)
+			scan_health_overhead(C, usr)
 			update_medical_record(C)
 
 

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -317,26 +317,7 @@ that cannot be itched
 		"<span class='alert'>You have analyzed [M]'s vitals.</span>")
 		boutput(user, scan_health(M, src.reagent_scan, src.disease_detection, src.organ_scan, visible = 1))
 
-		// lord forgive me for this sin
-		// output a pop-up overhead thing to the client,
-		// if they want flying text
-		if (user.client && !user.client.preferences?.flying_chat_hidden)
-
-			var/image/chat_maptext/chat_text = null
-			var/h_pct = M.max_health ? round(100 * M.health / M.max_health) : M.health
-			var/oxy = round(M.get_oxygen_deprivation())
-			var/tox = round(M.get_toxin_damage())
-			var/burn = round(M.get_burn_damage())
-			var/brute = round(M.get_brute_damage())
-
-			var/popup_text = "<span class='ol c pixel'><span class='vga'>[h_pct]%</span>\n<span style='color: #40b0ff;'>[oxy]</span> - <span style='color: #33ff33;'>[tox]</span> - <span style='color: #ffee00;'>[burn]</span> - <span style='color: #ff6666;'>[brute]</span></span>"
-			chat_text = make_chat_maptext(M, popup_text, force = 1)
-			if(chat_text)
-				chat_text.measure(user.client)
-				for(var/image/chat_maptext/I in user.chat_text.lines)
-					if(I != chat_text)
-						I.bump_up(chat_text.measured_height)
-				chat_text.show_to(user.client)
+		scan_health_overhead(M, user)
 
 		update_medical_record(M)
 

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -299,6 +299,27 @@
 			break
 	return
 
+// output a health pop-up overhead thing to the client
+/proc/scan_health_overhead(var/mob/M as mob, var/mob/C as mob) // M is who we're scanning, C is who to give the overhead to
+	if (C.client && !C.client.preferences?.flying_chat_hidden)
+
+		var/image/chat_maptext/chat_text = null
+		var/h_pct = M.max_health ? round(100 * M.health / M.max_health) : M.health
+		var/oxy = round(M.get_oxygen_deprivation())
+		var/tox = round(M.get_toxin_damage())
+		var/burn = round(M.get_burn_damage())
+		var/brute = round(M.get_brute_damage())
+
+		var/popup_text = "<span class='ol c pixel'><span class='vga'>[h_pct]%</span>\n<span style='color: #40b0ff;'>[oxy]</span> - <span style='color: #33ff33;'>[tox]</span> - <span style='color: #ffee00;'>[burn]</span> - <span style='color: #ff6666;'>[brute]</span></span>"
+		chat_text = make_chat_maptext(M, popup_text, force = 1)
+		if(chat_text)
+			chat_text.measure(C.client)
+			for(var/image/chat_maptext/I in C.chat_text.lines)
+				if(I != chat_text)
+					I.bump_up(chat_text.measured_height)
+			chat_text.show_to(C.client)
+	return
+
 /proc/scan_reagents(var/atom/A as turf|obj|mob, var/show_temp = 1, var/single_line = 0, var/visible = 0, var/medical = 0)
 	if (!A)
 		return "<span class='alert'>ERROR: NO SUBJECT DETECTED</span>"

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -318,7 +318,6 @@
 				if(I != chat_text)
 					I.bump_up(chat_text.measured_height)
 			chat_text.show_to(C.client)
-	return
 
 /proc/scan_reagents(var/atom/A as turf|obj|mob, var/show_temp = 1, var/single_line = 0, var/visible = 0, var/medical = 0)
 	if (!A)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the overhead pop-up that appears when using a health scanner on someone to upgraded ProDoc glasses, eye implants, nuke ops health monitor, and floor scanners.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Quality of life for doctors.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Lythine
(+)Added overhead health pop-up to upgraded ProDocs and floor scanners.
```
