### PR TITLE
Fix radio bugs #4478 & #4479

### DIFF
--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -195,6 +195,18 @@ var/list/headset_channel_lookup
 
 				return TRUE
 
+/obj/item/device/radio/Topic(href, href_list)
+	if (usr.stat)
+		return
+
+	if ((issilicon(usr) || isAI(usr)) || (src in usr) || (usr.loc == src.loc))
+		if (href_list["track"])
+			// wait is tracking here? really? what? ???? ????????????
+			var/mob/living/silicon/A = locate(href_list["track2"])
+			var/heard_name = href_list["track3"]
+			A.ai_name_track(heard_name)
+			return
+
 /obj/item/device/radio/attack_self(mob/user as mob)
 	src.ui_interact(user)
 

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -43,6 +43,9 @@
 		if(src.pixel_x == 0 && src.pixel_y == 0)
 			update_pixel_offset_dir(src,null,src.dir)
 
+/obj/item/device/radio/intercom/ui_state(mob/user)
+	return tgui_default_state
+
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)
 	SPAWN_DBG(0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

<!-- [BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This fixes #4478 & fixes #4479

#4478 - Use default state on intercoms just like machinery does.
#4479 - Copied over the old Topic call for tracking players from chat.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Let those poor AI players play game again.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Luxizzle
(+)Fixed AIs not able to track players from chat.
(+)Fixed AIs not able to interact with intercoms.
```
