### PR TITLE
Fixed material processor exploit with certain items and re-enabled these items

### DIFF
--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -41,38 +41,92 @@
 
 			var/mat_id
 
-			if(exists_nearby)
-				exists_nearby.change_stack_amount(totalAmount)
-				mat_id = exists_nearby.material.mat_id
-			else
-				var/newType = getProcessedMaterialForm(X.material)
-				var/obj/item/material_piece/P = unpool(newType)
-				P.set_loc(get_output_location())
-				P.setMaterial(copyMaterial(X.material))
-				P.change_stack_amount(totalAmount - P.amount)
-				mat_id = P.material.mat_id
+			//Check for exploitable inputs and divide the result accordingly
+			var/div_factor = 1
+			var/second_mat = null
+			if (istype(X, /obj/item/sheet))
+				div_factor = 10
 
-			if (istype(output_location, /obj/machinery/manufacturer))
-				var/obj/machinery/manufacturer/M = output_location
-				M.update_resource_amount(mat_id, totalAmount * 10)
+			else if (istype(X, /obj/item/rods))
+				div_factor = 20
 
+			else if (istype(X, /obj/item/tile))
+				div_factor = 40
+
+			else if (istype(X, /obj/item/cable_coil))
+				var/obj/item/cable_coil/C = X
+				div_factor = 30
+				second_mat = C.conductor
+
+			else if (istype(X, /obj/item/raw_material/shard))
+				div_factor = 10
+
+			//Output processed amount if there is enough input material
+			var/out_amount = round(totalAmount/div_factor)
+			if (out_amount > 0)
+				if(exists_nearby)
+					exists_nearby.change_stack_amount(out_amount)
+					mat_id = exists_nearby.material.mat_id
+				else
+					var/newType = getProcessedMaterialForm(X.material)
+					var/obj/item/material_piece/P = unpool(newType)
+					P.set_loc(get_output_location())
+					P.setMaterial(copyMaterial(X.material))
+					P.change_stack_amount(out_amount - P.amount)
+					mat_id = P.material.mat_id
+
+				if (istype(output_location, /obj/machinery/manufacturer))
+					var/obj/machinery/manufacturer/M = output_location
+					M.update_resource_amount(mat_id, out_amount * 10)
+
+				//If the input was a cable coil, output the conductor too
+				if (second_mat)
+					var/obj/item/material_piece/second_exists_nearby = null
+					var/second_mat_id
+					for(var/obj/item/material_piece/G in output_location)
+						if(isSameMaterial(G.material, second_mat))
+							second_exists_nearby = G
+							break
+
+					if(exists_nearby)
+						second_exists_nearby.change_stack_amount(out_amount)
+						second_mat_id = second_exists_nearby.material.mat_id
+					else
+						var/newType = getProcessedMaterialForm(second_mat)
+						var/obj/item/material_piece/PC = unpool(newType)
+						PC.set_loc(get_output_location())
+						PC.setMaterial(copyMaterial(second_mat))
+						PC.change_stack_amount(out_amount - PC.amount)
+						second_mat_id = PC.material.mat_id
+
+					if (istype(output_location, /obj/machinery/manufacturer))
+						var/obj/machinery/manufacturer/M = output_location
+						M.update_resource_amount(second_mat_id, out_amount * 10)
+
+			//Delete items in processor and output leftovers
+			var/leftovers = (totalAmount/div_factor-out_amount)*div_factor
 			for(var/atom/movable/D in matches)
+				var/obj/item/R = D
+				if (leftovers != 0 && R.amount)
+					R.change_stack_amount(leftovers-R.amount)
+					R.set_loc(src.loc)
+					leftovers = 0
+					continue
 				D.set_loc(null)
 				qdel(D)
 				D = null
 
-			playsound(src.loc, "sound/effects/pop.ogg", 40, 1)
-			flick("fab3-work",src)
+			if (out_amount > 0)//No animation and beep if nothing processed
+				playsound(src.loc, "sound/effects/pop.ogg", 40, 1)
+				flick("fab3-work",src)
+			else
+				playsound(src.loc, "sound/machines/buzz-two.ogg", 40, 1)
 		return
 
 	attackby(var/obj/item/W as obj, mob/user as mob)
 		//Wire: Fix for: undefined proc or verb /turf/simulated/floor/set loc()
 		//		like somehow a dude tried to load a turf? how the fuck? whatever just kill me
 		if (!istype(W))
-			return
-
-		if(isExploitableObject(W))
-			boutput(user, "<span class='alert'>\the [src] grumps at you and refuses to use [W].</span>")
 			return
 
 		if(istype(W, /obj/item/material_piece))
@@ -175,8 +229,6 @@
 			for (var/obj/item/raw_material/M in O.contents)
 				if(!M.material)
 					continue
-				if(isExploitableObject(M))
-					continue
 				if(istype(M, /obj/item/material_piece))
 					continue
 				M.set_loc(src)
@@ -194,7 +246,7 @@
 
 
 		//if (istype(W, /obj/item/raw_material/) || istype(W, /obj/item/sheet/) || istype(W, /obj/item/rods/) || istype(W, /obj/item/tile/) || istype(W, /obj/item/cable_coil))
-		if(!isExploitableObject(W) && W.material && !istype(W, /obj/item/material_piece))
+		if(W.material && !istype(W, /obj/item/material_piece))
 			quickload(user, W)
 		else
 			attackby(W, user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The material processor now accepts shards, rods, sheets, cable coils, and floor tiles. To prevent exploits, the material processor only returns 1 bar for every 10 sheets, 20 rods, 40 tiles, 10 shards, or 30 cable lengths. Cable coils also return the correct amounts of rubber and conductor.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There was an exploit that allowed material multiplication with the material processor. This was fixed by disabling the exploitable items. This change fixes the exploit itself and re-enables these items.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Fixes the exploit with sheets, rods, shards, tiles, and cable coils in the material processor and re-enables processing these items.
```
