### PR TITLE
Electropack sprite bug

### DIFF
--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -630,6 +630,7 @@ Green Wire: <a href='?src=\ref[src];wires=[WIRE_TRANSMIT]'>[src.wires & WIRE_TRA
 
 /obj/item/device/radio/electropack
 	name = "\improper Electropack"
+	wear_image_icon = 'icons/mob/back.dmi'
 	icon_state = "electropack0"
 	var/code = 2.0
 	var/on = 0.0


### PR DESCRIPTION
[Bug - Minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes electropack call for a worn state where it didn't before. Now when somebody wears an electropack it can now be seen on the mobs back.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs stinky

