### PR TITLE
feat: show how many seconds you need to wait to exit cryosleep

### DIFF
--- a/code/WorkInProgress/cryospawn.dm
+++ b/code/WorkInProgress/cryospawn.dm
@@ -216,10 +216,17 @@
 		if (isnum(entered)) // fix for cannot compare 614825 to "involuntary" (sadly there is no fix for spy sassing me about a runtime HE CAUSED, THE BUTT)
 			var/time_of_day = world.timeofday + ((world.timeofday < entered) ? 864000 : 0) //Offset the time of day in case of midnight rollover
 			if ((entered + CRYOSLEEP_DELAY) > time_of_day) // is the time entered plus 15 minutes greater than the current time? the mob hasn't waited long enough
-				var/time_left = round((entered + CRYOSLEEP_DELAY - time_of_day)/600) // format this so it's nice and clear how many minutes are left to wait
-
+				var/time_left = entered + CRYOSLEEP_DELAY - time_of_day
 				if (time_left >= 0)
-					boutput(user, "<b>You must wait [time_left] minute[s_es(time_left)] before you can leave cryosleep.</b>")
+					var/minutes = round(time_left / (1 MINUTE))
+					var/seconds = round((time_left % (1 MINUTE)) / (1 SECOND))
+
+					var/time_left_message = "[seconds] second[s_es(seconds)]"
+
+					if(minutes >= 1)
+						time_left_message = "[minutes] minute[s_es(minutes)] and [time_left_message]"
+
+					boutput(user, "<b>You must wait at least [time_left_message] until you can leave cryosleep.</b>")
 					user.last_cryotron_message = ticker.round_elapsed_ticks
 					return 0
 		if (alert(user, "Would you like to leave cryogenic storage?", "Confirmation", "Yes", "No") == "No")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Shows the seconds left in cryosleep.

`You must wait at least 4 minutes and 20 seconds until you can leave cryosleep.`

`You must wait at least 10 seconds until you can leave cryosleep.`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

incredibly impatient crew members

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(+)Include seconds in Cryosleep countdown so progress can be estimated below 1 minute.
```
