### PR TITLE
Weaken Poltergeist click-drag TK (also clean up  other TK code)

### DIFF
--- a/code/mob/wraith.dm
+++ b/code/mob/wraith.dm
@@ -40,6 +40,7 @@
 	//probably will change these around, but these might be alright to start. -kyle
 	var/holy_water_tol = 0		//unused presently
 	var/formaldehyde_tol = 25
+	var/weak_tk = FALSE			//if their click-drag TK is strong or not. Poltergeists prolly should not have strong tk, mebe one day.
 
 	var/datum/movement_controller/movement_controller
 

--- a/code/mob/wraith/poltergeist.dm
+++ b/code/mob/wraith/poltergeist.dm
@@ -10,6 +10,7 @@
 	var/obj/spookMarker/marker = null
 	haunt_duration = 150
 	death_icon_state = "derangedghost"
+	weak_tk = TRUE
 	var/max_dist_marker = 15
 	var/max_dist_master = 12
 	var/following_master = 0

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -201,37 +201,6 @@
 			else return
 		return ..(I, user)
 
-
-	MouseDrop(atom/over_object as mob|obj|turf)
-		..()
-		if (iswraith(usr))
-			if(!src.anchored && isitem(src))
-				src.throw_at(over_object, 7, 1)
-				logTheThing("combat", usr, null, "throws [src] with wtk.")
-		else if (ismegakrampus(usr))
-			if(!src.anchored && isitem(src))
-				src.throw_at(over_object, 7, 1)
-				logTheThing("combat", usr, null, "throws [src] with k_tk.")
-		else if(usr.bioHolder && usr.bioHolder.HasEffect("telekinesis_drag") && istype(src, /obj) && isturf(src.loc) && isalive(usr)  && usr.canmove && get_dist(src,usr) <= 7 )
-			var/datum/bioEffect/TK = usr.bioHolder.GetEffect("telekinesis_drag")
-
-			if(!src.anchored && (isitem(src) || TK.variant == 2))
-				src.throw_at(over_object, 7, 1)
-				logTheThing("combat", usr, null, "throws [src] with tk.")
-
-#ifdef HALLOWEEN
-		else if (istype(usr, /mob/dead/observer))	//ghost
-			if(!src.anchored && isitem(src))
-				var/obj/item/I = src
-				if (I.w_class > W_CLASS_NORMAL)
-					return
-				if (istype(usr:abilityHolder, /datum/abilityHolder/ghost_observer))
-					var/datum/abilityHolder/ghost_observer/GH = usr:abilityHolder
-					if (GH.spooking)
-						src.throw_at(over_object, 7-I.w_class, 1)
-						logTheThing("combat", usr, null, "throws [src] with g_tk.")
-#endif
-
 	serialize(var/savefile/F, var/path, var/datum/sandbox/sandbox)
 		F["[path].type"] << type
 		serialize_icon(F, path, sandbox)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -711,7 +711,7 @@
 		if (iswraith(usr))
 			var/mob/wraith/W = usr
 			//Basically so poltergeists need to be close to an object to send it flying far...
-			if (W.weak_tk && (get_dist(src, W) > 2))
+			if (W.weak_tk && !IN_RANGE(src, W, 2))
 				src.throw_at(over_object, 1, 1)
 				boutput(W, "<span class='alert'>You're too far away to properly manipulate this physical item!</span>")
 				logTheThing("combat", usr, null, "moves [src] with wtk.")

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -702,6 +702,41 @@
 			else
 				actions.start(new /datum/action/bar/private/icon/pickup/then_obj_click(src, over_object, params), usr)
 
+	//Click-drag tk stuff
+	if(!src.anchored)
+
+		if (iswraith(usr))
+			var/mob/wraith/W = usr
+			//Basically so poltergeists need to be close to an object to send it flying far...
+			if (W.weak_tk && get_dist(src, W) > 1)
+				src.throw_at(over_object, 1, 1)
+				boutput(W, "<span class='alert'>You're too far away to manipulate this physical item!</span>")
+				logTheThing("combat", usr, null, "moves [src] with wtk.")
+				return
+			src.throw_at(over_object, 7, 1)
+			logTheThing("combat", usr, null, "throws [src] with wtk.")
+		else if (ismegakrampus(usr))
+			src.throw_at(over_object, 7, 1)
+			logTheThing("combat", usr, null, "throws [src] with k_tk.")
+		else if(usr.bioHolder && usr.bioHolder.HasEffect("telekinesis_drag") && isturf(src.loc) && isalive(usr)  && usr.canmove && get_dist(src,usr) <= 7 )
+			var/datum/bioEffect/TK = usr.bioHolder.GetEffect("telekinesis_drag")
+
+			if(TK.variant == 2)
+				src.throw_at(over_object, 7, 1)
+				logTheThing("combat", usr, null, "throws [src] with tk.")
+
+#ifdef HALLOWEEN
+		else if (istype(usr, /mob/dead/observer))	//ghost
+			var/obj/item/I = src
+			if (I.w_class > W_CLASS_NORMAL)
+				return
+			if (istype(usr:abilityHolder, /datum/abilityHolder/ghost_observer))
+				var/datum/abilityHolder/ghost_observer/GH = usr:abilityHolder
+				if (GH.spooking)
+					src.throw_at(over_object, 7-I.w_class, 1)
+					logTheThing("combat", usr, null, "throws [src] with g_tk.")
+#endif
+
 //equip an item, given an inventory hud object or storage item UI thing
 /obj/item/proc/try_equip_to_inventory_object(var/mob/user, var/atom/over_object, var/params)
 	var/atom/movable/screen/hud/S = over_object

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -653,7 +653,10 @@
 /obj/item/MouseDrop(atom/over_object, src_location, over_location, over_control, params)
 	..()
 
-	if (usr.stat || usr.restrained() || !can_reach(usr, src) || usr.getStatusDuration("paralysis") || usr.sleeping || usr.lying || isAIeye(usr) || isAI(usr) || isrobot(usr) || isghostcritter(usr) || (over_object && over_object.event_handler_flags & NO_MOUSEDROP_QOL))
+	if (!src.anchored)
+		click_drag_tk(over_object, src_location, over_location, over_control, params)
+
+	if (usr.stat || usr.restrained() || !can_reach(usr, src) || usr.getStatusDuration("paralysis") || usr.sleeping || usr.lying || isAIeye(usr) || isAI(usr) || isrobot(usr) || isghostcritter(usr) || !iswraith(usr) || (over_object && over_object.event_handler_flags & NO_MOUSEDROP_QOL))
 		return
 
 	var/on_turf = isturf(src.loc)
@@ -702,15 +705,15 @@
 			else
 				actions.start(new /datum/action/bar/private/icon/pickup/then_obj_click(src, over_object, params), usr)
 
-	//Click-drag tk stuff
+	//Click-drag tk stuff.  
+/obj/item/proc/click_drag_tk(atom/over_object, src_location, over_location, over_control, params)
 	if(!src.anchored)
-
 		if (iswraith(usr))
 			var/mob/wraith/W = usr
 			//Basically so poltergeists need to be close to an object to send it flying far...
-			if (W.weak_tk && get_dist(src, W) > 1)
+			if (W.weak_tk && (get_dist(src, W) > 2))
 				src.throw_at(over_object, 1, 1)
-				boutput(W, "<span class='alert'>You're too far away to manipulate this physical item!</span>")
+				boutput(W, "<span class='alert'>You're too far away to properly manipulate this physical item!</span>")
 				logTheThing("combat", usr, null, "moves [src] with wtk.")
 				return
 			src.throw_at(over_object, 7, 1)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -656,7 +656,7 @@
 	if (!src.anchored)
 		click_drag_tk(over_object, src_location, over_location, over_control, params)
 
-	if (usr.stat || usr.restrained() || !can_reach(usr, src) || usr.getStatusDuration("paralysis") || usr.sleeping || usr.lying || isAIeye(usr) || isAI(usr) || isrobot(usr) || isghostcritter(usr) || !iswraith(usr) || (over_object && over_object.event_handler_flags & NO_MOUSEDROP_QOL))
+	if (usr.stat || usr.restrained() || !can_reach(usr, src) || usr.getStatusDuration("paralysis") || usr.sleeping || usr.lying || isAIeye(usr) || isAI(usr) || isrobot(usr) || isghostcritter(usr) || (over_object && over_object.event_handler_flags & NO_MOUSEDROP_QOL))
 		return
 
 	var/on_turf = isturf(src.loc)


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The main player facing change here is that Poltergeists now need to be within 2 tiles of an item to be able to throw it somewhere with their click-drag telekinesis. Otherwise they just toss it one tile. This does not effect wraiths. I might add some way for the Poltergeists to spend points or something to "unlock" the fully powered ability, but idk. They should be able to use it while inside their master too.

On the technical side, I did a slight refactor to the tk code. It used to be in /obj/mouseDrop and then they did isitem(src) checks in all instances, which is bad. So I moved it down to the child proc in obj/item. It should calculate this first, on all unanchored items. No functionality should change. I tested it on all variants: genetics, krampus, wraith, poltergeists but the Halloween ghost tk.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It can be pretty tough playing against a wraith with even just one or two poltergeists inside it using their TK so easily. Naturally, they're supposed to be able to do this, but I hoped that they would also have to rely on their other abilities to assist their wraith.  

Also, I feel like I woulda done this when I made poltergeists since I tried to make all their stuff weaker than the wraith, but I didn't think of a way to change the click-drag tk at the time. 


## Changelog
```changelog
(u)kyle
(+)Poltergeists now need to be near an item to throw it telekinetically. Otherwise you only can toss it one tile.
```
