### PR TITLE
fixes there only being one token for nukie murder box vr

### DIFF
--- a/code/modules/admin/antagifiers.dm
+++ b/code/modules/admin/antagifiers.dm
@@ -185,7 +185,7 @@
 	makeAntag(mob/living/carbon/human/M as mob)
 		var/uplink = new /obj/item/uplink/syndicate/virtual(get_turf(M))
 		M.put_in_hand_or_eject(uplink) // try to eject it into the users hand, if we can
-		boutput(M, "<span class='combat'>You can spawn fancy Syndicate gear with the virual uplink! Go hog wild.</span>")
+		boutput(M, "<span class='combat'>You can spawn fancy Syndicate gear with the virtual uplink! Go hog wild.</span>")
 
 	werewolf
 		name = "WEREWOLF.EXE"
@@ -217,3 +217,14 @@
 		makeAntag(mob/living/carbon/human/M as mob)
 			boutput(M, "<span class='combat'>You're a wizard, <s>Harry</s> [M]! Don't forget to pick your spells.</span>")
 			equip_wizard(M, 1, 1)
+
+	nuclear
+		name = "NUKE_TKN.EXE"
+		desc = "A syndicoin mining rig. Get some sweet syndicate requistion tokens"
+		icon = 'icons/obj/items/items.dmi'
+		icon_state = "req-token"
+
+		makeAntag(mob/living/carbon/human/M as mob)
+			var/token = new /obj/item/requisition_token/syndicate/vr(get_turf(M))
+			M.put_in_hand_or_eject(token) // try to eject it into the users hand, if we can
+			boutput(M, "<span class='combat'>Redeem your freshly mined syndicoin in the nearby weapon vendor.</span>")

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -432,7 +432,7 @@
 		icon_state = "req-token"
 
 		vr
-			name = "NUKE_TKN.EXE"
+			name = "syndicoin requisition token"
 
 	security
 		desc = "An NT-provided token compatible with the Security Weapons Vendor."

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -42100,7 +42100,7 @@
 /area/sim/gunsim)
 "clQ" = (
 /obj/table/reinforced/auto,
-/obj/item/requisition_token/syndicate/vr,
+/obj/traitorifier/virtual/nuclear,
 /turf/unsimulated/floor/setpieces/gauntlet{
 	desc = "This place is going to be a fucking mess.";
 	name = "\proper the murderbox"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [FEATURE] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Implements a token dispenser instead of a single solitary token for the syndicate weapons vendor in the vr murderbox

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

one token wasn't really enough to fight your friends
