### PR TITLE
Removes ass tearing message on Rathens Secret

### DIFF
--- a/code/modules/events/gimmick/bigfart.dm
+++ b/code/modules/events/gimmick/bigfart.dm
@@ -89,6 +89,8 @@
 			B = new /obj/item/clothing/head/butt/cyberbutt(T)
 			B.donor = H
 			ThrowRandom(B, dist = 6, speed = 1)
+		H.show_text("<span class='alert'><b>[H]</b>'s [magical ? "arse" : "ass"] tears itself away from \his body[magical ? " in a magical explosion" : null]!</span>",\
+		"<span class='alert'>[changer ? "Our" : "Your"] [magical ? "arse" : "ass"] tears itself away from [changer ? "our" : "your"] body[magical ? " in a magical explosion" : null]!</span>")
 		H.changeStatus("weakened", 2 SECONDS)
 		severed_something = TRUE
 		H.force_laydown_standup()
@@ -153,7 +155,7 @@
 	H.TakeDamage("chest", 10, 0, 0, DAMAGE_STAB)
 	if(magical && prob(10))
 		boutput(H, "<span class='notification'>[changer ? "We" : "You"] hear an otherworldly force let out a short, disappointed cluck at [changer ? "our" : "your"] lack of an arse.</span>")
-	H.visible_message("<span class='alert'>[is_bot ? "Oily chunks of twisted shrapnel" : "Wadded hunks of blood and gore"] burst out of where <b>[H]</b>'s [magical ? "arse" : "ass"] used to be!</span>",\
+	H.show_text("<span class='alert'>[is_bot ? "Oily chunks of twisted shrapnel" : "Wadded hunks of blood and gore"] burst out of where <b>[H]</b>'s [magical ? "arse" : "ass"] used to be!</span>",\
 	"<span class='alert'>[nobutt_phrase[assmagic]]</span>")
 	H.changeStatus("weakened", 3 SECONDS)
 	H.force_laydown_standup()

--- a/code/modules/events/gimmick/bigfart.dm
+++ b/code/modules/events/gimmick/bigfart.dm
@@ -89,8 +89,6 @@
 			B = new /obj/item/clothing/head/butt/cyberbutt(T)
 			B.donor = H
 			ThrowRandom(B, dist = 6, speed = 1)
-		H.visible_message("<span class='alert'><b>[H]</b>'s [magical ? "arse" : "ass"] tears itself away from \his body[magical ? " in a magical explosion" : null]!</span>",\
-		"<span class='alert'>[changer ? "Our" : "Your"] [magical ? "arse" : "ass"] tears itself away from [changer ? "our" : "your"] body[magical ? " in a magical explosion" : null]!</span>")
 		H.changeStatus("weakened", 2 SECONDS)
 		severed_something = TRUE
 		H.force_laydown_standup()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes ass tearing message on Rathens Secret


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previous iterations of Rathen Secret included smoke. Now that the smoke is removed, the chat is prone to heavy spam from wizards. It's better to remove the message entirely because it's not neccesaray to provide a description for something that is plainly visible and understandable to the player.


