### PR TITLE
adds name changing option to roles that can spawn as mutantraces

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1308,6 +1308,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_foot = /obj/item/clothing/shoes/tourist
 	slot_lhan = /obj/item/camera
 	slot_rhan = /obj/item/storage/photo_album
+	change_name_on_spawn = 1
 
 	special_setup(var/mob/living/carbon/human/M)
 		..()
@@ -1537,6 +1538,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_lhan = /obj/item/storage/briefcase
 	slot_foot = /obj/item/clothing/shoes/brown
 	alt_names = list("Salesman", "Merchant")
+	change_name_on_spawn = 1
 
 	special_setup(var/mob/living/carbon/human/M)
 		..()
@@ -2606,6 +2608,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 	slot_foot = /obj/item/clothing/shoes/tourist
 	slot_lhan = /obj/item/camera
 	slot_rhan = /obj/item/storage/photo_album
+	change_name_on_spawn = 1
 
 	special_setup(var/mob/living/carbon/human/M)
 		..()
@@ -2653,7 +2656,7 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 	allow_traitors = 0
 	cant_spawn_as_rev = 1
 	var/team = 0 //1 = NT, 2 = SY
-	
+
 	special_setup(var/mob/living/carbon/human/M)
 		..()
 		if (!M)
@@ -2680,8 +2683,8 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 		if (istype(headset))
 			headset.set_secure_frequency("g",freq)
 			headset.secure_classes["g"] = RADIOCL_SYNDICATE
-			headset.cant_self_remove = 0 
-			headset.cant_other_remove = 0 
+			headset.cant_self_remove = 0
+			headset.cant_other_remove = 0
 
 	nanotrasen
 		name = "NanoTrasen Pod Pilot"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds change_name_on_spawn to both tourist roles and the saleman role. This allows those roles to change their name when spawning, similar to clowns, boxers, etc.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These roles are capable of spawning as mutantraces. This lets players change their name just in case, so they don't have to go around playing as John Bob the very, definitely, nonhuman martian or illithid or whatever.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Vaskritaya
(+)Salesman and tourists can now change their name on spawn, in case they spawn as a mutantrace or just if they feel like it.
```
