### PR TITLE
booster gene adjustment

### DIFF
--- a/code/modules/medical/genetics/bioEffects/hemochromia.dm
+++ b/code/modules/medical/genetics/bioEffects/hemochromia.dm
@@ -82,7 +82,7 @@ ABSTRACT_TYPE(/datum/bioEffect/hemochromia)
 	lockedDiff = 2
 	lockedChars = list("A","T","C","G")
 	lockedTries = 12
-	stability_loss = 0
+	stability_loss = 5
 	icon_state  = "hemochromia_unknown"
 	occur_in_genepools = 0
 	acceptable_in_mutini = 0

--- a/code/modules/medical/genetics/bioEffects/hemochromia.dm
+++ b/code/modules/medical/genetics/bioEffects/hemochromia.dm
@@ -82,7 +82,7 @@ ABSTRACT_TYPE(/datum/bioEffect/hemochromia)
 	lockedDiff = 2
 	lockedChars = list("A","T","C","G")
 	lockedTries = 12
-	stability_loss = 5
+	stability_loss = 0
 	icon_state  = "hemochromia_unknown"
 	occur_in_genepools = 0
 	acceptable_in_mutini = 0

--- a/code/modules/medical/genetics/bioEffects/meta.dm
+++ b/code/modules/medical/genetics/bioEffects/meta.dm
@@ -18,7 +18,7 @@
 	New(var/for_global_list = 0)
 		..()
 		if (!for_global_list)
-			name = "Booster Gene"
+			name = "Booster Gene X"
 
 	OnAdd()
 		var/mob/living/L = owner
@@ -49,7 +49,7 @@
 	New(var/for_global_list = 0)
 		..()
 		if (!for_global_list)
-			name = "Booster Gene"
+			name = "Booster Gene Y"
 
 	OnAdd()
 		var/mob/living/L = owner
@@ -79,7 +79,7 @@
 	New(var/for_global_list = 0)
 		..()
 		if (!for_global_list)
-			name = "Booster Gene"
+			name = "Booster Gene Z"
 
 	OnAdd()
 		var/mob/living/L = owner

--- a/code/modules/medical/genetics/bioEffects/meta.dm
+++ b/code/modules/medical/genetics/bioEffects/meta.dm
@@ -15,11 +15,6 @@
 	lockedTries = 10
 	curable_by_mutadone = 0
 
-	New(var/for_global_list = 0)
-		..()
-		if (!for_global_list)
-			name = "Booster Gene X"
-
 	OnAdd()
 		var/mob/living/L = owner
 		var/datum/bioHolder/B = L.bioHolder
@@ -46,11 +41,6 @@
 	lockedTries = 10
 	curable_by_mutadone = 0
 
-	New(var/for_global_list = 0)
-		..()
-		if (!for_global_list)
-			name = "Booster Gene Y"
-
 	OnAdd()
 		var/mob/living/L = owner
 		var/datum/bioHolder/B = L.bioHolder
@@ -75,11 +65,6 @@
 	lockedChars = list("G","C","A","T")
 	lockedTries = 10
 	curable_by_mutadone = 0
-
-	New(var/for_global_list = 0)
-		..()
-		if (!for_global_list)
-			name = "Booster Gene Z"
 
 	OnAdd()
 		var/mob/living/L = owner


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
makes it so the booster genes say what they are in the scanner like they do in the record
~~attempts to fix a issue were type-u would take 5 stability even if it was in your genetic record~~
~~(im assuming it had to do with the type-a costing 5 even though its supposedly stable.)~~


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
generally get annoyed when activating a booster from the scanner and its actually the one that removes all genes fixing #4611 
~~type-u taking 5 stability even though it was in your genetic record is wack~~

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)RSG250
(+)booster genes now show what they are in the scanner like the record
```
