### PR TITLE
Adds an alternate Hot Toddy recipe which works in cocktail shakers

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1479,6 +1479,16 @@ datum
 			mix_sound = 'sound/misc/drinkfizz.ogg'
 			drinkrecipe = 1
 
+		hot_toddy_halfnhalf
+			name = "Hot Toddy"
+			id = "hottoddy_halfnhalf"
+			result = "hottoddy"
+			required_reagents = list("halfandhalf" = 2, "bourbon" = 1)
+			result_amount = 3
+			mix_phrase = "The drink suddenly fills the room with a festive aroma."
+			mix_sound = 'sound/misc/drinkfizz.ogg'
+			drinkrecipe = 1
+
 		bees_knees
 			name = "Bee's knees"
 			id = "beesknees"


### PR DESCRIPTION
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a recipe which takes half and half instead of lemon juice/tea separately.
Fixes #4850

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bartenders should be able to use their shaker to mix drinks consistently. Having both recipes work is more intuitive as well.