### PR TITLE
Fix for Kondaru routing depot south router

### DIFF
--- a/code/obj/machinery/launcherloader_kondaru.dm
+++ b/code/obj/machinery/launcherloader_kondaru.dm
@@ -111,7 +111,7 @@
 
 /obj/machinery/cargo_router/kd_depot_south
 	New()
-		destinations = list("Catering" = NORTH,"Engineering" = NORTH,"Mining" = WEST)
+		destinations = list("Catering" = WEST,"Engineering" = WEST,"Mining" = WEST)
 		default_direction = SOUTH
 		..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA -->

Changes the kd_depot_south cargo router to send Catering and Engineering tagged objects west instead of north, fixing an issue introduced with alterations to nearby belt layout.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes cargo go where it's supposed to.
