### PR TITLE
Check hands for spy PDA

### DIFF
--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -187,39 +187,42 @@
 	//find a PDA, hide the uplink inside
 	var/loc = ""
 	var/obj/item/device/R = null
-	if (!R && istype(traitor_mob.belt, /obj/item/device/pda2))
+	if (istype(traitor_mob.belt, /obj/item/device/pda2))
 		R = traitor_mob.belt
 		loc = "on your belt"
-	if (!R && istype(traitor_mob.r_store, /obj/item/device/pda2))
+	else if (istype(traitor_mob.r_store, /obj/item/device/pda2))
 		R = traitor_mob.r_store
-		loc = "In your pocket"
-	if (!R && istype(traitor_mob.l_store, /obj/item/device/pda2))
+		loc = "In your right pocket"
+	else if (istype(traitor_mob.l_store, /obj/item/device/pda2))
 		R = traitor_mob.l_store
-		loc = "In your pocket"
-	if (!R && istype(traitor_mob.wear_id, /obj/item/device/pda2))
+		loc = "In your left pocket"
+	else if (istype(traitor_mob.wear_id, /obj/item/device/pda2))
 		R = traitor_mob.wear_id
 		loc = "In your ID slot"
-	if (!R && istype(traitor_mob.l_hand, /obj/item/storage))
+	else if (istype(traitor_mob.l_hand, /obj/item/device/pda2))
+		R = traitor_mob.l_hand
+		loc = "In your left hand"
+	else if (istype(traitor_mob.r_hand, /obj/item/device/pda2))
+		R = traitor_mob.r_hand
+		loc = "In your right hand"
+	else if (istype(traitor_mob.l_hand, /obj/item/storage))
 		var/obj/item/storage/S = traitor_mob.l_hand
 		var/list/L = S.get_contents()
 		for (var/obj/item/device/pda2/foo in L)
 			R = foo
 			loc = "in the [S.name] in your left hand"
-			break
-	if (!R && istype(traitor_mob.r_hand, /obj/item/storage))
+	else if (istype(traitor_mob.r_hand, /obj/item/storage))
 		var/obj/item/storage/S = traitor_mob.r_hand
 		var/list/L = S.get_contents()
 		for (var/obj/item/device/pda2/foo in L)
 			R = foo
 			loc = "in the [S.name] in your right hand"
-			break
-	if (!R && istype(traitor_mob.back, /obj/item/storage))
+	else if (istype(traitor_mob.back, /obj/item/storage))
 		var/obj/item/storage/S = traitor_mob.back
 		var/list/L = S.get_contents()
 		for (var/obj/item/device/pda2/foo in L)
 			R = foo
-			loc = "in the [S.name] in your backpack"
-			break
+			loc = "in the [S.name] on your back"
 
 	if (!R) //They have no PDA. Make one!
 		R = new /obj/item/device/pda2(traitor_mob)

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -192,19 +192,19 @@
 		loc = "on your belt"
 	else if (istype(traitor_mob.r_store, /obj/item/device/pda2))
 		R = traitor_mob.r_store
-		loc = "In your right pocket"
+		loc = "in your right pocket"
 	else if (istype(traitor_mob.l_store, /obj/item/device/pda2))
 		R = traitor_mob.l_store
-		loc = "In your left pocket"
+		loc = "in your left pocket"
 	else if (istype(traitor_mob.wear_id, /obj/item/device/pda2))
 		R = traitor_mob.wear_id
-		loc = "In your ID slot"
+		loc = "in your ID slot"
 	else if (istype(traitor_mob.l_hand, /obj/item/device/pda2))
 		R = traitor_mob.l_hand
-		loc = "In your left hand"
+		loc = "in your left hand"
 	else if (istype(traitor_mob.r_hand, /obj/item/device/pda2))
 		R = traitor_mob.r_hand
-		loc = "In your right hand"
+		loc = "in your right hand"
 	else
 		if (istype(traitor_mob.l_hand, /obj/item/storage))
 			var/obj/item/storage/S = traitor_mob.l_hand

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -224,6 +224,12 @@
 			for (var/obj/item/device/pda2/foo in L)
 				R = foo
 				loc = "in the [S.name] on your back"
+		if (!R && istype(traitor_mob.belt, /obj/item/storage))
+			var/obj/item/storage/S = traitor_mob.belt
+			var/list/L = S.get_contents()
+			for (var/obj/item/device/pda2/foo in L)
+				R = foo
+				loc = "in the [S.name] on your belt"
 
 	if (!R) //They have no PDA. Make one!
 		R = new /obj/item/device/pda2(traitor_mob)

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -205,24 +205,25 @@
 	else if (istype(traitor_mob.r_hand, /obj/item/device/pda2))
 		R = traitor_mob.r_hand
 		loc = "In your right hand"
-	else if (istype(traitor_mob.l_hand, /obj/item/storage))
-		var/obj/item/storage/S = traitor_mob.l_hand
-		var/list/L = S.get_contents()
-		for (var/obj/item/device/pda2/foo in L)
-			R = foo
-			loc = "in the [S.name] in your left hand"
-	else if (istype(traitor_mob.r_hand, /obj/item/storage))
-		var/obj/item/storage/S = traitor_mob.r_hand
-		var/list/L = S.get_contents()
-		for (var/obj/item/device/pda2/foo in L)
-			R = foo
-			loc = "in the [S.name] in your right hand"
-	else if (istype(traitor_mob.back, /obj/item/storage))
-		var/obj/item/storage/S = traitor_mob.back
-		var/list/L = S.get_contents()
-		for (var/obj/item/device/pda2/foo in L)
-			R = foo
-			loc = "in the [S.name] on your back"
+	else
+		if (istype(traitor_mob.l_hand, /obj/item/storage))
+			var/obj/item/storage/S = traitor_mob.l_hand
+			var/list/L = S.get_contents()
+			for (var/obj/item/device/pda2/foo in L)
+				R = foo
+				loc = "in the [S.name] in your left hand"
+		if (!R && istype(traitor_mob.r_hand, /obj/item/storage))
+			var/obj/item/storage/S = traitor_mob.r_hand
+			var/list/L = S.get_contents()
+			for (var/obj/item/device/pda2/foo in L)
+				R = foo
+				loc = "in the [S.name] in your right hand"
+		if (!R && istype(traitor_mob.back, /obj/item/storage))
+			var/obj/item/storage/S = traitor_mob.back
+			var/list/L = S.get_contents()
+			for (var/obj/item/device/pda2/foo in L)
+				R = foo
+				loc = "in the [S.name] on your back"
 
 	if (!R) //They have no PDA. Make one!
 		R = new /obj/item/device/pda2(traitor_mob)

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -190,15 +190,15 @@
 	if (istype(traitor_mob.belt, /obj/item/device/pda2))
 		R = traitor_mob.belt
 		loc = "on your belt"
+	else if (istype(traitor_mob.wear_id, /obj/item/device/pda2))
+		R = traitor_mob.wear_id
+		loc = "in your ID slot"
 	else if (istype(traitor_mob.r_store, /obj/item/device/pda2))
 		R = traitor_mob.r_store
 		loc = "in your right pocket"
 	else if (istype(traitor_mob.l_store, /obj/item/device/pda2))
 		R = traitor_mob.l_store
 		loc = "in your left pocket"
-	else if (istype(traitor_mob.wear_id, /obj/item/device/pda2))
-		R = traitor_mob.wear_id
-		loc = "in your ID slot"
 	else if (istype(traitor_mob.l_hand, /obj/item/device/pda2))
 		R = traitor_mob.l_hand
 		loc = "in your left hand"
@@ -212,24 +212,28 @@
 			for (var/obj/item/device/pda2/foo in L)
 				R = foo
 				loc = "in the [S.name] in your left hand"
-		if (!R && istype(traitor_mob.r_hand, /obj/item/storage))
+				break
+		if (istype(traitor_mob.r_hand, /obj/item/storage))
 			var/obj/item/storage/S = traitor_mob.r_hand
 			var/list/L = S.get_contents()
 			for (var/obj/item/device/pda2/foo in L)
 				R = foo
 				loc = "in the [S.name] in your right hand"
-		if (!R && istype(traitor_mob.back, /obj/item/storage))
+				break
+		if (istype(traitor_mob.back, /obj/item/storage))
 			var/obj/item/storage/S = traitor_mob.back
 			var/list/L = S.get_contents()
 			for (var/obj/item/device/pda2/foo in L)
 				R = foo
 				loc = "in the [S.name] on your back"
-		if (!R && istype(traitor_mob.belt, /obj/item/storage))
+				break
+		if (istype(traitor_mob.belt, /obj/item/storage))
 			var/obj/item/storage/S = traitor_mob.belt
 			var/list/L = S.get_contents()
 			for (var/obj/item/device/pda2/foo in L)
 				R = foo
 				loc = "in the [S.name] on your belt"
+				break
 
 	if (!R) //They have no PDA. Make one!
 		R = new /obj/item/device/pda2(traitor_mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check to see if a PDA is in the player's hands for a PDA before unnecessarily making them a new one.
Adds a check to find PDA in belt storage for fannypacks.
Tells you which pocket your PDA is in.
Fixes an incorrect message telling you that you have the PDA in a backpack in your backpack.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Creating a spy PDA doesn't check your hands, if you are moving it at round start the game may not find the PDA and make you an an extra PDA.