### PR TITLE
Lowers the space of fanny packs to 5

### DIFF
--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -125,6 +125,7 @@
 	item_state = "fanny"
 	flags = FPRINT | TABLEPASS | ONBELT | NOSPLASH
 	w_class = W_CLASS_BULKY
+	slots = 5
 	max_wclass = 3
 	does_not_open_in_pocket = 0
 	stamina_damage = 0
@@ -154,6 +155,7 @@
 	desc = "It's different than a fanny pack. It's tactical and action-packed!"
 	icon_state = "syndie"
 	item_state = "syndie"
+	slots = 7
 
 /* -------------------- Belts -------------------- */
 

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -144,6 +144,7 @@
 	item_state = "funny"
 	spawn_contents = list(/obj/item/storage/box/starter,\
 	/obj/item/storage/box/balloonbox)
+	slots = 7
 
 /obj/item/storage/fanny/funny/mini
 	name = "mini funny pack"


### PR DESCRIPTION
[Balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lowers the slots in fanny packs and funny packs from 7 to 5. This does not lower the amount of space in the syndicate belt pack.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fanny packs are very very good belts that have no real restrictions or difficulty in getting. They currently are functionally the same as a backpack except you can also wear a backpack as well as a fanny pack. I believe these should be toned down slightly as to be not as good as a backpack.

## Changelog

```changelog
(u)DimWhat
(*)Made fanny packs (not funny packs) only have inventory 5 slots.
```
