### PR TITLE
Portable reclaimer fix

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -994,7 +994,7 @@
 			if(!istype(M, /obj/item/cable_coil))
 				if (!istype(M.material))
 					continue
-				if (!(M.material.material_flags & MATERIAL_CRYSTAL) || !(M.material.material_flags & MATERIAL_METAL))
+				if (!(M.material.material_flags & MATERIAL_CRYSTAL) && !(M.material.material_flags & MATERIAL_METAL))
 					continue
 
 			M.set_loc(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes loading material sheets/ores into the reclaimer via clickdrag

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Closes #4589 and #4606 


