### PR TITLE
Add a new admin command for loading in special shuttles

### DIFF
--- a/_std/defines/landmarks.dm
+++ b/_std/defines/landmarks.dm
@@ -17,6 +17,15 @@
 #define LANDMARK_GPS_WAYPOINT "GPS Waypoint"
 #define LANDMARK_ARTIFACT_SPAWN "artifact spawner"
 
+// centcom shuttle landmarks
+#define LANDMARK_SHUTTLE_COG1 "shuttle-cog1"
+#define LANDMARK_SHUTTLE_COG2 "shuttle-cog2"
+#define LANDMARK_SHUTTLE_SEALAB "shuttle-sealab"
+#define LANDMARK_SHUTTLE_MANTA "shuttle-manta"
+#define LANDMARK_SHUTTLE_DONUT2 "shuttle-donut2"
+#define LANDMARK_SHUTTLE_DONUT3 "shuttle-donut3"
+#define LANDMARK_SHUTTLE_DESTINY "shuttle-destiny"
+
 // nukies
 
 #define LANDMARK_SYNDICATE "Syndicate-Spawn"

--- a/assets/maps/shuttles/cog1/cog1-dojo.dmm
+++ b/assets/maps/shuttles/cog1/cog1-dojo.dmm
@@ -1,0 +1,401 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/turf/unsimulated/floor/dojo/sand/horizontal,
+/area/shuttle/escape/centcom/cogmap)
+"bg" = (
+/obj/machinery/computer/shuttle/embedded/south,
+/turf/unsimulated/floor/tatami,
+/area/shuttle/escape/centcom/cogmap)
+"bC" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/obj/lantern{
+	dir = 4
+	},
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"bK" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/lantern{
+	dir = 8
+	},
+/turf/unsimulated/floor/wood/two,
+/area/shuttle/escape/centcom/cogmap)
+"gh" = (
+/obj/decal/fakeobjects/swordrack{
+	pixel_y = 5
+	},
+/turf/unsimulated/wall/auto/sengoku{
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"ib" = (
+/turf/unsimulated/wall/auto/sengoku{
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"ik" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/wood/two,
+/area/shuttle/escape/centcom/cogmap)
+"kb" = (
+/obj/decal/wallscroll/scroll2{
+	pixel_y = 32
+	},
+/turf/unsimulated/floor/wood/two,
+/area/shuttle/escape/centcom/cogmap)
+"kM" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 9;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"lQ" = (
+/obj/lantern{
+	pixel_y = 10
+	},
+/turf/unsimulated/wall/auto/sengoku{
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"mo" = (
+/obj/machinery/door/unpowered/wood/pyro,
+/turf/unsimulated/floor/dojo/sand/vertical,
+/area/shuttle/escape/centcom/cogmap)
+"oQ" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"pk" = (
+/obj/lattice{
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"sm" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 5;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"uH" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 8
+	},
+/turf/unsimulated/floor/dojo/stone,
+/area/shuttle/escape/centcom/cogmap)
+"vJ" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/dojo/sand/vertical,
+/area/shuttle/escape/centcom/cogmap)
+"vM" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/wood/two,
+/area/shuttle/escape/centcom/cogmap)
+"vR" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/tatami,
+/area/shuttle/escape/centcom/cogmap)
+"wk" = (
+/obj/machinery/door/unpowered/wood/pyro,
+/turf/unsimulated/floor/wood/two,
+/area/shuttle/escape/centcom/cogmap)
+"xl" = (
+/turf/unsimulated/wall/water/border,
+/area/shuttle/escape/centcom/cogmap)
+"xP" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-L"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"yt" = (
+/turf/unsimulated/floor/tatami,
+/area/shuttle/escape/centcom/cogmap)
+"yB" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"zF" = (
+/turf/unsimulated/floor/dojo/stone,
+/area/shuttle/escape/centcom/cogmap)
+"AD" = (
+/turf/unsimulated/wall/auto/paper{
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Ck" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-M"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"Cl" = (
+/obj/machinery/door/unpowered/wood/pyro,
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"Fa" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/wood/two,
+/area/shuttle/escape/centcom/cogmap)
+"Fd" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 4
+	},
+/turf/unsimulated/floor/dojo/stone,
+/area/shuttle/escape/centcom/cogmap)
+"Gd" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"IL" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/dojo/sand/circle,
+/area/shuttle/escape/centcom/cogmap)
+"Ny" = (
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"Rb" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"RH" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/lantern{
+	dir = 4
+	},
+/turf/unsimulated/floor/wood/two,
+/area/shuttle/escape/centcom/cogmap)
+"Sm" = (
+/obj/decal/fakeobjects/lotus{
+	icon_state = "lotus_2"
+	},
+/turf/unsimulated/wall/water/border,
+/area/shuttle/escape/centcom/cogmap)
+"UH" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"XZ" = (
+/obj/decal/wallscroll{
+	pixel_y = 32
+	},
+/turf/unsimulated/floor/wood/two,
+/area/shuttle/escape/centcom/cogmap)
+"Ya" = (
+/obj/machinery/sleeper/compact,
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"Ym" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/lantern{
+	dir = 8
+	},
+/turf/unsimulated/floor/dojo/sand/circle,
+/area/shuttle/escape/centcom/cogmap)
+"Ze" = (
+/obj/lantern{
+	pixel_y = 10
+	},
+/turf/unsimulated/wall/auto/paper{
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Zk" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 10;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"ZU" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-R"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+
+(1,1,1) = {"
+oQ
+ib
+ib
+ib
+ib
+ib
+Fd
+ib
+ik
+ik
+ik
+ib
+ib
+pk
+UH
+UH
+UH
+"}
+(2,1,1) = {"
+kM
+ZU
+vJ
+Ym
+ib
+kb
+zF
+bK
+Fa
+Fa
+Fa
+bK
+AD
+ik
+AD
+Rb
+Rb
+"}
+(3,1,1) = {"
+Zk
+Ck
+IL
+ab
+mo
+zF
+zF
+Fa
+Fa
+Fa
+Fa
+Fa
+ik
+vM
+AD
+AD
+pk
+"}
+(4,1,1) = {"
+sm
+xP
+vJ
+IL
+lQ
+xl
+zF
+Fa
+Fa
+Fa
+Fa
+Fa
+Ze
+vR
+vR
+AD
+AD
+"}
+(5,1,1) = {"
+Rb
+ib
+ib
+ib
+gh
+Sm
+zF
+zF
+zF
+zF
+zF
+zF
+wk
+yt
+bg
+AD
+AD
+"}
+(6,1,1) = {"
+kM
+ZU
+Ya
+yB
+lQ
+xl
+zF
+Fa
+Fa
+Fa
+Fa
+Fa
+Ze
+vR
+vR
+AD
+AD
+"}
+(7,1,1) = {"
+Zk
+Ck
+Gd
+Ny
+Cl
+zF
+zF
+Fa
+Fa
+Fa
+Fa
+Fa
+ik
+vM
+AD
+AD
+pk
+"}
+(8,1,1) = {"
+sm
+xP
+Ya
+bC
+ib
+XZ
+zF
+RH
+Fa
+Fa
+Fa
+RH
+AD
+ik
+AD
+Rb
+Rb
+"}
+(9,1,1) = {"
+oQ
+ib
+ib
+ib
+ib
+ib
+uH
+ib
+ik
+ik
+ik
+ib
+ib
+pk
+UH
+UH
+UH
+"}

--- a/assets/maps/shuttles/cog1/cog1-dream.dmm
+++ b/assets/maps/shuttles/cog1/cog1-dream.dmm
@@ -1,0 +1,406 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"b" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"d" = (
+/obj/decal/stage_edge/dojo,
+/obj/decal/stone_lamp{
+	desc = "An incredibly heavy stone lamp. No human could possibly hope to even so much as budge it in the slightest.";
+	name = "lamp of atlas";
+	pixel_y = -5
+	},
+/turf/unsimulated/floor/dream/beach,
+/area/shuttle/escape/centcom/cogmap)
+"f" = (
+/turf/unsimulated/floor/dream/beach{
+	icon_state = "shore-6"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"g" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/turf/unsimulated/floor/dojo/stone,
+/area/shuttle/escape/centcom/cogmap)
+"h" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"i" = (
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/turf/unsimulated/floor/dojo/stone,
+/area/shuttle/escape/centcom/cogmap)
+"j" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 5;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"k" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-M"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"l" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/dream/beach,
+/area/shuttle/escape/centcom/cogmap)
+"m" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/dojo/stone,
+/area/shuttle/escape/centcom/cogmap)
+"o" = (
+/turf/unsimulated/floor/dojo/stone,
+/area/shuttle/escape/centcom/cogmap)
+"p" = (
+/turf/unsimulated/wall/auto/sengoku{
+	icon_state = "10";
+	name = "wall";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"q" = (
+/turf/unsimulated/floor/dream/beach{
+	icon_state = "space-1"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"r" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 10;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"t" = (
+/turf/unsimulated/floor/dream/beach{
+	icon_state = "shore-1"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"u" = (
+/obj/decal/fakeobjects/dreambeach/biggest/big_palm,
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/dream/beach,
+/area/shuttle/escape/centcom/cogmap)
+"v" = (
+/turf/unsimulated/wall/auto/sengoku{
+	icon_state = "12";
+	name = "wall";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"w" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/dojo/stone,
+/area/shuttle/escape/centcom/cogmap)
+"y" = (
+/turf/unsimulated/floor/dream/beach{
+	icon_state = "shore-2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"z" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/cogmap)
+"A" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 9;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"B" = (
+/turf/unsimulated/floor/dojo/stonestair,
+/area/shuttle/escape/centcom/cogmap)
+"C" = (
+/turf/unsimulated/floor/dream/beach,
+/area/shuttle/escape/centcom/cogmap)
+"D" = (
+/turf/unsimulated/floor/dream/beach{
+	icon_state = "shore-7"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"E" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/dojo/stone,
+/area/shuttle/escape/centcom/cogmap)
+"G" = (
+/turf/unsimulated/wall/auto/sengoku{
+	icon_state = "6";
+	name = "wall";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"H" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"I" = (
+/turf/unsimulated/floor/dream/beach{
+	icon_state = "shore-3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"J" = (
+/obj/lattice{
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"N" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/dojo/stone,
+/area/shuttle/escape/centcom/cogmap)
+"O" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/dream/beach,
+/area/shuttle/escape/centcom/cogmap)
+"P" = (
+/turf/simulated/shuttle/wall/cockpit{
+	dir = 1
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Q" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/dream/beach,
+/area/shuttle/escape/centcom/cogmap)
+"R" = (
+/turf/unsimulated/wall/auto/sengoku{
+	icon_state = "5";
+	name = "wall";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"T" = (
+/turf/unsimulated/wall/auto/sengoku,
+/area/shuttle/escape/centcom/cogmap)
+"U" = (
+/obj/machinery/computer/shuttle/embedded/south,
+/turf/unsimulated/floor/dream/beach{
+	icon_state = "space-1"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"V" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-L"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"W" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-R"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"X" = (
+/turf/unsimulated/floor/dream/beach{
+	icon_state = "beach-0"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Y" = (
+/turf/unsimulated/wall/auto/sengoku{
+	icon_state = "3";
+	name = "wall";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Z" = (
+/turf/unsimulated/wall/auto/sengoku{
+	icon_state = "9";
+	name = "wall";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+
+(1,1,1) = {"
+b
+G
+Y
+Y
+Y
+Y
+z
+Y
+Y
+Y
+Y
+Y
+R
+J
+a
+a
+a
+"}
+(2,1,1) = {"
+A
+W
+w
+w
+d
+C
+C
+Q
+Q
+Q
+Q
+Q
+p
+Y
+R
+h
+h
+"}
+(3,1,1) = {"
+r
+k
+N
+o
+B
+C
+C
+C
+Q
+O
+Q
+C
+f
+t
+p
+R
+J
+"}
+(4,1,1) = {"
+j
+V
+w
+w
+d
+C
+C
+C
+C
+C
+C
+C
+X
+y
+q
+T
+H
+"}
+(5,1,1) = {"
+h
+Y
+Y
+Y
+v
+l
+C
+C
+u
+C
+C
+C
+X
+y
+U
+T
+P
+"}
+(6,1,1) = {"
+A
+W
+E
+g
+d
+C
+C
+C
+C
+C
+C
+C
+X
+y
+q
+T
+H
+"}
+(7,1,1) = {"
+r
+k
+m
+o
+B
+C
+C
+C
+Q
+O
+Q
+C
+D
+I
+G
+Z
+J
+"}
+(8,1,1) = {"
+j
+V
+i
+i
+d
+C
+C
+Q
+Q
+Q
+Q
+Q
+G
+Y
+Z
+h
+h
+"}
+(9,1,1) = {"
+b
+p
+Y
+Y
+Y
+Y
+z
+Y
+Y
+Y
+Y
+Y
+Z
+J
+a
+a
+a
+"}

--- a/assets/maps/shuttles/cog1/cog1-iomoon.dmm
+++ b/assets/maps/shuttles/cog1/cog1-iomoon.dmm
@@ -1,0 +1,53 @@
+"a" = (/obj/lattice{icon_state = "lattice-dir"},/turf/unsimulated/outdoors/grass,/area/centcom/outside)
+"b" = (/turf/unsimulated/outdoors/grass,/area/shuttle/escape/centcom/cogmap)
+"d" = (/obj/overlay{bound_height = 64; bound_width = 64; desc = "An enormous artifact of some sort. You feel uncomfortable just being near it."; icon = 'icons/effects/64x64.dmi'; icon_state = "powercore_ring2"; layer = 3.9; name = "central ring"; pixel_x = 16; pixel_y = 17},/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor2"},/area/shuttle/escape/centcom/cogmap)
+"h" = (/turf/unsimulated/outdoors/grass,/area/centcom/outside)
+"i" = (/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor2"},/area/shuttle/escape/centcom/cogmap)
+"j" = (/obj/machinery/shuttle/engine/propulsion{dir = 5; icon_state = "alt_propulsion"},/turf/unsimulated/outdoors/grass,/area/shuttle/escape/centcom/cogmap)
+"k" = (/obj/machinery/shuttle/engine/heater{dir = 1; icon_state = "alt_heater-M"},/obj/window/reinforced/south,/turf/unsimulated/floor/plating,/area/shuttle/escape/centcom/cogmap)
+"n" = (/obj/decal/glow{anchored = 1; brightness = 2; color_b = 0.8; color_g = 1; color_r = 0; desc = "Some manner of glowing power conveyor."; icon = 'icons/obj/machines/heavy_fiber.dmi'; name = "power conduit"},/obj/stool/chair/comfy/shuttle/brown,/turf/unsimulated/iomoon/ancient_floor,/area/shuttle/escape/centcom/cogmap)
+"o" = (/obj/decal/glow{anchored = 1; brightness = 2; color_b = 0.8; color_g = 1; color_r = 0; desc = "Some manner of glowing power conveyor."; dir = 6; icon = 'icons/obj/machines/heavy_fiber.dmi'; icon_state = ""; name = "power conduit"},/obj/stool/chair/comfy/shuttle/brown,/turf/unsimulated/iomoon/ancient_floor,/area/shuttle/escape/centcom/cogmap)
+"q" = (/obj/decal/glow{anchored = 1; brightness = 2; color_b = 0.8; color_g = 1; color_r = 0; desc = "Some manner of glowing power conveyor."; dir = 9; icon = 'icons/obj/machines/heavy_fiber.dmi'; icon_state = ""; name = "power conduit"},/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor3"},/area/shuttle/escape/centcom/cogmap)
+"r" = (/obj/machinery/shuttle/engine/propulsion{dir = 10; icon_state = "alt_propulsion"},/turf/unsimulated/outdoors/grass,/area/shuttle/escape/centcom/cogmap)
+"s" = (/obj/decal/glow{anchored = 1; brightness = 2; color_b = 0.8; color_g = 1; color_r = 0; desc = "Some manner of glowing power conveyor."; dir = 10; icon = 'icons/obj/machines/heavy_fiber.dmi'; icon_state = ""; name = "power conduit"},/obj/stool/chair/comfy/shuttle/brown,/turf/unsimulated/iomoon/ancient_floor,/area/shuttle/escape/centcom/cogmap)
+"t" = (/obj/decal/glow{anchored = 1; brightness = 2; color_b = 0.8; color_g = 1; color_r = 0; desc = "Some manner of glowing power conveyor."; icon = 'icons/obj/machines/heavy_fiber.dmi'; name = "power conduit"},/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor3"},/area/shuttle/escape/centcom/cogmap)
+"v" = (/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor3"},/area/shuttle/escape/centcom/cogmap)
+"w" = (/obj/decal/glow{anchored = 1; brightness = 2; color_b = 0.8; color_g = 1; color_r = 0; desc = "Some manner of glowing power conveyor."; dir = 9; icon = 'icons/obj/machines/heavy_fiber.dmi'; icon_state = ""; name = "power conduit"},/obj/stool/chair/comfy/shuttle/brown,/turf/unsimulated/iomoon/ancient_floor,/area/shuttle/escape/centcom/cogmap)
+"x" = (/obj/decal/glow{anchored = 1; brightness = 2; color_b = 0.8; color_g = 1; color_r = 0; desc = "Some manner of glowing power conveyor."; icon = 'icons/obj/machines/heavy_fiber.dmi'; name = "power conduit"},/obj/stool/chair/comfy/shuttle,/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor3"},/area/shuttle/escape/centcom/cogmap)
+"y" = (/obj/overlay{bound_height = 160; bound_width = 160; desc = "An enormous artifact of some sort. You feel uncomfortable just being near it."; icon = 'icons/effects/160x160.dmi'; icon_state = "powercore_ring3"; layer = 3.9; name = "enormous artifact"},/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor2"},/area/shuttle/escape/centcom/cogmap)
+"z" = (/obj/machinery/door/airlock/pyro/external{dir = 4},/turf/unsimulated/iomoon/ancient_floor,/area/shuttle/escape/centcom/cogmap)
+"A" = (/obj/machinery/shuttle/engine/propulsion{dir = 9; icon_state = "alt_propulsion"},/turf/unsimulated/outdoors/grass,/area/shuttle/escape/centcom/cogmap)
+"H" = (/obj/indestructible/invisible_block,/turf/unsimulated/outdoors/grass,/area/shuttle/escape/centcom/cogmap)
+"J" = (/obj/lattice{icon_state = "lattice-dir-b"},/turf/unsimulated/outdoors/grass,/area/centcom/outside)
+"K" = (/obj/decal/glow{anchored = 1; brightness = 2; color_b = 0.8; color_g = 1; color_r = 0; desc = "Some manner of glowing power conveyor."; dir = 4; icon = 'icons/obj/machines/heavy_fiber.dmi'; icon_state = ""; name = "power conduit"},/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor3"},/area/shuttle/escape/centcom/cogmap)
+"L" = (/obj/wingrille_spawn/auto,/turf/unsimulated/iomoon/ancient_floor,/area/shuttle/escape/centcom/cogmap)
+"N" = (/obj/decal/glow{anchored = 1; brightness = 2; color_b = 0.8; color_g = 1; color_r = 0; desc = "Some manner of glowing power conveyor."; dir = 5; icon = 'icons/obj/machines/heavy_fiber.dmi'; icon_state = ""; name = "power conduit"},/obj/stool/chair/comfy/shuttle/brown,/turf/unsimulated/iomoon/ancient_floor,/area/shuttle/escape/centcom/cogmap)
+"O" = (/obj/stool/chair/comfy/shuttle/brown,/turf/unsimulated/iomoon/ancient_floor,/area/shuttle/escape/centcom/cogmap)
+"P" = (/turf/simulated/shuttle/wall/cockpit{dir = 1},/area/shuttle/escape/centcom/cogmap)
+"Q" = (/obj/stool/chair/comfy/shuttle/red,/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor2"},/area/shuttle/escape/centcom/cogmap)
+"S" = (/obj/decal/glow{anchored = 1; brightness = 2; color_b = 0.8; color_g = 1; color_r = 0; desc = "Some manner of glowing power conveyor."; dir = 5; icon = 'icons/obj/machines/heavy_fiber.dmi'; icon_state = ""; name = "power conduit"},/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor3"},/area/shuttle/escape/centcom/cogmap)
+"U" = (/obj/machinery/computer/shuttle/embedded/south,/obj/stool/chair/comfy/shuttle/pilot,/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor3"},/area/shuttle/escape/centcom/cogmap)
+"V" = (/obj/machinery/shuttle/engine/heater{dir = 1; icon_state = "alt_heater-L"},/obj/window/reinforced/south,/turf/unsimulated/floor/plating,/area/shuttle/escape/centcom/cogmap)
+"W" = (/obj/machinery/shuttle/engine/heater{dir = 1; icon_state = "alt_heater-R"},/obj/window/reinforced/south,/turf/unsimulated/floor/plating,/area/shuttle/escape/centcom/cogmap)
+"X" = (/obj/decal/glow{anchored = 1; brightness = 2; color_b = 0.8; color_g = 1; color_r = 0; desc = "Some manner of glowing power conveyor."; dir = 4; icon = 'icons/obj/machines/heavy_fiber.dmi'; icon_state = ""; name = "power conduit"},/obj/stool/chair/comfy/shuttle,/turf/unsimulated/iomoon/ancient_floor{icon_state = "ancientfloor3"},/area/shuttle/escape/centcom/cogmap)
+"Z" = (/turf/unsimulated/iomoon/ancient_wall,/area/shuttle/escape/centcom/cogmap)
+
+(1,1,1) = {"
+bArjhArjb
+ZWkVZWkVZ
+ZwXXXXXNZ
+ZxviiivxZ
+ZxiiiiixZ
+ZxiiiiixZ
+ztiiiiitz
+ZtidiiitZ
+LtyiiiitL
+LtQQQQQtL
+LtvQQQvtL
+ZsSvQvqoZ
+ZZnvQvnZZ
+JZsKKKoZJ
+aZZOUOZZa
+ahZZZZZha
+ahJHPHJha
+"}

--- a/assets/maps/shuttles/cog1/cog1-martian.dmm
+++ b/assets/maps/shuttles/cog1/cog1-martian.dmm
@@ -1,0 +1,368 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"b" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"d" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/simulated/martian/wall{
+	dir = 5;
+	icon_state = "diagonalWall"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"g" = (
+/obj/stool/chair/comfy/shuttle/green{
+	dir = 4
+	},
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"h" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"i" = (
+/obj/machinery/door/airlock/pyro/medical{
+	name = "First-Aid Station"
+	},
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"j" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 5;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"k" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-M"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"m" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Secure Transport"
+	},
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"p" = (
+/turf/simulated/martian/wall{
+	dir = 6;
+	icon_state = "diagonalWall"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"r" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 10;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"s" = (
+/obj/stool/chair/comfy/shuttle,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"u" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/obj/map/light/dimred,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"v" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/radio,
+/obj/map/light/dimred,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"w" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"x" = (
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"z" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/cogmap)
+"A" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 9;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"B" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/map/light/dimred,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"C" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/simulated/martian/wall{
+	dir = 4;
+	icon_state = "diagonalWall"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"E" = (
+/obj/map/light/dimred,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"F" = (
+/turf/simulated/martian/wall{
+	dir = 8;
+	icon_state = "diagonalWall"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"H" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"J" = (
+/obj/lattice{
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"K" = (
+/obj/machinery/sleeper/compact,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"L" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"N" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"P" = (
+/turf/simulated/shuttle/wall/cockpit{
+	dir = 1
+	},
+/area/shuttle/escape/centcom/cogmap)
+"R" = (
+/turf/simulated/martian/wall{
+	dir = 5;
+	icon_state = "diagonalWall"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"U" = (
+/obj/machinery/computer/shuttle/embedded/south,
+/obj/stool/chair/comfy/shuttle/pilot,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"V" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-L"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"W" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-R"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"X" = (
+/obj/machinery/door/airlock/pyro/command,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap)
+"Y" = (
+/turf/simulated/martian/wall,
+/area/shuttle/escape/centcom/cogmap)
+"Z" = (
+/turf/simulated/martian/wall{
+	dir = 4;
+	icon_state = "diagonalWall"
+	},
+/area/shuttle/escape/centcom/cogmap)
+
+(1,1,1) = {"
+b
+F
+Y
+Y
+Y
+Y
+z
+Y
+N
+N
+N
+Y
+R
+J
+a
+a
+a
+"}
+(2,1,1) = {"
+A
+W
+w
+w
+Y
+Z
+x
+s
+s
+s
+s
+p
+Y
+Y
+R
+h
+h
+"}
+(3,1,1) = {"
+r
+k
+w
+E
+m
+x
+E
+s
+B
+s
+B
+s
+N
+v
+p
+d
+J
+"}
+(4,1,1) = {"
+j
+V
+w
+w
+Y
+x
+x
+s
+s
+s
+s
+s
+Y
+L
+L
+Y
+H
+"}
+(5,1,1) = {"
+h
+Y
+Y
+Y
+Y
+x
+E
+x
+E
+x
+E
+x
+X
+x
+U
+Y
+P
+"}
+(6,1,1) = {"
+A
+W
+K
+g
+Y
+x
+x
+s
+s
+s
+s
+s
+Y
+L
+L
+Y
+H
+"}
+(7,1,1) = {"
+r
+k
+K
+E
+i
+x
+E
+s
+B
+s
+B
+s
+N
+u
+F
+C
+J
+"}
+(8,1,1) = {"
+j
+V
+K
+x
+Y
+R
+x
+s
+s
+s
+s
+F
+Y
+Y
+Z
+h
+h
+"}
+(9,1,1) = {"
+b
+p
+Y
+Y
+Y
+Y
+z
+Y
+N
+N
+N
+Y
+Z
+J
+a
+a
+a
+"}

--- a/assets/maps/shuttles/cog1/cog1-syndicate.dmm
+++ b/assets/maps/shuttles/cog1/cog1-syndicate.dmm
@@ -1,0 +1,584 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"cE" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm17"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"ds" = (
+/turf/simulated/shuttle/wall{
+	dir = 10;
+	icon_state = "diagonalWall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"dH" = (
+/obj/access_spawn/security,
+/obj/machinery/door/airlock/pyro/syndicate{
+	name = "reinforced internal airlock";
+	opacity = 0;
+	req_access_txt = null
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"dT" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-L"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"ew" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm8"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"eN" = (
+/turf/simulated/shuttle/wall{
+	dir = 6;
+	icon_state = "wall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"fi" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm6"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"fC" = (
+/obj/stool/chair/comfy/shuttle/red,
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"fR" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"fX" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 9;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"gO" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"gP" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm7"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"ji" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-R"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"jv" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/circuit/red,
+/area/shuttle/escape/centcom/cogmap)
+"jF" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"kQ" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm15"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"lq" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"mx" = (
+/turf/unsimulated/floor/redblack{
+	dir = 5
+	},
+/area/shuttle/escape/centcom/cogmap)
+"mL" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"pE" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm16"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"qb" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"sS" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm20"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"uu" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm4"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"uI" = (
+/obj/decal/poster/wallsign/stencil/right/s{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/y{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"vi" = (
+/obj/decal/poster/wallsign/stencil/right/i{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/n{
+	pixel_x = -12;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/d{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/c{
+	pixel_y = 6
+	},
+/obj/machinery/light/small/floor{
+	pixel_y = 8
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"vj" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 5;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"xo" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 10;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"zN" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"zV" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/redblack{
+	dir = 10
+	},
+/area/shuttle/escape/centcom/cogmap)
+"AE" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"Ce" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"Cs" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"CP" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/radio{
+	desc = "A portable radio used to report local emergencies.";
+	frequency = 1449;
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "radio";
+	name = "emergency radio"
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"DO" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-M"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"EL" = (
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"Fn" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"FM" = (
+/obj/decal/poster/wallsign/stencil/right/a{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/t{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/e{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"GX" = (
+/obj/decal/fakeobjects/shuttleweapon,
+/turf/simulated/shuttle/wall{
+	dir = 6;
+	icon_state = "wall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"IR" = (
+/obj/access_spawn/medical,
+/obj/machinery/door/airlock/pyro/syndicate{
+	name = "reinforced internal airlock";
+	opacity = 0;
+	req_access_txt = null
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"Jc" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm14"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Jk" = (
+/turf/simulated/shuttle/wall/cockpit{
+	icon_state = "shuttlecock_syndie"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Jr" = (
+/obj/item/storage/wall/emergency{
+	dir = 8
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Kf" = (
+/obj/machinery/computer/shuttle/embedded/south,
+/obj/stool/chair/comfy/shuttle/pilot,
+/turf/unsimulated/floor/circuit/red,
+/area/shuttle/escape/centcom/cogmap)
+"KP" = (
+/turf/unsimulated/floor/redblack{
+	dir = 9
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Mm" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Pt" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm19"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Px" = (
+/obj/decal/fakeobjects/shuttleweapon,
+/turf/simulated/shuttle/wall{
+	dir = 10;
+	icon_state = "diagonalWall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Qe" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm5"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Qn" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm18"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"QY" = (
+/obj/decal/fakeobjects/shuttleweapon/base,
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Sm" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/redblack{
+	dir = 6
+	},
+/area/shuttle/escape/centcom/cogmap)
+"SE" = (
+/obj/access_spawn/heads,
+/obj/machinery/door/airlock/pyro/syndicate{
+	name = "reinforced internal airlock";
+	opacity = 0;
+	req_access_txt = null
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"Tc" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/red,
+/area/shuttle/escape/centcom/cogmap)
+"TI" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/circuit/red,
+/area/shuttle/escape/centcom/cogmap)
+"UI" = (
+/obj/lattice{
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"UP" = (
+/turf/unsimulated/floor/red,
+/area/shuttle/escape/centcom/cogmap)
+"Vs" = (
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+"Wm" = (
+/turf/simulated/shuttle/wall{
+	dir = 8;
+	icon_state = "diagonalWall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Wq" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Xx" = (
+/turf/simulated/shuttle/wall{
+	dir = 6;
+	icon_state = "diagonalWall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"XB" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm1"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"XE" = (
+/obj/item/storage/wall/emergency,
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap)
+"XG" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm21"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"ZY" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/cogmap)
+
+(1,1,1) = {"
+fR
+Wm
+mL
+mL
+mL
+mL
+ZY
+mL
+zN
+zN
+zN
+QY
+Px
+UI
+Fn
+Fn
+Fn
+"}
+(2,1,1) = {"
+fX
+ji
+Ce
+Ce
+mL
+fC
+UP
+Tc
+Tc
+Tc
+Tc
+fC
+mL
+QY
+Px
+AE
+AE
+"}
+(3,1,1) = {"
+xo
+DO
+Ce
+Cs
+dH
+UP
+KP
+Jc
+Ce
+uu
+zV
+Tc
+zN
+CP
+mL
+ds
+UI
+"}
+(4,1,1) = {"
+vj
+dT
+Ce
+Ce
+mL
+Tc
+Pt
+kQ
+uI
+Qe
+XB
+Tc
+mL
+jv
+jv
+mL
+qb
+"}
+(5,1,1) = {"
+AE
+mL
+Jr
+mL
+XE
+Tc
+sS
+pE
+vi
+fi
+Mm
+UP
+SE
+TI
+Kf
+mL
+Jk
+"}
+(6,1,1) = {"
+fX
+ji
+gO
+lq
+mL
+Tc
+XG
+cE
+FM
+gP
+Wq
+Tc
+mL
+jv
+jv
+mL
+qb
+"}
+(7,1,1) = {"
+xo
+DO
+Vs
+Cs
+IR
+UP
+mx
+Qn
+Ce
+ew
+Sm
+Tc
+zN
+jF
+mL
+eN
+UI
+"}
+(8,1,1) = {"
+vj
+dT
+EL
+EL
+mL
+fC
+UP
+Tc
+Tc
+Tc
+Tc
+fC
+mL
+QY
+GX
+AE
+AE
+"}
+(9,1,1) = {"
+fR
+Xx
+mL
+mL
+mL
+mL
+ZY
+mL
+zN
+zN
+zN
+QY
+GX
+UI
+Fn
+Fn
+Fn
+"}

--- a/assets/maps/shuttles/cog1/cog1-zenshuttle.dmm
+++ b/assets/maps/shuttles/cog1/cog1-zenshuttle.dmm
@@ -1,0 +1,398 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"b" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 5;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"c" = (
+/turf/simulated/wall/auto/shuttle,
+/area/shuttle/escape/centcom/cogmap)
+"d" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/stool/chair/comfy/green,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"e" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"f" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 10;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"g" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"h" = (
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"j" = (
+/turf/unsimulated/floor/dojo/sand/vertical,
+/area/shuttle/escape/centcom/cogmap)
+"k" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"m" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/cogmap)
+"q" = (
+/obj/lattice{
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"r" = (
+/turf/simulated/shuttle/wall/cockpit{
+	dir = 1
+	},
+/area/shuttle/escape/centcom/cogmap)
+"t" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"u" = (
+/obj/stool/chair/comfy/green{
+	dir = 8
+	},
+/turf/unsimulated/floor/dojo/sand/circle,
+/area/shuttle/escape/centcom/cogmap)
+"w" = (
+/obj/machinery/computer/shuttle/embedded/south,
+/obj/stool/chair/comfy/shuttle/pilot,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"x" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-L"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"y" = (
+/turf/unsimulated/floor/dojo/sand/circle,
+/area/shuttle/escape/centcom/cogmap)
+"z" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"A" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"B" = (
+/obj/stool/chair/comfy/green,
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"C" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-R"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"D" = (
+/obj/stool/chair/comfy/green{
+	dir = 4
+	},
+/turf/unsimulated/floor/dojo/sand/circle,
+/area/shuttle/escape/centcom/cogmap)
+"E" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"F" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-M"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"H" = (
+/turf/unsimulated/floor/dojo/sand/horizontal,
+/area/shuttle/escape/centcom/cogmap)
+"J" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"K" = (
+/obj/table/wood/round/auto,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"M" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"N" = (
+/obj/stool/chair/comfy/green{
+	dir = 4
+	},
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"O" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"P" = (
+/obj/stool/chair/comfy/green{
+	dir = 8
+	},
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"Q" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"R" = (
+/obj/stool/chair/comfy/green{
+	dir = 1
+	},
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"S" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"T" = (
+/obj/tree1,
+/turf/unsimulated/floor/dojo/sand/circle,
+/area/shuttle/escape/centcom/cogmap)
+"V" = (
+/obj/table/wood/round/auto,
+/turf/unsimulated/floor/dojo/sand,
+/area/shuttle/escape/centcom/cogmap)
+"W" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 9;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"X" = (
+/obj/stool/chair/comfy/green{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"Z" = (
+/obj/stool/chair/comfy/green{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+
+(1,1,1) = {"
+Q
+S
+O
+O
+O
+O
+m
+O
+O
+O
+O
+O
+M
+q
+a
+a
+a
+"}
+(2,1,1) = {"
+W
+C
+N
+h
+h
+H
+h
+H
+h
+B
+V
+R
+E
+O
+M
+k
+k
+"}
+(3,1,1) = {"
+f
+F
+V
+R
+y
+j
+j
+j
+y
+h
+P
+h
+d
+K
+A
+M
+q
+"}
+(4,1,1) = {"
+b
+x
+u
+j
+H
+h
+H
+h
+H
+j
+y
+h
+g
+Z
+Q
+z
+t
+"}
+(5,1,1) = {"
+k
+c
+H
+h
+H
+j
+T
+j
+H
+h
+H
+h
+g
+Q
+w
+z
+r
+"}
+(6,1,1) = {"
+W
+C
+D
+j
+H
+h
+H
+h
+H
+j
+y
+h
+g
+X
+Q
+z
+t
+"}
+(7,1,1) = {"
+f
+F
+V
+R
+y
+j
+j
+j
+y
+h
+N
+h
+d
+K
+S
+e
+q
+"}
+(8,1,1) = {"
+b
+x
+P
+h
+h
+H
+h
+H
+h
+B
+V
+R
+J
+O
+e
+k
+k
+"}
+(9,1,1) = {"
+Q
+A
+O
+O
+O
+O
+m
+O
+O
+O
+O
+O
+e
+q
+a
+a
+a
+"}

--- a/assets/maps/shuttles/cog1/cog1_default.dmm
+++ b/assets/maps/shuttles/cog1/cog1_default.dmm
@@ -1,0 +1,489 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"cg" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"ch" = (
+/obj/machinery/computer/shuttle/embedded/south,
+/obj/stool/chair/comfy/shuttle/pilot,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"cx" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"es" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"eB" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/cogmap)
+"fv" = (
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"gq" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"hJ" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"hY" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-M"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"iY" = (
+/obj/machinery/door/airlock/pyro/medical{
+	name = "First-Aid Station"
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"kv" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"kA" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"lc" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"mM" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"nf" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"nz" = (
+/turf/simulated/shuttle/wall/cockpit{
+	dir = 1
+	},
+/area/shuttle/escape/centcom/cogmap)
+"pC" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"qj" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 9;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"ri" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/cogmap)
+"vr" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-R"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"vJ" = (
+/obj/item/storage/wall/emergency{
+	dir = 8
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"vL" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-L"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"wG" = (
+/obj/stool/chair/comfy/shuttle/green,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"xe" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"xs" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"xZ" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/radio,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"zB" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 5;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"zJ" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Er" = (
+/obj/item/storage/wall/emergency,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"EZ" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"FZ" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"IX" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Jd" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "15"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Ke" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"KJ" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/cogmap)
+"KN" = (
+/obj/lattice{
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"LU" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"MN" = (
+/obj/machinery/door/airlock/pyro/command,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"MZ" = (
+/obj/machinery/sleeper/compact,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"OJ" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"QC" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/cogmap)
+"Te" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"VM" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"VO" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"WZ" = (
+/obj/stool/chair/comfy/shuttle,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/cogmap)
+"XV" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Secure Transport"
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Yh" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 10;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"Yp" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Yq" = (
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/cogmap)
+"Yu" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"YO" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/cogmap)
+"Zz" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/cogmap)
+
+(1,1,1) = {"
+gq
+xs
+Ke
+Ke
+Ke
+Jd
+KJ
+IX
+eB
+eB
+eB
+Ke
+pC
+KN
+LU
+LU
+LU
+"}
+(2,1,1) = {"
+qj
+vr
+Zz
+OJ
+OJ
+cx
+Yq
+YO
+WZ
+WZ
+WZ
+YO
+Yp
+VM
+pC
+nf
+nf
+"}
+(3,1,1) = {"
+Yh
+hY
+Zz
+OJ
+FZ
+XV
+Yq
+WZ
+WZ
+WZ
+WZ
+WZ
+VM
+xZ
+VO
+pC
+KN
+"}
+(4,1,1) = {"
+zB
+vL
+Zz
+OJ
+OJ
+cx
+Yq
+WZ
+WZ
+WZ
+WZ
+WZ
+cx
+zJ
+zJ
+cx
+kA
+"}
+(5,1,1) = {"
+nf
+EZ
+Ke
+vJ
+Ke
+Er
+Yq
+Yq
+Yq
+QC
+Yq
+Yq
+MN
+lc
+ch
+cx
+nz
+"}
+(6,1,1) = {"
+qj
+vr
+kv
+mM
+wG
+cx
+Yq
+WZ
+WZ
+WZ
+WZ
+WZ
+cx
+zJ
+zJ
+cx
+kA
+"}
+(7,1,1) = {"
+Yh
+hY
+kv
+fv
+Te
+iY
+Yq
+WZ
+WZ
+WZ
+WZ
+WZ
+VM
+xe
+cg
+es
+KN
+"}
+(8,1,1) = {"
+zB
+vL
+kv
+MZ
+MZ
+cx
+Yq
+ri
+WZ
+WZ
+WZ
+ri
+Yp
+VM
+es
+nf
+nf
+"}
+(9,1,1) = {"
+gq
+Yu
+Ke
+Ke
+Ke
+Jd
+KJ
+hJ
+eB
+eB
+eB
+Ke
+es
+KN
+LU
+LU
+LU
+"}

--- a/assets/maps/shuttles/cog2/cog2_default.dmm
+++ b/assets/maps/shuttles/cog2/cog2_default.dmm
@@ -1,0 +1,660 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ap" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"bl" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"bv" = (
+/obj/item/storage/wall/medical{
+	pixel_z = -1
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"dw" = (
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	opacity = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"eY" = (
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"fa" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"ie" = (
+/turf/unsimulated/floor/stairs{
+	icon_state = "Stairs_wide"
+	},
+/area/centcom)
+"ii" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "4"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"kK" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"kS" = (
+/obj/indestructible/shuttle_corner,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"lu" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"on" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"qz" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"rz" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"sc" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"tw" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"tW" = (
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"wA" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"wS" = (
+/obj/item/storage/wall/emergency{
+	pixel_y = 4;
+	pixel_z = -5
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"xH" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"xJ" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"yj" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"zX" = (
+/turf/unsimulated/floor/stairs{
+	dir = 1;
+	icon_state = "Stairs2_wide"
+	},
+/area/centcom)
+"CG" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Db" = (
+/turf/unsimulated/wall{
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"De" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Dj" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"DG" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"DY" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Ex" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"Fy" = (
+/obj/machinery/door/airlock/pyro/medical{
+	dir = 4;
+	name = "First-Aid Station";
+	opacity = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Gp" = (
+/turf/unsimulated/floor/stairs{
+	dir = 1;
+	icon_state = "Stairs_wide"
+	},
+/area/centcom)
+"He" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Hp" = (
+/turf/unsimulated/floor/stairs{
+	icon_state = "Stairs2_wide"
+	},
+/area/centcom)
+"Hx" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Ii" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Jz" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"KD" = (
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"KG" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Lt" = (
+/turf/simulated/shuttle/wall/cockpit,
+/area/shuttle/escape/centcom/cogmap2)
+"LV" = (
+/turf/unsimulated/wall{
+	dir = 1;
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"Mw" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Om" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"OG" = (
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Secure Transport";
+	opacity = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"OT" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "15"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"RS" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Sh" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"St" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Vt" = (
+/obj/stool/chair/comfy/shuttle/green{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"VN" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"WY" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Xc" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Xr" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"XB" = (
+/obj/machinery/computer/shuttle/embedded/east,
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"XN" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"XZ" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"YS" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"ZJ" = (
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"ZN" = (
+/obj/item/storage/wall/fire{
+	pixel_z = -1
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+
+(1,1,1) = {"
+wA
+yj
+tw
+tw
+tw
+yj
+tw
+tw
+tw
+yj
+wA
+"}
+(2,1,1) = {"
+wA
+kS
+ZJ
+tW
+eY
+ii
+ZJ
+tW
+eY
+kK
+wA
+"}
+(3,1,1) = {"
+tw
+XN
+lu
+He
+lu
+XN
+sc
+sc
+sc
+XN
+tw
+"}
+(4,1,1) = {"
+ii
+bv
+Vt
+fa
+Vt
+XN
+sc
+XZ
+sc
+XN
+ii
+"}
+(5,1,1) = {"
+Ex
+OT
+Xr
+Fy
+Xr
+YS
+Xr
+OG
+Xr
+OT
+on
+"}
+(6,1,1) = {"
+wA
+ZN
+Sh
+KD
+Sh
+Sh
+Sh
+KD
+Sh
+XN
+wA
+"}
+(7,1,1) = {"
+wA
+Jz
+Sh
+KD
+Sh
+Sh
+Sh
+KD
+Sh
+Jz
+wA
+"}
+(8,1,1) = {"
+Db
+wS
+qz
+KD
+St
+Jz
+VN
+KD
+DY
+Mw
+LV
+"}
+(9,1,1) = {"
+ie
+Dj
+KD
+KD
+KD
+KD
+KD
+KD
+KD
+Dj
+zX
+"}
+(10,1,1) = {"
+Hp
+Dj
+KD
+KD
+KD
+xH
+KD
+KD
+KD
+Dj
+Gp
+"}
+(11,1,1) = {"
+Db
+DG
+Sh
+Sh
+KD
+KD
+KD
+Sh
+Sh
+Mw
+LV
+"}
+(12,1,1) = {"
+wA
+Jz
+Sh
+Sh
+Sh
+KD
+Sh
+Sh
+Sh
+Jz
+wA
+"}
+(13,1,1) = {"
+wA
+Jz
+Sh
+Ii
+Sh
+KD
+Sh
+Ii
+Sh
+Jz
+wA
+"}
+(14,1,1) = {"
+wA
+Mw
+De
+Sh
+Sh
+KD
+Sh
+Sh
+ap
+DG
+wA
+"}
+(15,1,1) = {"
+wA
+Ex
+OT
+Hx
+Xr
+dw
+Xr
+Hx
+OT
+on
+wA
+"}
+(16,1,1) = {"
+wA
+rz
+Hx
+KG
+Xc
+CG
+Xc
+bl
+Hx
+rz
+wA
+"}
+(17,1,1) = {"
+wA
+Om
+Ex
+RS
+Xc
+XB
+Xc
+WY
+on
+Om
+wA
+"}
+(18,1,1) = {"
+wA
+Om
+wA
+Ex
+Xr
+Xr
+Xr
+on
+wA
+Om
+wA
+"}
+(19,1,1) = {"
+wA
+Om
+wA
+rz
+xJ
+Lt
+xJ
+rz
+wA
+Om
+wA
+"}

--- a/assets/maps/shuttles/cog2/cog2_martian.dmm
+++ b/assets/maps/shuttles/cog2/cog2_martian.dmm
@@ -1,0 +1,493 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bb" = (
+/turf/simulated/martian/wall{
+	dir = 6;
+	icon_state = "diagonalWall"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"cw" = (
+/obj/table/reinforced/auto,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"dg" = (
+/turf/unsimulated/floor/stairs{
+	icon_state = "Stairs2_wide"
+	},
+/area/centcom)
+"ju" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"nn" = (
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"og" = (
+/obj/machinery/computer/shuttle/embedded/east,
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 4
+	},
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"pm" = (
+/obj/overlay{
+	desc = "The corpse of a long dead space thing.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "marscorpse";
+	name = "dessicated alien"
+	},
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"pZ" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/obj/map/light/dimred,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"qn" = (
+/obj/overlay{
+	desc = "The corpse of a long dead space thing.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "marscorpse";
+	name = "dessicated alien"
+	},
+/obj/map/light/dimred,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"rZ" = (
+/obj/decal/aliencomputer{
+	desc = "This appears to be some sort of martian computer. Or maybe a television.  Or an arcade machine.  Who the hell knows?";
+	icon_state = "display_off";
+	pixel_y = -30
+	},
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"tR" = (
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"uF" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/radio,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"vQ" = (
+/turf/unsimulated/wall{
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"xV" = (
+/turf/unsimulated/floor/stairs{
+	dir = 1;
+	icon_state = "Stairs2_wide"
+	},
+/area/centcom)
+"yn" = (
+/turf/space,
+/area/shuttle/escape/centcom/cogmap2)
+"zl" = (
+/turf/unsimulated/floor/stairs{
+	icon_state = "Stairs_wide"
+	},
+/area/centcom)
+"zq" = (
+/turf/simulated/martian/wall{
+	dir = 4;
+	icon_state = "diagonalWall"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"BE" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"Ed" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"FV" = (
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"GJ" = (
+/turf/unsimulated/floor/stairs{
+	dir = 1;
+	icon_state = "Stairs_wide"
+	},
+/area/centcom)
+"Hm" = (
+/obj/map/light/dimred,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"Jr" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"MN" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"NK" = (
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"NP" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"ON" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"QA" = (
+/turf/simulated/martian/wall{
+	dir = 5;
+	icon_state = "diagonalWall"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Ry" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"SD" = (
+/obj/overlay{
+	desc = "The corpse of a long dead space thing.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "marscorpse";
+	name = "dessicated alien"
+	},
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"SV" = (
+/turf/simulated/martian/wall{
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"SZ" = (
+/turf/simulated/shuttle/wall/cockpit{
+	icon_state = "shuttlecock_busted"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"UG" = (
+/obj/table/reinforced/auto,
+/obj/random_item_spawner/med_kit,
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"Vk" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"VR" = (
+/obj/machinery/door/unpowered/martian{
+	opacity = 0
+	},
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"Xf" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/simulated/martian/floor,
+/area/shuttle/escape/centcom/cogmap2)
+"Yc" = (
+/turf/simulated/martian/wall{
+	dir = 8;
+	icon_state = "diagonalWall"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Yl" = (
+/turf/unsimulated/wall{
+	dir = 1;
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"ZA" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+
+(1,1,1) = {"
+ju
+ZA
+ON
+ON
+ON
+ZA
+ON
+ON
+ON
+ZA
+ju
+"}
+(2,1,1) = {"
+ju
+Yc
+NK
+FV
+nn
+SV
+NK
+FV
+nn
+QA
+ju
+"}
+(3,1,1) = {"
+ON
+SV
+Jr
+cw
+Jr
+SV
+MN
+MN
+MN
+SV
+ON
+"}
+(4,1,1) = {"
+SV
+SV
+Xf
+qn
+rZ
+SV
+MN
+Hm
+MN
+SV
+SV
+"}
+(5,1,1) = {"
+bb
+SV
+SV
+VR
+SV
+SV
+SV
+VR
+SV
+SV
+zq
+"}
+(6,1,1) = {"
+ju
+SV
+MN
+tR
+MN
+MN
+MN
+tR
+MN
+SV
+ju
+"}
+(7,1,1) = {"
+ju
+Ry
+pZ
+tR
+MN
+pZ
+MN
+SD
+pZ
+Ry
+ju
+"}
+(8,1,1) = {"
+vQ
+SV
+MN
+tR
+MN
+MN
+MN
+tR
+MN
+SV
+Yl
+"}
+(9,1,1) = {"
+zl
+Vk
+tR
+tR
+tR
+tR
+tR
+tR
+tR
+Vk
+xV
+"}
+(10,1,1) = {"
+dg
+Vk
+tR
+tR
+tR
+tR
+tR
+tR
+tR
+Vk
+GJ
+"}
+(11,1,1) = {"
+vQ
+SV
+MN
+MN
+pm
+tR
+MN
+MN
+MN
+SV
+Yl
+"}
+(12,1,1) = {"
+ju
+Ry
+MN
+pZ
+MN
+tR
+MN
+pZ
+MN
+Ry
+ju
+"}
+(13,1,1) = {"
+ju
+Ry
+MN
+MN
+MN
+tR
+MN
+MN
+MN
+Ry
+ju
+"}
+(14,1,1) = {"
+ju
+SV
+SV
+Ry
+SV
+VR
+SV
+Ry
+SV
+SV
+ju
+"}
+(15,1,1) = {"
+ju
+bb
+SV
+uF
+tR
+tR
+tR
+UG
+SV
+zq
+ju
+"}
+(16,1,1) = {"
+ju
+Ed
+Ry
+MN
+pZ
+SD
+pZ
+MN
+Ry
+Ed
+ju
+"}
+(17,1,1) = {"
+ju
+NP
+bb
+SV
+MN
+og
+MN
+SV
+zq
+NP
+ju
+"}
+(18,1,1) = {"
+ju
+NP
+ju
+bb
+SV
+yn
+SV
+zq
+ju
+NP
+ju
+"}
+(19,1,1) = {"
+ju
+NP
+ju
+Ed
+BE
+SZ
+BE
+Ed
+ju
+NP
+ju
+"}

--- a/assets/maps/shuttles/destiny/destiny_default.dmm
+++ b/assets/maps/shuttles/destiny/destiny_default.dmm
@@ -1,0 +1,315 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"c" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"d" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/destiny)
+"e" = (
+/turf/simulated/shuttle/wall/cockpit{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/destiny)
+"f" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"g" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/destiny)
+"i" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/destiny)
+"k" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"m" = (
+/obj/machinery/computer/shuttle/embedded/north,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/destiny)
+"o" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/destiny)
+"q" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom/destiny)
+"v" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/destiny)
+"w" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"x" = (
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/destiny)
+"z" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"C" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/destiny)
+"E" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"I" = (
+/obj/machinery/shuttle/engine/propulsion{
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"K" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"L" = (
+/turf/simulated/wall/auto/shuttle,
+/area/shuttle/escape/centcom/destiny)
+"S" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"U" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"V" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
+	},
+/area/shuttle/escape/centcom/destiny)
+"Y" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"Z" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/destiny)
+
+(1,1,1) = {"
+w
+w
+w
+S
+Y
+Z
+d
+C
+C
+C
+d
+Z
+q
+i
+i
+i
+z
+a
+"}
+(2,1,1) = {"
+a
+a
+Y
+C
+g
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+f
+I
+"}
+(3,1,1) = {"
+S
+Y
+v
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+E
+I
+"}
+(4,1,1) = {"
+k
+L
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+U
+I
+"}
+(5,1,1) = {"
+e
+L
+m
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+V
+a
+"}
+(6,1,1) = {"
+k
+L
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+f
+I
+"}
+(7,1,1) = {"
+S
+c
+o
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+E
+I
+"}
+(8,1,1) = {"
+a
+a
+c
+C
+g
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+U
+I
+"}
+(9,1,1) = {"
+w
+w
+w
+S
+c
+q
+d
+C
+C
+C
+d
+q
+Z
+i
+i
+i
+K
+a
+"}

--- a/assets/maps/shuttles/donut2/donut2_default.dmm
+++ b/assets/maps/shuttles/donut2/donut2_default.dmm
@@ -1,0 +1,646 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aI" = (
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Secure Transport";
+	opacity = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"bz" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut2)
+"bW" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"cr" = (
+/obj/item/storage/wall/emergency{
+	pixel_y = 4
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/donut2)
+"dh" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "15"
+	},
+/area/shuttle/escape/centcom/donut2)
+"ed" = (
+/turf/simulated/shuttle/wall/cockpit{
+	dir = 4;
+	layer = 50
+	},
+/area/shuttle/escape/centcom/donut2)
+"fM" = (
+/obj/item/storage/wall/fire,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/donut2)
+"gm" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut2)
+"gI" = (
+/turf/unsimulated/wall{
+	dir = 1;
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"iw" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut2)
+"jA" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"lk" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"ou" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"oL" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"oU" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"ri" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"rU" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"tG" = (
+/obj/machinery/door/airlock/pyro/medical{
+	dir = 4;
+	name = "First-Aid Station";
+	opacity = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"uE" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"vY" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/donut2)
+"xR" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"xS" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"xV" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
+	},
+/area/shuttle/escape/centcom/donut2)
+"yN" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"Ck" = (
+/obj/item/storage/wall/medical{
+	pixel_z = -1
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/donut2)
+"CD" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"DA" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/donut2)
+"DO" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/radio,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Em" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"FS" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Gb" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "8"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Gd" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"HA" = (
+/obj/machinery/sleeper/compact,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"HV" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"HZ" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut2)
+"If" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"Io" = (
+/turf/unsimulated/wall{
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"JS" = (
+/obj/machinery/computer/shuttle/embedded/west,
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut2)
+"La" = (
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	opacity = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut2)
+"LM" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"Ns" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"NM" = (
+/obj/indestructible/shuttle_corner,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"Od" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"OL" = (
+/obj/stool/chair/comfy/shuttle/green{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Pz" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/donut2)
+"PK" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"QK" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
+	},
+/area/shuttle/escape/centcom/donut2)
+"TD" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"Vz" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut2)
+"VV" = (
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"Wb" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Wf" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"WE" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Xk" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/donut2)
+"XU" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"Yz" = (
+/turf/unsimulated/floor/stairs{
+	dir = 1
+	},
+/area/centcom)
+"YA" = (
+/turf/unsimulated/floor/stairs,
+/area/centcom)
+
+(1,1,1) = {"
+Od
+Od
+Od
+Od
+Gd
+ed
+Gd
+Od
+Od
+Od
+Od
+"}
+(2,1,1) = {"
+Od
+Od
+Od
+NM
+Em
+Em
+Em
+LM
+Od
+Od
+Od
+"}
+(3,1,1) = {"
+Od
+Od
+NM
+iw
+WE
+JS
+WE
+HZ
+LM
+Od
+Od
+"}
+(4,1,1) = {"
+Od
+Od
+vY
+DO
+WE
+bz
+WE
+gm
+vY
+Od
+Od
+"}
+(5,1,1) = {"
+Od
+NM
+dh
+Vz
+Em
+La
+Em
+Vz
+dh
+LM
+Od
+"}
+(6,1,1) = {"
+Od
+Pz
+CD
+TD
+TD
+VV
+TD
+TD
+uE
+Xk
+Od
+"}
+(7,1,1) = {"
+Io
+Xk
+TD
+Ns
+TD
+VV
+TD
+Ns
+TD
+Pz
+gI
+"}
+(8,1,1) = {"
+YA
+xS
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+xS
+Yz
+"}
+(9,1,1) = {"
+Io
+cr
+TD
+VV
+TD
+TD
+TD
+VV
+TD
+Pz
+gI
+"}
+(10,1,1) = {"
+Od
+yN
+TD
+VV
+TD
+Ns
+TD
+VV
+TD
+yN
+Od
+"}
+(11,1,1) = {"
+Od
+yN
+TD
+VV
+TD
+TD
+TD
+VV
+TD
+yN
+Od
+"}
+(12,1,1) = {"
+Io
+fM
+ou
+VV
+QK
+yN
+xV
+VV
+rU
+Pz
+gI
+"}
+(13,1,1) = {"
+YA
+xS
+VV
+VV
+TD
+TD
+TD
+VV
+VV
+xS
+Yz
+"}
+(14,1,1) = {"
+Io
+Xk
+TD
+VV
+TD
+TD
+TD
+VV
+TD
+Pz
+gI
+"}
+(15,1,1) = {"
+NM
+dh
+Em
+tG
+Em
+FS
+Em
+aI
+Em
+dh
+LM
+"}
+(16,1,1) = {"
+Gb
+Ck
+OL
+PK
+OL
+vY
+DA
+Wb
+DA
+vY
+Gb
+"}
+(17,1,1) = {"
+HV
+vY
+HA
+lk
+HA
+vY
+DA
+DA
+DA
+vY
+HV
+"}
+(18,1,1) = {"
+Od
+Wf
+xR
+ri
+oU
+Gb
+XU
+jA
+bW
+oL
+Od
+"}
+(19,1,1) = {"
+Od
+If
+HV
+HV
+HV
+If
+HV
+HV
+HV
+If
+Od
+"}

--- a/assets/maps/shuttles/donut2/donut2_syndicate.dmm
+++ b/assets/maps/shuttles/donut2/donut2_syndicate.dmm
@@ -1,0 +1,705 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aI" = (
+/obj/machinery/door/airlock/pyro/syndicate{
+	dir = 4;
+	name = "reinforced internal airlock";
+	opacity = 0;
+	req_access_txt = null
+	},
+/obj/access_spawn/medical,
+/turf/unsimulated/floor/red,
+/area/shuttle/escape/centcom/donut2)
+"bn" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm18"
+	},
+/area/shuttle/escape/centcom/donut2)
+"br" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/red,
+/area/shuttle/escape/centcom/donut2)
+"bW" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"dv" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/redblack/corner{
+	dir = 1
+	},
+/area/shuttle/escape/centcom/donut2)
+"dQ" = (
+/obj/decal/fakeobjects/shuttleweapon{
+	dir = 4
+	},
+/turf/simulated/shuttle/wall{
+	dir = 8;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"ed" = (
+/turf/simulated/shuttle/wall/cockpit{
+	dir = 8;
+	icon_state = "shuttlecock_syndie"
+	},
+/area/shuttle/escape/centcom/donut2)
+"fQ" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm2"
+	},
+/area/shuttle/escape/centcom/donut2)
+"fV" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/donut2)
+"gI" = (
+/turf/unsimulated/wall{
+	dir = 1;
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"gX" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm6"
+	},
+/area/shuttle/escape/centcom/donut2)
+"if" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"jA" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"la" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm19"
+	},
+/area/shuttle/escape/centcom/donut2)
+"ln" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm14"
+	},
+/area/shuttle/escape/centcom/donut2)
+"me" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/red,
+/area/shuttle/escape/centcom/donut2)
+"mt" = (
+/obj/decal/poster/wallsign/stencil/right/a{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/t{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/e{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/donut2)
+"on" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/turf/unsimulated/floor/redblack/corner{
+	dir = 1
+	},
+/area/shuttle/escape/centcom/donut2)
+"oo" = (
+/obj/machinery/sleeper/compact,
+/turf/unsimulated/floor/redblack/corner{
+	dir = 4
+	},
+/area/shuttle/escape/centcom/donut2)
+"oL" = (
+/turf/simulated/shuttle/wall{
+	dir = 6;
+	icon_state = "wall3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"oU" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"pv" = (
+/turf/unsimulated/floor/red,
+/area/shuttle/escape/centcom/donut2)
+"ri" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"rD" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm15"
+	},
+/area/shuttle/escape/centcom/donut2)
+"rZ" = (
+/obj/machinery/sleeper/compact,
+/turf/unsimulated/floor/redblack/corner,
+/area/shuttle/escape/centcom/donut2)
+"tk" = (
+/obj/machinery/door/airlock/pyro/syndicate{
+	dir = 4;
+	name = "reinforced internal airlock";
+	opacity = 0;
+	req_access_txt = null
+	},
+/obj/access_spawn/heads,
+/turf/unsimulated/floor/red,
+/area/shuttle/escape/centcom/donut2)
+"tG" = (
+/obj/machinery/door/airlock/pyro/syndicate{
+	dir = 4;
+	name = "reinforced internal airlock";
+	opacity = 0;
+	req_access_txt = null
+	},
+/obj/access_spawn/security,
+/turf/unsimulated/floor/red,
+/area/shuttle/escape/centcom/donut2)
+"vM" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm16"
+	},
+/area/shuttle/escape/centcom/donut2)
+"wm" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm4"
+	},
+/area/shuttle/escape/centcom/donut2)
+"xA" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/redblack/corner{
+	dir = 1
+	},
+/area/shuttle/escape/centcom/donut2)
+"xQ" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm5"
+	},
+/area/shuttle/escape/centcom/donut2)
+"xR" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"xS" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 1
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/donut2)
+"xV" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm7"
+	},
+/area/shuttle/escape/centcom/donut2)
+"yN" = (
+/obj/wingrille_spawn/auto/crystal,
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/donut2)
+"AN" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm20"
+	},
+/area/shuttle/escape/centcom/donut2)
+"BQ" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/redblack/corner{
+	dir = 4
+	},
+/area/shuttle/escape/centcom/donut2)
+"Cb" = (
+/turf/unsimulated/floor/redblack/corner,
+/area/shuttle/escape/centcom/donut2)
+"DA" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/turf/unsimulated/floor/redblack/corner{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"DO" = (
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/donut2)
+"DP" = (
+/turf/simulated/shuttle/wall{
+	dir = 10;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Ef" = (
+/turf/unsimulated/floor/redblack/corner{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"Gb" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/donut2)
+"Gd" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"Go" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm1"
+	},
+/area/shuttle/escape/centcom/donut2)
+"He" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/donut2)
+"HA" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/redblack/corner{
+	dir = 4
+	},
+/area/shuttle/escape/centcom/donut2)
+"HV" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"If" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"Io" = (
+/turf/unsimulated/wall{
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"JS" = (
+/obj/machinery/computer/shuttle/embedded/west,
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 8
+	},
+/turf/unsimulated/floor/red,
+/area/shuttle/escape/centcom/donut2)
+"LM" = (
+/obj/decal/fakeobjects/shuttleweapon{
+	dir = 4
+	},
+/turf/simulated/shuttle/wall{
+	dir = 10;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Mv" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm8"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Ns" = (
+/obj/decal/poster/wallsign/stencil/right/s{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/y{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/donut2)
+"NM" = (
+/turf/simulated/shuttle/wall{
+	dir = 8;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Od" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"Oi" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/redblack/corner{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/donut2)
+"OL" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/redblack/corner,
+/area/shuttle/escape/centcom/donut2)
+"Pz" = (
+/obj/decal/fakeobjects/shuttleweapon/base{
+	dir = 8
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3";
+	opacity = 0
+	},
+/area/shuttle/escape/centcom/donut2)
+"PK" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/red,
+/area/shuttle/escape/centcom/donut2)
+"QK" = (
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm17"
+	},
+/area/shuttle/escape/centcom/donut2)
+"TD" = (
+/obj/decal/poster/wallsign/stencil/right/i{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/n{
+	pixel_x = -12;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/d{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/decal/poster/wallsign/stencil/right/c{
+	pixel_y = 6
+	},
+/obj/machinery/light/small/floor{
+	pixel_y = 8
+	},
+/turf/unsimulated/floor/black,
+/area/shuttle/escape/centcom/donut2)
+"VV" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/black{
+	icon_state = "cairngorm21"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Wf" = (
+/turf/simulated/shuttle/wall{
+	dir = 6;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"XU" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"Yz" = (
+/turf/unsimulated/floor/stairs{
+	dir = 1
+	},
+/area/centcom)
+"YA" = (
+/turf/unsimulated/floor/stairs,
+/area/centcom)
+
+(1,1,1) = {"
+Od
+Od
+Od
+Od
+Gd
+ed
+Gd
+Od
+Od
+Od
+Od
+"}
+(2,1,1) = {"
+Od
+Od
+Od
+NM
+Gb
+Gb
+Gb
+DP
+Od
+Od
+Od
+"}
+(3,1,1) = {"
+Od
+Od
+dQ
+Gb
+br
+JS
+br
+Gb
+LM
+Od
+Od
+"}
+(4,1,1) = {"
+Od
+Od
+Pz
+DO
+me
+pv
+me
+DO
+Pz
+Od
+Od
+"}
+(5,1,1) = {"
+Od
+dQ
+Gb
+DO
+br
+pv
+br
+DO
+Gb
+LM
+Od
+"}
+(6,1,1) = {"
+Od
+Pz
+Gb
+yN
+Gb
+tk
+Gb
+yN
+Gb
+Pz
+Od
+"}
+(7,1,1) = {"
+Io
+Gb
+He
+fV
+br
+pv
+br
+fV
+He
+Gb
+gI
+"}
+(8,1,1) = {"
+YA
+xS
+Cb
+pv
+pv
+pv
+pv
+pv
+Ef
+xS
+Yz
+"}
+(9,1,1) = {"
+Io
+Gb
+br
+xA
+ln
+DO
+wm
+HA
+br
+Gb
+gI
+"}
+(10,1,1) = {"
+Od
+yN
+br
+la
+rD
+Ns
+xQ
+Go
+br
+yN
+Od
+"}
+(11,1,1) = {"
+Od
+yN
+me
+AN
+vM
+TD
+gX
+fQ
+me
+yN
+Od
+"}
+(12,1,1) = {"
+Io
+Gb
+br
+VV
+QK
+mt
+xV
+if
+br
+Gb
+gI
+"}
+(13,1,1) = {"
+YA
+xS
+pv
+Ef
+bn
+DO
+Mv
+Cb
+pv
+xS
+Yz
+"}
+(14,1,1) = {"
+Io
+Gb
+BQ
+pv
+br
+me
+br
+pv
+dv
+Gb
+gI
+"}
+(15,1,1) = {"
+NM
+Gb
+Gb
+tG
+Gb
+Gb
+Gb
+aI
+Gb
+Gb
+DP
+"}
+(16,1,1) = {"
+Gb
+Gb
+OL
+PK
+Oi
+Gb
+rZ
+PK
+DA
+Gb
+Gb
+"}
+(17,1,1) = {"
+HV
+Gb
+HA
+br
+xA
+Gb
+oo
+pv
+on
+Gb
+HV
+"}
+(18,1,1) = {"
+Od
+Wf
+xR
+ri
+oU
+Gb
+XU
+jA
+bW
+oL
+Od
+"}
+(19,1,1) = {"
+Od
+If
+HV
+HV
+HV
+If
+HV
+HV
+HV
+If
+Od
+"}

--- a/assets/maps/shuttles/donut3/donut3-cave.dmm
+++ b/assets/maps/shuttles/donut3/donut3-cave.dmm
@@ -1,0 +1,572 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"au" = (
+/obj/decal/cleanable/dirt,
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"bb" = (
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"bx" = (
+/obj/decal/mushrooms/type6,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"eV" = (
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"gS" = (
+/obj/decal/cleanable/dirt,
+/obj/map/light/graveyard,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"is" = (
+/obj/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"iy" = (
+/obj/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"jt" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"jP" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"kb" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"lw" = (
+/obj/decal/cleanable/dirt,
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"mm" = (
+/obj/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"my" = (
+/obj/structure/woodwall,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"pz" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"pJ" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"qy" = (
+/obj/decal/mushrooms/type3,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"re" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"ro" = (
+/obj/item/reagent_containers/food/snacks/donut/custom/frosted{
+	desc = "IT HIM, IT REALLY HIM";
+	name = "smol donut"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"rJ" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"rQ" = (
+/obj/decal/cleanable/dirt,
+/obj/structure/woodwall,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"sG" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/map/light/graveyard,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"tq" = (
+/obj/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"tZ" = (
+/obj/decal/cleanable/dirt,
+/obj/item/raw_material/rock,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"uH" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"vJ" = (
+/obj/item/raw_material/rock,
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/obj/map/light/graveyard,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"Ax" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"AM" = (
+/obj/item/raw_material/rock,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"Bz" = (
+/obj/decal/cleanable/dirt,
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"BR" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"DQ" = (
+/obj/decal/cleanable/dirt,
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/map/light/graveyard,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"GN" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/obj/map/light/graveyard,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"HT" = (
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"Io" = (
+/obj/machinery/computer/shuttle,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"Kz" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"Op" = (
+/obj/decal/mushrooms/type1,
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"OQ" = (
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater"
+	},
+/turf/unsimulated/wall/cave,
+/area/shuttle/escape/centcom/donut3)
+"PI" = (
+/obj/decal/cleanable/cobweb,
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"PY" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/obj/map/light/graveyard,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"Qc" = (
+/obj/decal/mushrooms/type2,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"Sm" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"SI" = (
+/obj/machinery/shuttle/engine/propulsion{
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut3)
+"Tb" = (
+/obj/decal/mushrooms/type4,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"TO" = (
+/obj/map/light/graveyard,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"Uj" = (
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 1
+	},
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"Xr" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/obj/map/light/graveyard,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"Yg" = (
+/obj/decal/cleanable/cobweb,
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/map/light/graveyard,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"Yl" = (
+/obj/machinery/computer/announcement,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"YO" = (
+/obj/item/raw_material/rock,
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/cave,
+/area/shuttle/escape/centcom/donut3)
+"YT" = (
+/turf/unsimulated/wall/cave,
+/area/shuttle/escape/centcom/donut3)
+
+(1,1,1) = {"
+kb
+kb
+kb
+kb
+YT
+pJ
+pJ
+my
+my
+pJ
+pJ
+YT
+YT
+YT
+YT
+YT
+OQ
+SI
+kb
+"}
+(2,1,1) = {"
+Kz
+Kz
+jt
+YT
+YT
+rJ
+rJ
+bb
+bb
+bb
+bb
+eV
+rQ
+eV
+bb
+YT
+YT
+YT
+kb
+"}
+(3,1,1) = {"
+kb
+kb
+kb
+YT
+YO
+tZ
+Op
+bb
+jP
+Xr
+bb
+bb
+YT
+YT
+bb
+rJ
+YT
+BR
+SI
+"}
+(4,1,1) = {"
+jt
+YT
+pJ
+YT
+DQ
+eV
+AM
+bb
+YT
+YT
+uH
+bb
+YT
+Yg
+bb
+bb
+PY
+pz
+SI
+"}
+(5,1,1) = {"
+YT
+YT
+Ax
+YT
+mm
+eV
+lw
+bb
+PY
+YT
+YT
+bb
+YT
+bx
+jP
+bb
+re
+Sm
+SI
+"}
+(6,1,1) = {"
+pJ
+re
+PY
+YT
+YT
+bb
+YT
+YT
+YT
+YT
+Yg
+AM
+YT
+YT
+YT
+eV
+YT
+YT
+kb
+"}
+(7,1,1) = {"
+pJ
+Yl
+Uj
+my
+Qc
+TO
+YT
+ro
+kb
+YT
+YT
+YT
+YT
+bb
+my
+bb
+YT
+kb
+kb
+"}
+(8,1,1) = {"
+pJ
+Io
+Uj
+YT
+YT
+YT
+YT
+kb
+kb
+YT
+Bz
+bb
+qy
+TO
+YT
+YT
+YT
+kb
+kb
+"}
+(9,1,1) = {"
+pJ
+iy
+vJ
+YT
+au
+rJ
+YT
+YT
+YT
+YT
+sG
+eV
+YT
+YT
+YT
+PI
+YT
+YT
+kb
+"}
+(10,1,1) = {"
+YT
+YT
+Tb
+my
+gS
+eV
+bb
+TO
+bb
+YT
+uH
+eV
+eV
+eV
+bb
+bb
+re
+BR
+SI
+"}
+(11,1,1) = {"
+jt
+YT
+pJ
+YT
+tq
+jP
+YT
+uH
+eV
+bb
+bb
+YT
+YT
+YT
+GN
+bb
+re
+pz
+SI
+"}
+(12,1,1) = {"
+kb
+kb
+kb
+YT
+YT
+YT
+YT
+YO
+eV
+eV
+re
+YT
+sG
+eV
+bb
+bb
+YT
+Sm
+SI
+"}
+(13,1,1) = {"
+Kz
+Kz
+jt
+YT
+YT
+sG
+bb
+bb
+eV
+bb
+PY
+YT
+is
+HT
+jP
+YT
+YT
+YT
+kb
+"}
+(14,1,1) = {"
+kb
+kb
+kb
+kb
+YT
+pJ
+pJ
+my
+my
+pJ
+pJ
+YT
+YT
+YT
+YT
+YT
+OQ
+SI
+kb
+"}

--- a/assets/maps/shuttles/donut3/donut3_default.dmm
+++ b/assets/maps/shuttles/donut3/donut3_default.dmm
@@ -1,0 +1,800 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom/donut3)
+"ak" = (
+/obj/machinery/door/airlock/pyro/glass/command,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut3)
+"ar" = (
+/obj/item/storage/wall/medical{
+	dir = 4;
+	pixel_x = -32;
+	pixel_z = -1
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"dc" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut3)
+"eO" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/donut3)
+"fK" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
+/turf/space,
+/area/shuttle/escape/centcom/donut3)
+"gp" = (
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut3)
+"he" = (
+/obj/machinery/shuttle/engine/propulsion{
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut3)
+"iz" = (
+/obj/machinery/door/airlock/pyro/medical/alt,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"iJ" = (
+/obj/machinery/door/airlock/pyro/security,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"iU" = (
+/obj/item/storage/wall/emergency{
+	pixel_y = 32
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"jm" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"lX" = (
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut3)
+"mG" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/donut3)
+"nf" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"nJ" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut3)
+"pE" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"pP" = (
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/donut3)
+"pV" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut3)
+"ql" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"qS" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"ra" = (
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor6"
+	},
+/area/shuttle/escape/centcom/donut3)
+"ri" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut3)
+"sm" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0;
+	icon_state = "7"
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"tJ" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-L"
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/escape/centcom/donut3)
+"uD" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"vs" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/donut3)
+"wQ" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"yh" = (
+/obj/machinery/door/airlock/pyro/glass,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor6"
+	},
+/area/shuttle/escape/centcom/donut3)
+"yL" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"yW" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "8"
+	},
+/area/shuttle/escape/centcom/donut3)
+"zi" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut3)
+"zx" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/escape/centcom/donut3)
+"Be" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"Cb" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"Cg" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Cj" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"Cu" = (
+/obj/table/auto,
+/obj/mug_rack{
+	pixel_x = -26;
+	pixel_y = 4
+	},
+/obj/machinery/coffeemaker{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/machinery/light,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor6"
+	},
+/area/shuttle/escape/centcom/donut3)
+"DH" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"DS" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"Ez" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"Fh" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "4"
+	},
+/area/shuttle/escape/centcom/donut3)
+"FA" = (
+/obj/stool/chair/comfy/shuttle/green{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor6"
+	},
+/area/shuttle/escape/centcom/donut3)
+"FS" = (
+/obj/machinery/light,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"HB" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/obj/indestructible/shuttle_corner{
+	dir = 0;
+	icon_state = "7"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"HR" = (
+/obj/machinery/computer/announcement,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut3)
+"IW" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Jq" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"JW" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Kc" = (
+/obj/machinery/computer/shuttle,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Lb" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"Nh" = (
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater"
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Nl" = (
+/obj/table/auto,
+/obj/table/auto,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -6
+	},
+/obj/item/storage/firstaid/brute{
+	pixel_x = 7
+	},
+/obj/item/storage/firstaid/oxygen{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"NW" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Og" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/donut3)
+"OZ" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 7
+	},
+/obj/item/device/radio{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Qy" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/escape/centcom/donut3)
+"QN" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"QT" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut3)
+"Rg" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/donut3)
+"RB" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut3)
+"Sk" = (
+/obj/item/storage/wall/fire{
+	pixel_y = 32
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"SS" = (
+/obj/table/auto,
+/obj/item/kitchen/food_box/donut_box,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor6"
+	},
+/area/shuttle/escape/centcom/donut3)
+"TP" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut3)
+"VW" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"Wb" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"Xb" = (
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Xf" = (
+/obj/item/reagent_containers/food/snacks/donut/custom/frosted{
+	desc = "IT HIM, IT REALLY HIM";
+	name = "smol donut"
+	},
+/obj/reagent_dispensers/cleanable/ants,
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"XE" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/donut3)
+"YN" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"YQ" = (
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"Zi" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/donut3)
+
+(1,1,1) = {"
+Wb
+Wb
+Wb
+Wb
+RB
+DS
+DS
+Ez
+Ez
+DS
+DS
+ql
+aa
+ql
+ql
+sm
+Nh
+he
+Wb
+"}
+(2,1,1) = {"
+Cb
+Cb
+qS
+RB
+VW
+wQ
+jm
+YQ
+YQ
+jm
+wQ
+jm
+vs
+mG
+Og
+JW
+aa
+QT
+Wb
+"}
+(3,1,1) = {"
+Wb
+Wb
+Wb
+vs
+Be
+YQ
+YQ
+YQ
+YQ
+YQ
+jm
+jm
+yW
+pP
+pP
+Og
+JW
+tJ
+he
+"}
+(4,1,1) = {"
+qS
+RB
+nJ
+Rg
+Be
+YQ
+DH
+YQ
+YQ
+DH
+YQ
+YQ
+iJ
+pP
+pP
+pP
+IW
+Qy
+he
+"}
+(5,1,1) = {"
+RB
+pV
+zi
+yW
+Be
+YQ
+Cj
+Cj
+Cj
+Cj
+YQ
+Lb
+Fh
+pP
+pP
+pP
+eO
+zx
+he
+"}
+(6,1,1) = {"
+nJ
+XE
+lX
+ak
+YQ
+FS
+DS
+DS
+DS
+DS
+QN
+Lb
+Cg
+ql
+ql
+ql
+HB
+ri
+Wb
+"}
+(7,1,1) = {"
+nJ
+HR
+gp
+Fh
+Sk
+Lb
+DS
+Xf
+Wb
+DS
+YQ
+YQ
+yh
+ra
+ra
+Cu
+vs
+Wb
+Wb
+"}
+(8,1,1) = {"
+nJ
+Kc
+gp
+yW
+iU
+Lb
+DS
+Wb
+Wb
+DS
+YQ
+YQ
+yh
+FA
+FA
+SS
+vs
+Wb
+Wb
+"}
+(9,1,1) = {"
+nJ
+XE
+lX
+ak
+YQ
+FS
+DS
+DS
+DS
+DS
+QN
+Lb
+Cg
+ql
+ql
+ql
+NW
+QT
+Wb
+"}
+(10,1,1) = {"
+dc
+TP
+OZ
+Fh
+Be
+YQ
+jm
+jm
+jm
+jm
+YQ
+Lb
+yW
+Nl
+ar
+Xb
+Zi
+tJ
+he
+"}
+(11,1,1) = {"
+qS
+dc
+nJ
+Rg
+Be
+YQ
+DH
+YQ
+YQ
+DH
+YQ
+YQ
+iz
+Xb
+Xb
+Xb
+pE
+Qy
+he
+"}
+(12,1,1) = {"
+Wb
+Wb
+Wb
+vs
+Be
+YQ
+YQ
+YQ
+YQ
+YQ
+Cj
+Cj
+Fh
+Xb
+Xb
+nf
+uD
+fK
+he
+"}
+(13,1,1) = {"
+Cb
+Cb
+qS
+dc
+yL
+Jq
+Cj
+YQ
+YQ
+Cj
+Jq
+Cj
+vs
+YN
+nf
+uD
+NW
+ri
+Wb
+"}
+(14,1,1) = {"
+Wb
+Wb
+Wb
+Wb
+dc
+DS
+DS
+Ez
+Ez
+DS
+DS
+ql
+NW
+ql
+ql
+NW
+Nh
+he
+Wb
+"}

--- a/assets/maps/shuttles/manta/manta_default.dmm
+++ b/assets/maps/shuttles/manta/manta_default.dmm
@@ -1,0 +1,499 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"df" = (
+/obj/machinery/shuttle/engine/heater/seaheater_middle,
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"et" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/manta)
+"fu" = (
+/turf/unsimulated/wall{
+	dir = 4;
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadwindow_1";
+	name = "window";
+	opacity = 0
+	},
+/area/centcom)
+"gx" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+"hE" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/radio,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+"jj" = (
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-L"
+	},
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"jq" = (
+/obj/machinery/door/airlock/pyro/medical,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/manta)
+"jz" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"jM" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"lg" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/manta)
+"lK" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/manta)
+"oY" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/manta)
+"qC" = (
+/obj/machinery/door/airlock/pyro/security,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/manta)
+"sb" = (
+/turf/unsimulated/wall/setpieces/leadwall{
+	dir = 5
+	},
+/area/centcom)
+"sL" = (
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"tH" = (
+/obj/item/storage/wall/emergency,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/manta)
+"tO" = (
+/obj/table/auto,
+/obj/item/storage/firstaid/oxygen{
+	pixel_x = -6
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = 2
+	},
+/obj/item/storage/firstaid/brute{
+	pixel_x = 9
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/manta)
+"uE" = (
+/turf/space/fluid,
+/area/centcom)
+"wC" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+"yl" = (
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+"AF" = (
+/obj/item/storage/wall/medical{
+	pixel_y = 32
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/manta)
+"AL" = (
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"Bn" = (
+/obj/indestructible/shuttle_corner,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/manta)
+"Cd" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+"CC" = (
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/manta)
+"Dt" = (
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/manta)
+"Dx" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"Dy" = (
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/manta)
+"DW" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/manta)
+"Il" = (
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
+	},
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"IJ" = (
+/obj/machinery/computer/shuttle,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+"IR" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/manta)
+"Jj" = (
+/obj/machinery/shuttle/engine/propulsion/sea_propulsion,
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"JA" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/manta)
+"KM" = (
+/turf/unsimulated/wall/setpieces/leadwall{
+	dir = 6
+	},
+/area/centcom)
+"LV" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+"MK" = (
+/obj/machinery/shuttle/engine/propulsion{
+	icon_state = "alt_propulsion"
+	},
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"Nu" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+"Pb" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+"Pd" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"PZ" = (
+/turf/unsimulated/wall/setpieces/leadwall{
+	dir = 9
+	},
+/area/centcom)
+"QE" = (
+/obj/indestructible/shuttle_corner,
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"RD" = (
+/turf/unsimulated/wall{
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadwall"
+	},
+/area/centcom)
+"RQ" = (
+/obj/machinery/door/airlock/pyro/command,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+"VK" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/manta)
+"Ww" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom/manta)
+"XK" = (
+/obj/stool/chair/comfy/shuttle/green,
+/turf/unsimulated/floor/shuttle{
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/manta)
+"XR" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+"XY" = (
+/turf/unsimulated/wall/setpieces/leadwall{
+	dir = 10
+	},
+/area/centcom)
+"Zh" = (
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/manta)
+
+(1,1,1) = {"
+uE
+uE
+uE
+uE
+uE
+QE
+Pd
+Pd
+et
+Cd
+Ww
+et
+Dx
+sb
+RD
+RD
+XY
+"}
+(2,1,1) = {"
+AL
+QE
+Ww
+et
+et
+oY
+Nu
+Pb
+Zh
+XR
+IR
+tO
+JA
+Dx
+uE
+uE
+fu
+"}
+(3,1,1) = {"
+AL
+Pd
+Nu
+gx
+Pd
+Pb
+Zh
+Pb
+Zh
+Pb
+IR
+AF
+XK
+JA
+df
+Jj
+sb
+"}
+(4,1,1) = {"
+AL
+Pd
+Zh
+LV
+Pd
+Pb
+XR
+Pb
+Zh
+Zh
+jq
+CC
+VK
+XK
+JA
+Dx
+AL
+"}
+(5,1,1) = {"
+Pd
+Pd
+XR
+LV
+IR
+Pb
+Zh
+Pb
+Zh
+Pb
+IR
+Dt
+Dt
+CC
+XK
+jj
+MK
+"}
+(6,1,1) = {"
+Pd
+IJ
+yl
+Zh
+RQ
+Zh
+Zh
+Zh
+Zh
+Pb
+lg
+et
+et
+et
+et
+Il
+MK
+"}
+(7,1,1) = {"
+Pd
+Pd
+XR
+LV
+IR
+Pb
+Zh
+Pb
+Zh
+Pb
+IR
+Dy
+Dy
+Dy
+lK
+sL
+MK
+"}
+(8,1,1) = {"
+AL
+Pd
+Zh
+LV
+Pd
+Pb
+XR
+Pb
+Zh
+Zh
+qC
+Dy
+DW
+lK
+Bn
+jz
+AL
+"}
+(9,1,1) = {"
+AL
+Pd
+wC
+hE
+Pd
+Pb
+Zh
+Pb
+Zh
+Pb
+tH
+Dy
+lK
+Bn
+df
+Jj
+PZ
+"}
+(10,1,1) = {"
+AL
+jM
+oY
+et
+et
+Ww
+wC
+Pb
+Zh
+XR
+IR
+lK
+Bn
+jz
+uE
+uE
+fu
+"}
+(11,1,1) = {"
+uE
+uE
+uE
+uE
+uE
+jM
+Pd
+Pd
+et
+Cd
+oY
+et
+jz
+PZ
+RD
+RD
+KM
+"}

--- a/assets/maps/shuttles/sealab/oshan-meat.dmm
+++ b/assets/maps/shuttles/sealab/oshan-meat.dmm
@@ -1,0 +1,675 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"gM" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"iz" = (
+/obj/grassplug{
+	desc = "Gross";
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/grassplug{
+	desc = "Gross";
+	dir = 8;
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/railing{
+	dir = 8;
+	layer = 3.3;
+	name = "bone railing"
+	},
+/obj/railing{
+	layer = 3.2;
+	name = "bone railing"
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"iN" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"iS" = (
+/obj/grassplug{
+	desc = "Gross";
+	dir = 8;
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/railing{
+	dir = 8;
+	layer = 3.3;
+	name = "bone railing"
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"jh" = (
+/obj/grassplug{
+	desc = "Gross";
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/grassplug{
+	desc = "Gross";
+	dir = 8;
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/railing{
+	layer = 3.2;
+	name = "bone railing"
+	},
+/obj/railing{
+	dir = 8;
+	layer = 3.3;
+	name = "bone railing"
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"lO" = (
+/obj/machinery/light/small/floor/harsh,
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"nJ" = (
+/obj/grassplug{
+	desc = "Gross";
+	dir = 1;
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/grassplug{
+	desc = "Gross";
+	dir = 8;
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/railing{
+	dir = 1;
+	layer = 3.2;
+	name = "bone railing"
+	},
+/obj/railing{
+	dir = 8;
+	layer = 3.3;
+	name = "bone railing"
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"qJ" = (
+/obj/machinery/door/unpowered/martian/meat,
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"ru" = (
+/obj/stomachacid,
+/obj/map/light/meatland,
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"sI" = (
+/obj/grassplug{
+	desc = "Gross";
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/grassplug{
+	desc = "Gross";
+	dir = 1;
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/grassplug{
+	desc = "Gross";
+	dir = 8;
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/pool_springboard{
+	dir = 4;
+	pixel_x = 16
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"tv" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"tK" = (
+/obj/machinery/light/small/floor/harsh,
+/obj/railing{
+	dir = 8;
+	layer = 3.3;
+	name = "bone railing"
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"vZ" = (
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 4
+	},
+/obj/machinery/light/small/floor/harsh,
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"ww" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"xb" = (
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"xA" = (
+/obj/machinery/door/unpowered/martian/meat,
+/turf/unsimulated/floor/setpieces/bloodfloor,
+/area/shuttle/escape/centcom/sealab)
+"xL" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"yB" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/obj/machinery/light/small/floor/harsh,
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"zq" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/obj/machinery/light/small/floor/harsh,
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"zU" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor,
+/area/shuttle/escape/centcom/sealab)
+"Ao" = (
+/obj/pool_springboard,
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"CM" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"DY" = (
+/obj/machinery/computer/shuttle{
+	dir = 8
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor,
+/area/shuttle/escape/centcom/sealab)
+"Fs" = (
+/obj/grassplug{
+	desc = "Gross";
+	dir = 8;
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"Hj" = (
+/obj/stomachacid,
+/obj/grassplug{
+	desc = "Gross";
+	dir = 1;
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"HZ" = (
+/obj/stomachacid,
+/obj/grassplug{
+	desc = "Gross";
+	dir = 1;
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/railing{
+	dir = 1;
+	layer = 3.2;
+	name = "bone railing"
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"Ip" = (
+/obj/railing{
+	dir = 8;
+	layer = 3.3;
+	name = "bone railing"
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Mk" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Nq" = (
+/obj/grassplug{
+	desc = "Gross";
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"OR" = (
+/obj/grassplug{
+	desc = "Gross";
+	icon = 'icons/misc/meatland.dmi';
+	icon_state = "acid_corners";
+	name = "Fleshy Floor"
+	},
+/obj/railing{
+	layer = 3.2;
+	name = "bone railing"
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"PX" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"QK" = (
+/turf/unsimulated/floor/setpieces/bloodfloor,
+/area/shuttle/escape/centcom/sealab)
+"Ul" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"We" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"Wp" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"WT" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"Xb" = (
+/turf/unsimulated/wall/setpieces/bloodwall{
+	icon_state = "bloodwall_2";
+	name = "Meaty Wall"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Yv" = (
+/obj/stomachacid,
+/turf/unsimulated/floor/setpieces/bloodfloor/stomach,
+/area/shuttle/escape/centcom/sealab)
+"Yw" = (
+/obj/meatlight,
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Yx" = (
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+"YK" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/setpieces/bloodfloor{
+	icon_state = "bloodfloor_2";
+	name = "Fleshy Floor"
+	},
+/area/shuttle/escape/centcom/sealab)
+
+(1,1,1) = {"
+We
+We
+We
+WT
+WT
+WT
+We
+We
+We
+WT
+WT
+WT
+We
+We
+We
+"}
+(2,1,1) = {"
+WT
+Xb
+Xb
+tv
+xL
+iN
+Xb
+Xb
+Xb
+tv
+xL
+iN
+Xb
+Xb
+WT
+"}
+(3,1,1) = {"
+Xb
+Xb
+gM
+Ul
+Ul
+Ul
+YK
+PX
+PX
+YK
+yB
+PX
+PX
+Xb
+Xb
+"}
+(4,1,1) = {"
+Xb
+Yw
+Yx
+Yx
+lO
+Yx
+Xb
+PX
+zq
+Xb
+Xb
+CM
+Yx
+Yw
+Xb
+"}
+(5,1,1) = {"
+Xb
+CM
+Yx
+Xb
+YK
+Xb
+Xb
+PX
+PX
+PX
+Xb
+Xb
+Yx
+Wp
+Xb
+"}
+(6,1,1) = {"
+Xb
+Xb
+qJ
+Xb
+lO
+Yx
+Yx
+Yx
+sI
+Yx
+lO
+Xb
+qJ
+YK
+Xb
+"}
+(7,1,1) = {"
+YK
+Yw
+Yx
+Yx
+Yx
+nJ
+iS
+iS
+Yv
+iz
+Yx
+Yx
+Yx
+Yw
+YK
+"}
+(8,1,1) = {"
+YK
+PX
+Yx
+Yx
+Yw
+Hj
+ru
+Yv
+ru
+Nq
+Yw
+Yx
+Yx
+PX
+YK
+"}
+(9,1,1) = {"
+Xb
+PX
+Yx
+Yx
+HZ
+Yv
+Yv
+Yv
+Yv
+Yv
+Fs
+jh
+Yx
+PX
+Xb
+"}
+(10,1,1) = {"
+Mk
+Yx
+lO
+Yx
+HZ
+ru
+Yv
+Yv
+Yv
+Yv
+ru
+OR
+lO
+Yx
+Mk
+"}
+(11,1,1) = {"
+Xb
+PX
+Yx
+Yx
+Yw
+Hj
+OR
+tK
+Ao
+HZ
+Yv
+OR
+Yx
+PX
+Xb
+"}
+(12,1,1) = {"
+YK
+PX
+Yx
+Yx
+Yx
+Ip
+Ip
+Yx
+Yx
+Ip
+Ip
+Ip
+Yx
+PX
+YK
+"}
+(13,1,1) = {"
+YK
+PX
+Yx
+Xb
+Xb
+YK
+Xb
+xA
+Xb
+YK
+Xb
+Xb
+Yx
+Yx
+YK
+"}
+(14,1,1) = {"
+Xb
+Yw
+Yx
+Xb
+zU
+xb
+QK
+QK
+QK
+xb
+ww
+Xb
+Yx
+Yw
+Xb
+"}
+(15,1,1) = {"
+Xb
+Xb
+Yx
+Xb
+ww
+vZ
+zU
+DY
+ww
+vZ
+ww
+Xb
+Yx
+Xb
+Xb
+"}
+(16,1,1) = {"
+We
+Xb
+Xb
+Xb
+YK
+YK
+YK
+Xb
+YK
+YK
+YK
+Xb
+Xb
+Xb
+We
+"}

--- a/assets/maps/shuttles/sealab/oshan-minisubs.dmm
+++ b/assets/maps/shuttles/sealab/oshan-minisubs.dmm
@@ -1,0 +1,441 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"gf" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"iN" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/drainage,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"kz" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"kA" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"sx" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"tv" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"ur" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Secure Transport";
+	opacity = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"xl" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/obj/machinery/drainage,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"xL" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"xY" = (
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"zK" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/space/fluid,
+/area/shuttle/escape/centcom/sealab)
+"Aa" = (
+/obj/machinery/door/airlock/pyro/command{
+	opacity = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"Jz" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
+	},
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"LM" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"Mk" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/machinery/drainage,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"RJ" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"SP" = (
+/obj/machinery/door/airlock/pyro/medical{
+	name = "First-Aid Station";
+	opacity = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"Ug" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/sealab)
+"We" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"WT" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"Xb" = (
+/obj/machinery/computer/shuttle/embedded/east,
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 4
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"YK" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+
+(1,1,1) = {"
+We
+We
+We
+We
+We
+We
+We
+We
+We
+WT
+We
+We
+We
+We
+We
+"}
+(2,1,1) = {"
+We
+We
+WT
+We
+We
+We
+We
+We
+LM
+tv
+xL
+We
+We
+WT
+We
+"}
+(3,1,1) = {"
+We
+LM
+Jz
+xL
+We
+We
+We
+We
+gf
+iN
+gf
+We
+LM
+Jz
+xL
+"}
+(4,1,1) = {"
+We
+SP
+iN
+SP
+We
+We
+We
+We
+Ug
+sx
+Ug
+We
+ur
+xl
+ur
+"}
+(5,1,1) = {"
+We
+Ug
+xY
+Ug
+We
+We
+We
+We
+kA
+YK
+kz
+We
+Ug
+RJ
+Ug
+"}
+(6,1,1) = {"
+We
+kA
+YK
+kz
+We
+We
+WT
+We
+We
+We
+We
+We
+kA
+YK
+kz
+"}
+(7,1,1) = {"
+We
+We
+We
+We
+We
+LM
+Jz
+xL
+We
+We
+We
+We
+We
+We
+We
+"}
+(8,1,1) = {"
+We
+We
+We
+We
+We
+Aa
+Mk
+Aa
+We
+We
+We
+We
+We
+We
+We
+"}
+(9,1,1) = {"
+We
+We
+We
+We
+We
+Ug
+Xb
+Ug
+We
+We
+We
+We
+We
+We
+We
+"}
+(10,1,1) = {"
+We
+We
+We
+We
+We
+kA
+YK
+kz
+We
+We
+We
+We
+We
+We
+We
+"}
+(11,1,1) = {"
+We
+WT
+We
+We
+We
+We
+We
+We
+We
+We
+We
+We
+We
+WT
+We
+"}
+(12,1,1) = {"
+LM
+Jz
+xL
+We
+We
+WT
+We
+We
+We
+WT
+We
+We
+LM
+Jz
+xL
+"}
+(13,1,1) = {"
+gf
+iN
+gf
+We
+zK
+Jz
+xL
+We
+LM
+tv
+xL
+We
+ur
+xl
+ur
+"}
+(14,1,1) = {"
+Ug
+sx
+Ug
+We
+gf
+iN
+gf
+We
+gf
+iN
+gf
+We
+Ug
+RJ
+Ug
+"}
+(15,1,1) = {"
+kA
+YK
+kz
+We
+Ug
+sx
+Ug
+We
+Ug
+sx
+Ug
+We
+kA
+YK
+kz
+"}
+(16,1,1) = {"
+We
+We
+We
+We
+kA
+YK
+kz
+We
+kA
+YK
+kz
+We
+We
+We
+We
+"}

--- a/assets/maps/shuttles/sealab/oshan_default.dmm
+++ b/assets/maps/shuttles/sealab/oshan_default.dmm
@@ -1,0 +1,705 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/item/storage/wall/medical{
+	dir = 4
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"cs" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/sealab)
+"dy" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"el" = (
+/obj/item/storage/wall/fire{
+	dir = 4;
+	pixel_z = -4
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"ez" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"eD" = (
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"eX" = (
+/obj/landmark/load_prefab_shuttledmm/sealab,
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"ig" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"ih" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/sealab)
+"js" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"jN" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"lc" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "10"
+	},
+/area/shuttle/escape/centcom/sealab)
+"li" = (
+/obj/table/reinforced/auto,
+/obj/item/device/radio,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"mu" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"mR" = (
+/obj/stool/chair/comfy/shuttle/green,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"nT" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"ou" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"tn" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"un" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom/sealab)
+"va" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/sealab)
+"wQ" = (
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/sealab)
+"yC" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"yP" = (
+/obj/stool/chair/comfy/shuttle/green{
+	dir = 1
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"zv" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Cv" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Da" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"Fw" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"Gg" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"IN" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"Jg" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "5"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Ji" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Jj" = (
+/obj/machinery/light/small/floor,
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"Kp" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"KB" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"LP" = (
+/obj/machinery/door/airlock/pyro/command,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Mu" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/sealab)
+"MB" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "4"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Ok" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"OM" = (
+/obj/machinery/computer/shuttle{
+	dir = 4;
+	icon_state = "turret1"
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Pe" = (
+/obj/item/storage/wall/emergency{
+	dir = 8
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"PF" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "9"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Rw" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Rx" = (
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Secure Transport";
+	opacity = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"RD" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"RX" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"Sm" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/sealab)
+"SN" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor4"
+	},
+/area/shuttle/escape/centcom/sealab)
+"ST" = (
+/obj/item/storage/wall/fire{
+	dir = 4;
+	pixel_z = -4
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/sealab)
+"TC" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"TS" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Uh" = (
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"UI" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "6"
+	},
+/area/shuttle/escape/centcom/sealab)
+"UJ" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"Vg" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"Wh" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Wj" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"WR" = (
+/obj/machinery/door/airlock/pyro/medical{
+	dir = 4;
+	name = "First-Aid Station";
+	opacity = 0
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"WY" = (
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Xf" = (
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 8
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"XO" = (
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"Yl" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/turf/unsimulated/floor/shuttle{
+	dir = 8;
+	icon_state = "floor2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"YU" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "15"
+	},
+/area/shuttle/escape/centcom/sealab)
+
+(1,1,1) = {"
+tn
+tn
+tn
+IN
+IN
+IN
+tn
+tn
+tn
+IN
+IN
+IN
+tn
+tn
+eX
+"}
+(2,1,1) = {"
+IN
+Kp
+Wh
+jN
+Ji
+zv
+aa
+un
+aa
+jN
+Ji
+zv
+ou
+nT
+IN
+"}
+(3,1,1) = {"
+MB
+Sm
+mR
+eD
+eD
+eD
+yP
+Sm
+Mu
+Mu
+wQ
+Mu
+Mu
+Sm
+Sm
+"}
+(4,1,1) = {"
+RX
+va
+ez
+WY
+Rw
+WY
+ez
+Sm
+Cv
+wQ
+SN
+wQ
+Cv
+cs
+UJ
+"}
+(5,1,1) = {"
+Kp
+YU
+Gg
+Gg
+WR
+Gg
+Gg
+ST
+Gg
+Gg
+Rx
+Gg
+Gg
+YU
+nT
+"}
+(6,1,1) = {"
+cs
+Vg
+TC
+TC
+XO
+TC
+TC
+TC
+TC
+TC
+XO
+TC
+TC
+mu
+va
+"}
+(7,1,1) = {"
+RD
+TC
+TC
+XO
+Wj
+XO
+XO
+XO
+XO
+XO
+Wj
+XO
+TC
+TC
+RD
+"}
+(8,1,1) = {"
+Sm
+TC
+TC
+XO
+UI
+js
+Gg
+Pe
+Gg
+js
+Jg
+XO
+TC
+TC
+Sm
+"}
+(9,1,1) = {"
+ig
+XO
+XO
+XO
+Sm
+yC
+Yl
+OM
+Yl
+li
+Sm
+XO
+XO
+XO
+ig
+"}
+(10,1,1) = {"
+RD
+XO
+XO
+XO
+LP
+Ok
+Uh
+Uh
+Uh
+Ok
+LP
+XO
+XO
+XO
+RD
+"}
+(11,1,1) = {"
+ig
+XO
+XO
+XO
+Sm
+TS
+dy
+Xf
+dy
+yC
+Sm
+XO
+XO
+XO
+ig
+"}
+(12,1,1) = {"
+Sm
+KB
+KB
+XO
+lc
+js
+Gg
+el
+Gg
+js
+PF
+XO
+KB
+KB
+Sm
+"}
+(13,1,1) = {"
+RD
+KB
+KB
+XO
+XO
+TC
+TC
+TC
+TC
+TC
+XO
+XO
+KB
+KB
+RD
+"}
+(14,1,1) = {"
+cs
+Fw
+KB
+Wj
+XO
+XO
+XO
+XO
+XO
+XO
+XO
+Wj
+KB
+Da
+va
+"}
+(15,1,1) = {"
+RX
+YU
+Fw
+KB
+KB
+KB
+Jj
+KB
+Jj
+KB
+KB
+KB
+Da
+YU
+UJ
+"}
+(16,1,1) = {"
+tn
+RX
+ih
+Gg
+RD
+RD
+RD
+Pe
+RD
+RD
+RD
+Gg
+ih
+UJ
+tn
+"}

--- a/code/datums/prefab_shuttles.dm
+++ b/code/datums/prefab_shuttles.dm
@@ -1,0 +1,87 @@
+var/list/prefab_shuttles = list()
+
+ABSTRACT_TYPE(/datum/prefab_shuttle)
+/datum/prefab_shuttle
+	var/prefab_path = null
+	var/landmark = null
+
+	proc/inialize_prefabs()
+		switch(map_settings.escape_centcom)
+			if(/area/shuttle/escape/centcom/cogmap)
+				for(var/prefab_type in concrete_typesof(/datum/prefab_shuttle/cog1))
+					var/datum/prefab_shuttle/D = new prefab_type()
+					prefab_shuttles.Add(D)
+			if(/area/shuttle/escape/centcom/cogmap2)
+				for(var/prefab_type in concrete_typesof(/datum/prefab_shuttle/cog2))
+					var/datum/prefab_shuttle/D = new prefab_type()
+					prefab_shuttles.Add(D)
+			if(/area/shuttle/escape/centcom/manta)
+				for(var/prefab_type in concrete_typesof(/datum/prefab_shuttle/manta))
+					var/datum/prefab_shuttle/D = new prefab_type()
+					prefab_shuttles.Add(D)
+			if(/area/shuttle/escape/centcom/sealab)
+				for(var/prefab_type in concrete_typesof(/datum/prefab_shuttle/sealab))
+					var/datum/prefab_shuttle/D = new prefab_type()
+					prefab_shuttles.Add(D)
+			if(/area/shuttle/escape/centcom/donut2)
+				for(var/prefab_type in concrete_typesof(/datum/prefab_shuttle/donut2))
+					var/datum/prefab_shuttle/D = new prefab_type()
+					prefab_shuttles.Add(D)
+			if(/area/shuttle/escape/centcom/donut3)
+				for(var/prefab_type in concrete_typesof(/datum/prefab_shuttle/donut3))
+					var/datum/prefab_shuttle/D = new prefab_type()
+					prefab_shuttles.Add(D)
+			else
+				return
+
+/datum/prefab_shuttle/cog1
+	prefab_path = "assets/maps/shuttles/cog1/cog1_default.dmm"
+	landmark = LANDMARK_SHUTTLE_COG1
+
+	dojo
+		prefab_path = "assets/maps/shuttles/cog1/cog1-dojo.dmm"
+	dream
+		prefab_path = "assets/maps/shuttles/cog1/cog1-dream.dmm"
+	iomoon
+		prefab_path = "assets/maps/shuttles/cog1/cog1-iomoon.dmm"
+	martian
+		prefab_path = "assets/maps/shuttles/cog1/cog1-martian.dmm"
+	syndicate
+		prefab_path = "assets/maps/shuttles/cog1/cog1-syndicate.dmm"
+	zen
+		prefab_path = "assets/maps/shuttles/cog1/cog1-zenshuttle.dmm"
+
+/datum/prefab_shuttle/cog2
+	prefab_path = "assets/maps/shuttles/cog2/cog2_default.dmm"
+	landmark = LANDMARK_SHUTTLE_COG2
+
+	martian
+		prefab_path = "assets/maps/shuttles/cog2/cog2_martian.dmm"
+
+/datum/prefab_shuttle/manta
+	prefab_path = "assets/maps/shuttles/manta/manta_default.dmm"
+	landmark = LANDMARK_SHUTTLE_MANTA
+
+/datum/prefab_shuttle/sealab
+	prefab_path = "assets/maps/shuttles/sealab/oshan_default.dmm"
+	landmark = LANDMARK_SHUTTLE_SEALAB
+
+	meat
+		prefab_path = "assets/maps/shuttles/sealab/oshan-meat.dmm"
+	minisubs
+		prefab_path = "assets/maps/shuttles/sealab/oshan-minisubs.dmm"
+
+/datum/prefab_shuttle/donut2
+	prefab_path = "assets/maps/shuttles/donut2/donut2_default.dmm"
+	landmark = LANDMARK_SHUTTLE_DONUT2
+
+/datum/prefab_shuttle/donut3
+	prefab_path = "assets/maps/shuttles/donut3/donut3_default.dmm"
+	landmark = LANDMARK_SHUTTLE_DONUT3
+
+	cave
+		prefab_path = "assets/maps/shuttles/donut3/donut3-cave.dmm"
+
+/datum/prefab_shuttle/destiny
+	prefab_path = "assets/maps/shuttles/destiny/destiny_default.dmm"
+	landmark = LANDMARK_SHUTTLE_DESTINY

--- a/code/datums/prefab_shuttles.dm
+++ b/code/datums/prefab_shuttles.dm
@@ -1,6 +1,4 @@
 var/list/prefab_shuttles = list()
-
-ABSTRACT_TYPE(/datum/prefab_shuttle)
 /datum/prefab_shuttle
 	var/prefab_path = null
 	var/landmark = null

--- a/code/datums/prefab_shuttles.dm
+++ b/code/datums/prefab_shuttles.dm
@@ -31,6 +31,10 @@ ABSTRACT_TYPE(/datum/prefab_shuttle)
 				for(var/prefab_type in concrete_typesof(/datum/prefab_shuttle/donut3))
 					var/datum/prefab_shuttle/D = new prefab_type()
 					prefab_shuttles.Add(D)
+			if(/area/shuttle/escape/centcom/destiny)
+				for(var/prefab_type in concrete_typesof(/datum/prefab_shuttle/destiny))
+					var/datum/prefab_shuttle/D = new prefab_type()
+					prefab_shuttles.Add(D)
 			else
 				return
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -336,6 +336,7 @@ var/list/admin_verbs = list(
 		/client/proc/cmd_blindfold_monkeys,
 		/client/proc/cmd_swampify_station,
 		/client/proc/cmd_trenchify_station,
+		/client/proc/cmd_special_shuttle,
 
 		/datum/admins/proc/toggleaprilfools,
 		/client/proc/cmd_admin_pop_off_all_the_limbs_oh_god,

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2826,3 +2826,19 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 				message_admins("[key_name(src)] generated a trench on station Z[hostile_mob_toggle ? " with hostile mobs" : ""].")
 	else
 		boutput(src, "You must be at least an Administrator to use this command.")
+
+/client/proc/cmd_special_shuttle()
+	SET_ADMIN_CAT(ADMIN_CAT_FUN)
+	set name = "Special Shuttle"
+	set desc = "Spawn in a special escape shuttle"
+	admin_only
+	if(src.holder.level >= LEVEL_ADMIN)
+		var/datum/prefab_shuttle/shuttle = tgui_input_list(src, "Select a shuttle", "Special Shuttle", prefab_shuttles)
+		if (!shuttle) return
+		var/loaded = file2text(shuttle.prefab_path)
+		var/turf/T = landmarks[shuttle.landmark][1]
+		if(T && loaded)
+			var/dmm_suite/D = new/dmm_suite()
+			D.read_map(loaded,T.x,T.y,T.z,shuttle.prefab_path, DMM_OVERWRITE_OBJS)
+	else
+		boutput(src, "You must be at least an Administrator to use this command.")

--- a/code/obj/landmark.dm
+++ b/code/obj/landmark.dm
@@ -291,3 +291,25 @@ var/global/list/job_start_locations = list()
 		var/obj/overlay/tile_effect/lighting/L = locate() in vistarget.vis_contents
 		if(L)
 			vistarget.vis_contents -= L
+
+/obj/landmark/load_prefab_shuttledmm
+	name = "custom shuttle dmm loading location"
+	desc = "Tells the dmm loader where to put the bottom left corner of the shuttle prefab."
+	icon = 'icons/effects/mapeditor.dmi'
+	icon_state = "landmark"
+	color = "#ff0000"
+
+	cog1
+		name = LANDMARK_SHUTTLE_COG1
+	cog2
+		name = LANDMARK_SHUTTLE_COG2
+	sealab
+		name = LANDMARK_SHUTTLE_SEALAB
+	manta
+		name = LANDMARK_SHUTTLE_MANTA
+	donut2
+		name = LANDMARK_SHUTTLE_DONUT2
+	donut3
+		name = LANDMARK_SHUTTLE_DONUT3
+	destiny
+		name = LANDMARK_SHUTTLE_DESTINY

--- a/code/world.dm
+++ b/code/world.dm
@@ -618,6 +618,10 @@ var/f_color_selector_handler/F_Color_Selector
 	Z_LOG_DEBUG("World/Init", "Running map-specific initialization...")
 	map_settings.init()
 
+	Z_LOG_DEBUG("World/Init", "Initialize prefab shuttle datums...")
+	var/datum/prefab_shuttle/D = new
+	D.inialize_prefabs()
+
 	UPDATE_TITLE_STATUS("Ready")
 	current_state = GAME_STATE_PREGAME
 	Z_LOG_DEBUG("World/Init", "Now in pre-game state.")

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -106,6 +106,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\pipe_network.dm"
 #include "code\datums\pipeline.dm"
 #include "code\datums\powernet_data.dm"
+#include "code\datums\prefab_shuttles.dm"
 #include "code\datums\preferences.dm"
 #include "code\datums\recipes.dm"
 #include "code\datums\research.dm"

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -78652,6 +78652,10 @@
 /turf/space,
 /turf/cordon,
 /area/cordon)
+"jhW" = (
+/obj/landmark/load_prefab_shuttledmm/destiny,
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
 "jiO" = (
 /obj/decal/fakeobjects/core{
 	desc = "It looks inactive.  Hope there isn't any fuel left in there...";
@@ -80275,6 +80279,12 @@
 	dir = 1
 	},
 /area/crypt/graveyard)
+"oag" = (
+/obj/landmark/load_prefab_shuttledmm/manta,
+/turf/unsimulated/wall/setpieces/leadwall{
+	dir = 10
+	},
+/area/centcom)
 "oaM" = (
 /obj/decal/fakeobjects{
 	anchored = 1;
@@ -80602,6 +80612,10 @@
 /obj/machinery/light/small/floor,
 /turf/unsimulated/floor/darkblue,
 /area/syndicate_station/battlecruiser)
+"pdC" = (
+/obj/landmark/load_prefab_shuttledmm/donut2,
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
 "peF" = (
 /obj/stool/chair{
 	dir = 1
@@ -81546,6 +81560,10 @@
 	},
 /turf/unsimulated/outdoors/snow,
 /area/centcom/offices/virvatuli)
+"rRm" = (
+/obj/landmark/load_prefab_shuttledmm/sealab,
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
 "rTJ" = (
 /obj/fitness/stacklifter,
 /turf/unsimulated/floor/wood/two,
@@ -81942,6 +81960,10 @@
 	icon_state = "Stairs_wide"
 	},
 /area/centcom)
+"trU" = (
+/obj/landmark/load_prefab_shuttledmm/donut3,
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
 "ttO" = (
 /obj/critter/zombie/meatmonaut{
 	desc = "That suit is decidedly not Juicer, but then again who knows what you can salvage in the fleshier parts of the frontier.";
@@ -82721,6 +82743,10 @@
 	opacity = 0
 	},
 /area/titlescreen)
+"wDy" = (
+/obj/landmark/load_prefab_shuttledmm/cog2,
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
 "wEA" = (
 /obj/indestructible/shuttle_corner{
 	dir = 4;
@@ -83079,6 +83105,13 @@
 	icon_state = "shore-7"
 	},
 /area/titlescreen)
+"xNT" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/landmark/load_prefab_shuttledmm/cog1,
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
 "xOg" = (
 /obj/stool/chair{
 	dir = 1
@@ -122903,7 +122936,7 @@ dpM
 dpM
 dpM
 dpT
-aES
+wDy
 aES
 dsh
 dsl
@@ -129850,7 +129883,7 @@ dqZ
 aES
 aES
 aES
-aES
+pdC
 djp
 dkX
 dny
@@ -131385,7 +131418,7 @@ duN
 aCn
 duT
 duK
-aES
+trU
 aES
 aES
 aES
@@ -137404,7 +137437,7 @@ dte
 dte
 dte
 dtl
-aES
+jhW
 aES
 aES
 aES
@@ -138636,7 +138669,7 @@ dob
 dob
 aES
 aES
-aES
+rRm
 aES
 djp
 dRF
@@ -141934,7 +141967,7 @@ dnA
 dkJ
 dkK
 dkK
-dnt
+oag
 dmq
 dny
 dny
@@ -145584,7 +145617,7 @@ dRf
 dRk
 dqA
 dqA
-dqA
+xNT
 dqg
 dse
 dFl

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)mon apr 19 21
+(u)Sovexe
+(*)Added a new verb, Special-Shuttle. Allows you to replace the escape shuttle with one of the available prefabs.
 (t)sun apr 11 21
 (u)Sovexe
 (*)Added a new verb, trenchify. Turns the station Z level into a trench. Hostile mobs are optional.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds in a new admin command to make it easy to load in a selection of prefab shuttles
* maps can be either public or secret
* the selection of maps in this PR are some of Sord's. I will be adding more to secret after.

Early example: https://streamable.com/vhgbr6

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* fun
* easier for non-coder/mapper admins