### PR TITLE
Gives spliced seed items color

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -254,7 +254,8 @@
 
 								var/datum/plantgenes/DNA = P.plantgenes
 								var/datum/plantgenes/PDNA = S.plantgenes
-								S.generic_seed_setup(stored)
+								if (!stored.hybrid && !stored.unique_seed)
+									S.generic_seed_setup(stored)
 								HYPpassplantgenes(DNA,PDNA)
 								if (stored.hybrid)
 									var/datum/plant/hybrid = new /datum/plant(S)
@@ -262,6 +263,7 @@
 										if (issaved(stored.vars[V]) && V != "holder")
 											hybrid.vars[V] = stored.vars[V]
 									S.planttype = hybrid
+									S.plant_seed_color(stored.seedcolor)
 								user.visible_message("<span class='notice'><b>[user]</b> spits out a seed.</span>",\
 								"<span class='notice'>You spit out a seed.</span>")
 					if(src.dropped_item)

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1237,6 +1237,7 @@
 							seedname = "[MUT.name_prefix][growing.name][MUT.name_suffix]"
 
 					S.name = "[seedname] seed"
+					S.plant_seed_color(growing.seedcolor)
 					HYPpassplantgenes(HDNA,SDNA)
 					S.generation = src.generation
 					if(growing.hybrid)

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -352,6 +352,7 @@
 						HYPpassplantgenes(DNA,SDNA)
 
 						S.name = stored.name
+						S.plant_seed_color(stored.seedcolor)
 						if (stored.hybrid)
 							var/datum/plant/hybrid = new /datum/plant(S)
 							for(var/V in stored.vars)
@@ -550,6 +551,9 @@
 				P.cantscan = dominantspecies.cantscan
 				P.nectarlevel = dominantspecies.nectarlevel
 				S.name = "[P.name] seed"
+
+				P.seedcolor = rgb(round((GetRedPart(P1.seedcolor) + GetRedPart(P2.seedcolor)) / 2), round((GetGreenPart(P1.seedcolor) + GetGreenPart(P2.seedcolor)) / 2), round((GetBluePart(P1.seedcolor) + GetBluePart(P2.seedcolor)) / 2))
+				S.plant_seed_color(P.seedcolor)
 
 				var/newgenome = P1.genome + P2.genome
 				if (newgenome)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When splicing, seeds will now average the seed color of the seeds used for splicing. 
![image](https://user-images.githubusercontent.com/60405592/117994536-9ffcf000-b30e-11eb-81f7-56ce5883c415.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This helps differentiate spliced seeds from strange seeds and other spliced seeds.

