### PR TITLE
Fixes roller beds unbuckling the patients on their own

### DIFF
--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -283,16 +283,13 @@
 		parts_type = /obj/item/furniture_parts/bed/roller
 		scoot_sounds = list( 'sound/misc/chair/office/scoot1.ogg', 'sound/misc/chair/office/scoot2.ogg', 'sound/misc/chair/office/scoot3.ogg', 'sound/misc/chair/office/scoot4.ogg', 'sound/misc/chair/office/scoot5.ogg' )
 
-	Move()
-		. = ..()
-		if (. && src.buckled_guy)
-			var/mob/living/carbon/C = src.buckled_guy
-			if(src.buckled_guy.loc == src.loc)
+		Move()
+			. = ..()
+			if (. && src.buckled_guy)
+				var/mob/living/carbon/C = src.buckled_guy
 				C.buckled = null
 				C.Move(src.loc)
 				C.buckled = src
-			else
-				src.unbuckle()
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/clothing/suit/bedsheet))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title. Apparently fcfe8e4425e442c29a8956d63cfc4af3829de28a broke the roller beds but I'm pretty sure we can get away with just moving the Move() proc to the roller beds only, so it doesn't affect all the beds, and thus, prevent them from teleporting people.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #4373

