### PR TITLE
Fix omnitool attack

### DIFF
--- a/code/obj/item/tool/omnitool.dm
+++ b/code/obj/item/tool/omnitool.dm
@@ -47,6 +47,8 @@
 		if (src.omni_mode == "prying")
 			if (!pry_surgery(M, user))
 				return ..()
+		else
+			..()
 
 	get_desc(var/dist)
 		if (dist < 3)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the attack proc on omnitools so non-prying modes also harm things.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #4277, closes #4221. I can't fathom how nobody noticed sooner since the wirecutter mode the goto item for AI murder and it must have been a thing since mutant dismemberment got merged.



