### PR TITLE
Shitty Bill's hairstyle update

### DIFF
--- a/code/mob/living/carbon/human/gimmick.dm
+++ b/code/mob/living/carbon/human/gimmick.dm
@@ -389,6 +389,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 	initializeBioholder()
 		. = ..()
 		bioHolder.mobAppearance.customization_second = "Tramp"
+		bioHolder.mobAppearance.customization_third = "Long Beard"
 		bioHolder.age = 62
 		bioHolder.bloodType = "A-"
 		bioHolder.mobAppearance.gender = "male"

--- a/code/z_adventurezones/timeship.dm
+++ b/code/z_adventurezones/timeship.dm
@@ -366,6 +366,7 @@ var/list/timewarp_interior_sounds = list('sound/ambience/industrial/Timeship_Gon
 
 	initializeBioholder()
 		bioHolder.mobAppearance.customization_second = "Tramp"
+		bioHolder.mobAppearance.customization_third = "Long Beard"
 		bioHolder.mobAppearance.underwear = "briefs"
 		bioHolder.age = 3500
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Updates Shitty Bill's current hairstyle, to match their pre-human resprite looks in a better way. Also does the same to ill-looking fellow, for consistency, since their hairstyle is identical.

Current Bill on the left, new Bill on the right: 

![0](https://user-images.githubusercontent.com/62990808/118848851-6e1bf880-b8cf-11eb-84ec-2876185cf3c7.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Human Resprite kinda stripped Bill of their iconic hobo look, this PR attempts to fix it