### PR TITLE
Adds vocal translator to Medical Manufacturers

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2282,6 +2282,15 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	create = 1
 	category = "Clothing"
 
+/datum/manufacture/monkey_translator
+	name = "Vocal Translator"
+	item_paths = list("CRY-1", "MET-1", "CON-1")
+	item_amounts = list(4, 4, 4)
+	item_outputs = list(/obj/item/clothing/mask/monkey_translator)
+	time = 10 SECONDS
+	create = 1
+	category = "Clothing"
+
 /datum/manufacture/hermes
 	name = "Offering to the Fabricator Gods"
 	item_paths = list("MET-3","CON-2","POW-3","DEN-3","FAB-1","INS-1")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2195,6 +2195,7 @@
 		/datum/manufacture/eyepatch,
 		/datum/manufacture/blindfold,
 		/datum/manufacture/muzzle,
+		/datum/manufacture/monkey_translator,
 		/datum/manufacture/body_bag,
 		/datum/manufacture/implanter,
 		/datum/manufacture/implant_health,


### PR DESCRIPTION
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Name says it all. This will make monkey players have a much easier time to be able to talk to other people without having to drain cargo of their budget.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the only way to get a vocal translator is to grab one of the two in an animal control locker which is not on all maps, or to buy monkey crates from cargo which drains their budget for a single item. I think this could stand to be made easier to make more of without making a bunch of monkeys in cargo.

## Changelog

```changelog
(u)DimWhat
(+)Added vocal translators to medical manufacturers
```
