### PR TITLE
Improve ATM responsiveness when using card or cash

### DIFF
--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -746,6 +746,7 @@
 		if(istype(I, /obj/item/card/id))
 			boutput(user, "<span class='notice'>You swipe your ID card in the ATM.</span>")
 			src.scan = I
+			attack_hand(user)
 			return
 		if(istype(I, /obj/item/spacecash/))
 			if (afterlife)
@@ -756,6 +757,7 @@
 				src.accessed_record.fields["current_money"] += I.amount
 				I.amount = 0
 				pool(I)
+				attack_hand(user)
 			else boutput(user, "<span class='alert'>You need to log in before depositing cash!</span>")
 			return
 		if(istype(I, /obj/item/lotteryTicket))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds an attack_hand call to the ATM's ID card and space cash interactions to refresh the ATM screen after using said items.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes ATMs vastly less annoying to use.

