### PR TITLE
Attempt to fix welding fuel explosions

### DIFF
--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -224,11 +224,11 @@ datum
 					if(!T.reagents)
 						T.create_reagents(volume)
 					else
-						T.reagents.maximum_volume = T.reagents.maximum_volume + volume			
-					
+						T.reagents.maximum_volume = T.reagents.maximum_volume + volume
+
 					if(!T.reagents.has_reagent("thermite"))
 						T.UpdateOverlays(image('icons/effects/effects.dmi',icon_state = "thermite"), "thermite")
-						
+
 					T.reagents.add_reagent("thermite", volume, null)
 					if (T.active_hotspot)
 						T.reagents.temperature_reagents(T.active_hotspot.temperature, T.active_hotspot.volume, 10, 300)
@@ -664,7 +664,9 @@ datum
 						holder.del_reagent(id)
 					return
 
-				if (!caused_fireflash)
+				if (caused_fireflash)
+					return
+				else
 					var/list/covered = holder.covered_turf()
 					if (covered.len < 4 || (volume / holder.total_volume) > min_req_fluid)
 						if(covered.len > 0) //possible fix for bug where caused_fireflash was set to 1 without fireflash going off, allowing fuel to reach any temp without igniting

--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -658,6 +658,10 @@ datum
 			var/caused_fireflash = 0
 			var/min_req_fluid = 0.10 //at least 10% of the fluid needs to be oil for it to ignite
 
+			unpooled(pooltype)
+				. = ..()
+				caused_fireflash = 0 //scream. Band-aid fix for unpooled fuel sometimes coming with caused_fireflash preset to True.
+
 			reaction_temperature(exposed_temperature, exposed_volume)
 				if(volume < 1)
 					if (holder)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* PR #3473 broke a safety check that prevented fuel tanks from self fire flash exposing which in turn caused issues that broke admin fuel explosion logging
* Additionally includes a bandaid fix to force `caused_fireflash` to be false when unpooling fuel preventing a bug where fuel could reach any temp and never explode.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* fixes fuel explosion logging for admins
* fixes bug that prevents fuel tanks from exploding at all