### PR TITLE
Minor Cogmap 1 Fixes

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -61447,7 +61447,6 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "kZL" = (
-/obj/disposalpipe/segment,
 /obj/item/cell/supercell/charged{
 	pixel_x = -7;
 	pixel_y = 11
@@ -104099,7 +104098,7 @@ cvi
 ctD
 cwi
 ctD
-cwi
+ctD
 cxq
 cxq
 cxq

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -108609,8 +108609,8 @@ caY
 bYe
 caY
 caY
-aif
-aif
+cir
+cir
 cir
 ahh
 cnO

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -2820,7 +2820,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/main)
 "ahr" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -4153,7 +4153,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/main)
 "akr" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -4599,7 +4599,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/main)
 "alz" = (
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -5493,7 +5493,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/brig)
+/area/station/security/main)
 "anB" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -5506,7 +5506,7 @@
 /turf/simulated/floor/red/side{
 	dir = 5
 	},
-/area/station/security/brig)
+/area/station/security/main)
 "anH" = (
 /obj/machinery/computer/arcade{
 	desc = "The VR representation of a popular computer game."
@@ -5985,7 +5985,7 @@
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
-/area/station/security/brig)
+/area/station/security/main)
 "aoN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/solar/north)
@@ -8100,7 +8100,7 @@
 /obj/disposalpipe/segment/transport,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/main)
 "aul" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -42597,7 +42597,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/grime,
-/area/space)
+/area/station/routing/depot)
 "bRc" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -61838,7 +61838,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/security/brig)
+/area/station/security/main)
 "nhn" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/light{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
_A few quick fixes for minor mistakes on Cogmap 1, I considered these too small & minor to really necessitate a PR for each, so i'm PRing them all at once._


-The brig overlapped into the Security area at a few tiles, and also took up the tiles infront of the Armoury. Converted these tiles to be properly part of Security.
-Routing Depot had a single tile of the space area, corrected w/ surrounding tiles.

-Removed two orphaned disposals pipes at `X133, Y091` & `X155, Y126`

-Converted the walls below the toilet across from Robotics to be windows, as this is what they were originally before my fix PRs _(albiet on the same tile as walls, presumably by mistake)_, this makes either side of Escape symmetrical again.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Minor bugs and issues are still bugs, even if they are almost unnoticeable!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

N/A; changes are not player-visible.