### PR TITLE
Redfines HoS hat as a hat and not a helmet, and slightly edits the description.

### DIFF
--- a/code/WorkInProgress/Azungarstuff.dm
+++ b/code/WorkInProgress/Azungarstuff.dm
@@ -1139,7 +1139,7 @@
 		else
 			if(ishuman(hit_atom))
 				var/mob/living/carbon/human/user = usr
-				var/hos = (istype(user.head, /obj/item/clothing/head/hosberet) || istype(user.head, /obj/item/clothing/head/helmet/HoS))
+				var/hos = (istype(user.head, /obj/item/clothing/head/hosberet) || istype(user.head, /obj/item/clothing/head/hos_hat))
 				if(hos)
 					var/mob/living/carbon/human/H = hit_atom
 					H.changeStatus("stunned", 90)

--- a/code/datums/commodity.dm
+++ b/code/datums/commodity.dm
@@ -923,7 +923,7 @@
 
 /datum/commodity/contraband/hosberet
 	comname = "Head of Security Beret"
-	comtype = /obj/item/clothing/head/helmet/HoS
+	comtype = /obj/item/clothing/head/hos_hat
 	desc = "The beloved beret of an NT HoS."
 	price = 10000
 	baseprice = 10000

--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -100,7 +100,7 @@ ABSTRACT_TYPE(/datum/objective/crew/headofsecurity)
 		explanation_text = "Don't lose your hat/beret!"
 		medal_name = "Hatris"
 		check_completion()
-			if(owner.current && owner.current.check_contents_for(/obj/item/clothing/head/helmet/HoS))
+			if(owner.current && owner.current.check_contents_for(/obj/item/clothing/head/hos_hat))
 				return 1
 			else
 				return 0

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -349,7 +349,7 @@
 	station_bounties[/obj/item/clothing/head/merchant_hat] = 1
 	station_bounties[/obj/item/clothing/head/beret/prisoner] = 2
 	station_bounties[/obj/item/clothing/head/caphat] = 3
-	station_bounties[/obj/item/clothing/head/helmet/HoS] = 3
+	station_bounties[/obj/item/clothing/head/hos_hat] = 3
 
 	station_bounties[/obj/item/disk/data/floppy/read_only/communications] = 2
 	station_bounties[/obj/item/disk/data/floppy/read_only/authentication] = 3

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -261,7 +261,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	slot_poc1 = /obj/item/requisition_token/security
 	slot_poc2 = /obj/item/storage/security_pouch //replaces sec starter kit
 	slot_foot = /obj/item/clothing/shoes/swat
-	slot_head = /obj/item/clothing/head/helmet/HoS
+	slot_head = /obj/item/clothing/head/hos_hat
 	slot_ears = /obj/item/device/radio/headset/command/hos
 	slot_eyes = /obj/item/clothing/glasses/sunglasses/sechud
 
@@ -274,7 +274,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	slot_jump = /obj/item/clothing/under/rank/head_of_securityold
 	slot_suit = /obj/item/clothing/suit/armor/vest
 	slot_foot = /obj/item/clothing/shoes/swat
-	slot_head = /obj/item/clothing/head/helmet/HoS
+	slot_head = /obj/item/clothing/head/hos_hat
 	slot_ears = /obj/item/device/radio/headset/command/hos
 	slot_eyes = /obj/item/clothing/glasses/sunglasses/sechud
 #endif

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -147,7 +147,7 @@ proc/create_fluff(var/datum/mind/target)
 		target_name = pick(items)
 		switch(target_name)
 			if("Head of Security\'s beret")
-				steal_target = /obj/item/clothing/head/helmet/HoS
+				steal_target = /obj/item/clothing/head/hos_hat
 			if("prisoner\'s beret")
 				steal_target = /obj/item/clothing/head/beret/prisoner
 			if("DetGadget hat")
@@ -184,7 +184,7 @@ proc/create_fluff(var/datum/mind/target)
 		target_name = pick(items)
 		switch(target_name)
 			if("Head of Security\'s beret")
-				steal_target = /obj/item/clothing/head/helmet/HoS
+				steal_target = /obj/item/clothing/head/hos_hat
 			if("prisoner\'s beret")
 				steal_target = /obj/item/clothing/head/beret/prisoner
 			if("DetGadget hat")

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -627,13 +627,13 @@
 
 			if ("hatstomp", "stomphat")
 				if (!src.restrained())
-					var/obj/item/clothing/head/helmet/HoS/hat = src.find_type_in_hand(/obj/item/clothing/head/helmet/HoS)
+					var/obj/item/clothing/head/hos_hat/hat = src.find_type_in_hand(/obj/item/clothing/head/hos_hat)
 					var/hat_or_beret = null
 					var/already_stomped = null // store the picked phrase in here
 					var/on_head = 0
 
 					if (!hat) // if the find_type_in_hand() returned 0 earlier
-						if (istype(src.head, /obj/item/clothing/head/helmet/HoS)) // maybe it's on our head?
+						if (istype(src.head, /obj/item/clothing/head/hos_hat)) // maybe it's on our head?
 							hat = src.head
 							on_head = 1
 						else // if not then never mind

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -796,7 +796,7 @@
 		/obj/item/clothing/head/mj_hat,
 		/obj/item/clothing/head/that,
 		/obj/item/clothing/head/NTberet,
-		/obj/item/clothing/head/helmet/HoS,
+		/obj/item/clothing/head/hos_hat,
 		/obj/item/clothing/head/hosberet,
 		/obj/item/clothing/head/caphat,
 		/obj/item/clothing/head/fancy/captain,

--- a/code/obj/critter/turtle.dm
+++ b/code/obj/critter/turtle.dm
@@ -216,8 +216,8 @@
 	gender = MALE
 	var/obj/item/wearing_beret = 0	//Don't really need this var, but I like it better than checking contents every time we wanna see if he's got the beret
 	var/search_frequency = 30	//number of cycles between searches
-	var/preferred_hat = /obj/item/clothing/head/helmet/HoS 	//if this is not null then the only hat type he will wear is this path.
-	
+	var/preferred_hat = /obj/item/clothing/head/hos_hat 	//if this is not null then the only hat type he will wear is this path.
+
 	ai_think()
 		..()
 		//find clown
@@ -298,7 +298,7 @@
 	proc/give_beret(var/obj/hat, var/mob/user)
 		if (shell_count || wearing_beret) return 0
 
-		var/obj/item/clothing/head/helmet/HoS/beret = hat
+		var/obj/item/clothing/head/hos_hat/beret = hat
 		if (istype(beret))
 			if (beret.folds == 0)
 				beret.folds = 1
@@ -339,7 +339,7 @@
 		if (beret)
 			if (ishuman(M))
 				var/mob/living/carbon/human/H = M
-				if (H.job == "Head of Security" && istype(beret, /obj/item/clothing/head/helmet/HoS))
+				if (H.job == "Head of Security" && istype(beret, /obj/item/clothing/head/hos_hat))
 					H.put_in_hand_or_drop(beret)
 				else if (H.job == "NanoTrasen Commander" && istype(beret, /obj/item/clothing/head/NTberet/commander))
 					H.put_in_hand_or_drop(beret)
@@ -380,7 +380,7 @@
 	proc/update_icon()
 		if (src.alive)
 			if (src.wearing_beret)
-				if (istype(wearing_beret, /obj/item/clothing/head/helmet/HoS))
+				if (istype(wearing_beret, /obj/item/clothing/head/hos_hat))
 					src.icon_state = "turtle-beret"
 				else if (istype(wearing_beret, /obj/item/clothing/head/NTberet/commander))
 					src.icon_state = "turtle-beret-com"
@@ -389,7 +389,7 @@
 				src.icon_state = "turtle"
 		else
 			if (src.wearing_beret)
-				if (istype(wearing_beret, /obj/item/clothing/head/helmet/HoS))
+				if (istype(wearing_beret, /obj/item/clothing/head/hos_hat))
 					src.icon_state = "turtle-dead-beret"
 				else if (istype(wearing_beret, /obj/item/clothing/head/NTberet/commander))
 					src.icon_state = "turtle-dead-beret-com"
@@ -405,7 +405,7 @@
 	New()
 		..()
 		//Make the beret
-		var/obj/item/clothing/head/helmet/HoS/beret = new/obj/item/clothing/head/helmet/HoS(src)
+		var/obj/item/clothing/head/hos_hat/beret = new/obj/item/clothing/head/hos_hat(src)
 		//fold it
 		beret.folds = 1
 		beret.name = "HoS Beret"

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -2966,7 +2966,7 @@ On that note, CentComm would like to remind trainees that they do not recieve cl
 		else
 			if(ishuman(hit_atom))
 				var/mob/living/carbon/human/user = usr
-				var/hos = (istype(user.head, /obj/item/clothing/head/hosberet) || istype(user.head, /obj/item/clothing/head/helmet/HoS))
+				var/hos = (istype(user.head, /obj/item/clothing/head/hosberet) || istype(user.head, /obj/item/clothing/head/hos_hat))
 				if(hos)
 					var/mob/living/carbon/human/H = hit_atom
 					H.changeStatus("stunned", 2 SECONDS)

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -1303,3 +1303,33 @@
 	wear_image_icon = 'icons/mob/fruithat.dmi'
 	icon_state = "headsprout"
 	item_state = "headsprout"
+
+
+/obj/item/clothing/head/hos_hat
+	name = "HoS Hat"
+	icon_state = "hoscap"
+	uses_multiple_icon_states = 1
+	item_state = "hoscap"
+	c_flags = SPACEWEAR
+	var/is_a_communist = 0
+	var/folds = 0
+	desc = "Actually, this hat is from a fast-food restaurant, that's why it folds like it was made of paper."
+	setupProperties()
+		..()
+		setProperty("meleeprot_head", 3)
+
+/obj/item/clothing/head/hos_hat/attack_self(mob/user as mob)
+	if(user.r_hand == src || user.l_hand == src)
+		if(!src.folds)
+			src.folds = 1
+			src.name = "HoS Beret"
+			src.icon_state = "hosberet"
+			src.item_state = "hosberet"
+			boutput(user, "<span class='notice'>You fold the hat into a beret.</span>")
+		else
+			src.folds = 0
+			src.name = "HoS Hat"
+			src.icon_state = "hoscap"
+			src.item_state = "hoscap"
+			boutput(user, "<span class='notice'>You unfold the beret back into a hat.</span>")
+		return

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -1316,7 +1316,7 @@
 	desc = "Actually, this hat is from a fast-food restaurant, that's why it folds like it was made of paper."
 	setupProperties()
 		..()
-		setProperty("meleeprot_head", 3)
+		setProperty("meleeprot_head", 7)
 
 /obj/item/clothing/head/hos_hat/attack_self(mob/user as mob)
 	if(user.r_hand == src || user.l_hand == src)

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -564,35 +564,6 @@
 		setProperty("disorient_resist_eye", 25)
 		setProperty("exploprot", 20)
 
-/obj/item/clothing/head/helmet/HoS
-	name = "HoS Hat"
-	icon_state = "hoscap"
-	uses_multiple_icon_states = 1
-	item_state = "hoscap"
-	c_flags = SPACEWEAR | COVERSEYES | BLOCKCHOKE
-	var/is_a_communist = 0
-	var/folds = 0
-	desc = "Actually, you got this hat from a fast-food restaurant, that's why it folds like it was made of paper."
-	setupProperties()
-		..()
-		setProperty("meleeprot_head", 7)
-
-/obj/item/clothing/head/helmet/HoS/attack_self(mob/user as mob)
-	if(user.r_hand == src || user.l_hand == src)
-		if(!src.folds)
-			src.folds = 1
-			src.name = "HoS Beret"
-			src.icon_state = "hosberet"
-			src.item_state = "hosberet"
-			boutput(user, "<span class='notice'>You fold the hat into a beret.</span>")
-		else
-			src.folds = 0
-			src.name = "HoS Hat"
-			src.icon_state = "hoscap"
-			src.item_state = "hoscap"
-			boutput(user, "<span class='notice'>You unfold the beret back into a hat.</span>")
-		return
-
 /obj/item/clothing/head/helmet/siren
 	name = "siren helmet"
 	desc = "A big flashing light that you put on your head. It also plays a siren for when you need to arrest someone!"


### PR DESCRIPTION
[Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the "blockchoke" and "coverseyes" functions of the HoS hat, and changes the definitions from a helmet to a normal hat. This makes it so the HoS can be choked and also receive CPR while wearing this hat. Also redfines all instances of /obj/item/clothing/head/helmet/HoS to a new definition of /obj/item/clothing/head/hos_hat. Finally, edits the HoS hat's descrption a little to make more sense.
From this

> "Actually, you got this hat from a fast-food restaurant, that's why it folds like it was made of paper."

to this

> "Actually, this hat is from a fast-food restaurant, that's why it folds like it was made of paper."

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Also the HoS is unable to receive CPR nor be choked at all when wearing a hat nowhere near the neck which I find to be silly.

## Changelog

```changelog
(u)DimWhat
(+)Anyone wearing the Head of Security's hat is now able to be choked or receive CPR.
```
