### PR TITLE
Spatial Interdictor install v2: crates this time

### DIFF
--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -126,6 +126,36 @@
 		req_access = list(access_engineering)
 		spawn_contents = list(/obj/item/pipebomb/bomb/engineering = 6)
 
+	interdictor
+		name = "interdictor assembly kit"
+		desc = "Contains mainboards, blueprints and a usage guide for spatial interdictors."
+		req_access = list(access_engineering)
+
+		make_my_stuff()
+			if (..()) // make_my_stuff is called multiple times due to lazy init, so the parent returns 1 if it actually fired and 0 if it already has
+				var/obj/item/interdictor_board/B1 = new(src)
+				B1.pixel_x = -6
+				B1.pixel_y = -3
+
+				var/obj/item/interdictor_board/B2 = new(src)
+				B2.pixel_x = -6
+
+				var/obj/item/interdictor_board/B3 = new(src)
+				B3.pixel_x = -6
+				B3.pixel_y = 3
+
+				var/obj/item/paper/manufacturer_blueprint/interdictor_rod/B4 = new(src)
+				B4.pixel_x = 8
+				B4.pixel_y = -3
+
+				var/obj/item/paper/manufacturer_blueprint/interdictor_frame/B5 = new(src)
+				B5.pixel_x = 8
+				B5.pixel_y = 3
+
+				var/obj/item/paper/book/interdictor/B6 = new(src)
+				B6.pixel_y = 1
+				return 1
+
 /obj/storage/secure/crate/medical
 	desc = "A secure medical crate."
 	name = "medical crate"

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -6403,8 +6403,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/security/brig/genpop)
 "py" = (
-/obj/table/auto,
-/obj/machinery/phone,
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
 "pz" = (
@@ -7583,6 +7582,10 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/paper/engine{
+	pixel_x = 12;
+	pixel_y = 19
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
 "sg" = (
@@ -8122,8 +8125,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/item/paper/engine{
-	pixel_x = 5
+/obj/machinery/phone/wall{
+	pixel_x = 9;
+	pixel_y = 5
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
@@ -9552,16 +9556,16 @@
 /obj/item/clothing/gloves/yellow,
 /obj/item/storage/firstaid/fire,
 /obj/item/extinguisher,
+/obj/item/device/radio/intercom/engineering{
+	dir = 4
+	},
 /obj/item/device/transfer_valve{
-	pixel_x = 5;
-	pixel_y = 14
+	pixel_x = 10;
+	pixel_y = 8
 	},
 /obj/item/device/transfer_valve{
 	pixel_x = -8;
-	pixel_y = 18
-	},
-/obj/item/device/radio/intercom/engineering{
-	dir = 4
+	pixel_y = 7
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -34353,7 +34353,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/reagent_dispensers/watertank/fountain,
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/white,
 /area/station/engine/engineering)
 "btr" = (
@@ -36425,7 +36425,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
-/obj/storage/cart,
+/obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor,
 /area/station/quartermaster/storage)
 "bxa" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -34472,6 +34472,7 @@
 /area/station/engine/power)
 "bJj" = (
 /obj/machinery/light,
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor,
 /area/station/engine/power)
 "bJk" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -47929,6 +47929,7 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/blue,
 /area/station/engine/coldloop)
 "bZy" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -22659,6 +22659,10 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/phone/wall{
+	pixel_x = 9;
+	pixel_y = 5
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "dTY" = (
@@ -45923,8 +45927,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "qnP" = (
-/obj/table/reinforced/auto,
-/obj/machinery/phone,
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -43158,6 +43158,7 @@
 /obj/item/device/radio/intercom/loudspeaker/speaker/east{
 	pixel_x = -22
 	},
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/yellowblack{
 	dir = 8
 	},

--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -4136,6 +4136,14 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Chief Engineer"
+	},
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "yellow";
+	icon_state = "bedsheet-yellow"
+	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce{
 	name = "Maru Bridge"
@@ -4156,10 +4164,6 @@
 	dir = 4
 	},
 /obj/storage/crate/rcd,
-/obj/machinery/phone/wall{
-	pixel_x = 24;
-	pixel_y = 4
-	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce{
 	name = "Maru Bridge"
@@ -4640,6 +4644,10 @@
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/phone/wall{
+	pixel_x = 9;
+	pixel_y = 5
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce{
@@ -6415,19 +6423,12 @@
 /turf/simulated/floor/redblack,
 /area/station/security/secwing)
 "nr" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
-	},
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/landmark/start{
-	name = "Chief Engineer"
-	},
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce{
 	name = "Maru Bridge"

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -53482,6 +53482,7 @@
 	name = "Engineering Control Room"
 	})
 "cDY" = (
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},

--- a/maps/icarus.dmm
+++ b/maps/icarus.dmm
@@ -10661,6 +10661,10 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/stool/chair/yellow,
+/obj/landmark/start{
+	name = "Engineer"
+	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering)
 "axk" = (
@@ -11326,16 +11330,11 @@
 	},
 /area/station/engine/engineering)
 "ayD" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Engineer"
-	},
 /obj/item/device/radio/intercom/engineering{
 	dir = 4;
 	pixel_x = -20
 	},
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
 "ayE" = (
@@ -26260,6 +26259,15 @@
 /obj/cable,
 /turf/simulated/floor/airless/plating,
 /area/research_outpost/indigo_rye)
+"bQn" = (
+/obj/stool/chair/yellow{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Engineer"
+	},
+/turf/simulated/floor,
+/area/station/storage/primary)
 "bQW" = (
 /obj/cable{
 	d1 = 1;
@@ -70118,7 +70126,7 @@ ayK
 azf
 azN
 aAv
-aAS
+bQn
 aBr
 azg
 aCc

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -14842,6 +14842,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -7907,6 +7907,7 @@
 	pixel_x = 10;
 	tag = ""
 	},
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/private)
 "axe" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -47684,6 +47684,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
+"qnG" = (
+/obj/storage/secure/crate/eng/interdictor,
+/turf/simulated/floor/yellow,
+/area/station/engine/engineering)
 "qqR" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -107770,7 +107774,7 @@ ayu
 bgL
 aff
 bge
-bhr
+qnG
 bkt
 blj
 blV

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -17207,6 +17207,10 @@
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/grey,
 /area/station/mining/staff_room)
+"fdx" = (
+/obj/storage/secure/crate/eng/interdictor,
+/turf/simulated/floor/yellow/side,
+/area/station/engine/storage)
 "fdK" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/redblack{
@@ -63503,7 +63507,12 @@
 /area/station/hallway/primary/south)
 "skD" = (
 /obj/table/auto,
-/obj/item/storage/box/cablesbox,
+/obj/item/storage/box/cablesbox{
+	pixel_x = -9
+	},
+/obj/item/storage/box/cablesbox{
+	pixel_x = 6
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/engine/storage)
 "skL" = (
@@ -153955,7 +153964,7 @@ vqL
 vqL
 xwt
 vqL
-skD
+fdx
 ykD
 tmI
 xIf


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Creates an Engineering secure crate to hold equipment for construction and use of the spatial interdictor, and places it into Engineering departments in the following maps: Atlas, Clarion, Cogmap, Cogmap 2, Destiny, Donut 3, Fleet, Horizon, Icarus, Kondaru, Manta, Oshan and Ozymandias. Complement of other equipment in all affected maps has not changed, though a few maps needed slight rearrangement of items to make room.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Implements the Spatial Interdictor's prerequisites so people can actually use it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(*)Engineering departments have received a crate for assembly of the Spatial Interdictor, a device which can mitigate certain random events in its range of influence given sufficient power.
```
