### PR TITLE
Cog2 Interro Window Fix

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -32312,7 +32312,10 @@
 	dir = 4
 	},
 /obj/grille/steel,
-/turf/simulated/wall/auto/supernorn,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
 /area/station/security/main)
 "bvR" = (
 /obj/item/device/radio/intercom/security,
@@ -33407,17 +33410,21 @@
 /turf/simulated/floor/plating,
 /area/station/routing/security)
 "bxW" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/window/auto/reinforced,
 /obj/window_blinds/cog2{
 	dir = 4
 	},
 /obj/grille/steel,
-/turf/simulated/wall/auto/supernorn,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable,
+/turf/simulated/floor/plating,
 /area/station/security/main)
 "bxX" = (
 /obj/cable{


### PR DESCRIPTION
[mapping][bugfix]

## About the PR 
removes walls under interro windows on Cog2

## Why's this needed? 
how are people in the security router supposed to eavesdrop on interrogations otherwise?