### PR TITLE
Fixes invisible zero item stack

### DIFF
--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -35,7 +35,7 @@
 		return
 
 	split_stack(var/toRemove)
-		if(toRemove >= amount) return 0
+		if(toRemove >= amount || toRemove < 1) return 0
 		var/obj/item/material_piece/P = unpool(src.type)
 		P.set_loc(src.loc)
 		P.setMaterial(copyMaterial(src.material))

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -609,7 +609,7 @@
 	return 1
 
 /obj/item/proc/split_stack(var/toRemove)
-	if(toRemove >= amount) return 0
+	if(toRemove >= amount || toRemove < 1) return 0
 	var/obj/item/P = new src.type(src.loc)
 
 	if(src.material)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the possibility of clicking on a stack of items in the opposite hand, entering 0 in the dialog box, and getting an invisible stack of 0 items in the other hand.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #4669


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Fixes the creation of invisible, zero item stacks when entering 0 in a dialog for splitting a stack of items.
```