### PR TITLE
made artifact forms slightly less terrible to use

### DIFF
--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -58,10 +58,12 @@
 		O.UpdateName()
 
 	attack_hand(mob/user)
-		user.lastattacked = src.attached
-		if(src.attached)
+		var/obj/attachedobj = src.attached
+		if(istype(attachedobj) && attachedobj.artifact) // touch artifact we are attached to
 			src.attached.attack_hand(user)
-			user.lastattacked = src.attached
+			user.lastattacked = user
+		else // do sticker things
+			..()
 
 	stick_to(atom/A, pox, poy)
 		. = ..()
@@ -69,16 +71,20 @@
 			checkArtifactVars(A)
 
 	attackby(obj/item/W, mob/living/user)
-		if(istype(W, /obj/item/pen))
+		if(istype(W, /obj/item/pen)) // write on it
 			ui_interact(user)
-		else if((iscuttingtool(W) || issnippingtool(W)) && user.a_intent == INTENT_HELP)
+		else if((iscuttingtool(W) || issnippingtool(W)) && user.a_intent == INTENT_HELP && src.attached) // remove attached paper from artifact
 			boutput(user, "You manage to scrape \the [src] off of \the [src.attached].")
 			src.remove_from_attached()
 			src.add_fingerprint(user)
 			user.put_in_hand_or_drop(src)
-		else if (src.attached)
-			src.attached.attackby(W, user)
-			user.lastattacked = user
+		else
+			var/obj/attachedobj = src.attached
+			if(istype(attachedobj) && attachedobj.artifact) // hit artifact we are attached to
+				src.attached.attackby(W, user)
+				user.lastattacked = user
+			else // just sticker things
+				..()
 
 	get_desc()
 		. = src.artifactType!=""?"This one seems to be describing a [src.artifactType] type artifact.":""


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Artifact forms now only relay clicks to the thing they are attached to if said thing is an artifact.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People would get them stuck on the floor and other places and not know how to remove them, this makes it easier in those cases.
Should also fix issues where they could get stuck in backpack/pocket slots, I think?
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+) Artifact forms should now be easier to remove from non-artifacts. You can still remove them from artifacts via knives/scalpels/scissors/wirecutters/other stuff.
```
