### PR TITLE
Makes CE start with aurora belt, removes it from locker

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -323,14 +323,15 @@ ABSTRACT_TYPE(/datum/job/command)
 	allow_spy_theft = 0
 
 	slot_back = /obj/item/storage/backpack/withO2
-	slot_belt = /obj/item/device/pda2/chiefengineer
+	slot_belt = /obj/item/storage/belt/utility/prepared/ceshielded
 	slot_glov = /obj/item/clothing/gloves/yellow
 	slot_foot = /obj/item/clothing/shoes/brown
 	slot_head = /obj/item/clothing/head/helmet/hardhat
 	slot_eyes = /obj/item/clothing/glasses/meson
 	slot_jump = /obj/item/clothing/under/rank/chief_engineer
 	slot_ears = /obj/item/device/radio/headset/command/ce
-	slot_poc1 = /obj/item/paper/book/pocketguide/engineering
+	slot_poc1 = /obj/item/device/pda2/chiefengineer
+	slot_poc2 = /obj/item/paper/book/pocketguide/engineering
 	items_in_backpack = list(/obj/item/device/flash, /obj/item/rcd_ammo/medium)
 
 	special_setup(var/mob/living/carbon/human/M)

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -146,7 +146,6 @@
 	/obj/item/clothing/glasses/meson,
 	/obj/item/clothing/suit/fire,
 	/obj/item/clothing/mask/gas,
-	/obj/item/storage/belt/utility/prepared/ceshielded,
 	/obj/item/clothing/head/helmet/welding,
 	/obj/item/clothing/head/helmet/hardhat,
 	/obj/item/device/multitool,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes CE start with aurora belt, removes it from locker


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it'd be good to start moving jobs with unique gear to being tied to their station presence rather than their lockers, EG Janitor galoshes. 

