### PR TITLE
chore: Refactor death confetti to use component

### DIFF
--- a/_std/defines/component_defines.dm
+++ b/_std/defines/component_defines.dm
@@ -145,6 +145,9 @@
 /// When a mob dies
 #define COMSIG_MOB_DEATH "mob_death"
 
+/// When a mob fakes death
+#define COMSIG_MOB_FAKE_DEATH "mob_fake_death"
+
 #define COMSIG_MOB_PICKUP "mob_pickup"
 
 #define COMSIG_MOB_DROPPED "mob_drop"

--- a/code/datums/components/death_confetti.dm
+++ b/code/datums/components/death_confetti.dm
@@ -1,0 +1,22 @@
+/datum/component/death_confetti
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+
+/datum/component/death_confetti/Initialize()
+	if(!istype(parent, /atom/movable))
+		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_OBJ_CRITTER_DEATH, .proc/the_confetti)
+	RegisterSignal(parent, COMSIG_MOB_DEATH, .proc/the_confetti)
+	RegisterSignal(parent, COMSIG_MOB_FAKE_DEATH, .proc/the_confetti)
+
+/datum/component/death_confetti/proc/the_confetti()
+	var/atom/movable/AM = parent
+	var/turf/T = get_turf(AM)
+	particleMaster.SpawnSystem(new /datum/particleSystem/confetti(T))
+	SPAWN_DBG(1 SECOND)
+		playsound(T, "sound/voice/yayyy.ogg", 50, 1)
+
+/datum/component/death_confetti/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_OBJ_CRITTER_DEATH)
+	UnregisterSignal(parent, COMSIG_MOB_DEATH)
+	UnregisterSignal(parent, COMSIG_MOB_FAKE_DEATH)
+	. = ..()

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -987,6 +987,10 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		..()
 		if (!M)
 			return
+
+		// Yaaaaaay!
+		M.AddComponent(/datum/component/death_confetti)
+
 		M.bioHolder.AddEffect("clumsy", magical=1)
 		if (prob(50))
 			M.bioHolder.AddEffect("accent_comic", magical=1)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -198,7 +198,8 @@
 				boutput(world, "<span class='notice'><B>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</B></span>")
 	#undef VALID_MOB
 
-	if (deathConfettiActive || (src.mind && src.mind.assigned_role == "Clown")) //Active if XMAS or manually toggled. Or if theyre a clown. Clowns always have death confetti.
+	// Active if XMAS or manually toggled.
+	if (deathConfettiActive)
 		src.deathConfetti()
 
 	var/youdied = "You have died!"

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1274,10 +1274,18 @@
 
 			if ("deathgasp")
 				if (!voluntary || src.emote_check(voluntary,50))
-					if (deathConfettiActive || (src.mind && src.mind.assigned_role == "Clown"))
-						src.deathConfetti()
-					if (prob(15) && !ischangeling(src) && !isdead(src)) message = "<span class='regular'><B>[src]</B> seizes up and falls limp, peeking out of one eye sneakily.</span>"
+					if (prob(15) && !ischangeling(src) && !isdead(src))
+						message = "<span class='regular'><B>[src]</B> seizes up and falls limp, peeking out of one eye sneakily.</span>"
 					else
+						if (!isdead(src))
+							#ifdef COMSIG_MOB_FAKE_DEATH
+							SEND_SIGNAL(src, COMSIG_MOB_FAKE_DEATH)
+							#endif
+
+						// Active if XMAS or manually toggled.
+						if (deathConfettiActive)
+							src.deathConfetti()
+
 						message = "<span class='regular'><B>[src]</B> seizes up and falls limp, [his_or_her(src)] eyes dead and lifeless...</span>"
 						playsound(get_turf(src), "sound/voice/death_[pick(1,2)].ogg", 40, 0, 0, src.get_age_pitch())
 					m_type = 1

--- a/code/obj/deathbutton.dm
+++ b/code/obj/deathbutton.dm
@@ -17,9 +17,10 @@
 			. = "Like the last jerk that pressed it."
 
 	attack_hand(mob/user as mob)
-		var/dca = deathConfettiActive //Save the current state of death confetti
 		if (!user.stat)
-			deathConfettiActive = 1	//Yaaaaaaaaaaaaaaaay!!
+			//Yaaaaaaaaaaaaaaaay!!
+			user.AddComponent(/datum/component/death_confetti)
+
 			user.death()
 			if(!user || isdead(user)) //User gibbed or actually dead.
 				numkills++
@@ -27,7 +28,8 @@
 					name = "blue ribbon [src.name]"
 					src.overlays += new /image {icon = 'icons/misc/stickers.dmi'; icon_state = "1st_place"; pixel_x = 3; pixel_y = -2} ()
 
-			deathConfettiActive = dca	//Restore it.
+			var/datum/component/C = user.GetComponent(/datum/component/death_confetti)
+			C?.RemoveComponent()
 		return
 
 /obj/racist_button

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -247,6 +247,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\components\clown_disbelief_item.dm"
 #include "code\datums\components\controlled_by_mob.dm"
 #include "code\datums\components\crayonwalk.dm"
+#include "code\datums\components\death_confetti.dm"
 #include "code\datums\components\disposing_confetti.dm"
 #include "code\datums\components\drop_loot_on_death.dm"
 #include "code\datums\components\foldable.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

refactors death confetti for clowns into a reusable death confetti component

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

it's nice to have a reusable component for death confetti and now it's possible to reuse a mob faking their own death signals