### PR TITLE
Makes weapon vendors dispense stuff to the hand

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -71,6 +71,7 @@
 					var/atom/A = new M.path(src.loc)
 					playsound(src.loc, sound_buy, 80, 1)
 					src.vended(A)
+					usr.put_in_hand_or_eject(A)
 					return TRUE
 
 	attackby(var/obj/item/I, var/mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes weapon vendors the syndicate and sec one both dispense the redeemed items to the user's hands intead of the floor.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

other vending machines work like this, makes the suiting up phase of nukies a little faster wich I think is a good thing.