### PR TITLE
Stop arc plating from overwritting power cells' capacity and recharge rate

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -32,22 +32,6 @@
 			APC.cell = null
 		..()
 
-	onMaterialChanged()
-		..()
-		if (istype(src.material))
-			genrate = 0
-			if(src.material.hasProperty("radioactive"))
-				genrate += round((material.getProperty("radioactive") / 6.33))
-			if(src.material.hasProperty("n_radioactive"))
-				genrate += round((material.getProperty("n_radioactive") / 4.33))
-			if(src.material.hasProperty("electrical"))
-				maxcharge = round((src.material.getProperty("electrical") ** 2) * 3.333)
-			else
-				maxcharge = 2500
-
-			charge = maxcharge
-		return
-
 /obj/item/cell/supercell
 	maxcharge = 15000
 
@@ -80,6 +64,22 @@
 	New()
 		..()
 		processing_items |= src
+
+	onMaterialChanged()
+		..()
+		if (istype(src.material))
+			genrate = 0
+			if(src.material.hasProperty("radioactive"))
+				genrate += round((material.getProperty("radioactive") / 6.33))
+			if(src.material.hasProperty("n_radioactive"))
+				genrate += round((material.getProperty("n_radioactive") / 4.33))
+			if(src.material.hasProperty("electrical"))
+				maxcharge = round((src.material.getProperty("electrical") ** 2) * 3.333)
+			else
+				maxcharge = 2500
+
+			charge = maxcharge
+		return
 
 /obj/item/cell/charged
 	charge = 7500

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -875,17 +875,6 @@
 	var/sound_load = 'sound/weapons/gunload_click.ogg'
 	var/unusualCell = 0
 
-	onMaterialChanged()
-		..()
-		if(istype(src.material))
-			if(src.material.hasProperty("electrical"))
-				max_charge = round(material.getProperty("electrical") ** 1.33)
-			else
-				max_charge =  40
-
-		charge = max_charge
-		return
-
 	New()
 		..()
 		update_icon()
@@ -1030,16 +1019,6 @@
 	var/cycle = 0 //Recharge every other tick.
 	var/recharge_rate = 5.0
 
-	onMaterialChanged()
-		..()
-		if(istype(src.material))
-			recharge_rate = 0
-			if(src.material.hasProperty("radioactive"))
-				recharge_rate += ((src.material.getProperty("radioactive") / 10) / 2.5) //55(cerenkite) should give around 2.2, slightly less than a slow charge cell.
-			if(src.material.hasProperty("n_radioactive"))
-				recharge_rate += ((src.material.getProperty("n_radioactive") / 10) / 2)
-		return
-
 	New()
 		processing_items |= src
 		..()
@@ -1076,6 +1055,23 @@
 /obj/item/ammo/power_cell/self_charging/custom
 	name = "Power Cell"
 	desc = "A custom-made power cell."
+
+	onMaterialChanged()
+		..()
+		if(istype(src.material))
+			if(src.material.hasProperty("electrical"))
+				max_charge = round(material.getProperty("electrical") ** 1.33)
+			else
+				max_charge =  40
+
+			recharge_rate = 0
+			if(src.material.hasProperty("radioactive"))
+				recharge_rate += ((src.material.getProperty("radioactive") / 10) / 2.5) //55(cerenkite) should give around 2.2, slightly less than a slow charge cell.
+			if(src.material.hasProperty("n_radioactive"))
+				recharge_rate += ((src.material.getProperty("n_radioactive") / 10) / 2)
+
+		charge = max_charge
+		return
 
 /obj/item/ammo/power_cell/self_charging/slowcharge
 	name = "Power Cell - Atomic Slowcharge"


### PR DESCRIPTION
[BALANCE]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The PR makes it so that material changes only effect custom made power cells. The purpose of this change is to fix an exploit that allows players to arc plate any small or large power cell and have the `onMaterialChanged` overwrite the previous capacity and recharge rate.

Players will still be able to arc plate non-custom power cells, however this will no longer change the capacity or recharge rate. Custom power cells can't be plated, as they already have a material associated with them.

This has the side-effect of making midas touch and artifact bombs no longer effect the recharge rate and capacity of power cells that are touched / within the blast zone. However, I feel these were already pretty niche scenarios, and their removal cuts down some unnecessary confusion in the case it does happen.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having non-custom power cells changing recharge and capacity through arc plating defeats the purpose of having custom power cells craftable in the nano-fabricator. This is because the cost of arc plating (1 material block) is significantly cheaper than the cost of the nano-fab (2 / 4 material block).

Fixes #4859 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Blackrep
(+)Arc plating small / large power cells no longer changes their capacity or recharge rate.
```
