### PR TITLE
Guardbot cuff action uses ziptie cuffs

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -1229,7 +1229,7 @@
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	id = "secbot_cuff"
 	icon = 'icons/obj/items/items.dmi'
-	icon_state = "handcuff"
+	icon_state = "buddycuff"
 	var/obj/machinery/bot/secbot/master
 
 	New(var/obj/machinery/bot/secbot/the_bot)
@@ -1283,7 +1283,7 @@
 				uncuffable = 1
 
 			if(ishuman(master.target) && !uncuffable)
-				master.target.handcuffs = new /obj/item/handcuffs(master.target)
+				master.target.handcuffs = new /obj/item/handcuffs/guardbot(master.target)
 				master.target.setStatus("handcuffed", duration = INFINITE_STATUS)
 
 			if(!uncuffable)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes Guardbot cuff action use ziptie cuffs (including in the action bar). As a note, action bar when uncuffing oneself does not respect the icon state of the cuffs, but that's a separate issue.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #4409

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(+)Guardbots now (again?) use easier-to-escape biodegradable cuffs.
```
