### PR TITLE
Counts more stuff as suicide

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -224,6 +224,7 @@
 			SPAWN_DBG(0)
 				the_mob.emote("scream")
 				the_mob:canmove = 0
+				the_mob.suiciding = 1
 				for(var/i=0, i<30, i++)
 					if(!the_mob)
 						return
@@ -232,6 +233,7 @@
 					the_mob.pixel_y = rand(-5,5)
 					if (!the_mob.buckled) //Runtime fix: Cannot read null.anchored
 						the_mob.gib()
+						the_mob.suiciding = 0
 					if(!the_mob.buckled:anchored)
 						step(the_mob.buckled, pick(cardinal))
 					if(i>10)
@@ -244,6 +246,7 @@
 						sleep(0.3 SECONDS)
 				the_mob.unlock_medal( "Too Fast Too Furious", 1 )
 				the_mob.gib()
+				the_mob.suiciding = 0
 
 			return
 		SPAWN_DBG(0)

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -555,7 +555,9 @@
 					SPAWN_DBG(1 SECOND)
 						src.wear_mask.set_loc(src.loc)
 						src.wear_mask = null
+						src.suiciding = 1
 						src.gib()
+						src.suiciding = 0
 						return
 				else
 					src.show_text("You just don't feel kawaii enough to uguu right now!", "red")
@@ -617,7 +619,9 @@
 							hat.set_loc(src.loc)
 							src.head = null
 							src.add_karma(-10)
+							src.suiciding = 1
 							src.gib()
+							src.suiciding = 0
 					else if (istype(src.head, /obj/item/clothing/head) && !istype(src.head, /obj/item/clothing/head/fedora))
 						src.show_text("This hat just isn't [pick("fancy", "suave", "manly", "sexerific", "majestic", "euphoric")] enough for that!", "red")
 						//maptext_out = "<I>tips hat</I>"

--- a/code/obj/item/gun/russian.dm
+++ b/code/obj/item/gun/russian.dm
@@ -47,8 +47,12 @@
 			playsound(user, "sound/weapons/Gunshot.ogg", 100, 1)
 			for(var/mob/O in AIviewers(user, null))
 				if (O.client)	O.show_message("<span class='alert'><B>BOOM!</B> [user]'s head explodes.</span>", 1, "<span class='alert'>You hear someone's head explode.</span>", 2)
+				user.suiciding = 1
 				user.TakeDamage("head", 300, 0)
 				take_bleeding_damage(user, null, 500, DAMAGE_STAB)
+				SPAWN_DBG(50 SECONDS)
+					if (user && !isdead(user))
+						user.suiciding = 0
 			inventory_counter.update_number(0)
 			return 1
 		else

--- a/code/obj/item/storage/bible.dm
+++ b/code/obj/item/storage/bible.dm
@@ -173,7 +173,9 @@ var/global/list/bible_contents = list()
 		else
 			user.visible_message("<span class='alert'>[user] farts on the bible.<br><b>A mysterious force smites [user]!</b></span>")
 			logTheThing("combat", user, null, "farted on [src] at [log_loc(src)] last touched by <b>[src.fingerprintslast ? src.fingerprintslast : "unknown"]</b>.")
+			user.suiciding = 1
 			user.gib()
+			user.suiciding = 0
 			return 0
 
 /obj/item/storage/bible/evil


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->[BALANCE]
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
 Makes it so more methods of killing yourself count as suicide, I didn't touch some stuff on porpouse as those require more effort than going to the bar and grabbing a russian revolver or going to the chapel and grabbing a bible, if it should all count just tell me.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being able to easily blow up somewhere with no risk of it not working by using micro/macro bombs and something easily obtainable is bad.