### PR TITLE
Goldbuddy bugfix

### DIFF
--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -4984,7 +4984,7 @@
 
 			W.set_loc(src)
 			src.created_cell = W
-			src.stage = 3
+			src.stage = 2
 			src.icon_state = "goldbuddy_frame-[buddy_model]-2"
 			boutput(user, "You add the power cell to [src]!")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The golden PR-4 buddy was not able to be made properly due to some stinky coder making a typo, which in return made me very sad. The steps were broken and it did not require the PR-4 mainboard, which also meant you could not name your golden pal.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![2021-04-16 15_03_38-Goonstation Development_ NCS Atlas](https://user-images.githubusercontent.com/68257280/115073270-16503300-9ec6-11eb-94c3-db8cefc579be.png)
