### PR TITLE
Captain's locker access fix

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -31,6 +31,7 @@
 
 /obj/storage/secure/closet/command/captain
 	name = "\improper Captain's locker"
+	req_access_txt = "20"
 	spawn_contents = list(/obj/item/gun/energy/egun,
 	/obj/item/storage/box/id_kit,
 	/obj/item/storage/box/clothing/captain,

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -31,7 +31,7 @@
 
 /obj/storage/secure/closet/command/captain
 	name = "\improper Captain's locker"
-	req_access_txt = "20"
+	req_access = list(access_captain)
 	spawn_contents = list(/obj/item/gun/energy/egun,
 	/obj/item/storage/box/id_kit,
 	/obj/item/storage/box/clothing/captain,
@@ -54,7 +54,7 @@
 
 /obj/storage/secure/closet/command/hos
 	name = "\improper Head of Security's locker"
-	req_access_txt = "37"
+	req_access = list(access_maxsec)
 	spawn_contents = list(/obj/item/storage/box/id_kit,
 	/obj/item/handcuffs,
 	/obj/item/device/flash,
@@ -75,7 +75,7 @@
 
 /obj/storage/secure/closet/command/hop
 	name = "\improper Head of Personnel's locker"
-	req_access_txt = "55"
+	req_access = list(access_head_of_personnel)
 	spawn_contents = list(/obj/item/device/flash,
 	/obj/item/storage/box/id_kit,
 	/obj/item/storage/box/clothing/hop,
@@ -87,7 +87,7 @@
 
 /obj/storage/secure/closet/command/research_director
 	name = "\improper Research Director's locker"
-	req_access_txt = "11"
+	req_access = list(access_research_director)
 	spawn_contents = list(/obj/item/plant/herb/cannabis/spawnable,
 	/obj/item/device/light/zippo,
 	/obj/item/storage/box/clothing/research_director,
@@ -110,7 +110,7 @@
 
 /obj/storage/secure/closet/command/medical_director
 	name = "\improper Medical Director's locker"
-	req_access_txt = "53"
+	req_access = list(access_medical_director)
 	spawn_contents = list(/obj/item/storage/box/clothing/medical_director,
 	/obj/item/clothing/shoes/brown,
 	/obj/item/gun/implanter,
@@ -136,7 +136,7 @@
 
 /obj/storage/secure/closet/command/chief_engineer
 	name = "\improper Chief Engineer's locker"
-	req_access_txt = "49"
+	req_access = list(access_engineering_chief)
 	spawn_contents = list(/obj/item/storage/toolbox/mechanical/yellow_tools,
 	/obj/item/storage/box/clothing/chief_engineer,
 	/obj/item/clothing/gloves/yellow,
@@ -168,7 +168,7 @@
 
 /obj/storage/secure/closet/security
 	name = "\improper Security locker"
-	req_access_txt = "38"
+	req_access = list(access_securitylockers)
 	icon_state = "sec"
 	icon_closed = "sec"
 	icon_opened = "secure_red-open"
@@ -186,7 +186,7 @@
 
 /obj/storage/secure/closet/security/forensics
 	name = "Forensics equipment locker"
-	req_access_txt = "4"
+	req_access = list(access_forensics_lockers)
 	spawn_contents = list(/obj/item/storage/box/clothing/detective,
 	/obj/item/clothing/suit/wintercoat/security,
 	/obj/item/clothing/glasses/thermal,
@@ -202,7 +202,7 @@
 
 /obj/storage/secure/closet/security/armory
 	name = "\improper Special Equipment locker"
-	req_access_txt = "37"
+	req_access = list(access_maxsec)
 	spawn_contents = list(/obj/item/requisition_token/security = 2,
 	/obj/item/turret_deployer/riot = 2,
 	/obj/item/clothing/glasses/nightvision = 2,
@@ -213,7 +213,7 @@
 
 /obj/storage/secure/closet/brig
 	name = "\improper Confiscated Items locker"
-	req_access_txt = "2"
+	req_access = list(access_brig)
 
 // Old Mushroom-era feature I fixed up (Convair880).
 /obj/storage/secure/closet/brig/automatic
@@ -321,7 +321,7 @@
 	icon_state = "medical"
 	icon_closed = "medical"
 	icon_opened = "secure_white-open"
-	req_access_txt = "10"
+	req_access = list(access_medical_lockers)
 
 
 
@@ -399,7 +399,7 @@
 	icon_closed = "medical_restricted"
 	icon_state = "medical_restricted"
 	spawn_contents = list()
-	req_access_txt = "53"
+	req_access = list(access_medical_director)
 	make_my_stuff()
 		if (..()) // make_my_stuff is called multiple times due to lazy init, so the parent returns 1 if it actually fired and 0 if it already has
 			// let's organize the SHIT outta this closet too! hot damn
@@ -445,7 +445,7 @@
 	icon_state = "science"
 	icon_closed = "science"
 	icon_opened = "secure_white-open"
-	req_access_txt = "8"
+	req_access = list(access_tox_storage)
 
 /obj/storage/secure/closet/research/uniform
 	name = "science uniform locker"
@@ -501,7 +501,7 @@
 
 /obj/storage/secure/closet/engineering/electrical
 	name = "electrical supplies locker"
-	req_access_txt = "43"
+	req_access = list(access_engineering_power)
 	spawn_contents = list(/obj/item/clothing/gloves/yellow = 3,
 	/obj/item/storage/toolbox/electrical = 3,
 	/obj/item/device/multitool = 3)
@@ -513,7 +513,7 @@
 
 /obj/storage/secure/closet/engineering/mechanic
 	name = "\improper Mechanic's locker"
-	req_access_txt = "45"
+	req_access = list(access_engineering_mechanic)
 	spawn_contents = list(/obj/item/storage/toolbox/electrical,
 	/obj/item/clothing/suit/wintercoat/engineering,
 	/obj/item/storage/box/clothing/mechanic,
@@ -541,7 +541,7 @@
 
 /obj/storage/secure/closet/engineering/engineer
 	name = "\improper Engineer's locker"
-	req_access_txt = "44"
+	req_access = list(access_engineering_engine)
 	spawn_contents = list(/obj/item/storage/toolbox/mechanical,
 	/obj/item/storage/box/clothing/engineer,
 	/obj/item/clothing/suit/wintercoat/engineering,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the captain's locker require the same access to open as the captain's room, previously due to what I belive was an oversight anyone with bridge access could open the locker.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes sense. keeps it the same as all the other head lockers wich are tied to access to their respective rooms.