### PR TITLE
Adds 4 new secret bee-related chems.

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1485,7 +1485,7 @@ datum
 			result = "beesknees"
 			required_reagents = list("gin" = 1, "honey" = 1, "juice_lemon" = 1)
 			result_amount = 3
-			mix_phrase = "You hear a faint buzz from the solution and your knees faintly ache"
+			mix_phrase = "You hear a faint buzz from the solution and your knees faintly ache."
 			mix_sound = 'sound/misc/drinkfizz.ogg'
 			drinkrecipe = 1
 


### PR DESCRIPTION
[FEATURE] [SECRET]

## About the PR
~~This PR adds 4 new secret chems, all of which are bee-related, with the proportions of said bees getting larger, and each tier of the chem requires the last tier, plus other chems.~~

~~Adds: (Thank you RealB for the name)
Be-Bee: Infects you with Bee Fever, eventually turns you into a bee (akin to featherfluid/sheltestgrog, as are all of the rest)
Royal Be-Bee: Infects you with Royal Bee Fever, makes you a queen bee.
Royaler Be-Bee: Infects you with Royaler Bee Fever, which makes you a large queen bee.
Royalest Be-Bee: Infects you with Royalest Bee Fever, which makes you (to quote the code) an omega queen bee.~~

~~All of the infections can be cured by consuming garlic juice, since bees (apparently) don't like garlic.~~

## Why's this needed? 
~~There already is all sorts of critter conversion chems, and the bee critter's been sitting in the code, mostly unused, for a good amount of time now. In addition, I'd like to see bee critters be consistently playable, in some way.

Side note, since the chems are (hopefully) going in the secret submodule, the actual code for them are not in this PR.~~

Figured out a better way to do this, re-PRing shortly.

## Changelog

```changelog
(u)Zonespace
(*)Adds 4 new bee-related secret chems, the hints for them are in the Minor Changes section.
(+)Be-Bee: Think about all sorts of bee-related things, and give them a mix.
(+)Royal Be-Bee: It's all in the name.
(+)Royaler Be-Bee: Think about some potent bee-chem, and try mixing it with the previous incarnation of Be-Bee.
(+)Royalest Be-Bee: Take an even more powerful bee-chem, and mix it with the former tier of Be-Bee.
```