### PR TITLE
Cloners no longer give people health implants

### DIFF
--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -268,15 +268,7 @@
 
 	//Add an implant if needed
 	var/obj/item/implant/health/imp = locate(/obj/item/implant/health, subject)
-	if (isnull(imp))
-		imp = new /obj/item/implant/health(subject)
-		imp.implanted = 1
-		imp.owner = subject
-		subject.implant.Add(imp)
-//		imp.implanted = subject // this isn't how this works with new implants sheesh
-		R.fields["imp"] = "\ref[imp]"
-	//Update it if needed
-	else
+	if(!isnull(imp))
 		R.fields["imp"] = "\ref[imp]"
 
 	if (!isnull(subjMind)) //Save that mind so traitors can continue traitoring after cloning.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so clonescanning people no longer gives out free health implants. In order to receive death alerts you now need to implant people manually. If you want people's health status to show up in the cloner computer you'll need to implant them before scanning them.

Made at the request of @mybluecorners 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A while ago there have been changes to cloning which make it possible to clone people instantly which is good because staring at a black screen while being cloned sucks. However, especially with the addition of multi-pod cloning it is now very easy to just keep instantly cloning everyone that dies with little effort. This often leads to antagonists being ratted out immediately after dying by the fresh clone which is not great! This PR aims to make it so it is still possible to do this but it requires more effort on the part of the cloning staff. You either need to produce your own health implants to implant people with or you need to be checking the cloning console periodically without having the handy death alerts.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)pali
(*)Cloners no longer automatically implant people with health implants on scanning.
```
