### PR TITLE
Spatial Interdictor spatial tear interaction buff

### DIFF
--- a/code/modules/events/spatial_tear.dm
+++ b/code/modules/events/spatial_tear.dm
@@ -37,18 +37,16 @@
 
 	New(var/loc,var/duration)
 		..()
+		START_TRACKING
 		//spatial interdictor: mitigate spatial tears
 		//consumes 800 units of charge per tear segment weakened
 		//weakened tears can be traversed, but inflict minor brute damage
 		for (var/obj/machinery/interdictor/IX in by_type[/obj/machinery/interdictor])
 			if (IN_RANGE(IX,src,IX.interdict_range) && IX.expend_interdict(800))
-				src.alpha = 150
-				src.opacity = 0
-				src.stabilized = 1
-				src.name = "Stabilized Spatial Tear"
-				desc = "A breach in the spatial fabric, partially stabilized by an interdictor. Difficult to pass."
+				src.stabilize()
 				break
 		SPAWN_DBG(duration)
+			STOP_TRACKING
 			qdel(src)
 
 	attack_hand(mob/user)
@@ -63,6 +61,13 @@
 
 	proc/try_pass(mob/user)
 		actions.start(new /datum/action/bar/icon/push_through_tear(user, src), user)
+
+	proc/stabilize()
+		src.alpha = 150
+		src.opacity = 0
+		src.stabilized = 1
+		src.name = "Stabilized Spatial Tear"
+		desc = "A breach in the spatial fabric, partially stabilized by an interdictor. Difficult to pass."
 
 
 /datum/action/bar/icon/push_through_tear

--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -210,6 +210,12 @@
 
 	src.canInterdict = 1
 	playsound(src.loc, src.sound_interdict_on, 40, 0)
+	SPAWN_DBG(rand(30,40)) //after it's been on for a little bit, check for tears
+		if(src.canInterdict)
+			for (var/obj/forcefield/event/tear in by_type[/obj/forcefield/event])
+				SPAWN_DBG(rand(8,22)) //stagger stabilizations, since it's getting stabilized post-formation
+					if (!tear.stabilized && IN_RANGE(src,tear,src.interdict_range) && src.expend_interdict(800))
+						tear.stabilize()
 	src.updateicon()
 
 
@@ -256,22 +262,24 @@
 	<br>
 	Biomagnetic fields nulled on discharge
 	<br>
-	Black holes semi-stabilized, increasing time to respond**
+	Black holes semi-stabilized, increasing time to respond*
 	<br>
 	Radiation pulses safely remodulated within field range
 	<br>
-	Radiation storms interdicted on a per-individual basis*
+	Radiation storms interdicted on a per-individual basis**
 	<br>
 	Solar flare disruptions reduced per onboard interdictor
 	<br>
-	Spatial tears stabilized, permitting limited traversal**
+	Spatial tears stabilized, permitting limited traversal***
 	<br>
 	Unstable wormholes nulled when entry is attempted
 	<br>
 	<br>
-	<i>*ADVISORY: heavy interdiction cost. Multiple interdictors or powerful cell recommended for crowds.</i>
+	<i>*WARNING: total interdiction impossible, and device must be active beforehand.</i>
 	<br>
-	<i>**WARNING: total interdiction impossible, and device must be active beforehand.</i>
+	<i>**ADVISORY: heavy interdiction cost. Multiple interdictors or powerful cell recommended for crowds.</i>
+	<br>
+	<i>***ADVISORY: as a countermeasure to capacitance failure, interdicting spatial tears will require reinitializing the interdictor if it was not installed near the tear at the time of the event.</i>
 	<br>
 	<br>
 	In just a few short steps, worrying about the myriad hazards of space will be a thing of the past!^


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adjusts the Spatial Interdictor's function when acting on spatial tears; when initialized, after a brief delay, interdictors will now check for spatial tears in their range that haven't been stabilized, and stabilize them asynchronously over a few seconds.

The guide book has been updated to indicate this change in behavior, and spatial tears now use START_TRACKING and STOP_TRACKING in new and disposing events respectively so the interdictors can efficiently check for their presence.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes interdicting spatial tears a more flexible thing, instead of requiring an interdictor everywhere a spatial tear could pop up. They're not fully dissipated (still can't pull things through) and you need to have the interdictor completely charged to initialize it, so it should be fine balance-wise.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(+)Spatial Interdictors may now interdict spatial tears after they form, requiring a fresh initialization within range of the tear.
```
