### PR TITLE
Removes the 250 blood minimum for cows to perform the milk emote

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -2039,7 +2039,13 @@
 		var/obj/item/storage/toilet/toilet = locate() in mob.loc
 		var/obj/item/reagent_containers/glass/beaker = locate() in mob.loc
 
-		if (!ishuman(mob))
+		var/can_output = 0
+		if (ishuman(mob))
+			var/mob/living/carbon/human/H = mob
+			if (H.blood_volume > 0)
+				can_output = 1
+
+		if (!can_output)
 			.= "<B>[mob]</B> strains, but fails to output milk!"
 		else if (toilet && (mob.buckled != null))
 			for (var/obj/item/storage/toilet/T in mob.loc)

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -2039,13 +2039,7 @@
 		var/obj/item/storage/toilet/toilet = locate() in mob.loc
 		var/obj/item/reagent_containers/glass/beaker = locate() in mob.loc
 
-		var/can_output = 0
-		if (ishuman(mob))
-			var/mob/living/carbon/human/H = mob
-			if (H.blood_volume > 250)
-				can_output = 1
-
-		if (!can_output)
+		if (!ishuman(mob))
 			.= "<B>[mob]</B> strains, but fails to output milk!"
 		else if (toilet && (mob.buckled != null))
 			for (var/obj/item/storage/toilet/T in mob.loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This allows players with the bovine trait to milk themselves regardless of their blood level. This can result in death, but requires ignoring the stacking symptoms of blood loss.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
At the request of asche on Discord. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Removes the blood level check for performing the milk emote.
```
