### PR TITLE
Fixes to gnome chompski's teleport logic.

### DIFF
--- a/code/obj/misc_junk.dm
+++ b/code/obj/misc_junk.dm
@@ -103,11 +103,9 @@
 		for_by_tcl(iterated_container, /obj/storage)
 			if (!iterated_container.open && iterated_container.z == Z_LEVEL_STATION)
 				eligible_containers += iterated_container
-		if (length(eligible_containers))
-			container = pick(eligible_containers)
-
-		if (container == null)  // no eligible target containers to move to
+		if (!length(eligible_containers))
 			return
+		container = pick(eligible_containers)
 
 		playsound(src.loc,"sound/misc/gnomechuckle.ogg" ,50,1)
 		src.set_loc(container)

--- a/code/obj/misc_junk.dm
+++ b/code/obj/misc_junk.dm
@@ -86,24 +86,31 @@
 			last_laugh = world.time
 
 	process()
-		if(prob(50) || current_state < GAME_STATE_PLAYING) // Takes around 12 seconds for ol chompski to vanish
+		if (prob(50) || current_state < GAME_STATE_PLAYING) // Takes around 12 seconds for ol chompski to vanish
 			return
-		// No teleporting if youre in a crate
-		if(istype(src.loc,/obj/storage) || istype(src.loc,/mob/living))
+		// No teleporting if youre in a container
+		if (istype(src.loc,/obj/storage) || istype(src.loc,/mob/living))
 			return
 		// Nobody can ever see Chompski move
-		for(var/mob/M in viewers(src))
-			if(M.mind) // Only players. Monkeys and NPCs are fine. Chompski trusts them.
+		for (var/mob/M in viewers(src))
+			if (M.mind) // Only players. Monkeys and NPCs are fine. Chompski trusts them.
 				return
 		//oh boy time to move
+
+		var/list/potential_containers = by_type[/obj/storage].Copy()
+
+		var/obj/storage/container
+		while (length(potential_containers))
+			container = pick(potential_containers)
+			if (container.open == 0 && container.z == 1)  // container is closed and on station z-level
+				break
+			potential_containers -= container
+
+		if (container == null)  // no eligible target containers to move to
+			return
+
 		playsound(src.loc,"sound/misc/gnomechuckle.ogg" ,50,1)
-		var/obj/crate = pick(by_type[/obj/storage])
-		while(crate.z != 1)
-			crate = pick(by_type[/obj/storage])
-		src.set_loc(crate)
-
-
-
+		src.set_loc(container)
 /obj/item/c_tube
 	name = "cardboard tube"
 	icon = 'icons/obj/items/items.dmi'

--- a/code/obj/misc_junk.dm
+++ b/code/obj/misc_junk.dm
@@ -99,10 +99,11 @@
 
 		var/list/potential_containers = by_type[/obj/storage].Copy()
 
-		var/obj/storage/container
+		var/obj/storage/container = null
 		while (length(potential_containers))
-			container = pick(potential_containers)
-			if (container.open == 0 && container.z == 1)  // container is closed and on station z-level
+			var/obj/storage/random_container = pick(potential_containers)
+			if (random_container.open == 0 && random_container.z == 1)  // container is closed and on station z-level
+				container = random_container
 				break
 			potential_containers -= container
 

--- a/code/obj/misc_junk.dm
+++ b/code/obj/misc_junk.dm
@@ -97,15 +97,14 @@
 				return
 		//oh boy time to move
 
-		var/list/potential_containers = by_type[/obj/storage].Copy()
-
 		var/obj/storage/container = null
-		while (length(potential_containers))
-			var/obj/storage/random_container = pick(potential_containers)
-			if (random_container.open == 0 && random_container.z == 1)  // container is closed and on station z-level
-				container = random_container
-				break
-			potential_containers -= container
+
+		var/list/eligible_containers = list()
+		for_by_tcl(iterated_container, /obj/storage)
+			if (!iterated_container.open && iterated_container.z == Z_LEVEL_STATION)
+				eligible_containers += iterated_container
+		if (length(eligible_containers))
+			container = pick(eligible_containers)
 
 		if (container == null)  // no eligible target containers to move to
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gnome Chompski no longer teleports inside already opened containers, which had to be closed and opened again for him to actually appear.
When searching for containers, copies the list of potential containers and picks from it while removing already checked items to avoid repeats.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gnome Chompski's current teleportation logic lets him teleport inside already opened containers. This means they must be closed and opened again for him to actually appear, thus making finding him unnecessarily difficult. The PR fixes that by adding the additional condition.
Additionally, current implementation brute-force picks from the list of storages until it finds one, with the potential to check the same containers multiple times and the (very unlikely but theoretically feasible) possibility to loop infinitely if the container list has no eligible elements. The PR ~~copies the list and removes already picked elements~~ creates a list of eligible elements and picks randomly from it instead to avoid repeats. Current live implementation also runtime errors in the (very unlikely) event that there are no storage objects to jump to, which the PR also resolves.