### PR TITLE
Adds movespeed buff to nuke ops Scout armour.

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1118,6 +1118,11 @@
 			icon_state = "syndie_specialist-infiltrator"
 			item_state = "syndie_specialist-infiltrator"
 
+		setupProperties()
+			..()
+			setProperty("space_movespeed", 0.75)
+
+
 		firebrand
 			name = "specialist operative firesuit"
 			icon_state = "syndie_specialist-firebrand"

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1120,7 +1120,7 @@
 
 		setupProperties()
 			..()
-			setProperty("space_movespeed", 0.75)
+			setProperty("space_movespeed", -0.25)
 
 
 		firebrand


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wearing the armour provided in the nuke ops Scout class crate gives you a slight speed buff. 25% faster than not wearing it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Scouts have a niche around getting in and out of combat quickly, their gear should support that. Plus with the knight having a major slow applied on their armour, I thought it'd be fun to have other classes with movement variation too.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gannets
(*)Nuke ops Scout armour now provides a move speed boost to the wearer.
```
