### PR TITLE
fix: guardbuddies should stop arresting someone if they're cuffed

### DIFF
--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -1947,9 +1947,14 @@
 	onEnd()
 		..()
 		if (src.failchecks())
+			// One of the possible failed checks is that they're cuffed so
+			// we can stop trying to arrest them.
+			if (task.arrest_target?.hasStatus("handcuffed"))
+				task.drop_arrest_target()
+
 			return
 
-		if (task.arrest_target.hasStatus("handcuffed") || !isturf(task.arrest_target.loc))
+		if (!isturf(task.arrest_target.loc))
 			task.drop_arrest_target()
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

fixes when there are multiple guardbuddies they get stuck in an infinite loop
of incapacitating and attempting to cuff someone over and over.

it's caused by the handcuffed check being after another handcuffed
check which caused an early bail out of the function in the cuffing
action

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

this is really funny to watch but not that much fun to be a part of

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(+)Fix guardbuddy logic so they will eventually stop trying to arrest you if there's more than one of them.
```
