### PR TITLE
Minor oxygen vendor fixes

### DIFF
--- a/code/obj/machinery/air_vendor.dm
+++ b/code/obj/machinery/air_vendor.dm
@@ -155,7 +155,7 @@ obj/machinery/air_vendor
 			if(href_list["fill"])
 				if (holding)
 					var/cost = fill_cost()
-					if(credits > cost)
+					if(credits >= cost)
 						src.credits -= cost
 						src.fill()
 						boutput(usr, "<span class='notice'>You fill up the [src.holding].</span>")

--- a/code/obj/machinery/air_vendor.dm
+++ b/code/obj/machinery/air_vendor.dm
@@ -50,7 +50,7 @@ obj/machinery/air_vendor
 
 	proc/fill_cost()
 		if(!holding) return 0
-		return round((src.target_pressure - MIXTURE_PRESSURE(src.holding.air_contents)) * src.holding.air_contents.volume * src.air_cost)
+		return clamp(round((src.target_pressure - MIXTURE_PRESSURE(src.holding.air_contents)) * src.holding.air_contents.volume * src.air_cost), 0, INFINITY)
 
 	proc/fill()
 		if(!holding) return

--- a/code/obj/machinery/air_vendor.dm
+++ b/code/obj/machinery/air_vendor.dm
@@ -163,7 +163,7 @@ obj/machinery/air_vendor
 						return
 					else if(scan)
 						var/datum/data/record/account = FindBankAccountByName(src.scan.registered)
-						if (account && account.fields["current_money"] > cost)
+						if (account && account.fields["current_money"] >= cost)
 							account.fields["current_money"] -= cost
 							src.fill()
 							boutput(usr, "<span class='notice'>You fill up the [src.holding].</span>")

--- a/code/obj/machinery/air_vendor.dm
+++ b/code/obj/machinery/air_vendor.dm
@@ -50,7 +50,7 @@ obj/machinery/air_vendor
 
 	proc/fill_cost()
 		if(!holding) return 0
-		return round(src.target_pressure * src.holding.air_contents.volume * src.air_cost)
+		return round((src.target_pressure - MIXTURE_PRESSURE(src.holding.air_contents)) * src.holding.air_contents.volume * src.air_cost)
 
 	proc/fill()
 		if(!holding) return


### PR DESCRIPTION
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Two improvements to the oxygen vending machines:
1. They now account for the amount of the air in the tank when charging you, instead of charging you to fill to a certain amount regardless.
2. Fixed an off-by-one thing where you'd need X+1 credits to buy X credits worth of air.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it behave... about how you'd expect it to behave.