### PR TITLE
Adds reagent scanner to botany PDA cartridges

### DIFF
--- a/code/obj/item/device/pda2/cartridges.dm
+++ b/code/obj/item/device/pda2/cartridges.dm
@@ -338,6 +338,7 @@
 		New()
 			..()
 			src.root.add_file( new /datum/computer/file/pda_program/scan/plant_scan(src))
+			src.root.add_file( new /datum/computer/file/pda_program/scan/reagent_scan(src))
 			src.root.add_file( new /datum/computer/file/text/handbook_botanist(src))
 			src.read_only = 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Botanists use reagent scanners often and very often there's a limited amount of them in hydroponics. Since scientists, doctors, and even geneticists have access to them in their PDAs, I think it's only fair to give it to botanists aswell.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Added reagent scanner to botany PDA cartridges.
```
