### PR TITLE
fix: prevent ambience loop from playing forever in some cases

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -227,7 +227,9 @@ ABSTRACT_TYPE(/area) // don't instantiate this directly dummies, use /area/space
 				if (sound_loop)
 					SPAWN_DBG(1 DECI SECOND)
 						var/area/mobarea = get_area(M)
-						if (M?.client && (mobarea?.sound_group != src?.sound_group) && !mobarea.sound_loop)
+						// If the area we are exiting has a sound loop but the new area doesn't
+						// we should stop the ambience or it will play FOREVER causing player insanity
+						if (M?.client && !mobarea?.sound_loop)
 							M.client.playAmbience(src, AMBIENCE_LOOPING, 0) //pass 0 to cancel
 
 		if ((isliving(A) || iswraith(A)) || locate(/mob) in A)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

if you exit an area with a sound loop into an area without a sound loop
for ambience, we should always stop the ambience

if you were traveling from one area to another where the sound group
was the same but the new area didn't have a sound loop, the ambience
sound loop would never be stopped

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

this exhibited itself in the candy shop.  going from
the candy shop into space would never end the sound loop, driving
players to insanity

fixes #4607