### PR TITLE
Removes earning the banned medal on being banned.

### DIFF
--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -171,7 +171,6 @@ var/global/list/playersSeen = list()
 
 		var/replacement_text
 		if (targetC)
-			targetC.mob.unlock_medal("Banned", 1)
 			boutput(targetC, "<span class='alert'><BIG><B>You have been banned by [row["akey"]].<br>Reason: [row["reason"]]</B></BIG></span>")
 			boutput(targetC, "<span class='alert'>To try to resolve this matter head to https://forum.ss13.co</span>")
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes earning the banned medal on being banned. This only removes the line of code that gives you the medal on getting banned, one of the developers with medals access would be needed to fully remove it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As far as I know, the medal isn't used for any administrative purposes and depsite people being old that having the medal isnt a badge of honour, people continue to do so. It's best to just remove it

