### PR TITLE
Adds a GPS PDA program and adds it to the default PDA programs

### DIFF
--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -322,6 +322,7 @@
 			src.hd.root.add_file(new /datum/computer/file/text/pda2manual)
 			src.hd.root.add_file(new /datum/computer/file/pda_program/robustris)
 			src.hd.root.add_file(new /datum/computer/file/pda_program/emergency_alert)
+			src.hd.root.add_file(new /datum/computer/file/pda_program/gps)
 			src.hd.root.add_file(new /datum/computer/file/pda_program/cargo_request(src))
 			if(length(src.default_muted_mailgroups))
 				src.host_program.muted_mailgroups = src.default_muted_mailgroups

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1231,3 +1231,47 @@ Using electronic "Detomatix" BOMB program is perhaps less simple!<br>
 
 		src.master.add_fingerprint(usr)
 		return
+
+/datum/computer/file/pda_program/gps
+	name = "Space GPS"
+	size = 2
+	var/x = -1
+	var/y = -1
+	var/z = -1
+
+	return_text()
+		if(..())
+			return
+
+		var/dat = src.return_text_header()
+		dat += "<h4>Space GPS: Pocket Edition</h4>"
+
+		dat += "<a href='byond://?src=\ref[src];getloc=1'>Get Coordinates</a>"
+		if (x >= 0)
+
+			var/landmark = "Unknown"
+			switch (src.z)
+				if (1)
+					landmark = capitalize(station_or_ship())
+				if (2)
+					landmark = "Restricted"
+				if (3)
+					landmark = "Debris Field"
+
+			dat += "<BR>X = [src.x], Y = [src.y], Landmark: [landmark]"
+
+		return dat
+
+	Topic(href, href_list)
+		if(..())
+			return
+
+		if (href_list["getloc"])
+			var/turf/T = get_turf(usr)
+			src.x = T.x
+			src.y = T.y
+			src.z = T.z
+
+		src.master.add_fingerprint(usr)
+		src.master.updateSelfDialog()
+		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL][feature][input wanted]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a Space GPS program to the list of PDA programs and adds it to the list of default programs on all PDA's. The program can only get the user's coordinates and uses the same landmark notation as the separate GPS device. It does not interact with packets, navigate to locations, track other devices, or allow others to track the user.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
After the removal of the port-a-sci PDA app summon feature, getting unexpectedly lost in the trench, asteroid belt, debris field, or far from the station is difficult to recover from. Being able to relay a user's own coordinates would enable fun rescue missions without having to comb the entire z-level. The limited feature set is intentional to keep the physical GPS useful and prevent packet nerds from tracking everyone on station.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(*)Added a Space GPS program to the default list set of PDA programs.
```
