### PR TITLE
Fixes mulebot access level for pathing

### DIFF
--- a/code/modules/robotics/bot/mulebot.dm
+++ b/code/modules/robotics/bot/mulebot.dm
@@ -14,6 +14,7 @@
 	soundproofing = 0
 	on = 1
 	locked = 1
+	access_lookup = "Captain"
 	var/atom/movable/load = null		// the loaded crate (usually)
 
 	var/beacon_freq = 1445
@@ -70,8 +71,6 @@
 
 	New()
 		..()
-		botcard = new(src)
-		botcard.access = get_access("Captain")
 
 		var/global/mulecount = 0
 		if(!suffix)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The mulebot is supposed to have all access in order to make deliveries to all its potential destinations. This fixes the mulebot's access so it can make deliveries. Mulebot's access is now set via access_lookup rather than directly modifying the bot's virtual ID card.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The mulebot had its access set to captain level on spawn, but the bot_parent overwrote it to assistant since it's access_lookup was never changed from the default. This prevented it from making deliveries beyond any door a staff assistant could not pass. This also addresses one of the comments on #4057.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Fixed mulebot access level
```
