### PR TITLE
fix: don't show paper through inactive cameras

### DIFF
--- a/code/obj/machinery/camera.dm
+++ b/code/obj/machinery/camera.dm
@@ -278,6 +278,7 @@
 	if(istype(W,/obj/item/parts/human_parts)) //dumb easter egg incoming
 		user.visible_message("<span class='alert'>[user] wipes [src] with the bloody end of [W.name]. What the fuck?</span>", "<span class='alert'>You wipe [src] with the bloody end of [W.name]. What the fuck?</span>")
 		return
+
 	if (issnippingtool(W))
 		src.camera_status = !( src.camera_status )
 		if (!( src.camera_status ))
@@ -303,7 +304,12 @@
 				updateCoverage() //(must happen in spawn!)
 		// now disconnect anyone using the camera
 		src.disconnect_viewers()
-	else if (istype(W, /obj/item/paper))
+		return
+
+	if (!src.camera_status)
+		return
+
+	if (istype(W, /obj/item/paper))
 		if (last_paper && ( (last_paper + 80) >= world.time))
 			return
 		last_paper = world.time


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

you can currently cut a camera then show paper through the
broken camera

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

it's a broken camera so why can you use it to show a paper?
this means you can annoy the AI even more.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(+)Prevent showing paper through cameras when the camera is inactive.
```
