### PR TITLE
Makes NT pilots wear their special helmet and makes it have no slowdown.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2698,7 +2698,7 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 		slot_back = /obj/item/storage/backpack/NT
 		slot_belt = /obj/item/gun/energy/blaster_pod_wars/nanotrasen
 		slot_jump = /obj/item/clothing/under/misc/turds
-		slot_head = /obj/item/clothing/head/helmet/space/ntso
+		slot_head = /obj/item/clothing/head/helmet/space/nanotrasen/pilot
 		slot_suit = /obj/item/clothing/suit/space/nanotrasen/pilot
 		slot_foot = /obj/item/clothing/shoes/swat
 		slot_card = /obj/item/card/id/pod_wars/nanotrasen

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -380,11 +380,16 @@
 	item_state = "nthelm2"
 	desc = "Well protected helmet used by certain Nanotrasen bodyguards."
 
+
 /obj/item/clothing/head/helmet/space/nanotrasen/pilot
 	name = "Nanotrasen Pilot Helmet"
 	icon_state = "nanotrasen_pilot"
 	item_state = "nanotrasen_pilot"
 	desc = "A space helmet used by certain Nanotrasen pilots."
+
+	setupProperties()
+		..()
+		setProperty("space_movespeed", 0)
 
 /obj/item/clothing/head/helmet/swat
 	name = "swat helmet"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the helmet worn by NT pilots with the NT pilot helmet and removes the slowdown on the pilot helmet to match the previous helmet.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
NT pilots have a unique space helmet that they could be using instead of the NTSO one. I believe they should be using that helmet instead.

## Changelog

```changelog
(u)DimWhat
(+)Made NT pilots wear a unique helmet for pod wars.
```
