### PR TITLE
Clarifies and tones down setup.dm's comment

### DIFF
--- a/_std/setup.dm
+++ b/_std/setup.dm
@@ -1,7 +1,7 @@
 // PLEASE DONT ADD STUFF TO THIS THAT ISNT DIRECTLY RELATED TO GAME SETUP
 
 //#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1 //Uncomment this to just skip everything possible and get into the game asap.
-//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1 // uncomment this to use atlas as the single map. will horribly break things but speeds up compile/boot times.
+//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1 // uncomment this to use atlas as the single map and disable all other z levels. Speeds up compile/boot times but will fuck those things up
 
 #ifdef RUNTIME_CHECKING
 #define ABSTRACT_VIOLATION_CRASH

--- a/_std/setup.dm
+++ b/_std/setup.dm
@@ -1,7 +1,7 @@
 // PLEASE DONT ADD STUFF TO THIS THAT ISNT DIRECTLY RELATED TO GAME SETUP
 
 //#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1 //Uncomment this to just skip everything possible and get into the game asap.
-//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1 // uncomment this to use atlas as the single map and disable all other z levels. Speeds up compile/boot times but will fuck those things up
+//#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1 // uncomment this to use atlas as the single map and disable all other z levels. Speeds up compile/boot times but will mess up anything relying on other z-levels
 
 #ifdef RUNTIME_CHECKING
 #define ABSTRACT_VIOLATION_CRASH


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Clarifies and tones down setup.dm's comment
Changes `// uncomment this to use atlas as the single map. will horribly break things but speeds up compile/boot times.` 
to `// uncomment this to use atlas as the single map and disable all other z levels. Speeds up compile/boot times but will fuck those things up`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Clarification and more accurate

