### PR TITLE
Blacklists cable coil from material processor

### DIFF
--- a/code/modules/materials/Mat_ProcsDefines.dm
+++ b/code/modules/materials/Mat_ProcsDefines.dm
@@ -10,7 +10,7 @@ var/global/list/material_cache = list()
 /atom/var/datum/material/material = null
 
 /proc/isExploitableObject(var/atom/A)
-	if(istype(A, /obj/item/tile) || istype(A, /obj/item/rods) || istype(A, /obj/item/sheet)) return 1
+	if(istype(A, /obj/item/tile) || istype(A, /obj/item/rods) || istype(A, /obj/item/sheet) || istype(A, /obj/item/cable_coil)) return 1
 	return 0
 
 /// This contains the names of the trigger lists on materials. Required for copying materials. Remember to keep this updated if you add new triggers.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title. The cable coil will still fit in portable reclaimers, allowing you to get 1 synthrubber block from 1 coil stack

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Honestly, I wouldn't even consider this change a nerf, rather than a fix for an oversight
The metal sheets are already blacklisted from material processor, which makes sense - imagine inserting a stack of 50 metal sheets and receiving 50 metal bars - it does seem broken, and yet, using cable coils lets you do just that - a single stack of wires gives you 30 synthrubber, enough for 15 pairs of synthrubber gloves.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)You can no longer put cable coils into the material processor. Wires can still be inserted into the portable reclaimer, letting you convert one coil stack into one synthrubber block.
```
