### PR TITLE
Remove miss chance when attacking cyborgs

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -1064,25 +1064,6 @@
 
 	return 1
 
-/mob/living/silicon/robot/melee_attack_test(var/mob/attacker, var/obj/item/I, var/def_zone, var/disarm_check = 0)
-	if (!..())
-		return 0
-
-	if (I)
-		var/hit_chance = 50
-		if (def_zone == "chest")
-			hit_chance = 90
-		else if (def_zone == "head")
-			hit_chance = 70
-		if(!client || is_incapacitated(src))
-			hit_chance = 100
-		if (!prob(hit_chance))
-			playsound(loc, "sound/impact_sounds/Generic_Swing_1.ogg", 50, 1, 1)
-			src.visible_message("<span class='alert'><b>[attacker] swings at [src], but misses!</b></span>")
-			return 0
-
-	return 1
-
 /mob/living/melee_attack_test(var/mob/attacker, var/obj/item/I, var/def_zone, var/disarm_check = 0)
 	if (!..())
 		return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Previously, when attacking cyborgs there was a 10% chance of missing if attacking a cyborg's chest, 30% chance of missing if attacking their head, and 50% chance of missing if attacking a limb.

This removes those miss chances, meaning that it will take slightly fewer attacks (same number of actual hits) to destroy/damage a cyborg, on average.

To anyone who took account of previous behavior when attacking cyborgs, you may find that you can destroy their limbs easier than before to allow for easier neutralization of the threat (e.g. hit a light cyborg's legs a few times to really slow it down by destroying one if you don't really want to completely destroy the cyborg by attacking its head/chest).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Inconsistent with combat behavior with humans, passive RNG can be pretty bad. These miss chances were not intuitive or explained in any way. While this is more of a larger "meta" thing, this may make attacking their legs to slow them down, for example, a more viable strategy than before.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Mordent
(*)You no longer randomly miss cyborgs when melee attacking them.
```
