### PR TITLE
Pretty heavily reduced effectiveness of cyborg shields

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -751,18 +751,21 @@
 
 	blob_act(var/power)
 		if (!isdead(src))
+			var/damage = 6 + power / 5
 			for (var/obj/item/roboupgrade/physshield/R in src.contents)
 				if (R.activated)
-					boutput(src, "<span class='notice'>Your force shield absorbs the blob's attack!</span>")
-					src.cell.use(power * 50 * R.overheat())
-					playsound(src.loc, "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
-					src.update_bodypart()
-					return 1
+					var/damage_reduced_by = min(damage, R.damage_reduction)
+					src.cell.use(damage_reduced_by * R.cell_drain_per_damage_reduction)
+					damage -= damage_reduced_by
+					playsound(get_turf(src), "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
+			if (damage <= 0)
+				boutput(usr, "<span class='notice'>Your shield completely blocks the attack!</span>")
+				return 1
 			boutput(src, "<span class='alert'>The blob attacks you!</span>")
-			var/damage = 6 + power / 5
 			for (var/obj/item/parts/robot_parts/RP in src.contents)
-				if (RP.ropart_take_damage(damage,damage/2) == 1) src.compborg_lose_limb(RP)
-			// maybe the blob is a little acidic?? idk
+				// maybe the blob is a little acidic?? idk
+				if (RP.ropart_take_damage(damage, damage/2) == 1)
+					src.compborg_lose_limb(RP)
 			src.update_bodypart()
 			return 1
 		return 0
@@ -815,13 +818,14 @@
 		var/fire_protect = 0
 		for (var/obj/item/roboupgrade/R in src.contents)
 			if (istype(R, /obj/item/roboupgrade/physshield) && R.activated)
-				var/obj/item/roboupgrade/physshield/P = R
-				src.cell.use((4-severity) * 100 * P.overheat())
+				var/obj/item/roboupgrade/physshield/S = R
+				src.cell.use((4-severity) * S.cell_drain_per_damage_reduction)
 				boutput(src, "<span class='notice'>Your force shield absorbs some of the blast!</span>")
 				playsound(src.loc, "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
 				severity++
 			if (istype(R, /obj/item/roboupgrade/fireshield) && R.activated)
-				src.cell.use((4-severity) * 50)
+				var/obj/item/roboupgrade/fireshield/S = R
+				src.cell.use((4-severity) * S.cell_drain_per_damage_reduction)
 				boutput(src, "<span class='notice'>Your fire shield absorbs some of the blast!</span>")
 				playsound(src.loc, "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
 				fire_protect = 1
@@ -873,7 +877,7 @@
 			src.do_disorient(clamp(P.power*4, P.proj_data.power*2, P.power+80), weakened = P.power*2, stunned = P.power*2, disorient = min(P.power, 80), remove_stamina_below_zero = 0) //bad hack, but it'll do
 			src.emote("twitch_v")// for the above, flooring stam based off the power of the datum is intentional
 
-		log_shot(P,src)
+		log_shot(P, src)
 		src.visible_message("<span class='alert'><b>[src]</b> is struck by [P]!</span>")
 		var/damage = (P.power / 3) * dmgmult
 		if (damage < 1)
@@ -881,27 +885,23 @@
 
 		for (var/obj/item/roboupgrade/R in src.contents)
 			if (istype(R, /obj/item/roboupgrade/physshield) && R.activated && dmgtype == 0)
-				var/obj/item/roboupgrade/physshield/phys = R
-				if(phys.overheat_level < phys.max_overheat)
-					shoot_reflected_to_sender(P, src)
-					src.cell.use(damage * 50 * phys.overheat())
-					boutput(src, "<span class='notice'>Your force shield deflects the shot!</span>")
-					playsound(src.loc, "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
-					return
-				else
-					boutput(src, "<span class='notice'>Your force shield absorbs some of the shot!</span>")
-					src.cell.use(damage * 50 * phys.overheat())
-					playsound(src.loc, "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
-					damage = damage/2
-					return
-			if (istype(R, /obj/item/roboupgrade/fireshield) && R.activated && dmgtype == 1)
-				shoot_reflected_to_sender(P, src)
-				src.cell.use(damage * 25)
-				boutput(src, "<span class='notice'>Your fire shield deflects the shot!</span>")
+				var/obj/item/roboupgrade/physshield/S = R
+				var/damage_reduced_by = min(damage, S.damage_reduction)
+				src.cell.use(damage_reduced_by * S.cell_drain_per_damage_reduction)
+				damage -= damage_reduced_by
 				playsound(src.loc, "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
-				return
+			if (istype(R, /obj/item/roboupgrade/fireshield) && R.activated && dmgtype == 1)
+				var/obj/item/roboupgrade/fireshield/S = R
+				var/damage_reduced_by = min(damage, S.damage_reduction)
+				src.cell.use(damage_reduced_by * S.cell_drain_per_damage_reduction)
+				damage -= damage_reduced_by
+				playsound(src.loc, "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
 
-		if(src.material) src.material.triggerOnBullet(src, src, P)
+		if (damage < 1)
+			return
+
+		if (src.material)
+			src.material.triggerOnBullet(src, src, P)
 
 		var/obj/item/parts/robot_parts/PART = null
 		if (ismob(P.shooter))
@@ -923,9 +923,9 @@
 			var/list/parts = list()
 			for (var/obj/item/parts/robot_parts/RP in src.contents)
 				parts.Add(RP)
-			if (parts.len > 0)
+			if (length(parts) > 0)
 				PART = pick(parts)
-		if (PART?.ropart_take_damage(damage,damage) == 1)
+		if (PART?.ropart_take_damage(damage, damage) == 1)
 			src.compborg_lose_limb(PART)
 
 	emag_act(var/mob/user, var/obj/item/card/emag/E)
@@ -969,11 +969,13 @@
 			src.gib()
 			return
 
-		var/Pshield = 0
-		var/Fshield = 0
+		var/Pshield = FALSE
+		var/Fshield = FALSE
 		for (var/obj/item/roboupgrade/R in src.contents)
-			if (istype(R, /obj/item/roboupgrade/physshield) && R.activated) Pshield = 1
-			if (istype(R, /obj/item/roboupgrade/fireshield) && R.activated) Fshield = 1
+			if (istype(R, /obj/item/roboupgrade/physshield) && R.activated)
+				Pshield = TRUE
+			if (istype(R, /obj/item/roboupgrade/fireshield) && R.activated)
+				Fshield = TRUE
 
 		if (Pshield)
 			src.cell.use(200)
@@ -989,28 +991,29 @@
 				playsound(src.loc, "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
 			else
 				for (var/obj/item/parts/robot_parts/RP in src.contents)
-					if (RP.ropart_take_damage(0,35) == 1) src.compborg_lose_limb(RP)
-				if (istype(cell,/obj/item/cell/erebite))
+					if (RP.ropart_take_damage(0, 35) == 1) src.compborg_lose_limb(RP)
+				if (istype(cell, /obj/item/cell/erebite))
 					src.visible_message("<span class='alert'><b>[src]'s</b> erebite cell violently detonates!</span>")
 					explosion(cell, src.loc, 1, 2, 4, 6, 1)
 					SPAWN_DBG(1 DECI SECOND)
-						qdel (src.cell)
+						qdel(src.cell)
 						src.cell = null
-			update_bodypart()
-		return
+			src.update_bodypart()
 
 	temperature_expose(null, temp, volume)
-		var/Fshield = 0
+		var/Fshield = FALSE
 
 		src.material?.triggerTemp(src, temp)
 
 		for(var/atom/A in src.contents)
-			if(A.material)
-				A.material.triggerTemp(A, temp)
+			A.material?.triggerTemp(A, temp)
 
 		for (var/obj/item/roboupgrade/R in src.contents)
-			if (istype(R, /obj/item/roboupgrade/fireshield) && R.activated) Fshield = 1
-		if (Fshield == 0)
+			if (istype(R, /obj/item/roboupgrade/fireshield) && R.activated)
+				Fshield = TRUE
+				break
+
+		if (!Fshield)
 			if (istype(cell,/obj/item/cell/erebite))
 				src.visible_message("<span class='alert'><b>[src]'s</b> erebite cell violently detonates!</span>")
 				explosion(cell, src.loc, 1, 2, 4, 6, 1)
@@ -2513,9 +2516,6 @@
 				src.update_appearance()
 				src.borg_death_alert(ROBOT_DEATH_MOD_KILLSWITCH)
 
-
-
-
 	var/image/i_head
 	var/image/i_head_decor
 
@@ -2780,16 +2780,22 @@
 		burn = max(burn, 0)
 		if (burn == 0 && brute == 0)
 			return 0
-		for (var/obj/item/roboupgrade/R in src.upgrades) //if 50% of the damage is less than 4, ignore it, elsewise take 50% damage
+		for (var/obj/item/roboupgrade/R in src.upgrades)
+			// shield upgrades reduce damage taken (and drain the power cell)
 			if (istype(R, /obj/item/roboupgrade/fireshield) && R.activated)
-				src.cell.use(burn * 25)
-				burn = ((burn * 0.5) < 4) ? 0 : (burn * 0.5)
+				var/obj/item/roboupgrade/fireshield/S = R
+				var/damage_reduced_by = min(burn, S.damage_reduction)
+				src.cell.use(damage_reduced_by * S.cell_drain_per_damage_reduction)
+				burn -= damage_reduced_by
 				playsound(get_turf(src), "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
+				continue
 			if (istype(R, /obj/item/roboupgrade/physshield) && R.activated)
-				var/obj/item/roboupgrade/physshield/P = R
-				src.cell.use(brute * 50 * P.overheat())
-				brute = ((brute * 0.5) < 4) ? 0 : (brute * 0.5)
+				var/obj/item/roboupgrade/physshield/S = R
+				var/damage_reduced_by = min(brute, S.damage_reduction)
+				src.cell.use(damage_reduced_by * S.cell_drain_per_damage_reduction)
+				brute -= damage_reduced_by
 				playsound(get_turf(src), "sound/impact_sounds/Energy_Hit_1.ogg", 40, 1)
+				continue
 		if (burn == 0 && brute == 0)
 			boutput(usr, "<span class='notice'>Your shield completely blocks the attack!</span>")
 			return 0

--- a/code/modules/robotics/robot/upgrade/force_shield.dm
+++ b/code/modules/robotics/robot/upgrade/force_shield.dm
@@ -2,17 +2,7 @@
 	name = "cyborg force shield upgrade"
 	desc = "A force field generator that protects a cyborg from physical harm."
 	icon_state = "up-Pshield"
-	drainrate = 250
+	drainrate = 100
 	borg_overlay = "up-pshield"
-	var/overheat_level = 0
-	var/max_overheat = 5
-
-	//TODO: Convert this to a status on the cyborg with a switch(overheat_level) on icon state so they can see when they're overheating
-	// It'd work a lot better but fuuuuuuuuuuuuuuck I wanna be done looking at cyborg code, jesus
-
-	proc/overheat()
-		SPAWN_DBG(COMBAT_CLICK_DELAY * 2)
-			overheat_level--
-			overheat_level = max(0,overheat_level)
-		overheat_level++
-		return min(max_overheat,overheat_level)
+	var/damage_reduction = 4
+	var/cell_drain_per_damage_reduction = 50

--- a/code/modules/robotics/robot/upgrade/force_shield.dm
+++ b/code/modules/robotics/robot/upgrade/force_shield.dm
@@ -5,4 +5,4 @@
 	drainrate = 100
 	borg_overlay = "up-pshield"
 	var/damage_reduction = 4
-	var/cell_drain_per_damage_reduction = 50
+	var/cell_drain_per_damage_reduction = 100

--- a/code/modules/robotics/robot/upgrade/heat_shield.dm
+++ b/code/modules/robotics/robot/upgrade/heat_shield.dm
@@ -5,4 +5,4 @@
 	drainrate = 100
 	borg_overlay = "up-fshield"
 	var/damage_reduction = 4
-	var/cell_drain_per_damage_reduction = 50
+	var/cell_drain_per_damage_reduction = 100

--- a/code/modules/robotics/robot/upgrade/heat_shield.dm
+++ b/code/modules/robotics/robot/upgrade/heat_shield.dm
@@ -4,3 +4,5 @@
 	icon_state = "up-Fshield"
 	drainrate = 100
 	borg_overlay = "up-fshield"
+	var/damage_reduction = 4
+	var/cell_drain_per_damage_reduction = 50

--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -67,8 +67,12 @@
 							items += /obj/item/roboupgrade/jetpack
 							item_amounts += 1
 							picker = rand(1,4)
-							items += pick(/obj/item/roboupgrade/physshield,/obj/item/roboupgrade/teleport,/*
-							/obj/item/roboupgrade/opticthermal,*//obj/item/roboupgrade/speed)
+							items += pick(
+								/obj/item/roboupgrade/physshield,
+								/obj/item/roboupgrade/teleport,
+								// /obj/item/roboupgrade/opticthermal,
+								/obj/item/roboupgrade/speed,
+							)
 							item_amounts += 1
 						if(2)
 							items += /obj/item/reagent_containers/glass/beaker/large/antitox


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][BUG][INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Rebalances cyborg shields to be much less of an "I win" button.

They now reduce damage taken by melee attacks by 4 points (at a cost of 100 power per point). Previously they reduced damage by 50% and then ignored it if 4 or less, so any attacks that did 8 damage or less were mitigated entirely). This means that basically everything will be more effective against them than previously. A circular saw aiming at the head of a standard cyborg destroys them in 44 hits with the shield, 22 without (previously, as saws do 8 damage, they did no *actual* damage against the cyborg).

For gunshots, the projectile reflecting/overheat mechanic was removed. They do the same damage reduction as for melee attacks above (making them typically *much* less effective against bullets as most of them are higher-damage weapons). A Sirius assault rifle firing at the head of a standard cyborg destroys them in 11 shots with the shield, 8 without.

Bullet-code had a bug where physical shields would block all damage if they were on at all (regardless of their overheat status). Overheating is no longer a thing (and reflection is no longer a thing), so bullets are now much more effective against cyborgs with shield (whereas before they were completely useless, and potentially dangerous to yourself!)

Physical shields no longer provide immunity against blob attacks (reducing damage taken, still, but cyborgs should be much more careful around blobs).

Drain rate of the force shield has been dropped from 250 to 100.

This does not fix the bug about the shield upgrade effect showing/not showing.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- The bug with projectiles that weren't reflected not doing any damage at all is bad, and should be fixed whether the greater PR is fixed or not.
- Cyborgs with this upgrade are much more mortal now, with it more increasing durability rather than making you mostly invincible. This should encourage people to not rely on it entirely and instead consider using heavier parts.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Mordent
(*)Cyborg shield upgrades have been pretty heavily reduced in effectiveness, especially against higher-damage weapons. They no longer reflect projectiles.
(*)Drain rate of cyborg force shield upgrade reduced by 60% (250 to 100)
```