### PR TITLE
Small fix for Donut 3 disposal pipes

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -47619,7 +47619,6 @@
 /obj/grille/catwalk/jen/side{
 	dir = 4
 	},
-/obj/disposalpipe/segment,
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -79902,15 +79901,8 @@
 /area/station/medical/medbay/lobby)
 "xrP" = (
 /obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/grille/catwalk/jen/side{
 	dir = 4
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes disposal network connection with the research chutes and removes two leftover pipes

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugfix

