### PR TITLE
Fix cog2 fire door + alarm

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -50070,7 +50070,9 @@
 	},
 /area/station/maintenance/central)
 "ceq" = (
-/obj/machinery/door/firedoor/pyro,
+/obj/machinery/door/firedoor/pyro{
+	dir = 4
+	},
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
 	},
@@ -65524,10 +65526,6 @@
 /obj/item/reagent_containers/glass/bottle/formaldehyde,
 /obj/item/reagent_containers/syringe,
 /obj/item/hand_labeler,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "E APC";


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
On cogmap 2:
-Fixes the direction of a firedoor on an airlock at the engineering podbay/maint crossroads.
-Removes a fire alarm from under the morgue APC. There's another alarm two tiles up so it'll probably not be missed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's some small stuff that's wrong.