### PR TITLE
Fix for error in Kondaru router definition

### DIFF
--- a/code/obj/machinery/launcherloader_kondaru.dm
+++ b/code/obj/machinery/launcherloader_kondaru.dm
@@ -32,7 +32,7 @@
 
 /obj/machinery/cargo_router/kd_sci_eject
 	New()
-		destinations = list("Catering" = EAST,"Disposal" = EAST,"Pod Bay" = EAST,"Medbay" = EAST,"Research" = EAST,"Export" = SOUTH,"Security" = EAST,"Mining" = EAST,"Engineering" = EAST,"QM" = EAST)
+		destinations = list("Catering" = EAST,"Disposal" = EAST,"Pod Bay" = EAST,"Medbay" = EAST,"Research" = EAST,"Export" = EAST,"Security" = EAST,"Mining" = EAST,"Engineering" = EAST,"QM" = EAST)
 		default_direction = WEST
 		..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the definition for the kd_sci_eject cargo router (located right in front of the Research endpoint's insertion chute) to correctly send items tagged for Export to the east instead of south.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #4541
