### PR TITLE
Hair cutting bug fix

### DIFF
--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -66,12 +66,13 @@
 
 	var/non_murderous_failure = 0
 	var/mob/living/carbon/human/H = M
+	var/datum/appearanceHolder/AH = M.bioHolder.mobAppearance
 	if(ishuman(M) && ((H.head && H.head.c_flags & COVERSEYES) || (H.wear_mask && H.wear_mask.c_flags & COVERSEYES) || (H.glasses && H.glasses.c_flags & COVERSEYES)))
 		// you can't stab someone in the eyes wearing a mask!
 		boutput(user, "<span class='notice'>You're going to need to remove that mask/helmet/glasses first.</span>")
 		non_murderous_failure = BARBERY_FAILURE
 
-	if((M.bioHolder.mobAppearance.customization_first == "None") && (M.bioHolder.mobAppearance.customization_second == "None") && (M.bioHolder.mobAppearance.customization_third = "None"))
+	if((AH.customization_first == "None") && (AH.customization_second == "None") && (AH.customization_third == "None"))
 		boutput(user, "<span class='alert'>There is nothing to cut!</span>")
 		non_murderous_failure = BARBERY_FAILURE
 

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -71,7 +71,7 @@
 		boutput(user, "<span class='notice'>You're going to need to remove that mask/helmet/glasses first.</span>")
 		non_murderous_failure = BARBERY_FAILURE
 
-	if(M.bioHolder.mobAppearance.customization_first == "None")
+	if((M.bioHolder.mobAppearance.customization_first == "None") && (M.bioHolder.mobAppearance.customization_second == "None") && (M.bioHolder.mobAppearance.customization_third = "None"))
 		boutput(user, "<span class='alert'>There is nothing to cut!</span>")
 		non_murderous_failure = BARBERY_FAILURE
 
@@ -112,10 +112,6 @@
 	if(ishuman(M) && ((H.head && H.head.c_flags & COVERSEYES) || (H.wear_mask && H.wear_mask.c_flags & COVERSEYES) || (H.glasses && H.glasses.c_flags & COVERSEYES)))
 		// you can't stab someone in the eyes wearing a mask!
 		boutput(user, "<span class='notice'>You're going to need to remove that mask/helmet/glasses first.</span>")
-		non_murderous_failure = BARBERY_FAILURE
-
-	if(M.bioHolder.mobAppearance.customization_second == "None")
-		boutput(user, "<span class='alert'>You can't get a closer shave than that!</span>")
 		non_murderous_failure = BARBERY_FAILURE
 
 	if(issilicon(M))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so you can still cut someone's hair despite them not having the first hair, removes the check for lack of second hair too since it is now unneeded. 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently not having the first or second hair stops you from cutting all the other hairs. for example if you had an mohawk on your second hair overlay but no overlay on your first one you would never be able to shave the mohawk. this changes that.