### PR TITLE
Revert "splash contents when attacking using a drinking glass in harm intent"

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -473,17 +473,6 @@
 			boutput(user, "<span class='alert'>Nothing left in [src], oh no!</span>")
 			return 0
 
-		if (user.a_intent == INTENT_HARM)
-			src.reagents.physical_shock(14)
-			if (src.splash_all_contents)
-				boutput(user, "<span class='notice'>You splash all of the solution onto [M].</span>")
-				M.visible_message("<span class='alert'><b>[user.name]</b> splashes the [src.name]'s contents onto [M.name]!</span>")
-			else
-				boutput(user, "<span class='notice'>You apply [src.amount_per_transfer_from_this] units of the solution to [M].</span>")
-				M.visible_message("<span class='alert'><b>[user.name]</b> applies some of the [src.name]'s contents to [M.name].</span>")
-			logTheThing("combat", user, M, "splashes [src] onto [constructTarget(M,"combat")] [log_reagents(src)] at [log_loc(M)].")
-			return
-
 		if (iscarbon(M) || ismobcritter(M))
 			if (M == user)
 				M.visible_message("<span class='notice'>[M] takes a sip from [src].</span>")


### PR DESCRIPTION
Reverts goonstation/goonstation#3381

I think this is a pretty unintuitive and frustrating mechanic, and according to an impromptu poll in Discord, other players agree. 