### PR TITLE
Replaces wraithsmoke with a smoke-grenade-like effect

### DIFF
--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -528,7 +528,7 @@
 				if (trgloc && isturf(trgloc))
 					var/datum/effects/system/bad_smoke_spread/S = new /datum/effects/system/bad_smoke_spread/(trgloc)
 					if (S)
-						S.set_up(20, 0, trgloc)
+						S.set_up(20, 0, trgloc, null, "#000000")
 						S.start()
 				//particleMaster.SpawnSystem(new/datum/particleSystem/areaSmoke("#ffffff", 30, trgloc))
 				return 0

--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -528,9 +528,8 @@
 				if (trgloc && isturf(trgloc))
 					var/datum/effects/system/bad_smoke_spread/S = new /datum/effects/system/bad_smoke_spread/(trgloc)
 					if (S)
-						S.set_up(15, 0, trgloc, null, "#000000")
+						S.set_up(15, 0, trglosmc, null, "#000000")
 						S.start()
-				//particleMaster.SpawnSystem(new/datum/particleSystem/areaSmoke("#ffffff", 30, trgloc))
 				return 0
 			if (4)
 				boutput(holder.owner, "<span class='notice'>Matter from your realm appears near the designated location!</span>")

--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -528,7 +528,7 @@
 				if (trgloc && isturf(trgloc))
 					var/datum/effects/system/bad_smoke_spread/S = new /datum/effects/system/bad_smoke_spread/(trgloc)
 					if (S)
-						S.set_up(20, 0, trgloc, null, "#000000")
+						S.set_up(15, 0, trgloc, null, "#000000")
 						S.start()
 				//particleMaster.SpawnSystem(new/datum/particleSystem/areaSmoke("#ffffff", 30, trgloc))
 				return 0

--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -528,7 +528,7 @@
 				if (trgloc && isturf(trgloc))
 					var/datum/effects/system/bad_smoke_spread/S = new /datum/effects/system/bad_smoke_spread/(trgloc)
 					if (S)
-						S.set_up(15, 0, trglosmc, null, "#000000")
+						S.set_up(15, 0, trgloc, null, "#000000")
 						S.start()
 				return 0
 			if (4)

--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -525,16 +525,12 @@
 			if (3)
 				boutput(holder.owner, "<span class='notice'>Smoke rises in the designated location.</span>")
 				var/turf/trgloc = get_turf(holder.owner)
-				var/list/affected = block(locate(trgloc.x - 3,trgloc.y - 3,trgloc.z), locate(trgloc.x + 3,trgloc.y + 3,trgloc.z))
-				if(!affected.len) return
-				var/list/centerview = view(4, trgloc)
-				for(var/atom/A in affected)
-					if(!(A in centerview)) continue
-					//if (A == holder.owner) continue
-					var/obj/smokeDummy/D = new(A)
-					SPAWN_DBG(15 SECONDS)
-						qdel(D)
-				particleMaster.SpawnSystem(new/datum/particleSystem/areaSmoke("#ffffff", 30, trgloc))
+				if (trgloc && isturf(trgloc))
+					var/datum/effects/system/bad_smoke_spread/S = new /datum/effects/system/bad_smoke_spread/(trgloc)
+					if (S)
+						S.set_up(20, 0, trgloc)
+						S.start()
+				//particleMaster.SpawnSystem(new/datum/particleSystem/areaSmoke("#ffffff", 30, trgloc))
 				return 0
 			if (4)
 				boutput(holder.owner, "<span class='notice'>Matter from your realm appears near the designated location!</span>")

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -942,60 +942,6 @@ toxic - poisons
 			explosion_new(null, T, 36, 0.45)
 		return
 
-/obj/smokeDummy
-	name = ""
-	desc = ""
-	invisibility = 101
-	anchored = 1
-	density = 0
-	opacity = 0
-	var/list/affected = list()
-
-	disposing()
-		remove()
-		return ..()
-
-	New(var/atom/sloc)
-		if(!sloc) return
-		src.set_loc(sloc)
-		for(var/mob/M in src.loc)
-			Crossed(M)
-		return ..()
-
-	proc/remove()
-		for(var/mob/M in affected)
-			M.removeOverlayComposition(/datum/overlayComposition/smoke)
-			M.updateOverlaysClient(M.client)
-		affected.Cut()
-		return
-
-	Crossed(atom/movable/O)
-		if(ishuman(O) && prob(30))
-			var/mob/living/carbon/human/H = O
-			if (H.internal != null && H.wear_mask && (H.wear_mask.c_flags & MASKINTERNALS))
-			else
-				H.emote("cough")
-				if (prob(20))	//remove this maybe. it shoudla been stunning, but has been broken since the status system updates.
-					H.setStatus("stunned",max(H.getStatusDuration("stunned"), 20))
-
-		if(ismob(O))
-			var/mob/M = O
-			if (M.client && !isobserver(M) && !iswraith(M) && !isintangible(M)) // fuck you stop affecting ghosts FUCK YOU
-				M.addOverlayComposition(/datum/overlayComposition/smoke)
-				M.updateOverlaysClient(M.client)
-				affected.Add(O)
-		return ..()
-
-	Uncrossed(atom/movable/O)
-		if(ismob(O))
-			var/mob/M = O
-			if (M.client && !isobserver(M) && !iswraith(M) && !isintangible(M)) // FUCK YOU
-				if(!(locate(/obj/smokeDummy) in M.loc))
-					M.removeOverlayComposition(/datum/overlayComposition/smoke)
-					M.updateOverlaysClient(M.client)
-					affected.Remove(M)
-		return ..()
-
 /datum/projectile/bullet/smoke
 	name = "smoke grenade"
 	sname = "smokeshot"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the wraith's current full-screen-overlay thing with the same effect as smoke grenades/smokeshot, colored pitch black to make it spookier. The size of the smoke is halfway between smokeshot and a smoke grenade; it's currently enough to fill a small room or block roughly 3x4 of hallway. I'm open to reducing it a bit if that's wanted- the main aim of this PR was to get rid of the goofy full-screen overlay which is literally worse than being blind, so I don't mind if this is still a strong ability.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Full screen overlay sucks. Full screen overlay which can be used every 20 seconds, lasts for 15, and is fully accessible to every poltergeist really sucks.

## Pictures
Without xray:
![image](https://user-images.githubusercontent.com/67879783/115777788-949b5200-a36a-11eb-96cd-42d094797bd8.png)
With xray:
![image2](https://user-images.githubusercontent.com/67879783/115777740-88af9000-a36a-11eb-962d-ad2f5d5c9119.png)



