### PR TITLE
Fixs clown car bug where a passanger attempting to walk would eject everyone from the clown car

### DIFF
--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -60,9 +60,7 @@ Contains:
 		for(var/mob/M in src){\
 			M.glide_size = src.glide_size;\
 			M.animate_movement = SYNC_STEPS;}\
-		src.do_special_on_relay(user, dir);\
-	} else {\
-		for (var/mob in src.contents) { var/mob/M = mob; M.set_loc(src.loc); }} ; \
+		src.do_special_on_relay(user, dir);}\
 	} while(false)
 //////////////////////////////// Vehicle parent ///////////////////////////////////////
 ABSTRACT_TYPE(/obj/vehicle)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #4562 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugfix

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Camryn Buttes
(+)Clown cars should now be able to reliably hold their passengers hostage again.
```
