### PR TITLE
feature: add hugs/love to the hypo whitelist for medical wholesomeness

### DIFF
--- a/code/modules/chemistry/tools/hyposprays.dm
+++ b/code/modules/chemistry/tools/hyposprays.dm
@@ -3,7 +3,8 @@ var/global/list/chem_whitelist = list("antihol", "charcoal", "epinephrine", "ins
 "oculine", "mannitol", "penteticacid", "styptic_powder", "methamphetamine", "spaceacillin", "saline",\
 "salicylic_acid", "cryoxadone", "blood", "bloodc", "synthflesh",\
 "menthol", "cold_medicine", "antihistamine", "ipecac",\
-"booster_enzyme", "anti_fart", "goodnanites", "smelling_salt")
+"booster_enzyme", "anti_fart", "goodnanites", "smelling_salt",\
+"hugs", "love")
 
 /* =================================================== */
 /* -------------------- Hypospray -------------------- */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Updates the Hypo chem whitelist to add Hugs & Love to it.  This also applies to the NT Syringe gun.

Thanks, Dr Floorpills, for the suggestion!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

sometimes, the shift is tough.  as MD you just need to go on a rampage
of wholesomeness with the NT Syringe gun.  if meth is in the whitelist,
why not allow for love and hugs to be as well?

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)imnotjames
(+)Allow love and hugs to be used in the hypo & NT Syringe gun.  Why can't we just all be friends?
```
