### PR TITLE
feat: you can use a fork or a spoon for mashed potatoes

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -191,29 +191,37 @@
 					boutput(M, "<span class='alert'>You can't eat [src]!</span>")
 					return 0
 				if (!bypass_utensils)
-					if (src.needfork && !user.find_type_in_hand(/obj/item/kitchen/utensil/fork))
-						boutput(M, "<span class='alert'>You need a fork to eat [src]!</span>")
+					var/utensil = null
+
+					if (src.needfork && user.find_type_in_hand(/obj/item/kitchen/utensil/fork))
+						utensil = user.find_type_in_hand(/obj/item/kitchen/utensil/fork)
+					else if (src.needspoon && user.find_type_in_hand(/obj/item/kitchen/utensil/spoon))
+						utensil = user.find_type_in_hand(/obj/item/kitchen/utensil/spoon)
+
+					// If it's a plastic fork we've found then test if we've broken it
+					var/obj/item/kitchen/utensil/fork/plastic/plastic_fork = utensil
+					if (istype(plastic_fork))
+						if (prob(20))
+							plastic_fork.break_utensil(M)
+							utensil = null
+
+					// If it's a plastic spoon we've found then test if we've broken it
+					var/obj/item/kitchen/utensil/spoon/plastic/plastic_spoon = utensil
+					if (istype(plastic_spoon))
+						if (prob(20))
+							plastic_fork.break_utensil(M)
+							utensil = null
+
+					if (!utensil)
+						if (needfork && needspoon)
+							boutput(M, "<span class='alert'>You need a fork or spoon to eat [src]!</span>")
+						else if (needfork)
+							boutput(M, "<span class='alert'>You need a fork to eat [src]!</span>")
+						else if (needspoon)
+							boutput(M, "<span class='alert'>You need a spoon to eat [src]!</span>")
+
 						M.visible_message("<span class='alert'>[user] stares glumly at [src].</span>")
 						return
-					if (src.needfork && user.find_type_in_hand(/obj/item/kitchen/utensil/fork/plastic) && prob(20))
-						// this can be kinda fucky if they're eating with two forks in hand.
-						// basically, the fork in their left hand will always be chosen
-						// I guess people in space are all left handed
-						for (var/obj/item/kitchen/utensil/fork/plastic/F in user.equipped_list(check_for_magtractor = 0))
-							F.break_utensil(M)
-							M.visible_message("<span class='alert'>[user] stares glumly at [src].</span>")
-							return
-					if (src.needspoon && !user.find_type_in_hand(/obj/item/kitchen/utensil/spoon))
-						boutput(M, "<span class='alert'>You need a spoon to eat [src]!</span>")
-						M.visible_message("<span class='alert'>[user] stares glumly at [src].</span>")
-						return
-					if (src.needspoon && user.find_type_in_hand(/obj/item/kitchen/utensil/spoon/plastic) && prob(20))
-						// this can be kinda fucky if they're eating with two forks in hand.
-						// basically, the fork in their left hand will always be chosen
-						// I guess people in space are all left handed
-						for (var/obj/item/kitchen/utensil/spoon/plastic/S in user.equipped_list(check_for_magtractor = 0))
-							S.break_utensil(M)
-							M.visible_message("<span class='alert'>[user] stares glumly at [src].</span>")
 
 				//no or broken stomach
 				if (ishuman(M))

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -209,7 +209,7 @@
 					var/obj/item/kitchen/utensil/spoon/plastic/plastic_spoon = utensil
 					if (istype(plastic_spoon))
 						if (prob(20))
-							plastic_fork.break_utensil(M)
+							plastic_spoon.break_utensil(M)
 							utensil = null
 
 					if (!utensil)

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -1900,6 +1900,7 @@
 	amount = 5
 	heal_amt = 1
 	needfork = 1
+	needspoon = 1
 	food_color = "#FF6699"
 	food_effects = list("food_hp_up_big")
 

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -1887,6 +1887,7 @@
 	amount = 5
 	heal_amt = 1
 	needfork = 1
+	needspoon = 1
 	food_color = "#FFFFFF"
 	initial_volume = 50
 	initial_reagents = list("mashedpotatoes"=25)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[Feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

before people start tearing each other [apart in the forums over the right way to eat mashed potatoes](https://forum.ss13.co/showthread.php?tid=16430) I've proactively made it possible to use EITHER A FORK OR SPOON to eat mashed potatoes

This refactors all foods so the requirement for a fork or spoon is no longer exclusive

just don't use a straw for the mashed potatoes you monster

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I eat mashed potatoes with a spoon?

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(+)Sure, use a spoon to eat mashed potatoes, why not?
```
