### PR TITLE
chore: refactor vehicle's relaymove to not use macro

### DIFF
--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -13,55 +13,6 @@ Contains:
 //------------------ Vehicle Defines --------------------///
 #define MINIMUM_EFFECTIVE_DELAY 0.001 //absolute maximum speed for vehicles (lower is faster), do not set to 0 or division by 0 will happen
 
-/**
-	* This macro handles the code that USED to be defined individually in each vehicle's relaymove() proc
-	* all non-machinery vehicles except forklifts and skateboards use this now
-	*	the params passed through are the same as are passed to relaymove()
-	* src should always be the vehicle that's moving
-	* user is the mob that initiated the relaymove() call. Note that this does NOT have to be the same as the vehicles "rider"
-	* this is an important distinction to make because some vehicles can have multiple OCCUPANTS but none of them can have multiple RIDERS
-	* dir is the direction we're going to travel in
-	* we reset the overlays to null in case the relaymove() call was initiated by a passenger rather than the driver (we shouldn't have a rider overlay if there is no rider!)
-	* Then, we check to see what mob initiated the relaymove()
-	* if it wasn't the rider, we jump to a bit of code that ensures no weirdness with unusual passenger ejections
-	* if it WAS initiated by the rider, we got ahead and cap the speed (td) to MINIMUM_EFFECTIVE_DELAY and then apply the rider overlay if needed
-	* Then, we check to make sure we aren't riding in space without a booster upgrade
-	* Next, we do some simple math to adjust the vehicle's glide_size based on its speed and to compensate for lag
-	* IMPORTANTLY: we also set the glide_size for all occupants of the vehicle to the same value that we used for the vehicle itself
-	* and set the occupant's animate_movement to SYNC_STEPS
-	* This helps to SIGNIFICANTLY smooth the apparent motion of the camera at higher speeds (almost buttery at default speed of 2)
-	* Unfortunately, there is still some stuttering at higher speeds, but it has been lessened quite a bit.
-	* Then, we finally actually walk the src vehicle in the dir direction with td delay between steps
-	* The vehicle will keep moving in this direction until stopped or the direction is changed
-	* Next, we.... uhhhhhh... well, we do the glide_size and animation adjustments AGAIN.
-	* I really have no idea why we do this, but it was present in pod movement code, and I asked mbc about it and we were both too scared to change it
-	* So, if you want to optimize this some more, I'd start by looking into removing that bit of code
-	* LASTLY, we call do_special_on_relay() to handle any special behaviors we want the vehicle to perform each time relaymove() is called
-	* NOTE:
-	* this means that do_special_on_relay() will only get called when the rider is performing a direction input
-	* and NOT whenever the vehicle actually MOVES.
-	* For that, you'll want to override the vehicles Move() proc with the custom behavior you want.
-	*/
-#define V_DO_MOVE(src, user, dir) do { \
-	src.overlays = null ; \
-	if(src.rider && user == src.rider) { \
-		var/td = max(src.delay, MINIMUM_EFFECTIVE_DELAY); \
-		if(src.rider_visible) {src.overlays += src.rider};\
-		if (!src.booster_upgrade) { \
-			var/turf/T = get_turf(src) ;\
-			if(T.throw_unlimited && istype(T, /turf/space)) { break };}\
-		src.glide_size = (32 / td) * world.tick_lag ;\
-		for(var/mob/M in src){\
-			M.glide_size = src.glide_size ;\
-			M.animate_movement = SYNC_STEPS;}\
-		if(src.booster_upgrade) {src.overlays += booster_image };\
-		walk(src, dir, td) ;\
-		src.glide_size = (32 / td) * world.tick_lag ;\
-		for(var/mob/M in src){\
-			M.glide_size = src.glide_size;\
-			M.animate_movement = SYNC_STEPS;}\
-		src.do_special_on_relay(user, dir);}\
-	} while(false)
 //////////////////////////////// Vehicle parent ///////////////////////////////////////
 ABSTRACT_TYPE(/obj/vehicle)
 /obj/vehicle
@@ -198,8 +149,61 @@ ABSTRACT_TYPE(/obj/vehicle)
 			NB.screen_loc = "NORTH-2,[x_btt]"
 			x_btt++
 
+
+	// This handles the code that USED to be defined individually in each vehicle's relaymove() proc
+	// all non-machinery vehicles except forklifts and skateboards use this now
 	relaymove(mob/user as mob, dir)
-		V_DO_MOVE(src, user, dir)
+		// we reset the overlays to null in case the relaymove() call was initiated by a
+		// passenger rather than the driver (we shouldn't have a rider overlay if there is no rider!)
+		src.overlays = null
+
+		if(!src.rider || user != src.rider)
+			return
+
+		var/td = max(src.delay, MINIMUM_EFFECTIVE_DELAY)
+
+		if(src.rider_visible)
+			src.overlays += src.rider
+
+		// You can't move in space without the booster upgrade
+		if (src.booster_upgrade)
+			src.overlays += booster_image
+		else
+			var/turf/T = get_turf(src)
+
+			if(T.throw_unlimited && istype(T, /turf/space))
+				return
+
+		// Next, we do some simple math to adjust the vehicle's glide_size based on its speed and to compensate for lag
+		src.glide_size = (32 / td) * world.tick_lag
+
+		// we set the glide_size for all occupants of the vehicle to the same value that we used for the vehicle itself
+		// and set the occupant's animate_movement to SYNC_STEPS
+		// This helps to SIGNIFICANTLY smooth the apparent motion of the camera at higher speeds (almost buttery at default speed of 2)
+		// Unfortunately, there is still some stuttering at higher speeds, but it has been lessened quite a bit.
+		for(var/mob/M in src)
+			M.glide_size = src.glide_size ;
+			M.animate_movement = SYNC_STEPS;
+
+		// We finally actually walk the src vehicle in the dir direction with td delay between steps
+		// The vehicle will keep moving in this direction until stopped or the direction is changed
+		walk(src, dir, td)
+
+		// We.... uhhhhhh... well, we do the glide_size and animation adjustments AGAIN.
+		// I really have no idea why we do this, but it was present in pod movement code,
+		// and I asked mbc about it and we were both too scared to change it
+		// So, if you want to optimize this some more, I'd start by looking into removing that bit of code
+		src.glide_size = (32 / td) * world.tick_lag
+
+		for(var/mob/M in src)
+			M.glide_size = src.glide_size;
+			M.animate_movement = SYNC_STEPS;
+
+		// LASTLY, we call do_special_on_relay() to handle any special behaviors we want the vehicle to perform each time relaymove() is called
+		// NOTE: this means that do_special_on_relay() will only get called when the rider is performing a direction input
+		//       and NOT whenever the vehicle actually MOVES.
+		//       For that, you'll want to override the vehicles Move() proc with the custom behavior you want.
+		src.do_special_on_relay(user, dir);
 
 	proc/do_special_on_relay(mob/user as mob, dir) //empty placeholder for when we successfully have the rider relay a move
 		return
@@ -2248,7 +2252,9 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 
 	src.update_overlays()
 
-//We, unfortunately, can't use V_DO_MOVE() here because the forklift has some special behaviors with overlays and underlays that produce weird behaviors (ghost riders, phantom crates) when combined with V_DO_MOVE()
+//We, unfortunately, can't use the base relaymove here because the forklift has some
+// special behaviors with overlays and underlays that produce weird behaviors
+// (ghost riders, phantom crates) when combined with the base relaymove
 /obj/vehicle/forklift/relaymove(mob/user as mob, direction)
 
 	if (user.stat)


### PR DESCRIPTION
[cleanliness]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

the macro was only used in one place, so it was not really
bringing much to the table

this just makes the code a bit easier to read and also
moves the comments to be in-line rather than as a block
above the code

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

prettier code & easier to understand for relaymove