### PR TITLE
Makes the armory auth cancelable by the HoS

### DIFF
--- a/.github/CONTRIBUTOR_GUIDELINES.md
+++ b/.github/CONTRIBUTOR_GUIDELINES.md
@@ -2,6 +2,8 @@
 
 [ToC]
 
+{%hackmd @ZeWaka/dark-theme %}
+
 ## Making PRs (read before making a PR)
 Aside from the actual changes to the repo that you make, opening a PR has some required sections in the initial PR comment. Here are the general guidelines for filling out each section.
 
@@ -12,10 +14,10 @@ Aside from the actual changes to the repo that you make, opening a PR has some r
 - Give your reasoning or opinion why you think your change is needed or would improve things.
 
 ### Changelog (Optional)
-* Use the markdown and text`## Changelog` to denote this section. (our changelog bot searches for this string)
+* Use the markdown and text`## Changelog` to denote this section. Be sure to use the code block with `‍```changelog`.
 * This section is **not required** for small changes such as: code cleanup, small sprite updates, small code changes that don't result in balance issues, small map changes.
-* Use the **minor tag**, (+) for things like multiple sprite changes or updates, adding a small feature, making a small change to an existing object/process.
-* Use the **major tag**, (*) for things that are large changes. Things that affect game balance in any modest way, adding a new feature, updating a whole large suite of sprites, making a large change to a current map such as changing a department layout or moving critical systems or door access.
+* Use the **minor tag**, `(+)` for things like multiple sprite changes or updates, adding a small feature, making a small change to an existing object/process.
+* Use the **major tag**, `(*)` for things that are large changes. Things that affect game balance in any modest way, adding a new feature, updating a whole large suite of sprites, making a large change to a current map such as changing a department layout or moving critical systems or door access.
 * The most important thing to remember when making changelog entries is that you keep text **descriptive and concise**. Keep related changelog entries to one line when possible. Unless your PR is touches lots of different systems and is very large or makes lots of balance changes, you'll likely never need more than 3 lines or sentences. Think of what information will be relevant to a player.
 * Your suggested changelog can be changed by devs prior to being merged if the merging developer is dissatisfied with it. This will be done by editing the initial comment on the PR made by the contributor so our bot can parse that text and add it to the viewable in-game changelog.
 * If you use sprites from another user, do your best to credit them in a changelog bullet entry.

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -187,21 +187,25 @@
 		return ..()
 
 	if (!W:access) //no access
+		src.add_fingerprint(user)
 		boutput(user, "The access level of [W] is not high enough.")
 		return
 
 	var/list/cardaccess = W:access
 	if(!istype(cardaccess, /list) || !length(cardaccess)) //no access
+		src.add_fingerprint(user)
 		boutput(user, "The access level of [W] is not high enough.")
 		return
 
 	if(!(access_securitylockers in W:access)) //doesn't have this access
+		src.add_fingerprint(user)
 		boutput(user, "The access level of [W] is not high enough.")
 		return
 
 	if(authed && (access_maxsec in W:access))
 		var/choice = alert(user, "Would you like to unauthorize security's access to riot gear?", "Armory Unauthorization", "Unauthorize", "No")
 		if(get_dist(user, src) > 1) return
+		src.add_fingerprint(user)
 		switch(choice)
 			if("Unauthorize")
 				if(GET_COOLDOWN(src, "unauth"))
@@ -222,6 +226,7 @@
 
 	var/choice = alert(user, text("Would you like to authorize access to riot gear? [] authorization\s are still needed.", src.auth_need - src.authorized.len), "Armory Auth", "Authorize", "Repeal")
 	if(get_dist(user, src) > 1) return
+	src.add_fingerprint(user)
 	switch(choice)
 		if("Authorize")
 			if (user in src.authorized)

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -176,9 +176,6 @@
 		return ..()
 	if (!user)
 		return ..()
-	if(authed && (!(access_maxsec in W:access)))
-		boutput(user, "Armory has already been authorized!")
-		return
 
 	if (istype(W, /obj/item/device/pda2) && W:ID_card)
 		W = W:ID_card
@@ -200,6 +197,10 @@
 	if(!(access_securitylockers in W:access)) //doesn't have this access
 		src.add_fingerprint(user)
 		boutput(user, "The access level of [W] is not high enough.")
+		return
+
+	if(authed && (!(access_maxsec in W:access)))
+		boutput(user, "Armory has already been authorized!")
 		return
 
 	if(authed && (access_maxsec in W:access))

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -68,12 +68,15 @@
 			if ("help")
 				if (!signal.data["topic"])
 					returnsignal.data["description"] = "Armory Authorization Computer - allows for lowering of armory access level to SECURITY. Wireless authorization requires NETPASS_HEADS"
-					returnsignal.data["topics"] = "authorize"
+					returnsignal.data["topics"] = "authorize and unauthorize"
 				else
 					returnsignal.data["topic"] = signal.data["topic"]
 					switch (lowertext(signal.data["topic"]))
 						if ("authorize")
 							returnsignal.data["description"] = "Authorizes armory access. Requires NETPASS_HEADS. Requires close range transmission."
+							returnsignal.data["args"] = "acc_code"
+						if ("unauthorize")
+							returnsignal.data["description"] = "Unauthorizes armory access. Requires NETPASS_HEADS. Requires close range transmission."
 							returnsignal.data["args"] = "acc_code"
 						else
 							returnsignal.data["description"] = "ERROR: UNKNOWN TOPIC"
@@ -86,6 +89,18 @@
 					returnsignal.data["acc_code"] = netpass_security
 					returnsignal.data["data"] = "authorize"
 					authorize()
+				else
+					returnsignal.data["command"] = "nack"
+					returnsignal.data["data"] = "badpass"
+			if ("unauthorize")
+				if(!IN_RANGE(signal.source, src, radiorange))
+					returnsignal.data["command"] = "nack"
+					returnsignal.data["data"] = "outofrange"
+				else if (signal.data["acc_code"] == netpass_heads)
+					returnsignal.data["command"] = "ack"
+					returnsignal.data["acc_code"] = netpass_security
+					returnsignal.data["data"] = "unauthorize"
+					unauthorize()
 				else
 					returnsignal.data["command"] = "nack"
 					returnsignal.data["data"] = "badpass"
@@ -189,11 +204,11 @@
 		if(get_dist(user, src) > 1) return
 		switch(choice)
 			if("Unauthorize")
-				if(ON_COOLDOWN(src, "unauth", 5 MINUTES))
-					boutput(user, "<span class='alert'> The armory computer cannot take your commands at the moment! Wait [ON_COOLDOWN(src, "unauth", 0)/10] seconds!</span>")
+				if(GET_COOLDOWN(src, "unauth"))
+					boutput(user, "<span class='alert'> The armory computer cannot take your commands at the moment! Wait [GET_COOLDOWN(src, "unauth")/10] seconds!</span>")
 					playsound( src.loc,"sound/machines/airlock_deny.ogg", 10, 0 )
 					return
-				if(!ON_COOLDOWN(src, "Unauth", 5 MINUTES))
+				if(!ON_COOLDOWN(src, "unauth", 5 MINUTES))
 					unauthorize()
 					playsound(src.loc,"sound/machines/chime.ogg", 10, 1)
 					boutput(user,"<span class='notice'> The armory's equipments have returned to having their default access!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. --> [BALANCE] [INPUT WANTED] [WIKI]
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the HoS able to unauth the armory, it has a cooldown to prevent spamming auth messages, 5 minutes, might be too much, unsure, one thing I wish I had done but I couldn't wrap my head around it was making unauthing it send a pda message to the sec mail group, I am also unsure if the sounds I used are good, they were the best things I could think of, I am taking suggestions.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It is a pretty common request from HoS players as there is currently no way of closing the armory after it has been authorized.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Arthur Holiday
(*)The HoS can now unauthorize the armory.
```
