### PR TITLE
fix: handle invalid Z-level in GET_NEARBY

### DIFF
--- a/code/modules/spatial_hashing.dm
+++ b/code/modules/spatial_hashing.dm
@@ -1,7 +1,6 @@
 //this is designed for sounds - but maybe could be adapted for more collision / range checking stuff in the future
 
-
-#define GET_NEARBY(A,range) spatial_z_maps[A.z].get_nearby(A,range)
+#define GET_NEARBY(A,range) (A.z <= 0 || A.z > spatial_z_maps.len) ? null : spatial_z_maps[A.z].get_nearby(A,range)
 
 #define CELL_POSITION(X,Y) clamp(((round(X / cellsize)) + (round(Y / cellsize)) * cellwidth) + 1,1,hashmap.len)
 

--- a/code/modules/spatial_hashing.dm
+++ b/code/modules/spatial_hashing.dm
@@ -1,6 +1,6 @@
 //this is designed for sounds - but maybe could be adapted for more collision / range checking stuff in the future
 
-#define GET_NEARBY(A,range) (A.z <= 0 || A.z > spatial_z_maps.len) ? null : spatial_z_maps[A.z].get_nearby(A,range)
+#define GET_NEARBY(A,range) (A.z <= 0 || A.z > length(spatial_z_maps)) ? null : spatial_z_maps[A.z].get_nearby(A,range)
 
 #define CELL_POSITION(X,Y) clamp(((round(X / cellsize)) + (round(Y / cellsize)) * cellwidth) + 1,1,hashmap.len)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[bug] [runtime]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds guards to the `GET_NEARBY` macro so that invalid z-indices cause a `null` value to be used instead

this was done via other code before going into `GET_NEARBY` before https://github.com/goonstation/goonstation/commit/ec3a402c2924d7750b67a7cb347cf7e497c6f647#diff-01045599dea985cc8c68b567a927052f64cab4b2222bcd076b151f6525b77510L124

## Why's this needed? <!-- Describe why you think this should be added to the game. -->


during prefab generation there's a few mobs that are created which create sounds in an invalid Z-level `0`.  this caused runtime errors when we tried to play a sound because we'd look up the Z-level and get a list index out of bounds runtime

fixes #4856 