### PR TITLE
fix: be supportive of blind wizards by giving them VISORs

### DIFF
--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -39,6 +39,10 @@
 		I.layer = initial(I.layer)
 
 	if(robe) wizard_mob.equip_if_possible(new /obj/item/clothing/suit/wizrobe(wizard_mob), wizard_mob.slot_wear_suit)
+
+	if (wizard_mob.traitHolder && wizard_mob.traitHolder.hasTrait("blind"))
+		wizard_mob.equip_if_possible(new /obj/item/clothing/glasses/visor(wizard_mob), wizard_mob.slot_glasses)
+
 	wizard_mob.equip_if_possible(new /obj/item/clothing/under/shorts/black(wizard_mob), wizard_mob.slot_w_uniform)
 	wizard_mob.equip_if_possible(new /obj/item/clothing/head/wizard(wizard_mob), wizard_mob.slot_head)
 	if(wizard_mob.traitHolder && wizard_mob.traitHolder.hasTrait("deaf"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

the Space Wizard Federation is now equipping blind wizards with
VIS-tech Optical Rejuvinator goggles to allow them to be capable
in combat

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

blind-trait wizards don't receive the correct equipment but do receive the blindness.

that's not fun.

fixes #4503

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(+)The Space Wizard Federation is now equipping blind wizards with VIS-tech Optical Rejuvinator goggles!
```
