### PR TITLE
fix: correctly remove and add cameras from turf coverage

### DIFF
--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -464,8 +464,8 @@
 	if(!src.cameras)
 		return
 
-	src.cameras &= C
-	C.coveredTiles &= src
+	src.cameras -= C
+	C.coveredTiles -= src
 
 	if(!src.cameras.len)
 		src.cameras = null
@@ -509,7 +509,7 @@
 		prev_tiles = coveredTiles
 
 	for(var/turf/T in view(CAM_RANGE, get_turf(src)))
-		new_tiles += T
+		new_tiles |= T
 
 	if (prev_tiles)
 		for(var/turf/O as anything in (prev_tiles - new_tiles))
@@ -535,13 +535,13 @@
 			if(src.coveredTiles == null)
 				src.coveredTiles = list(t)
 			else
-				src.coveredTiles += t
+				src.coveredTiles |= t
 		else
-			t.cameras += src
+			t.cameras |= src
 			if(src.coveredTiles == null)
 				src.coveredTiles = list(t)
 			else
-				src.coveredTiles += t
+				src.coveredTiles |= t
 
 		if (cam_amount < t.cameras.len)
 			if (t.aiImage)


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

this uses the correct list ops so that cameras are removed and added to turfs when they're being removed and added from the coverage

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

 this fixes many cases where cameras being snipped don't actually get removed from the AI's camera coverage, or where bot cameras being disposed don't remove them from coverage

fixes #4641

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(+)AI is no longer an all-seeing entity and snipped cameras should correctly be removed from coverage.
```
