### PR TITLE
fix telekinetic pull's click drag

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -705,7 +705,7 @@
 			else
 				actions.start(new /datum/action/bar/private/icon/pickup/then_obj_click(src, over_object, params), usr)
 
-	//Click-drag tk stuff.  
+	//Click-drag tk stuff.
 /obj/item/proc/click_drag_tk(atom/over_object, src_location, over_location, over_control, params)
 	if(!src.anchored)
 		if (iswraith(usr))
@@ -721,10 +721,10 @@
 		else if (ismegakrampus(usr))
 			src.throw_at(over_object, 7, 1)
 			logTheThing("combat", usr, null, "throws [src] with k_tk.")
-		else if(usr.bioHolder && usr.bioHolder.HasEffect("telekinesis_drag") && isturf(src.loc) && isalive(usr)  && usr.canmove && get_dist(src,usr) <= 7 )
+		else if(usr.bioHolder && usr.bioHolder.HasEffect("telekinesis_drag") && istype(src, /obj)  && isturf(src.loc) && isalive(usr)  && usr.canmove && get_dist(src,usr) <= 7 )
 			var/datum/bioEffect/TK = usr.bioHolder.GetEffect("telekinesis_drag")
 
-			if(TK.variant == 2)
+			if(!src.anchored && (isitem(src) || TK.variant == 2))
 				src.throw_at(over_object, 7, 1)
 				logTheThing("combat", usr, null, "throws [src] with tk.")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes a bug where telekinetic pull genetic power lost its click drag unintentionally when code was fixed up. this may clean the code, but "telekinesis_drag" is the genetic power "telekinetic pull" and with out the part put back in that part the click drag does not work.
fixes #4828


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
before #4768 where tk code was also cleaned up, telekinetic pull had the ability to click drag objects from a distance and fling them around. this reintroduces that. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

