### PR TITLE
Infinite capacity for Port-a-Puke

### DIFF
--- a/code/WorkInProgress/what-the-fuck-am-i-doing.dm
+++ b/code/WorkInProgress/what-the-fuck-am-i-doing.dm
@@ -184,6 +184,8 @@
 			src.SubscribeToProcess()
 		src.n_occupants++
 
+		src.update_icon()
+
 		occupant.bioHolder?.AddEffect("stinky")
 
 		for(var/obj/O in src)
@@ -203,5 +205,4 @@
 			return
 
 		src.add_fingerprint(usr)
-		src.on_accept_occupant(usr)
-		src.update_icon()
+		usr.set_loc(src)

--- a/code/WorkInProgress/what-the-fuck-am-i-doing.dm
+++ b/code/WorkInProgress/what-the-fuck-am-i-doing.dm
@@ -5,79 +5,129 @@
 	desc = "A weapon of pure terror."
 	density = 1
 	anchored = 0
-	var/mob/occupant = null
 	p_class = 1.5
+	processing_tier = PROCESSING_FULL
+	var/list/list/mob/occupant_buckets
+	var/current_bucket
+	var/n_occupants = 0
+	var/max_occupants = 1
+
+
+	New()
+		..()
+		src.occupant_buckets = list()
+		src.occupant_buckets.len = 8 // based on processing_tier
+		for(var/i in 1 to occupant_buckets.len)
+			src.occupant_buckets[i] = list()
+		src.UnsubscribeProcess() // will get subscribed when the first victim enters
+
+
+	disposing()
+		src.occupant_buckets = null
+		. = ..()
+
+
+	Exited(atom/movable/Obj, atom/newloc)
+		. = ..()
+		if(isliving(Obj))
+			src.on_eject_occupant(Obj)
+
+
+	Entered(atom/movable/Obj, atom/OldLoc)
+		if(isliving(Obj) && src.n_occupants >= src.max_occupants)
+			Obj.set_loc(OldLoc)
+			Obj.visible_message("<span class='alert'>[Obj] doesn't manage to fit into \the [src].</span>")
+			return FALSE
+		. = ..()
+		if(isliving(Obj))
+			src.on_accept_occupant(Obj)
+
 
 	process()
+		src.current_bucket++
+		for(var/mob/living/L in src.occupant_buckets[src.current_bucket])
+			src.process_occupant(L)
+		src.current_bucket = src.current_bucket % length(src.occupant_buckets)
 
-		if(src.occupant && ishuman(occupant))
-			var/mob/living/carbon/human/H = occupant
-
-			if(src.occupant.loc != src)
-				src.occupant = null
-				src.update_icon()
-				return
-
-			if (isdead(H))
-				src.visible_message("<span class='alert'>[src] spits out a dead corpse.</span>")
-				src.eject_occupant()
-				return
-
-			if(H.health <= -180 && prob(25))
-				src.visible_message("<span class='alert'>[src] spits out a near lifeless corpse.</span>")
-				src.eject_occupant()
-				return
-
-			src.occupant.TakeDamage("All", 10, 0, 0, DAMAGE_BLUNT)
-
-			playsound(get_turf(src), pick('sound/machines/mixer.ogg','sound/impact_sounds/Slimy_Splat_1.ogg','sound/misc/meat_plop.ogg','sound/effects/brrp.ogg','sound/impact_sounds/Metal_Clang_1.ogg','sound/effects/pump.ogg','sound/effects/syringeproj.ogg'), 100, 1)
-
-			if (prob(5))
-				visible_message("<span class='alert'>[H] pukes their guts out!</span>")
-				playsound(get_turf(src), pick('sound/impact_sounds/Slimy_Splat_1.ogg','sound/misc/meat_plop.ogg'), 100, 1)
-				for (var/turf/T in range(src, rand(1, 3)))
-					make_cleanable( /obj/decal/cleanable/blood/gibs,T)
-
-				if (prob(5) && H.organHolder && H.organHolder.heart)
-					H.organHolder.drop_organ("heart")
-					H.visible_message("<span class='alert'><b>Wait, is that their heart!?</b></span>")
-
-			if (prob(15))
-				visible_message("<span class='alert'>[src] sprays vomit all around itself!</span>")
-				playsound(get_turf(src), pick('sound/impact_sounds/Slimy_Splat_1.ogg','sound/misc/meat_plop.ogg'), 100, 1)
-				for (var/turf/T in range(src, rand(1, 3)))
-					if (prob(5))
-						make_cleanable( /obj/decal/cleanable/greenpuke,T)
-					else
-						make_cleanable( /obj/decal/cleanable/vomit,T)
-
-			if (prob(25))
-				for (var/mob/O in viewers(src, null))
-					if (O != occupant)
-						O.show_message("<span class='alert'><b>[occupant]</b> is puking over and over! It's all slimy and stringy. Oh god.</span>", 1)
-						if (prob(66) && ishuman(O))
-							O.show_message("<span class='alert'>You feel [pick("<b>really</b>", "")] ill from watching that.</span>")
-							for (var/mob/V in viewers(O, null))
-								V.show_message("<span class='alert'>[O] pukes all over \himself!</span>", 1)
-								O.vomit()
-
-			if (prob(30))
-				boutput(H, "<span class='alert'>You [pick("have a gut-wrenching sensation", "feel horribly sick", "feel like you're going to throw up", "feel like you're going to puke")]</span>")
-
-			if (prob(40))
-				H.emote("scream")
+		if(src.current_bucket == 0 && src.n_occupants > 0)
+			process_big_effects()
 
 
-		else
+	proc/process_big_effects()
+		playsound(get_turf(src),
+			pick(
+				"sound/machines/mixer.ogg",
+				"sound/impact_sounds/Slimy_Splat_1.ogg",
+				"sound/misc/meat_plop.ogg",
+				"sound/effects/brrp.ogg",
+				"sound/impact_sounds/Metal_Clang_1.ogg",
+				"sound/effects/pump.ogg",
+				"sound/effects/syringeproj.ogg")
+			, 100, 1)
+
+		if (prob(15))
+			visible_message("<span class='alert'>[src] sprays vomit all around itself!</span>")
+			playsound(get_turf(src), pick("sound/impact_sounds/Slimy_Splat_1.ogg","sound/misc/meat_plop.ogg"), 100, 1)
+			for (var/turf/T in range(src, rand(1, 3)))
+				if(T.density)
+					continue
+				if (prob(5))
+					make_cleanable(/obj/decal/cleanable/greenpuke, T)
+				else
+					make_cleanable(/obj/decal/cleanable/vomit, T)
+
+
+	proc/process_occupant(mob/living/occupant)
+		if(occupant.loc != src)
+			src.update_icon()
 			return
+
+		if (isdead(occupant))
+			src.visible_message("<span class='alert'>[src] spits out a dead corpse.</span>")
+			occupant.set_loc(src.loc)
+			return
+
+		if(occupant.health <= -180 && prob(25))
+			src.visible_message("<span class='alert'>[src] spits out a near lifeless corpse.</span>")
+			occupant.set_loc(src.loc)
+			return
+
+		occupant.TakeDamage("All", 10, 0, 0, DAMAGE_BLUNT)
+
+		if (prob(5))
+			visible_message("<span class='alert'>[occupant] pukes [his_or_her(occupant)] guts out!</span>")
+			playsound(get_turf(src), pick("sound/impact_sounds/Slimy_Splat_1.ogg","sound/misc/meat_plop.ogg"), 100, 1)
+			for (var/turf/T in range(src, rand(1, 3)))
+				if(T.density)
+					continue
+				make_cleanable(/obj/decal/cleanable/blood/gibs, T)
+
+			if (prob(5) && occupant.organHolder?.heart)
+				occupant.organHolder.drop_organ("heart")
+				occupant.visible_message("<span class='alert'><b>Wait, is that [his_or_her(occupant)] heart!?</b></span>")
+
+		if (prob(30))
+			boutput(occupant, "<span class='alert'>You [pick("have a gut-wrenching sensation", "feel horribly sick", "feel like you're going to throw up", "feel like you're going to puke")]</span>")
+
+		if (prob(25))
+			for (var/mob/O in viewers(src, null))
+				if (O == occupant || isdead(O))
+					continue
+				O.show_message("<span class='alert'><b>[occupant]</b> is puking over and over! It's all slimy and stringy. Oh god.</span>", 1)
+				if (prob(66))
+					O.vomit()
+					O.visible_message("<span class='alert'>[O] pukes all over \himself!</span>", "<span class='alert'>You feel [pick("<b>really</b>", "")] ill from watching that.</span>")
+
+		if (prob(40))
+			SPAWN_DBG(0) // linter demands this
+				occupant.emote("scream")
 
 
 	relaymove(mob/user as mob)
 		boutput(user, "<span class='alert'>You're trapped inside!</span>")
-		return
+
 
 	attackby(var/obj/item/I as obj, var/mob/user as mob)
-
 		if (!isliving(user))
 			boutput(user, "<span class='alert'>You're dead! Quit that!</span>")
 			return
@@ -88,30 +138,18 @@
 			if (!G.affecting || !ismob(G.affecting))
 				return
 
-			if (src.occupant)
-				boutput(user, "<span class='alert'>\the [src] already has a victim!</span>")
-				return
-
-			if (!ishuman(G.affecting))
-				boutput(user, "<span class='alert'>You can't put a non-human in there, you idiot!</span>")
-				return
-
-			var/mob/living/carbon/human/H = G.affecting
+			var/mob/living/target = G.affecting
 			var/mob/living/L = user
 
-			if (isdead(H))
-				boutput(user, "<span class='alert'>[H] is dead and cannot be forced to puke.</span>")
+			if (isdead(target))
+				boutput(user, "<span class='alert'>[target] is dead and cannot be forced to puke.</span>")
 				return
 
-			if (isghostdrone(L))
-				boutput(user, "<span class='alert'>You can't put a non-human in there, you idiot!</span>")
-				return
-
-			if (L.pulling == H)
+			if (L.pulling == target)
 				L.pulling = null
 
 			src.add_fingerprint(user)
-			src.accept_occupant(H)
+			target.set_loc(src)
 			src.update_icon()
 			qdel(G)
 			return
@@ -122,33 +160,39 @@
 			playsound(get_turf(src), "sound/items/Ratchet.ogg", 40, 0, 0)
 			return
 
-		..()
+		. = ..()
 
 
-	proc/eject_occupant()
-		if(src.occupant)
-			src.occupant.name_prefix("puke covered")
-			src.occupant.UpdateName()
-			src.occupant.set_loc(get_turf(src))
-			src.occupant = null
-			update_icon()
-			return
+	proc/on_eject_occupant(mob/living/occupant)
+		for(var/list/bucket in src.occupant_buckets)
+			bucket -= occupant
+		occupant.name_prefix("puke covered")
+		occupant.UpdateName()
+		src.n_occupants--
+		if(src.n_occupants <= 0)
+			src.UnsubscribeProcess()
+		update_icon()
 
-	proc/accept_occupant(var/mob/M)
-		if(!src.occupant)
-			src.occupant = M
+	proc/on_accept_occupant(mob/living/occupant)
+		var/list/target_bucket = src.occupant_buckets[1]
+		for(var/list/bucket in src.occupant_buckets)
+			if(length(bucket) < length(target_bucket))
+				target_bucket = bucket
+		target_bucket += occupant
 
-			M.bioHolder?.AddEffect("stinky")
+		if(src.n_occupants <= 0)
+			src.SubscribeToProcess()
+		src.n_occupants++
 
-			for(var/obj/O in src)
-				O.set_loc(get_turf(src))
+		occupant.bioHolder?.AddEffect("stinky")
 
-			M.set_loc(src)
+		for(var/obj/O in src)
+			O.set_loc(get_turf(src))
 
 
 	proc/update_icon()
-		icon_state = src.occupant ? "puke_1" : "puke_0"
-		return
+		icon_state = src.n_occupants > 0 ? "puke_1" : "puke_0"
+
 
 	verb/enter()
 		set name = "Enter"
@@ -158,16 +202,6 @@
 		if (!isalive(usr))
 			return
 
-		if (!ishuman(usr))
-			boutput(usr, "<span class='alert'>You're not a human, you can't put yourself in there!</span>")
-			return
-
-		if (src.occupant)
-			boutput(usr, "<span class='alert'>It's already occupied.</span>")
-			return
-
 		src.add_fingerprint(usr)
-		src.accept_occupant(usr)
+		src.on_accept_occupant(usr)
 		src.update_icon()
-
-		return

--- a/code/WorkInProgress/what-the-fuck-am-i-doing.dm
+++ b/code/WorkInProgress/what-the-fuck-am-i-doing.dm
@@ -10,7 +10,7 @@
 	var/list/list/mob/occupant_buckets
 	var/current_bucket
 	var/n_occupants = 0
-	var/max_occupants = 1
+	var/max_occupants = INFINITY
 
 
 	New()


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR refactors port-a-puke code to be less bad. It also adds support for multiple occupants and increases the occupant limit from 1 to infinity. Non-human mobs now fit into the port-a-puke. It now processes only when it needs to and it splits its occupants into buckets so they don't all puke at once and cause too much chat spam.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
@Camryn-Buttes requested I make this based on [this thread](https://forum.ss13.co/showthread.php?tid=16281) so ask her.


## Changelog

```changelog
(u)pali
(*)Port-a-Puke now has unlimited capacity for mobs
```
