### PR TITLE
Fixes item stacking for building materials

### DIFF
--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -1048,7 +1048,7 @@ MATERIAL
 		if (!( istype(W, /obj/item/tile) ))
 			return
 		if (W.material && src.material && !isSameMaterial(W.material, src.material))
-			boutput(user, "<span class='alert'>You can't mix 2 stacks of different metals!</span>")
+			boutput(user, "<span class='alert'>You can't mix 2 stacks of different materials!</span>")
 			return
 		var/success = stack_item(W)
 		if (!success)

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -159,6 +159,8 @@ MATERIAL
 				boutput(user, "<span class='alert'>You can't mix different reinforcements!</span>")
 				return
 			var/success = stack_item(W)
+			if(!user.is_in_hands(src))
+				user.put_in_hand(src)
 			if (!success)
 				boutput(user, "<span class='alert'>You can't put any more sheets in this stack!</span>")
 			else
@@ -726,6 +728,8 @@ MATERIAL
 				boutput(user, "<span class='alert'>You can't mix 2 stacks of different metals!</span>")
 				return
 			var/success = stack_item(W)
+			if(!user.is_in_hands(src))
+				user.put_in_hand(src)
 			if (!success)
 				boutput(user, "<span class='alert'>You can't put any more rods in this stack!</span>")
 			else
@@ -1044,6 +1048,8 @@ MATERIAL
 		if (!( istype(W, /obj/item/tile) ))
 			return
 		var/success = stack_item(W)
+		if(!user.is_in_hands(src))
+			user.put_in_hand(src)
 		if(!success)
 			boutput(user, "<span class='alert'>You cannot combine [src] with [W] as they contain different materials!</span>")
 			return

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -159,11 +159,11 @@ MATERIAL
 				boutput(user, "<span class='alert'>You can't mix different reinforcements!</span>")
 				return
 			var/success = stack_item(W)
-			if(!user.is_in_hands(src))
-				user.put_in_hand(src)
 			if (!success)
 				boutput(user, "<span class='alert'>You can't put any more sheets in this stack!</span>")
 			else
+				if(!user.is_in_hands(src))
+					user.put_in_hand(src)
 				boutput(user, "<span class='notice'>You add [S] to the stack. It now has [S.amount] sheets.</span>")
 			return
 
@@ -728,11 +728,11 @@ MATERIAL
 				boutput(user, "<span class='alert'>You can't mix 2 stacks of different metals!</span>")
 				return
 			var/success = stack_item(W)
-			if(!user.is_in_hands(src))
-				user.put_in_hand(src)
 			if (!success)
 				boutput(user, "<span class='alert'>You can't put any more rods in this stack!</span>")
 			else
+				if(!user.is_in_hands(src))
+					user.put_in_hand(src)
 				boutput(user, "<span class='notice'>You add [success] rods to the stack. It now has [src.amount] rods.</span>")
 			return
 
@@ -1047,12 +1047,16 @@ MATERIAL
 
 		if (!( istype(W, /obj/item/tile) ))
 			return
+		if (W.material && src.material && !isSameMaterial(W.material, src.material))
+			boutput(user, "<span class='alert'>You can't mix 2 stacks of different metals!</span>")
+			return
 		var/success = stack_item(W)
+		if (!success)
+			boutput(user, "<span class='alert'>You can't put any more tiles in this stack!</span>")
+			return
 		if(!user.is_in_hands(src))
 			user.put_in_hand(src)
-		if(!success)
-			boutput(user, "<span class='alert'>You cannot combine [src] with [W] as they contain different materials!</span>")
-			return
+		boutput(user, "<span class='notice'>You add [success] tiles to the stack. It now has [src.amount] tiles.</span>")
 		tooltip_rebuild = 1
 		if (!W.pooled)
 			W.add_fingerprint(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title. Rods, floortiles, and sheets will yet again stay in your hand when you're stacking them off the floor.
Also adds a material check to the floortiles, to stop the game from screaming about stacking tiles with different materials when you're exceeding the max stack amount.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #4488
