### PR TITLE
Remove threat rating for roundstart/trait-based mutantraces on SecScanners

### DIFF
--- a/code/obj/machinery/secscanner.dm
+++ b/code/obj/machinery/secscanner.dm
@@ -196,8 +196,6 @@
 				threatcount += 4
 			else if (istype(perp.mutantrace, /datum/mutantrace/cat))
 				threatcount += 3
-			else
-				threatcount += 2
 
 		for (var/datum/data/record/R as anything in data_core.security)
 			if (R.fields["name"] != perp.name && perp.traitHolder.hasTrait("immigrant") && perp.traitHolder.hasTrait("jailbird"))


### PR DESCRIPTION
[qol]

## About the PR 
Removes the automatic +2 threat rating that roundstart trait-based mutantraces get on Security Scanners. This means even with items like stashed zip guns, mutantraces would automatically trigger the scanners because of the added +2 threat rating, which seems unfair!

This doesn't change the Cat Person mutantrace threat addition of +3, but could; this also doesn't touch at all the additional threat ratings for Hunters, Werewolves, and Shamblers; those should still register correctly.

## Why's this needed?
Tending away from necessitating mutantraces as being "negative" or inherently criminal is a good thing, I think.