### PR TITLE
Lets chaplains pick up a bible with Faith inside it

### DIFF
--- a/code/obj/item/storage/bible.dm
+++ b/code/obj/item/storage/bible.dm
@@ -255,8 +255,8 @@ var/global/list/bible_contents = list()
 		if(src.contents.len > 0)
 			. += " It feels a bit heavier than it should."
 
-	attack_hand(var/mob/user as mob)
-		if (user.traitHolder && user.traitHolder.hasTrait("training_chaplain"))
+	attack_hand(mob/user as mob)
+		if (user.traitHolder && user.traitHolder.hasTrait("training_chaplain") && user.is_in_hands(src))
 			var/obj/item/gun/kinetic/faith/F = locate() in src.contents
 			if(F)
 				user.put_in_hand_or_drop(F)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes it so you can remove Faith from the bible only if it's in your hands.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Multiple "how do I pick up a bible without pulling out Faith" mhelps prompted me to do that.

