### PR TITLE
Point-blank implant gun fix

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1630,6 +1630,7 @@ circuitry. As a result neurotoxins can cause massive damage.<BR>
 	hit_type = DAMAGE_STAB
 	casing = /obj/item/casing/small
 	icon_turf_hit = "bhole-small"
+	shot_number = 1
 	//silentshot = 1
 	var/obj/item/implant/my_implant = null
 	var/mob/implant_master = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets `shot_number` on the implanter projectile datum from the default 0 to 1, so that the for loop that creates the projectiles in point-blank shooty code runs. (gun_parent.dm, line 329 for those curious/confused)

From a brief look at other datums there's probably more guns/ammo types with potentially the same issue but I don't understand gun code enough to make broader changes with any confidence. The implant gun tested fine for me and it's _probably_ one of the more likely things to get fired point-blank anyway.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Closes #4782 
