### PR TITLE
Adds more mutantrace friendly lawbringer phrases

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1323,7 +1323,7 @@
 					current_projectile.cost = 30
 					item_state = "lawg-execute"
 					playsound(M, "sound/vox/exterminate.ogg", 50)
-				if ("smokeshot")
+				if ("smokeshot","fog")
 					set_current_projectile(projectiles["smokeshot"])
 					current_projectile.cost = 50
 					item_state = "lawg-smokeshot"
@@ -1333,7 +1333,7 @@
 					current_projectile.cost = 60
 					item_state = "lawg-knockout"
 					playsound(M, "sound/vox/sleep.ogg", 50)
-				if ("hotshot")
+				if ("hotshot","incendiary")
 					set_current_projectile(projectiles["hotshot"])
 					current_projectile.cost = 60
 					item_state = "lawg-hotshot"
@@ -1345,11 +1345,11 @@
 					playsound(M, "sound/vox/high.ogg", 50)
 					SPAWN_DBG(0.4 SECONDS)
 						playsound(M, "sound/vox/explosive.ogg", 50)
-				if ("clownshot")
+				if ("clownshot","clown")
 					set_current_projectile(projectiles["clownshot"])
 					item_state = "lawg-clownshot"
 					playsound(M, "sound/vox/clown.ogg", 30)
-				if ("pulse", "push")
+				if ("pulse", "push","punch")
 					set_current_projectile(projectiles["pulse"])
 					item_state = "lawg-pulse"
 					playsound(M, "sound/vox/push.ogg", 50)
@@ -1357,7 +1357,7 @@
 					/datum/projectile/energy_bolt/pulse
 		else		//if you're not the owner and try to change it, then fuck you
 			switch(text)
-				if ("detain","execute","knockout","hotshot","bigshot","highexplosive","he","clownshot", "pulse")
+				if ("detain","execute","knockout","hotshot","incendiary","bigshot","highexplosive","he","clownshot","clown", "pulse", "punch")
 					random_burn_damage(M, 50)
 					M.changeStatus("weakened", 4 SECONDS)
 					elecflash(src,power=2)

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1349,7 +1349,7 @@
 					set_current_projectile(projectiles["clownshot"])
 					item_state = "lawg-clownshot"
 					playsound(M, "sound/vox/clown.ogg", 30)
-				if ("pulse", "push","punch")
+				if ("pulse", "push", "throw")
 					set_current_projectile(projectiles["pulse"])
 					item_state = "lawg-pulse"
 					playsound(M, "sound/vox/push.ogg", 50)

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -1457,7 +1457,7 @@ automatically adopt your criminal control strategy of choice.<br>
 <td>Lawbringer™ warranty is voided if exposed to clowns. Keep them at bay.</td>
 </tr>
 <tr>
-<td><b>"Pulse" / "Push" / "Punch"</b></td>
+<td><b>"Pulse" / "Push" / "Throw"</b></td>
 <td>35 PU</td>
 <td>Just like our patented Pulse Rifle™s, this Mode sends your enemies flying! Keep crime at arm's length!</td>
 </tr>

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -1432,12 +1432,12 @@ automatically adopt your criminal control strategy of choice.<br>
 <td>Turn your Lawbringer™ into your favourite sidearm with these .38 Full Metal Jacket rounds!</td>
 </tr>
 <tr>
-<td><b>"Hotshot"</b></td>
+<td><b>"Hotshot" / "Incendiary"</b></td>
 <td>60 PU</td>
 <td>This handy flare gun/flamethrower option is sure to heat things up! The Lawbringer™ is not certified fireproof. Do not set on fire.</td>
 </tr>
 <tr>
-<td><b>"Smokeshot"</b></td>
+<td><b>"Smokeshot" / "Fog"</b></td>
 <td>50 PU</td>
 <td>Never use a riot launcher again! These smoke grenades will let you manage line of sight with ease.</td>
 </tr>
@@ -1452,12 +1452,12 @@ automatically adopt your criminal control strategy of choice.<br>
 <td>You'll be the talk of the station when you bust down a wall with one of these explosive rounds! May cause loss of limbs or life.</td>
 </tr>
 <tr>
-<td><b>"Clownshot"</b></td>
+<td><b>"Clownshot" / "Clown"</b></td>
 <td>15 PU</td>
 <td>Lawbringer™ warranty is voided if exposed to clowns. Keep them at bay.</td>
 </tr>
 <tr>
-<td><b>"Pulse" / "Push"</b></td>
+<td><b>"Pulse" / "Push" / "Punch"</b></td>
 <td>35 PU</td>
 <td>Just like our patented Pulse Rifle™s, this Mode sends your enemies flying! Keep crime at arm's length!</td>
 </tr>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds lawbringer phrases that mutantraces like lizards and cows can use.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Saurians were previously unable to use pulse, hotshot, clownshot, and smokeshot. Cows were unable to use smokeshot. This fixes both


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)SynthFox
(*)Added "throw", "incendiary", "fog", and "clown" to the list of acceptable lawbringer mode phrases.
```
