### PR TITLE
Rathen's Secret stun nerf

### DIFF
--- a/code/modules/events/gimmick/bigfart.dm
+++ b/code/modules/events/gimmick/bigfart.dm
@@ -157,7 +157,10 @@
 		boutput(H, "<span class='notification'>[changer ? "We" : "You"] hear an otherworldly force let out a short, disappointed cluck at [changer ? "our" : "your"] lack of an arse.</span>")
 	H.visible_message("<span class='alert'>[is_bot ? "Oily chunks of twisted shrapnel" : "Wadded hunks of blood and gore"] burst out of where <b>[H]</b>'s [magical ? "arse" : "ass"] used to be!</span>",\
 	"<span class='alert'>[nobutt_phrase[assmagic]]</span>")
-	H.changeStatus("weakened", 3 SECONDS)
+	if(magical)
+		H.changeStatus("weakened", 1 DECI SECOND)
+	else
+		H.changeStatus("weakened", 3 SECONDS)
 	H.force_laydown_standup()
 	if(!severed_something)
 		H.emote("scream")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Reduces the weakened duration of magical ass explosions from 3 seconds to 0.1 seconds (no change to forced laydown), causing its stun to be similar to a defibrillator's.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Prepared at mbc's request to put a damper on the ass-blasting meta.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(*)Rathen's Secret nerfed - weaken duration reduced from 3 seconds to 0.1 seconds.
```
