### PR TITLE
chore: don't use named params for triggerOnHit

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -147,13 +147,13 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		explode_limit = limit
 		..()
 
-	execute(var/obj/item/owner, var/mob/attacker, var/mob/attacked, var/obj/attackobj, var/meleeorthrow)
+	execute(var/obj/item/owner)
 		if(explode_limit && explode_count >= explode_limit) return
 		if(world.time - lastTrigger < 50) return
 		lastTrigger = world.time
 		if(prob(trigger_chance))
 			explode_count++
-			var/turf/tloc = get_turf(attacked)
+			var/turf/tloc = get_turf(owner)
 			explosion(owner, tloc, 0, 1, 2, 3, 1)
 			tloc.visible_message("<span class='alert'>[owner] explodes!</span>")
 			qdel(owner)
@@ -607,7 +607,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 				wall_owner.dismantle_wall(1)
 
 /datum/materialProc/cardboard_on_hit // MARK: add to ignorant children
-	execute(var/atom/owner, var/mob/attacker, var/obj/attackobj, var/meleeorthrow)
+	execute(var/atom/owner, var/obj/attackobj, var/mob/attacker, var/meleeorthrow)
 		if (meleeorthrow == 1) //if it was a melee attack
 			if (issnippingtool(attackobj)||iscuttingtool(attackobj))
 				if (isExploitableObject(owner))

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -240,7 +240,7 @@
 
 	proc/triggerOnHit(var/atom/owner, var/obj/attackobj, var/mob/attacker, var/meleeorthrow)
 		for(var/datum/materialProc/X in triggersOnHit)
-			call(X,  "execute")(owner, attacker = attacker, attackobj = attackobj, meleeorthrow = meleeorthrow)
+			call(X,  "execute")(owner, attackobj, attacker, meleeorthrow)
 		return
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[cleanliness] [bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

uses standard parameters for trigger proc calls rather than named parameters

while it meant that you could specify the params in any order or potentially
omit some params, it meant you'd get unclear runtime errors

this also updates the generic explode which is only used by erebite
to always use the source's turf location as the explosion source


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

this caused more problems than it solved.  in particular, if a trigger
such as for plasma stone or molitz didn't have `attacker` / `meleeorthrow`
defined it caused them to not activate as intended & emitted runtime errors

as such, this means that we don't get runtime errors on molitz / plasmastone hits