### PR TITLE
fix: force the syndicate clown mask to equip even if wearing a mask

### DIFF
--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -340,6 +340,10 @@
 				U.visible_message(__red("[src] latches onto [T]'s face!"),__red("You slap [src] onto [T]'s face!'"))
 				logTheThing("combat",user,target,"forces [T] to wear [src] (cursed clown mask) at [log_loc(T)].")
 				U.u_equip(src)
+
+				// If we don't empty out that slot first, it could blip the mask out of existence
+				T.drop_from_slot(T.wear_mask)
+
 				T.equip_if_possible(src,T.slot_wear_mask)
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

this drops whatever mask the target was wearing when they have the syndicate
clown mask slapped onto their face.  it drops to the floor in the same
way the cluwne mask does

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

without this change, the syndicate clown mask will just blip out of existence
after it says it latches onto their face to everyone involved

fixes #4549

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(+)Wearing other masks no longer protects you from the Honking of the Syndicate Clown Mask
```
