### PR TITLE
removes simmed floors at central command

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -30567,11 +30567,6 @@
 	dir = 10
 	},
 /area/crypt/graveyard)
-"bHg" = (
-/turf/simulated/floor/airless/orangeblack/corner{
-	dir = 4
-	},
-/area/centcom)
 "bHh" = (
 /obj/shrub{
 	dir = 4
@@ -38544,7 +38539,7 @@
 /turf/unsimulated/floor/caution/westeast,
 /area/owlery/staffhall)
 "cdi" = (
-/turf/simulated/floor/airless/orangeblack/corner,
+/turf/unsimulated/floor/orangeblack/corner,
 /area/centcom)
 "cdj" = (
 /obj/machinery/light{
@@ -69968,7 +69963,7 @@
 /obj/landmark/viscontents_spawn{
 	targetZ = 4
 	},
-/turf/simulated/floor/stairs/wide/other{
+/turf/unsimulated/floor/stairs/wide/other{
 	dir = 1
 	},
 /area/centcom/offices{
@@ -145981,7 +145976,7 @@ dmr
 dmw
 dmw
 bwb
-bHg
+dnv
 cdi
 bwb
 dmw


### PR DESCRIPTION
[bug - minor]

## About the PR 
admins spend their free time trying to turn floors at central command into pizza; however superiors at nanotrasen hate that and so i have made the floors unsimmed to prevent pizza floors at centcomm. also bombs and prying tiles and stuff i guess.

## Why's this needed? 
fun is no longer allowed.

(centcomm should all be unsimmed!)