### PR TITLE
feat: prioritize completion when cloning with many pods

### DIFF
--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -142,9 +142,8 @@
 	get_desc(dist, mob/user)
 		. = ""
 		if ((!isnull(src.occupant)) && (!isdead(src.occupant)))
-			var/completion = clamp(100 - ((src.occupant.max_health - src.occupant.health) - heal_level), 0, 100)
 			//var/completion = (100 * ((src.occupant.health + 100) / (src.heal_level + 100)))
-			. += "<br>Currently [!src.attempting ? "preparing a new body" : "cloning [src.occupant]"]. [round(completion)]% complete."
+			. += "<br>Currently [!src.attempting ? "preparing a new body" : "cloning [src.occupant]"]. [src.get_progress()]% complete."
 
 		var/meat_pct = round( 100 * (src.meat_level / MAXIMUM_MEAT_LEVEL) )
 
@@ -425,7 +424,7 @@
 				power_usage = 200
 				return ..()
 
-			else if ((src.occupant.max_health - src.occupant.health) > src.heal_level)
+			else if (src.get_progress() < 100)
 
 				if (src.attempting)
 					// If we're cloning an actual person, make weird noises
@@ -476,7 +475,7 @@
 					src.failed_tick_counter = 0
 				previous_heal = src.occupant.health
 
-				if ((src.occupant.health + (100 - src.occupant.max_health)) > 50 && src.failed_tick_counter >= 2 && (src.time_started + eject_wait < TIME))
+				if (src.get_progress() > 50 && src.failed_tick_counter >= 2 && (src.time_started + eject_wait < TIME))
 					// Wait a few ticks to see if they stop gaining health.
 					// Once that's the case, boot em
 					src.connected_message("Cloning Process Complete.", "success")
@@ -488,7 +487,7 @@
 				power_usage = 7500
 				return ..()
 
-			else if (src.occupant.max_health - src.occupant.health <= src.heal_level)
+			else if (src.get_progress() >= 100)
 				// Clone is more or less fully complete!
 
 				if (src.attempting && (src.time_started + eject_wait < TIME))
@@ -788,6 +787,14 @@
 		else
 			animate_shake(src,3,rand(1,4),rand(1,4))
 
+	proc/get_progress()
+		if (!src.occupant)
+			return 0
+
+		if (src.heal_level == 0)
+			return 100
+
+		return round(clamp(100 - ((src.occupant.max_health - src.occupant.health) - src.heal_level), 0, 100))
 
 	//SOME SCRAPS I GUESS
 	/* EMP grenade/spell effect

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -306,10 +306,22 @@
 		if (isnull(pod1))
 			pod1 = P
 			continue
-		if (pod1.attempting && !P.attempting)
+
+		if (P.attempting)
+			// If this new pod is currently working, skip it.
+			continue
+
+		if (pod1.attempting)
 			pod1 = P
 			continue
-		if (!P.attempting && pod1.meat_level < P.meat_level)
+
+		// Pick the pod that has the most progress
+		if (pod1.get_progress() < P.get_progress())
+			pod1 = P
+			continue
+
+		// If they're both the same progress, pick the one with the most MEAT
+		if (pod1.get_progress() == P.get_progress() && pod1.meat_level < P.meat_level)
 			pod1 = P
 			continue
 
@@ -821,7 +833,7 @@ proc/find_ghost_by_key(var/find_key)
 		.["podNames"] += P.name
 		.["meatLevels"] += P.meat_level
 		.["cloneSlave"] += P.cloneslave
-		.["completion"] += (!isnull(P.occupant) ? clamp(100 - ((P.occupant.max_health - P.occupant.health) - P.heal_level), 0, 100) : 0)
+		.["completion"] += P.get_progress()
 	if(!isnull(src.scanner))
 		. += list(
 			"scannerOccupied" = src.scanner.occupant,


### PR DESCRIPTION
[QOL]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

this makes it so that when there are multiple cloning pods we
focus more on the occupant's health & how quickly the clone will
get out rather than the amount of MEAT that's in the pod

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

gets people out of the cloner faster during hectic rounds.

this is to prevent people from having to try crazy workarounds like unhooking pods
that aren't ready yet and hooking them back up again to speed up a cloning.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(+)The cloning process now prioritizes pods that are closest to completion.
```
