### PR TITLE
Adjust incapacitated determination for TGUI

### DIFF
--- a/code/modules/tgui/states/not_incapacitated.dm
+++ b/code/modules/tgui/states/not_incapacitated.dm
@@ -26,8 +26,4 @@ var/global/datum/ui_state/tgui_not_incapacitated_state/tgui_not_incapacitated_tu
 		return UI_CLOSE
 	if(!can_act(user) || (turf_check && !isturf(user.loc)))
 		return UI_DISABLED
-	if(isliving(user))
-		var/mob/living/L = user
-		if(L.lying)
-			return UI_DISABLED
 	return UI_INTERACTIVE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug-minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes lying check from incapacitation determination for TGUI.  Allows for those without legs to operate newer TGUI, namely headsets.  This behavior doesn't make sense for a number of handheld devices  in regards to lack of lags or simply lying down.

This will allow people lying to adjust various TGUI machinery/devices: TEG, Canisters, Dispensers, GeneTek, Power Monitors..... 
- Exclusion of lying should be explicit if that is desired behavior.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #4577
