### PR TITLE
Makes TTV backpacks give the correct ammount of cable when unmade

### DIFF
--- a/code/obj/item/device/transfer_valve.dm
+++ b/code/obj/item/device/transfer_valve.dm
@@ -156,7 +156,8 @@
 				else
 					flags &= ~ONBACK
 					var/turf/location = get_turf(src)
-					new /obj/item/cable_coil/cut/small(location)
+					var/obj/item/cable_coil/cut/C = new /obj/item/cable_coil/cut(location)
+					C.amount = 2
 					boutput(usr, "<span class='notice'>You detach the loops of wire from [src]!</span>")
 					update_icon()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes TTV Backpacks only create 2 cables when you unmake them
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It costs 2 to make one, it shouldn't randomly give me 1-5 when I unmake one