### PR TITLE
Fix renaming objects, cyborgs, ID cards, and so forth

### DIFF
--- a/code/obj.dm
+++ b/code/obj.dm
@@ -105,7 +105,7 @@
 
 	UpdateName()
 		if (isnull(src.real_name && !isnull(src.name))
-			real_name = name
+			src.real_name = src.name
 		src.name = "[name_prefix(null, 1)][src.real_name || initial(src.name)][name_suffix(null, 1)]"
 
 	proc/can_access_remotely(mob/user)

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -102,6 +102,7 @@
 			artifact:holder = null
 		remove_dialogs()
 		..()
+
 	UpdateName()
 		if (src.real_name == null && name != null)
 			real_name = name

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -102,6 +102,10 @@
 			artifact:holder = null
 		remove_dialogs()
 		..()
+	UpdateName()
+		if (src.real_name == null && name != null)
+			real_name = name
+		src.name = "[name_prefix(null, 1)][src.real_name || initial(src.name)][name_suffix(null, 1)]"
 
 	proc/can_access_remotely(mob/user)
 		. = FALSE

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -104,7 +104,7 @@
 		..()
 
 	UpdateName()
-		if (src.real_name == null && name != null)
+		if (isnull(src.real_name && !isnull(src.name))
 			real_name = name
 		src.name = "[name_prefix(null, 1)][src.real_name || initial(src.name)][name_suffix(null, 1)]"
 

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -104,7 +104,7 @@
 		..()
 
 	UpdateName()
-		if (isnull(src.real_name && !isnull(src.name))
+		if (isnull(src.real_name) && !isnull(src.name))
 			src.real_name = src.name
 		src.name = "[name_prefix(null, 1)][src.real_name || initial(src.name)][name_suffix(null, 1)]"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

We use real_name in updating the name of objects now, and if we update the name of something with no real_name we define one as the current name.

This fixes a huge variety of renaming bugs, lablers now work on ID cards and borgs and as far as I can tell anything else.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Borgs don't like losing their name and ID cards were weird and also these problems were everywhere
Fixes #4592 , probably others.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Penny
(+)Hand labeler will no longer destroy the names of borgs, ID cards, and other items
```
