### PR TITLE
Sets all wizard hair zones to white

### DIFF
--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -23,6 +23,7 @@
 
 	wizard_mob.bioHolder.mobAppearance.customization_first_color = "#FFFFFF"
 	wizard_mob.bioHolder.mobAppearance.customization_second_color = "#FFFFFF"
+	wizard_mob.bioHolder.mobAppearance.customization_third_color = "#FFFFFF"
 	wizard_mob.cust_two_state = "wiz"
 	wizard_mob.update_colorful_parts()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Only two wizard haireas were set to white. This sets all three.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If we are forcing two surely we should be forcing all three.