### PR TITLE
Gives blue NT ID card to several jobs, adds it to agent card's ID list

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1419,6 +1419,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	cant_spawn_as_rev = 1
 	slot_back = /obj/item/storage/backpack/withO2
 	slot_belt = /obj/item/device/pda2/heads
+	slot_card = /obj/item/card/id/nt
 	slot_jump = /obj/item/clothing/under/misc/lawyer/black // so they can slam tables
 	slot_foot = /obj/item/clothing/shoes/brown
 	slot_ears = /obj/item/device/radio/headset/command
@@ -1453,6 +1454,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 	slot_back = /obj/item/storage/backpack/withO2
 	slot_belt = /obj/item/device/pda2/heads
+	slot_card = /obj/item/card/id/nt
 	slot_jump = /obj/item/clothing/under/misc/NT
 	slot_foot = /obj/item/clothing/shoes/brown
 	slot_ears = /obj/item/device/radio/headset/command
@@ -2323,7 +2325,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 	slot_foot = /obj/item/clothing/shoes/swat
 	slot_ears = /obj/item/device/radio/headset/command/nt //needs their own secret channel
 	slot_mask = /obj/item/clothing/mask/breath
-	slot_card = /obj/item/card/id/command
+	slot_card = /obj/item/card/id/nt
 	slot_poc1 = /obj/item/spacecash/fivehundred
 	slot_poc2 = /obj/item/storage/pouch/bullet_9mm
 	items_in_backpack = list(/obj/item/gun/energy/ntgun,
@@ -2368,7 +2370,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 	slot_glov = /obj/item/clothing/gloves/swat/NT
 	slot_eyes = /obj/item/clothing/glasses/sunglasses/sechud
 	slot_ears = /obj/item/device/radio/headset/command/nt //needs their own secret channel
-	slot_card = /obj/item/card/id/command
+	slot_card = /obj/item/card/id/nt
 	slot_poc1 = /obj/item/device/pda2/ntso
 	slot_poc2 = /obj/item/spacecash/fivehundred
 	items_in_backpack = list(/obj/item/storage/firstaid/regular,

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -112,6 +112,9 @@ GAUNTLET CARDS
 /obj/item/card/id/command
 	icon_state = "id_com"
 
+/obj/item/card/id/nt
+	icon_state = "polaris"
+
 /obj/item/card/id/security
 	icon_state = "id_sec"
 
@@ -236,12 +239,14 @@ GAUNTLET CARDS
 	if(!src.registered)
 		var/reg = copytext(src.sanitize_name(input(user, "What name would you like to put on this card?", "Agent card name", ishuman(user) ? user.real_name : user.name)), 1, 100)
 		var/ass = copytext(src.sanitize_name(input(user, "What occupation would you like to put on this card?\n Note: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Staff Assistant"), 1), 1, 100)
-		var/color = input(user, "What color should the ID's color band be?\nClick cancel to abort the forging process.") as null|anything in list("clown","golden","blue","red","green","purple","yellow","No band")
+		var/color = input(user, "What color should the ID's color band be?\nClick cancel to abort the forging process.") as null|anything in list("clown","golden","NT","blue","red","green","purple","yellow","No band")
 		switch (color)
 			if ("clown")
 				src.icon_state = "id_clown"
 			if ("golden")
 				src.icon_state = "gold"
+			if ("NT")
+				src.icon_state = "polaris"
 			if ("No band")
 				src.icon_state = "id"
 			if ("blue")

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -593,6 +593,8 @@
 				return 1
 			if("gold")
 				return 1
+			if("polaris")
+				return 1
 			else
 				return 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes NTSO (both Special and Security operatives), inspector and regional director start with a blue Nanotrasen ID card (this one):

![0](https://user-images.githubusercontent.com/62990808/118011650-95634a80-b350-11eb-9a62-ed2d9a54f53d.png)
Also adds it to the agent card's list of pickable card colours and the NARCS turret whitelist.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

NTSO, regional director and inspector aren't really employees of the station, they're visitors and they represent Nanotrasen. Giving them a blue ID makes them distinct from the other crewmembers and adds some flavour.
Also adding it to agent card expands the gimmick potential of that item.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)NTSO, regional director and inspector start with a blue Nanotrasen ID card now.
(+)Blue NT card is also available on the list of agent card's pickable card colours.
```
