### PR TITLE
changes ghost drone equipped() proc to work with magtractors differently

### DIFF
--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -578,6 +578,9 @@
 	equipped()
 		if (!active_tool)
 			return null
+		if(istype(active_tool, /obj/item/magtractor))
+			var/obj/item/magtractor/mag = active_tool
+			return mag.holding ? mag.holding : mag
 		return active_tool
 
 	u_equip(obj/item/W as obj)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This changes the equipped() proc for ghostdrones to return the item their magtractor is holding, if they are currently using a magtractor.
If the magtractor is not holding anything, the magtractor will be returned instead.

Might have problems with some existing code, but I haven't found any issues so far.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #4674 