### PR TITLE
feat: allow putting the syndicate hat on bees

### DIFF
--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -45,7 +45,7 @@
 	"butt-nc","butt-plant","butt-cyber","purplebutt","santa","yellow","blue","red","green","black","white",
 	"psyche","wizard","wizardred","wizardpurple","witch","obcrown","macrown","safari","viking","dolan",
 	"camhat","redcamhat","mailcap","paper","policehelm","bikercap","apprentice","chavcap","flatcap","ntberet",
-	"captain-fancy","rank-fancy","mime_beret","mime_bowler","buckethat")
+	"captain-fancy","rank-fancy","mime_beret","mime_bowler","buckethat", "syndicate_top", "syndicate_top_biggest")
 
 	var/sleep_y_offset = 5 // this amount removed from the hat's pixel_y on sleep or death
 	var/hat_y_offset = 0
@@ -489,6 +489,38 @@
 
 		src.hat = ourHat
 
+		// TIME. FOR. CRIME.
+		if (istype(src.hat, /obj/item/clothing/head/bighat/syndicate))
+			var/obj/item/clothing/head/bighat/syndicate/beeBigHat = src.hat
+			var/icon/workingIcon = new /icon(beeBigHat.wear_image_icon, beeBigHat.icon_state, SOUTH)
+
+			workingIcon.Shift(SOUTH, 5)
+
+			var/icon/leftIcon = new /icon()
+			leftIcon.Insert(workingIcon, "hat", SOUTH)
+			leftIcon.Insert(workingIcon, "hat", WEST)
+			leftIcon.Shift(WEST, 2)
+			hat_overlay_left = image(leftIcon, "hat")
+
+			var/icon/rightIcon = new /icon()
+			rightIcon.Insert(workingIcon, "hat", NORTH)
+			rightIcon.Insert(workingIcon, "hat", EAST)
+			rightIcon.Shift(WEST, 4)
+			hat_overlay_right = image(rightIcon, "hat")
+
+			// ANNOUNCE THE CRIME!
+
+			SPAWN_DBG(1 SECOND)
+				playsound(src.loc, "sound/vox/bees.ogg", 100, 1)
+				sleep(1 SECOND)
+				playsound(src.loc, "sound/vox/great.ogg", 100, 1)
+				sleep(1 SECOND)
+				playsound(src.loc, "sound/vox/at.ogg", 100, 1)
+				sleep(1 SECOND)
+				playsound(src.loc, "sound/vox/crime.ogg", 100, 1)
+
+			return
+
 		var/icon/newHatIcon = new /icon()
 		var/icon/workingIcon = new /icon(src.hat_icon, "bhat-[src.hat.icon_state]", SOUTH)
 		newHatIcon.Insert(workingIcon, "hat", SOUTH)
@@ -803,8 +835,10 @@
 		/obj/item/clothing/head/apprentice,
 		/obj/item/clothing/head/wizard,
 		/obj/item/clothing/head/wizard/red,
+		/obj/item/clothing/head/bighat/syndicate,
 		/obj/item/clothing/head/helmet/viking,
-		/obj/item/clothing/head/void_crown
+		/obj/item/clothing/head/void_crown,
+		/obj/item/clothing/head/bighat/syndicate/biggest
 	)
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

bee great at crime

I couldn't fit the sprite in the bee DMI so I had to reuse bighat and shift it

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

![crime-bees](https://user-images.githubusercontent.com/1551593/118218544-a17d0400-b445-11eb-8e2e-4d57835cb1a8.png)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(+)Bees can wear a big big hat now.
```
