### PR TITLE
Adds Vocal Translators to Valuchimp Machines

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1715,6 +1715,7 @@
 	create_products()
 		..()
 		product_list += new/datum/data/vending_product(/mob/living/carbon/human/npc/monkey, rand(10, 15), logged_on_vend=TRUE)
+		product_list += new/datum/data/vending_product(/obj/item/clothing/mask/monkey_translator, rand(5,10), logged_on_vend=TRUE)
 
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/snacks/plant/banana, rand(1,20), hidden=1)
 

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1715,9 +1715,10 @@
 	create_products()
 		..()
 		product_list += new/datum/data/vending_product(/mob/living/carbon/human/npc/monkey, rand(10, 15), logged_on_vend=TRUE)
-		product_list += new/datum/data/vending_product(/obj/item/clothing/mask/monkey_translator, rand(5,10), logged_on_vend=TRUE)
-
+		
+		product_list += new/datum/data/vending_product(/obj/item/clothing/mask/monkey_translator, rand(1,2), hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/food/snacks/plant/banana, rand(1,20), hidden=1)
+		
 
 /obj/machinery/vending/magivend
 	name = "MagiVend"


### PR DESCRIPTION
## About the PR 
This PR adds vocal translators to Valuchimp machines.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, vocal translators are limited to the ones that spawn on map and being ordered through the cardlocked monkey crate.  Given that being able to talk is a key part of such a social game, adding more sources  of vocal translators enables players who get turned into monkeys to continue to communicate with the crew, even if QM is unable/unwilling to order more. Longer term, I think the monkey crates should be replaced entirely with buildable valuchimps, and as such vocal translators need a new location. The machines seem fitting, and enable monkeys to get vocal translators from: the kitchen, genetics, and science. I see at the same time there's also an "add vocal translators to medical manufacturers" PR, I don't think it would be in conflict to have them in both places. This also enables vocal translators to be restocked at similar costs/rates per translator to the existing monkey crate.


## Changelog

```changelog
(u)COOLVAPE
(+)Added vocal translators as a hidden item in Valuchimp Machines.
```
