### PR TITLE
Enables repairing nuclear bomb with combat engineer's battle wrench

### DIFF
--- a/code/obj/item/tool/wrench.dm
+++ b/code/obj/item/tool/wrench.dm
@@ -42,7 +42,7 @@
 
 /obj/item/wrench/battle //for nuke ops class
 	name = "battle wrench"
-	desc = "A heavy industrial wrench that packs a mean punch when used as a bludgeon."
+	desc = "A heavy industrial wrench that packs a mean punch when used as a bludgeon. Can be applied to the Nuclear bomb to repair it in small increments."
 	icon_state = "wrench-battle"
 	item_state = "wrench-battle"
 	force = 10.0

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -7,6 +7,7 @@
 	anchored = 0
 	event_handler_flags = IMMUNE_MANTA_PUSH
 	var/health = 150
+	var/max_health = 150
 	var/armed = 0
 	var/det_time = 0
 	var/timer_default = 6000 // 10 min.
@@ -249,7 +250,10 @@
 			playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Light_1.ogg', 100, 1)
 			attack_particle(user,src)
 
-		..()
+		if (istype(W, /obj/item/wrench/battle) && src.health <= src.max_health)
+			SETUP_GENERIC_ACTIONBAR(user, src, 5 SECONDS, /obj/machinery/nuclearbomb/proc/repair_nuke, null, 'icons/obj/items/tools/wrench.dmi', "battle-wrench", "[usr] repairs the [src]!")
+			return
+
 		return
 
 	ex_act(severity)
@@ -287,6 +291,11 @@
 			src.take_damage(damage / 1.7)
 		else if (P.proj_data.damage_type == D_PIERCING)
 			src.take_damage(damage)
+
+	proc/repair_nuke()
+		src.health += 5
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
+		return
 
 	proc/open_wire_panel(var/mob/user)
 		user.s_active = src.wirepanel

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -6,8 +6,8 @@
 	density = 1
 	anchored = 0
 	event_handler_flags = IMMUNE_MANTA_PUSH
-	var/_health = 150
-	var/_max_health = 150
+	_health = 150
+	_max_health = 150
 	var/armed = 0
 	var/det_time = 0
 	var/timer_default = 6000 // 10 min.
@@ -235,6 +235,10 @@
 				//	open_wire_panel(user)
 				//	return
 
+		if (istype(W, /obj/item/wrench/battle) && src._health <= src._max_health)
+			SETUP_GENERIC_ACTIONBAR(user, src, 5 SECONDS, /obj/machinery/nuclearbomb/proc/repair_nuke, null, 'icons/obj/items/tools/wrench.dmi', "battle-wrench", "[usr] repairs the [src]!")
+			return
+
 		if (W && !(istool(W, TOOL_SCREWING | TOOL_SNIPPING) || istype(W, /obj/item/disk/data/floppy/read_only/authentication)))
 			switch (W.force)
 				if (0 to 19)
@@ -249,10 +253,6 @@
 			logTheThing("combat", user, null, "attacks [src] with [W] at [log_loc(src)].")
 			playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Light_1.ogg', 100, 1)
 			attack_particle(user,src)
-
-		if (istype(W, /obj/item/wrench/battle) && src._health <= src._max_health)
-			SETUP_GENERIC_ACTIONBAR(user, src, 5 SECONDS, /obj/machinery/nuclearbomb/proc/repair_nuke, null, 'icons/obj/items/tools/wrench.dmi', "battle-wrench", "[usr] repairs the [src]!")
-			return
 
 		return
 
@@ -293,7 +293,7 @@
 			src.take_damage(damage)
 
 	proc/repair_nuke()
-		src._health += min(src._health+5, src._max_health)
+		src._health = min(src._health+5, src._max_health)
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 		return
 
@@ -443,7 +443,7 @@
 	icon_state = "nuclearbomb"
 	density = 1
 	anchored = 0
-	var/_health = 10
+	_health = 10
 
 	proc/checkhealth()
 		if (src._health <= 0)

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -6,8 +6,8 @@
 	density = 1
 	anchored = 0
 	event_handler_flags = IMMUNE_MANTA_PUSH
-	var/health = 150
-	var/max_health = 150
+	var/_health = 150
+	var/_max_health = 150
 	var/armed = 0
 	var/det_time = 0
 	var/timer_default = 6000 // 10 min.
@@ -97,7 +97,7 @@
 			else
 				. += "It is firmly anchored to the floor by its floor bolts. A screwdriver could undo them."
 
-			switch(src.health)
+			switch(src._health)
 				if(80 to 125)
 					. += "<span class='alert'>It is a little bit damaged.</span>"
 				if(40 to 79)
@@ -250,7 +250,7 @@
 			playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Light_1.ogg', 100, 1)
 			attack_particle(user,src)
 
-		if (istype(W, /obj/item/wrench/battle) && src.health <= src.max_health)
+		if (istype(W, /obj/item/wrench/battle) && src._health <= src._max_health)
 			SETUP_GENERIC_ACTIONBAR(user, src, 5 SECONDS, /obj/machinery/nuclearbomb/proc/repair_nuke, null, 'icons/obj/items/tools/wrench.dmi', "battle-wrench", "[usr] repairs the [src]!")
 			return
 
@@ -293,7 +293,7 @@
 			src.take_damage(damage)
 
 	proc/repair_nuke()
-		src.health += 5
+		src._health += min(src._health+5, src._max_health)
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 		return
 
@@ -309,7 +309,7 @@
 
 	proc/take_damage(var/amount)
 		if(!isitspacemas)
-			switch(src.health)
+			switch(src._health)
 				if(80 to 125)
 					src.icon_state = "nuclearbomb1"
 				if(40 to 80)
@@ -318,8 +318,8 @@
 					src.icon_state = "nuclearbomb3"
 		if (!isnum(amount) || amount < 1)
 			return
-		src.health = max(0,src.health - amount)
-		if (src.health < 1)
+		src._health = max(0,src._health - amount)
+		if (src._health < 1)
 			src.visible_message("<b>[src]</b> breaks and falls apart into useless pieces!")
 			robogibs(src.loc,null)
 			playsound(src.loc, 'sound/impact_sounds/Machinery_Break_1.ogg', 50, 2)
@@ -443,10 +443,10 @@
 	icon_state = "nuclearbomb"
 	density = 1
 	anchored = 0
-	var/health = 10
+	var/_health = 10
 
 	proc/checkhealth()
-		if (src.health <= 0)
+		if (src._health <= 0)
 			src.visible_message("<span class='alert'><b>[src] pops!</b></span>")
 			playsound(src.loc, 'sound/impact_sounds/Slimy_Splat_1.ogg', 100, 1)
 			var/obj/decal/cleanable/balloon/decal = make_cleanable(/obj/decal/cleanable/balloon,src.loc)
@@ -457,6 +457,6 @@
 		..()
 		user.lastattacked = src
 		playsound(src.loc, 'sound/impact_sounds/Slimy_Hit_1.ogg', 100, 1)
-		src.health -= W.force
+		src._health -= W.force
 		checkhealth()
 		return

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -14569,13 +14569,12 @@
 /turf/unsimulated/floor/specialroom/medbay,
 /area/marsoutpost)
 "aVd" = (
-/obj/syndi_putt_spawner,
-/obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "delivery2"
+/obj/indestructible/shuttle_corner{
+	dir = 8;
+	icon_state = "wall3_trans"
 	},
-/obj/access_spawn/syndie_shuttle,
-/turf/unsimulated/floor/shuttlebay,
-/area/syndicate_station/battlecruiser)
+/turf/space,
+/area/space)
 "aVe" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8
@@ -45842,9 +45841,12 @@
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "cvY" = (
-/obj/machinery/light/small/floor,
-/turf/unsimulated/floor/darkpurple,
-/area/syndicate_station/battlecruiser)
+/obj/indestructible/shuttle_corner{
+	dir = 1;
+	icon_state = "wall3_trans"
+	},
+/turf/space,
+/area/space)
 "cvZ" = (
 /obj/rack,
 /obj/item/tank/jetpack/syndicate,
@@ -45892,10 +45894,10 @@
 /turf/unsimulated/floor/red,
 /area/syndicate_station/battlecruiser)
 "cwh" = (
-/obj/submachine/weapon_vendor/syndicate,
-/obj/machinery/light,
-/turf/unsimulated/floor/red,
-/area/syndicate_station/battlecruiser)
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/space)
 "cwi" = (
 /obj/decal/boxingrope{
 	dir = 4
@@ -51155,6 +51157,14 @@
 /obj/machinery/light/lamp/green,
 /turf/unsimulated/floor/wood/two,
 /area/owlery/owleryhall)
+"cIL" = (
+/obj/syndi_putt_spawner,
+/obj/decal/tile_edge/stripe/extra_big{
+	icon_state = "delivery2"
+	},
+/obj/access_spawn/syndie_shuttle,
+/turf/unsimulated/floor/shuttlebay,
+/area/syndicate_station/battlecruiser)
 "cIM" = (
 /obj/storage/crate/loot,
 /turf/simulated/floor/white,
@@ -61435,6 +61445,10 @@
 /obj/death_button/clean_gunsim,
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/sim/gunsim)
+"dfn" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/unsimulated/floor/plating/random,
+/area/space)
 "dfo" = (
 /obj/decal/tile_edge/stripe{
 	dir = 6;
@@ -62081,7 +62095,6 @@
 /obj/rack,
 /obj/item/tank/jetpack/syndicate,
 /obj/item/tank/jetpack/syndicate,
-/obj/machinery/light,
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "dgx" = (
@@ -77254,6 +77267,7 @@
 /obj/item/clothing/gloves/yellow,
 /obj/item/clothing/gloves/yellow,
 /obj/item/clothing/gloves/yellow,
+/obj/machinery/light,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "ecr" = (
@@ -82639,6 +82653,14 @@
 	opacity = 0
 	},
 /area/titlescreen)
+"woz" = (
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/unsimulated/floor/red,
+/area/space)
 "wpG" = (
 /obj/item/storage/wall/fire{
 	pixel_y = 32
@@ -107463,16 +107485,16 @@ cnw
 cnw
 cnw
 cnw
-aJC
-aKf
-aKz
-aKz
-aKz
-aKf
-aKf
-aKf
-aKf
-aKf
+aVd
+cwh
+dfn
+dfn
+dfn
+cwh
+cwh
+cwh
+cwh
+cwh
 cnw
 cnw
 cnw
@@ -108666,8 +108688,8 @@ cnw
 bBm
 bDt
 ccu
-aVd
 cIJ
+cIL
 cIJ
 cUT
 dds
@@ -108676,7 +108698,7 @@ bqV
 dfo
 dfQ
 dfQ
-dgv
+bqV
 aKf
 dgQ
 xQV
@@ -108968,8 +108990,8 @@ btF
 bvh
 bDt
 ccu
+cIL
 cIJ
-aVd
 cIJ
 cUT
 ddB
@@ -109270,13 +109292,13 @@ cnw
 bBm
 bDt
 ccu
-aVd
 cIJ
-aVd
+cIJ
+cIJ
 cIJ
 ddG
 des
-cvY
+bqV
 dfo
 dfQ
 dfQ
@@ -109572,8 +109594,8 @@ btF
 bvh
 bDt
 ccu
+cIL
 cIJ
-aVd
 cIJ
 cUT
 dds
@@ -109874,8 +109896,8 @@ cnw
 bBm
 bDt
 ccu
-aVd
 cIJ
+cIL
 cIJ
 cUT
 ddB
@@ -113193,7 +113215,7 @@ aKf
 aKz
 aKz
 aKf
-byE
+woz
 cas
 cIa
 cKQ
@@ -114115,7 +114137,7 @@ btf
 dhh
 btf
 cwa
-cwh
+cwg
 aKf
 dhx
 bqW
@@ -115323,7 +115345,7 @@ btf
 pbO
 btf
 cwa
-cwh
+cwg
 aKf
 cwk
 dhN
@@ -116227,7 +116249,7 @@ dgk
 dgM
 dgO
 eaP
-dfH
+btf
 dgi
 cwg
 aKf
@@ -116523,16 +116545,16 @@ cnw
 cnw
 cnw
 cnw
-aKA
-aKf
-aKf
-aKf
-aKf
-aKf
-aKf
-aKf
-aKf
-aKf
+cvY
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
 cnw
 cnw
 cnw

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -14569,12 +14569,13 @@
 /turf/unsimulated/floor/specialroom/medbay,
 /area/marsoutpost)
 "aVd" = (
-/obj/indestructible/shuttle_corner{
-	dir = 8;
-	icon_state = "wall3_trans"
+/obj/syndi_putt_spawner,
+/obj/decal/tile_edge/stripe/extra_big{
+	icon_state = "delivery2"
 	},
-/turf/space,
-/area/space)
+/obj/access_spawn/syndie_shuttle,
+/turf/unsimulated/floor/shuttlebay,
+/area/syndicate_station/battlecruiser)
 "aVe" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 8
@@ -45841,12 +45842,9 @@
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "cvY" = (
-/obj/indestructible/shuttle_corner{
-	dir = 1;
-	icon_state = "wall3_trans"
-	},
-/turf/space,
-/area/space)
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/darkpurple,
+/area/syndicate_station/battlecruiser)
 "cvZ" = (
 /obj/rack,
 /obj/item/tank/jetpack/syndicate,
@@ -45894,10 +45892,10 @@
 /turf/unsimulated/floor/red,
 /area/syndicate_station/battlecruiser)
 "cwh" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
-/area/space)
+/obj/submachine/weapon_vendor/syndicate,
+/obj/machinery/light,
+/turf/unsimulated/floor/red,
+/area/syndicate_station/battlecruiser)
 "cwi" = (
 /obj/decal/boxingrope{
 	dir = 4
@@ -51157,14 +51155,6 @@
 /obj/machinery/light/lamp/green,
 /turf/unsimulated/floor/wood/two,
 /area/owlery/owleryhall)
-"cIL" = (
-/obj/syndi_putt_spawner,
-/obj/decal/tile_edge/stripe/extra_big{
-	icon_state = "delivery2"
-	},
-/obj/access_spawn/syndie_shuttle,
-/turf/unsimulated/floor/shuttlebay,
-/area/syndicate_station/battlecruiser)
 "cIM" = (
 /obj/storage/crate/loot,
 /turf/simulated/floor/white,
@@ -61445,10 +61435,6 @@
 /obj/death_button/clean_gunsim,
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/sim/gunsim)
-"dfn" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/unsimulated/floor/plating/random,
-/area/space)
 "dfo" = (
 /obj/decal/tile_edge/stripe{
 	dir = 6;
@@ -62095,6 +62081,7 @@
 /obj/rack,
 /obj/item/tank/jetpack/syndicate,
 /obj/item/tank/jetpack/syndicate,
+/obj/machinery/light,
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "dgx" = (
@@ -77267,7 +77254,6 @@
 /obj/item/clothing/gloves/yellow,
 /obj/item/clothing/gloves/yellow,
 /obj/item/clothing/gloves/yellow,
-/obj/machinery/light,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
 "ecr" = (
@@ -82653,14 +82639,6 @@
 	opacity = 0
 	},
 /area/titlescreen)
-"woz" = (
-/obj/machinery/light{
-	dir = 4;
-	layer = 9.1;
-	pixel_x = 10
-	},
-/turf/unsimulated/floor/red,
-/area/space)
 "wpG" = (
 /obj/item/storage/wall/fire{
 	pixel_y = 32
@@ -107485,16 +107463,16 @@ cnw
 cnw
 cnw
 cnw
-aVd
-cwh
-dfn
-dfn
-dfn
-cwh
-cwh
-cwh
-cwh
-cwh
+aJC
+aKf
+aKz
+aKz
+aKz
+aKf
+aKf
+aKf
+aKf
+aKf
 cnw
 cnw
 cnw
@@ -108688,8 +108666,8 @@ cnw
 bBm
 bDt
 ccu
+aVd
 cIJ
-cIL
 cIJ
 cUT
 dds
@@ -108698,7 +108676,7 @@ bqV
 dfo
 dfQ
 dfQ
-bqV
+dgv
 aKf
 dgQ
 xQV
@@ -108990,8 +108968,8 @@ btF
 bvh
 bDt
 ccu
-cIL
 cIJ
+aVd
 cIJ
 cUT
 ddB
@@ -109292,13 +109270,13 @@ cnw
 bBm
 bDt
 ccu
+aVd
 cIJ
-cIJ
-cIJ
+aVd
 cIJ
 ddG
 des
-bqV
+cvY
 dfo
 dfQ
 dfQ
@@ -109594,8 +109572,8 @@ btF
 bvh
 bDt
 ccu
-cIL
 cIJ
+aVd
 cIJ
 cUT
 dds
@@ -109896,8 +109874,8 @@ cnw
 bBm
 bDt
 ccu
+aVd
 cIJ
-cIL
 cIJ
 cUT
 ddB
@@ -113215,7 +113193,7 @@ aKf
 aKz
 aKz
 aKf
-woz
+byE
 cas
 cIa
 cKQ
@@ -114137,7 +114115,7 @@ btf
 dhh
 btf
 cwa
-cwg
+cwh
 aKf
 dhx
 bqW
@@ -115345,7 +115323,7 @@ btf
 pbO
 btf
 cwa
-cwg
+cwh
 aKf
 cwk
 dhN
@@ -116249,7 +116227,7 @@ dgk
 dgM
 dgO
 eaP
-btf
+dfH
 dgi
 cwg
 aKf
@@ -116545,16 +116523,16 @@ cnw
 cnw
 cnw
 cnw
-cvY
-cwh
-cwh
-cwh
-cwh
-cwh
-cwh
-cwh
-cwh
-cwh
+aKA
+aKf
+aKf
+aKf
+aKf
+aKf
+aKf
+aKf
+aKf
+aKf
 cnw
 cnw
 cnw


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows nuke ops combat engineers to repair damage done to the nuclear bomb by hitting it with their battle wrench. It repairs 5 points of health damage after a 5 second action bar completes.

Note: The wrench currently does it's standard damage before the repair procs, so i'd like to fix that before it's merged.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It would be nice to give operative teams the chance to recover from bad starts or repelled pushes.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gannets
(*)Nuke ops combat engineers can now hit the nuclear bomb with their battle wrench to repair a small amount of damage dealt to it.
```
