### PR TITLE
fix: change deafness trait points from 1 to 0

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -271,12 +271,12 @@
 	isPositive = 1
 
 /obj/trait/deaf
-	name = "Deaf (+1) \[Body\]"
+	name = "Deaf (0) \[Body\]"
 	cleanName = "Deaf"
 	desc = "Spawn with permanent deafness and an auditory headset."
 	id = "deaf"
 	category = "body"
-	points = 1
+	points = 0
 	isPositive = 0
 
 	onAdd(var/mob/owner)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

drops the trait point you receive from the `Deaf` trait from 1 to 0

there will likely be a follow up PR modifying how apply_sonic_stun
works for those with hearing loss, but until then this negates
the free point given for a combat effective upgrade

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

deafness and hearing loss is is not incredibly debilitating within
the context of Space Station 13.  in some cases, it can be an
improvement over other players - such as to overcome flashbangs,
the vampire screech, or the shambler scream

the trait makes you unable to hear without a special hearing devices,
but gives you one on start.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)imnotjames
(+)Removed trait point from Deaf trait
```
