### PR TITLE
fix: replace step_rand with navigate_to to prevent bots escaping boxes

### DIFF
--- a/code/modules/robotics/bot/buttbot.dm
+++ b/code/modules/robotics/bot/buttbot.dm
@@ -10,6 +10,7 @@
 	icon = 'icons/obj/bots/aibots.dmi'
 	icon_state = "buttbot"
 	layer = 5.0 // Todo layer
+	bot_move_delay = BUTTBOT_MOVE_SPEED
 	density = 0
 	anchored = 0
 	on = 1
@@ -114,8 +115,7 @@
 				src.navigate_to(A, BUTTBOT_MOVE_SPEED, 0, 30)
 				break
 	else
-		SPAWN_DBG(0)
-			step_rand(src,1)
+		src.navigate_to(get_step_rand(src))
 
 /obj/machinery/bot/buttbot/process(mult)
 	if(src.exploding)

--- a/code/modules/robotics/bot/chefbot.dm
+++ b/code/modules/robotics/bot/chefbot.dm
@@ -15,16 +15,14 @@
 	/// Doesn't feel right to have this guy *constantly* flipping its lid like a methed up graytider
 	dynamic_processing = 0
 
-/obj/machinery/bot/chefbot/proc/do_step()
-	step_rand(src, 1)
-
 /obj/machinery/bot/chefbot/process()
 	. = ..()
 	if (raging)
 		return
 	if(prob(60) && src.on == 1)
+		src.navigate_to(get_step_rand(src))
+
 		SPAWN_DBG(0)
-			do_step()
 			if(prob(src.emagged * 20))
 				drama()
 			if(prob(30 + src.emagged * 30))

--- a/code/modules/robotics/bot/duckbot.dm
+++ b/code/modules/robotics/bot/duckbot.dm
@@ -65,8 +65,7 @@
 						src.navigate_to(get_turf(M), src.bot_move_delay, 0, 100)
 						break
 	else
-		SPAWN_DBG(0)
-			step_rand(src,1)
+		src.navigate_to(get_step_rand(src))
 
 /// Sends the duckbot to a random spot on the station
 /obj/machinery/bot/duckbot/proc/mystical_journey()

--- a/code/modules/robotics/bot/goosebot.dm
+++ b/code/modules/robotics/bot/goosebot.dm
@@ -19,8 +19,7 @@
 	return
 
 /obj/machinery/bot/goosebot/proc/wakka_wakka()
-	SPAWN_DBG(0)
-		step_rand(src,1)
+	src.navigate_to(get_step_rand(src))
 
 /obj/machinery/bot/goosebot/process()
 	. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

some bots have an idle wander where they move 1 tile away from where they were before.  they did this via `step_rand`.
instead, this replaces it with `navigate_to` so that the bots follow consistent rules for movement

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

bots that `step_rand` ignore the fact that they are contained in a crate or should enter a specific area.  they just step randomly.

this meant that buttbots and duckbots would just wander out of crates - but emagged duckbots and emagged buttbots wouldn't because they navigate_to a target.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)edwardly
(+)duckbots, buttbots, chefbots, etc, can be contained within a crate and won't wander out of them
```
