### PR TITLE
Splashing Black Powder now gives forensic gunshot residue

### DIFF
--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -809,6 +809,11 @@ datum
 						if(!D.reagents) D.create_reagents(10)
 						D.reagents.add_reagent("blackpowder", 5, null)
 				return
+			reaction_mob(var/mob/living/carbon/human/M, var/method=TOUCH, var/volume)
+				. = ..()
+				if (ishuman(M) && volume >= 10)
+					M.gunshot_residue = 1
+				return
 
 		combustible/nitrogentriiodide
 			//This is the parent and should not be spawned


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Splashing 10 or more units of black powder will make the target, on forensic scanners, appear to have gunshot residue on them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, there's no way to fake gunshot residue, and black powder being a close-enough representation, seems to work. Also, framing people for murder is fun.


## Changelog

```changelog
(u)Zonespace
(+)Getting splashed with Black Powder now gives gunshot residue.
```
