### PR TITLE
Spatial Interdictor installation into maps

### DIFF
--- a/code/WorkInProgress/tarmStuff.dm
+++ b/code/WorkInProgress/tarmStuff.dm
@@ -1,4 +1,5 @@
 //GUNS GUNS GUNS
+//asdf hands typing words
 /obj/item/gun/kinetic/g11
 	name = "\improper Manticore assault rifle"
 	desc = "An assault rifle capable of firing single precise bursts. The magazines holders are embossed with \"Anderson Para-Munitions\""

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -5852,6 +5852,7 @@
 	dir = 1;
 	level = 2
 	},
+/obj/storage/crate/furnacefuel,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "og" = (
@@ -5866,6 +5867,7 @@
 	can_rupture = 0;
 	dir = 10
 	},
+/obj/storage/crate/furnacefuel,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "oi" = (
@@ -6250,15 +6252,14 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "pc" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4;
 	layer = 2.13
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "pd" = (
@@ -6314,7 +6315,30 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "pk" = (
-/obj/storage/secure/closet/engineering/engineer,
+/obj/table/auto,
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
 "pl" = (
@@ -6696,12 +6720,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/combustion_chamber)
 "qf" = (
-/obj/storage/crate/furnacefuel,
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/storage/secure/closet/engineering/engineer,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
 "qg" = (
@@ -9627,12 +9651,12 @@
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/southeast)
 "wF" = (
-/obj/storage/crate/furnacefuel,
 /obj/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/storage/secure/closet/engineering/engineer,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
 "wH" = (
@@ -17269,6 +17293,10 @@
 	icon_state = "fred2"
 	},
 /area/station/crew_quarters/cafeteria)
+"Qh" = (
+/obj/machinery/shieldgenerator/energy_shield,
+/turf/simulated/floor/orangeblack,
+/area/station/engine/engineering)
 "Qi" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -59644,7 +59672,7 @@ tw
 sm
 vE
 wF
-pk
+Qh
 zc
 zG
 zG

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -34353,7 +34353,30 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/reagent_dispensers/watertank/fountain,
+/obj/table/auto,
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
+	},
 /turf/simulated/floor/white,
 /area/station/engine/engineering)
 "btr" = (
@@ -36425,7 +36448,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
-/obj/storage/cart,
+/obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
 "bxa" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -43708,6 +43708,7 @@
 	dir = 8;
 	tag = ""
 	},
+/obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -64574,13 +64575,36 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/reagent_dispensers/watertank/fountain,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 6
 	},
 /obj/cable/brown{
 	icon_state = "4-8"
+	},
+/obj/table/wood/auto,
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -46059,7 +46059,29 @@
 /area/station/engine/coldloop)
 "bVq" = (
 /obj/table/reinforced/auto,
-/obj/random_item_spawner/tools,
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
+	},
 /turf/simulated/floor/blue,
 /area/station/engine/coldloop)
 "bVr" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -43732,8 +43732,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/light_switch/north,
 /obj/machinery/power/data_terminal,
+/obj/machinery/phone/wall{
+	pixel_x = -6;
+	pixel_y = 32
+	},
+/obj/machinery/light_switch/north{
+	pixel_x = 10
+	},
 /turf/simulated/floor/yellow/corner{
 	dir = 8
 	},
@@ -45924,7 +45930,29 @@
 /area/station/crew_quarters/courtroom)
 "qnP" = (
 /obj/table/reinforced/auto,
-/obj/machinery/phone,
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -14438,9 +14438,28 @@
 	})
 "dWu" = (
 /obj/table/auto,
-/obj/item/storage/toolbox{
-	pixel_x = 1;
-	pixel_y = 7
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
 	},
 /turf/simulated/floor/yellowblack{
 	dir = 1

--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -3876,13 +3876,30 @@
 	name = "Maru Bridge"
 	})
 "io" = (
-/obj/storage/crate,
-/obj/item/fuel_pellet/cerenkite,
-/obj/item/fuel_pellet/cerenkite,
-/obj/item/fuel_pellet/cerenkite,
-/obj/item/fuel_pellet/cerenkite,
-/obj/item/fuel_pellet/cerenkite,
-/obj/item/fuel_pellet/cerenkite,
+/obj/table/auto,
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
+	},
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/yellowblack{
 	dir = 1
@@ -4136,6 +4153,14 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "yellow";
+	icon_state = "bedsheet-yellow"
+	},
+/obj/landmark/start{
+	name = "Chief Engineer"
+	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce{
 	name = "Maru Bridge"
@@ -4155,11 +4180,17 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/obj/storage/crate/rcd,
 /obj/machinery/phone/wall{
 	pixel_x = 24;
 	pixel_y = 4
 	},
+/obj/storage/crate,
+/obj/item/fuel_pellet/cerenkite,
+/obj/item/fuel_pellet/cerenkite,
+/obj/item/fuel_pellet/cerenkite,
+/obj/item/fuel_pellet/cerenkite,
+/obj/item/fuel_pellet/cerenkite,
+/obj/item/fuel_pellet/cerenkite,
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce{
 	name = "Maru Bridge"
@@ -6415,19 +6446,12 @@
 /turf/simulated/floor/redblack,
 /area/station/security/secwing)
 "nr" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
-	},
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/landmark/start{
-	name = "Chief Engineer"
-	},
+/obj/storage/crate/rcd,
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce{
 	name = "Maru Bridge"

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -53474,7 +53474,30 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/disposal_pipedispenser/mobile,
+/obj/table/reinforced/auto,
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
+	},
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -53482,6 +53505,7 @@
 	name = "Engineering Control Room"
 	})
 "cDY" = (
+/obj/machinery/disposal_pipedispenser/mobile,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},

--- a/maps/icarus.dmm
+++ b/maps/icarus.dmm
@@ -12397,16 +12397,29 @@
 /area/station/storage/primary)
 "aAT" = (
 /obj/table/auto,
-/obj/item/rods/steel{
-	amount = 50
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
 	},
-/obj/item/rods/steel{
-	amount = 50
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
 	},
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
+	},
 /turf/simulated/floor,
 /area/station/storage/primary)
 "aAU" = (
@@ -12585,11 +12598,20 @@
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/t_scanner,
-/obj/item/wrench,
 /obj/item/device/radio/intercom/engineering{
 	dir = 4;
 	pixel_x = -20
 	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 16
+	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 16
+	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = 16
+	},
+/obj/item/wrench,
 /turf/simulated/floor/yellow/side,
 /area/station/storage/primary)
 "aBp" = (
@@ -12643,6 +12665,14 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/chem_grenade/metalfoam,
+/obj/item/rods/steel{
+	amount = 50;
+	pixel_x = -15
+	},
+/obj/item/rods/steel{
+	amount = 50;
+	pixel_x = -15
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/storage/primary)
 "aBt" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -49204,13 +49204,28 @@
 /area/station/quartermaster/cargobay)
 "kWb" = (
 /obj/table/auto,
-/obj/item/storage/toolbox/electrical,
-/obj/item/clothing/gloves/yellow,
-/obj/item/device/multitool,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 12
+	},
+/obj/item/clothing/gloves/yellow{
+	pixel_y = 8
+	},
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = -5
+	},
+/obj/item/device/multitool{
+	pixel_y = 8
+	},
+/obj/item/wrench{
+	pixel_y = -4
+	},
+/obj/item/device/t_scanner{
+	pixel_x = -9
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
@@ -51562,7 +51577,9 @@
 /area/station/routing/security)
 "nwG" = (
 /obj/table/auto,
-/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 7
+	},
 /obj/item/clothing/gloves/yellow,
 /obj/item/device/multitool,
 /obj/item/device/radio/intercom/engineering{
@@ -57477,12 +57494,32 @@
 /area/station/security/main)
 "tMd" = (
 /obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/device/t_scanner,
-/obj/item/wrench,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
+	},
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
 	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -7128,7 +7128,30 @@
 /turf/simulated/floor/bot,
 /area/station/engine/storage)
 "avm" = (
-/obj/storage/secure/closet/engineering/welding,
+/obj/table/auto,
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
+	},
 /turf/simulated/floor/bot,
 /area/station/engine/storage)
 "avo" = (
@@ -37718,6 +37741,11 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/security/hos)
+"gIq" = (
+/obj/machinery/light/incandescent/warm,
+/obj/storage/secure/closet/engineering/welding,
+/turf/simulated/floor/bot,
+/area/station/engine/storage)
 "gJi" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light/incandescent/netural{
@@ -92608,7 +92636,7 @@ auW
 avD
 avY
 avV
-auT
+gIq
 aui
 azB
 azU

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -43571,7 +43571,29 @@
 "ceL" = (
 /obj/machinery/light/incandescent/warm,
 /obj/table/wood/auto,
-/obj/item/decoration/flower_vase,
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
+	},
 /turf/simulated/floor,
 /area/station/engine/storage)
 "ceM" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -40077,6 +40077,10 @@
 /obj/disposalpipe/trunk/mail/west,
 /obj/item/hand_labeler,
 /obj/item/device/audio_log,
+/obj/item/decoration/flower_vase{
+	pixel_x = -8;
+	pixel_y = 23
+	},
 /turf/simulated/floor,
 /area/station/engine/storage)
 "bUw" = (

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -43887,6 +43887,33 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"mES" = (
+/obj/table/auto,
+/obj/item/interdictor_board{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/interdictor_board{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_frame{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/paper/manufacturer_blueprint/interdictor_rod{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/paper/book/interdictor{
+	pixel_x = 3
+	},
+/turf/simulated/floor/yellow/side,
+/area/station/engine/storage)
 "mFj" = (
 /obj/table/auto,
 /obj/machinery/networked/storage/scanner{
@@ -63503,7 +63530,12 @@
 /area/station/hallway/primary/south)
 "skD" = (
 /obj/table/auto,
-/obj/item/storage/box/cablesbox,
+/obj/item/storage/box/cablesbox{
+	pixel_x = -9
+	},
+/obj/item/storage/box/cablesbox{
+	pixel_x = 8
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/storage)
 "skL" = (
@@ -153955,7 +153987,7 @@ vqL
 vqL
 xwt
 vqL
-skD
+mES
 ykD
 tmI
 xIf


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Installs blueprints, components and guide for the Spatial Interdictor into the engineering departments of maps, as follows.

- Atlas: Added to engine control room. Furnace fuel was moved into engine room to open the space, with the other opened space now holding an energy-shield generator.
- Clarion: Added to engine control room. Water cooler moved out into the warehouse/lounge area, making it also usable by quartermasters.
- Cogmap: New table added in main Engineering hall. Water cooler moved west.
- Cogmap2: Added to a table in cold loop that previously held only random tools.
- Destiny: Added to the control room table that previously held a phone (new wall phone introduced instead).
- Donut 3: Placed on the table right outside the Engineering staff room, replacing an emergency toolbox.
- Fleet: Added to the Maru's bridge, reorganized a few items to fit it.
- Horizon: Added to a new table in the Engineering control room.
- Icarus: Added to engineering storage (table contents reorganized).
- Kondaru: Added to engineering storage (table contents reorganized).
- Manta: New table occupying the previous location of the welding supplies locker (said locker now lives next to the welding fuel tank).
- Oshan: Added to a table in engineering storage that previously held a vase (it was moved to the next table over).
- Ozymandias: Added to engineering storage (table contents reorganized).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Implements the Spatial Interdictor's prerequisites so people can actually use it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(*)Engineering departments have received equipment to construct a new device, the Spatial Interdictor, that mitigates or nullifies certain random events in an area.
```
