### PR TITLE
chore: erase racist button

### DIFF
--- a/code/obj/deathbutton.dm
+++ b/code/obj/deathbutton.dm
@@ -31,19 +31,3 @@
 			var/datum/component/C = user.GetComponent(/datum/component/death_confetti)
 			C?.RemoveComponent()
 		return
-
-/obj/racist_button
-	name = "button that will make you racist if you press it"
-	desc = "A button.  One that makes you racist (if you press it)."
-	icon = 'icons/obj/stationobjs.dmi'
-	icon_state = "doorctrl0"
-	layer = EFFECTS_LAYER_UNDER_1
-	anchored = 1
-
-	attack_hand(mob/user as mob)
-		var/mob/living/carbon/human/H = user
-		if (istype(H))
-
-			if(H.bioHolder)
-				H.visible_message("<span class='alert'><B>[H.name] is too racist!</B></span>", "<span class='alert'><B>That's too racist!</B></span>")
-				H.owlgib()

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -46032,7 +46032,7 @@
 /turf/unsimulated/floor/plating/scorched,
 /area/crater/biodome/south)
 "cwE" = (
-/obj/racist_button{
+/obj/death_button{
 	pixel_x = -15
 	},
 /obj/map/light/lava,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Remove what is probably an older joke that might have been funny at some point.

It's a button that declares the person that presses it a racist and then gibs them.  Err.. "makes them a racist"?

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

we don't really need a button that does this.  I don't really get the joke.

We need less of these in the world, let's not have a button for this.
