### PR TITLE
Adds acid-proof masks to the Cairngorm

### DIFF
--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -166,6 +166,10 @@
 	color_g = 0.8
 	color_b = 0.8
 
+	syndicate
+		name = "syndicate field protective mask"
+		item_function_flags = IMMUNE_TO_ACID
+
 /obj/item/clothing/mask/gas/voice
 	name = "gas mask"
 	desc = "A close-fitting mask that can filter some environmental toxins or be connected to an air supply."

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -81414,14 +81414,16 @@
 /area/centcom/lounge)
 "sdh" = (
 /obj/rack,
-/obj/item/clothing/mask/gas/swat,
-/obj/item/clothing/mask/gas/swat,
-/obj/item/clothing/mask/gas/swat,
-/obj/item/clothing/mask/gas/swat,
-/obj/item/clothing/mask/gas/swat,
-/obj/item/clothing/mask/gas/swat,
-/obj/item/clothing/mask/gas/swat,
-/obj/item/clothing/mask/gas/swat,
+/obj/item/clothing/mask/gas/swat/syndicate,
+/obj/item/clothing/mask/gas/swat/syndicate,
+/obj/item/clothing/mask/gas/swat/syndicate,
+/obj/item/clothing/mask/gas/swat/syndicate,
+/obj/item/clothing/mask/gas/swat/syndicate,
+/obj/item/clothing/mask/gas/swat/syndicate,
+/obj/item/clothing/mask/gas/swat/syndicate,
+/obj/item/clothing/mask/gas/swat/syndicate,
+/obj/item/clothing/mask/gas/swat/syndicate,
+/obj/item/clothing/mask/gas/swat/syndicate,
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "seT" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds acid proof masks to the Cairngorm, replacing the non-acid proof swat masks.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nuke ops armour and helmets are acid-proof. Why not masks too?


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gannets
(+)Added acid-proof masks to the Cairngorm
```
