### PR TITLE
Portable reclaimers now load materials from boxes and satchels

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -31,8 +31,8 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //////////// OPTIONS TO GO FAST
 
-//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
-//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
+#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
+#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
 //#define Z_LOG_ENABLE 1  // Enable additional world.log logging
 
 

--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -31,8 +31,8 @@ o+`        `-` ``..-:yooos-..----------..`
 
 //////////// OPTIONS TO GO FAST
 
-#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
-#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
+//#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
+//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
 //#define Z_LOG_ENABLE 1  // Enable additional world.log logging
 
 

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -881,6 +881,7 @@
 			BAR.set_loc(output_location)
 
 		playsound(src.loc, sound_process, 40, 1)
+
 	proc/loadreclaim(obj/item/W as obj, mob/user as mob)
 		. = FALSE
 		if (istype(W,/obj/item/raw_material/) || istype(W,/obj/item/sheet/) || istype(W,/obj/item/rods/) || istype(W,/obj/item/tile/) || istype(W,/obj/item/cable_coil) || istype(W,/obj/item/wizard_crystal))
@@ -893,22 +894,27 @@
 		if (W.cant_drop) //For borg held items
 			boutput(user, "<span class='alert'>You can't put that in [src] when it's attached to you!</span>")
 			return ..()
+
 		if (istype(W,/obj/item/storage/) || istype(W,/obj/item/satchel/))
 			var/obj/item/storage/S = W
 			var/obj/item/satchel/B = W
 			for(var/obj/item/O in W)
 				if (loadreclaim(O))
+					. = TRUE
 					if (istype(S))
 						S.hud.remove_object(O)
 					else if (istype(B))
 						B.satchel_updateicon()
 			//Users loading individual items would make an annoying amount of messages
 			//But loading a container is more noticable and there should be less
-			user.visible_message("<b>[user.name]</b> loads [S] into [src].")
-			playsound(get_turf(src), sound_load, 40, 1)
+			if (.)
+				user.visible_message("<b>[user.name]</b> loads [S] into [src].")
+				playsound(get_turf(src), sound_load, 40, 1)
+
 		else if (loadreclaim(W, user))
 			boutput(user, "You load [W] into [src].")
 			playsound(get_turf(src), sound_load, 40, 1)
+
 		else
 			. = ..()
 

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -894,7 +894,6 @@
 		if (W.cant_drop) //For borg held items
 			boutput(user, "<span class='alert'>You can't put that in [src] when it's attached to you!</span>")
 			return ..()
-
 		if (istype(W,/obj/item/storage/) || istype(W,/obj/item/satchel/))
 			var/obj/item/storage/S = W
 			var/obj/item/satchel/B = W
@@ -903,8 +902,8 @@
 					. = TRUE
 					if (istype(S))
 						S.hud.remove_object(O)
-					else if (istype(B))
-						B.satchel_updateicon()
+			if (istype(B) || .)
+				B.satchel_updateicon()
 			//Users loading individual items would make an annoying amount of messages
 			//But loading a container is more noticable and there should be less
 			if (.)

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -908,7 +908,7 @@
 			//Users loading individual items would make an annoying amount of messages
 			//But loading a container is more noticable and there should be less
 			if (.)
-				user.visible_message("<b>[user.name]</b> loads [S] into [src].")
+				user.visible_message("<b>[user.name]</b> loads [W] into [src].")
 				playsound(get_turf(src), sound_load, 40, 1)
 
 		else if (loadreclaim(W, user))

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -881,20 +881,36 @@
 			BAR.set_loc(output_location)
 
 		playsound(src.loc, sound_process, 40, 1)
+	proc/loadreclaim(obj/item/W as obj, mob/user as mob)
+		. = FALSE
+		if (istype(W,/obj/item/raw_material/) || istype(W,/obj/item/sheet/) || istype(W,/obj/item/rods/) || istype(W,/obj/item/tile/) || istype(W,/obj/item/cable_coil) || istype(W,/obj/item/wizard_crystal))
+			W.set_loc(src)
+			if (user) user.u_equip(W)
+			W.dropped()
+			. = TRUE
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (W.cant_drop) //For borg held items
 			boutput(user, "<span class='alert'>You can't put that in [src] when it's attached to you!</span>")
 			return ..()
-		if (istype(W,/obj/item/raw_material/) || istype(W,/obj/item/sheet/) || istype(W,/obj/item/rods/) || istype(W,/obj/item/tile/) || istype(W,/obj/item/cable_coil) || istype(W,/obj/item/wizard_crystal))
+		if (istype(W,/obj/item/storage/) || istype(W,/obj/item/satchel/))
+			var/obj/item/storage/S = W
+			var/obj/item/satchel/B = W
+			for(var/obj/item/O in W)
+				if (loadreclaim(O))
+					if (istype(S))
+						S.hud.remove_object(O)
+					else if (istype(B))
+						B.satchel_updateicon()
+			//Users loading individual items would make an annoying amount of messages
+			//But loading a container is more noticable and there should be less
+			user.visible_message("<b>[user.name]</b> loads [S] into [src].")
+			playsound(get_turf(src), sound_load, 40, 1)
+		else if (loadreclaim(W, user))
 			boutput(user, "You load [W] into [src].")
-			W.set_loc(src)
-			user.u_equip(W)
-			W.dropped()
 			playsound(get_turf(src), sound_load, 40, 1)
 		else
-			..()
-			return
+			. = ..()
 
 	MouseDrop(over_object, src_location, over_location)
 		if(!isliving(usr))

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -882,7 +882,7 @@
 
 		playsound(src.loc, sound_process, 40, 1)
 
-	proc/loadreclaim(obj/item/W as obj, mob/user as mob)
+	proc/load_reclaim(obj/item/W as obj, mob/user as mob)
 		. = FALSE
 		if (istype(W,/obj/item/raw_material/) || istype(W,/obj/item/sheet/) || istype(W,/obj/item/rods/) || istype(W,/obj/item/tile/) || istype(W,/obj/item/cable_coil) || istype(W,/obj/item/wizard_crystal))
 			W.set_loc(src)
@@ -899,7 +899,7 @@
 			var/obj/item/storage/S = W
 			var/obj/item/satchel/B = W
 			for(var/obj/item/O in W)
-				if (loadreclaim(O))
+				if (load_reclaim(O))
 					. = TRUE
 					if (istype(S))
 						S.hud.remove_object(O)
@@ -911,7 +911,7 @@
 				user.visible_message("<b>[user.name]</b> loads [W] into [src].")
 				playsound(get_turf(src), sound_load, 40, 1)
 
-		else if (loadreclaim(W, user))
+		else if (load_reclaim(W, user))
 			boutput(user, "You load [W] into [src].")
 			playsound(get_turf(src), sound_load, 40, 1)
 

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -897,7 +897,10 @@
 		if (istype(W,/obj/item/storage/) || istype(W,/obj/item/satchel/))
 			var/obj/item/storage/S = W
 			var/obj/item/satchel/B = W
-			for(var/obj/item/O in W)
+			var/items = W
+			if(istype(S))
+				items = S.get_contents()
+			for(var/obj/item/O in items)
 				if (load_reclaim(O))
 					. = TRUE
 					if (istype(S))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Portable reclaimers will now accept compatible materials from boxes and satchels, simply smack them against the reclaimer.

![image](https://user-images.githubusercontent.com/13049028/115777251-e5f71180-a369-11eb-8734-094a9cfca356.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Reduces the tedium of collecting materials for your job each round

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Penny
(+)Portable reclaimers now load materials directly from boxes and satchels
```
