### PR TITLE
Makes jailbird + stowaway combo possible again

### DIFF
--- a/code/mob/living/life/arrest_icon.dm
+++ b/code/mob/living/life/arrest_icon.dm
@@ -9,7 +9,7 @@
 
 			//TODO : move this code somewhere else that updates from an event trigger instead of constantly
 			var/arrestState = ""
-			var/added_to_records = 0
+			var/added_to_records = FALSE
 			var/see_face = 1
 			if (istype(H.wear_mask) && !H.wear_mask.see_face)
 				see_face = 0
@@ -26,7 +26,7 @@
 				else if (R.fields["name"] == H.name && H.traitHolder.hasTrait("immigrant") && H.traitHolder.hasTrait("jailbird"))
 					if(!added_to_records)
 						arrestState = ""
-						added_to_records = 1
+						added_to_records = TRUE
 
 				if ((R.fields["name"] == visibleName) && ((R.fields["criminal"] == "*Arrest*") || R.fields["criminal"] == "Parolled" || R.fields["criminal"] == "Incarcerated" || R.fields["criminal"] == "Released"))
 					arrestState = R.fields["criminal"] // Found a record of some kind

--- a/code/mob/living/life/arrest_icon.dm
+++ b/code/mob/living/life/arrest_icon.dm
@@ -9,7 +9,8 @@
 
 			//TODO : move this code somewhere else that updates from an event trigger instead of constantly
 			var/arrestState = ""
-
+			var/added_to_records = 0
+			var/jailbird_spotted = 0
 			var/see_face = 1
 			if (istype(H.wear_mask) && !H.wear_mask.see_face)
 				see_face = 0
@@ -19,10 +20,15 @@
 				see_face = 0
 			var/visibleName = see_face ? H.real_name : H.name
 
-			if(H.traitHolder.hasTrait("immigrant") && H.traitHolder.hasTrait("jailbird"))
-				arrestState = "*Arrest*"
-
 			for (var/datum/data/record/R as anything in data_core.security)
+				if (R.fields["name"] != H.name && H.traitHolder.hasTrait("immigrant") && H.traitHolder.hasTrait("jailbird"))
+					arrestState = "*Arrest*"
+					jailbird_spotted = 1
+				else if (R.fields["name"] == H.name && H.traitHolder.hasTrait("immigrant") && H.traitHolder.hasTrait("jailbird"))
+					if(!added_to_records && jailbird_spotted)
+						arrestState = ""
+						added_to_records = 1
+
 				if ((R.fields["name"] == visibleName) && ((R.fields["criminal"] == "*Arrest*") || R.fields["criminal"] == "Parolled" || R.fields["criminal"] == "Incarcerated" || R.fields["criminal"] == "Released"))
 					arrestState = R.fields["criminal"] // Found a record of some kind
 					break

--- a/code/mob/living/life/arrest_icon.dm
+++ b/code/mob/living/life/arrest_icon.dm
@@ -22,8 +22,9 @@
 
 			for (var/datum/data/record/R as anything in data_core.security)
 				if (R.fields["name"] != H.name && H.traitHolder.hasTrait("immigrant") && H.traitHolder.hasTrait("jailbird"))
-					arrestState = "*Arrest*"
-					jailbird_spotted = 1
+					if(!added_to_records)
+						arrestState = "*Arrest*"
+						jailbird_spotted = 1
 				else if (R.fields["name"] == H.name && H.traitHolder.hasTrait("immigrant") && H.traitHolder.hasTrait("jailbird"))
 					if(!added_to_records && jailbird_spotted)
 						arrestState = ""

--- a/code/mob/living/life/arrest_icon.dm
+++ b/code/mob/living/life/arrest_icon.dm
@@ -10,7 +10,6 @@
 			//TODO : move this code somewhere else that updates from an event trigger instead of constantly
 			var/arrestState = ""
 			var/added_to_records = 0
-			var/jailbird_spotted = 0
 			var/see_face = 1
 			if (istype(H.wear_mask) && !H.wear_mask.see_face)
 				see_face = 0
@@ -24,9 +23,8 @@
 				if (R.fields["name"] != H.name && H.traitHolder.hasTrait("immigrant") && H.traitHolder.hasTrait("jailbird"))
 					if(!added_to_records)
 						arrestState = "*Arrest*"
-						jailbird_spotted = 1
 				else if (R.fields["name"] == H.name && H.traitHolder.hasTrait("immigrant") && H.traitHolder.hasTrait("jailbird"))
-					if(!added_to_records && jailbird_spotted)
+					if(!added_to_records)
 						arrestState = ""
 						added_to_records = 1
 

--- a/code/mob/living/life/arrest_icon.dm
+++ b/code/mob/living/life/arrest_icon.dm
@@ -19,6 +19,9 @@
 				see_face = 0
 			var/visibleName = see_face ? H.real_name : H.name
 
+			if(H.traitHolder.hasTrait("immigrant") && H.traitHolder.hasTrait("jailbird"))
+				arrestState = "*Arrest*"
+
 			for (var/datum/data/record/R as anything in data_core.security)
 				if ((R.fields["name"] == visibleName) && ((R.fields["criminal"] == "*Arrest*") || R.fields["criminal"] == "Parolled" || R.fields["criminal"] == "Incarcerated" || R.fields["criminal"] == "Released"))
 					arrestState = R.fields["criminal"] // Found a record of some kind

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -128,7 +128,6 @@
 	var/warn_minor_crime = 0
 
 	var/added_to_records = 0
-	var/jailbird_spotted = 0
 	/// Set a bot to guard an area, and they'll go there and mill around
 	var/area/guard_area
 	/// Arrest anyone who arent security / heads if they're in this area?
@@ -939,9 +938,8 @@
 			if (R.fields["name"] != perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
 				if(!added_to_records)
 					threatcount += 5
-					jailbird_spotted = 1
 			else if ((R.fields["name"] == perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird")))
-				if(!added_to_records && jailbird_spotted)
+				if(!added_to_records)
 					threatcount -= 5
 					added_to_records = 1
 

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -937,8 +937,9 @@
 
 		for (var/datum/data/record/R as anything in data_core.security)
 			if (R.fields["name"] != perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
-				threatcount += 5
-				jailbird_spotted = 1
+				if(!added_to_records)
+					threatcount += 5
+					jailbird_spotted = 1
 			else if ((R.fields["name"] == perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird")))
 				if(!added_to_records && jailbird_spotted)
 					threatcount -= 5

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -127,6 +127,8 @@
 	/// Obey the threat threshold. Otherwise, just cuff em
 	var/warn_minor_crime = 0
 
+	var/added_to_records = 0
+	var/jailbird_spotted = 0
 	/// Set a bot to guard an area, and they'll go there and mill around
 	var/area/guard_area
 	/// Arrest anyone who arent security / heads if they're in this area?
@@ -933,8 +935,14 @@
 		if(istype(perp.mutantrace, /datum/mutantrace/abomination))
 			threatcount += 5
 
-		if(perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
-			threatcount += 5
+		for (var/datum/data/record/R as anything in data_core.security)
+			if (R.fields["name"] != perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
+				threatcount += 5
+				jailbird_spotted = 1
+			else if ((R.fields["name"] == perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird")))
+				if(!added_to_records && jailbird_spotted)
+					threatcount -= 5
+					added_to_records = 1
 
 		//Agent cards lower threat level
 		if((istype(perp.wear_id, /obj/item/card/id/syndicate)))

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -934,7 +934,7 @@
 			threatcount += 5
 
 		if(perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
-			threatcount +=5
+			threatcount += 5
 
 		//Agent cards lower threat level
 		if((istype(perp.wear_id, /obj/item/card/id/syndicate)))

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -933,6 +933,9 @@
 		if(istype(perp.mutantrace, /datum/mutantrace/abomination))
 			threatcount += 5
 
+		if(perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
+			threatcount +=5
+
 		//Agent cards lower threat level
 		if((istype(perp.wear_id, /obj/item/card/id/syndicate)))
 			threatcount -= 2

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -127,7 +127,7 @@
 	/// Obey the threat threshold. Otherwise, just cuff em
 	var/warn_minor_crime = 0
 
-	var/added_to_records = 0
+	var/added_to_records = FALSE
 	/// Set a bot to guard an area, and they'll go there and mill around
 	var/area/guard_area
 	/// Arrest anyone who arent security / heads if they're in this area?
@@ -941,7 +941,7 @@
 			else if ((R.fields["name"] == perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird")))
 				if(!added_to_records)
 					threatcount -= 5
-					added_to_records = 1
+					added_to_records = TRUE
 
 		//Agent cards lower threat level
 		if((istype(perp.wear_id, /obj/item/card/id/syndicate)))

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -198,6 +198,9 @@
 			else
 				threatcount += 2
 
+		if(perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
+			threatcount +=5
+
 		//if((isnull(perp:wear_id)) || (istype(perp:wear_id, /obj/item/card/id/syndicate)))
 		var/obj/item/card/id/perp_id = perp.equipped()
 		if (!istype(perp_id))

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -20,7 +20,7 @@
 	var/check_records = 1
 
 	var/last_perp = 0
-	var/added_to_records = 0
+	var/added_to_records = FALSE
 	var/last_contraband = 0
 	//var/area/area = 0
 	var/emagged = 0
@@ -206,7 +206,7 @@
 			else if ((R.fields["name"] == perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird")))
 				if(!added_to_records)
 					threatcount -= 5
-					added_to_records = 1
+					added_to_records = TRUE
 
 		//if((isnull(perp:wear_id)) || (istype(perp:wear_id, /obj/item/card/id/syndicate)))
 		var/obj/item/card/id/perp_id = perp.equipped()

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -21,7 +21,6 @@
 
 	var/last_perp = 0
 	var/added_to_records = 0
-	var/jailbird_spotted = 0
 	var/last_contraband = 0
 	//var/area/area = 0
 	var/emagged = 0
@@ -204,9 +203,8 @@
 			if (R.fields["name"] != perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
 				if(!added_to_records)
 					threatcount += 5
-					jailbird_spotted = 1
 			else if ((R.fields["name"] == perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird")))
-				if(!added_to_records && jailbird_spotted)
+				if(!added_to_records)
 					threatcount -= 5
 					added_to_records = 1
 

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -20,6 +20,8 @@
 	var/check_records = 1
 
 	var/last_perp = 0
+	var/added_to_records = 0
+	var/jailbird_spotted = 0
 	var/last_contraband = 0
 	//var/area/area = 0
 	var/emagged = 0
@@ -198,8 +200,14 @@
 			else
 				threatcount += 2
 
-		if(perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
-			threatcount += 5
+		for (var/datum/data/record/R as anything in data_core.security)
+			if (R.fields["name"] != perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
+				threatcount += 5
+				jailbird_spotted = 1
+			else if ((R.fields["name"] == perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird")))
+				if(!added_to_records && jailbird_spotted)
+					threatcount -= 5
+					added_to_records = 1
 
 		//if((isnull(perp:wear_id)) || (istype(perp:wear_id, /obj/item/card/id/syndicate)))
 		var/obj/item/card/id/perp_id = perp.equipped()

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -199,7 +199,7 @@
 				threatcount += 2
 
 		if(perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
-			threatcount +=5
+			threatcount += 5
 
 		//if((isnull(perp:wear_id)) || (istype(perp:wear_id, /obj/item/card/id/syndicate)))
 		var/obj/item/card/id/perp_id = perp.equipped()

--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -202,8 +202,9 @@
 
 		for (var/datum/data/record/R as anything in data_core.security)
 			if (R.fields["name"] != perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))
-				threatcount += 5
-				jailbird_spotted = 1
+				if(!added_to_records)
+					threatcount += 5
+					jailbird_spotted = 1
 			else if ((R.fields["name"] == perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird")))
 				if(!added_to_records && jailbird_spotted)
 					threatcount -= 5


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes people with jailbird + stowaway combo trigger sec scanners, makes them chased by secbots regardless of everything and gives them the sechud arrest icon.

Creating a security record clears all of the things mentioned above.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently, stowaways, aren't appearing on the manifest at all, and thus, they aren't listed on the security records. So if someone has jailbird + stowaway, the jailbird trait doesn't apply the arrest status due to lack of security record. This PR basically forces a arrest status for people with this trait combo, making their lives much worse! (which is a good thing)

Also fixes #4293 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Having jailbird + stowaway trait combo sets you to arrest again. Creating a security record with a proper name clears the arrest status.
```
