### PR TITLE
Use a first aid kit on a medical belt to load all the contents with one click

### DIFF
--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -355,6 +355,16 @@
 	)
 	in_list_or_max = 1
 
+	attackby(obj/item/W as obj, mob/user as mob, obj/item/storage/T)
+		if (istype(W, /obj/item/storage/firstaid/regular))
+			var/obj/item/storage/S = W
+			for (var/obj/item/I in S.get_contents())
+				if (..(I, user, S) == 0)
+					break
+			return
+		else
+			return ..()
+
 /obj/item/storage/belt/mining
 	name = "miner's belt"
 	desc = "Can hold various mining tools."

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -200,14 +200,6 @@
 		if(!can_use())
 			boutput(user, "<span class='alert'>You need to wear [src] for that.</span>")
 			return
-		if (istype(W, /obj/item/storage/toolbox) || istype(W, /obj/item/storage/box) || istype(W, /obj/item/storage/belt))
-			var/obj/item/storage/S = W
-			for (var/obj/item/I in S.get_contents())
-				if (..(I, user, S) == 0)
-					break
-			return
-		else
-			return ..()
 
 /obj/item/storage/belt/utility
 	name = "utility belt"
@@ -354,16 +346,6 @@
 		/obj/item/robodefibrillator
 	)
 	in_list_or_max = 1
-
-	attackby(obj/item/W as obj, mob/user as mob, obj/item/storage/T)
-		if (istype(W, /obj/item/storage/firstaid/regular))
-			var/obj/item/storage/S = W
-			for (var/obj/item/I in S.get_contents())
-				if (..(I, user, S) == 0)
-					break
-			return
-		else
-			return ..()
 
 /obj/item/storage/belt/mining
 	name = "miner's belt"

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -200,6 +200,7 @@
 		if(!can_use())
 			boutput(user, "<span class='alert'>You need to wear [src] for that.</span>")
 			return
+		return ..()
 
 /obj/item/storage/belt/utility
 	name = "utility belt"

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -128,6 +128,12 @@
 			return
 		var/canhold = src.check_can_hold(W,user)
 		if (canhold <= 0)
+			if(istype(W, /obj/item/storage) && (canhold == 0 || canhold == -1))
+				var/obj/item/storage/S = W
+				for (var/obj/item/I in S.get_contents())
+					if(src.check_can_hold(I) > 0)
+						src.attackby(I, user, S)
+				return
 			switch (canhold)
 				if(0)
 					boutput(user, "<span class='alert'>[src] cannot hold [W].</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The Medical Doctor spawns with an empty medical belt and a full First Aid kit, and has to load all the contents of the first aid kit one by one into the belt. This takes the functionality of the Engineer's ability to auto-load their toolbox into their utility belt, and adds it to the basic First Aid kit and medical belt.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Removes a very annoying inventory shuffle for doctors at roundstart.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Jan.antilles
(*)Using a First Aid kit on a Medical Belt now loads the kit's contents into the belt with one click.
```
