### PR TITLE
feature: apply sonic stun from flashbang to deaf mobs

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2424,8 +2424,6 @@ datum
 							continue
 						if (!M.ears_protected_from_sound())
 							boutput(M, "<span class='alert'><b>[hootmode ? "HOOT" : "BANG"]</b></span>")
-						else
-							continue
 
 						var/checkdist = get_dist(M, location)
 						var/weak = max(0, 2 * (3 - checkdist))
@@ -2455,8 +2453,6 @@ datum
 								continue
 							if (!M.ears_protected_from_sound())
 								boutput(M, "<span class='alert'><b>[hootmode ? "HOOT" : "BANG"]</b></span>")
-							else
-								continue
 
 							var/checkdist = get_dist(M, location)
 							var/weak = max(0, 2 * (3 - checkdist))

--- a/code/obj/artifacts/artifact_machines/noise_maker.dm
+++ b/code/obj/artifacts/artifact_machines/noise_maker.dm
@@ -76,8 +76,6 @@
 					continue
 				if (!M.ears_protected_from_sound())
 					boutput(M, "<span class='alert'>The loud, horrible noises painfully batter your eardrums!</span>")
-				else
-					continue
 
 				var/weak = 0
 				var/ear_damage = 2

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -324,10 +324,10 @@
 		return 0
 	return 1
 
-/mob/proc/hearing_check(var/consciousness_check = 0)
+/mob/proc/hearing_check(var/consciousness_check = 0, var/ear_disability_check = 1)
 	return 1
 
-/mob/living/carbon/human/hearing_check(var/consciousness_check = 0)
+/mob/living/carbon/human/hearing_check(var/consciousness_check = 0, var/ear_disability_check = 1)
 	if (consciousness_check && (src.stat || src.getStatusDuration("paralysis") || src.sleeping))
 		// you may be physically capable of hearing it, but you're sure as hell not mentally able when you're out cold
 		.= 0
@@ -340,24 +340,24 @@
 			else if (src.ears.block_hearing_when_worn <= HEARING_ANTIDEAF)
 				return 1
 
-		if (src.ear_disability || src.get_ear_damage(1))
+		if (ear_disability_check && (src.ear_disability || src.get_ear_damage(1)))
 			.= 0
 
-/mob/living/silicon/hearing_check(var/consciousness_check = 0)
+/mob/living/silicon/hearing_check(var/consciousness_check = 0, var/ear_disability_check = 1)
 	if (consciousness_check && (src.getStatusDuration("paralysis") || src.sleeping || src.stat))
 		return 0
 
-	if (src.ear_disability)
+	if (ear_disability_check && src.ear_disability)
 		return 0
 
 	return 1
 
 // Bit redundant at the moment, but we might get ear transplants at some point, who knows? Just put 'em here (Convair880).
-/mob/proc/ears_protected_from_sound()
+/mob/proc/ears_protected_from_sound(var/ear_disability_check = 1)
 	return 0
 
-/mob/living/carbon/human/ears_protected_from_sound()
-	if (!src.hearing_check(1))
+/mob/living/carbon/human/ears_protected_from_sound(var/ear_disability_check = 1)
+	if (!src.hearing_check(1, ear_disability_check))
 		return 1
 	return 0
 
@@ -372,6 +372,9 @@
 	if (DO_NOTHING)
 		return
 
+	// If the target is deaf but is still affected, set this to true
+	var/is_deaf = FALSE
+
 	// Target checks.
 	var/mod_weak = 0 // Note: these aren't multipliers.
 	var/mod_stun = 0
@@ -381,8 +384,17 @@
 	var/mod_eardamage = 0
 	var/mod_eartempdeaf = 0
 
-	if (src.ears_protected_from_sound())
+	if (src.ears_protected_from_sound(0))
 		return
+
+	if (!src.hearing_check())
+		// If the target's ears aren't protected from sound
+		// but the target fails the hearing check then we mark
+		// them as deaf and won't damage their ears more.
+		// However, we will still apply this as a concussion.
+		mod_eardamage = -INFINITY
+		mod_eartempdeaf = -INFINITY
+		is_deaf = TRUE
 
 	if (ishuman(src))
 		var/mob/living/carbon/human/H = src
@@ -405,7 +417,10 @@
 	//DEBUG_MESSAGE("Apply_sonic_stun() called for [src] at [log_loc(src)]. W: [weak], S: [stun], MS: [misstep], SL: [slow], DI: [drop_item], ED: [ears_damage], EF: [ear_tempdeaf]")
 
 	// Stun target mob.
-	boutput(src, "<span class='alert'><b>You hear an extremely loud noise!</b></span>")
+	if (is_deaf)
+		boutput(src, "<span class='alert'><b>You feel a wave of concussive force rattle your head!</b></span>")
+	else
+		boutput(src, "<span class='alert'><b>You hear an extremely loud noise!</b></span>")
 
 
 #ifdef USE_STAMINA_DISORIENT
@@ -428,7 +443,10 @@
 			src.take_ear_damage(ear_tempdeaf, 1)
 
 		if (weak == 0 && stun == 0 && prob(max(0, min(drop_item, 100))))
-			src.show_message(__red("<B>You drop what you were holding to clutch at your ears!</B>"))
+			if (is_deaf)
+				src.show_message(__red("<B>You drop what you were holding to clutch at your head!</B>"))
+			else
+				src.show_message(__red("<B>You drop what you were holding to clutch at your ears!</B>"))
 			src.drop_item()
 
 	return


### PR DESCRIPTION
[BALANCE] [INPUT WANTED]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

if the mob is deaf and is not wearing the auditory headset
we should still apply the sonic stun to them.

this does not affect users wearing earplugs or earmuffs because of space magic

Testing Done

- [x] Deaf Trait with Auditory Headset in - treats you like you aren't deaf
- [x] Deaf Trait without auditory headset - treats you like you're deaf
- [x] Deaf Trait with earplugs in - completely immune to the flashbang
- [x] Temporary Deafness without Earplugs - treats you like you're deaf, doesn't further damage ears
- [x] No Deaf Trait without Auditory Headset - treats you like you're not deaf, damages ears
- [x] No Deaf Trait without Auditory Headset - treats you like you're not deaf, damages ears
- [x] No Deaf Trait with earplugs in - completely immune to flashbang

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

balance: it's become a bit of a "thing" on the main servers to run with the deaf trait.  it's a +1 trait point.
however, if you pair it with sechuds, when you go up against any security force, you pop out the
auditory headset and voila, completely immune to flashbangs.  Same immunity when you're going
against vampires or shamblers.

even without hearing, sonic blasts affect those that are unable to hear in various ways in "reality", so
I don't think this is too out there for the RP servers

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(*)Apply sonic stun to deaf mobs even without auditory headset - such as the shambler scream, vampire screech, and flashbangs.
```
