### PR TITLE
Adds items to hacked gaming vendors 

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2084,8 +2084,8 @@
 		product_list += new/datum/data/vending_product(/obj/item/gobowl/w, 1, cost=PAY_TRADESMAN/4)
 		product_list += new/datum/data/vending_product(/obj/item/card_box/clow, 5, cost=PAY_TRADESMAN/2) // (this is an anime joke)
 		product_list += new/datum/data/vending_product(/obj/item/clow_key, 5, cost=PAY_TRADESMAN/2)      //      (please laugh)
-		product_list += new/datum/data/vending_product(/obj/item/dice/weighted, rand(1,3), cost=PAY_TRADESMAN/3, hidden=1)
-		product_list += new/datum/data/vending_product(/obj/item/dice/d1, rand(0,1), cost=PAY_TRADESMAN/2, hidden=1)
+		product_list += new/datum/data/vending_product(/obj/item/dice/weighted, rand(1,3), cost=PAY_TRADESMAN/2, hidden=1)
+		product_list += new/datum/data/vending_product(/obj/item/dice/d1, rand(0,1), cost=PAY_TRADESMAN/3, hidden=1)
 
 /obj/machinery/vending/clothing
 	name = "FancyPantsCo Sew-O-Matic"

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2084,6 +2084,8 @@
 		product_list += new/datum/data/vending_product(/obj/item/gobowl/w, 1, cost=PAY_TRADESMAN/4)
 		product_list += new/datum/data/vending_product(/obj/item/card_box/clow, 5, cost=PAY_TRADESMAN/2) // (this is an anime joke)
 		product_list += new/datum/data/vending_product(/obj/item/clow_key, 5, cost=PAY_TRADESMAN/2)      //      (please laugh)
+		product_list += new/datum/data/vending_product(/obj/item/dice/weighted, rand(1,3), cost=PAY_TRADESMAN/3, hidden=1)
+		product_list += new/datum/data/vending_product(/obj/item/dice/d1, rand(0,1), cost=PAY_TRADESMAN/2, hidden=1)
 
 /obj/machinery/vending/clothing
 	name = "FancyPantsCo Sew-O-Matic"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Hacked gaming vendors now offer between 1-3 weighted dice, and 0-1 D1's in the hidden listings

![image](https://user-images.githubusercontent.com/13049028/115309088-9eca1000-a120-11eb-96cf-e9357ceaf33a.png)

Zoldorf always has 8 of these but dice fit in with the gaming machine as well, and it's fun to find hidden items anyway.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

More making vending machines consistent with hidden items in as many station level vending machines as possible.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

None for me thanks
