### PR TITLE
Don & Doff Actionbars

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -587,6 +587,7 @@ var/datum/action_controller/actions
 	var/slot						    //The slot number
 	var/turf/start
 	var/hidden
+	var/clumsy = FALSE
 
 	New(var/Source, var/Item, var/Slot, var/ExtraDuration = 0, var/Hidden = 0)
 		source = Source
@@ -616,7 +617,9 @@ var/datum/action_controller/actions
 
 			item_duration *= familiarity_scale ? familiarity_scale : 1
 
-		if( source.bioHolder?.HasEffect("clumsy")	)
+		if( (source.bioHolder?.HasEffect("clumsy") && prob(33)) \
+			|| (source.reagents && prob(source.reagents.get_reagent_amount("ethanol") * 0.8)) 	)
+			clumsy = TRUE
 			duration *= 1.2
 
 		duration += ExtraDuration
@@ -633,7 +636,7 @@ var/datum/action_controller/actions
 			icon = item.icon
 			icon_state = item.icon_state
 			for(var/mob/O in AIviewers(owner))
-				O.show_message("<span class='alert'><B>[source] tries to put on [item]!</B></span>", 1)
+				O.show_message("<span class='alert'><B>[source] tries to put on [item][clumsy ? " but struggles a bit" : ""]!</B></span>", 1)
 		else
 			var/obj/item/I = source.get_slot(slot)
 

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -601,11 +601,8 @@ var/datum/action_controller/actions
 		// don
 		if(item)
 			familiarity_scale = item.get_dondoff_familiarity(source)
-
 			if(item.duration_put > 0)
 				item_duration += item.duration_put
-			else
-				item_duration += 1.5 SECONDS
 
 			item_duration *= familiarity_scale ? familiarity_scale : 1
 			duration += item_duration
@@ -616,8 +613,6 @@ var/datum/action_controller/actions
 			familiarity_scale = item.get_dondoff_familiarity(source)
 			if(I.duration_remove  > 0)
 				duration += I.duration_remove
-			else
-				duration += 0.5 SECONDS
 
 			item_duration *= familiarity_scale ? familiarity_scale : 1
 

--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -324,6 +324,8 @@
 					autoequip_slot(slot_head, head)
 					autoequip_slot(slot_back, back)
 
+					if(actions.hasAction(master,"dondoff"))
+						return
 
 					for (var/datum/hud/storage/S in user.huds) //ez storage stowing
 						S.master.attackby(I, user, params)
@@ -370,7 +372,7 @@
 			if ("equip")
 				var/obj/item/I = master.equipped()
 				if (I)
-					#define autoequip_slot(slot, var_name) if (master.can_equip(I, master.slot) && !(master.var_name && master.var_name.cant_self_remove)) { master.u_equip(I); var/obj/item/C = master.var_name; if (C) { /*master.u_equip(C);*/ C.unequipped(master); master.var_name = null; if(!master.put_in_hand(C)){master.drop_from_slot(C, get_turf(C))} } master.force_equip(I, master.slot); return }
+					#define autoequip_slot(slot, var_name) if (master.can_equip(I, master.slot) && !(master.var_name && master.var_name.cant_self_remove) && !master.don_doff(I, master.slot)) { master.u_equip(I); var/obj/item/C = master.var_name; if (C) { /*master.u_equip(C);*/ C.unequipped(master); master.var_name = null; if(!master.put_in_hand(C)){master.drop_from_slot(C, get_turf(C))} } master.force_equip(I, master.slot); return }
 					autoequip_slot(slot_shoes, shoes)
 					autoequip_slot(slot_gloves, gloves)
 					autoequip_slot(slot_wear_id, wear_id)
@@ -535,7 +537,7 @@
 					else
 						master.client << link("https://wiki.ss13.co/Construction")
 
-			#define clicked_slot(slot) var/obj/item/W = master.get_slot(master.slot); if (W) { master.click(W, params); } else { var/obj/item/I = master.equipped(); if (!I || !master.can_equip(I, master.slot) || istype(I.loc, /obj/item/parts/)) { return; } master.u_equip(I); master.force_equip(I, master.slot); }
+			#define clicked_slot(slot) var/obj/item/W = master.get_slot(master.slot); if (W) { master.click(W, params); } else { var/obj/item/I = master.equipped(); if (!I || !master.can_equip(I, master.slot) || istype(I.loc, /obj/item/parts/) || master.don_doff(I, master.slot)) { return; } master.u_equip(I); master.force_equip(I, master.slot); }
 			if("belt")
 				clicked_slot(slot_belt)
 			if("storage1")

--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -312,7 +312,7 @@
 				if (I)
 					// this doesnt unequip the original item because that'd cause all the items to drop if you swapped your jumpsuit, I expect this to cause problems though
 					// ^-- You don't say.
-					#define autoequip_slot(slot, var_name) if (master.can_equip(I, master.slot) && !istype(I.loc, /obj/item/parts) && !(master.var_name && master.var_name.cant_self_remove)) { master.u_equip(I); var/obj/item/C = master.var_name; if (C) { /*master.u_equip(C);*/ C.unequipped(master); master.var_name = null; if(!master.put_in_hand(C)){master.drop_from_slot(C, get_turf(C))} } master.force_equip(I, master.slot); return }
+					#define autoequip_slot(slot, var_name) if (master.can_equip(I, master.slot) && !istype(I.loc, /obj/item/parts) && !(master.var_name && master.var_name.cant_self_remove) && !master.don_doff(I, master.slot)) { master.u_equip(I); var/obj/item/C = master.var_name; if (C) { /*master.u_equip(C);*/ C.unequipped(master); master.var_name = null; if(!master.put_in_hand(C)){master.drop_from_slot(C, get_turf(C))} } master.force_equip(I, master.slot); return }
 					autoequip_slot(slot_shoes, shoes)
 					autoequip_slot(slot_gloves, gloves)
 					autoequip_slot(slot_wear_id, wear_id)

--- a/code/global.dm
+++ b/code/global.dm
@@ -387,6 +387,8 @@ var/global
 	manualblinking = 0
 	speechpopups = 1
 
+	dondoffscale = 1
+
 	monkeysspeakhuman = 0
 	late_traitors = 1
 	no_automatic_ending = 0

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1283,6 +1283,9 @@
 /mob/proc/swap_hand()
 	return
 
+/mob/proc/don_doff()
+	return
+
 /mob/proc/u_equip(obj/item/W)
 	if (W == src.r_hand)
 		src.r_hand = null

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1283,7 +1283,7 @@
 /mob/proc/swap_hand()
 	return
 
-/mob/proc/don_doff()
+/mob/proc/don_doff(obj/item/I, slot)
 	return
 
 /mob/proc/u_equip(obj/item/W)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2305,7 +2305,12 @@
 
 /mob/living/carbon/human/don_doff(obj/item/I, slot)
 	if(!dondoffscale) return
+	if( slot in list(slot_l_store,  slot_r_store,  slot_l_hand, slot_r_hand) )
+		if(actions.hasAction(src,"dondoff"))
+			return TRUE
+		return FALSE
 	actions.start(new/datum/action/bar/icon/donDoffItem(src, I, slot), usr)
+
 	return TRUE
 
 /mob/living/carbon/human/emp_act()

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2005,6 +2005,39 @@
 		if (slot_r_store)
 			return src.r_store
 
+/mob/living/carbon/human/proc/clear_slot(slot)
+	switch(slot)
+		if (slot_back)
+			src.back = null
+		if (slot_wear_mask)
+			src.wear_mask = null
+		if (slot_l_hand)
+			src.l_hand = null
+		if (slot_r_hand)
+			src.r_hand = null
+		if (slot_belt)
+			src.belt = null
+		if (slot_wear_id)
+			src.wear_id = null
+		if (slot_ears)
+			src.ears = null
+		if (slot_glasses)
+			src.glasses = null
+		if (slot_gloves)
+			src.gloves = null
+		if (slot_head)
+			src.head = null
+		if (slot_shoes)
+			src.shoes = null
+		if (slot_wear_suit)
+			src.wear_suit = null
+		if (slot_w_uniform)
+			src.w_uniform = null
+		if (slot_l_store)
+			src.l_store = null
+		if (slot_r_store)
+			src.r_store = null
+
 /mob/living/carbon/human/proc/force_equip(obj/item/I, slot)
 	//warning: icky code
 	var/equipped = 0
@@ -2269,6 +2302,11 @@
 			SEND_SIGNAL(src.equipped(), COMSIG_ITEM_SWAP_TO, src)
 	if(src.equipped() && (src.equipped().item_function_flags & USE_INTENT_SWITCH_TRIGGER) && !src.equipped().two_handed)
 		src.equipped().intent_switch_trigger(src)
+
+/mob/living/carbon/human/don_doff(obj/item/I, slot)
+	if(!dondoffscale) return
+	actions.start(new/datum/action/bar/icon/donDoffItem(src, I, slot), usr)
+	return TRUE
 
 /mob/living/carbon/human/emp_act()
 	boutput(src, "<span class='alert'><B>Your equipment malfunctions.</B></span>")

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2305,6 +2305,11 @@
 
 /mob/living/carbon/human/don_doff(obj/item/I, slot)
 	if(!dondoffscale) return
+
+	var/obj/item/removed = src.get_slot(slot)
+	if(removed?.duration_remove <= 0 && I.duration_put <= 0)
+		return
+
 	if( slot in list(slot_l_store,  slot_r_store,  slot_l_hand, slot_r_hand) )
 		if(actions.hasAction(src,"dondoff"))
 			return TRUE

--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -439,7 +439,7 @@
 			if(I.duration_remove > 0)
 				duration = I.duration_remove
 			else
-				duration = 25
+				duration = 2.5 SECONDS
 		..()
 
 	onStart()

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -39,7 +39,7 @@
 	var/hitsound = 'sound/impact_sounds/Generic_Hit_1.ogg'
 	var/stamina_damage = STAMINA_ITEM_DMG //amount of stamina removed from target per hit.
 	var/stamina_cost = STAMINA_ITEM_COST  //amount of stamina removed from USER per hit. This cant bring you below 10 points and you will not be able to attack if it would.
-	
+
 	var/stamina_crit_chance = STAMINA_CRIT_CHANCE //Crit chance when attacking with this.
 	var/datum/item_special/special = null // Contains the datum which executes the items special, if it has one, when used beyond melee range.
 	var/hide_attack = 0 //If 1, hide the attack animation + particles. Used for hiding attacks with silenced .22 and sleepy pen
@@ -120,7 +120,7 @@
 	var/rarity = ITEM_RARITY_COMMON // Just a little thing to indicate item rarity. RPG fluff.
 	pressure_resistance = 50
 	var/obj/item/master = null
-	
+
 	var/last_tick_duration = 1 // amount of time spent between previous tick and this one (1 = normal)
 	var/last_processing_tick = -1
 
@@ -1051,13 +1051,18 @@
 
 	if (src.loc == user)
 		var/in_pocket = 0
+		var/slot
 		if(issilicon(user)) //if it's a borg's shit, stop here
 			return 0
 		if (ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(H.l_store == src || H.r_store == src)
 				in_pocket = 1
+			slot = H.get_slot_from_item(src)
+
 		if (!cant_self_remove || (!cant_drop && (user.l_hand == src || user.r_hand == src)) || in_pocket == 1)
+			if( user.don_doff(null, slot))
+				return 0
 			user.u_equip(src)
 		else
 			boutput(user, "<span class='alert'>You can't remove this item.</span>")
@@ -1088,6 +1093,7 @@
 		bible_contents.Remove(src) // UNF
 		for_by_tcl(bible, /obj/item/storage/bible)
 			bible.hud.remove_item(src)
+
 	user.put_in_hand_or_drop(src)
 
 	if (src.artifact)
@@ -1518,3 +1524,6 @@
 
 /obj/item/proc/can_pickup(mob/user)
 	return !src.anchored
+
+/obj/item/proc/get_dondoff_familiarity(mob/user)
+	return

--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -10,6 +10,9 @@
 	item_state = "armor"
 	body_parts_covered = TORSO|LEGS|ARMS
 
+	duration_put = 3.0 SECONDS
+	duration_remove = 2.0 SECONDS
+
 	setupProperties()
 		..()
 		setProperty("coldprot", 10)

--- a/code/obj/item/clothing/armor.dm
+++ b/code/obj/item/clothing/armor.dm
@@ -13,6 +13,11 @@
 	duration_put = 3.0 SECONDS
 	duration_remove = 2.0 SECONDS
 
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_security"))
+			. = 0.5
+
 	setupProperties()
 		..()
 		setProperty("coldprot", 10)
@@ -90,6 +95,9 @@
 	var/obj/item/pipebomb/bomb/pipebomb = null
 	var/obj/item/reagent_containers/glass/beaker/beaker = null
 	var/payload = ""
+
+	duration_put = 6.0 SECONDS
+	duration_remove = 3 SECONDS
 
 	New()
 		..()
@@ -284,11 +292,28 @@
 		setProperty("meleeprot", 7)
 		setProperty("rangedprot", 1.5)
 
+	get_dondoff_familiarity(mob/user)
+		if(.)
+			. = 1
+		else if( user.mind?.assigned_role == "Captain" )
+			. = 0.5
+		else
+			. = 1.5
+
 /obj/item/clothing/suit/armor/capcoat //old alt armour for the captain
 	name = "captain's coat"
 	desc = "A luxorious formal coat made for the station's captain. It seems to be made out of some thermally resistant material."
 	icon_state = "capcoat"
 	item_state = "capcoat"
+
+	get_dondoff_familiarity(mob/user)
+		if(.)
+			. = 1
+		else if( user.mind?.assigned_role == "Captain" )
+			. = 0.5
+		else
+			. = 1.5
+
 	setupProperties()
 		..()
 		setProperty("coldprot", 35)
@@ -301,6 +326,14 @@
 	desc = "A rather well armored coat tailored in a traditional naval fashion."
 	icon_state = "hopcoat"
 	item_state = "hopcoat"
+
+	get_dondoff_familiarity(mob/user)
+		if(.)
+			. = 1
+		else if( user.mind?.assigned_role == "Head of Personnel" )
+			. = 0.5
+		else
+			. = 1.5
 
 	setupProperties()
 		..()
@@ -343,6 +376,9 @@
 	desc = "A heavily armored suit that protects against moderate damage."
 	icon_state = "heavy"
 	item_state = "heavy"
+	duration_put = 4.0 SECONDS
+	duration_remove = 2.5 SECONDS
+
 	setupProperties()
 		..()
 		setProperty("meleeprot", 12)
@@ -431,6 +467,11 @@
 	desc = "A lightly-armored and stylish cape, made of heat-resistant materials. It probably won't keep you warm, but it would make a great security blanket!"
 	icon_state = "hos-cape"
 	item_state = "hos-cape"
+
+	get_dondoff_familiarity(mob/user)
+		if( user.mind?.assigned_role == "Head of Security" )
+			. = 0.1
+
 	setupProperties()
 		..()
 		setProperty("meleeprot", 3)

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -118,6 +118,12 @@
 	desc = "Helps protect from vacuum for a short period of time."
 	seal_hair = 1
 	path_prot = 0
+	duration_put = 1 SECOND
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_medical") )
+			. = 0.5
 
 	setupProperties()
 		..()
@@ -131,6 +137,12 @@
 	c_flags = COVERSEYES | COVERSMOUTH | BLOCKCHOKE
 	desc = "Asbestos, right near your face. Perfect!"
 	seal_hair = 1
+	duration_put = 2 SECOND
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_medical") )
+			. = 0.5
 
 	setupProperties()
 		..()
@@ -1117,6 +1129,12 @@
 	permeability_coefficient = 0
 	c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
 	seal_hair = 1
+	duration_put = 2 SECOND
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_medical") )
+			. = 0.5
 
 	setupProperties()
 		..()
@@ -1311,6 +1329,12 @@
 	setupProperties()
 		..()
 		setProperty("meleeprot_head", 7)
+
+	get_dondoff_familiarity(mob/user)
+		if( user.mind?.assigned_role == "Head of Security" )
+			. = 0.5
+
+
 
 /obj/item/clothing/head/hos_hat/attack_self(mob/user as mob)
 	if(user.r_hand == src || user.l_hand == src)

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -23,6 +23,7 @@
 	desc = "Helps protect against vacuum."
 	seal_hair = 1
 	path_prot = 0
+	duration_put = 1 SECOND
 
 	onMaterialChanged()
 		if(src.material)

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -7,6 +7,12 @@
 	item_state = "helmet"
 	desc = "Somewhat protects your head from being bashed in."
 	protective_temperature = 500
+	duration_put = 1 SECOND
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_security") )
+			. = 0.5
 
 	setupProperties()
 		..()
@@ -24,6 +30,11 @@
 	seal_hair = 1
 	path_prot = 0
 	duration_put = 1 SECOND
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_engineer") || user.traitHolder?.hasTrait("training_security") )
+			. = 0.5
 
 	onMaterialChanged()
 		if(src.material)
@@ -189,6 +200,12 @@
 	item_state = "space_helmet_syndicate"
 	desc = "The standard space helmet of the dreaded Syndicate."
 	item_function_flags = IMMUNE_TO_ACID
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if( user.mind?.assigned_role == "MODE" )
+			. = 0.5
+
 	old
 		icon_state = "syndicate-OLD"
 		desc = "A relic of the past."
@@ -533,6 +550,10 @@
 	color_g = 0.5
 	color_b = 0.5
 	var/nodarken = 0
+
+	get_dondoff_familiarity(mob/user)
+		if(user.traitHolder?.hasTrait("training_engineer") )
+			. = 0.5
 
 	setupProperties()
 		..()

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -110,6 +110,8 @@
 	color_b = 0.8
 	path_prot = 0
 
+	duration_put = 2 SECONDS
+
 	setupProperties()
 		..()
 		setProperty("coldprot", 7)

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -112,6 +112,11 @@
 
 	duration_put = 2 SECONDS
 
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_engineer") || user.traitHolder?.hasTrait("training_security") )
+			. = 0.75
+
 	setupProperties()
 		..()
 		setProperty("coldprot", 7)

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -183,6 +183,8 @@
 	body_parts_covered = TORSO|LEGS|ARMS
 	permeability_coefficient = 0.01
 	over_hair = 1
+	duration_put = 3 SECONDS
+	duration_remove = 1 SECONDS
 
 	setupProperties()
 		..()
@@ -969,6 +971,7 @@
 	permeability_coefficient = 0.02
 	protective_temperature = 1000
 	over_hair = 1
+	duration_put = 2.5 SECONDS
 
 	onMaterialChanged()
 		if(src.material)

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -183,8 +183,13 @@
 	body_parts_covered = TORSO|LEGS|ARMS
 	permeability_coefficient = 0.01
 	over_hair = 1
-	duration_put = 3 SECONDS
+	duration_put = 4 SECONDS
 	duration_remove = 1 SECONDS
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_medical") )
+			. = 0.5
 
 	setupProperties()
 		..()
@@ -239,6 +244,8 @@
 	desc = "A suit that protects against biological contamination. Somebody slapped some armor onto the chest."
 	icon_state = "armorbio"
 	item_state = "armorbio"
+	duration_put = 5 SECONDS
+	duration_remove = 2 SECONDS
 	setupProperties()
 		..()
 		setProperty("meleeprot", 5)
@@ -259,11 +266,16 @@
 	desc = "A protective padded suit for emergency response personnel. Offers limited thermal and biological protection. Somebody slapped some armor onto the chest."
 	icon_state = "para_armor"
 	item_state = "paramedic"
+
 	setupProperties()
 		..()
 		setProperty("meleeprot", 5)
 		setProperty("rangedprot", 1.9)
 
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_medical") || user.traitHolder?.hasTrait("training_security")  )
+			. = 0.5
 
 	para_troop
 		icon_state = "para_sec"
@@ -288,6 +300,12 @@
 	item_state = "hev"
 	c_flags = SPACEWEAR
 	body_parts_covered = TORSO|LEGS|ARMS
+	duration_put = 5 SECONDS
+	duration_remove = 2 SECONDS
+
+	get_dondoff_familiarity(mob/user)
+		if(user.traitHolder?.hasTrait("training_engineer") )
+			. = 0.5
 
 	setupProperties()
 		..()
@@ -308,6 +326,8 @@
 	body_parts_covered = TORSO|LEGS|ARMS
 	permeability_coefficient = 0.005
 	over_hair = 1
+	duration_put = 5 SECONDS
+	duration_remove = 2 SECONDS
 
 	New()
 		. = ..()
@@ -511,6 +531,7 @@
 	item_state = "straight_jacket"
 	body_parts_covered = TORSO|LEGS|ARMS
 	restrain_wearer = 1
+	duration_put = 2 SECONDS
 
 	setupProperties()
 		..()
@@ -836,6 +857,13 @@
 	permeability_coefficient = 0.50
 	body_parts_covered = TORSO|LEGS|ARMS
 	protective_temperature = 4500
+	duration_put = 2 SECONDS
+	duration_remove = 1 SECONDS
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_engineer") )
+			. = 0.5
 
 	setupProperties()
 		..()
@@ -874,6 +902,8 @@
 	item_state = "thermal"
 
 	protective_temperature = 100000
+	duration_put = 4 SECONDS
+	duration_remove = 2 SECONDS
 
 	setupProperties()
 		..()
@@ -972,6 +1002,12 @@
 	protective_temperature = 1000
 	over_hair = 1
 	duration_put = 2.5 SECONDS
+	duration_remove = 2 SECONDS
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_engineer") || user.traitHolder?.hasTrait("training_security") )
+			. = 0.5
 
 	onMaterialChanged()
 		if(src.material)
@@ -1015,6 +1051,7 @@
 	c_flags = SPACEWEAR
 	body_parts_covered = TORSO|LEGS|ARMS
 	var/rip = 0
+	duration_put = 3.5 SECONDS
 
 	setupProperties()
 		..()
@@ -1044,6 +1081,11 @@
 	icon_state = "spacecap"
 	item_state = "spacecap"
 
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if( user.mind?.assigned_role == "Captain" )
+			. = 0.5
+
 	setupProperties()
 		..()
 		setProperty("space_movespeed", 0.4)
@@ -1063,6 +1105,11 @@
 	desc = "A suit that protects against low pressure environments. Issued to syndicate operatives."
 	contraband = 3
 	item_function_flags = IMMUNE_TO_ACID
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if( user.mind?.assigned_role == "MODE" )
+			. = 0.5
 
 	setupProperties()
 		..()
@@ -1224,6 +1271,13 @@
 	c_flags = SPACEWEAR
 	body_parts_covered = TORSO|LEGS|ARMS
 	mats = 45 //should not be cheap to make at mechanics, increased from 15.
+	duration_put = 4 SECONDS
+	duration_remove = 2 SECONDS
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_engineer") )
+			. = 0.5
 
 
 #ifdef UNDERWATER_MAP
@@ -1251,10 +1305,16 @@
 		desc = "An armored space suit, not for your average expendable chumps. No sir."
 		icon_state = "indusred"
 		item_state = "indusred"
+
 		setupProperties()
 			..()
 			setProperty("meleeprot", 9)
 			setProperty("rangedprot", 2)
+
+		get_dondoff_familiarity(mob/user)
+			. = ..()
+			if( user.mind?.assigned_role == "MODE" )
+				. = 0.5
 
 		specialist
 			name = "specialist heavy operative combat armor"
@@ -1279,6 +1339,14 @@
 	c_flags = SPACEWEAR
 	body_parts_covered = TORSO|LEGS|ARMS
 	mats = 60 //should be the most expensive armor.
+
+	duration_put = 4 SECONDS
+	duration_remove = 2 SECONDS
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_engineer") || user.traitHolder?.hasTrait("training_security")  )
+			. = 0.5
 
 	setupProperties()
 		..()
@@ -1509,6 +1577,12 @@
 	body_parts_covered = TORSO|LEGS|ARMS
 	permeability_coefficient = 0
 	over_hair = 1
+	duration_put = 4 SECOND
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_medical") )
+			. = 0.5
 
 /obj/item/clothing/suit/security_badge
 	name = "Security Badge"

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -22,6 +22,9 @@
 
 	duration_remove = 6.5 SECONDS
 
+	get_dondoff_familiarity(mob/user)
+		. = 0.07 // don't really care about jumpsuits but want current value for pickpocketing
+
 	setupProperties()
 		..()
 		setProperty("coldprot", 5)

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -360,6 +360,7 @@ Contains:
 	module_research = list("atmospherics" = 4)
 	distribute_pressure = 17 // setting these things to start at the minimum pressure needed to breathe - Haine
 	compatible_with_TTV = 0
+	duration_put = 2 SECONDS
 
 	New()
 		..()

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -30,6 +30,7 @@ Contains:
 	stamina_damage = 55
 	stamina_cost = 23
 	stamina_crit_chance = 10
+	duration_put = 2 SECONDS
 
 	New()
 		..()
@@ -64,6 +65,11 @@ Contains:
 			var/mob/living/carbon/location = loc
 			if(location.internal==src)
 				.= 1
+
+	get_dondoff_familiarity(mob/user)
+		. = ..()
+		if(user.traitHolder?.hasTrait("training_engineer"))
+			. = 0.5
 
 	attack_self(mob/user as mob)
 		if (!(src.air_contents))
@@ -360,7 +366,6 @@ Contains:
 	module_research = list("atmospherics" = 4)
 	distribute_pressure = 17 // setting these things to start at the minimum pressure needed to breathe - Haine
 	compatible_with_TTV = 0
-	duration_put = 2 SECONDS
 
 	New()
 		..()

--- a/code/z_adventurezones/biodome.dm
+++ b/code/z_adventurezones/biodome.dm
@@ -655,6 +655,7 @@ SYNDICATE DRONE FACTORY AREAS
 	cant_other_remove = 1
 	w_class = W_CLASS_NORMAL
 	var/processing = 0
+	duration_put = 4 SECONDS
 
 	setupProperties()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance][add to wiki][help wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

*Adds actionbars when wearing or removing certain equipment.
 - https://docs.google.com/spreadsheets/d/1GjsdWvnHx28w02Qcdg5odcij0lJ5XgKzsybwf2dfKOg/edit?usp=sharing
   - NOTE: This a preliminary pass of the don/doff times for an "unfamiliar" individual.  -1 takes no time.
 - Allow for training and "familiarity" to equipment interactions
 👨‍⚕️(Medical Training) - 👮 (Security Training) -👩‍🔧(Engineering Training)
   - Tanks/Jetpacks take 1/2 👩‍🔧 (Otherwise 2 seconds)
   - Firesuits/SUV Suit take 1/2 time 👩‍🔧
   - Welding Helmet takes 1/2 time 👩‍🔧
   - Spacesuits take 1/2 time 👩‍🔧 or 👮
   - Gas Masks takes 3/4 time 👩‍🔧 or 👨‍⚕️
   - EmergencyHood/Rad Hood/Chem Hood take 1/2 time 👨‍⚕️
   - Chemsuits/Biosuits take 1/2 time 👨‍⚕️
     - Paramedic Armored takes 1/2 👨‍⚕️ or 👮
   - Armor takes 1/2 👮
   - Helmets takes 1/2 👮
     - Space Helmets 1/2 👮or 👩‍🔧
   - HoS, HoP, and Captain gear use 1/2 to corresponding Head...
     -  Some regalia takes NORMAL time for those familiar with that class of clothing and 50% longer for those that aren't. 
     - HoS's Cape only really has actionbar for !HoS
   - Traitor/Nukie gear use 1/2 time ONLY for people assigned that role. (TODO)
 - Allow for effects to adjust equipment interactions.
   - Crime reduces time by 10%
   - Clumsy has 1/3 chance of increasing by 20%
   - Ethanol has chance scaled with consumption of increasing by 20% (not stacking with clumsy)
 - Small amounts of movement are allowed without completely stopping actionbar.

Global variable used as a scaling factor to allow for evaluation of feature.

- [ ] Additional development pending Developer interest.
- [ ] Address above TODO items.
- [ ] Additional pass on equipment.
- [ ] Break don/doff duration into constants to avoid magic numbers and standardize behavior.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Increases strategic depth/value by limiting ability for immediate tactical response by adding animation priority to changing equipment.  Favors aggressors who are equipped to deal with the defender's current equipment, as the state can not be immediately changed.  Additionally further action of the aggressor has the ability to delay or stop the defends ability to adjust their equipment.

Additionally this adds another lever to pull to adjust the value of a piece or class of equipment going forward.



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(*)Actionbars added to wearing and removing more complicated equipment.  Duration adjusted based on training, traits (clumsy), and drunkenness.
```
