### PR TITLE
Resolve TEG alloying and Sleeping Haunted TEG

### DIFF
--- a/code/WorkInProgress/TempEngine.dm
+++ b/code/WorkInProgress/TempEngine.dm
@@ -923,7 +923,7 @@ datum/pump_ui/circulator_ui
 			if(probmult(5)) grump -= (min(stoked_sum/10, 15)*mult)
 
 		// Use classic grump if not handled by variant
-		if(!src.active_form?.on_grump(src, mult))
+		if(!src.active_form?.on_grump(mult))
 			classic_grump(mult)
 
 	// engine looping sounds and hazards

--- a/code/datums/teg_transform.dm
+++ b/code/datums/teg_transform.dm
@@ -90,14 +90,14 @@ datum/teg_transformation
 		. = ..()
 
 	/// Return False by default to cause classic grump behavior
-	proc/on_grump()
+	proc/on_grump(mult)
 		return FALSE
 
 	/// Base transformation to assign material
 	proc/on_transform(obj/machinery/power/generatorTemp/teg)
 		var/datum/material/M
 		src.teg = teg
-		if(src.mat_id)
+		if(initial(src.mat_id))
 			M = getMaterial(src.mat_id)
 		else
 			M = copyMaterial(src.teg.semiconductor.material)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - major]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Corrects bug introduced to ensure Haunted TEG does not get superseded by matsci TEG.  This reintroduced use of "getMaterial" for alloy material strings which is invalid.

-  Current behavior fails into a functioning state where the transformation never completes as it attempts to assign the material "null" which does not match the material of the semiconductor causing it to attempt to transform forever.  It never benefits from the material but continues to function as if it had never transformed.

Corrects bug introduced when converting probability to `probmult()` for Haunted TEG where I assumed I was just cleaning up maths but changed how a function was being called along the way.  This caused the Haunted TEG grump to be incorrectly called causing it to just... sit there... dreaming... waiting for the stars to be right...

- If Haunted TEG entered the failed state no action would be taken.  Passing a reference as `mult` to `percentmult` appears to not result in a case where the prob() call would never (or EXTREMELY rarely) be called.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves inability to alloy TEG
Resolves inactivity of Haunted TEG