### PR TITLE
Makes Wizard Hoods Block Hair, Witch Hat Not Block Face

### DIFF
--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -645,13 +645,13 @@
 	desc = "A green hood, full of magic, wonder, cromulence, and maybe a spider or two."
 	icon_state = "wizardgreen"
 	item_state = "wizardgreen"
+	seal_hair = 1
 
 /obj/item/clothing/head/wizard/witch
 	name = "witch hat"
 	desc = "Broomstick and cat not included."
 	icon_state = "witch"
 	item_state = "wizardnec"
-	see_face = 0
 
 /obj/item/clothing/head/wizard/necro
 	name = "necromancer hood"
@@ -659,6 +659,7 @@
 	icon_state = "wizardnec"
 	item_state = "wizardnec"
 	see_face = 0
+	seal_hair = 1
 
 /obj/item/clothing/head/pinkwizard //no magic properties
 	name = "pink wizard hat"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes it so the green wizard hood and black necromancer hood block hair. Without doing this they look kinda wrong imo, and are very prone to hair sticking through them. Based on feedback given in the human resprite thread (though this was an issue before human-resprite) Also changes the witch hat to not block your face like a gas mask; I've always been annoyed by that since it doesn't visually block your face *at all*.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Looks better imo, more aesthetically consistent. Witch hat change is a very minor nitpick thing but I think it's also more consistent.


![](https://cdn.discordapp.com/attachments/799118122899996754/836226601175351396/unknown.png)

(These guys have hair, but you can't see it. Previously the hair would've poked through the top a bit, depending on what hair it was)