### PR TITLE
Small fix for cog1 ephemeral xmas decorations

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -128275,7 +128275,7 @@ adC
 adC
 adC
 adC
-sZw
+avj
 sZw
 aGq
 arn
@@ -128290,7 +128290,7 @@ arn
 arn
 aGq
 sZw
-sZw
+avj
 adC
 adC
 adC


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes two non-ephemeral christmas lights in cog1 botany and cleans up their placement a little bit

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugfix