### PR TITLE
Fixes eating things which don't need a utensil

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -212,7 +212,7 @@
 							plastic_spoon.break_utensil(M)
 							utensil = null
 
-					if (!utensil)
+					if (!utensil && (needfork || needspoon))
 						if (needfork && needspoon)
 							boutput(M, "<span class='alert'>You need a fork or spoon to eat [src]!</span>")
 						else if (needfork)


### PR DESCRIPTION
[major]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently when we have a null utensil, that could mean we need one and didn't find one, or that we don't need one at all. Currently the logic always goes to "we need a utensil and don't have one", even if we never needed one at all.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
LET PEOPLE EAT
