### PR TITLE
Removes orphaned WIres & Disposal Pipes from Manta

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -26267,9 +26267,6 @@
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
 "btu" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -26431,12 +26428,14 @@
 /turf/simulated/floor/bot,
 /area/station/quartermaster/cargobay)
 "btR" = (
-/obj/wingrille_spawn/auto,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/crewquarters/garbagegarbs)
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/ai_monitored/armory)
 "btS" = (
 /obj/table/glass/auto,
 /turf/simulated/floor,
@@ -31732,7 +31731,6 @@
 /turf/simulated/floor/carpet,
 /area/station/science/restroom)
 "bJN" = (
-/obj/disposalpipe/segment,
 /obj/table/reinforced/auto,
 /obj/machinery/computer/security/wooden_tv/small{
 	pixel_y = 8
@@ -35857,15 +35855,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
-"czS" = (
-/obj/disposalpipe/switch_junction/left/south{
-	mail_tag = "Mining"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
 "cAp" = (
 /obj/machinery/light/incandescent/blueish{
 	dir = 4;
@@ -36957,6 +36946,9 @@
 	},
 /obj/landmark/start{
 	name = "Captain"
+	},
+/obj/disposalpipe/segment{
+	dir = 8
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -40485,15 +40477,6 @@
 	},
 /turf/simulated/floor,
 /area/station/crewquarters/garbagegarbs)
-"mQB" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/black,
-/area/station/ai_monitored/armory)
 "mSY" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -42312,9 +42295,6 @@
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "qSq" = (
-/obj/disposalpipe/junction{
-	dir = 4
-	},
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
 	pixel_y = 20
@@ -42324,6 +42304,10 @@
 	},
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/special/submarinesdown,
 /area/station/hallway/portlowerhallway)
@@ -78706,7 +78690,7 @@ acV
 ghs
 acT
 arU
-btR
+mnz
 mnz
 btU
 btW
@@ -79008,7 +78992,7 @@ bcj
 jnH
 byk
 bcj
-bjW
+bcj
 bcj
 mFN
 bcj
@@ -79310,7 +79294,7 @@ bta
 bta
 bym
 bta
-czS
+bta
 bta
 hlB
 bta
@@ -87121,7 +87105,7 @@ aFB
 aFB
 aqO
 dOI
-mQB
+btR
 azk
 atV
 sUk

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -39402,15 +39402,6 @@
 /area/station/hangar/engine{
 	name = "Submarine Bay (Engineering)"
 	})
-"knL" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/engine/elect)
 "kpZ" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
@@ -77762,7 +77753,7 @@ bmG
 bnN
 aJJ
 bgr
-knL
+box
 acV
 aHa
 aHj

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -13030,7 +13030,6 @@
 	pixel_y = 26;
 	text = "NF"
 	},
-/obj/machinery/disposal/mail/small/autoname/research/telescience/north,
 /turf/simulated/floor/caution/south,
 /area/station/engine/elect)
 "aKD" = (
@@ -15253,9 +15252,6 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
-	},
-/obj/disposalpipe/segment/ejection{
-	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
@@ -25250,16 +25246,10 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/lobby)
 "bqG" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "bqH" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
 	icon_state = "1-2"
@@ -34760,6 +34750,9 @@
 	dir = 8;
 	layer = -1
 	},
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/construction)
 "bSj" = (
@@ -37989,9 +37982,6 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen/therustykrab)
 "hco" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/wingrille_spawn/auto,
 /obj/cable{
 	icon_state = "0-4"
@@ -44092,9 +44082,6 @@
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
 "vzA" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
 /obj/wingrille_spawn/auto,
 /obj/cable{
 	icon_state = "0-2"

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -531,9 +531,6 @@
 	message = "1";
 	name = "mail chute-'Head of Security'"
 	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
@@ -5140,9 +5137,6 @@
 /obj/access_spawn/security,
 /obj/machinery/door/airlock/pyro/glass/security{
 	name = "Visitation"
-	},
-/obj/cable{
-	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/ejection,
 /turf/simulated/floor,
@@ -15276,6 +15270,9 @@
 /obj/disposalpipe/trunk/ejection{
 	dir = 1
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
 "aRy" = (
@@ -16447,9 +16444,6 @@
 "aUL" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Interrogation"
-	},
-/obj/cable{
-	icon_state = "2-8"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -18206,9 +18200,6 @@
 /area/station/security/secwing)
 "aZl" = (
 /obj/stool/chair/wooden,
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/cable,
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/wood,
@@ -23781,7 +23772,7 @@
 /obj/machinery/power/apc/autoname_west,
 /obj/cable,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/red/checker,
 /area/station/medical/medbay/treatment2)
@@ -30826,9 +30817,6 @@
 /obj/machinery/computer/card/console_lower{
 	dir = 8
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor,
 /area/station/seaturtlebridge)
 "bGC" = (
@@ -35988,9 +35976,6 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/obj/cable{
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/red/checker,
 /area/station/medical/medbay/treatment1)
 "cOx" = (
@@ -36438,10 +36423,11 @@
 /area/abandonedship)
 "dOI" = (
 /obj/machinery/computer3/generic/communications,
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/weapon_stand/rifle_rack/recharger,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "dPl" = (
@@ -38136,9 +38122,6 @@
 	anchored = 0;
 	dir = 1
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/light/incandescent/cool{
 	nostick = 1
 	},
@@ -38775,9 +38758,6 @@
 /area/station/engine/engineering/ce)
 "iIQ" = (
 /obj/submachine/slot_machine,
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/flasher/genpop/new_walls/west{
 	pixel_x = 24
 	},
@@ -40505,6 +40485,15 @@
 	},
 /turf/simulated/floor,
 /area/station/crewquarters/garbagegarbs)
+"mQB" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/ai_monitored/armory)
 "mSY" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -42371,9 +42360,6 @@
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/listeningpost/syndicateassaultvessel)
 "raw" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/table/reinforced/auto,
 /obj/machinery/cell_charger,
 /obj/item/cell/supercell/charged,
@@ -43968,6 +43954,9 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
 	pixel_y = 20
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/station/hangar/starboard)
@@ -87132,7 +87121,7 @@ aFB
 aFB
 aqO
 dOI
-xVU
+mQB
 azk
 atV
 sUk
@@ -89558,7 +89547,7 @@ aWz
 abR
 mrf
 aWn
-kIf
+qZI
 ono
 kIf
 wdi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removed orphaned cables, reconnected small orphaned sections of cabling
Also removed orphaned disposals pipes

also removed a single tile of the mechanics area because that was in a hallway somehow?????

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

bugs bad
functional stuff good.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

*N/A; No player-visible changes.*