### PR TITLE
Adds more pods to the Cairngorm

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -14569,13 +14569,12 @@
 /turf/unsimulated/floor/specialroom/medbay,
 /area/marsoutpost)
 "aVd" = (
-/obj/syndi_putt_spawner,
-/obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "delivery2"
+/obj/indestructible/shuttle_corner{
+	dir = 8;
+	icon_state = "wall3_trans"
 	},
-/obj/access_spawn/syndie_shuttle,
-/turf/unsimulated/floor/shuttlebay,
-/area/syndicate_station/battlecruiser)
+/turf/space,
+/area/space)
 "aVe" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8
@@ -45842,9 +45841,12 @@
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "cvY" = (
-/obj/machinery/light/small/floor,
-/turf/unsimulated/floor/darkpurple,
-/area/syndicate_station/battlecruiser)
+/obj/indestructible/shuttle_corner{
+	dir = 1;
+	icon_state = "wall3_trans"
+	},
+/turf/space,
+/area/space)
 "cvZ" = (
 /obj/rack,
 /obj/item/tank/jetpack/syndicate,
@@ -45892,10 +45894,10 @@
 /turf/unsimulated/floor/red,
 /area/syndicate_station/battlecruiser)
 "cwh" = (
-/obj/submachine/weapon_vendor/syndicate,
-/obj/machinery/light,
-/turf/unsimulated/floor/red,
-/area/syndicate_station/battlecruiser)
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/space)
 "cwi" = (
 /obj/decal/boxingrope{
 	dir = 4
@@ -51155,6 +51157,14 @@
 /obj/machinery/light/lamp/green,
 /turf/unsimulated/floor/wood/two,
 /area/owlery/owleryhall)
+"cIL" = (
+/obj/syndi_putt_spawner,
+/obj/decal/tile_edge/stripe/extra_big{
+	icon_state = "delivery2"
+	},
+/obj/access_spawn/syndie_shuttle,
+/turf/unsimulated/floor/shuttlebay,
+/area/syndicate_station/battlecruiser)
 "cIM" = (
 /obj/storage/crate/loot,
 /turf/simulated/floor/white,
@@ -61435,6 +61445,10 @@
 /obj/death_button/clean_gunsim,
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/sim/gunsim)
+"dfn" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/unsimulated/floor/plating/random,
+/area/space)
 "dfo" = (
 /obj/decal/tile_edge/stripe{
 	dir = 6;
@@ -62081,7 +62095,6 @@
 /obj/rack,
 /obj/item/tank/jetpack/syndicate,
 /obj/item/tank/jetpack/syndicate,
-/obj/machinery/light,
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "dgx" = (
@@ -77254,6 +77267,7 @@
 /obj/item/clothing/gloves/yellow,
 /obj/item/clothing/gloves/yellow,
 /obj/item/clothing/gloves/yellow,
+/obj/machinery/light,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "ecr" = (
@@ -82639,6 +82653,14 @@
 	opacity = 0
 	},
 /area/titlescreen)
+"woz" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/unsimulated/floor/red,
+/area/space)
 "wpG" = (
 /obj/item/storage/wall/fire{
 	pixel_y = 32
@@ -107463,16 +107485,16 @@ cnw
 cnw
 cnw
 cnw
-aJC
-aKf
-aKz
-aKz
-aKz
-aKf
-aKf
-aKf
-aKf
-aKf
+aVd
+cwh
+dfn
+dfn
+dfn
+cwh
+cwh
+cwh
+cwh
+cwh
 cnw
 cnw
 cnw
@@ -108666,8 +108688,8 @@ cnw
 bBm
 bDt
 ccu
-aVd
 cIJ
+cIL
 cIJ
 cUT
 dds
@@ -108676,7 +108698,7 @@ bqV
 dfo
 dfQ
 dfQ
-dgv
+bqV
 aKf
 dgQ
 xQV
@@ -108968,8 +108990,8 @@ btF
 bvh
 bDt
 ccu
+cIL
 cIJ
-aVd
 cIJ
 cUT
 ddB
@@ -109270,13 +109292,13 @@ cnw
 bBm
 bDt
 ccu
-aVd
 cIJ
-aVd
+cIJ
+cIJ
 cIJ
 ddG
 des
-cvY
+bqV
 dfo
 dfQ
 dfQ
@@ -109572,8 +109594,8 @@ btF
 bvh
 bDt
 ccu
+cIL
 cIJ
-aVd
 cIJ
 cUT
 dds
@@ -109874,8 +109896,8 @@ cnw
 bBm
 bDt
 ccu
-aVd
 cIJ
+cIL
 cIJ
 cUT
 ddB
@@ -113193,7 +113215,7 @@ aKf
 aKz
 aKz
 aKf
-byE
+woz
 cas
 cIa
 cKQ
@@ -114115,7 +114137,7 @@ btf
 dhh
 btf
 cwa
-cwh
+cwg
 aKf
 dhx
 bqW
@@ -115323,7 +115345,7 @@ btf
 pbO
 btf
 cwa
-cwh
+cwg
 aKf
 cwk
 dhN
@@ -116227,7 +116249,7 @@ dgk
 dgM
 dgO
 eaP
-dfH
+btf
 dgi
 cwg
 aKf
@@ -116523,16 +116545,16 @@ cnw
 cnw
 cnw
 cnw
-aKA
-aKf
-aKf
-aKf
-aKf
-aKf
-aKf
-aKf
-aKf
-aKf
+cvY
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
 cnw
 cnw
 cnw

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -14569,12 +14569,13 @@
 /turf/unsimulated/floor/specialroom/medbay,
 /area/marsoutpost)
 "aVd" = (
-/obj/indestructible/shuttle_corner{
-	dir = 8;
-	icon_state = "wall3_trans"
+/obj/syndi_putt_spawner,
+/obj/decal/tile_edge/stripe/extra_big{
+	icon_state = "delivery2"
 	},
-/turf/space,
-/area/space)
+/obj/access_spawn/syndie_shuttle,
+/turf/unsimulated/floor/shuttlebay,
+/area/syndicate_station/battlecruiser)
 "aVe" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8
@@ -45841,12 +45842,9 @@
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "cvY" = (
-/obj/indestructible/shuttle_corner{
-	dir = 1;
-	icon_state = "wall3_trans"
-	},
-/turf/space,
-/area/space)
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/darkpurple,
+/area/syndicate_station/battlecruiser)
 "cvZ" = (
 /obj/rack,
 /obj/item/tank/jetpack/syndicate,
@@ -45894,10 +45892,10 @@
 /turf/unsimulated/floor/red,
 /area/syndicate_station/battlecruiser)
 "cwh" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
-/area/space)
+/obj/submachine/weapon_vendor/syndicate,
+/obj/machinery/light,
+/turf/unsimulated/floor/red,
+/area/syndicate_station/battlecruiser)
 "cwi" = (
 /obj/decal/boxingrope{
 	dir = 4
@@ -51157,14 +51155,6 @@
 /obj/machinery/light/lamp/green,
 /turf/unsimulated/floor/wood/two,
 /area/owlery/owleryhall)
-"cIL" = (
-/obj/syndi_putt_spawner,
-/obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "delivery2"
-	},
-/obj/access_spawn/syndie_shuttle,
-/turf/unsimulated/floor/shuttlebay,
-/area/syndicate_station/battlecruiser)
 "cIM" = (
 /obj/storage/crate/loot,
 /turf/simulated/floor/white,
@@ -61445,10 +61435,6 @@
 /obj/death_button/clean_gunsim,
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/sim/gunsim)
-"dfn" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/unsimulated/floor/plating/random,
-/area/space)
 "dfo" = (
 /obj/decal/tile_edge/stripe{
 	dir = 6;
@@ -62095,6 +62081,7 @@
 /obj/rack,
 /obj/item/tank/jetpack/syndicate,
 /obj/item/tank/jetpack/syndicate,
+/obj/machinery/light,
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "dgx" = (
@@ -77267,7 +77254,6 @@
 /obj/item/clothing/gloves/yellow,
 /obj/item/clothing/gloves/yellow,
 /obj/item/clothing/gloves/yellow,
-/obj/machinery/light,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "ecr" = (
@@ -82653,14 +82639,6 @@
 	opacity = 0
 	},
 /area/titlescreen)
-"woz" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/unsimulated/floor/red,
-/area/space)
 "wpG" = (
 /obj/item/storage/wall/fire{
 	pixel_y = 32
@@ -107485,16 +107463,16 @@ cnw
 cnw
 cnw
 cnw
-aVd
-cwh
-dfn
-dfn
-dfn
-cwh
-cwh
-cwh
-cwh
-cwh
+aJC
+aKf
+aKz
+aKz
+aKz
+aKf
+aKf
+aKf
+aKf
+aKf
 cnw
 cnw
 cnw
@@ -108688,8 +108666,8 @@ cnw
 bBm
 bDt
 ccu
+aVd
 cIJ
-cIL
 cIJ
 cUT
 dds
@@ -108698,7 +108676,7 @@ bqV
 dfo
 dfQ
 dfQ
-bqV
+dgv
 aKf
 dgQ
 xQV
@@ -108990,8 +108968,8 @@ btF
 bvh
 bDt
 ccu
-cIL
 cIJ
+aVd
 cIJ
 cUT
 ddB
@@ -109292,13 +109270,13 @@ cnw
 bBm
 bDt
 ccu
+aVd
 cIJ
-cIJ
-cIJ
+aVd
 cIJ
 ddG
 des
-bqV
+cvY
 dfo
 dfQ
 dfQ
@@ -109594,8 +109572,8 @@ btF
 bvh
 bDt
 ccu
-cIL
 cIJ
+aVd
 cIJ
 cUT
 dds
@@ -109896,8 +109874,8 @@ cnw
 bBm
 bDt
 ccu
+aVd
 cIJ
-cIL
 cIJ
 cUT
 ddB
@@ -113215,7 +113193,7 @@ aKf
 aKz
 aKz
 aKf
-woz
+byE
 cas
 cIa
 cKQ
@@ -114137,7 +114115,7 @@ btf
 dhh
 btf
 cwa
-cwg
+cwh
 aKf
 dhx
 bqW
@@ -115345,7 +115323,7 @@ btf
 pbO
 btf
 cwa
-cwg
+cwh
 aKf
 cwk
 dhN
@@ -116249,7 +116227,7 @@ dgk
 dgM
 dgO
 eaP
-btf
+dfH
 dgi
 cwg
 aKf
@@ -116545,16 +116523,16 @@ cnw
 cnw
 cnw
 cnw
-cvY
-cwh
-cwh
-cwh
-cwh
-cwh
-cwh
-cwh
-cwh
-cwh
+aKA
+aKf
+aKf
+aKf
+aKf
+aKf
+aKf
+aKf
+aKf
+aKf
 cnw
 cnw
 cnw

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -60556,16 +60556,6 @@
 	},
 /turf/unsimulated/floor/shuttlebay,
 /area/syndicate_station/battlecruiser)
-"dds" = (
-/obj/machinery/vehicle/pod_smooth/syndicate,
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/decal/tile_edge/stripe{
-	dir = 6;
-	icon_state = "bot2"
-	},
-/obj/access_spawn/syndie_shuttle,
-/turf/unsimulated/floor/shuttlebay,
-/area/syndicate_station/battlecruiser)
 "ddt" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/unsimulated/floor/grey,
@@ -60620,10 +60610,6 @@
 /area/afterlife/bar)
 "ddB" = (
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/decal/tile_edge/stripe{
-	dir = 6;
-	icon_state = "bot2"
-	},
 /turf/unsimulated/floor/shuttlebay,
 /area/syndicate_station/battlecruiser)
 "ddD" = (
@@ -60647,6 +60633,11 @@
 /turf/unsimulated/floor/grey,
 /area/afterlife/bar)
 "ddG" = (
+/obj/syndi_putt_spawner,
+/obj/decal/tile_edge/stripe/extra_big{
+	icon_state = "delivery2"
+	},
+/obj/access_spawn/syndie_shuttle,
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/unsimulated/floor/shuttlebay,
 /area/syndicate_station/battlecruiser)
@@ -82601,6 +82592,15 @@
 	name = "plating"
 	},
 /area/hospital/samostrel)
+"vZe" = (
+/obj/machinery/vehicle/pod_smooth/syndicate,
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "bot2"
+	},
+/obj/access_spawn/syndie_shuttle,
+/turf/unsimulated/floor/shuttlebay,
+/area/syndicate_station/battlecruiser)
 "wiU" = (
 /obj/admin_plaque{
 	desc = "Scream!";
@@ -108666,11 +108666,11 @@ cnw
 bBm
 bDt
 ccu
-aVd
-cIJ
-cIJ
 cUT
-dds
+vZe
+cIJ
+cIJ
+ddG
 des
 bqV
 dfo
@@ -108968,10 +108968,10 @@ btF
 bvh
 bDt
 ccu
+cUT
+cUT
 cIJ
 aVd
-cIJ
-cUT
 ddB
 des
 bqV
@@ -109270,7 +109270,7 @@ cnw
 bBm
 bDt
 ccu
-aVd
+cIJ
 cIJ
 aVd
 cIJ
@@ -109572,11 +109572,11 @@ btF
 bvh
 bDt
 ccu
+cUT
+vZe
 cIJ
 aVd
-cIJ
-cUT
-dds
+ddB
 des
 bqV
 dfo
@@ -109874,11 +109874,11 @@ cnw
 bBm
 bDt
 ccu
-aVd
-cIJ
-cIJ
 cUT
-ddB
+cUT
+cIJ
+cIJ
+ddG
 des
 bqV
 dfo


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds two more small pods to the Cairngorm to fit the extra potential operatives.
Also adds a couple of extra lights in expanded areas that were too dark.

![image](https://user-images.githubusercontent.com/8319565/114928407-7a251e00-9e2a-11eb-97e1-e08a91c8a018.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There should be enough transport to get every operative to the station.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gannets
(+)Additional pods added to the Syndicate Battlecruiser Cairngorm.
```
