### PR TITLE
Neon lining inventory counter

### DIFF
--- a/code/obj/item/neon_lining.dm
+++ b/code/obj/item/neon_lining.dm
@@ -23,6 +23,7 @@
 	rand_pos = 1
 	event_handler_flags = USE_GRAB_CHOKE | USE_FLUID_ENTER
 	special_grab = /obj/item/grab
+	inventory_counter_enabled = 1
 
 	var/lining_item_color = "blue"
 
@@ -59,12 +60,14 @@
 		else
 			amount -= used
 			tooltip_rebuild = 1
+			src.updateicon()
 			return 1
 
 	proc/take(var/amt, var/newloc)
 		if (amt > amount)
 			amt = amount
 			tooltip_rebuild = 1
+			src.updateicon()
 		if (amt == amount)
 			if (ismob(loc))
 				var/mob/owner = loc
@@ -78,6 +81,7 @@
 
 	proc/updateicon()
 		set_icon_state("item_[lining_item_color]")
+		inventory_counter?.update_number(amount)
 		return
 
 /obj/item/neon_lining/cut
@@ -116,6 +120,7 @@
 		tooltip_rebuild = 1
 		take(1, user.loc)
 		boutput(user, "You cut a piece off the [base_name].")
+		src.updateicon()
 		return
 
 	else if (istype(W, /obj/item/neon_lining))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an inventory counter to neon lining, just like cable coils have them!
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The sprite doesn't indicate the amount at all + inventory counters are cool.