### PR TITLE
Firebrand axe buff, napalm smoke grenades

### DIFF
--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -532,3 +532,17 @@
 
 		beakers += B1
 		beakers += B2
+
+/obj/item/chem_grenade/plasma
+	name = "plasma grenade"
+	desc = "A grenade that will fill an area with plasma gas."
+	icon = 'icons/obj/items/grenade.dmi'
+	icon_state = "incendiary"
+	icon_state_armed = "incendiary1"
+	stage = 2
+
+	New()
+		..()
+		var/obj/item/reagent_containers/glass/B1 = new(src)
+		B1.reagents.add_reagent("plasma", 20)
+		beakers += B1

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -533,9 +533,9 @@
 		beakers += B1
 		beakers += B2
 
-/obj/item/chem_grenade/plasma
-	name = "plasma gas grenade"
-	desc = "A grenade that will fill an area with plasma gas."
+/obj/item/chem_grenade/napalm
+	name = "napalm smoke grenade"
+	desc = "A grenade that will fill an area with napalm smoke."
 	icon = 'icons/obj/items/grenade.dmi'
 	icon_state = "incendiary"
 	icon_state_armed = "incendiary1"
@@ -546,7 +546,7 @@
 		var/obj/item/reagent_containers/glass/B1 = new(src)
 		var/obj/item/reagent_containers/glass/B2 = new(src)
 
-		B1.reagents.add_reagent("plasma", 25)
+		B1.reagents.add_reagent("syndicate_napalm", 25)
 		B1.reagents.add_reagent("sugar",25)
 
 		B2.reagents.add_reagent("phosphorus", 25)

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -544,5 +544,13 @@
 	New()
 		..()
 		var/obj/item/reagent_containers/glass/B1 = new(src)
-		B1.reagents.add_reagent("plasma", 20)
+		var/obj/item/reagent_containers/glass/B2 = new(src)
+
+		B1.reagents.add_reagent("plasma", 25)
+		B1.reagents.add_reagent("sugar",25)
+
+		B2.reagents.add_reagent("phosphorus", 25)
+		B2.reagents.add_reagent("potassium", 25)
+
 		beakers += B1
+		beakers += B2

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -534,7 +534,7 @@
 		beakers += B2
 
 /obj/item/chem_grenade/plasma
-	name = "plasma grenade"
+	name = "plasma gas grenade"
 	desc = "A grenade that will fill an area with plasma gas."
 	icon = 'icons/obj/items/grenade.dmi'
 	icon_state = "incendiary"

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -876,7 +876,7 @@
 			throwforce = 25
 			throw_speed = 4
 			throw_range = 8
-			stamina_damage = 40
+			stamina_damage = 45
 			stamina_cost = 25
 			stamina_crit_chance = 10
 		else

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -872,22 +872,22 @@
 	proc/set_values()
 		if(two_handed)
 			src.click_delay = 15
-			force = 30
-			throwforce = 20
+			force = 40
+			throwforce = 25
 			throw_speed = 4
 			throw_range = 8
 			stamina_damage = 40
-			stamina_cost = 27
-			stamina_crit_chance = 5
+			stamina_cost = 25
+			stamina_crit_chance = 10
 		else
 			src.click_delay = 10
-			force = 15
-			throwforce = 5
+			force = 20
+			throwforce = 10
 			throw_speed = 2
 			throw_range = 4
-			stamina_damage = 30
-			stamina_cost = 20
-			stamina_crit_chance = 2
+			stamina_damage = 25
+			stamina_cost = 15
+			stamina_crit_chance = 5
 		tooltip_rebuild = 1
 		return
 

--- a/code/obj/item/storage/ammo_pouches.dm
+++ b/code/obj/item/storage/ammo_pouches.dm
@@ -125,9 +125,9 @@
 		spawn_contents = list(/obj/item/old_grenade/stinger/frag = 3,
 		/obj/item/old_grenade/stinger = 3)
 
-	plasma
-		name = "plasma gas grenade pouch"
-		spawn_contents = list(/obj/item/chem_grenade/plasma = 6)
+	napalm
+		name = "napalm smoke grenade pouch"
+		spawn_contents = list(/obj/item/chem_grenade/napalm = 6)
 
 // dumb idiot gannets shouldn't have called these "ammo_pouches" if he was gonna make pouches for non-ammo things. wow.
 

--- a/code/obj/item/storage/ammo_pouches.dm
+++ b/code/obj/item/storage/ammo_pouches.dm
@@ -125,6 +125,10 @@
 		spawn_contents = list(/obj/item/old_grenade/stinger/frag = 3,
 		/obj/item/old_grenade/stinger = 3)
 
+	plasma
+		name = "plasma gas grenade pouch"
+		spawn_contents = list(/obj/item/chem_grenade/plasma = 6)
+
 // dumb idiot gannets shouldn't have called these "ammo_pouches" if he was gonna make pouches for non-ammo things. wow.
 
 /obj/item/storage/medical_pouch

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -504,6 +504,7 @@
 		desc = "A crate containing a Specialist Operative loadout."
 		spawn_contents = list(/obj/item/gun/flamethrower/backtank/napalm,
 		/obj/item/fireaxe,
+		/obj/item/storage/grenade_pouch/plasma,
 		/obj/item/storage/grenade_pouch/incendiary,
 		/obj/item/clothing/suit/space/syndicate/specialist/firebrand,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/firebrand)

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -504,7 +504,7 @@
 		desc = "A crate containing a Specialist Operative loadout."
 		spawn_contents = list(/obj/item/gun/flamethrower/backtank/napalm,
 		/obj/item/fireaxe,
-		/obj/item/storage/grenade_pouch/plasma,
+		/obj/item/storage/grenade_pouch/napalm,
 		/obj/item/storage/grenade_pouch/incendiary,
 		/obj/item/clothing/suit/space/syndicate/specialist/firebrand,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/firebrand)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Improves one and two handed damage and stamina damage of the fire axe.
Adds napalm smoke grenades and a grenade pouch to fit them. These grenades smoke an area with syndicate napalm, which is easily ignited by flamethrowers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Firebrand is the least picked nuke ops class according to data gathered by Pali. These improvements should help to improve the class' ability to deny areas with gas grenades and up their single-target damage with the fire axe buffs.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gannets
(*)Added a pouch of napalm smoke grenades to the Firebrand class crate.
(+)Buffed damage and stamina damage of the fire-axe, in both one and two-handed modes.
```
