### PR TITLE
Hitting a small storage container with another small storage container moves the contents

### DIFF
--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -355,6 +355,16 @@
 	)
 	in_list_or_max = 1
 
+	attackby(obj/item/W as obj, mob/user as mob, obj/item/storage/T)
+		if (istype(W, /obj/item/storage/firstaid/regular))
+			var/obj/item/storage/S = W
+			for (var/obj/item/I in S.get_contents())
+				if (..(I, user, S) == 0)
+					break
+			return
+		else
+			return ..()
+
 /obj/item/storage/belt/mining
 	name = "miner's belt"
 	desc = "Can hold various mining tools."

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -200,14 +200,6 @@
 		if(!can_use())
 			boutput(user, "<span class='alert'>You need to wear [src] for that.</span>")
 			return
-		if (istype(W, /obj/item/storage/toolbox) || istype(W, /obj/item/storage/box) || istype(W, /obj/item/storage/belt))
-			var/obj/item/storage/S = W
-			for (var/obj/item/I in S.get_contents())
-				if (..(I, user, S) == 0)
-					break
-			return
-		else
-			return ..()
 
 /obj/item/storage/belt/utility
 	name = "utility belt"
@@ -354,16 +346,6 @@
 		/obj/item/robodefibrillator
 	)
 	in_list_or_max = 1
-
-	attackby(obj/item/W as obj, mob/user as mob, obj/item/storage/T)
-		if (istype(W, /obj/item/storage/firstaid/regular))
-			var/obj/item/storage/S = W
-			for (var/obj/item/I in S.get_contents())
-				if (..(I, user, S) == 0)
-					break
-			return
-		else
-			return ..()
 
 /obj/item/storage/belt/mining
 	name = "miner's belt"

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -200,6 +200,7 @@
 		if(!can_use())
 			boutput(user, "<span class='alert'>You need to wear [src] for that.</span>")
 			return
+		return ..()
 
 /obj/item/storage/belt/utility
 	name = "utility belt"

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -128,6 +128,12 @@
 			return
 		var/canhold = src.check_can_hold(W,user)
 		if (canhold <= 0)
+			if(istype(W, /obj/item/storage) && (canhold == 0 || canhold == -1))
+				var/obj/item/storage/S = W
+				for (var/obj/item/I in S.get_contents())
+					if(src.check_can_hold(I) > 0)
+						src.attackby(I, user, S)
+				return
 			switch (canhold)
 				if(0)
 					boutput(user, "<span class='alert'>[src] cannot hold [W].</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Hitting a small storage container like a box, kit, backpack, or belt with another small storage item that cannot be placed into it will now move all the contents into the container instead. This takes the functionality that allowed for an Engineer to click their empty belt with a toolbox and move over all the toolbox's contents, and moves it to the storage container parent so that everyone can do a little less click-shuffling.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This takes a quality of life feature that is great for Engineers and expands it, making the change at the parent level to avoid code duplication across container types.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Jan.antilles
(*)Hitting a small storage container (such as a box or belt) with another small storage container that can't fit into it will move all its contents with one click.
```
