### PR TITLE
Adds Z5 level names to the GPS device and PDA app

### DIFF
--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -40,6 +40,12 @@
 			. =  "Landmark: Restricted"
 		else if (T.z == 3)
 			. =  "Landmark: Debris Field"
+		else if (T.z == 5)
+			#ifdef UNDERWATER_MAP
+			. =  "Landmark: Trench"
+			#else
+			. =  "Landmark: Asteroid Field"
+			#endif
 		return
 
 	proc/show_HTML(var/mob/user)

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1257,6 +1257,12 @@ Using electronic "Detomatix" BOMB program is perhaps less simple!<br>
 					landmark = "Restricted"
 				if (3)
 					landmark = "Debris Field"
+				if (5)
+					#ifdef UNDERWATER_MAP
+					landmark = "Trench"
+					#else
+					landmark = "Asteroid Field"
+					#endif
 
 			dat += "<BR>X = [src.x], Y = [src.y], Landmark: [landmark]"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When the GPS device or PDA app reports coordinates it will report 'Asteroid Field' or 'Trench' in Z level 5 rather than 'Unknown.'


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These devices currently will say the landmark is unknown for the mining Z level. Only Z levels 4 and 5 return 'unknown,' so this doesn't hide any information from experienced players, but does introduce some confusing ambiguity to people who don't know this. This change removes this potential confusion.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Added the names "Trench" and "Asteroid Field" to the landmarks the GPS device and app can report.
```
