### PR TITLE
Human Resprite: Scrubs pathing change

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2196,7 +2196,7 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	name = "Navy Scrubs"
 	item_paths = list("FAB-1")
 	item_amounts = list(4)
-	item_outputs = list(/obj/item/clothing/under/scrub/navy)
+	item_outputs = list(/obj/item/clothing/under/scrub/blue)
 	time = 5 SECONDS
 	create = 1
 	category = "Clothing"
@@ -2205,7 +2205,7 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	name = "Violet Scrubs"
 	item_paths = list("FAB-1")
 	item_amounts = list(4)
-	item_outputs = list(/obj/item/clothing/under/scrub/violet)
+	item_outputs = list(/obj/item/clothing/under/scrub/purple)
 	time = 5 SECONDS
 	create = 1
 	category = "Clothing"

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -1112,11 +1112,11 @@
 		icon_state = "scrub-m"
 		item_state = "darkred"
 
-	navy
+	blue
 		icon_state = "scrub-n"
 		item_state = "darkblue"
 
-	violet
+	purple
 		icon_state = "scrub-v"
 		item_state = "lightpurple"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## scrub scrub scrub <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the filepath of two scrubs from /navy and /violet to /blue and /purple, like they are on master. This means it won't make problems on maps and won't need to be updated on maps, which is one less thing to worry about. Filepath can be changed after human resprite if it's really really important feeling. Got permission from Flourish who was the one who originally made this change to set it back :eye:

also means you wont have to delete the scrubs on atlas to get it to run on human-resprite, yay

oh yeah also this is for [human resprite]