### PR TITLE
Remove RCD from ghostdrones

### DIFF
--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -59,7 +59,6 @@
 		var/obj/item/cell/cerenkite/charged/CELL = new /obj/item/cell/cerenkite/charged(src)
 		src.cell = CELL
 
-
 		src.health = src.max_health
 		src.botcard.access = list(access_maint_tunnels, access_ghostdrone, access_engineering,access_external_airlocks,
 						access_engineering_storage, access_engineering_atmos, access_engineering_engine, access_engineering_power)
@@ -70,7 +69,6 @@
 		src.tools = list(
 			new /obj/item/magtractor(src),
 			new /obj/item/tool/omnitool/silicon(src),
-			new /obj/item/rcd/safe(src),
 			new /obj/item/lamp_manufacturer(src),
 			new /obj/item/device/analyzer/atmospheric(src),
 			new /obj/item/device/t_scanner(src),
@@ -1320,7 +1318,7 @@
 			new /obj/item/rcd/construction/safe(src),
 			new /obj/item/material_shaper(src),
 			new /obj/item/room_planner(src),
-			)
+		)
 
 		//Make all the tools un-drop-able (to closets/tables etc)
 		for (var/obj/item/O in MT)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT WANTED][REMOVAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Removes the RCD from ghostdrones

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Ghostdrone grief consistently involves using the RCD to either block off or depressurize areas. While there are other ways they can grief, taking away their easy-access, rechargeable (and thus theoretically infinite), grief-machine will make doing so harder.

Yes, legitimate users of the RCD will pay the price, but anyone wanting to put the effort into building can probably get their hands on some metal sheets very easily (the ghostdrone has pretty good access for that stuff, and the tools needed to break in if needed).

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Mordent
(*)Removed RCD from ghostdrones.
```