### PR TITLE
Balance matsci spacesuits

### DIFF
--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -42,7 +42,7 @@
 
 			if(material.hasProperty("density"))
 				var/prot = round(material.getProperty("density") / 20)
-				setProperty("meleeprot_head", prot)
+				setProperty("meleeprot_head", 2+prot)
 			else
 				setProperty("meleeprot_head", 2)
 

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -984,9 +984,9 @@
 				setProperty("viralprot", 40)
 
 			if(material.hasProperty("density"))
-				var/prot = round(material.getProperty("density") / 17)
+				var/prot = round(material.getProperty("density") / 13)
 				setProperty("meleeprot", prot)
-				setProperty("rangedprot", (0.1 + round(prot/10)))
+				setProperty("rangedprot", (0.2 + round(prot/10, 0.1)))
 			else
 				setProperty("meleeprot", 2)
 				setProperty("rangedprot", 0.4)


### PR DESCRIPTION
[BUG][BALANCE]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The PR accomplishes two main goals. First, fixes a rounding bug which made any space suit made from an alloy that had the density property have a ranged protection 0.1. Second buffs their melee and ranged protection. Using the density of bohrum (40) as a baseline, the following will now happen
1. Less dense alloys will produce les protective spacesuits compared to a non-matsci set.
2. Bohrum and similar densities will produce a spacesuit as protective as a non-matsci set.
3. Denser alloys will produce more protective spacesuits compared to a non-matsci set.

Comparison of pre / post changes to ranged and melee protection using the following alloy:
![image](https://user-images.githubusercontent.com/84296283/118526866-b0e2a280-b70e-11eb-9715-226d1e677b7f.png)
(Ignore the difference in viral resistance, pre-version alloy had permeability property tacked on, but the densities are the same)
![image](https://user-images.githubusercontent.com/84296283/118526819-9f00ff80-b70e-11eb-8691-f5bd420833c6.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If a person puts a lot of effort into making a high quality alloy to make a custom space suit, they should probably be rewarded with something that protects them better than a standard space suit. Currently instead they receive a space suit that gives them less protection than if they had just grabbed an emergency suit from the pod bay.

This could potentially get people more interested in matsci.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Blackrep
(+)Fixed a bug that unintentionally nerfed a matsci space suit's ranged protection.
(+)Buffed the melee and ranged protection of matsci space suits based on material used.
```
