### PR TITLE
Fixes broken item stacking for engi borg's building materials

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -562,15 +562,23 @@
 
 /obj/item/proc/stack_item(obj/item/other)
 	var/added = 0
-
-	if (other != src && check_valid_stack(other))
-		if (src.amount + other.amount > max_stack)
-			added = max_stack - src.amount
-		else
-			added = other.amount
-
-		src.change_stack_amount(added)
-		other.change_stack_amount(-added)
+	if(isrobot(other.loc))
+		max_stack = 500
+		if (other != src && check_valid_stack(src))
+			if (src.amount + other.amount > max_stack)
+				added = max_stack - other.amount
+			else
+				added = src.amount
+			src.change_stack_amount(-added)
+			other.change_stack_amount(added)
+	else
+		if (other != src && check_valid_stack(other))
+			if (src.amount + other.amount > max_stack)
+				added = max_stack - src.amount
+			else
+				added = other.amount
+			src.change_stack_amount(added)
+			other.change_stack_amount(-added)
 
 	return added
 

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -131,6 +131,8 @@ MATERIAL
 			..(user)
 
 	attackby(obj/item/W, mob/user as mob)
+		if(isrobot(user))
+			max_stack = 500
 		if (istype(W, /obj/item/sheet))
 			var/obj/item/sheet/S = W
 			if (S.material && src.material && !isSameMaterial(S.material, src.material))
@@ -692,6 +694,8 @@ MATERIAL
 			..(user)
 
 	attackby(obj/item/W as obj, mob/user as mob)
+		if(isrobot(user))
+			max_stack = 500
 		if (isweldingtool(W))
 			if(src.amount < 2)
 				boutput(user, "<span class='alert'>You need at least two rods to make a material sheet.</span>")
@@ -974,9 +978,9 @@ MATERIAL
 		..()
 		src.pixel_x = rand(0, 14)
 		src.pixel_y = rand(0, 14)
-		src.inventory_counter.update_number(amount)
 		SPAWN_DBG(0)
 			update_stack_appearance()
+			src.inventory_counter.update_number(amount)
 		return
 
 	check_valid_stack(atom/movable/O as obj)
@@ -1047,6 +1051,8 @@ MATERIAL
 
 		if (!( istype(W, /obj/item/tile) ))
 			return
+		if(isrobot(user))
+			max_stack = 500
 		if (W.material && src.material && !isSameMaterial(W.material, src.material))
 			boutput(user, "<span class='alert'>You can't mix 2 stacks of different materials!</span>")
 			return

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -131,8 +131,6 @@ MATERIAL
 			..(user)
 
 	attackby(obj/item/W, mob/user as mob)
-		if(isrobot(user))
-			max_stack = 500
 		if (istype(W, /obj/item/sheet))
 			var/obj/item/sheet/S = W
 			if (S.material && src.material && !isSameMaterial(S.material, src.material))
@@ -166,7 +164,10 @@ MATERIAL
 			else
 				if(!user.is_in_hands(src))
 					user.put_in_hand(src)
-				boutput(user, "<span class='notice'>You add [S] to the stack. It now has [S.amount] sheets.</span>")
+				if(isrobot(user))
+					boutput(user, "<span class='notice'>You add [success] sheets to the stack. It now has [S.amount] sheets.</span>")
+				else
+					boutput(user, "<span class='notice'>You add [success] sheets to the stack. It now has [src.amount] sheets.</span>")
 			return
 
 		else if (istype(W,/obj/item/rods))
@@ -694,8 +695,6 @@ MATERIAL
 			..(user)
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if(isrobot(user))
-			max_stack = 500
 		if (isweldingtool(W))
 			if(src.amount < 2)
 				boutput(user, "<span class='alert'>You need at least two rods to make a material sheet.</span>")
@@ -737,7 +736,10 @@ MATERIAL
 			else
 				if(!user.is_in_hands(src))
 					user.put_in_hand(src)
-				boutput(user, "<span class='notice'>You add [success] rods to the stack. It now has [src.amount] rods.</span>")
+				if(isrobot(user))
+					boutput(user, "<span class='notice'>You add [success] rods to the stack. It now has [W.amount] rods.</span>")
+				else
+					boutput(user, "<span class='notice'>You add [success] rods to the stack. It now has [src.amount] rods.</span>")
 			return
 
 		if (istype(W, /obj/item/organ/head))
@@ -1051,8 +1053,6 @@ MATERIAL
 
 		if (!( istype(W, /obj/item/tile) ))
 			return
-		if(isrobot(user))
-			max_stack = 500
 		if (W.material && src.material && !isSameMaterial(W.material, src.material))
 			boutput(user, "<span class='alert'>You can't mix 2 stacks of different materials!</span>")
 			return
@@ -1062,7 +1062,10 @@ MATERIAL
 			return
 		if(!user.is_in_hands(src))
 			user.put_in_hand(src)
-		boutput(user, "<span class='notice'>You add [success] tiles to the stack. It now has [src.amount] tiles.</span>")
+		if(isrobot(user))
+			boutput(user, "<span class='notice'>You add [success] tiles to the stack. It now has [W.amount] tiles.</span>")
+		else
+			boutput(user, "<span class='notice'>You add [success] tiles to the stack. It now has [src.amount] tiles.</span>")
 		tooltip_rebuild = 1
 		if (!W.pooled)
 			W.add_fingerprint(user)

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1446,7 +1446,7 @@
 					ReplaceWithEngineFloor()
 
 					if (C)
-						C:amount -= 2
+						C.change_stack_amount(-2)
 						if (C:amount <= 0)
 							qdel(C) //wtf
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

-Fixes inventory counter not updating when equipping floor tiles
-Fixes absolutely broken item stacking that just made stacking items as a borg impossible
-Increases max_stack for borgs to 500, so they can restock their materials up to the roundstart 500 they have
-Fixes inventory counter not updating when reinforcing the floors with rods


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Closes #4168
Fixes a bug I discovered
