### PR TITLE
Remove floor melting functionality from chems

### DIFF
--- a/code/procs/fireflash.dm
+++ b/code/procs/fireflash.dm
@@ -175,7 +175,7 @@
 /proc/fireflash_sm(atom/center, radius, temp, falloff, capped = 1, bypass_RNG = 0)
 	var/list/affected = fireflash_s(center, radius, temp, falloff)
 	for (var/turf/T in affected)
-		if (istype(T, /turf/simulated) && !T.loc:sanctuary)
+		if (istype(T, /turf/simulated/wall) && !T.loc:sanctuary)
 			var/mytemp = affected[T]
 			var/melt = 1643.15 // default steel melting point
 			if (T.material && T.material.hasProperty("flammable") && ((T.material.material_flags & MATERIAL_METAL) || (T.material.material_flags & MATERIAL_CRYSTAL) || (T.material.material_flags & MATERIAL_RUBBER)))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the floor melting functionality from chemicals by specifying that only simulated walls can be melted in fireflash.dm


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
In it's current state, it's way too easy to remove huge chunks of floors with chemicals. 
The time it takes for someone in chemistry to disable a department is under 1 minutes with just one chem smoke, 
The time it takes to repair and repressurise that department can take over 10 minutes, and thats being very generous. The ratio between the two isn't fair and its one of the many things that makes chemistry a frankly overpowered and annoying mechanic to deal with. Making an area completely inhabitable should require more effort a chem group button. bombs and RCDs are balanced in that regard.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Carbaodox
(*)Combustible chemicals no longer melt floor tiles like butter. They only have an effect on walls now
```
