### PR TITLE
Kondaru supply delivery point fix

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -60978,7 +60978,7 @@
 /area/station/medical/robotics)
 "xHo" = (
 /turf/space,
-/area/station/quartermaster/cargobay)
+/area/supply/delivery_point)
 "xHp" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reintroduces the supply delivery point accidentally removed during APC coverage fixes in prior fix batch.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #2079
