### PR TITLE
Changes the AI eye's 'return to mainframe' verb to 'recall to mainframe' for consistency

### DIFF
--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -285,7 +285,7 @@
 
 	verb/cmd_return_mainframe()
 		set category = "AI Commands"
-		set name = "Return to Mainframe"
+		set name = "Recall to Mainframe"
 
 		return_mainframe()
 		return


### PR DESCRIPTION
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently if you're an AI in a shell, to return to your mainframe you use the 'recall to mainframe' verb. If you're an AI eye and want to do the same thing, you use the 'return to mainframe' verb. This isn't really noticeable if you're using the commands tab, but it's a bother if you're using the command bar for verbs.

'Return' and 'recall' are pretty much interchangeable here, but I picked recall because it sounds cooler.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the commands have different names despite being identical, and it's a weird inconsistency. I always mix up if I need to type 'return' or 'recall' into the command bar to head back to my mainframe.