### PR TITLE
Fix kinetic ammo counter not updating on manual reloads

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -161,8 +161,8 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 			src.ejectcasings()
 			src.casings_to_eject = 0
 
-			src.update_icon()
 			src.ammo.amount_left = 0
+			src.update_icon()
 			src.add_fingerprint(user)
 			ammoHand.add_fingerprint(user)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - TRIVIAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the `attack_hand` method so that the gun's `update_icon` method is called after the ammo's `amount_left` is set to 0.

### Before

https://user-images.githubusercontent.com/84296283/119766865-c6c93380-be83-11eb-9d7b-2ee98f10cca9.mp4

### After

https://user-images.githubusercontent.com/84296283/119766874-ccbf1480-be83-11eb-984f-2a9d87d564bd.mp4

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes a bug that made it look like a gun was still loaded even though in reality it had no magazine in it. The icon would display a non-zero ammo counter while firing it would show the "no ammo" message, leading to some confusion.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

