### PR TITLE
Ghostdrone cardboard RCD exploit fix

### DIFF
--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -305,10 +305,8 @@ Broken RCD + Effects
 						var/turf/simulated/floor/T = A:ReplaceWithFloor()
 						if (!restricted_materials || !safe_deconstruct)
 							T.setMaterial(getMaterial(material_name))
-						else if(!("steel" in restricted_materials))
-							T.setMaterial(getMaterial("steel"))
 						else
-							T.setMaterial(getMaterial("negativematter"))
+							T.setMaterial(getMaterial("steel"))
 						log_construction(user, "deconstructs a wall ([A])")
 						return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

-Makes C-RCD no longer convert cardboard walls into cardboard floors.
-Gets rid of a wonky cardboard RCD code bit that I feel shouldn't be there yet in the current state of cardboard RCD, even if there is a plan to expand it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Cardboard floors can be removed with cardboard RCD. Letting ghostdrones convert and remove station floors is a bad idea.
