### PR TITLE
Makes satchels layer under tails.

### DIFF
--- a/_std/defines/layer.dm
+++ b/_std/defines/layer.dm
@@ -27,11 +27,11 @@
 #define MOB_OVERMASK_LAYER (MOB_OVERLAY_BASE-4.8) // for mutant details that go over masks
 #define MOB_HEAD_LAYER1		(MOB_OVERLAY_BASE-5) // masks
 #define MOB_EARS_LAYER		(MOB_OVERLAY_BASE-5.5)
-#define MOB_HAIR_LAYER2		(MOB_OVERLAY_BASE-6)
 #define MOB_GLASSES_LAYER 	(MOB_OVERLAY_BASE-7)
 #define MOB_BACK_LAYER 		(MOB_OVERLAY_BASE-8)
 #define MOB_OVERSUIT_LAYER1 (MOB_OVERLAY_BASE-8.7)	// For mutant oversuit (de)tails when facing north
 #define MOB_OVERSUIT_LAYER2 (MOB_OVERLAY_BASE-8.8)	// If we have another one
+#define MOB_BACK_LAYER_SATCHEL  (MOB_OVERLAY_BASE-8.9)  // For satchels so they don't show over a tail or something
 #define MOB_ARMOR_LAYER 	(MOB_OVERLAY_BASE-9)
 #define MOB_HAND_LAYER2 	(MOB_OVERLAY_BASE-10) 	// gloves
 #define MOB_HAND_LAYER1 	(MOB_OVERLAY_BASE-11)

--- a/_std/defines/layer.dm
+++ b/_std/defines/layer.dm
@@ -27,6 +27,7 @@
 #define MOB_OVERMASK_LAYER (MOB_OVERLAY_BASE-4.8) // for mutant details that go over masks
 #define MOB_HEAD_LAYER1		(MOB_OVERLAY_BASE-5) // masks
 #define MOB_EARS_LAYER		(MOB_OVERLAY_BASE-5.5)
+#define MOB_HAIR_LAYER2		(MOB_OVERLAY_BASE-6)
 #define MOB_GLASSES_LAYER 	(MOB_OVERLAY_BASE-7)
 #define MOB_BACK_LAYER 		(MOB_OVERLAY_BASE-8)
 #define MOB_OVERSUIT_LAYER1 (MOB_OVERLAY_BASE-8.7)	// For mutant oversuit (de)tails when facing north

--- a/code/WorkInProgress/rewardsLocker.dm
+++ b/code/WorkInProgress/rewardsLocker.dm
@@ -42,6 +42,7 @@
 			M.real_name = "medic's satchel"
 			M.desc = "A thick, wearable container made of synthetic fibers, able to carry a number of objects comfortably on a crewmember's shoulder. (Base Item: [prev1])"
 			activator.set_clothing_icon_dirty()
+			M.wear_layer = MOB_BACK_LAYER_SATCHEL
 
 		else if (istype(activator.back, /obj/item/storage/backpack/NT) || activator.back.icon_state == "NTbackpack")
 			var/obj/item/storage/backpack/M = activator.back
@@ -57,6 +58,7 @@
 			M.real_name = "NT satchel"
 			M.desc = "A thick, wearable container made of synthetic fibers, able to carry a number of objects comfortably on a crewmember's shoulder. (Base Item: [prev2])"
 			activator.set_clothing_icon_dirty()
+			M.wear_layer = MOB_BACK_LAYER_SATCHEL
 
 		else if (istype(activator.back, /obj/item/storage/backpack/captain))
 			if (activator.back.icon_state == "capbackpack")
@@ -73,6 +75,7 @@
 				M.real_name = "Captains Satchel"
 				M.desc = "A fancy designer bag made out of space snake leather and encrusted with plastic expertly made to look like gold. (Base Item: [prev3])"
 				activator.set_clothing_icon_dirty()
+				M.wear_layer = MOB_BACK_LAYER_SATCHEL
 			else
 				var/obj/item/storage/backpack/M = activator.back
 				var/prev3 = M.name
@@ -87,6 +90,7 @@
 				M.real_name = "Captains Satchel"
 				M.desc = "A fancy designer bag made out of rare blue space snake leather and encrusted with plastic expertly made to look like gold. (Base Item: [prev3])"
 				activator.set_clothing_icon_dirty()
+				M.wear_layer = MOB_BACK_LAYER_SATCHEL
 
 		else if (istype(activator.back, /obj/item/storage/backpack))
 			var/obj/item/storage/backpack/M = activator.back
@@ -102,6 +106,7 @@
 			M.real_name = "satchel"
 			M.desc = "A thick, wearable container made of synthetic fibers, able to carry a number of objects comfortably on a crewmember's shoulder. (Base Item: [prev3])"
 			activator.set_clothing_icon_dirty()
+			M.wear_layer = MOB_BACK_LAYER_SATCHEL
 
 		else
 			boutput(activator, "<span class='alert'>Whatever it is you've got on your back, it can't be reskinned!</span>")

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -68,6 +68,7 @@
 	name = "satchel"
 	desc = "A thick, wearable container made of synthetic fibers, able to carry a number of objects comfortably on a crewmember's shoulder."
 	icon_state = "satchel"
+	wear_layer = MOB_BACK_LAYER_SATCHEL // satchels show over the tail of lizards normally, they should be BEHIND the tail
 
 /obj/item/storage/backpack/satchel/syndie
 	name = "\improper Syndicate Satchel"


### PR DESCRIPTION
[Bug - Minor]

## About the PR 
Creates a new layer under the outer suit tail details for satchels. This shouldn't change anything than how objects that are satchels are layered.
![image](https://user-images.githubusercontent.com/40079883/119706372-81731a80-be1f-11eb-9abe-f83df0ee375f.png)

## Why's this needed? 
Currently satchels are displayed over a tail, which is weird and breaks perspective of the sprite. Realistically the tail would be seen in front of something like that.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)Made satchels layer under tails.
```