### PR TITLE
Allows the wiretap upgrade to be scanned by syndicate scanners

### DIFF
--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -377,3 +377,5 @@ Secure Frequency:
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "syndie_upgr"
 	w_class = W_CLASS_TINY
+	is_syndicate = 1
+	mats = 12


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows for the syndicate wiretap upgrade to be scanned, using a syndicate device analyzer. It costs 12 materials, with no non-standard materials needed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I feel that the wiretap fits with what the syndicate device analyzer can scan, being mechanical/technical traitor items. In additon, it just felt a bit odd for this not to be scannable.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(*)Syndicate Wiretap can now be scanned using a syndicate device analyzer.
```
