### PR TITLE
Attempting to eat or drink with a mask or headwear that covers the mouth will now fail.

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -186,13 +186,11 @@
 			return 0
 		if (iscarbon(M) || ismobcritter(M))
 			if (M == user)
-#ifdef RP_MODE
 				if (ishuman(M))
 					var/mob/living/carbon/human/H = M
 					if ((M.wear_mask && (HAS_FLAG(M.wear_mask.c_flags, COVERSMOUTH))) || H.head && (HAS_FLAG(H.head.c_flags, COVERSMOUTH)))
 						boutput(M, "<span class='alert'>You can't eat [src] with your mouth covered!</span>")
 						return 0
-#endif
 				//can this person eat this food?
 				if(!M.can_eat(src))
 					boutput(M, "<span class='alert'>You can't eat [src]!</span>")
@@ -284,7 +282,6 @@
 				user, "<span class='alert'>You try to feed [M] [src], but they can't eat that!</span>",\
 				M, "<span class='alert'><b>[user]</b> tries to feed you [src], but you can't eat that!</span>")
 				return 0
-#ifdef RP_MODE
 			else if (ishuman(M))
 				var/mob/living/carbon/human/H = M
 				if ((M.wear_mask && (HAS_FLAG(M.wear_mask.c_flags, COVERSMOUTH))) || H.head && (HAS_FLAG(H.head.c_flags, COVERSMOUTH)))
@@ -292,7 +289,6 @@
 					user, "<span class='alert'>You try to feed [M] [src], but their mouth is covered!</span>",\
 					M, "<span class='alert'><b>[user]</b> tries to feed you [src], but your mouth is covered!</span>")
 					return 0
-#endif
 			else
 				user.tri_message("<span class='alert'><b>[user]</b> tries to feed [M] [src]!</span>",\
 				user, "<span class='alert'>You try to feed [M] [src]!</span>",\
@@ -501,24 +497,19 @@
 
 		if (iscarbon(M) || ismobcritter(M))
 			if (M == user)
-#ifdef RP_MODE
 				if (ishuman(M))
 					var/mob/living/carbon/human/H = M
 					if ((M.wear_mask && (HAS_FLAG(M.wear_mask.c_flags, COVERSMOUTH))) || H.head && (HAS_FLAG(H.head.c_flags, COVERSMOUTH)))
 						boutput(M, "<span class='alert'>You can't drink [src] with your mouth covered!</span>")
 						return
-#endif
 				M.visible_message("<span class='notice'>[M] takes a sip from [src].</span>")
 			else
 				user.visible_message("<span class='alert'>[user] attempts to force [M] to drink from [src].</span>")
-				logTheThing("combat", user, M, "attempts to force [constructTarget(M,"combat")] to drink from [src] [log_reagents(src)] at [log_loc(user)].")
-#ifdef RP_MODE
 				if (ishuman(M))
 					var/mob/living/carbon/human/H = M
 					if ((M.wear_mask && (HAS_FLAG(M.wear_mask.c_flags, COVERSMOUTH))) || H.head && (HAS_FLAG(H.head.c_flags, COVERSMOUTH)))
 						user.visible_message("<span class='alert'>[user] attempts to force [M] to drink from [src], but their mouth is covered!.</span>")
 						return
-#endif
 				if (!do_mob(user, M))
 					if (user && ismob(user))
 						user.show_text("You were interrupted!", "red")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[REMOVAL] [EXPERIMENTAL] [FUCK]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You will be unable to eat or feed food or drink to someone if they are wearing a mask or hat with the flag `COVERSMOUTH`. This includes space helmets, breath masks, and other similar gear. This does not prevent the clown from eating; that would be shameful.

This applies to all servers, including Goon Classic. *dabs*

![image](https://user-images.githubusercontent.com/66253095/114814600-d0c53480-9df7-11eb-8e20-4cd6e25f9884.png)
![image](https://user-images.githubusercontent.com/66253095/114814607-d458bb80-9df7-11eb-84d7-3f6dfc306933.png)
![image](https://user-images.githubusercontent.com/66253095/114814611-d753ac00-9df7-11eb-9da5-d7c074e52ea2.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
my immersion!!!
i don't really expect this to be popular at all, but i think it's *slightly* funny

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DisturbHerb
(+)You can no longer eat or drink if you have a mask or hat that obscures your mouth. This applies to feeding others, as well.
```
