### PR TITLE
fix: prevent cubes from communicating to non-cubes

### DIFF
--- a/code/mob/living/carbon/cube.dm
+++ b/code/mob/living/carbon/cube.dm
@@ -4,6 +4,7 @@
 /mob/living/carbon/cube
 	name = "cube"
 	real_name = "cube"
+	say_language = "cubic" // How they communicate to each other is a mystery.
 	desc = "cubic"
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "meatcube"
@@ -63,21 +64,8 @@
 	proc/pop()
 		src.gib(1)
 
-	say_quote(var/text)
-		if(src.emote_allowed)
-			if(!(src.client && src.client.holder))
-				src.emote_allowed = 0
-
-			if (narrator_mode)
-				playsound(src.loc, 'sound/vox/scream.ogg', 80, 0, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
-			else
-				playsound(get_turf(src), src.sound_scream, 80, 0, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
-
-			SPAWN_DBG(5 SECONDS)
-				src.emote_allowed = 1
-			return "screams!"
-		else
-			return "[get_cube_action()]."
+	say_verb()
+		return src.get_cube_action()
 
 	proc/specific_emotes(var/act, var/param = null, var/voluntary = 0)
 		return null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

this is a fix to `/mob/living/carbon/cube`

when cubes speak their text is overridden via `say_quote` but that doesn't prevent text over their head

instead, they now speak and understand cubic, and can still understand human language - but not animal.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

it's for everyone's sake, really.

but in general cubes aren't supposed to be able to communicate except through screaming and bleeding everywhere, so this fixes that

This comes up with the syndicate trash cart causing issues where people speaking can make crunching more cubes difficult