### PR TITLE
Make lipstick be the same color as the crayon it was made from

### DIFF
--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -1573,3 +1573,14 @@
 	item2 = /obj/item/item_box/figure_capsule
 	cookbonus = 10
 	output = /obj/item/pen/crayon/lipstick
+
+	specialOutput(obj/submachine/ourCooker)
+		if (!ourCooker)
+			return null
+		var/obj/item/pen/crayon/lipstick/lipstick = new /obj/item/pen/crayon/lipstick
+		for (var/obj/item/pen/crayon/C in ourCooker.contents)
+			lipstick.font_color = C.font_color
+			lipstick.color_name = hex2color_name(lipstick.font_color)
+			lipstick.name = "[lipstick.color_name] lipstick"
+			lipstick.update_icon()
+		return lipstick


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature][crayons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When you make lipstick, its a random color. Now it is not.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Color.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Stonepillar
(+)Lipstick now uses the same color as the crayon that was used to make it.
```
