### PR TITLE
Documents the fact that the NT loyalist trait prevents you from spawning as a revhead

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -508,7 +508,7 @@
 /obj/trait/loyalist
 	name = "NT loyalist (-1) \[Trinkets\]"
 	cleanName = "NT loyalist"
-	desc = "Start with a Nanotrasen Beret as your trinket."
+	desc = "Start with a Nanotrasen Beret as your trinket. You love working for Nanotrasen, and would never start a revolution against them."
 	id = "loyalist"
 	icon_state = "beretP"
 	points = -1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a bit of text to the trait description to clarify that behavior.
I'm kinda uninspired and can't think of a way to make it clear without sounding janky, so feel free to suggest something better.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a thing people should probably know