### PR TITLE
Stun baton nerf, cus I've been feeling brave/stupid/both with my PRs lately.

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -43,8 +43,8 @@
 	var/uses_electricity = 1 // Does it use electricity? Certain interactions don't work with a wooden baton.
 	var/status = 1 //1 is on, 0 is off
 
-	var/stun_normal_weakened = 20
-	var/stun_normal_stuttering = 20
+	var/stun_normal_weakened = 10
+	var/stun_normal_stuttering = 10
 	var/stun_harm_weakened = 8 // Only used when next flag is set to 1.
 	var/instant_harmbaton_stun = 0 // Legacy behaviour for harmbaton, that is an instant knockdown.
 #ifdef USE_STAMINA_DISORIENT


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Nerfs the stun baton to only knock down and weaken people for 10 seconds total on 2 hits. Still completely drains stamina in two hits. Before hand, it actually stunned for 20 seconds, but stuns cap out at 30 seconds so technically the total is 40.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The stun baton is supposed to primarily be the Sec Officers tool for confirming an arrest. However, due to its very generous stun it's become a meta weapon, superior over all other lethal weapons due to being able to take down a person for 30 seconds with 2 hits. With this nerf, you get a 30 second stun, you'll need to stun someone over 4 times. This shouldn't make a difference in arresting people for Sec but lower it's combat potential.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Carbadox
(*)The stun baton no longer knock down and weakens for 20 seconds but instead, only 10 seconds now. This shouldn't make a difference in Security arresting people but lower it's nerf it's very powerful combat potential. 
```
