### PR TITLE
Decreases implant breaking time.

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1170,7 +1170,7 @@ var/datum/action_controller/actions
 				O.show_message("<span class='alert'><B>[owner] butchers [target].[target.butcherable == 2 ? "<b>WHAT A MONSTER</b>" : null]</B></span>", 1)
 
 /datum/action/bar/icon/rev_flash
-	duration = 13 SECONDS
+	duration = 4 SECONDS
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED
 	id = "rev_flash"
 	icon = 'icons/ui/actions.dmi'


### PR DESCRIPTION
[Balance]
## About the PR 
Lowers the amount of time until a loyalty implant is broken by a revolutionary flash from 13 seconds to 4 seconds. This would make converting loyalty implanted crew members much easier than before and actually kinda feasible in an scuffle between the loyal and the revolutionaries.


## Why's this needed? 
Talked about this on gooncord, MBC and a few others seemed to have problems with the amount of time breaking an implant takes.

## Changelog

```changelog
(u)DimWhat
(*)The amount of time to break a loyalty implant with a revolutionary flash has been lowered to 4 seconds.
```
