### PR TITLE
Ship to cargo admin button, very slight code refactor.

### DIFF
--- a/code/modules/admin/admin_holder.dm
+++ b/code/modules/admin/admin_holder.dm
@@ -59,7 +59,8 @@
 			"Delete",\
 			"Possess",\
 			"Create Poster",\
-			"Copy Here",
+			"Copy Here",\
+			"Ship to Cargo"\
 			)
 			admin_interact_verbs["mob"] = list(\
 			"Player Options",\
@@ -88,7 +89,8 @@
 			"Swap Minds",\
 			"Transfer Client To",\
 			"Shamecube",\
-			"Create Poster"\
+			"Create Poster",\
+			"Ship to Cargo"\
 			)
 			admin_interact_verbs["turf"] = list(\
 			"Jump To Turf",\

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1991,6 +1991,8 @@ var/list/fun_images = list()
 			C.cmd_admin_delete(A)
 		if("Copy Here")
 			semi_deep_copy(A, src.loc)
+		if("Ship to Cargo")
+			C.cmd_admin_ship_movable_to_cargo(A)
 
 		if("Player Options")
 			C.cmd_admin_playeropt(A)

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2845,3 +2845,19 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 			message_admins("[key_name(src)] replaced the shuttle with [shuttle].")
 	else
 		boutput(src, "You must be at least an Administrator to use this command.")
+
+/client/proc/cmd_admin_ship_movable_to_cargo(atom/movable/AM)
+	SET_ADMIN_CAT(ADMIN_CAT_UNUSED)
+	set name = "Ship to Cargo"
+	set popup_menu = 0
+	admin_only
+
+	if (AM.anchored)
+		boutput(src, "Target is anchored and you probably shouldn't be shipping it!")
+		return
+
+	if (tgui_alert(src.mob, "Are you sure you want to ship [AM]?", "Confirmation", list("Yes", "No")) == "Yes")
+		shippingmarket.receive_crate(AM)
+		logTheThing("admin", usr, AM, "has shipped [AM] to cargo.")
+		logTheThing("diary", usr, AM, "has shipped [AM] to cargo.", "admin")
+		message_admins("[key_name(usr)] has shipped [AM] to cargo.")

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -240,7 +240,7 @@
 		if(transmit_connection != null)
 			transmit_connection.post_signal(null, pdaSignal)
 
-	proc/receive_crate(obj/storage/S)
+	proc/receive_crate(atom/movable/shipped_thing)
 
 		var/turf/spawnpoint
 		for(var/turf/T in get_area_turfs(/area/supply/spawn_point))
@@ -260,11 +260,11 @@
 			logTheThing("debug", null, null, "<b>Shipping: </b> No target turfs found! Can't deliver crate")
 			return
 
-		S.set_loc(spawnpoint)
+		shipped_thing.set_loc(spawnpoint)
 
 		var/datum/radio_frequency/transmit_connection = radio_controller.return_frequency("1149")
 		var/datum/signal/pdaSignal = get_free_signal()
-		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT", "group"=list(MGD_CARGO, MGA_SHIPPING), "sender"="00000000", "message"="Shipment arriving to Cargo Bay: [S.name].")
+		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT", "group"=list(MGD_CARGO, MGA_SHIPPING), "sender"="00000000", "message"="Shipment arriving to Cargo Bay: [shipped_thing.name].")
 		pdaSignal.transmission_method = TRANSMISSION_RADIO
 		transmit_connection.post_signal(null, pdaSignal)
 
@@ -280,7 +280,7 @@
 					if (P && !P.density)
 						P.close()
 
-		S.throw_at(target, 100, 1)
+		shipped_thing.throw_at(target, 100, 1)
 
 // Debugging and admin verbs (mostly coder)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a "ship to cargo" admin button on tilde-click which can ship targetted mobs or objects.

Anchored objects aren't shippable to avoid issues, communicated by a message to the user, even though it's technically possible. If an admin wants to force it they can edit the anchored state anyways.

Also very slightly refactors shipping market's receive_crate proc's argument type to better reflect the procs it uses and gives it a more clear name.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Potential admin gimmickery.