### PR TITLE
prevent unscrewing the nuclear bomb from nukeops mode

### DIFF
--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -95,7 +95,7 @@
 			if (!src.anchored)
 				. += "The floor bolts have been unsecured. The bomb can be moved around."
 			else
-				. += "It is firmly anchored to the floor by its floor bolts. A screwdriver could undo them."
+				. += "It is firmly anchored to the floor by its floor bolts."
 
 			switch(src._health)
 				if(80 to 125)
@@ -228,7 +228,8 @@
 
 			if (src.armed && src.anchored && !(user.mind in NUKEMODE.syndicates))
 				if (isscrewingtool(W))
-					actions.start(new /datum/action/bar/icon/unanchorNuke(src), user)
+					// Give the player a notice so they realize what has happened
+					boutput(user, "<span class='alert'>The screws are all weird safety-bit types! You can't turn them!</span>")
 					return
 				//else if (istype(W,/obj/item/wirecutters/))
 				//	user.visible_message("<b>[user]</b> opens up [src]'s wiring panel and takes a look.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

removes the ability to unanchor the nuke once it's been anchored

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

this is very often done by crew members and helpful borgs, not
realizing that the nukies will steal the nuke and hide it in a pod, the 
listening post, or really any other random spot on the station Z level that
is difficult to find within the now-reduced time period

or a borg will zip zop zoom on in, unscrew the nuke, and then
zoom off station to hide it in another z-level.  the nukies then just
kinda sit there a bit dumbfounded, unsure what to do

instantly it turns the mode from being a king of the
hill to a hide-and-seek kind of game, which does not seem to
be the intention of this game mode

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(*)Removes the ability to unanchor the nuclear bomb once it's been anchored
```
