### PR TITLE
Adjust silver fulminate

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -183,7 +183,7 @@ datum
 
 			physical_shock(var/force)
 				if (volume <= holder.total_volume/4) //be somewhat stable to shock if prepared like bang snaps
-					if (prob(max(0,force-12)*12) //safe to run with, but not sprint. 24% chance to pop on your face when thrown
+					if (prob(max(0,force-12)*12)) //safe to run with, but not sprint. 24% chance to pop on your face when thrown
 						explode()
 				else
 					if (prob(force*5))

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -157,7 +157,7 @@ datum
 				var/datum/reagents/silver_fulminate_holder = holder
 				var/silver_fulminate_volume = volume
 				silver_fulminate_holder.del_reagent("silver_fulminate")
-				silver_fulminate_holder.temperature_reagents(silver_fulminate_holder.total_temperature + silver_fulminate_volume*200,10,35,500)
+				silver_fulminate_holder.temperature_reagents(silver_fulminate_holder.total_temperature + silver_fulminate_volume*20,10,1,500)
 
 			reaction_temperature(var/exposed_temperature, var/exposed_volume)
 				if (exposed_temperature >= T0C + 30)
@@ -182,8 +182,12 @@ datum
 				pop(get_turf(O), amount)
 
 			physical_shock(var/force)
-				if (prob(force*5))
-					explode()
+				if (volume <= holder.total_volume/4) //be somewhat stable to shock if prepared like bang snaps
+					if (prob(max(0,force-12)*12) //safe to run with, but not sprint. 24% chance to pop on your face when thrown
+						explode()
+				else
+					if (prob(force*5))
+						explode()
 
 			on_transfer(var/datum/reagents/source, var/datum/reagents/target, var/transferred_volume)
 				var/datum/reagent/silver_fulminate/target_silver_fulminate = target.get_reagent("silver_fulminate")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Improves silver fulminate's ability to be used as a primary explosive and bang snap, improving its strength as a heating element, namely:
Ups its heating strength to allow it to cause reactions (20K per unit, up to its' built-in maximum of 10 units where it explodes)
Makes fulminate stable enough to run with (but not sprint with) if it's diluted down to 25% or less. inspired by how bang snaps work but space-ified to make it usable

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows silver fulminate to be used as bang snaps, but with potentially mean/interesting applications. As a disincentive for particularly mean mixes, if thrown it has a 24% chance of blowing up in your face instead.

My patch fixing its' heating ability last year still left it as pretty much unused, so maybe this'll carve out a niche for it.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TDHooligan
(+)Silver fulminate is now hotter & significantly safer to carry when 25% concentrated or less.
```


[balance]