### PR TITLE
Fixes roller bed teleportation (again) and allows roller beds to be pulled without someone on them

### DIFF
--- a/code/mob/living/life/canmove.dm
+++ b/code/mob/living/life/canmove.dm
@@ -4,6 +4,7 @@
 		//check_if_buckled()
 		if (owner.buckled)
 			if (owner.buckled.loc != owner.loc)
+				owner.buckled.buckled_guy = null
 				owner.buckled = null
 				return ..()
 			owner.lying = istype(owner.buckled, /obj/stool/bed) || istype(owner.buckled, /obj/machinery/conveyor)

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -326,6 +326,8 @@
 		if (!ticker)
 			user.show_text("You can't buckle anyone in before the game starts.", "red")
 			return 0
+		if (C.buckled)
+			boutput(user, "They're already buckled into something!", "red")
 		if (src.security)
 			user.show_text("There's nothing you can buckle them to!", "red")
 			return 0
@@ -674,6 +676,8 @@
 		if (!ticker)
 			boutput(user, "You can't buckle anyone in before the game starts.")
 			return 0
+		if (M.buckled)
+			boutput(user, "They're already buckled into something!", "red")
 		if (!( iscarbon(M) ) || get_dist(src, user) > 1 || M.loc != src.loc || user.restrained() || !isalive(user))
 			return 0
 		if(src.buckled_guy && src.buckled_guy.buckled == src && src.buckled_guy != M)

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -284,7 +284,7 @@
 		scoot_sounds = list( 'sound/misc/chair/office/scoot1.ogg', 'sound/misc/chair/office/scoot2.ogg', 'sound/misc/chair/office/scoot3.ogg', 'sound/misc/chair/office/scoot4.ogg', 'sound/misc/chair/office/scoot5.ogg' )
 
 	Move()
-		if(src.buckled_guy.loc != src.loc)
+		if(src.buckled_guy?.loc != src.loc)
 			src.unbuckle()
 		. = ..()
 		if (. && src.buckled_guy)

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -328,6 +328,7 @@
 			return 0
 		if (C.buckled)
 			boutput(user, "They're already buckled into something!", "red")
+			return 0
 		if (src.security)
 			user.show_text("There's nothing you can buckle them to!", "red")
 			return 0
@@ -678,6 +679,7 @@
 			return 0
 		if (M.buckled)
 			boutput(user, "They're already buckled into something!", "red")
+			return 0
 		if (!( iscarbon(M) ) || get_dist(src, user) > 1 || M.loc != src.loc || user.restrained() || !isalive(user))
 			return 0
 		if(src.buckled_guy && src.buckled_guy.buckled == src && src.buckled_guy != M)


### PR DESCRIPTION
[bug] [runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes two things, and generally unsmells buckle code a bit:
1. Fixes #4880. As-is rollerbeds runtime every time you pull them without someone buckled to them, meaning they can't be pulled (and produce assloads of runtimes).
2. Fixes #4820. When the `canmove` process ensures that mobs are actually in the same location as the thing they're buckled to, it nulls the mob's `buckled`, but not the buckled-to object's `buckled_guy`. This results in a person who can freely moved around, and a confused object which still thinks someone is buckled to it, and keeps dragging them along (from any distance)!

Also makes it so you can't buckle someone into something if they're already buckled to something else, which also resulted in the aforementioned asymmetrical buckle state. 

I tested this in the realm of buckling into and out of chairs/beds, but if there's some bizarre bug any of this could create, lemme know.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs are bad

bucklecode is a fuck