### PR TITLE
Fixes monkey burn states

### DIFF
--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -702,7 +702,7 @@
 			//src.fire_lying = image('icons/mob/human.dmi', "fire3_l", MOB_EFFECT_LAYER)
 		if (ismonkey(src))
 			src.fire_standing = SafeGetOverlayImage("fire", 'icons/mob/monkey.dmi', istate, MOB_EFFECT_LAYER)
-		if (istype(src:mutantrace, /datum/mutantrace/lizard))
+		else if (istype(src:mutantrace, /datum/mutantrace/lizard))
 			src.fire_standing = SafeGetOverlayImage("fire", 'icons/mob/lizard.dmi', istate, MOB_EFFECT_LAYER)
 		else
 			src.fire_standing = SafeGetOverlayImage("fire", 'icons/mob/human.dmi', istate, MOB_EFFECT_LAYER)


### PR DESCRIPTION
[bug - minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #4830 which entails monkeys having the incorrect burning states that defaulted to humans instead of their unique burn state.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug stinky.