### PR TITLE
Guardbuddies actually cuff people now

### DIFF
--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -1917,41 +1917,36 @@
 //Buddy handcuff bar thing
 /datum/action/bar/icon/buddy_cuff
 	duration = 30 // zippy zipcuffs
-	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
+	interrupt_flags = INTERRUPT_MOVE
 	id = "buddy_cuff"
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "handcuff"
 	var/obj/machinery/bot/guardbot/master
 	var/datum/computer/file/guardbot_task/security/task
 
-	New(var/the_bot, var/the_task)
+	New(the_bot, the_task)
 		src.master = the_bot
 		src.task = the_task
 		..()
 
 	onUpdate()
 		..()
-		if (!master || !master.on || master.idle || master.stunned || !IN_RANGE(master, task.arrest_target, 1) || !task.arrest_target || task.arrest_target.hasStatus("handcuffed") || master.moving)
+		if (src.failchecks())
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
 	onStart()
 		..()
-		task.cuffing = 1
-		if (!master || !master.on || master.idle || master.stunned || !IN_RANGE(master, task.arrest_target, 1) || !task.arrest_target || task.arrest_target.hasStatus("handcuffed") || master.moving)
+		if (src.failchecks())
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
 		playsound(master, "sound/weapons/handcuffs.ogg", 30, 1, -2)
 		master.visible_message("<span class='alert'><B>[master] is trying to put handcuffs on [task.arrest_target]!</B></span>")
 
-	onInterrupt()
-		..()
-		task.cuffing = 0
-
 	onEnd()
 		..()
-		if (!master || !master.on || master.idle || master.stunned || !IN_RANGE(master, task.arrest_target, 1) || !task.arrest_target || task.arrest_target.hasStatus("handcuffed") || master.moving)
+		if (src.failchecks())
 			return
 
 		if (task.arrest_target.hasStatus("handcuffed") || !isturf(task.arrest_target.loc))
@@ -1978,8 +1973,6 @@
 			var/arrest_message = pick(task.arrested_messages)
 			master.speak(arrest_message)
 
-		task.cuffing = 0
-
 		var/bot_location = get_area(master)
 		var/last_target = task.arrest_target
 		var/turf/LT_loc = get_turf(last_target)
@@ -1999,6 +1992,13 @@
 		pdaSignal.transmission_method = TRANSMISSION_RADIO
 		if(transmit_connection != null)
 			transmit_connection.post_signal(master, pdaSignal)
+
+	/// Interrupts the action if the bot cant (or shouldnt be able to) continue cuffing
+	proc/failchecks()
+		if (!master || !master.on || master.idle || master.stunned || master.moving)
+			return 1
+		if (!IN_RANGE(master, task.arrest_target, 1) || !task.arrest_target || task.arrest_target.hasStatus("handcuffed"))
+			return 1
 
 //Robot tools.  Flash boards, batons, etc
 /obj/item/device/guardbot_tool
@@ -2697,7 +2697,6 @@
 		var/list/target_names = list() //Dudes we are preprogrammed to arrest.
 		var/tmp/mode = 0 //0: Patrol, 1: Arresting somebody
 		var/tmp/arrest_attempts = 0
-		var/tmp/cuffing = 0
 		var/tmp/last_cute_action = 0
 
 		var/weapon_access = access_carrypermit //These guys can use guns, ok!
@@ -2809,42 +2808,47 @@
 
 					if(!master.moving)
 						find_patrol_target()
+				/*
+				Hunt and arrest mode. Like an angry secbot, but cuter and sometimes has a gun
+				Script should go as follows:
+					Check if the bot is cuffing someone, and don't do anything else if they are (otherwise they just stunlock people like dorks)
+					Check if the bot has a valid target (living, and not dead, and also existing) Done second since the cuffbar implies it has a target already
+					Check if the bot can see the target.
+						If it can, shoot them, then check if they're in cuffing range.
+							If in cuffing range, cuff em, then stand still until they're done.
+							If not, go after them!
+						If it can't, go after them! And get a little frustrated too.
+				*/
 				if(1)
-					if(!arrest_target || !master.tool)
-						src.mode = 0
+					// First, check if we're already cuffing someone. Quit getting sidetracked, you scatterbrained rectangles
+					if(actions.hasAction(src.master, "buddy_cuff"))
 						return
 
-					if(arrest_target)
+					// Next check if they have someone to arrest, and that they're alive. And that they're living.
+					if(!src.arrest_target || !isliving(src.arrest_target) || isdead(src.arrest_target))
+						src.mode = 0
+						src.drop_arrest_target()
+						return // target doesnt exist, is a ghost, or has given up the ghost
 
-						if(!(arrest_target in view(7,master)) && !master.moving)
-							//qdel(master.mover)
-							master.frustration += 2
-							if (master.mover)
-								master.mover.master = null
-								master.mover = null
-							master.navigate_to(arrest_target,ARREST_DELAY, 0, 0)
-							return
+					// Can we "see" them?
+					if(IN_RANGE(master, arrest_target, 7))
+						// Shoot them!
+						master.bot_attack(arrest_target, src.lethal)
+					else
+						// Otherwise get frustrated
+						master.frustration += 2
 
-						else
-							var/targdist = get_dist(master, arrest_target)
-							if((targdist <= 1) || master.tool && master.tool.is_gun || master.budgun || (master.tool == /obj/item/device/guardbot_tool/gun))	// If you have a gun, USE IT AAA
-								if (!isliving(arrest_target) || isdead(arrest_target))
-									mode = 0
-									drop_arrest_target()
-									return
-
-								master.bot_attack(arrest_target, src.lethal)
-								if(targdist <= 1 && !cuffing && (arrest_target.getStatusDuration("weakened") || arrest_target.getStatusDuration("stunned")))
-									actions.start(new/datum/action/bar/icon/buddy_cuff(src.master, src), src.master)
-									return
-							if(!master.path || !master.path.len || (4 < get_dist(arrest_target,master.path[master.path.len])) )
-								master.moving = 0
-								//master.current_movepath = "HEH" //Stop any current movement.
-								master.navigate_to(arrest_target,ARREST_DELAY, 0,0)
-
-					return
-
-			return
+					// Right up against them? Book em!
+					if(IN_RANGE(src.master, src.arrest_target, 1) && is_incapacitated(src.arrest_target))
+						actions.start(new/datum/action/bar/icon/buddy_cuff(src.master, src), src.master)
+					// Otherwise, go get them!
+					else
+						if (master.mover)
+							master.mover.master = null
+							master.mover = null
+						master.moving = 0
+						master.navigate_to(arrest_target,ARREST_DELAY, 0, 0)
+						//master.current_movepath = "HEH" //Stop any current movement.
 
 		task_input(input)
 			if(..()) return 1
@@ -2860,14 +2864,14 @@
 						src.arrest_target = null
 						src.last_found = world.time
 					src.arrest_attempts = 0
-					src.cuffing = 0
+					actions.stopId("buddy_cuff", src.master)
 
 					return 1
 
 				if("path_error","path_blocked")
 					src.arrest_attempts++
 					if(src.arrest_attempts >= 2)
-						src.cuffing = 0
+						actions.stopId("buddy_cuff", src.master)
 						src.target = null
 						if(arrest_target)
 							src.arrest_target = null
@@ -3070,7 +3074,7 @@
 			drop_arrest_target()
 				src.arrest_target = null
 				src.last_found = world.time
-				src.cuffing = 0
+				actions.stopId("buddy_cuff", src.master)
 				src.master.frustration = 0
 				master.set_emotion()
 				return
@@ -3314,7 +3318,6 @@
 		var/tmp/mob/living/carbon/arrest_target = null
 		var/tmp/arrest_attempts = 0
 		var/tmp/follow_attempts = 0
-		var/tmp/cuffing = 0
 		var/tmp/mode = 0 //0: Following protectee, 1: Arresting threat
 
 		var/lethal = 0 //Do we use lethal force (if possible) ?
@@ -3393,7 +3396,7 @@
 					src.protected = null
 					src.arrest_attempts = 0
 					src.follow_attempts = 0
-					src.cuffing = 0
+					actions.stopId("buddy_cuff", src.master)
 				if("path_error","path_blocked")
 
 					if (src.protected)
@@ -3457,7 +3460,7 @@
 
 			drop_arrest_target()
 				src.arrest_target = null
-				src.cuffing = 0
+				actions.stopId("buddy_cuff", src.master)
 				return
 
 			check_buddy()

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -2830,8 +2830,8 @@
 						src.drop_arrest_target()
 						return // target doesnt exist, is a ghost, or has given up the ghost
 
-					// Can we "see" them?
-					if(IN_RANGE(master, arrest_target, 7))
+					// Can we /see/ them?
+					if(src.arrest_target in view(7,get_turf(master)))
 						// Shoot them!
 						master.bot_attack(arrest_target, src.lethal)
 					else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changed Buddy_Cuff action bar interrupt flags not to interrupt if the Buddy tries to start another action.

Reworked the Buddy security task's go-attack-them mode to first check if they're cuffing someone, then continue only if they are not. Also added comments.

Removed src.cuffing and replaced it with a check for an active Buddy_Cuff action bar. Accomplishes the same thing without having to keep a var updated.

Moved the long duplicated fail checks in Buddy_Cuff to a proc. Mainly for readability.

Buddies also seem to move around a lot more when chasing people. Probably because I made them always try to navigate to the target, even if they're already moving. Kinda accidental.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Long overdue fix for Guardbots being massive fucking bullies, stunlocking one person over and over. What a pal.

fix #3943

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Superlagg
(*)Guardbuddies will now actually handcuff people instead of just bullying them all day.
```
