### PR TITLE
Pod Wars Map Update

### DIFF
--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -20,6 +20,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
 "ad" = (
@@ -41,6 +45,10 @@
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/fstation/observatory)
 "aj" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/red/corner,
 /area/pod_wars/spacejunk/fstation)
 "al" = (
@@ -49,9 +57,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -74,27 +80,40 @@
 	},
 /area/pod_wars/spacejunk/dorgun)
 "at" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/brightwell)
 "au" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/red/side,
 /area/pod_wars/spacejunk/fstation)
 "aw" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
 /area/pod_wars/spacejunk/fstation)
 "ax" = (
 /obj/machinery/door/airlock/pyro/glass/sci,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/purple,
 /area/pod_wars/spacejunk/fstation/primary)
+"ay" = (
+/obj/grille/catwalk{
+	dir = 9;
+	icon_state = "catwalk_cross"
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
+	},
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "aA" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -103,55 +122,59 @@
 	dir = 4
 	},
 /area/pod_wars/spacejunk/nancy/landingpad)
-"aB" = (
+"aC" = (
+/obj/machinery/power/furnace,
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-8"
 	},
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
 	},
-/obj/control_point_computer{
-	dir = 4;
-	name = "Reliant Control Console"
-	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
+/turf/simulated/floor/engine,
+/area/pod_wars/team1/powergen)
 "aD" = (
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/brightwell)
-"aF" = (
-/obj/machinery/light{
-	dir = 1
+"aE" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
 	},
-/turf/unsimulated/floor/specialroom/bar,
-/area/pod_wars/team2/bar)
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	tag = "icon-catwalk (WEST)"
+	},
+/area/pod_wars/spacejunk/fstation/landingpads)
 "aH" = (
 /turf/unsimulated/floor/yellow/corner{
 	dir = 1
 	},
 /area/pod_wars/team2/mining)
+"aI" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/fstation)
 "aJ" = (
 /obj/machinery/vending/snack,
 /turf/unsimulated/floor/red/side{
 	dir = 9
 	},
 /area/pod_wars/team2/bridge)
-"aK" = (
-/obj/machinery/sleeper/compact,
-/turf/unsimulated/floor/white,
-/area/pod_wars/team1/medbay)
 "aL" = (
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
@@ -166,17 +189,6 @@
 	dir = 1
 	},
 /area/pod_wars/spacejunk/uvb67/crew)
-"aO" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/uvb67/power)
 "aR" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -221,6 +233,19 @@
 	},
 /turf/simulated/floor/blue/side,
 /area/pod_wars/spacejunk/snackstand)
+"aZ" = (
+/obj/table/auto,
+/obj/machinery/glass_recycler/chemistry,
+/obj/item/storage/box/beakerbox{
+	pixel_x = -8;
+	pixel_y = 15
+	},
+/obj/item/storage/box/beakerbox{
+	pixel_x = 8;
+	pixel_y = 15
+	},
+/turf/unsimulated/floor/white,
+/area/pod_wars/team1/medbay)
 "ba" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools,
@@ -229,15 +254,28 @@
 	},
 /area/pod_wars/spacejunk/fstation/power)
 "bc" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/stool/chair{
 	dir = 8
 	},
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
+"be" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/storage/crate,
+/obj/random_item_spawner/shoe/one_or_zero,
+/obj/item/record/random,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "bf" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/red/side,
 /area/pod_wars/spacejunk/fstation)
 "bg" = (
@@ -245,9 +283,7 @@
 /turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "bh" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/nancy/warehouse)
 "bl" = (
@@ -257,8 +293,15 @@
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team2/bar)
 "bm" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
 /turf/simulated/floor/caution/east,
 /area/pod_wars/spacejunk/fstation/secdock)
+"bn" = (
+/obj/item/caution,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "bp" = (
 /obj/machinery/portable_reclaimer,
 /turf/unsimulated/floor/yellow/side{
@@ -273,11 +316,16 @@
 	dir = 10;
 	icon_state = "catwalk_cross"
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	tag = "icon-catwalk (WEST)"
 	},
 /area/pod_wars/spacejunk/fstation/landingpads)
+"bt" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "bu" = (
 /obj/machinery/clonepod/pod_wars{
 	team_num = 1
@@ -289,6 +337,7 @@
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost)
 "by" = (
+/obj/disposalpipe/segment,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -299,6 +348,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/side{
 	dir = 6
 	},
@@ -308,7 +358,11 @@
 	dir = 4;
 	icon_state = "alt_heater"
 	},
-/turf/space,
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/floor/airless,
 /area/pod_wars/team2/power)
 "bC" = (
 /turf/simulated/floor/black,
@@ -319,25 +373,44 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
 /area/pod_wars/spacejunk/miningoutpost)
+"bE" = (
+/obj/storage/crate,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "bG" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/hangar)
+"bH" = (
+/obj/machinery/light/incandescent/netural,
+/obj/landmark/start{
+	name = "Syndicate Pod Pilot"
+	},
+/turf/unsimulated/floor/white,
+/area/pod_wars/team2/cloning)
 "bL" = (
 /obj/machinery/macrofab/pod_wars/syndicate{
 	dir = 8
 	},
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/hangar)
+"bM" = (
+/obj/disposalpipe/junction/left/east,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/pod_wars/spacejunk/fstation)
 "bO" = (
 /obj/machinery/processor,
 /turf/unsimulated/floor/yellow/side{
@@ -373,9 +446,7 @@
 /area/pod_wars/spacejunk/uvb67/crew)
 "bT" = (
 /obj/table/auto,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost/crewquarters)
 "bU" = (
@@ -394,7 +465,7 @@
 	},
 /area/pod_wars/spacejunk/fstation/landingpads)
 "ca" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/yellow/side,
 /area/pod_wars/team1/starboardhall)
 "cb" = (
@@ -415,9 +486,7 @@
 /turf/unsimulated/floor/blue/side,
 /area/pod_wars/team1/manufacturing)
 "cf" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/shrub{
 	dir = 6
 	},
@@ -432,6 +501,10 @@
 	},
 /area/pod_wars/team1/manufacturing)
 "ch" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/green/corner{
 	dir = 4
 	},
@@ -442,9 +515,7 @@
 /area/pod_wars/spacejunk/fstation/secdock)
 "ck" = (
 /obj/table/auto,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/random_item_spawner/tableware/some,
 /turf/simulated/floor/green,
 /area/pod_wars/spacejunk/fstation/mess)
@@ -455,6 +526,10 @@
 "cn" = (
 /obj/forcefield/energyshield/perma,
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/t2d2_horizontal,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/hangar)
 "co" = (
@@ -479,12 +554,12 @@
 /area/space)
 "cr" = (
 /obj/machinery/r_door_control/podbay/t2d2/new_walls/east,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
-"cs" = (
-/obj/landmark/start,
-/turf/unsimulated/floor/blue,
-/area/pod_wars/team1/manufacturing)
 "cu" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -516,6 +591,8 @@
 /obj/item/spraybottle/cleaner,
 /obj/item/reagent_containers/glass/bottle/cleaner,
 /obj/item/reagent_containers/glass/bottle/cleaner,
+/obj/item/spraybottle/cleaner/tsunami,
+/obj/item/record/random/chronoquest,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -531,13 +608,24 @@
 /area/pod_wars/spacejunk/snackstand)
 "cB" = (
 /obj/shrub,
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/red/side{
 	dir = 6
 	},
 /area/pod_wars/spacejunk/fstation)
+"cD" = (
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "cE" = (
 /obj/machinery/nanofab/mining,
-/turf/simulated/floor/bot,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost)
 "cF" = (
 /obj/machinery/door/airlock/pyro/glass,
@@ -553,6 +641,13 @@
 	dir = 10
 	},
 /area/pod_wars/team1/manufacturing)
+"cH" = (
+/obj/storage/crate,
+/obj/random_item_spawner/shoe/one_or_zero,
+/obj/random_item_spawner/medicine/one,
+/obj/random_item_spawner/junk/maybe_few,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "cI" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -561,21 +656,49 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/mining)
-"cP" = (
-/obj/machinery/light{
+"cJ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/storage/crate,
+/obj/random_item_spawner/snacks/one_or_zero,
+/obj/random_item_spawner/tools/one_or_zero,
+/obj/random_item_spawner/medicine/one,
+/obj/random_item_spawner/med_tool/one_or_zero,
+/obj/random_item_spawner/junk/maybe_few,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"cK" = (
+/obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 9
 	},
-/area/pod_wars/team1/bridge)
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/miningoutpost)
+"cL" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/autoname_east,
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/uvb67/central)
 "cQ" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_12)
 "cT" = (
 /obj/deployable_turret/pod_wars/nt/activated/south,
-/turf/unsimulated/floor/caution/misc{
-	dir = 6
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/corner/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
 	},
 /area/pod_wars/team1/hangar)
 "cU" = (
@@ -589,17 +712,14 @@
 	},
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/fstation/maintdock)
-"cV" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/pod_wars/team1/powergen)
 "cW" = (
 /turf/simulated/floor/circuit/red,
 /area/pod_wars/spacejunk/fstation/computercore)
 "cX" = (
 /obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 4
+	},
+/obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -666,8 +786,19 @@
 /area/pod_wars/spacejunk/miningoutpost)
 "dn" = (
 /obj/deployable_turret/pod_wars/sy/activated/south,
-/turf/unsimulated/floor/caution/corner/se,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 6
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/mining)
+"do" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/uvb67/central)
 "dp" = (
 /obj/cable,
 /obj/machinery/power/apc/autoname_south,
@@ -696,17 +827,13 @@
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/nancy/warehouse)
 "dw" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/pod_wars/spacejunk/fstation)
 "dy" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/shrub,
 /turf/unsimulated/floor/red/side{
 	dir = 5
@@ -720,7 +847,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/r_door_control/podbay/t2condoor/new_walls/south,
-/turf/unsimulated/floor/caution/corner/nw,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/hangar)
 "dD" = (
 /obj/machinery/neosmelter,
@@ -733,20 +865,17 @@
 	},
 /area/pod_wars/team2/mining)
 "dF" = (
-/obj/machinery/power/solar/diner,
 /obj/cable{
-	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/solar/west,
 /turf/simulated/floor/airless{
 	icon_state = "solarbase";
 	name = "solar paneling"
 	},
 /area/pod_wars/spacejunk/uvb67/solars)
 "dG" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
 	icon_state = "0-2"
@@ -768,10 +897,33 @@
 	dir = 8
 	},
 /area/pod_wars/spacejunk/snackstand)
+"dL" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit/one_or_zero,
+/obj/random_item_spawner/med_kit/one_or_zero,
+/obj/random_item_spawner/med_kit/one_or_zero,
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/uvb67/crew)
 "dM" = (
 /obj/stool/chair/office,
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/secdock)
+"dN" = (
+/obj/table/auto,
+/obj/machinery/glass_recycler/chemistry,
+/obj/item/storage/box/beakerbox{
+	pixel_x = -8;
+	pixel_y = 15
+	},
+/obj/item/storage/box/beakerbox{
+	pixel_x = 8;
+	pixel_y = 15
+	},
+/obj/machinery/light/incandescent/netural,
+/turf/unsimulated/floor/white,
+/area/pod_wars/team2/cloning)
 "dO" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -784,30 +936,44 @@
 /obj/deployable_turret/pod_wars/nt/activated/west,
 /turf/space,
 /area/space)
+"dQ" = (
+/turf/unsimulated/floor/yellow/side{
+	dir = 9
+	},
+/area/pod_wars/team1/mining)
 "dR" = (
 /turf/unsimulated/floor/yellow/side,
 /area/pod_wars/team1/starboardhall)
+"dS" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/airless,
+/area/pod_wars/team2/power)
 "dV" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/caution/east,
-/area/pod_wars/spacejunk/fstation/secdock)
-"dX" = (
-/obj/machinery/light,
-/turf/unsimulated/floor/specialroom/bar,
-/area/pod_wars/team1/bar)
-"dY" = (
-/obj/machinery/light{
+/obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
+/turf/simulated/floor/caution/east,
+/area/pod_wars/spacejunk/fstation/secdock)
+"dW" = (
+/obj/grille/catwalk{
+	dir = 9
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
+/area/space)
+"dX" = (
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team1/bar)
 "dZ" = (
-/obj/machinery/light{
-	dir = 8;
-	tag = ""
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/circuit/red,
 /area/pod_wars/spacejunk/fstation/computercore)
 "ea" = (
@@ -819,7 +985,7 @@
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
 "ef" = (
-/obj/machinery/light/small/floor,
+/obj/machinery/light/small/floor/netural,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/central_hallway)
 "eh" = (
@@ -828,14 +994,39 @@
 	},
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
+"ej" = (
+/obj/table/auto,
+/obj/machinery/microwave,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/red/side{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/uvb67/crew)
+"ek" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/uvb67/central)
+"el" = (
+/obj/storage/crate,
+/obj/random_item_spawner/junk/maybe_few,
+/obj/random_item_spawner/tools/one_or_zero,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "em" = (
 /obj/machinery/drainage,
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation)
 "en" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/table/auto,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
@@ -844,34 +1035,23 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/storage)
-"ep" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/airless/plating,
-/area/pod_wars/spacejunk/uvb67/central)
 "eq" = (
 /obj/table/auto,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/defib_mount,
 /obj/item/reagent_containers/glass/beaker/large/epinephrine,
 /obj/item/reagent_containers/glass/beaker/large/epinephrine,
 /obj/item/robodefibrillator,
 /obj/item/robodefibrillator,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
 "er" = (
 /obj/mopbucket,
 /obj/item/reagent_containers/glass/bucket,
+/obj/machinery/disposal/small/east,
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation)
 "es" = (
@@ -882,9 +1062,15 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/caution/east,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
 "ev" = (
+/obj/disposalpipe/segment,
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
@@ -913,6 +1099,10 @@
 /area/space)
 "eA" = (
 /obj/machinery/r_door_control/podbay/t1d4/new_walls/east,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "eB" = (
@@ -945,11 +1135,9 @@
 /area/pod_wars/spacejunk/reliant/landingpads)
 "eF" = (
 /obj/grille/catwalk,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/airless/plating/catwalk,
-/area/space)
+/area/pod_wars/spacejunk/miningoutpost)
 "eG" = (
 /obj/shrub,
 /turf/simulated/floor/green/side{
@@ -962,12 +1150,26 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/uvb67/central)
+"eI" = (
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/fstation/landingpads)
 "eJ" = (
 /obj/machinery/manufacturer/qm,
 /turf/unsimulated/floor/yellow/side{
 	dir = 4
 	},
 /area/pod_wars/team1/mining)
+"eK" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
+	},
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/pod_wars/spacejunk/reliant)
 "eM" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -992,16 +1194,24 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/engine{
-	dir = 6;
-	icon_state = "engine_caution_misc"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
 	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/corner/extra_big{
+	dir = 6
+	},
+/turf/simulated/floor/engine,
 /area/pod_wars/team1/powergen)
 "eP" = (
 /obj/storage/secure/closet/fridge,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
@@ -1084,6 +1294,7 @@
 /area/pod_wars/spacejunk/fstation/maintdock)
 "eY" = (
 /obj/submachine/chef_sink{
+	density = 0;
 	dir = 8;
 	name = "utility sink";
 	pixel_y = 3
@@ -1093,6 +1304,10 @@
 "fa" = (
 /obj/forcefield/energyshield/perma,
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/t2d1_horizontal,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/hangar)
 "fb" = (
@@ -1101,7 +1316,7 @@
 /turf/space,
 /area/space)
 "fc" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /obj/shrub,
 /turf/simulated/floor/yellow/side{
 	dir = 10
@@ -1126,14 +1341,6 @@
 	dir = 8
 	},
 /area/pod_wars/spacejunk/miningoutpost)
-"fk" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
-	},
-/area/pod_wars/spacejunk/reliant/landingpads)
 "fl" = (
 /obj/cable{
 	d2 = 8;
@@ -1164,8 +1371,11 @@
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/fstation/observatory)
 "fp" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/plating,
+/obj/storage/crate,
+/obj/random_item_spawner/medicine/one,
+/obj/random_item_spawner/med_tool/one_or_zero,
+/obj/random_item_spawner/med_kit/one_or_zero,
+/turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "fq" = (
 /obj/landmark/start{
@@ -1175,6 +1385,13 @@
 	dir = 4
 	},
 /area/pod_wars/team1/mining)
+"fr" = (
+/obj/machinery/vending/snack,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/red/side{
+	dir = 8
+	},
+/area/pod_wars/spacejunk/uvb67/crew)
 "fs" = (
 /turf/simulated/floor/red/side{
 	dir = 9
@@ -1192,6 +1409,16 @@
 	dir = 4
 	},
 /area/pod_wars/spacejunk/fstation/crewquarters)
+"fx" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/fstation)
 "fy" = (
 /obj/stool/bed,
 /obj/window/cubicle{
@@ -1216,6 +1443,7 @@
 	dir = 9;
 	icon_state = "catwalk_cross"
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1
 	},
@@ -1226,10 +1454,15 @@
 	icon_state = "wall3"
 	},
 /area/pod_wars/spacejunk/dorgun)
-"fF" = (
-/obj/machinery/light{
-	dir = 4
+"fE" = (
+/obj/grille/catwalk{
+	dir = 9
 	},
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/uvb67/central)
+"fF" = (
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -1248,8 +1481,9 @@
 /turf/unsimulated/floor/yellow,
 /area/pod_wars/team1/mining)
 "fJ" = (
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_middle,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
+	},
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team1/porthall)
 "fK" = (
@@ -1262,12 +1496,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/light/incandescent/netural,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_west"
-	},
+/turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "fN" = (
 /obj/cable{
@@ -1309,20 +1542,54 @@
 /area/pod_wars/spacejunk/fstation)
 "fU" = (
 /obj/machinery/manufacturer/pod_wars/syndicate,
-/turf/unsimulated/floor/delivery,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 5
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/central_hallway)
 "fV" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/spacejunk/reliant)
 "fW" = (
 /obj/table/auto,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/random_item_spawner/tableware/some,
 /obj/random_item_spawner/snacks/one_or_zero,
 /turf/simulated/floor/green,
 /area/pod_wars/spacejunk/fstation/mess)
+"fY" = (
+/obj/storage/secure/closet/fridge,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "fZ" = (
 /turf/unsimulated/floor/red/corner{
 	dir = 1
@@ -1353,7 +1620,12 @@
 /turf/space,
 /area/space)
 "gh" = (
-/turf/unsimulated/floor/caution/corner/sw,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/hangar)
 "gi" = (
 /obj/lattice,
@@ -1369,8 +1641,19 @@
 "gj" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/spacejunk/fstation/computercore)
+"gk" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/fstation)
 "gm" = (
-/turf/simulated/floor/airless/plating,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "gn" = (
 /turf/simulated/floor/purple/side{
@@ -1392,7 +1675,12 @@
 /area/pod_wars/spacejunk/miningoutpost/crewquarters)
 "gu" = (
 /obj/deployable_turret/pod_wars/nt/activated/west,
-/turf/unsimulated/floor/caution/corner/sw,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/mining)
 "gw" = (
 /obj/storage/secure/closet/fridge,
@@ -1410,14 +1698,13 @@
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/record/random/chronoquest,
 /turf/simulated/floor/blue/side{
 	dir = 10
 	},
 /area/pod_wars/spacejunk/snackstand)
 "gx" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/blue/side{
 	dir = 5
 	},
@@ -1427,6 +1714,10 @@
 /obj/access_spawn/heads,
 /turf/unsimulated/floor/blue,
 /area/pod_wars/team1/manufacturing)
+"gz" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/engine,
+/area/pod_wars/team1/powergen)
 "gA" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -1435,6 +1726,14 @@
 	dir = 8
 	},
 /area/pod_wars/team1/bridge)
+"gB" = (
+/obj/machinery/light/incandescent/netural,
+/obj/table/auto,
+/obj/machinery/recharger,
+/turf/unsimulated/floor/yellow/side{
+	dir = 10
+	},
+/area/pod_wars/team2/mining)
 "gC" = (
 /obj/cable{
 	d1 = 1;
@@ -1443,6 +1742,12 @@
 	},
 /turf/simulated/floor/yellow/corner,
 /area/pod_wars/spacejunk/miningoutpost)
+"gD" = (
+/obj/disposalpipe/junction/right/east,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/pod_wars/spacejunk/fstation)
 "gE" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team1/manufacturing)
@@ -1464,10 +1769,11 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/uvb67/central)
-"gK" = (
-/obj/machinery/light,
-/turf/unsimulated/floor/red/side,
-/area/pod_wars/team2/bridge)
+"gJ" = (
+/obj/machinery/light/incandescent/netural,
+/obj/machinery/chem_master,
+/turf/unsimulated/floor/white,
+/area/pod_wars/team2/medbay)
 "gM" = (
 /obj/shrub{
 	dir = 1
@@ -1476,15 +1782,32 @@
 	dir = 5
 	},
 /area/pod_wars/spacejunk/fstation)
+"gN" = (
+/obj/machinery/light/incandescent/netural,
+/obj/machinery/manufacturer/general,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/unsimulated/floor/yellow/side{
+	dir = 1
+	},
+/area/pod_wars/team2/mining)
+"gO" = (
+/obj/machinery/light/incandescent/netural,
+/obj/machinery/nanofab/mining,
+/turf/unsimulated/floor/yellow/side,
+/area/pod_wars/team1/mining)
 "gP" = (
 /obj/wingrille_spawn/crystal/full,
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team1/porthall)
+"gQ" = (
+/obj/machinery/portable_reclaimer,
+/turf/unsimulated/floor/plating,
+/area/pod_wars/team1/mining)
 "gT" = (
 /obj/mopbucket,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/item/reagent_containers/glass/bucket,
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -1495,9 +1818,13 @@
 	dir = 1
 	},
 /area/pod_wars/spacejunk/fstation)
+"gV" = (
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/nancy/landingpad)
 "gX" = (
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_middle,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
+	},
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team1/starboardhall)
 "gY" = (
@@ -1564,12 +1891,6 @@
 	dir = 1
 	},
 /area/pod_wars/spacejunk/fstation/command)
-"hl" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/unsimulated/floor/specialroom/bar,
-/area/pod_wars/team1/bar)
 "hm" = (
 /obj/warp_beacon/pod_wars{
 	current_owner = 2;
@@ -1578,20 +1899,41 @@
 /obj/lattice,
 /turf/space,
 /area/space)
-"hq" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+"hn" = (
+/obj/table/auto,
+/obj/machinery/glass_recycler/chemistry,
+/obj/item/storage/box/beakerbox{
+	pixel_x = -8;
+	pixel_y = 15
 	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
+/obj/item/storage/box/beakerbox{
+	pixel_x = 8;
+	pixel_y = 15
+	},
+/turf/unsimulated/floor/white,
+/area/pod_wars/team2/medbay)
+"hp" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/uvb67/central)
 "hr" = (
 /obj/table/auto,
 /obj/machinery/glass_recycler/chemistry,
 /obj/item/storage/box/beakerbox,
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
+"hs" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/miningoutpost)
 "ht" = (
 /obj/cable{
 	d1 = 1;
@@ -1637,10 +1979,11 @@
 	},
 /area/pod_wars/spacejunk/uvb67/solars)
 "hx" = (
-/obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
@@ -1654,6 +1997,11 @@
 "hz" = (
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/secdock)
+"hB" = (
+/turf/unsimulated/floor/red/side{
+	dir = 10
+	},
+/area/pod_wars/team2/bridge)
 "hE" = (
 /obj/landmark/start{
 	name = "Syndicate Pod Pilot"
@@ -1662,6 +2010,10 @@
 	dir = 8
 	},
 /area/pod_wars/team2/mining)
+"hG" = (
+/obj/machinery/light/incandescent/netural,
+/turf/unsimulated/floor/red/side,
+/area/pod_wars/team2/bridge)
 "hH" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools/few,
@@ -1678,6 +2030,21 @@
 /obj/item/clothing/suit/bedsheet/yellow,
 /turf/simulated/floor/purple,
 /area/pod_wars/spacejunk/fstation/crewquarters)
+"hK" = (
+/obj/machinery/power/furnace{
+	desc = "Wow. This thing puts out a lot of heat! If only we had some carbon based material we could shove in here to burn...";
+	fuel = 150;
+	name = "Deluxe Room Heater"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"hL" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
+	},
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/reliant)
 "hM" = (
 /obj/random_pod_spawner/random_putt_spawner,
 /turf/space,
@@ -1694,6 +2061,9 @@
 	dir = 8
 	},
 /obj/cable,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/miningoutpost)
 "hQ" = (
@@ -1713,15 +2083,13 @@
 	},
 /area/pod_wars/team1/porthall)
 "hR" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/pod_wars/team1/bridge)
 "hT" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/table/reinforced/bar/auto,
 /obj/machinery/glass_recycler{
 	density = 1
@@ -1738,17 +2106,24 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/spacejunk/fstation/mess)
 "hW" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/manufacturer/general,
-/turf/unsimulated/floor/delivery,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/unsimulated/floor/blue/side{
+	dir = 9
+	},
 /area/pod_wars/team1/manufacturing)
 "hY" = (
 /turf/unsimulated/floor/yellow/side{
 	dir = 4
 	},
 /area/pod_wars/team2/mining)
+"hZ" = (
+/obj/disposalpipe/junction/right/south,
+/turf/simulated/floor/red/corner,
+/area/pod_wars/spacejunk/fstation)
 "ib" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -1760,16 +2135,17 @@
 /obj/forcefield/energyshield/perma/pod_wars/nanotrasen,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
-"id" = (
-/obj/machinery/light{
+"ie" = (
+/obj/machinery/light/incandescent/netural,
+/obj/grille/catwalk{
 	dir = 1
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/uvb67/central)
 "if" = (
 /mob/living/carbon/human/npc/monkey/oppenheimer/pod_wars,
 /turf/unsimulated/floor/red/side{
-	dir = 10
+	dir = 8
 	},
 /area/pod_wars/team2/bridge)
 "ig" = (
@@ -1784,12 +2160,14 @@
 /obj/item/spacecash/random/really_small,
 /obj/item/spacecash/random/tourist,
 /obj/item/spacecash/random/tourist,
+/obj/item/record/random/nostalgic,
 /turf/simulated/floor/blue/side{
 	dir = 5
 	},
 /area/pod_wars/spacejunk/fstation/command)
 "ii" = (
-/obj/machinery/power/terminal,
+/obj/reagent_dispensers/fueltank,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "ij" = (
@@ -1799,6 +2177,14 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/bar)
+"ik" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/fstation)
 "il" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -1835,9 +2221,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/spacejunk/nancy/powergen)
 "ir" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -1846,6 +2230,21 @@
 "is" = (
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation)
+"it" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/uvb67/power)
+"iw" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/corner/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/pod_wars/team2/hangar)
 "ix" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -1862,10 +2261,11 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/light/incandescent/netural,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
-/turf/simulated/floor/caution/west,
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/secdock)
 "iA" = (
 /obj/item/organ/eye,
@@ -1877,26 +2277,23 @@
 	},
 /turf/unsimulated/floor/white,
 /area/pod_wars/team2/medbay)
-"iG" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater-L"
-	},
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater"
-	},
-/turf/unsimulated/floor/airless,
-/area/pod_wars/team2/mining)
 "iH" = (
 /obj/landmark/start{
 	name = "Syndicate Pod Pilot"
 	},
-/turf/unsimulated/floor/caution/north,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/hangar)
 "iI" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/hangar)
 "iK" = (
 /turf/simulated/floor/green/side{
@@ -1906,22 +2303,22 @@
 "iL" = (
 /turf/simulated/floor/airless/grey,
 /area/pod_wars/spacejunk/greatwreck)
+"iM" = (
+/obj/machinery/light/incandescent/netural,
+/obj/storage/crate,
+/obj/random_item_spawner/med_kit/maybe_few,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "iN" = (
 /obj/shrub,
 /turf/simulated/floor/purple/side{
 	dir = 6
 	},
 /area/pod_wars/spacejunk/fstation)
-"iO" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/white,
-/area/pod_wars/spacejunk/fstation/medbay)
-"iQ" = (
-/obj/machinery/light,
-/turf/unsimulated/floor/yellow/side,
-/area/pod_wars/team1/mining)
+"iP" = (
+/obj/shrub/captainshrub,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "iR" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -1932,6 +2329,10 @@
 	dir = 9
 	},
 /area/pod_wars/spacejunk/fstation/mess)
+"iS" = (
+/obj/stool/bench/blue/auto,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "iV" = (
 /obj/machinery/portable_reclaimer,
 /obj/item_dispenser/bandage,
@@ -1939,6 +2340,10 @@
 	dir = 5
 	},
 /area/pod_wars/team1/manufacturing)
+"iW" = (
+/obj/machinery/vending/cola/blue,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "jf" = (
 /obj/machinery/computer/announcement{
 	name = "Nanotrasen Announcement Computer"
@@ -1982,12 +2387,6 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/storage)
-"jo" = (
-/obj/item_dispenser/bandage,
-/turf/simulated/floor/red/side{
-	dir = 5
-	},
-/area/pod_wars/spacejunk/uvb67/crew)
 "jq" = (
 /turf/unsimulated/floor/blue/side{
 	dir = 8
@@ -2012,16 +2411,14 @@
 	},
 /area/pod_wars/spacejunk/nancy/landingpad)
 "jt" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/purple/side,
 /area/pod_wars/spacejunk/fstation/primary)
 "jx" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
 "jy" = (
@@ -2042,6 +2439,18 @@
 	dir = 8
 	},
 /area/pod_wars/team1/starboardhall)
+"jB" = (
+/obj/machinery/conveyor/south{
+	move_lag = 15;
+	operating = 1
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
+"jC" = (
+/obj/machinery/light/incandescent/netural,
+/obj/machinery/chem_dispenser/medical/fortuna,
+/turf/simulated/floor/white,
+/area/pod_wars/spacejunk/fstation/medbay)
 "jD" = (
 /turf/unsimulated/floor/yellow/side{
 	dir = 1
@@ -2080,10 +2489,18 @@
 /area/pod_wars/spacejunk/fstation/power)
 "jL" = (
 /obj/machinery/r_door_control/podbay/t1d3/new_walls/east,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "jM" = (
 /obj/shrub,
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/green/side{
 	dir = 5
 	},
@@ -2097,15 +2514,6 @@
 /obj/item_dispenser/bandage,
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
-"jP" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/submachine/chef_sink{
-	name = "utility sink"
-	},
-/turf/simulated/floor,
-/area/pod_wars/spacejunk/uvb67/crew)
 "jR" = (
 /obj/stool/bed,
 /obj/window/cubicle{
@@ -2118,9 +2526,7 @@
 /turf/simulated/floor/purple,
 /area/pod_wars/spacejunk/fstation/crewquarters)
 "jT" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -2128,13 +2534,22 @@
 /area/pod_wars/team1/powergen)
 "jU" = (
 /obj/machinery/r_door_control/podbay/t1d2/new_walls/west,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "jW" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/caution/corner/sw,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/central_hallway)
 "jZ" = (
 /obj/shrub,
@@ -2144,7 +2559,12 @@
 /area/pod_wars/spacejunk/fstation)
 "ka" = (
 /obj/machinery/r_door_control/podbay/t1condoor/new_walls/south,
-/turf/unsimulated/floor/caution/east,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
 "kb" = (
 /obj/rack,
@@ -2157,6 +2577,10 @@
 /area/pod_wars/spacejunk/miningoutpost)
 "kc" = (
 /obj/machinery/r_door_control/podbay/t1d2/new_walls/east,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "ke" = (
@@ -2164,9 +2588,7 @@
 /turf/simulated/floor/plating,
 /area/space)
 "kf" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost/crewquarters)
 "ki" = (
@@ -2210,13 +2632,16 @@
 	dir = 6
 	},
 /area/pod_wars/team1/mining)
-"kp" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/chem_master,
-/turf/unsimulated/floor/white,
-/area/pod_wars/team2/medbay)
+"kr" = (
+/obj/storage/crate,
+/obj/random_item_spawner/tools/maybe_few,
+/obj/item/storage/belt/utility,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"ks" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/uvb67/central)
 "kt" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -2239,6 +2664,10 @@
 /obj/item/robodefibrillator,
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
+"kw" = (
+/obj/disposalpipe/segment,
+/turf/unsimulated/floor/wood/seven,
+/area/pod_wars/spacejunk/fstation/bar)
 "ky" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -2256,6 +2685,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -2266,11 +2696,9 @@
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/nancy/warehouse)
 "kD" = (
-/obj/machinery/light,
-/obj/table/auto,
-/obj/machinery/recharger,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/yellow/side{
-	dir = 6
+	dir = 4
 	},
 /area/pod_wars/team2/mining)
 "kE" = (
@@ -2278,9 +2706,7 @@
 /turf/unsimulated/floor/red/side,
 /area/pod_wars/team2/central_hallway)
 "kF" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/stool/chair,
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -2319,10 +2745,28 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team1/powergen)
+"kN" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/miningoutpost/crewquarters)
 "kP" = (
 /obj/machinery/neosmelter,
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team1/mining)
+"kQ" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/reliant/landingpads)
+"kS" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/turf/unsimulated/floor/white,
+/area/pod_wars/team1/medbay)
 "kT" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -2331,18 +2775,31 @@
 /area/pod_wars/spacejunk/fstation/command)
 "kU" = (
 /obj/table/glass/auto,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/purple,
 /area/pod_wars/spacejunk/fstation/crewquarters)
+"kV" = (
+/obj/control_point_computer{
+	dir = 4;
+	name = "Reliant Control Console"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "kW" = (
 /obj/landmark/start{
 	name = "NanoTrasen Pod Pilot"
 	},
-/turf/unsimulated/floor/caution/corner/nw,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
 "kX" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/table/auto,
 /obj/item/storage/belt/medical,
 /obj/item/storage/belt/medical,
@@ -2350,6 +2807,8 @@
 /obj/item/storage/belt/medical,
 /obj/item/reagent_containers/glass/beaker/large/brute,
 /obj/item/reagent_containers/glass/beaker/large/brute,
+/obj/item/clothing/glasses/healthgoggles/upgraded,
+/obj/item/clothing/glasses/healthgoggles/upgraded,
 /obj/item/clothing/glasses/healthgoggles/upgraded,
 /obj/item/clothing/glasses/healthgoggles/upgraded,
 /turf/unsimulated/floor/white,
@@ -2423,9 +2882,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -2453,12 +2910,28 @@
 /obj/random_item_spawner/shoe/maybe_few,
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/nancy/warehouse)
+"ls" = (
+/obj/storage/secure/closet/personal/empty,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"lt" = (
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "lu" = (
 /obj/stool/chair{
 	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/nancy)
+"ly" = (
+/obj/submachine/tape_deck,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "lB" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
@@ -2481,9 +2954,7 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/hangar)
 "lG" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
@@ -2494,11 +2965,33 @@
 	},
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/fstation/maintdock)
+"lI" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/uvb67/power)
+"lJ" = (
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/airless,
+/area/pod_wars/team1/mining)
 "lK" = (
 /turf/unsimulated/floor/blue/side{
 	dir = 4
 	},
 /area/pod_wars/team1/bridge)
+"lM" = (
+/obj/rack,
+/obj/random_item_spawner/hat/one,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "lN" = (
 /obj/machinery/processor,
 /turf/unsimulated/floor/yellow/side{
@@ -2511,9 +3004,24 @@
 	},
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
+"lR" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/grille/catwalk{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/fstation/landingpads)
 "lS" = (
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_left,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-L"
+	},
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team1/porthall)
 "lV" = (
@@ -2528,21 +3036,21 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/caution/north,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/maintdock)
 "lX" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/fstation/computercore)
 "ma" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/terminal{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/engine,
 /area/pod_wars/team1/powergen)
@@ -2576,6 +3084,10 @@
 	dir = 4
 	},
 /area/pod_wars/spacejunk/fstation/mess)
+"mh" = (
+/obj/machinery/gibber/output_east,
+/turf/simulated/floor/green/side,
+/area/pod_wars/spacejunk/fstation/mess)
 "mi" = (
 /turf/unsimulated/floor/blue/corner{
 	dir = 1
@@ -2591,19 +3103,8 @@
 /obj/random_item_spawner/desk_stuff/maybe_few,
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/nancy/warehouse)
-"mp" = (
-/obj/machinery/light,
-/obj/machinery/computer/magnet{
-	dir = 8
-	},
-/turf/unsimulated/floor/yellow/side{
-	dir = 6
-	},
-/area/pod_wars/team2/mining)
 "ms" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation)
 "mt" = (
@@ -2619,7 +3120,7 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 6
 	},
-/area/space)
+/area/pod_wars/spacejunk/miningoutpost)
 "mv" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -2637,6 +3138,9 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation)
@@ -2673,8 +3177,21 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/hangar)
+"mF" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/snackstand)
+"mG" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/pod_wars/spacejunk/fstation)
 "mK" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
@@ -2683,18 +3200,17 @@
 /obj/access_spawn/heads,
 /turf/unsimulated/floor/blue,
 /area/pod_wars/team1/manufacturing)
-"mL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/dorgun)
 "mN" = (
 /obj/deployable_turret/pod_wars/nt/activated/west,
-/turf/unsimulated/floor/caution/corner/nw,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/mining)
 "mO" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /obj/reagent_dispensers/fueltank,
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -2714,9 +3230,7 @@
 	},
 /area/space)
 "mR" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/macrofab/pod_wars/nanotrasen,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
@@ -2738,23 +3252,45 @@
 /area/pod_wars/spacejunk/miningoutpost/crewquarters)
 "mV" = (
 /obj/deployable_turret/pod_wars/sy/activated/north,
-/turf/unsimulated/floor/caution/misc{
-	dir = 6
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/corner/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
 	},
 /area/pod_wars/team2/hangar)
+"mW" = (
+/obj/storage/crate,
+/obj/item/record/poo,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/nancy/warehouse)
 "mX" = (
 /obj/machinery/power/furnace,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_west"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
+/turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "mY" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /obj/shrub,
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/purple/side{
 	dir = 10
 	},
@@ -2767,13 +3303,18 @@
 	},
 /turf/unsimulated/floor/red/side,
 /area/pod_wars/team2/central_hallway)
+"na" = (
+/obj/storage/crate,
+/obj/random_item_spawner/snacks/one_or_zero,
+/obj/random_item_spawner/med_tool/one_or_zero,
+/obj/random_item_spawner/junk/maybe_few,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "nd" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_7)
 "ne" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/landmark/start{
 	name = "Syndicate Pod Pilot"
 	},
@@ -2794,6 +3335,15 @@
 "ng" = (
 /turf/simulated/floor/airless/plating/damaged3,
 /area/pod_wars/spacejunk/greatwreck)
+"nh" = (
+/obj/item_dispenser/bandage,
+/obj/machinery/clonegrinder{
+	desc = "A high efficiency corpse grinder. It even grinds up whatever the corpse has on it! Use with caution!";
+	emagged = 1;
+	name = "Corpse Grinder 5000"
+	},
+/turf/unsimulated/floor/white,
+/area/pod_wars/team2/cloning)
 "ni" = (
 /obj/table/reinforced/auto,
 /obj/cable{
@@ -2832,15 +3382,20 @@
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team1/bar)
 "ns" = (
-/obj/item_dispenser/bandage,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/storage/crate,
+/obj/random_item_spawner/tools/one_or_zero,
+/obj/random_item_spawner/med_kit/one_or_zero,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "nt" = (
 /turf/unsimulated/floor/blue/side,
 /area/pod_wars/team1/bridge)
 "nu" = (
-/obj/machinery/power/solar/diner,
 /obj/cable,
+/obj/machinery/power/solar/west,
 /turf/simulated/floor/airless{
 	icon_state = "solarbase";
 	name = "solar paneling"
@@ -2849,20 +3404,32 @@
 "nw" = (
 /turf/simulated/floor/engine,
 /area/pod_wars/team1/powergen)
+"nA" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/purple/side{
+	dir = 1
+	},
+/area/pod_wars/spacejunk/fstation/primary)
 "nC" = (
 /obj/wingrille_spawn/crystal/full,
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team2/mining)
-"nD" = (
-/obj/machinery/manufacturer,
-/turf/unsimulated/floor/delivery,
-/area/pod_wars/team2/mining)
 "nE" = (
 /obj/deployable_turret/pod_wars/sy/activated/north,
-/turf/simulated/floor/engine{
-	dir = 6;
-	icon_state = "engine_caution_misc"
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
 	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/corner/extra_big{
+	dir = 6
+	},
+/turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "nF" = (
 /turf/unsimulated/floor/blue/corner{
@@ -2918,26 +3485,43 @@
 /area/pod_wars/spacejunk/fstation)
 "nQ" = (
 /obj/deployable_turret/pod_wars/sy/activated/south,
-/turf/unsimulated/floor/caution/corner/sw,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/mining)
 "nT" = (
 /turf/simulated/floor/yellow/side,
 /area/pod_wars/spacejunk/miningoutpost)
 "nU" = (
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_right,
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_right,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team1/mining)
 "nW" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/caution/corner/misc{
+/obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 6
 	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/central_hallway)
+"nY" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/side{
+	dir = 6
+	},
+/area/pod_wars/spacejunk/restaurant)
 "nZ" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_29)
@@ -2945,6 +3529,10 @@
 /obj/machinery/shuttle/engine/propulsion{
 	dir = 4;
 	icon_state = "alt_propulsion"
+	},
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/space)
@@ -2962,29 +3550,36 @@
 	},
 /turf/simulated/floor/yellow/side,
 /area/pod_wars/spacejunk/fstation)
+"og" = (
+/obj/table/reinforced/auto,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "oi" = (
+/obj/machinery/disposal/small/west,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
 /area/pod_wars/spacejunk/fstation/primary)
 "om" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side,
 /area/pod_wars/spacejunk/fstation)
-"on" = (
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater"
-	},
-/obj/machinery/shuttle/engine/heater{
-	dir = 4;
-	icon_state = "alt_heater"
-	},
-/turf/unsimulated/floor/airless,
-/area/pod_wars/team2/mining)
 "oo" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team2/power)
+"op" = (
+/obj/machinery/shuttle/engine/propulsion{
+	icon_state = "alt_propulsion"
+	},
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space,
+/area/pod_wars/team1/mining)
 "oq" = (
 /obj/item/storage/toilet{
 	dir = 4
@@ -3006,6 +3601,14 @@
 	icon_state = "wall3_space"
 	},
 /area/pod_wars/spacejunk/dorgun)
+"ou" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/storage/crate,
+/obj/random_item_spawner/tools/one_or_zero,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "ov" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -3094,12 +3697,13 @@
 	dir = 4;
 	req_access = null
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/red,
 /area/pod_wars/spacejunk/fstation/secdock)
 "oG" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/red/side{
 	dir = 1
 	},
@@ -3110,9 +3714,7 @@
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team2/cloning)
 "oI" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/macrofab/pod_wars/syndicate/mining{
 	dir = 4
 	},
@@ -3146,17 +3748,6 @@
 	},
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team1/bar)
-"oQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/landmark/start{
-	name = "NanoTrasen Pod Pilot"
-	},
-/turf/unsimulated/floor/yellow/side{
-	dir = 1
-	},
-/area/pod_wars/team1/mining)
 "oS" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -3172,8 +3763,19 @@
 	dir = 6
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
+"oW" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/fstation)
 "oX" = (
 /obj/machinery/door/airlock/pyro/external,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/nancy)
 "oY" = (
@@ -3185,6 +3787,11 @@
 "pa" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_3)
+"pb" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/orange,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "pd" = (
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
@@ -3206,6 +3813,14 @@
 	},
 /turf/space,
 /area/space)
+"ph" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/nancy)
 "pk" = (
 /obj/stool/chair/comfy/blue{
 	dir = 8
@@ -3255,6 +3870,13 @@
 	tag = "icon-catwalk (WEST)"
 	},
 /area/pod_wars/spacejunk/restaurant/solars)
+"po" = (
+/obj/table/reinforced/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "pp" = (
 /obj/wingrille_spawn/crystal/full,
 /turf/unsimulated/floor/plating,
@@ -3296,6 +3918,12 @@
 	dir = 4
 	},
 /area/pod_wars/team2/mining)
+"pA" = (
+/obj/disposalpipe/junction/right/east,
+/turf/simulated/floor/green/corner{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/fstation)
 "pB" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -3338,7 +3966,12 @@
 /area/pod_wars/spacejunk/fstation/maintdock)
 "pF" = (
 /obj/machinery/r_door_control/podbay/t2condoor/new_walls/north,
-/turf/unsimulated/floor/caution/west,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/unsimulated/floor/red/side{
+	dir = 1
+	},
 /area/pod_wars/team2/central_hallway)
 "pG" = (
 /obj/cable{
@@ -3361,16 +3994,22 @@
 	dir = 6
 	},
 /area/pod_wars/spacejunk/nancy/landingpad)
-"pK" = (
-/obj/machinery/light,
-/turf/simulated/floor/engine,
-/area/pod_wars/team1/powergen)
-"pM" = (
-/obj/machinery/light{
+"pI" = (
+/obj/machinery/power/monitor/console_upper{
 	dir = 4
 	},
-/turf/unsimulated/floor/shuttlebay,
-/area/pod_wars/team1/hangar)
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"pL" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "pN" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3379,16 +4018,11 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
 "pO" = (
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_left,
-/turf/unsimulated/floor/airless,
-/area/pod_wars/team1/powergen)
-"pQ" = (
-/obj/machinery/nanofab/mining,
-/turf/unsimulated/floor/yellow/side{
-	dir = 8
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-L"
 	},
-/area/pod_wars/team1/mining)
+/turf/unsimulated/floor/plating,
+/area/pod_wars/team1/powergen)
 "pR" = (
 /turf/unsimulated/floor/yellow/side,
 /area/pod_wars/team1/porthall)
@@ -3400,6 +4034,12 @@
 /obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/fstation/computercore)
+"pT" = (
+/obj/table/auto,
+/obj/random_item_spawner/tableware/some,
+/obj/random_item_spawner/snacks/one_or_zero,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "pU" = (
 /obj/cable{
 	d1 = 2;
@@ -3427,6 +4067,10 @@
 "pV" = (
 /obj/stool/chair/office{
 	dir = 8
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/primary)
@@ -3467,6 +4111,7 @@
 /obj/item/spraybottle/cleaner,
 /obj/item/reagent_containers/glass/bottle/cleaner,
 /obj/item/reagent_containers/glass/bottle/cleaner,
+/obj/item/spraybottle/cleaner/tsunami,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -3493,6 +4138,12 @@
 	tag = "icon-catwalk (WEST)"
 	},
 /area/pod_wars/spacejunk/restaurant/solars)
+"qb" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/white,
+/area/pod_wars/spacejunk/fstation/medbay)
 "qc" = (
 /obj/stool/chair/comfy/red{
 	dir = 4
@@ -3510,9 +4161,7 @@
 	},
 /area/pod_wars/spacejunk/snackstand)
 "qg" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/blue/side{
 	dir = 8
 	},
@@ -3530,12 +4179,15 @@
 /obj/wingrille_spawn/auto,
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team1/powergen)
-"ql" = (
-/obj/machinery/power/terminal{
+"qk" = (
+/obj/machinery/disposal/small/north{
+	pixel_y = 32
+	},
+/obj/disposalpipe/trunk,
+/turf/simulated/floor/purple/side{
 	dir = 1
 	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
+/area/pod_wars/spacejunk/fstation/crewquarters)
 "qn" = (
 /turf/simulated/floor/carpet/grime,
 /area/pod_wars/spacejunk/nancy)
@@ -3552,9 +4204,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/blue/side{
 	dir = 4
 	},
@@ -3569,11 +4219,20 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team1/powergen)
-"qu" = (
-/obj/machinery/light{
-	dir = 4
+"qt" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/caution/north,
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/restaurant)
+"qu" = (
+/obj/machinery/light/incandescent/netural,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/primary)
 "qv" = (
 /obj/machinery/vending/snack,
@@ -3586,13 +4245,32 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/power/apc/autoname_east,
 /obj/reagent_dispensers/fueltank,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/hangar)
+"qD" = (
+/obj/storage/closet,
+/obj/item/mop,
+/obj/item/mop,
+/obj/item/mop,
+/obj/item/mop,
+/obj/item/sponge,
+/obj/item/sponge,
+/obj/item/sponge,
+/obj/item/sponge,
+/obj/item/spraybottle/cleaner,
+/obj/item/spraybottle/cleaner,
+/obj/item/reagent_containers/glass/bottle/cleaner,
+/obj/item/reagent_containers/glass/bottle/cleaner,
+/obj/item/spraybottle/cleaner/tsunami,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/pod_wars/spacejunk/uvb67/crew)
 "qE" = (
 /obj/grille/catwalk{
 	dir = 6
@@ -3649,15 +4327,32 @@
 "qJ" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_14)
+"qK" = (
+/obj/decal/fakeobjects{
+	desc = "It seems to be locked";
+	dir = 4;
+	icon = 'icons/obj/computerpanel.dmi';
+	icon_state = "engine1";
+	name = "Engineering Console"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "qM" = (
 /obj/pod_base_critical_system/nanotrasen{
 	name = "Refinery Critical System"
+	},
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/space)
 "qO" = (
 /obj/forcefield/energyshield/perma,
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/t2d4_horizontal,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/hangar)
 "qR" = (
@@ -3686,12 +4381,28 @@
 	name = "solar paneling"
 	},
 /area/pod_wars/spacejunk/restaurant/solars)
-"qT" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/space)
 "qU" = (
 /turf/unsimulated/floor/white,
 /area/pod_wars/team2/cloning)
+"qX" = (
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	tag = "icon-catwalk (WEST)"
+	},
+/area/pod_wars/spacejunk/fstation/landingpads)
+"qY" = (
+/obj/machinery/light/incandescent/netural,
+/obj/table/auto,
+/obj/machinery/recharger,
+/turf/unsimulated/floor/yellow/side{
+	dir = 6
+	},
+/area/pod_wars/team2/mining)
 "qZ" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team1/mining)
@@ -3719,6 +4430,7 @@
 	dir = 10;
 	icon_state = "catwalk_cross"
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1
 	},
@@ -3730,16 +4442,20 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/nancy/powergen)
 "rj" = (
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_right,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team1/starboardhall)
+"rl" = (
+/obj/submachine/record_player,
+/obj/table/wood/auto,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "rm" = (
 /obj/grille/catwalk{
 	dir = 1;
@@ -3748,12 +4464,15 @@
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team1/mining)
 "rn" = (
-/obj/machinery/light/small/floor,
+/obj/machinery/light/small/floor/netural,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/hangar)
 "ro" = (
-/turf/unsimulated/floor/caution/corner/misc{
+/obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 6
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
 	},
 /area/pod_wars/team1/manufacturing)
 "rp" = (
@@ -3793,26 +4512,32 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/grime,
 /area/pod_wars/spacejunk/nancy)
-"rE" = (
-/obj/machinery/light{
-	dir = 1
+"rD" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/landmark/start{
-	name = "Syndicate Pod Pilot"
-	},
-/turf/unsimulated/floor/white,
-/area/pod_wars/team2/cloning)
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/reliant)
 "rH" = (
-/obj/machinery/light{
-	dir = 8;
-	tag = ""
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
 /area/pod_wars/spacejunk/fstation)
+"rJ" = (
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/pod_wars/team1/powergen)
 "rK" = (
 /obj/wingrille_spawn/auto,
 /turf/unsimulated/floor/plating,
@@ -3842,19 +4567,12 @@
 	dir = 4;
 	icon_state = "alt_propulsion"
 	},
-/turf/space,
-/area/pod_wars/team2/power)
-"rR" = (
 /obj/lattice{
-	dir = 9;
+	dir = 5;
 	icon_state = "lattice-dir"
 	},
-/obj/machinery/communications_dish,
-/obj/cable{
-	icon_state = "0-4"
-	},
 /turf/space,
-/area/pod_wars/spacejunk/reliant)
+/area/pod_wars/team2/power)
 "rS" = (
 /obj/machinery/shuttle/engine/propulsion{
 	dir = 8;
@@ -3869,6 +4587,11 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team1/powergen)
+"rW" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "rX" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -3876,9 +4599,8 @@
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/snackstand)
 "rZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
+/obj/storage/crate/furnacefuel,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -3906,9 +4628,7 @@
 /turf/unsimulated/floor/blue,
 /area/pod_wars/team1/bridge)
 "sj" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/purple/side{
 	dir = 6
 	},
@@ -3916,6 +4636,9 @@
 "sm" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -3928,15 +4651,22 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/unsimulated/floor/caution/west,
-/area/pod_wars/team1/manufacturing)
-"sr" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "alt_propulsion"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
-/turf/space,
-/area/pod_wars/team2/mining)
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/pod_wars/team1/manufacturing)
+"sp" = (
+/obj/decal/fakeobjects{
+	desc = "Wow! It's so fancy your brain can't even comprehend how it works!";
+	icon = 'icons/obj/fluid.dmi';
+	icon_state = "battery-0";
+	name = "Disposal Belt Power Unit"
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "ss" = (
 /turf/unsimulated/floor/blue,
 /area/pod_wars/team1/bridge)
@@ -3974,6 +4704,13 @@
 	icon_state = "catwalk_cross"
 	},
 /area/pod_wars/spacejunk/restaurant/landingpads)
+"sz" = (
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/junction/left/north,
+/turf/simulated/floor/purple/side{
+	dir = 8
+	},
+/area/pod_wars/spacejunk/fstation)
 "sB" = (
 /turf/unsimulated/floor/yellow/side{
 	dir = 9
@@ -4010,24 +4747,6 @@
 	dir = 6
 	},
 /area/pod_wars/spacejunk/uvb67/crew)
-"sJ" = (
-/obj/storage/closet,
-/obj/item/mop,
-/obj/item/mop,
-/obj/item/mop,
-/obj/item/mop,
-/obj/item/sponge,
-/obj/item/sponge,
-/obj/item/sponge,
-/obj/item/sponge,
-/obj/item/spraybottle/cleaner,
-/obj/item/spraybottle/cleaner,
-/obj/item/reagent_containers/glass/bottle/cleaner,
-/obj/item/reagent_containers/glass/bottle/cleaner,
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/pod_wars/spacejunk/uvb67/crew)
 "sK" = (
 /obj/cable{
 	d1 = 1;
@@ -4038,11 +4757,23 @@
 	dir = 4
 	},
 /area/pod_wars/spacejunk/miningoutpost)
+"sL" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/fstation/mess)
 "sM" = (
+/obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/purple/corner{
 	dir = 4
 	},
 /area/pod_wars/spacejunk/fstation)
+"sP" = (
+/obj/machinery/chem_master,
+/turf/unsimulated/floor/white,
+/area/pod_wars/team2/cloning)
 "sQ" = (
 /obj/grille/catwalk{
 	dir = 1;
@@ -4057,18 +4788,14 @@
 /obj/grille/catwalk{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4;
 	icon_state = "catwalk_cross"
 	},
 /area/pod_wars/team2/mining)
 "sS" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -4077,8 +4804,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/caution/corner/misc{
+/obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
 	},
 /area/pod_wars/team1/manufacturing)
 "sW" = (
@@ -4115,11 +4845,10 @@
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
 "td" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "4-8"
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "th" = (
 /obj/cable{
@@ -4157,14 +4886,36 @@
 "tn" = (
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/manufacturing)
+"to" = (
+/obj/grille/catwalk{
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/area/pod_wars/spacejunk/reliant/landingpads)
 "tp" = (
 /obj/forcefield/energyshield/perma,
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/t2d3_horizontal,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/hangar)
 "tq" = (
 /turf/simulated/floor/red/side,
 /area/pod_wars/spacejunk/fstation/secdock)
+"tr" = (
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
+/area/pod_wars/spacejunk/miningoutpost)
 "ts" = (
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/nancy/powergen)
@@ -4187,29 +4938,13 @@
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team2/mining)
 "tz" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/blue/side{
 	dir = 4
 	},
 /area/pod_wars/team1/bridge)
-"tB" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/space,
-/area/pod_wars/spacejunk/uvb67/central)
 "tC" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/red/side{
 	dir = 10
 	},
@@ -4219,6 +4954,7 @@
 	dir = 9;
 	icon_state = "catwalk_cross"
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	tag = "icon-catwalk (WEST)"
@@ -4261,8 +4997,12 @@
 	dir = 1
 	},
 /area/pod_wars/team1/starboardhall)
+"tL" = (
+/obj/machinery/light/small/floor/netural,
+/turf/unsimulated/floor/airless,
+/area/pod_wars/team2/central_hallway)
 "tN" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/red/side,
 /area/pod_wars/team2/central_hallway)
 "tP" = (
@@ -4308,21 +5048,25 @@
 "tW" = (
 /turf/simulated/floor/airless/plating/damaged2,
 /area/pod_wars/spacejunk/greatwreck)
-"tY" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
+"tX" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/space,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/uvb67/power)
+"tY" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/glass/command{
+	req_access = null
+	},
+/turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "ua" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/glass_recycler{
 	density = 1
 	},
@@ -4342,6 +5086,28 @@
 	dir = 8
 	},
 /area/pod_wars/team1/porthall)
+"uf" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/nancy)
+"ug" = (
+/obj/pod_base_critical_system/syndicate{
+	dir = 8;
+	name = "Secondary Engines Critical System"
+	},
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir";
+	tag = "icon-lattice-dir (EAST)"
+	},
+/turf/space,
+/area/space)
+"uh" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/miningoutpost)
 "ui" = (
 /turf/simulated/floor/carpet/red/fancy/edge/east,
 /area/pod_wars/spacejunk/nancy)
@@ -4360,10 +5126,7 @@
 /obj/item/reagent_containers/glass/beaker/large/antitox,
 /obj/item/reagent_containers/hypospray,
 /obj/item/reagent_containers/dropper,
-/obj/machinery/light{
-	dir = 8;
-	tag = ""
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/defib_mount,
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
@@ -4382,6 +5145,17 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/uvb67/central)
+"uo" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
+	},
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/pod_wars/team2/mining)
 "up" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/black,
@@ -4405,9 +5179,7 @@
 	},
 /area/pod_wars/spacejunk/reliant/landingpads)
 "uv" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/shrub,
 /turf/simulated/floor/yellow/side{
 	dir = 5
@@ -4476,15 +5248,18 @@
 /area/pod_wars/team2/mining)
 "uA" = (
 /obj/machinery/r_door_control/podbay/t1condoor/new_walls/south,
-/turf/unsimulated/floor/caution/west,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
 "uB" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/red/side{
 	dir = 1
 	},
@@ -4513,14 +5288,19 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/manufacturing)
 "uL" = (
-/obj/machinery/light{
-	dir = 8
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
 	},
-/turf/simulated/floor/caution/northsouth,
-/area/pod_wars/spacejunk/restaurant)
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "uM" = (
 /obj/forcefield/energyshield/perma,
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/t1d1_horizontal,
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
 "uN" = (
@@ -4542,11 +5322,13 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
+/obj/storage/crate/furnacefuel,
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/fstation/power)
 "uS" = (
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_left,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-L"
+	},
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team1/starboardhall)
 "uT" = (
@@ -4557,6 +5339,13 @@
 	dir = 4
 	},
 /area/pod_wars/spacejunk/restaurant/landingpads)
+"uU" = (
+/obj/machinery/light/incandescent/netural,
+/obj/submachine/chef_sink{
+	name = "utility sink"
+	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/uvb67/crew)
 "uV" = (
 /obj/grille/catwalk{
 	dir = 6
@@ -4569,7 +5358,12 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/caution/west,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
 "va" = (
 /obj/cable{
@@ -4579,20 +5373,17 @@
 	dir = 4
 	},
 /obj/access_spawn/syndie_shuttle,
-/turf/simulated/floor/engine{
-	dir = 6;
-	icon_state = "engine_caution_misc"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "vc" = (
 /turf/simulated/floor/blue/side,
 /area/pod_wars/spacejunk/fstation)
-"vd" = (
-/obj/deployable_turret/pod_wars/nt/activated/east,
-/turf/unsimulated/floor/caution/misc{
-	dir = 4
-	},
-/area/pod_wars/team1/bridge)
 "vf" = (
 /obj/table/reinforced/auto,
 /obj/cable{
@@ -4610,6 +5401,15 @@
 	dir = 5
 	},
 /area/pod_wars/team1/bridge)
+"vh" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/miningoutpost/crewquarters)
 "vi" = (
 /turf/simulated/floor/blue/side{
 	dir = 8
@@ -4631,6 +5431,10 @@
 "vo" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_28)
+"vq" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "vr" = (
 /obj/grille/catwalk{
 	dir = 1
@@ -4656,6 +5460,7 @@
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5
 	},
@@ -4665,10 +5470,13 @@
 	dir = 4
 	},
 /obj/access_spawn/heads,
-/turf/simulated/floor/engine{
-	dir = 6;
-	icon_state = "engine_caution_misc"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
 /area/pod_wars/team1/powergen)
 "vw" = (
 /obj/cable{
@@ -4686,6 +5494,29 @@
 	},
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team2/bar)
+"vB" = (
+/obj/grille/catwalk{
+	dir = 1
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
+/area/pod_wars/spacejunk/snackstand)
+"vC" = (
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
+"vD" = (
+/obj/table/wood/auto,
+/obj/item/record/random,
+/obj/item/record/random,
+/obj/item/record/random,
+/obj/item/record/random,
+/obj/item/record/random,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "vE" = (
 /obj/stool/chair/comfy/red{
 	dir = 1
@@ -4697,6 +5528,14 @@
 	dir = 1
 	},
 /area/pod_wars/team2/bridge)
+"vF" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/restaurant)
 "vG" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -4707,8 +5546,22 @@
 /area/pod_wars/team1/bridge)
 "vH" = (
 /obj/machinery/manufacturer/mining/pod_wars,
-/turf/unsimulated/floor/delivery,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/mining)
+"vJ" = (
+/obj/grille/catwalk{
+	dir = 8
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/uvb67/central)
 "vK" = (
 /obj/cable,
 /obj/machinery/power/smes{
@@ -4722,7 +5575,12 @@
 /area/pod_wars/spacejunk/fstation/power)
 "vL" = (
 /obj/machinery/r_door_control/podbay/t2condoor/new_walls/north,
-/turf/unsimulated/floor/caution/east,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/unsimulated/floor/red/side{
+	dir = 1
+	},
 /area/pod_wars/team2/central_hallway)
 "vN" = (
 /obj/machinery/power/apc/autoname_west,
@@ -4766,8 +5624,17 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/secdock)
+"vT" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/uvb67/power)
 "vU" = (
 /obj/random_item_spawner/tools/one_or_zero,
 /turf/unsimulated/floor/shuttlebay,
@@ -4783,7 +5650,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/purple/side{
 	dir = 10
 	},
@@ -4829,12 +5696,22 @@
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team1/bridge)
 "wg" = (
-/turf/simulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/primary)
-"wi" = (
-/obj/machinery/light{
+"wh" = (
+/obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/pod_wars/team1/bridge)
+"wi" = (
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
@@ -4843,6 +5720,15 @@
 /obj/decal/poster/wallsign/pw_map,
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team1/bar)
+"wk" = (
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "wl" = (
 /obj/table/auto,
 /obj/item/reagent_containers/glass/beaker/large/burn,
@@ -4867,11 +5753,36 @@
 	dir = 4
 	},
 /area/pod_wars/spacejunk/miningoutpost)
+"wo" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"wp" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/airless,
+/area/pod_wars/team2/power)
+"wr" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/uvb67/crew)
+"ws" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/nancy/landingpad)
 "wu" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_4)
 "wv" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/red/side,
 /area/pod_wars/spacejunk/fstation/secdock)
 "ww" = (
@@ -4888,15 +5799,30 @@
 	},
 /area/space)
 "wy" = (
-/obj/machinery/light{
-	dir = 4
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
 	},
-/turf/simulated/floor/caution/northsouth,
-/area/pod_wars/spacejunk/restaurant)
+/obj/machinery/power/apc/autoname_east,
+/obj/cable,
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/restaurant/landingpads)
+"wA" = (
+/obj/machinery/deep_fryer,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "wB" = (
 /obj/table/reinforced/bar/auto,
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team1/bar)
+"wC" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/pod_wars/spacejunk/fstation)
 "wE" = (
 /obj/stool/chair/comfy/red,
 /obj/landmark/start{
@@ -4906,7 +5832,12 @@
 /area/pod_wars/team2/bridge)
 "wF" = (
 /obj/machinery/r_door_control/podbay/t1condoor/new_walls/north,
-/turf/unsimulated/floor/caution/corner/se,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 6
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/hangar)
 "wG" = (
 /obj/grille/catwalk{
@@ -4940,7 +5871,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 10
 	},
@@ -4951,8 +5882,17 @@
 	},
 /turf/unsimulated/floor/white,
 /area/pod_wars/team2/cloning)
+"wO" = (
+/obj/item_dispenser/bandage,
+/obj/machinery/manufacturer/medical/pod_wars,
+/turf/unsimulated/floor/white,
+/area/pod_wars/team1/medbay)
 "wP" = (
-/turf/unsimulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/corner/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/hangar)
 "wQ" = (
 /obj/machinery/portable_reclaimer,
@@ -4976,6 +5916,13 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/central_hallway)
+"wU" = (
+/obj/machinery/light/incandescent/netural,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/airless/black,
+/area/pod_wars/spacejunk/reliant/landingpads)
 "wX" = (
 /turf/unsimulated/floor/yellow/side{
 	dir = 1
@@ -4987,10 +5934,20 @@
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
-"xb" = (
-/obj/machinery/light{
-	dir = 1
+"wZ" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/red,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"xa" = (
+/obj/cable{
+	icon_state = "2-4"
 	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/restaurant)
+"xb" = (
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/macrofab/pod_wars/nanotrasen/mining,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
@@ -5000,9 +5957,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -5010,6 +5965,17 @@
 "xf" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/deployable_turret/pod_wars/nt/activated/east,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/corner/extra_big{
+	dir = 6
 	},
 /turf/unsimulated/floor/blue/side{
 	dir = 4
@@ -5025,17 +5991,11 @@
 	chargelevel = 20000;
 	output = 5000
 	},
-/turf/simulated/floor/delivery,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/miningoutpost)
-"xj" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
-/area/pod_wars/spacejunk/reliant/landingpads)
 "xk" = (
 /obj/grille/catwalk{
 	dir = 8
@@ -5064,9 +6024,7 @@
 	},
 /area/pod_wars/spacejunk/fstation/crewquarters)
 "xn" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/purple/side{
 	dir = 4
 	},
@@ -5088,6 +6046,20 @@
 	dir = 9
 	},
 /area/pod_wars/spacejunk/fstation/power)
+"xq" = (
+/turf/unsimulated/floor/blue/corner{
+	dir = 1
+	},
+/area/pod_wars/team1/manufacturing)
+"xr" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "xs" = (
 /obj/grille/catwalk{
 	dir = 5;
@@ -5108,27 +6080,46 @@
 	},
 /area/pod_wars/spacejunk/fstation/landingpads)
 "xv" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/manufacturer/mining/pod_wars,
-/turf/unsimulated/floor/delivery,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/unsimulated/floor/yellow/side{
+	dir = 9
+	},
 /area/pod_wars/team2/mining)
+"xx" = (
+/obj/machinery/clonegrinder{
+	desc = "A high efficiency corpse grinder. It even grinds up whatever the corpse has on it! Use with caution!";
+	emagged = 1;
+	name = "Corpse Grinder 5000"
+	},
+/turf/unsimulated/floor/white,
+/area/pod_wars/team1/medbay)
 "xy" = (
 /turf/simulated/floor/green/side{
 	dir = 10
 	},
 /area/pod_wars/spacejunk/fstation/mess)
+"xz" = (
+/obj/submachine/mixing_desk,
+/obj/table/wood/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "xA" = (
 /obj/machinery/power/furnace,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/engine{
-	dir = 8;
-	icon_state = "engine_caution_corners"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
 	},
+/turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "xC" = (
 /obj/machinery/power/smes{
@@ -5136,17 +6127,30 @@
 	chargelevel = 15000;
 	output = 10000
 	},
-/turf/simulated/floor/engine{
-	dir = 6;
-	icon_state = "engine_caution_misc"
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
 	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/corner/extra_big{
+	dir = 6
+	},
+/turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "xF" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/caution/corner/misc{
+/obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
 	},
 /area/pod_wars/team2/central_hallway)
 "xG" = (
@@ -5157,6 +6161,10 @@
 /obj/pod_base_critical_system/syndicate{
 	dir = 8;
 	name = "Primary Engines Critical System"
+	},
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/space)
@@ -5176,6 +6184,15 @@
 	icon_state = "catwalk_cross"
 	},
 /area/pod_wars/spacejunk/snackstand)
+"xM" = (
+/obj/machinery/manufacturer/pod_wars/syndicate,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/unsimulated/floor/red/side{
+	dir = 1
+	},
+/area/pod_wars/team2/central_hallway)
 "xP" = (
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating/catwalk{
@@ -5202,14 +6219,15 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
 "xV" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -5223,8 +6241,19 @@
 	},
 /area/pod_wars/spacejunk/restaurant)
 "xY" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/purple/side,
+/area/pod_wars/spacejunk/fstation)
+"yb" = (
+/obj/wingrille_spawn/crystal/full,
+/turf/unsimulated/floor/plating,
+/area/pod_wars/team1/bar)
+"yf" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/fstation)
 "yg" = (
 /obj/cable,
@@ -5232,7 +6261,12 @@
 /turf/unsimulated/floor/yellow/side,
 /area/pod_wars/team1/starboardhall)
 "yi" = (
-/turf/unsimulated/floor/caution/north,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/hangar)
 "yj" = (
 /obj/machinery/processor,
@@ -5240,6 +6274,18 @@
 	dir = 4
 	},
 /area/pod_wars/team2/mining)
+"yk" = (
+/obj/machinery/chem_dispenser/soda,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"ym" = (
+/obj/window/auto/reinforced/indestructible/extreme,
+/obj/forcefield/energyshield/perma/pod_wars/nanotrasen{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/pod_wars/team1/medbay)
 "yn" = (
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -5251,19 +6297,21 @@
 	icon_state = "chair_couch-blue";
 	name = "ratty blue couch"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/blue/side{
 	dir = 9
 	},
 /area/pod_wars/spacejunk/fstation/command)
 "yp" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/blue/side,
 /area/pod_wars/team1/bridge)
 "ys" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/red/side{
 	dir = 6
 	},
@@ -5288,9 +6336,29 @@
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team1/bar)
 "yy" = (
-/obj/machinery/light,
-/turf/simulated/floor/caution/west,
+/obj/machinery/light/incandescent/netural,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/secdock)
+"yC" = (
+/obj/grille/catwalk{
+	dir = 5
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4;
+	icon_state = "catwalk_cross"
+	},
+/area/pod_wars/spacejunk/snackstand)
+"yD" = (
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/unsimulated/floor/wood/seven,
+/area/pod_wars/spacejunk/fstation/bar)
 "yE" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_23)
@@ -5298,6 +6366,7 @@
 /obj/grille/catwalk{
 	dir = 1
 	},
+/obj/machinery/light/small/floor/cool,
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/nancy/landingpad)
 "yH" = (
@@ -5320,13 +6389,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/primary)
 "yK" = (
-/obj/machinery/light{
-	dir = 8;
-	tag = ""
-	},
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -5342,10 +6410,19 @@
 	},
 /area/pod_wars/spacejunk/miningoutpost)
 "yN" = (
-/turf/unsimulated/floor/caution/corner/misc{
+/obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 5
 	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/hangar)
+"yP" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "yR" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -5364,6 +6441,9 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/engine,
 /area/pod_wars/team1/powergen)
 "yU" = (
@@ -5372,13 +6452,23 @@
 	},
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/secdock)
+"yW" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "yZ" = (
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/caution/northsouth,
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/restaurant)
 "za" = (
 /obj/grille/catwalk{
@@ -5403,24 +6493,19 @@
 	dir = 4
 	},
 /area/pod_wars/spacejunk/miningoutpost)
-"zd" = (
-/obj/machinery/light{
-	dir = 1
+"zf" = (
+/turf/unsimulated/floor/blue/corner{
+	dir = 4
 	},
-/turf/unsimulated/floor/white,
-/area/pod_wars/team1/medbay)
+/area/pod_wars/team1/manufacturing)
 "zg" = (
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
 /area/pod_wars/spacejunk/fstation/power)
-"zh" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/chem_dispenser/medical/fortuna,
-/turf/simulated/floor/white,
-/area/pod_wars/spacejunk/fstation/medbay)
+"zk" = (
+/turf/unsimulated/floor/red,
+/area/pod_wars/team2/bridge)
 "zl" = (
 /obj/cable{
 	d2 = 4;
@@ -5435,10 +6520,17 @@
 	dir = 9
 	},
 /area/pod_wars/spacejunk/restaurant)
+"zm" = (
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/uvb67/power)
 "zn" = (
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_middle,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
+	},
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team1/mining)
 "zo" = (
@@ -5451,7 +6543,7 @@
 /area/space)
 "zp" = (
 /obj/storage/crate/furnacefuel,
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "zs" = (
@@ -5471,6 +6563,17 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/bar)
+"zu" = (
+/obj/machinery/conveyor/south{
+	move_lag = 15;
+	operating = 1
+	},
+/obj/disposaloutlet,
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "zw" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/access_spawn/syndie_shuttle,
@@ -5482,14 +6585,13 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
-"zy" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/plating,
-/area/pod_wars/spacejunk/uvb67/crew)
 "zz" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
 "zA" = (
@@ -5498,12 +6600,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
-"zB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
 "zC" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor/white,
@@ -5517,17 +6613,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue,
 /area/pod_wars/spacejunk/fstation)
-"zF" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/uvb67/power)
 "zG" = (
 /obj/item_dispenser/barricade,
 /turf/unsimulated/floor/specialroom/bar,
@@ -5554,9 +6642,7 @@
 	},
 /area/pod_wars/team2/central_hallway)
 "zM" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -5566,6 +6652,9 @@
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/red/side{
 	dir = 6
 	},
@@ -5579,15 +6668,13 @@
 	icon_state = "catwalk_cross"
 	},
 /area/pod_wars/team1/mining)
-"zQ" = (
+"zR" = (
+/obj/machinery/power/apc/autoname_east,
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "0-8"
 	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/table/reinforced/auto,
+/obj/machinery/recharger,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "zS" = (
@@ -5609,8 +6696,25 @@
 /obj/wingrille_spawn/auto,
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team2/bar)
-"Ab" = (
-/obj/machinery/sleeper/compact,
+"zZ" = (
+/obj/surgery_tray,
+/obj/item/scalpel,
+/obj/item/scalpel,
+/obj/item/circular_saw{
+	pixel_x = 3;
+	pixel_y = 12
+	},
+/obj/item/circular_saw{
+	pixel_x = 3;
+	pixel_y = 12
+	},
+/obj/item/suture,
+/obj/item/suture,
+/obj/item/scissors/surgical_scissors,
+/obj/item/scissors/surgical_scissors,
+/obj/item/surgical_spoon,
+/obj/item/surgical_spoon,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team2/cloning)
 "Ae" = (
@@ -5622,8 +6726,20 @@
 /turf/space,
 /area/space)
 "Af" = (
-/turf/unsimulated/floor/caution/west,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
+"Ag" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/reliant)
 "Ah" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_10)
@@ -5637,18 +6753,13 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/caution/corner/misc{
+/obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
 	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/hangar)
-"An" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/unsimulated/floor/yellow/side{
-	dir = 4
-	},
-/area/pod_wars/team2/mining)
 "Ao" = (
 /obj/lattice{
 	dir = 9;
@@ -5656,8 +6767,18 @@
 	},
 /turf/space,
 /area/space)
+"Ap" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/nancy)
 "Ar" = (
 /obj/machinery/r_door_control/podbay/t2d4/new_walls/west,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "As" = (
@@ -5667,6 +6788,9 @@
 /area/pod_wars/spacejunk/fstation)
 "At" = (
 /obj/machinery/vending/snack,
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/nancy)
 "Au" = (
@@ -5675,9 +6799,7 @@
 /turf/unsimulated/floor/white,
 /area/pod_wars/team2/cloning)
 "Av" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/yellow/side{
 	dir = 9
@@ -5716,6 +6838,7 @@
 	dir = 6;
 	icon_state = "catwalk_cross"
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1
 	},
@@ -5748,8 +6871,21 @@
 	dir = 1
 	},
 /area/space)
+"AL" = (
+/obj/machinery/light/incandescent/netural,
+/obj/machinery/manufacturer/mining/pod_wars,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/unsimulated/floor/yellow/side{
+	dir = 10
+	},
+/area/pod_wars/team2/mining)
+"AN" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "AP" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /obj/table/reinforced/auto,
 /turf/simulated/floor/purple/side{
 	dir = 10
@@ -5757,12 +6893,18 @@
 /area/pod_wars/spacejunk/fstation/primary)
 "AR" = (
 /obj/machinery/vending/cola/red,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/nancy)
 "AS" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
@@ -5773,13 +6915,24 @@
 	dir = 5
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
+"AU" = (
+/obj/table/auto,
+/obj/item/reagent_containers/glass/beaker/large/brute,
+/obj/item/reagent_containers/glass/beaker/large/brute,
+/obj/item/clothing/glasses/healthgoggles/upgraded,
+/obj/item/clothing/glasses/healthgoggles/upgraded,
+/obj/machinery/light/incandescent/netural,
+/obj/item/clothing/glasses/healthgoggles/upgraded,
+/obj/item/clothing/glasses/healthgoggles/upgraded,
+/turf/unsimulated/floor/white,
+/area/pod_wars/team2/medbay)
 "AW" = (
 /obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
+	dir = 5
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
+	dir = 4;
+	icon_state = "catwalk_cross"
 	},
 /area/pod_wars/team1/mining)
 "AY" = (
@@ -5797,13 +6950,15 @@
 	dir = 1;
 	name = "Starboard Engines Critical System"
 	},
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir-b"
+	},
 /turf/space,
 /area/space)
 "Bb" = (
-/obj/storage/secure/closet/medical/medkit,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
+/obj/machinery/chem_master,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
 "Bd" = (
@@ -5820,6 +6975,12 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team1/porthall)
+"Bg" = (
+/obj/machinery/light/small/floor/netural,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/pod_wars/team2/mining)
 "Bh" = (
 /obj/machinery/r_door_control/podbay/t1d4/new_walls/east,
 /turf/unsimulated/floor/shuttlebay,
@@ -5842,6 +7003,12 @@
 	dir = 10
 	},
 /area/pod_wars/team1/porthall)
+"Bm" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/pod_wars/spacejunk/uvb67/crew)
 "Bn" = (
 /obj/table/auto,
 /obj/item/storage/belt/medical,
@@ -5856,8 +7023,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/light/incandescent/netural,
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -5872,7 +7040,24 @@
 	dir = 8;
 	tag = "icon-catwalk (WEST)"
 	},
-/area/space)
+/area/pod_wars/spacejunk/miningoutpost)
+"Bq" = (
+/obj/storage/closet,
+/obj/item/mop,
+/obj/item/mop,
+/obj/item/mop,
+/obj/item/mop,
+/obj/item/sponge,
+/obj/item/sponge,
+/obj/item/sponge,
+/obj/item/sponge,
+/obj/item/spraybottle/cleaner,
+/obj/item/spraybottle/cleaner,
+/obj/item/reagent_containers/glass/bottle/cleaner,
+/obj/item/reagent_containers/glass/bottle/cleaner,
+/obj/item/spraybottle/cleaner/tsunami,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Br" = (
 /obj/grille/catwalk{
 	dir = 1;
@@ -5883,6 +7068,10 @@
 	dir = 10;
 	icon_state = "catwalk_cross"
 	},
+/area/pod_wars/team2/mining)
+"Bt" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/airless/plating,
 /area/pod_wars/team2/mining)
 "Bv" = (
 /turf/unsimulated/floor/airless,
@@ -5898,9 +7087,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/power/apc/autoname_east,
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -5932,9 +7119,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
@@ -5947,6 +7132,15 @@
 /obj/item/reagent_containers/dropper,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
+"BG" = (
+/obj/stool/chair/office/red{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "BH" = (
 /obj/machinery/neosmelter,
 /turf/simulated/floor/plating,
@@ -5966,7 +7160,9 @@
 /area/pod_wars/spacejunk/fstation)
 "BK" = (
 /obj/submachine/chef_sink{
+	density = 0;
 	dir = 8;
+	name = "utility sink";
 	pixel_y = 3
 	},
 /turf/simulated/floor/green/side{
@@ -5979,12 +7175,15 @@
 /area/pod_wars/team2/hangar)
 "BN" = (
 /obj/storage/closet/welding_supply,
-/turf/unsimulated/floor/caution/north,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/hangar)
 "BO" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/landmark/start/latejoin,
 /turf/unsimulated/floor/blue/side{
 	dir = 5
@@ -6059,10 +7258,17 @@
 	dir = 6
 	},
 /area/pod_wars/spacejunk/fstation/command)
-"Cg" = (
-/obj/machinery/light{
-	dir = 8
+"Ce" = (
+/obj/grille/catwalk{
+	dir = 4
 	},
+/obj/machinery/light/small/floor/cool,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/nancy/landingpad)
+"Cg" = (
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/red/side{
 	dir = 8
 	},
@@ -6079,6 +7285,17 @@
 	dir = 4
 	},
 /area/pod_wars/spacejunk/uvb67/central)
+"Cj" = (
+/obj/item_dispenser/bandage,
+/obj/machinery/power/furnace{
+	desc = "Wow. This thing puts out a lot of heat! If only we had some carbon based material we could shove in here to burn...";
+	fuel = 150;
+	name = "Deluxe Room Heater"
+	},
+/turf/simulated/floor/red/side{
+	dir = 5
+	},
+/area/pod_wars/spacejunk/uvb67/crew)
 "Cl" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -6090,9 +7307,7 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
 	},
@@ -6134,19 +7349,29 @@
 	dir = 1
 	},
 /area/pod_wars/spacejunk/restaurant)
+"Cy" = (
+/obj/storage/crate,
+/obj/random_item_spawner/junk/maybe_few,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "Cz" = (
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
 /area/pod_wars/spacejunk/restaurant)
-"CB" = (
+"CA" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
+/obj/machinery/power/apc/autoname_east,
+/turf/simulated/floor/airless/black,
+/area/pod_wars/spacejunk/reliant/landingpads)
+"CC" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "CE" = (
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -6156,7 +7381,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/small/floor,
+/obj/machinery/light/small/floor/netural,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/manufacturing)
 "CJ" = (
@@ -6176,6 +7401,14 @@
 /obj/item_dispenser/bandage,
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
+"CO" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir";
+	tag = "icon-lattice-dir (EAST)"
+	},
+/turf/space,
+/area/pod_wars/spacejunk/uvb67/central)
 "CP" = (
 /obj/cable{
 	d1 = 1;
@@ -6187,20 +7420,13 @@
 	},
 /area/pod_wars/spacejunk/restaurant)
 "CR" = (
-/turf/unsimulated/floor/caution/corner/misc{
+/obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 5
 	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
-"CS" = (
-/obj/table/auto,
-/obj/machinery/microwave,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/pod_wars/spacejunk/uvb67/crew)
 "CT" = (
 /obj/machinery/vending/snack,
 /turf/unsimulated/floor/blue/side{
@@ -6240,23 +7466,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/pod_wars/team1/powergen)
-"Df" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/airless/plating,
-/area/pod_wars/spacejunk/uvb67/solars)
-"Dg" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
+"De" = (
+/obj/machinery/light/incandescent/netural,
+/obj/machinery/computer/magnet{
 	dir = 8
 	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
+/turf/unsimulated/floor/yellow/side{
+	dir = 6
+	},
+/area/pod_wars/team2/mining)
 "Dh" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team2/mining)
@@ -6264,25 +7482,21 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/caution/corner/se,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 6
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/central_hallway)
 "Dj" = (
 /obj/machinery/r_door_control/podbay/t2d1/new_walls/west,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
-"Dk" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/white,
-/area/pod_wars/spacejunk/brightwell)
-"Dl" = (
-/obj/table/auto,
-/obj/machinery/glass_recycler/chemistry,
-/obj/item/storage/box/beakerbox,
-/obj/item/storage/box/beakerbox,
-/turf/unsimulated/floor/white,
-/area/pod_wars/team2/medbay)
 "Dn" = (
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/fstation/computercore)
@@ -6297,6 +7511,11 @@
 "Ds" = (
 /turf/simulated/floor/purple/side,
 /area/pod_wars/spacejunk/fstation/primary)
+"Dt" = (
+/obj/stool/bench/blue/auto,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Dv" = (
 /obj/machinery/power/furnace,
 /obj/cable{
@@ -6331,9 +7550,7 @@
 /area/pod_wars/spacejunk/nancy/powergen)
 "Dz" = (
 /obj/machinery/vending/snack,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -6346,7 +7563,12 @@
 /obj/landmark/start{
 	name = "NanoTrasen Pod Pilot"
 	},
-/turf/unsimulated/floor/caution/corner/ne,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 5
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
 "DF" = (
 /obj/shrub,
@@ -6358,6 +7580,20 @@
 /obj/random_item_spawner/snacks/one_or_zero,
 /turf/simulated/floor/green,
 /area/pod_wars/spacejunk/fstation/mess)
+"DI" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/fstation/landingpads)
+"DK" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/snacks/sandwich/cheese,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow,
+/area/pod_wars/spacejunk/restaurant)
 "DL" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -6372,15 +7608,16 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
 /area/pod_wars/spacejunk/restaurant)
 "DN" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/green/corner{
 	dir = 1
 	},
@@ -6398,10 +7635,12 @@
 	},
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team2/bar)
+"DQ" = (
+/obj/machinery/manufacturer/medical/pod_wars,
+/turf/unsimulated/floor/white,
+/area/pod_wars/team2/medbay)
 "DT" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/blue/side{
 	dir = 8
 	},
@@ -6416,6 +7655,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "DY" = (
@@ -6443,37 +7683,30 @@
 	dir = 6
 	},
 /area/pod_wars/spacejunk/miningoutpost)
-"Eb" = (
-/obj/machinery/door/airlock/pyro/glass/sci{
-	dir = 4
-	},
-/turf/simulated/floor/purple,
-/area/pod_wars/spacejunk/fstation/computercore)
 "Ec" = (
 /obj/table/reinforced/auto,
 /turf/simulated/floor{
 	icon_state = "carpetSW"
 	},
 /area/pod_wars/spacejunk/nancy)
+"Ed" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Ee" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/manufacturer/general,
-/turf/unsimulated/floor/delivery,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/unsimulated/floor/blue/side{
+	dir = 5
+	},
 /area/pod_wars/team1/manufacturing)
 "Ef" = (
 /obj/wingrille_spawn/crystal/full,
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team1/starboardhall)
-"Eg" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/chem_dispenser/medical,
-/obj/item_dispenser/bandage,
-/turf/unsimulated/floor/white,
-/area/pod_wars/team1/medbay)
 "Eh" = (
 /obj/computerframe{
 	desc = "It is highly unlikely that this still works.";
@@ -6481,16 +7714,21 @@
 	icon_state = "datamedb";
 	name = "smashed computer"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/blue/side{
 	dir = 5
 	},
 /area/pod_wars/spacejunk/fstation/command)
+"Ej" = (
+/obj/machinery/chem_dispenser/alcohol,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Ek" = (
-/turf/unsimulated/floor/caution/corner/misc{
+/obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 9
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
 	},
 /area/pod_wars/team1/manufacturing)
 "El" = (
@@ -6518,17 +7756,15 @@
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "Ep" = (
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_middle,
-/turf/unsimulated/floor/airless,
-/area/pod_wars/team1/powergen)
-"Eq" = (
-/obj/machinery/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "alt_propulsion"
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
 	},
-/turf/space,
-/area/pod_wars/spacejunk/reliant)
+/turf/unsimulated/floor/plating,
+/area/pod_wars/team1/powergen)
+"Er" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "Es" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -6538,6 +7774,9 @@
 "Et" = (
 /obj/stool/chair{
 	dir = 8
+	},
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/purple/side{
 	dir = 8
@@ -6551,53 +7790,56 @@
 /obj/cable,
 /turf/simulated/floor/yellow/side,
 /area/pod_wars/spacejunk/fstation/power)
-"Ew" = (
-/obj/machinery/shuttle/engine/propulsion{
-	icon_state = "alt_propulsion"
-	},
-/turf/space,
-/area/pod_wars/team1/mining)
 "EA" = (
 /turf/simulated/floor/yellow/corner,
 /area/pod_wars/spacejunk/restaurant)
+"EB" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/purple/side,
+/area/pod_wars/spacejunk/fstation)
 "ED" = (
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/central_hallway)
 "EE" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/miningoutpost)
 "EG" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/red/side{
 	dir = 5
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
-"EH" = (
-/obj/table/auto,
-/obj/item/reagent_containers/glass/beaker/large/brute,
-/obj/item/reagent_containers/glass/beaker/large/brute,
-/obj/item/clothing/glasses/healthgoggles/upgraded,
-/obj/item/clothing/glasses/healthgoggles/upgraded,
-/obj/machinery/light,
-/turf/unsimulated/floor/white,
-/area/pod_wars/team2/medbay)
 "EI" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /obj/table/auto,
 /obj/machinery/recharger,
 /turf/unsimulated/floor/yellow/side{
 	dir = 6
 	},
 /area/pod_wars/team1/mining)
+"EJ" = (
+/obj/machinery/light/small/floor/netural,
+/turf/unsimulated/floor/airless,
+/area/pod_wars/team2/power)
 "EK" = (
 /turf/simulated/floor/yellow/side,
 /area/pod_wars/spacejunk/restaurant)
 "EL" = (
 /turf/space,
 /area/pod_wars/asteroid/major/maj_14)
+"EN" = (
+/obj/mopbucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"EO" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/disposal_pipedispenser/mobile,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "EP" = (
 /obj/lattice{
 	dir = 1;
@@ -6638,21 +7880,39 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/brightwell)
-"EU" = (
-/obj/machinery/light{
+"EV" = (
+/obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/uvb67/power)
+/turf/simulated/floor/bluewhite{
+	dir = 8
+	},
+/area/pod_wars/spacejunk/fstation/medbay)
 "EX" = (
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating,
-/area/space)
+/area/pod_wars/spacejunk/miningoutpost)
 "EY" = (
 /turf/unsimulated/floor/yellow/side{
 	dir = 6
 	},
 /area/pod_wars/team1/porthall)
+"EZ" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 5;
+	id = "fortuna"
+	},
+/obj/machinery/door/poddoor/pyro{
+	dir = 4;
+	id = "fortuna";
+	name = "JUNK SHOOTY DOOR"
+	},
+/obj/forcefield/energyshield/perma{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "Fa" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -6663,6 +7923,9 @@
 /area/pod_wars/spacejunk/miningoutpost)
 "Fc" = (
 /obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4
+	},
+/obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/purple,
@@ -6697,10 +7960,6 @@
 	},
 /turf/simulated/floor/purple/side,
 /area/pod_wars/spacejunk/fstation)
-"Fj" = (
-/obj/machinery/light,
-/turf/simulated/floor/white,
-/area/pod_wars/spacejunk/brightwell)
 "Fk" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team1/bar)
@@ -6717,20 +7976,24 @@
 /turf/space,
 /area/space)
 "Fn" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light/incandescent/netural,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/pod_wars/spacejunk/nancy)
-"Fp" = (
-/obj/storage/secure/closet/medical/medkit,
-/turf/unsimulated/floor/white,
-/area/pod_wars/team2/medbay)
 "Fq" = (
 /obj/landmark/start{
 	name = "Syndicate Pod Pilot"
 	},
-/turf/unsimulated/floor/caution/north,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/central_hallway)
 "Fr" = (
 /obj/cable{
@@ -6799,12 +8062,22 @@
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/t1condoor_horizontal,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
-"FI" = (
-/obj/machinery/portable_reclaimer,
-/turf/unsimulated/floor/yellow/side{
-	dir = 9
+"FH" = (
+/obj/deployable_turret/pod_wars/nt/activated/west,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
-/area/pod_wars/team1/mining)
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/corner/extra_big{
+	dir = 6
+	},
+/turf/unsimulated/floor/blue/side{
+	dir = 8
+	},
+/area/pod_wars/team1/bridge)
 "FJ" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -6814,15 +8087,19 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/miningoutpost)
-"FN" = (
-/obj/grille/catwalk{
-	dir = 10
+"FL" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/area/pod_wars/spacejunk/uvb67/central)
+/turf/space,
+/area/pod_wars/spacejunk/reliant)
+"FM" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/white,
+/area/pod_wars/spacejunk/fstation/medbay)
 "FO" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -6831,15 +8108,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/pod_wars/team1/mining)
-"FP" = (
-/obj/machinery/power/furnace,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_west"
-	},
-/area/pod_wars/team1/powergen)
 "FQ" = (
 /obj/grille/catwalk{
 	dir = 1
@@ -6858,14 +8126,16 @@
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/brightwell)
 "FT" = (
-/obj/machinery/light/small/floor,
+/obj/machinery/light/small/floor/netural,
 /obj/machinery/manufacturer/pod_wars/nanotrasen,
-/turf/unsimulated/floor/delivery,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
-"FU" = (
-/obj/machinery/light,
-/turf/simulated/floor/red/side,
-/area/pod_wars/spacejunk/uvb67/crew)
 "FV" = (
 /turf/unsimulated/floor/yellow/side{
 	dir = 1
@@ -6881,9 +8151,7 @@
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation)
 "FY" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/purple/side{
 	dir = 1
 	},
@@ -6912,9 +8180,7 @@
 	},
 /area/pod_wars/spacejunk/reliant/landingpads)
 "Gg" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -6964,16 +8230,16 @@
 /area/pod_wars/spacejunk/fstation)
 "Gs" = (
 /obj/machinery/r_door_control/podbay/t1d4/new_walls/west,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
-"Gu" = (
-/obj/machinery/light,
-/obj/table/auto,
-/obj/machinery/recharger,
-/turf/unsimulated/floor/yellow/side{
-	dir = 10
-	},
-/area/pod_wars/team2/mining)
+"Gv" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/airless/black,
+/area/pod_wars/spacejunk/reliant/landingpads)
 "Gw" = (
 /obj/machinery/vending/kitchen{
 	req_access_txt = null
@@ -7008,6 +8274,13 @@
 	},
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
+"GD" = (
+/obj/machinery/disposal/small/east,
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/unsimulated/floor/wood/seven,
+/area/pod_wars/spacejunk/fstation/bar)
 "GE" = (
 /turf/unsimulated/floor/red/side{
 	dir = 8
@@ -7018,6 +8291,7 @@
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1
 	},
@@ -7034,6 +8308,7 @@
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/reliant)
 "GJ" = (
+/obj/disposalpipe/segment,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -7044,12 +8319,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/maintdock)
 "GL" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/purple/side{
 	dir = 9
 	},
@@ -7068,6 +8342,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment,
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "GO" = (
@@ -7102,15 +8377,13 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/blue/side{
 	dir = 8
 	},
 /area/pod_wars/team1/manufacturing)
 "Hb" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side,
 /area/pod_wars/spacejunk/miningoutpost)
 "Hc" = (
@@ -7129,17 +8402,32 @@
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/uvb67/crew)
+"Hh" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/pod_wars/team1/mining)
 "Hi" = (
 /obj/grille/catwalk{
 	dir = 9
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
 	},
 /area/pod_wars/spacejunk/uvb67/central)
 "Hk" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "Hl" = (
@@ -7148,6 +8436,13 @@
 	dir = 5
 	},
 /area/pod_wars/spacejunk/fstation)
+"Hm" = (
+/obj/machinery/conveyor/east{
+	move_lag = 15;
+	operating = 1
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "Hn" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/spacejunk/fstation/secdock)
@@ -7155,6 +8450,18 @@
 /obj/machinery/vending/coffee,
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team1/bar)
+"Hq" = (
+/obj/storage/crate,
+/obj/random_item_spawner/snacks/one_or_zero,
+/obj/random_item_spawner/tools/one_or_zero,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"Hr" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/fstation/observatory)
 "Hs" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -7173,13 +8480,14 @@
 	dir = 9;
 	icon_state = "catwalk_cross"
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 9
 	},
 /area/pod_wars/spacejunk/uvb67/central)
 "Hy" = (
 /obj/storage/crate,
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/nancy/warehouse)
 "Hz" = (
@@ -7187,6 +8495,14 @@
 /obj/machinery/power/apc/autoname_south,
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team2/bar)
+"HA" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/blue/side{
+	dir = 8
+	},
+/area/pod_wars/spacejunk/fstation)
 "HB" = (
 /obj/rack,
 /obj/item/ore_scoop,
@@ -7207,6 +8523,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
 "HE" = (
@@ -7221,6 +8540,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -7241,11 +8561,11 @@
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team2/mining)
 "HJ" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/blue/side,
 /area/pod_wars/team1/manufacturing)
 "HK" = (
-/obj/machinery/light,
+/obj/loudspeaker,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "HL" = (
@@ -7281,9 +8601,19 @@
 	dir = 4
 	},
 /area/pod_wars/spacejunk/miningoutpost)
+"HO" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/blue/side{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/fstation)
 "HP" = (
 /obj/machinery/shuttle/engine/propulsion{
 	icon_state = "alt_propulsion"
+	},
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/pod_wars/team1/powergen)
@@ -7293,9 +8623,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_corners"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
 	},
+/turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "HT" = (
 /turf/unsimulated/floor{
@@ -7304,15 +8635,6 @@
 /area/pod_wars/team1/bridge)
 "HU" = (
 /obj/stool/bar,
-/turf/unsimulated/floor/wood/seven,
-/area/pod_wars/spacejunk/fstation/bar)
-"HV" = (
-/obj/stool/chair/wooden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "HW" = (
@@ -7327,7 +8649,7 @@
 /obj/machinery/door/airlock/pyro/glass/sci{
 	dir = 4
 	},
-/turf/simulated/floor/purple,
+/turf/simulated/floor/black,
 /area/pod_wars/spacejunk/fstation/computercore)
 "HY" = (
 /obj/landmark/start{
@@ -7384,8 +8706,15 @@
 	tag = "icon-catwalk (WEST)"
 	},
 /area/pod_wars/spacejunk/fstation/landingpads)
-"Im" = (
-/obj/machinery/light,
+"Ik" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
 "Ip" = (
@@ -7406,12 +8735,20 @@
 "Ir" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/spacejunk/miningoutpost)
-"Iu" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
+"Is" = (
+/obj/machinery/microwave,
+/obj/table/auto,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
+"Iv" = (
+/obj/machinery/door/airlock/pyro/glass/toxins{
+	dir = 4
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "Iw" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/snacks/sandwich/cheese,
@@ -7420,6 +8757,10 @@
 "Iy" = (
 /obj/stool/chair{
 	dir = 4
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -7452,12 +8793,6 @@
 "IF" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_5)
-"IG" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/airless/plating,
-/area/pod_wars/spacejunk/uvb67/central)
 "IH" = (
 /turf/unsimulated/floor/yellow/side{
 	dir = 4
@@ -7476,6 +8811,10 @@
 "IK" = (
 /obj/cable{
 	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/blue/side,
 /area/pod_wars/spacejunk/fstation/command)
@@ -7498,18 +8837,24 @@
 /area/pod_wars/spacejunk/fstation/maintdock)
 "IN" = (
 /obj/machinery/processor,
-/turf/simulated/floor/bot,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/miningoutpost)
 "IP" = (
 /obj/machinery/shuttle/engine/heater{
 	dir = 4;
-	icon_state = "alt_heater"
+	icon_state = "alt_heater-L"
 	},
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team2/power)
 "IQ" = (
-/turf/unsimulated/floor/caution/corner/misc{
+/obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 6
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
 	},
 /area/pod_wars/team1/hangar)
 "IT" = (
@@ -7521,15 +8866,38 @@
 	},
 /area/pod_wars/spacejunk/fstation/command)
 "IU" = (
-/turf/unsimulated/floor/caution/corner/nw,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/hangar)
 "IV" = (
+/obj/machinery/disposal/small/east,
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
 /area/pod_wars/spacejunk/fstation/mess)
+"IW" = (
+/obj/machinery/disposal/small/north{
+	pixel_y = 32
+	},
+/obj/disposalpipe/trunk,
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/pod_wars/spacejunk/fstation/secdock)
 "IX" = (
 /obj/machinery/door/airlock/pyro/glass,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/grime,
 /area/pod_wars/spacejunk/nancy)
 "IY" = (
@@ -7551,6 +8919,10 @@
 /area/pod_wars/spacejunk/fstation/observatory)
 "Ja" = (
 /obj/machinery/r_door_control/podbay/t2d2/new_walls/west,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "Jb" = (
@@ -7559,6 +8931,10 @@
 "Jd" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/spacejunk/nancy/warehouse)
+"Je" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating,
+/area/space)
 "Jf" = (
 /obj/machinery/computer/announcement{
 	dir = 4;
@@ -7578,26 +8954,19 @@
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/power)
 "Jh" = (
-/obj/machinery/light,
-/obj/machinery/manufacturer/medical/pod_wars,
+/obj/machinery/light/incandescent/netural,
+/obj/machinery/chem_dispenser/medical,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
-"Ji" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"Jk" = (
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/segment,
+/turf/simulated/floor/blue/side{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
+/area/pod_wars/spacejunk/fstation)
 "Jm" = (
-/obj/machinery/light{
-	dir = 8;
-	tag = ""
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/decal/fakeobjects/cpucontroller,
 /turf/simulated/floor/circuit/red,
 /area/pod_wars/spacejunk/fstation/computercore)
@@ -7608,32 +8977,24 @@
 	},
 /turf/space,
 /area/space)
-"Jo" = (
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_right,
-/turf/unsimulated/floor/airless,
-/area/pod_wars/team1/powergen)
+"Jp" = (
+/obj/machinery/launcher_loader/east{
+	id = "fortuna"
+	},
+/obj/machinery/conveyor/east{
+	move_lag = 15;
+	operating = 1
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "Jq" = (
 /turf/unsimulated/floor/yellow/corner,
 /area/pod_wars/team2/mining)
-"Jr" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/airless/plating,
-/area/pod_wars/spacejunk/uvb67/central)
 "Jt" = (
 /obj/grille/catwalk{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	icon_state = "catwalk_cross"
@@ -7645,7 +9006,7 @@
 	},
 /area/pod_wars/team1/manufacturing)
 "Jv" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/restaurant)
 "Jx" = (
@@ -7663,6 +9024,23 @@
 /obj/table/reinforced/bar/auto,
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team2/bar)
+"JA" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/uvb67/power)
+"JB" = (
+/obj/pod_base_critical_system/syndicate{
+	name = "Medbay Critical System"
+	},
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
 "JD" = (
 /obj/cable{
 	d2 = 8;
@@ -7683,10 +9061,18 @@
 	dir = 5
 	},
 /area/pod_wars/spacejunk/fstation/power)
-"JH" = (
-/obj/machinery/light{
-	dir = 1
+"JF" = (
+/obj/lattice{
+	icon_state = "lattice-dir-b"
 	},
+/obj/machinery/communications_dish,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/space,
+/area/pod_wars/spacejunk/reliant)
+"JH" = (
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -7695,7 +9081,7 @@
 /obj/stool/chair/wooden{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "JJ" = (
@@ -7705,9 +9091,8 @@
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation)
 "JK" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
@@ -7720,11 +9105,21 @@
 "JM" = (
 /obj/forcefield/energyshield/perma,
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/t1d3_horizontal,
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
 "JO" = (
 /turf/simulated/floor/red/side{
 	dir = 9
+	},
+/area/pod_wars/spacejunk/fstation)
+"JQ" = (
+/obj/disposalpipe/junction/left/south,
+/turf/simulated/floor/blue/side{
+	dir = 4
 	},
 /area/pod_wars/spacejunk/fstation)
 "JR" = (
@@ -7736,6 +9131,14 @@
 	tag = "icon-catwalk (WEST)"
 	},
 /area/pod_wars/spacejunk/snackstand)
+"JT" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/fstation/crewquarters)
 "JU" = (
 /obj/stool/chair{
 	dir = 8
@@ -7744,6 +9147,13 @@
 	dir = 8
 	},
 /area/pod_wars/spacejunk/restaurant)
+"JV" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/fstation/observatory)
 "JW" = (
 /turf/space,
 /area/space)
@@ -7759,16 +9169,10 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/storage)
-"Kc" = (
-/obj/storage/crate,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/pod_wars/spacejunk/nancy/warehouse)
 "Kd" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/green/side{
 	dir = 1
@@ -7778,6 +9182,18 @@
 /obj/wingrille_spawn/crystal/full,
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team2/bridge)
+"Ki" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/obj/warp_beacon/pod_wars{
+	control_point = "RELIANT";
+	name = "NSV Reliant"
+	},
+/obj/cable,
+/turf/space,
+/area/pod_wars/spacejunk/reliant)
 "Kk" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team2/bridge)
@@ -7823,6 +9239,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
+"Ku" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/uvb67/power)
 "Kw" = (
 /obj/table/auto,
 /obj/item/reagent_containers/glass/beaker/large/brute,
@@ -7831,12 +9254,11 @@
 /area/pod_wars/team2/medbay)
 "Kx" = (
 /obj/grille/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
+	dir = 1
 	},
+/obj/machinery/light/small/floor/cool,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
+	dir = 1
 	},
 /area/pod_wars/spacejunk/reliant/landingpads)
 "Ky" = (
@@ -7864,18 +9286,23 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/caution/south,
+/turf/simulated/floor/purple/side,
 /area/pod_wars/spacejunk/fstation/primary)
-"KB" = (
-/obj/machinery/clonepod/pod_wars{
-	team_num = 1
+"KC" = (
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
+/turf/unsimulated/floor/wood/seven,
+/area/pod_wars/spacejunk/fstation/bar)
+"KD" = (
+/obj/submachine/chef_sink{
+	density = 0;
+	dir = 8;
+	name = "utility sink";
+	pixel_y = 3
 	},
-/obj/item/cloneModule/speedyclone,
-/turf/unsimulated/floor/white,
-/area/pod_wars/team1/medbay)
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "KE" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -7887,14 +9314,16 @@
 	dir = 1;
 	icon_state = "catwalk_cross"
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
 /area/pod_wars/spacejunk/uvb67/central)
 "KG" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
@@ -7907,6 +9336,10 @@
 	dir = 1
 	},
 /area/pod_wars/spacejunk/fstation/crewquarters)
+"KI" = (
+/obj/machinery/light/incandescent/netural,
+/turf/unsimulated/floor/specialroom/bar,
+/area/pod_wars/team2/bar)
 "KK" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team1/powergen)
@@ -7920,6 +9353,18 @@
 	dir = 6
 	},
 /area/pod_wars/spacejunk/fstation/power)
+"KN" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow/corner,
+/area/pod_wars/spacejunk/restaurant)
+"KO" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/fstation/observatory)
 "KS" = (
 /obj/cable{
 	d1 = 2;
@@ -7930,14 +9375,8 @@
 	dir = 1
 	},
 /area/pod_wars/spacejunk/miningoutpost)
-"KW" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/pod_wars/spacejunk/miningoutpost/crewquarters)
 "KX" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/yellow/side,
 /area/pod_wars/team1/porthall)
 "KY" = (
@@ -7977,7 +9416,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/central_hallway)
 "Ld" = (
 /obj/cable{
@@ -8003,9 +9445,7 @@
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/restaurant/landingpads)
 "Lj" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/shrub,
 /obj/item_dispenser/bandage,
 /turf/unsimulated/floor/specialroom/bar,
@@ -8035,15 +9475,6 @@
 	},
 /turf/simulated/floor/red/side,
 /area/pod_wars/spacejunk/uvb67/crew)
-"Ls" = (
-/obj/machinery/vending/snack,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/red/side{
-	dir = 8
-	},
-/area/pod_wars/spacejunk/uvb67/crew)
 "Lt" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -8055,6 +9486,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/pyro/glass/med,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
 "Lw" = (
@@ -8072,8 +9504,18 @@
 	},
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/restaurant)
+"Ly" = (
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 10
+	},
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "Lz" = (
-/obj/item_dispenser/bandage,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team2/cloning)
 "LA" = (
@@ -8088,12 +9530,6 @@
 	icon_state = "wall3dir"
 	},
 /area/pod_wars/spacejunk/dorgun)
-"LG" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/caution/westeast,
-/area/pod_wars/spacejunk/restaurant)
 "LH" = (
 /obj/machinery/r_door_control/podbay/t2d4/new_walls/east,
 /turf/unsimulated/floor/shuttlebay,
@@ -8106,10 +9542,15 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/mining)
-"LM" = (
-/obj/machinery/light{
-	dir = 8
+"LL" = (
+/obj/machinery/power/smes/magical,
+/obj/cable{
+	icon_state = "0-8"
 	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"LM" = (
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "LO" = (
@@ -8122,12 +9563,35 @@
 	icon_state = "catwalk_cross"
 	},
 /area/pod_wars/team1/mining)
+"LQ" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	drive_range = 5;
+	id = "fortuna"
+	},
+/obj/machinery/conveyor/east{
+	move_lag = 15;
+	operating = 1
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "LR" = (
 /obj/landmark/start{
 	name = "Syndicate Pod Pilot"
 	},
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team2/bar)
+"LS" = (
+/obj/disposalpipe/junction/left/west,
+/turf/simulated/floor/purple/side,
+/area/pod_wars/spacejunk/fstation)
+"LT" = (
+/obj/machinery/conveyor/north{
+	move_lag = 15;
+	operating = 1
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "LU" = (
 /obj/machinery/power/smes/magical,
 /obj/cable{
@@ -8164,6 +9628,15 @@
 /obj/decal/poster/wallsign/pw_map,
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team1/manufacturing)
+"Mc" = (
+/obj/machinery/light/incandescent/netural,
+/obj/landmark/start{
+	name = "NanoTrasen Pod Pilot"
+	},
+/turf/unsimulated/floor/yellow/side{
+	dir = 1
+	},
+/area/pod_wars/team1/mining)
 "Md" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -8171,7 +9644,7 @@
 /turf/simulated/floor/engine,
 /area/pod_wars/team1/powergen)
 "Mf" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/blue/side,
 /area/pod_wars/spacejunk/fstation)
 "Mj" = (
@@ -8181,7 +9654,10 @@
 	},
 /area/pod_wars/team1/manufacturing)
 "Mk" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/nancy)
 "Mm" = (
@@ -8191,17 +9667,11 @@
 	},
 /area/pod_wars/team1/bridge)
 "Mn" = (
-/obj/machinery/shuttle/engine/heater/seaheater_right,
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_right,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team1/porthall)
-"Mp" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/space,
-/area/space)
 "Mr" = (
 /obj/wingrille_spawn/crystal/full,
 /turf/unsimulated/floor/plating,
@@ -8213,6 +9683,10 @@
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
+"Mt" = (
+/obj/machinery/light/small/floor/netural,
+/turf/unsimulated/floor/airless,
+/area/space)
 "Mw" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -8222,13 +9696,18 @@
 	},
 /area/pod_wars/team1/starboardhall)
 "Mx" = (
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater,
-/obj/machinery/shuttle/engine/heater/seaheater_left,
-/turf/unsimulated/floor/airless,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
 /area/pod_wars/team1/mining)
 "My" = (
-/turf/unsimulated/floor/caution/east,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/central_hallway)
 "MB" = (
 /obj/machinery/drainage,
@@ -8236,12 +9715,16 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/bar)
-"MF" = (
-/obj/machinery/light{
-	dir = 8
+"ME" = (
+/obj/machinery/power/furnace,
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/uvb67/power)
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/turf/simulated/floor/engine,
+/area/pod_wars/team1/powergen)
 "MG" = (
 /turf/unsimulated/floor/yellow/side{
 	dir = 5
@@ -8253,6 +9736,20 @@
 	dir = 1
 	},
 /area/pod_wars/spacejunk/snackstand)
+"MK" = (
+/obj/table/reinforced/auto,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/item/kitchen/food_box/lollipop,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "ML" = (
 /obj/cable{
 	d1 = 2;
@@ -8279,13 +9776,6 @@
 "MO" = (
 /turf/simulated/floor/purple/side,
 /area/pod_wars/spacejunk/fstation)
-"MP" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
 "MQ" = (
 /obj/cable{
 	d1 = 1;
@@ -8309,7 +9799,7 @@
 	dir = 8;
 	icon_state = "catwalk_cross"
 	},
-/area/space)
+/area/pod_wars/spacejunk/miningoutpost)
 "MT" = (
 /obj/wingrille_spawn/crystal/full,
 /turf/unsimulated/floor/plating,
@@ -8336,6 +9826,12 @@
 /obj/landmark/start/latejoin,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/fstation/observatory)
+"Na" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/pod_wars/team1/hangar)
 "Nc" = (
 /obj/control_point_computer{
 	name = "UBV-67 Control Console"
@@ -8356,9 +9852,7 @@
 /turf/simulated/floor/circuit/red,
 /area/pod_wars/spacejunk/fstation/computercore)
 "Nl" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/storage/secure/closet/brig,
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -8370,6 +9864,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/side,
 /area/pod_wars/spacejunk/fstation)
 "Nn" = (
@@ -8386,14 +9881,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
+"No" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/machinery/light/small/floor/cool,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/reliant/landingpads)
 "Nq" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/restaurant)
-"Nr" = (
-/turf/unsimulated/floor/caution/westeast,
-/area/pod_wars/team1/mining)
 "Nv" = (
 /obj/machinery/r_door_control/podbay/t2d3/new_walls/north{
 	pixel_x = 10
@@ -8408,34 +9909,31 @@
 	},
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/maintdock)
+"Ny" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/red/side,
+/area/pod_wars/spacejunk/uvb67/crew)
 "Nz" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team2/central_hallway)
-"NE" = (
-/obj/surgery_tray,
-/obj/item/scalpel,
-/obj/item/scalpel,
-/obj/item/circular_saw{
-	pixel_x = 3;
-	pixel_y = 12
+"NC" = (
+/turf/simulated/floor/airless/black,
+/area/pod_wars/spacejunk/reliant/landingpads)
+"ND" = (
+/obj/machinery/light/incandescent/netural,
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/item/circular_saw{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/obj/item/suture,
-/obj/item/suture,
-/obj/item/scissors/surgical_scissors,
-/obj/item/scissors/surgical_scissors,
-/obj/item/surgical_spoon,
-/obj/item/surgical_spoon,
-/turf/unsimulated/floor/white,
-/area/pod_wars/team2/cloning)
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "NF" = (
 /obj/landmark/start{
 	name = "NanoTrasen Pod Pilot"
 	},
-/turf/unsimulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
 "NG" = (
 /obj/machinery/deep_fryer,
@@ -8476,6 +9974,20 @@
 	dir = 8
 	},
 /area/pod_wars/team1/mining)
+"NQ" = (
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/turf/unsimulated/floor/white,
+/area/pod_wars/team2/medbay)
+"NR" = (
+/obj/machinery/conveyor/east{
+	move_lag = 15;
+	operating = 1
+	},
+/obj/machinery/crusher,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "NS" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -8484,13 +9996,12 @@
 	dir = 10
 	},
 /area/pod_wars/spacejunk/fstation/primary)
-"NU" = (
-/obj/pod_base_critical_system/syndicate{
-	dir = 8;
-	name = "Secondary Engines Critical System"
-	},
-/turf/space,
-/area/space)
+"NV" = (
+/obj/table/auto,
+/obj/machinery/glass_recycler,
+/obj/item/storage/box/glassbox,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "NW" = (
 /obj/surgery_tray,
 /obj/item/scalpel,
@@ -8531,9 +10042,15 @@
 	},
 /area/pod_wars/team2/bridge)
 "Ob" = (
-/obj/machinery/light,
-/turf/simulated/floor/caution/westeast,
-/area/pod_wars/spacejunk/restaurant)
+/obj/machinery/light/incandescent/netural,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "Oc" = (
 /obj/shrub,
 /turf/unsimulated/floor/specialroom/bar,
@@ -8543,6 +10060,10 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
+"Of" = (
+/obj/machinery/door/airlock/pyro/glass,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Og" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -8551,6 +10072,10 @@
 /obj/machinery/recharger,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/red/side,
 /area/pod_wars/spacejunk/fstation/secdock)
@@ -8563,12 +10088,29 @@
 	dir = 9
 	},
 /area/pod_wars/spacejunk/restaurant/landingpads)
+"Oi" = (
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
+"Ok" = (
+/obj/landmark/start,
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/fstation/mess)
 "Ol" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/snacks/toastcheese,
 /obj/item/reagent_containers/food/snacks/toastcheese,
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/restaurant)
+"On" = (
+/obj/table/wood/auto,
+/obj/machinery/light/incandescent/netural,
+/obj/item/record/random,
+/obj/item/record/random,
+/obj/item/record/random,
+/obj/item/record/random,
+/obj/item/record/random,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Oo" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -8604,7 +10146,10 @@
 /area/pod_wars/spacejunk/fstation/command)
 "Ot" = (
 /obj/storage/closet/welding_supply,
-/turf/unsimulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/hangar)
 "Ou" = (
 /obj/machinery/power/solar_control/west{
@@ -8616,12 +10161,17 @@
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
 "Ow" = (
-/obj/table/auto,
-/obj/machinery/glass_recycler/chemistry,
-/obj/item/storage/box/beakerbox,
-/obj/item/storage/box/beakerbox,
+/obj/machinery/chem_master,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
+"Ox" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/blue/side{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/fstation)
 "Oy" = (
 /obj/table/auto,
 /obj/item/storage/belt/utility,
@@ -8639,12 +10189,6 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/storage)
-"OA" = (
-/obj/deployable_turret/pod_wars/nt/activated/west,
-/turf/unsimulated/floor/caution/misc{
-	dir = 8
-	},
-/area/pod_wars/team1/bridge)
 "OB" = (
 /turf/unsimulated/floor/red/side{
 	dir = 5
@@ -8662,13 +10206,12 @@
 "OG" = (
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team1/hangar)
-"OI" = (
-/obj/storage/crate/furnacefuel,
-/obj/machinery/light{
-	dir = 1
+"OH" = (
+/obj/landmark{
+	name = "Observer-Start"
 	},
-/turf/simulated/floor/engine,
-/area/pod_wars/team2/power)
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/fstation/mess)
 "OJ" = (
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/restaurant)
@@ -8693,12 +10236,6 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/central_hallway)
-"OO" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/yellow,
-/area/pod_wars/spacejunk/restaurant)
 "OP" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -8724,6 +10261,14 @@
 "OU" = (
 /turf/simulated/floor/purple/corner,
 /area/pod_wars/spacejunk/fstation)
+"OW" = (
+/obj/machinery/light/incandescent/netural,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "OX" = (
 /obj/cable{
 	d1 = 1;
@@ -8742,9 +10287,7 @@
 	},
 /area/pod_wars/spacejunk/nancy)
 "OZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/blue/side{
 	dir = 5
 	},
@@ -8758,17 +10301,21 @@
 /area/pod_wars/spacejunk/miningoutpost/crewquarters)
 "Pb" = (
 /obj/machinery/r_door_control/podbay/t2d4/new_walls/east,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "Pd" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side,
 /area/pod_wars/spacejunk/restaurant)
 "Pf" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_2)
 "Pg" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -8805,6 +10352,9 @@
 /obj/pod_base_critical_system/nanotrasen{
 	name = "Bridge Critical System"
 	},
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "Pq" = (
@@ -8820,7 +10370,7 @@
 	dir = 8;
 	tag = "icon-catwalk (WEST)"
 	},
-/area/space)
+/area/pod_wars/spacejunk/miningoutpost)
 "Ps" = (
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -8838,6 +10388,10 @@
 /area/pod_wars/spacejunk/fstation)
 "Pu" = (
 /obj/machinery/r_door_control/podbay/t1d3/new_walls/west,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "Pw" = (
@@ -8847,6 +10401,10 @@
 /obj/submachine/foodprocessor,
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/restaurant)
+"Py" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/fstation/secdock)
 "Pz" = (
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
@@ -8878,7 +10436,15 @@
 /area/pod_wars/spacejunk/greatwreck)
 "PE" = (
 /obj/machinery/manufacturer/pod_wars/nanotrasen,
-/turf/unsimulated/floor/delivery,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
 "PF" = (
 /obj/lattice,
@@ -8919,6 +10485,10 @@
 	opacity = 0
 	},
 /area/pod_wars/spacejunk/brightwell)
+"PJ" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "PL" = (
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team2/mining)
@@ -8931,21 +10501,29 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
 /area/pod_wars/spacejunk/fstation/power)
 "PO" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/green/side{
 	dir = 5
 	},
 /area/pod_wars/spacejunk/fstation)
+"PP" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/uvb67/power)
 "PQ" = (
 /obj/grille/catwalk{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1;
 	icon_state = "catwalk_cross"
@@ -8966,10 +10544,18 @@
 	},
 /area/pod_wars/team1/starboardhall)
 "PU" = (
-/turf/simulated/floor/caution/northsouth,
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost)
 "PW" = (
 /obj/machinery/r_door_control/podbay/t1d1/new_walls/east,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "PX" = (
@@ -8979,6 +10565,12 @@
 	},
 /turf/space,
 /area/space)
+"PY" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/miningoutpost)
 "PZ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9008,7 +10600,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/red/side{
+/turf/unsimulated/floor/red/corner{
 	dir = 8
 	},
 /area/pod_wars/team2/central_hallway)
@@ -9034,6 +10626,10 @@
 /obj/machinery/shuttle/engine/propulsion{
 	icon_state = "alt_propulsion"
 	},
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
 /turf/space,
 /area/pod_wars/team1/porthall)
 "Qo" = (
@@ -9044,6 +10640,9 @@
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
+"Qq" = (
+/turf/unsimulated/floor/yellow/side,
+/area/pod_wars/team1/mining)
 "Qr" = (
 /obj/cable{
 	d1 = 1;
@@ -9064,8 +10663,38 @@
 	},
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost/crewquarters)
+"Qu" = (
+/obj/storage/crate/bin,
+/obj/item/radio_tape/advertisement/dans_tickets,
+/obj/item/radio_tape/advertisement/grones{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/radio_tape/audio_book/heisenbee,
+/obj/item/radio_tape/advertisement/danitos_burritos{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/radio_tape/advertisement/quik_noodles{
+	pixel_x = 2;
+	pixel_y = -6
+	},
+/obj/item/radio_tape/advertisement/pope_crunch,
+/obj/item/radio_tape/advertisement/captain_psa{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"Qv" = (
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/reliant/landingpads)
 "Qw" = (
 /obj/machinery/r_door_control/podbay/t1d1/new_walls/west,
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "Qx" = (
@@ -9078,8 +10707,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor{
-	icon_state = "floor"
+/turf/unsimulated/floor/blue/corner{
+	dir = 4
 	},
 /area/pod_wars/team1/manufacturing)
 "QA" = (
@@ -9089,6 +10718,11 @@
 /obj/access_spawn/syndie_shuttle,
 /turf/unsimulated/floor/red,
 /area/pod_wars/team2/bridge)
+"QB" = (
+/obj/machinery/disposal/small/west,
+/obj/disposalpipe/trunk,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/fstation/observatory)
 "QD" = (
 /turf/unsimulated/floor/yellow/side{
 	dir = 1
@@ -9098,6 +10732,10 @@
 /turf/unsimulated/floor/blue,
 /area/pod_wars/team1/manufacturing)
 "QF" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/purple/corner{
 	dir = 1
 	},
@@ -9117,6 +10755,17 @@
 /obj/landmark/start/latejoin,
 /turf/unsimulated/floor/red/side,
 /area/pod_wars/team2/central_hallway)
+"QM" = (
+/obj/item/device/radio/intercom{
+	desc = "A powerful radio transmitter. Enable the microphone to begin broadcasting your radio show.";
+	device_color = "#E52780";
+	icon = 'icons/obj/radiostation.dmi';
+	icon_state = "mixtable-1";
+	name = "broadcast radio"
+	},
+/obj/table/wood/auto,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "QO" = (
 /obj/lattice{
 	icon_state = "lattice-dir-b"
@@ -9124,11 +10773,25 @@
 /obj/deployable_turret/pod_wars/sy/activated/north,
 /turf/space,
 /area/space)
+"QQ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/storage/crate,
+/obj/random_item_spawner/tools/one_or_zero,
+/obj/random_item_spawner/shoe/one_or_zero,
+/obj/random_item_spawner/junk/maybe_few,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "QR" = (
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
+"QU" = (
+/obj/mic_stand,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "QV" = (
 /obj/machinery/chem_dispenser/alcohol,
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
@@ -9144,9 +10807,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/power/apc/autoname_east,
 /obj/reagent_dispensers/fueltank,
 /turf/unsimulated/floor{
@@ -9209,17 +10870,24 @@
 /turf/unsimulated/floor/red,
 /area/pod_wars/team2/hangar)
 "Rn" = (
-/obj/machinery/light{
-	dir = 8;
-	tag = ""
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/caution/north,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/primary)
+"Ro" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/airless,
+/area/pod_wars/team2/mining)
 "Rp" = (
 /obj/shrub,
 /turf/unsimulated/floor/red,
@@ -9249,12 +10917,6 @@
 	},
 /turf/space,
 /area/pod_wars/spacejunk/uvb67/central)
-"Rv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
 "Rx" = (
 /obj/lattice,
 /obj/cable,
@@ -9264,17 +10926,37 @@
 	},
 /turf/space,
 /area/space)
-"RC" = (
-/obj/machinery/light{
-	dir = 1
+"Ry" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
 	},
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/reliant)
+"RC" = (
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "RD" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/spacejunk/fstation/power)
+"RF" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 6
+	},
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "RJ" = (
-/turf/unsimulated/floor/caution/east,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
 "RK" = (
 /obj/machinery/manufacturer/medical/pod_wars,
@@ -9307,9 +10989,7 @@
 	},
 /area/pod_wars/team2/mining)
 "RP" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/red/side{
 	dir = 6
 	},
@@ -9318,17 +10998,18 @@
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_26)
 "RS" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/light/incandescent/netural,
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 4
 	},
 /area/pod_wars/spacejunk/restaurant)
 "RT" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/table/wood/round/champagne,
 /turf/unsimulated/floor/blue/side{
 	dir = 9
@@ -9341,7 +11022,7 @@
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/dorgun)
 "RV" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/dorgun)
 "RW" = (
@@ -9358,9 +11039,25 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/chem_master,
+/obj/table/auto,
+/obj/machinery/glass_recycler/chemistry,
+/obj/item/storage/box/beakerbox{
+	pixel_x = 8;
+	pixel_y = 15
+	},
+/obj/item/storage/box/beakerbox{
+	pixel_x = -8;
+	pixel_y = 15
+	},
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
+"Sb" = (
+/obj/machinery/computer/announcement/console_lower{
+	dir = 4;
+	name = "NSV Reliant Announcement Computer"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Sd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9443,6 +11140,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
@@ -9454,7 +11152,7 @@
 /area/pod_wars/team1/mining)
 "Ss" = (
 /obj/machinery/power/smes{
-	charge = 1e+006;
+	charge = 1e+007;
 	chargelevel = 15000;
 	output = 10000
 	},
@@ -9483,9 +11181,7 @@
 	},
 /area/pod_wars/team2/central_hallway)
 "Sv" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/blue/side{
 	dir = 9
 	},
@@ -9513,6 +11209,20 @@
 	dir = 4
 	},
 /area/pod_wars/spacejunk/miningoutpost)
+"SE" = (
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/fstation/computercore)
+"SF" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/unsimulated/floor/red,
+/area/pod_wars/team2/bridge)
 "SG" = (
 /obj/lattice{
 	dir = 9;
@@ -9522,15 +11232,18 @@
 /turf/space,
 /area/space)
 "SH" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/mopbucket,
 /obj/item/reagent_containers/glass/bucket/red,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/bar)
+"SI" = (
+/obj/storage/crate,
+/obj/item/mop,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/nancy/warehouse)
 "SJ" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/cable{
@@ -9543,8 +11256,17 @@
 "SK" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/spacejunk/nancy)
+"SL" = (
+/obj/machinery/chem_dispenser/medical,
+/turf/unsimulated/floor/white,
+/area/pod_wars/team2/cloning)
 "SM" = (
-/turf/unsimulated/floor/caution/west,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/central_hallway)
 "SP" = (
 /obj/machinery/vending/cola/blue,
@@ -9589,9 +11311,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor{
 	icon_state = "carpetN"
 	},
@@ -9632,6 +11352,7 @@
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
+/obj/item/record/random,
 /turf/simulated/floor/yellow/side{
 	dir = 6
 	},
@@ -9660,6 +11381,12 @@
 /obj/wingrille_spawn/auto,
 /turf/unsimulated/floor/plating,
 /area/pod_wars/team1/bar)
+"Td" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/pod_wars/spacejunk/reliant)
 "Te" = (
 /obj/grille/catwalk{
 	dir = 1;
@@ -9671,9 +11398,7 @@
 	},
 /area/pod_wars/spacejunk/fstation/landingpads)
 "Tg" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/stool/chair,
 /obj/landmark/start/latejoin,
 /turf/simulated/floor/purple,
@@ -9697,6 +11422,9 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/black/side{
 	dir = 4
 	},
@@ -9708,7 +11436,12 @@
 /turf/space,
 /area/space)
 "Ts" = (
-/turf/unsimulated/floor/caution/north,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/central_hallway)
 "Tt" = (
 /turf/simulated/floor/green/side,
@@ -9731,10 +11464,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/pod_wars/team1/powergen)
-"TA" = (
-/obj/machinery/light{
-	dir = 4
+"Tz" = (
+/obj/cable{
+	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"TA" = (
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/red/side{
 	dir = 4
 	},
@@ -9747,15 +11487,14 @@
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/uvb67/central)
 "TD" = (
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor/caution/north,
-/area/pod_wars/team2/hangar)
-"TE" = (
-/obj/machinery/light{
-	dir = 4
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
 	},
-/turf/unsimulated/floor/shuttlebay,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/hangar)
 "TF" = (
 /obj/machinery/recharger/wall{
@@ -9806,34 +11545,22 @@
 /obj/item/reagent_containers/dropper,
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
-"TO" = (
-/obj/machinery/power/furnace,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_corners"
-	},
-/area/pod_wars/team1/powergen)
 "TP" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/hangar)
-"TQ" = (
-/obj/grille/catwalk,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/airless/plating/catwalk,
-/area/space)
 "TR" = (
 /obj/machinery/vending/cola/red,
 /turf/unsimulated/floor/red/side{
 	dir = 10
 	},
 /area/pod_wars/team2/bridge)
+"TS" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/restaurant)
 "TT" = (
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/hangar)
@@ -9845,7 +11572,7 @@
 	dir = 5;
 	icon_state = "catwalk_cross"
 	},
-/area/space)
+/area/pod_wars/spacejunk/miningoutpost)
 "TV" = (
 /obj/cable{
 	d2 = 8;
@@ -9864,6 +11591,12 @@
 "TY" = (
 /turf/unsimulated/floor/yellow/corner,
 /area/pod_wars/team1/mining)
+"Ub" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/restaurant)
 "Ue" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -9945,17 +11678,28 @@
 /area/pod_wars/team2/central_hallway)
 "Uq" = (
 /obj/machinery/manufacturer/mining/pod_wars,
-/turf/simulated/floor/bot,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/miningoutpost)
 "Us" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/macrofab/pod_wars/syndicate/mining{
 	dir = 8
 	},
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/hangar)
+"Ut" = (
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 5
+	},
+/area/pod_wars/spacejunk/restaurant/landingpads)
 "Uu" = (
 /obj/stool/chair{
 	dir = 4
@@ -9969,7 +11713,12 @@
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/uvb67/central)
 "Uw" = (
-/turf/unsimulated/floor/caution/corner/se,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 6
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/hangar)
 "Ux" = (
 /turf/unsimulated/floor{
@@ -9987,10 +11736,15 @@
 	},
 /turf/space,
 /area/space)
-"UA" = (
-/obj/machinery/light{
-	dir = 1
+"Uz" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/fstation)
+"UA" = (
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
 "UC" = (
@@ -10003,10 +11757,13 @@
 	dir = 4
 	},
 /obj/access_spawn/syndie_shuttle,
-/turf/simulated/floor/engine{
-	dir = 6;
-	icon_state = "engine_caution_misc"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
 	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
 "UH" = (
 /obj/lattice{
@@ -10032,13 +11789,20 @@
 	dir = 4;
 	name = "Bridge Critical System"
 	},
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir-b"
+	},
 /turf/space,
 /area/space)
 "UL" = (
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/uvb67/central)
 "UO" = (
-/turf/unsimulated/floor/caution/south,
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/manufacturing)
 "UP" = (
 /obj/cable{
@@ -10058,6 +11822,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
 "UU" = (
@@ -10103,9 +11868,7 @@
 /area/pod_wars/team2/central_hallway)
 "Vf" = (
 /obj/reagent_dispensers/fueltank,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -10130,6 +11893,16 @@
 	},
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost/crewquarters)
+"Vl" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/disposal/small/south,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/blue/side,
+/area/pod_wars/spacejunk/fstation/command)
 "Vo" = (
 /obj/cable{
 	d1 = 1;
@@ -10146,11 +11919,26 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/unsimulated/floor/caution/north,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/central_hallway)
+"Vs" = (
+/obj/machinery/light/incandescent/netural,
+/obj/storage/crate,
+/obj/random_item_spawner/junk/maybe_few,
+/turf/simulated/floor/plating,
+/area/pod_wars/spacejunk/fstation)
 "Vt" = (
 /obj/machinery/shuttle/engine/propulsion{
 	icon_state = "alt_propulsion"
+	},
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/pod_wars/team1/starboardhall)
@@ -10170,10 +11958,15 @@
 "Vw" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_13)
-"Vy" = (
-/obj/machinery/light{
-	dir = 8
+"Vx" = (
+/obj/machinery/light/incandescent/netural,
+/obj/disposalpipe/segment{
+	dir = 4
 	},
+/turf/simulated/floor/purple/side,
+/area/pod_wars/spacejunk/fstation)
+"Vy" = (
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -10186,26 +11979,49 @@
 	dir = 4
 	},
 /area/pod_wars/team1/porthall)
+"VA" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/uvb67/power)
 "VB" = (
 /obj/machinery/manufacturer/general,
-/turf/unsimulated/floor/delivery,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/unsimulated/floor/yellow/side{
+	dir = 1
+	},
 /area/pod_wars/team2/mining)
 "VD" = (
-/turf/unsimulated/floor/caution/corner/ne,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 5
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/hangar)
 "VE" = (
-/obj/storage/secure/closet/medical/medkit,
+/obj/machinery/chem_dispenser/medical,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
 "VF" = (
 /obj/machinery/r_door_control/podbay/t2d1/new_walls/east,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "VG" = (
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/snackstand)
 "VH" = (
-/obj/machinery/light/small/floor,
+/obj/machinery/light/small/floor/netural,
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
 "VI" = (
@@ -10251,6 +12067,17 @@
 "VP" = (
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost/crewquarters)
+"VQ" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
+"VS" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/fstation/landingpads)
 "VT" = (
 /obj/wingrille_spawn/auto,
 /turf/unsimulated/floor/plating,
@@ -10343,6 +12170,10 @@
 "Wk" = (
 /obj/forcefield/energyshield/perma,
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/t1d4_horizontal,
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
 "Wl" = (
@@ -10389,20 +12220,12 @@
 "Wv" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_11)
-"Wx" = (
-/obj/lattice{
-	dir = 9;
-	icon_state = "lattice-dir"
-	},
+"Wy" = (
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/obj/warp_beacon/pod_wars{
-	control_point = "RELIANT";
-	name = "NSV Reliant"
-	},
-/turf/space,
-/area/pod_wars/spacejunk/reliant)
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/uvb67/power)
 "Wz" = (
 /obj/grille/catwalk{
 	dir = 1
@@ -10410,16 +12233,6 @@
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1
 	},
-/area/pod_wars/spacejunk/uvb67/central)
-"WC" = (
-/obj/lattice{
-	dir = 9;
-	icon_state = "lattice-dir-b"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/space,
 /area/pod_wars/spacejunk/uvb67/central)
 "WG" = (
 /obj/cable{
@@ -10468,14 +12281,6 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/uvb67/central)
-"WR" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
-/area/pod_wars/spacejunk/uvb67/crew)
 "WS" = (
 /obj/grille/catwalk,
 /turf/simulated/floor/airless/plating,
@@ -10483,6 +12288,12 @@
 "WT" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/pod_wars/team2/mining)
+"WU" = (
+/obj/disposalpipe/junction/right/north,
+/turf/simulated/floor/purple/side{
+	dir = 8
+	},
+/area/pod_wars/spacejunk/fstation)
 "WV" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -10525,6 +12336,23 @@
 	dir = 8
 	},
 /area/pod_wars/spacejunk/fstation)
+"Xe" = (
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/fstation/observatory)
+"Xf" = (
+/obj/decal/fakeobjects{
+	desc = "It seems to be locked";
+	dir = 4;
+	icon = 'icons/obj/computerpanel.dmi';
+	icon_state = "securitycomputer2";
+	name = "Weapons Console"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Xh" = (
 /obj/stool/bed,
 /obj/window/cubicle{
@@ -10536,12 +12364,11 @@
 /area/pod_wars/spacejunk/uvb67/crew)
 "Xi" = (
 /obj/machinery/door/airlock/pyro/glass/botany,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/green,
 /area/pod_wars/spacejunk/fstation/mess)
 "Xj" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/red/side{
 	dir = 9
 	},
@@ -10555,6 +12382,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation)
 "Xn" = (
@@ -10564,6 +12392,17 @@
 "Xp" = (
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/nancy/warehouse)
+"Xs" = (
+/obj/table/reinforced/auto,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/shrub/dead{
+	pixel_y = 12
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Xt" = (
 /obj/stool/bar,
 /obj/landmark/start{
@@ -10575,10 +12414,21 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/blue/side{
 	dir = 4
 	},
 /area/pod_wars/spacejunk/fstation)
+"Xv" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 8;
+	tag = "icon-catwalk (WEST)"
+	},
+/area/pod_wars/spacejunk/fstation/landingpads)
 "Xw" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10592,13 +12442,14 @@
 /area/pod_wars/asteroid/major/maj_21)
 "XA" = (
 /obj/machinery/r_door_control/podbay/t2d3/new_walls/west,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
 "XB" = (
-/obj/machinery/light{
-	dir = 8;
-	tag = ""
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/blue/side{
 	dir = 8
 	},
@@ -10616,16 +12467,6 @@
 	tag = "icon-catwalk (WEST)"
 	},
 /area/pod_wars/spacejunk/fstation/landingpads)
-"XD" = (
-/obj/machinery/power/furnace,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/engine{
-	dir = 8;
-	icon_state = "engine_caution_corners"
-	},
-/area/pod_wars/team1/powergen)
 "XE" = (
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -10645,24 +12486,23 @@
 /obj/item/spraybottle/cleaner,
 /obj/item/reagent_containers/glass/bottle/cleaner,
 /obj/item/reagent_containers/glass/bottle/cleaner,
+/obj/item/spraybottle/cleaner/tsunami,
+/obj/item/spraybottle/cleaner/tsunami,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/bar)
+"XG" = (
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/miningoutpost/crewquarters)
 "XH" = (
 /obj/storage/secure/closet/fridge/blood,
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team2/medbay)
 "XJ" = (
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/dorgun)
-"XK" = (
-/obj/pod_base_critical_system/syndicate{
-	name = "Medbay Critical System"
-	},
-/turf/space,
-/area/space)
 "XL" = (
 /obj/cable{
 	d1 = 1;
@@ -10676,12 +12516,13 @@
 /area/pod_wars/spacejunk/fstation)
 "XM" = (
 /obj/machinery/nanofab/refining,
-/turf/simulated/floor/bot,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost)
 "XO" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -10697,14 +12538,23 @@
 /area/pod_wars/spacejunk/uvb67/central)
 "XT" = (
 /obj/machinery/r_door_control/podbay/t2d3/new_walls/east,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
 /turf/space,
 /area/space)
-"XU" = (
-/obj/machinery/light{
-	dir = 1
+"XV" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/engine,
-/area/pod_wars/team1/powergen)
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/fstation/observatory)
+"XW" = (
+/obj/decal/poster/wallsign/pw_map,
+/turf/unsimulated/wall/auto/reinforced/supernorn,
+/area/pod_wars/team1/hangar)
 "XX" = (
 /obj/stool/chair{
 	dir = 8
@@ -10730,18 +12580,50 @@
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
+/obj/item/record/random,
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost/crewquarters)
 "Yb" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/miningoutpost)
+"Yc" = (
+/obj/machinery/power/furnace,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/pod_wars/team1/powergen)
+"Yd" = (
+/obj/machinery/clonepod/pod_wars{
+	team_num = 1
+	},
+/obj/machinery/light/incandescent/netural,
+/obj/item/cloneModule/speedyclone,
+/turf/unsimulated/floor/white,
+/area/pod_wars/team1/medbay)
+"Ye" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/pod_wars/spacejunk/fstation)
 "Yf" = (
 /obj/forcefield/energyshield/perma,
 /obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/t1d2_horizontal,
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team1/hangar)
 "Yg" = (
@@ -10764,6 +12646,10 @@
 /obj/pod_base_critical_system/nanotrasen{
 	dir = 1;
 	name = "Port Engines Critical System"
+	},
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/space)
@@ -10798,6 +12684,15 @@
 /obj/deployable_turret/pod_wars/nt/activated/east,
 /turf/space,
 /area/space)
+"Yo" = (
+/obj/grille/catwalk{
+	dir = 9;
+	icon_state = "catwalk_cross"
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 9
+	},
+/area/pod_wars/spacejunk/miningoutpost)
 "Yp" = (
 /turf/unsimulated/floor/yellow/corner{
 	dir = 8
@@ -10808,11 +12703,27 @@
 	dir = 1
 	},
 /area/pod_wars/spacejunk/fstation/command)
+"Yt" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
+	},
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/reliant)
 "Yu" = (
 /turf/unsimulated/floor/yellow/corner{
 	dir = 4
 	},
 /area/pod_wars/team1/mining)
+"Yw" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "Yx" = (
 /obj/table/auto,
 /turf/simulated/floor,
@@ -10838,13 +12749,20 @@
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/uvb67/central)
 "YC" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
+"YD" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/purple/corner{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/fstation)
 "YF" = (
 /obj/grille/catwalk{
 	dir = 5;
@@ -10855,10 +12773,13 @@
 	},
 /area/pod_wars/spacejunk/fstation/landingpads)
 "YG" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/light/incandescent/netural,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
 	},
-/turf/unsimulated/floor/caution/north,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/hangar)
 "YH" = (
 /obj/grille/catwalk{
@@ -10892,12 +12813,24 @@
 "YL" = (
 /turf/unsimulated/floor/airless,
 /area/pod_wars/team2/central_hallway)
+"YN" = (
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/blue/side{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/fstation)
 "YO" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/unsimulated/floor/caution/corner/misc{
+/obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 9
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
 	},
 /area/pod_wars/team2/hangar)
 "YR" = (
@@ -10908,19 +12841,25 @@
 /area/pod_wars/team1/medbay)
 "YS" = (
 /obj/machinery/r_door_control/podbay/t2condoor/new_walls/south,
-/turf/unsimulated/floor/caution/corner/ne,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 5
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/hangar)
 "YT" = (
 /obj/deployable_turret/pod_wars/sy/activated/west,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/light/incandescent/netural,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
 	},
-/turf/unsimulated/floor/caution/corner/nw,
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/central_hallway)
 "YU" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor/yellow/side{
 	dir = 1
 	},
@@ -10929,9 +12868,7 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/nancy)
 "YW" = (
@@ -10954,13 +12891,15 @@
 	dir = 1
 	},
 /area/pod_wars/spacejunk/fstation/secdock)
+"Zc" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/green/side,
+/area/pod_wars/spacejunk/fstation/mess)
 "Zd" = (
-/obj/grille/catwalk{
-	dir = 6
-	},
 /obj/grille/catwalk{
 	dir = 1
 	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1
 	},
@@ -10969,9 +12908,14 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/unsimulated/floor/caution/north,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team2/hangar)
 "Zg" = (
 /turf/simulated/floor/red/side,
@@ -10987,6 +12931,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/uvb67/power)
+"Zk" = (
+/obj/machinery/manufacturer/pod_wars/syndicate,
+/obj/decal/tile_edge{
+	icon_state = "mule_dropoff"
+	},
+/obj/decal/tile_edge/stripe/corner/extra_big2{
+	dir = 9
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/pod_wars/team2/central_hallway)
 "Zm" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -11003,24 +12959,34 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/fstation/power)
-"Zp" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/manufacturer/medical/pod_wars,
-/turf/unsimulated/floor/white,
-/area/pod_wars/team2/cloning)
 "Zr" = (
 /turf/simulated/floor/red/corner{
 	dir = 8
 	},
 /area/pod_wars/spacejunk/uvb67/crew)
+"Zs" = (
+/obj/grille/catwalk{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless/plating,
+/area/pod_wars/spacejunk/nancy/landingpad)
 "Zt" = (
 /obj/potted_plant/potted_plant4,
 /turf/simulated/floor/blue/side{
 	dir = 6
 	},
 /area/pod_wars/spacejunk/snackstand)
+"Zu" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/purple/side{
+	dir = 4
+	},
+/area/pod_wars/spacejunk/fstation)
 "Zv" = (
 /obj/machinery/door/airlock/pyro/glass/med{
 	hardened = 1
@@ -11036,6 +13002,22 @@
 	},
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/central_hallway)
+"ZA" = (
+/obj/grille/catwalk,
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 1
+	},
+/area/pod_wars/spacejunk/restaurant/landingpads)
+"ZC" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
+/area/pod_wars/team2/mining)
 "ZD" = (
 /obj/machinery/door/airlock/pyro/external,
 /turf/simulated/floor,
@@ -11046,18 +13028,6 @@
 	},
 /turf/unsimulated/floor/wood/seven,
 /area/pod_wars/spacejunk/fstation/bar)
-"ZH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
-"ZI" = (
-/obj/table/auto,
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/pod_wars/spacejunk/uvb67/crew)
 "ZJ" = (
 /turf/unsimulated/floor/red/side{
 	dir = 9
@@ -11068,7 +13038,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/r_door_control/podbay/t1condoor/new_walls/north,
-/turf/unsimulated/floor/caution/corner/sw,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
+	},
+/turf/unsimulated/floor{
+	icon_state = "floor"
+	},
 /area/pod_wars/team1/hangar)
 "ZL" = (
 /obj/machinery/door/airlock/pyro/glass{
@@ -11085,6 +13060,13 @@
 	dir = 1
 	},
 /area/space)
+"ZN" = (
+/obj/machinery/disposal/small/west,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/white,
+/area/pod_wars/spacejunk/fstation/medbay)
 "ZQ" = (
 /obj/stool/bed,
 /obj/window/cubicle{
@@ -11096,14 +13078,12 @@
 /obj/item/clothing/suit/bedsheet/blue,
 /turf/simulated/floor/purple,
 /area/pod_wars/spacejunk/fstation/crewquarters)
-"ZT" = (
-/obj/machinery/power/smes/magical,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+"ZS" = (
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/reliant)
+/turf/simulated/floor/purple/side,
+/area/pod_wars/spacejunk/fstation)
 "ZU" = (
 /obj/grille/catwalk{
 	dir = 9;
@@ -11116,6 +13096,15 @@
 "ZV" = (
 /turf/simulated/floor/purple/side,
 /area/pod_wars/spacejunk/fstation/crewquarters)
+"ZW" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/pod_wars/spacejunk/reliant)
 "ZY" = (
 /obj/machinery/vending/cola/blue,
 /turf/simulated/floor,
@@ -32265,12 +34254,12 @@ ZM
 ZM
 ZM
 ZM
-MS
-ZM
+FQ
+dW
 FQ
 FQ
-ZM
-MS
+dW
+FQ
 ZM
 ZM
 ZM
@@ -34281,7 +36270,7 @@ JW
 JW
 JW
 JW
-JW
+Vg
 JW
 JW
 JW
@@ -34776,14 +36765,14 @@ JW
 JW
 JW
 JW
-JW
+Je
 su
 su
+Je
 JW
 JW
 JW
-JW
-Vg
+eB
 JW
 JW
 JW
@@ -35278,10 +37267,10 @@ JW
 JW
 JW
 JW
-JW
+ad
 su
 su
-JW
+ad
 JW
 JW
 JW
@@ -35777,17 +37766,17 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-Mp
-su
-su
-Mp
-JW
-JW
-JW
-eB
+qZ
+pp
+pp
+qZ
+PH
+PH
+qZ
+pp
+pp
+pp
+qZ
 JW
 JW
 JW
@@ -36280,15 +38269,15 @@ JW
 JW
 JW
 qZ
-pp
-pp
+Jx
+la
 qZ
-PH
-PH
+Hh
+Hh
 qZ
-pp
-pp
-pp
+bO
+VM
+lN
 qZ
 JW
 JW
@@ -36775,29 +38764,29 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
+fb
+Tr
+Tr
 qZ
-Jx
-la
 qZ
-Nr
-Nr
 qZ
-bO
-pQ
-lN
 qZ
-JW
-JW
-JW
-JW
-JW
-JW
+Mc
+WX
+qZ
+PH
+PH
+qZ
+FV
+eR
+gO
+qZ
+qZ
+qZ
+qZ
+Tr
+Tr
+zb
 JW
 JW
 JW
@@ -37277,29 +39266,29 @@ JW
 JW
 JW
 JW
-fb
-Tr
-Tr
-qZ
-qZ
-qZ
-qZ
-oQ
-WX
-qZ
-PH
-PH
-qZ
-FV
+JW
+JW
+JW
+pp
+gQ
+Xb
+dQ
+Sr
+Yp
+VM
+VM
+VM
+VM
+Sr
 eR
-iQ
-qZ
-qZ
-qZ
-qZ
-Tr
-Tr
-zb
+NP
+Ks
+pp
+lJ
+op
+JW
+JW
+JW
 JW
 JW
 JW
@@ -37785,20 +39774,20 @@ JW
 pp
 Xb
 kP
-FI
-Sr
-Yp
-VM
-VM
-VM
-VM
-Sr
+FV
 eR
-NP
-Ks
+eR
+eR
+eR
+eR
+eR
+eR
+eR
+eR
+Qq
 pp
 Mx
-Ew
+op
 JW
 JW
 JW
@@ -38282,7 +40271,7 @@ JW
 JW
 JW
 JW
-JW
+vR
 qM
 pp
 Xb
@@ -38300,7 +40289,7 @@ PR
 Pq
 pp
 zn
-Ew
+op
 JW
 JW
 JW
@@ -38784,8 +40773,8 @@ JW
 JW
 JW
 JW
-JW
-JW
+Jn
+Tr
 pp
 Xb
 Xb
@@ -38802,7 +40791,7 @@ fq
 ko
 pp
 nU
-Ew
+op
 JW
 JW
 JW
@@ -39788,10 +41777,10 @@ JW
 JW
 JW
 JW
-JW
 bW
+ym
 bW
-kl
+aZ
 Bb
 VE
 bW
@@ -40289,9 +42278,9 @@ JW
 JW
 JW
 JW
-JW
 bW
 bW
+kS
 eq
 ed
 ed
@@ -40305,7 +42294,7 @@ Bl
 gP
 lS
 Qm
-JW
+Tr
 Yi
 JW
 JW
@@ -40791,9 +42780,9 @@ JW
 JW
 JW
 JW
-JW
 bW
-aK
+xx
+ed
 ed
 cx
 ld
@@ -40807,8 +42796,8 @@ KX
 gP
 fJ
 Qm
-JW
-JW
+Tr
+Va
 JW
 JW
 JW
@@ -41293,9 +43282,9 @@ JW
 JW
 JW
 JW
-JW
 bW
 bu
+ed
 ed
 ed
 YR
@@ -41793,11 +43782,11 @@ JW
 JW
 JW
 JW
-JW
 kn
-kn
+Mt
 bW
-KB
+Yd
+ed
 Sm
 yH
 yH
@@ -42295,11 +44284,11 @@ JW
 JW
 Vg
 Tr
-Tr
 wf
 oS
 bW
 Az
+ed
 VK
 ed
 ed
@@ -42797,16 +44786,16 @@ JW
 JW
 JW
 JW
-JW
 wf
-HT
+wh
 bW
 BF
+ed
 VK
 ed
 YR
 ed
-ed
+kl
 dh
 bW
 fR
@@ -42825,7 +44814,7 @@ uC
 uC
 uC
 uM
-JW
+Gh
 JW
 JW
 JW
@@ -43299,12 +45288,12 @@ JW
 JW
 JW
 JW
-JW
 wf
 oS
 bW
 bW
-Eg
+wO
+VK
 ed
 ed
 ed
@@ -43802,9 +45791,9 @@ JW
 JW
 JW
 wf
-wf
 HT
 HT
+bW
 bW
 RY
 ed
@@ -44304,17 +46293,17 @@ Mr
 Mr
 Mr
 wf
-cP
-OA
+hR
+HT
 hR
 bW
 bW
-zd
+zz
 zz
 gE
 gE
 hW
-kZ
+xq
 kZ
 fd
 kZ
@@ -44793,7 +46782,7 @@ JW
 JW
 JW
 JW
-JW
+eB
 JW
 JW
 JW
@@ -44806,7 +46795,7 @@ Mr
 pv
 jq
 qg
-jq
+FH
 jq
 jq
 CT
@@ -44815,7 +46804,7 @@ ed
 ed
 Gz
 Ju
-kZ
+xq
 ro
 RJ
 et
@@ -44823,7 +46812,7 @@ RJ
 CR
 ce
 VT
-wP
+Na
 OG
 mR
 uC
@@ -44833,7 +46822,7 @@ uC
 uC
 uC
 Yf
-JW
+Gh
 JW
 JW
 JW
@@ -45295,7 +47284,7 @@ JW
 JW
 JW
 JW
-JW
+eB
 JW
 JW
 JW
@@ -45797,7 +47786,7 @@ JW
 JW
 JW
 JW
-JW
+eB
 JW
 JW
 JW
@@ -46299,9 +48288,9 @@ JW
 JW
 JW
 JW
+eB
 JW
-JW
-JW
+vR
 Po
 Mr
 jf
@@ -46321,7 +48310,7 @@ ss
 ss
 gy
 QE
-cs
+QE
 UO
 tn
 PZ
@@ -46332,7 +48321,7 @@ FF
 uC
 uC
 uC
-OG
+XW
 uC
 uC
 uC
@@ -46801,10 +48790,10 @@ JW
 JW
 JW
 JW
+eB
 JW
-JW
-JW
-JW
+Jn
+Tr
 Mr
 Mm
 nF
@@ -47303,7 +49292,7 @@ JW
 JW
 JW
 JW
-JW
+eB
 JW
 JW
 JW
@@ -47805,7 +49794,7 @@ JW
 JW
 JW
 JW
-JW
+eB
 JW
 JW
 JW
@@ -48307,7 +50296,7 @@ JW
 JW
 JW
 JW
-JW
+eB
 JW
 JW
 JW
@@ -48347,7 +50336,7 @@ uC
 uC
 uC
 JM
-JW
+Gh
 JW
 JW
 JW
@@ -48823,16 +50812,16 @@ Mr
 Mr
 wf
 By
-vd
+HT
 hR
 Fk
 Fk
-hl
+dX
 dX
 gE
 gE
 Ee
-kZ
+zf
 kZ
 fd
 kZ
@@ -49322,11 +51311,11 @@ JW
 JW
 JW
 JW
-JW
 wf
 wf
 HT
 HT
+Fk
 Fk
 kG
 yx
@@ -49825,11 +51814,11 @@ JW
 JW
 JW
 JW
-JW
 wf
 oS
 Fk
 wj
+yx
 lg
 Xt
 yx
@@ -50208,8 +52197,8 @@ Xc
 Xc
 Xc
 Tu
-Xc
-Xc
+UL
+UL
 Tu
 Tu
 Tu
@@ -50327,10 +52316,10 @@ JW
 JW
 JW
 JW
-JW
 wf
-HT
+wh
 Fk
+yx
 yx
 lg
 wB
@@ -50355,7 +52344,7 @@ uC
 uC
 uC
 Wk
-JW
+Gh
 JW
 JW
 JW
@@ -50708,9 +52697,9 @@ Xc
 Xc
 Xc
 Xc
-Xc
-Xc
-Xc
+UL
+UL
+UL
 UL
 Tu
 Tu
@@ -50829,10 +52818,10 @@ JW
 JW
 Yn
 Tr
-Tr
 wf
 oS
 Fk
+yx
 yx
 lg
 no
@@ -50852,7 +52841,7 @@ OG
 uC
 uC
 tE
-pM
+jx
 uC
 uC
 Bh
@@ -51211,13 +53200,13 @@ Wz
 Wz
 Wz
 nH
-nH
-UL
-UL
-UL
-UL
-UL
-eH
+ie
+fE
+fE
+ks
+cL
+WG
+ek
 UL
 UL
 Tu
@@ -51331,11 +53320,11 @@ JW
 JW
 JW
 JW
-JW
 kn
-kn
+Mt
 Fk
-hl
+dX
+yx
 IC
 eV
 mc
@@ -51711,14 +53700,14 @@ Xc
 Xc
 Xc
 Xc
-Xc
 hu
+fe
 hu
-hu
+vT
 NI
 hu
 hu
-hu
+fe
 cu
 hu
 UL
@@ -51835,8 +53824,8 @@ JW
 JW
 JW
 JW
-JW
 Fk
+yx
 yx
 yx
 yx
@@ -52212,20 +54201,20 @@ Xc
 Xc
 Xc
 Xc
-Xc
 hu
 hu
 sY
 pd
 pd
 pd
+pd
 TF
 pd
-wY
+tX
 hu
 UL
 Tu
-Tu
+JW
 JW
 JW
 dF
@@ -52337,9 +54326,9 @@ JW
 JW
 JW
 JW
-JW
 Fk
 dt
+yx
 yx
 yx
 yx
@@ -52353,7 +54342,7 @@ ca
 Ef
 gX
 Vt
-JW
+Tr
 Ba
 JW
 JW
@@ -52706,28 +54695,28 @@ Xc
 Xc
 Xc
 Xc
-Ci
+vJ
 Xc
 Xc
-Ci
-Xc
+vJ
 Xc
 Xc
 Xc
 fe
 fe
+UA
 pd
 pd
 pd
-EU
+UA
 pd
 pd
 Qo
 Ss
 hu
+ks
 UL
-Tu
-Tu
+JW
 JW
 JW
 dF
@@ -52839,14 +54828,14 @@ JW
 JW
 JW
 JW
-JW
 Fk
 Fk
+yx
 hT
 ta
 yx
 yx
-dY
+dX
 yx
 Tc
 MG
@@ -52855,8 +54844,8 @@ di
 Ef
 rj
 Vt
-JW
-JW
+Tr
+Va
 JW
 JW
 JW
@@ -53208,18 +55197,18 @@ Xc
 Xc
 Xc
 Xc
-FN
+Ci
 Xc
 Xc
 Ci
 Xc
 Xc
 Xc
-Xc
 fe
 pd
 pd
-Im
+pd
+UA
 hu
 hu
 hu
@@ -53228,7 +55217,7 @@ wY
 Pi
 Zj
 WG
-Df
+WG
 KZ
 KZ
 KZ
@@ -53342,11 +55331,11 @@ JW
 JW
 JW
 JW
-JW
 Fk
+yb
 Fk
 ta
-dY
+dX
 yx
 KK
 KK
@@ -53717,20 +55706,20 @@ Ci
 Xc
 Xc
 Xc
-Xc
 fe
+Nc
 pd
 pd
-Im
+UA
 hu
 hu
 hu
-aO
-zF
+UA
+wY
 Ou
 hu
 UL
-Xx
+UL
 JW
 JW
 JW
@@ -53851,13 +55840,13 @@ KK
 KK
 KK
 KK
-XU
+gz
 nw
 nw
 Ty
 nw
 eD
-pK
+gz
 KK
 KK
 KK
@@ -54212,26 +56201,26 @@ Xc
 Xc
 Xc
 Xc
-Ci
+vJ
 Xc
 Xc
-Ci
-Xc
+vJ
 Xc
 Xc
 Xc
 fe
 fe
-Nc
+UA
 pd
 pd
-MF
 pd
-pd
+UA
+Qo
+Wy
 HD
 tG
-hu
-UL
+PP
+ks
 Xx
 Xx
 JW
@@ -54722,16 +56711,16 @@ Xc
 Xc
 Xc
 Xc
-Xc
 hu
 hu
 pd
 pd
 pd
 pd
+zm
 Ms
 pd
-wY
+tX
 hu
 UL
 Xx
@@ -55224,11 +57213,11 @@ Xc
 Xc
 Xc
 Xc
-Xc
-Xc
+UL
 hu
+fe
 hu
-hu
+vT
 NI
 hu
 hu
@@ -55353,8 +57342,8 @@ JW
 JW
 JW
 KK
-Sp
-Ta
+ln
+ln
 qj
 nw
 nw
@@ -55365,9 +57354,9 @@ nw
 ma
 nw
 nw
-Da
+nw
 Wr
-Jo
+Ep
 HP
 JW
 JW
@@ -55725,18 +57714,18 @@ KF
 Wz
 Wz
 Wz
-Wz
-Wz
-Wz
 nH
 nH
-UL
-UL
-UL
-UL
-UL
+nH
+ie
+PP
+pd
+pd
+hu
+Xx
+Xx
 eH
-UL
+ks
 UL
 Xx
 JW
@@ -55851,29 +57840,29 @@ JW
 JW
 JW
 JW
-fb
-Tr
-Tr
+JW
+JW
+JW
 KK
-KK
-KK
-KK
-XU
-Sn
-eM
-Wm
+Sp
+Ta
+qj
 nw
-Sn
-eM
-Wm
-pK
-KK
-KK
-KK
-KK
-Tr
-Tr
-zb
+nw
+Ty
+nw
+nw
+nw
+Ty
+nw
+nw
+Da
+Wr
+rJ
+HP
+JW
+JW
+JW
 JW
 JW
 JW
@@ -56223,18 +58212,18 @@ Xc
 Xc
 Xc
 Xc
-Ci
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
+RX
+Wf
+Wf
+Wf
+RX
 UL
-Xx
+UL
+UL
+fe
+pd
+UA
+hu
 Xx
 Xx
 YB
@@ -56353,29 +58342,29 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
+fb
+Tr
+Tr
 KK
-Da
-XD
-FP
-TO
-cV
-XD
-FP
-TO
+KK
+KK
+KK
+gz
+Sn
+eM
+Wm
 nw
+Sn
+eM
+Wm
+gz
 KK
-JW
-JW
-JW
-JW
-JW
-JW
+KK
+KK
+KK
+Tr
+Tr
+zb
 JW
 JW
 JW
@@ -56725,18 +58714,18 @@ Xc
 Xc
 Xc
 Xc
-Ci
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xx
-Xx
+RX
+Wo
+Yk
+YI
+RX
+RX
+RX
+RX
+RX
+pd
+pd
+hu
 Xx
 Xx
 YB
@@ -56862,15 +58851,15 @@ JW
 JW
 JW
 KK
-KK
-KK
-KK
-KK
-KK
-KK
-KK
-KK
-KK
+Da
+ME
+Yc
+aC
+gz
+ME
+Yc
+aC
+nw
 KK
 JW
 JW
@@ -57227,18 +59216,18 @@ Xc
 Xc
 Xc
 Xc
-Ci
-Xc
-Xc
-Xc
-Xc
-Xc
-Xc
-Xx
-Xx
-Xx
-Xx
-WQ
+RX
+WJ
+Yx
+YW
+RX
+fy
+vl
+Xh
+RX
+Qo
+Wy
+Ku
 WG
 WG
 Uv
@@ -57363,17 +59352,17 @@ JW
 JW
 JW
 JW
-eB
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-eB
+KK
+KK
+KK
+KK
+KK
+KK
+KK
+KK
+KK
+KK
+KK
 JW
 JW
 JW
@@ -57729,18 +59718,18 @@ Xc
 Xc
 Xc
 Xc
-Ci
-Xc
-Xc
-Xc
-Xc
-Xx
-Xx
-Xx
-Xx
-Xx
-Xx
-YB
+wr
+nJ
+Ra
+Zg
+RX
+aN
+lb
+Lp
+RX
+VA
+pd
+hu
 Xx
 Xx
 Xx
@@ -58231,21 +60220,21 @@ Xc
 Xc
 Xc
 Xc
-Ci
-Xc
-TB
-Wa
-Wa
-WG
-WG
-WG
-aW
-WG
-WG
-Uv
+RX
+Bm
+Ra
+Zr
+fr
+bR
+Ra
+Ny
+RX
+JA
+pd
+hu
 Xx
 Xx
-JW
+Xx
 Xx
 Xx
 Xx
@@ -58367,7 +60356,7 @@ JW
 JW
 JW
 JW
-Yn
+eB
 JW
 JW
 JW
@@ -58377,7 +60366,7 @@ JW
 JW
 JW
 JW
-Yn
+eB
 JW
 JW
 JW
@@ -58730,24 +60719,24 @@ Xc
 Xc
 Xc
 Xc
-Xc
-Xc
-Xc
-Ci
-Xc
-Xc
-Xc
+RX
+RX
+RX
+RX
+nJ
+Ra
+Ra
+Ra
+Ra
+Ra
+Zg
+RX
+JA
+UA
+hu
 Xx
 Xx
 Xx
-Xx
-YB
-Xx
-Xx
-Xx
-Xx
-JW
-JW
 JW
 Xx
 Xx
@@ -58869,6 +60858,7 @@ JW
 JW
 JW
 JW
+Yn
 JW
 JW
 JW
@@ -58878,8 +60868,7 @@ JW
 JW
 JW
 JW
-JW
-JW
+Yn
 JW
 JW
 JW
@@ -59232,23 +61221,23 @@ Xc
 Xc
 Xc
 Xc
-TB
-Wa
-WC
-Ci
-Xc
-Xc
-Xc
+RX
+uU
+Ra
+Hg
+nJ
+Ra
+Ra
+Ra
+Ra
+Ra
+da
+kI
+Ik
+it
+hu
 Xx
 Xx
-Xx
-Xx
-YB
-Xx
-Xx
-Xx
-JW
-JW
 JW
 JW
 JW
@@ -59734,22 +61723,22 @@ Xc
 Xc
 Xc
 Xc
-Xc
-Xc
-tB
-Ci
-Xc
-Xc
-Xc
+RX
+qD
+gp
+RX
+Cj
+SR
+dL
+ej
+rL
+Ln
+sH
+RX
+lI
+hu
+hu
 Xx
-Xx
-Xx
-Xx
-YB
-Xx
-Xx
-JW
-JW
 JW
 JW
 Xx
@@ -60228,27 +62217,27 @@ Xx
 Xx
 YB
 Xx
+Xc
+Xc
+Xc
+Xc
+Xc
+Xc
+Xc
+Xc
 RX
-Wf
-Wf
-Wf
 RX
-Xc
-Xc
-Xc
-Xc
-Xc
-TL
-Ci
-Xc
-Xc
-Xx
-Xx
-Xx
-Xx
-Xx
+RX
+RX
+RX
+RX
+RX
+RX
+RX
+RX
+RX
+RX
 YB
-Xx
 Xx
 Xx
 Xx
@@ -60726,31 +62715,31 @@ JW
 JW
 Xx
 Xx
-WQ
-WG
-Uv
-Xx
-RX
-Wo
-Yk
-YI
-RX
-RX
-RX
-RX
-RX
-Xc
-TL
-Ci
-Xx
-Xx
-Xx
-Xx
-Xx
 Xx
 Xx
 YB
 Xx
+Xc
+Xc
+Xx
+Xx
+Xc
+Xc
+Xc
+Xc
+Xc
+Xc
+CO
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+do
+hp
 Xx
 Xx
 Xx
@@ -61228,22 +63217,22 @@ JW
 JW
 Xx
 Xx
-YB
-RX
-RX
-RX
-RX
-WJ
-Yx
-YW
-RX
-fy
-vl
-Xh
-RX
+Xx
 Xx
 YB
+Xx
+Xc
+Xc
+Xx
+Xx
+Xx
+Xc
+Xc
+Xc
+Xx
+Xx
 UL
+Xx
 Xx
 Xx
 Xx
@@ -61730,21 +63719,21 @@ JW
 JW
 Xx
 Xx
-YB
-RX
-jP
-Ra
-Hg
-nJ
-Ra
-Zg
-RX
-aN
-lb
-Lp
-RX
 Xx
-ep
+Xx
+YB
+Xx
+Xc
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+WQ
 WG
 WG
 WG
@@ -62232,19 +64221,19 @@ JW
 JW
 Xx
 Xx
+Xx
+Xx
 YB
-RX
-sJ
-gp
-RX
-WR
-Ra
-Zr
-Ls
-bR
-Ra
-FU
-RX
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
 Xx
 YB
 Xx
@@ -62734,19 +64723,19 @@ JW
 JW
 Xx
 Xx
+Xx
+Xx
 YB
-RX
-RX
-RX
-RX
-nJ
-Ra
-Ra
-Ra
-Ra
-Ra
-Zg
-RX
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
 Xx
 YB
 Xx
@@ -63236,21 +65225,21 @@ JW
 JW
 JW
 Xx
+Xx
+Xx
 um
 WG
-IG
-UL
-zy
-nJ
-Ra
-Ra
-Ra
-Ra
-Ra
-da
-kI
 WG
-Jr
+WG
+WG
+WG
+WG
+aW
+WG
+WG
+WG
+WG
+Uv
 Xx
 Xx
 Xx
@@ -63740,19 +65729,19 @@ JW
 Xx
 Xx
 Xx
-YB
 Xx
-RX
-jo
-SR
-ZI
-CS
-rL
-Ln
-sH
-RX
 Xx
-YB
+Xx
+Xx
+Xx
+Xx
+Xx
+eH
+Xx
+Xx
+Xx
+Xx
+Xx
 Xx
 Xx
 Xx
@@ -64242,19 +66231,19 @@ JW
 Xx
 Xx
 Xx
-YB
 Xx
-RX
-RX
-RX
-RX
-RX
-RX
-RX
-RX
-RX
 Xx
-YB
+Xx
+Xx
+Xx
+Xx
+Xx
+eH
+Xx
+Xx
+Xx
+Xx
+Xx
 Xx
 Xx
 Xx
@@ -64744,19 +66733,19 @@ JW
 JW
 JW
 Xx
-um
-WG
-WG
-WG
-WG
-WG
-WG
-aW
-WG
-WG
-WG
-WG
-Uv
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+Xx
+eH
+Xx
+Xx
+Xx
+Xx
+Xx
 Xx
 Xx
 Xx
@@ -74463,9 +76452,9 @@ JW
 JW
 JW
 JW
+mF
 cz
-cz
-cz
+mF
 JW
 JW
 JW
@@ -76971,13 +78960,13 @@ JW
 GF
 Dq
 Dq
-Dq
+vB
 Dq
 oJ
-oJ
+yC
 oJ
 Dq
-Dq
+vB
 Dq
 Dq
 AD
@@ -82711,7 +84700,7 @@ Sy
 Ir
 Rs
 BH
-Rs
+cK
 Rs
 Ir
 Sy
@@ -83213,7 +85202,7 @@ Sy
 Ir
 Rs
 Rs
-Rs
+PY
 EE
 Ir
 Sy
@@ -83715,7 +85704,7 @@ Sy
 Ir
 Rs
 Rs
-Rs
+hs
 Rs
 Ir
 Sy
@@ -85730,9 +87719,9 @@ Hb
 Ir
 Ir
 Ir
+uh
 JW
-JW
-cq
+Yo
 eF
 MS
 wx
@@ -86235,7 +88224,7 @@ Yb
 EX
 EX
 TU
-qT
+Ir
 Bp
 gZ
 JW
@@ -86737,7 +88726,7 @@ Yb
 EX
 EX
 TU
-qT
+Ir
 Pr
 gZ
 JW
@@ -87236,10 +89225,10 @@ Hb
 Ir
 Ir
 Ir
+uh
 JW
-JW
-xs
-TQ
+tr
+eF
 mu
 wx
 JW
@@ -88079,12 +90068,12 @@ JW
 JW
 im
 mT
-Dk
+at
 aD
 aD
 aD
 aD
-Fj
+at
 mT
 im
 JW
@@ -90088,10 +92077,10 @@ JW
 JW
 JW
 mT
-Dk
+at
 aD
 aD
-Fj
+at
 mT
 JW
 JW
@@ -90234,7 +92223,7 @@ JW
 JW
 zT
 VP
-KW
+kf
 cb
 ZY
 Ia
@@ -91237,7 +93226,7 @@ JW
 JW
 JW
 zT
-VP
+vh
 zT
 Sy
 Sy
@@ -92240,9 +94229,9 @@ JW
 JW
 JW
 JW
-ad
-ad
-ad
+kN
+XG
+XG
 Sy
 Sy
 Sy
@@ -125323,14 +127312,14 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+vR
+Tr
+Tr
+Tr
+Tr
+Tr
+Tr
+pg
 JW
 JW
 JW
@@ -125824,16 +127813,16 @@ JW
 JW
 JW
 JW
+vR
+Va
 JW
 JW
 JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
+Jn
+pg
 JW
 JW
 JW
@@ -126326,6 +128315,7 @@ JW
 JW
 JW
 JW
+ge
 JW
 JW
 JW
@@ -126334,8 +128324,7 @@ JW
 JW
 JW
 JW
-JW
-JW
+ge
 JW
 JW
 JW
@@ -126472,16 +128461,16 @@ JW
 JW
 JW
 JW
-Oh
+ay
 xP
 xP
-xP
+ZA
 Lb
 Lb
+ZA
 xP
 xP
-xP
-ti
+Ly
 JW
 JW
 JW
@@ -126828,16 +128817,16 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+fV
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+fV
 JW
 JW
 JW
@@ -127328,20 +129317,20 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-Wx
-JW
-JW
-JW
-JW
-rR
-JW
-JW
+fV
+fV
+fV
+VQ
+pI
+Sb
+bC
+kV
+qK
+Xf
+VQ
+fV
+fV
+fV
 JW
 JW
 JW
@@ -127827,26 +129816,26 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-tY
-JW
-JW
-JW
-JW
-tY
-JW
-JW
-JW
-JW
-JW
+fV
+fV
+fV
+fV
+Qu
+GI
+bC
+ZW
+yP
+bC
+bC
+yP
+yP
+bC
+GI
+iP
+fV
+fV
+fV
+fV
 JW
 JW
 JW
@@ -127981,10 +129970,10 @@ JW
 JW
 JW
 JW
-JW
+PJ
 Lg
 Lg
-JW
+PJ
 JW
 JW
 JW
@@ -128329,26 +130318,26 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-tY
-JW
-JW
-JW
-JW
-tY
-JW
-JW
-JW
-JW
-JW
+GI
+QM
+ly
+QU
+bC
+GI
+bC
+FB
+bC
+bC
+bC
+bC
+bC
+bC
+GI
+bC
+ls
+bE
+lM
+GI
 JW
 JW
 JW
@@ -128483,10 +130472,10 @@ JW
 JW
 JW
 JW
-Za
-Lx
-Lx
-Za
+AN
+CC
+CC
+AN
 JW
 JW
 JW
@@ -128826,36 +130815,36 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+JF
+FL
+FL
+FL
+FL
+rD
+xz
+BG
+pL
+pL
 tY
-fV
-JW
-JW
-fV
+pL
+Tz
+Xs
+po
+MK
+Xs
+pL
+pL
 tY
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+pL
+pL
+pL
+wo
+rD
+FL
+FL
+FL
+FL
+Ki
 JW
 JW
 JW
@@ -128985,10 +130974,10 @@ JW
 JW
 JW
 JW
-Za
-LG
+AN
 Ob
-Za
+Ob
+AN
 JW
 JW
 JW
@@ -129333,26 +131322,26 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-fV
+GI
+rl
+bC
+bC
+bC
+GI
+bC
+bC
+og
 td
-fV
-JW
-JW
-fV
-td
-fV
-JW
-JW
-JW
-JW
+wk
+og
+bC
+bC
+GI
+bC
+bC
+EN
+KD
+GI
 JW
 JW
 JW
@@ -129835,26 +131824,26 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
 fV
 fV
 fV
-FB
-fV
+On
+vD
 GI
-GI
-fV
+bC
+bC
+og
+bC
 FB
+og
+bC
+bC
+GI
+Bq
+wZ
 fV
 fV
 fV
-JW
-JW
 JW
 JW
 JW
@@ -130339,21 +132328,21 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
 fV
+fV
+fV
+GI
 bC
 bC
-hq
-Dg
-CB
-aB
-CB
-Iu
-Rv
 bC
+bC
+FB
+bC
+bC
+bC
+GI
+fV
+fV
 fV
 JW
 JW
@@ -130503,7 +132492,7 @@ JW
 JW
 JW
 Oh
-ti
+Ly
 JW
 JW
 JW
@@ -130835,34 +132824,34 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
 ut
 Gf
 JW
 JW
+JW
+JW
+JW
+JW
 fV
 fV
-bC
+iM
 bC
 bC
 bC
 FB
 bC
 bC
-bC
+VQ
 fV
 fV
+JW
+JW
+JW
+JW
 JW
 JW
 ut
 Gf
-JW
-JW
 JW
 JW
 JW
@@ -131337,34 +133326,34 @@ JW
 JW
 JW
 JW
+kQ
+kQ
 JW
 JW
 JW
 JW
-JW
-JW
-xj
-fk
 JW
 JW
 JW
 fV
-fV
-fV
-zB
+HK
+bC
+bC
 bC
 FB
+bC
+bC
 HK
 fV
-fV
-fV
 JW
 JW
 JW
-xj
-fk
 JW
 JW
+JW
+JW
+kQ
+kQ
 JW
 JW
 JW
@@ -131839,34 +133828,34 @@ JW
 JW
 JW
 JW
+No
+kQ
 JW
 JW
-JW
-JW
-JW
-JW
-xj
-fk
 JW
 JW
 JW
 JW
 JW
 fV
-bC
-bC
-FB
-bC
+fV
+fV
+yW
+GI
+Ag
+yW
+fV
+fV
 fV
 JW
 JW
 JW
 JW
 JW
-xj
-fk
 JW
 JW
+kQ
+No
 JW
 JW
 JW
@@ -132004,12 +133993,12 @@ EK
 Za
 Za
 Za
-Za
-Za
-JW
+AN
+AN
+PJ
 JW
 uT
-uT
+xr
 JW
 JW
 JW
@@ -132341,34 +134330,34 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-xj
-fk
+kQ
+kQ
 JW
 JW
 JW
 JW
 JW
 fV
+fV
+fV
+fV
+VQ
 bC
 bC
 FB
 bC
+VQ
+fV
+fV
+fV
 fV
 JW
 JW
 JW
 JW
 JW
-xj
-fk
-JW
-JW
+kQ
+kQ
 JW
 JW
 JW
@@ -132507,7 +134496,7 @@ Vy
 OR
 ZD
 uL
-ZD
+vq
 WS
 WS
 sQ
@@ -132843,34 +134832,34 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-xj
-fk
+kQ
+kQ
 JW
 JW
 JW
 JW
 fV
 fV
+bC
+bC
+gm
+bC
+bC
+na
+ou
+bC
+bC
+gm
+bC
+bC
 fV
-zB
-MP
-fV
-fV
 fV
 JW
 JW
 JW
 JW
-xj
-fk
-JW
-JW
+kQ
+kQ
 JW
 JW
 JW
@@ -133002,14 +134991,14 @@ MM
 zl
 DM
 HZ
-DV
-DV
-EA
+xa
+qt
+KN
 RS
-Fd
-ZD
+nY
+wK
 wy
-ZD
+vq
 WS
 WS
 sQ
@@ -133345,34 +135334,34 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
 nM
-Kx
-vr
-vr
-vr
-gm
-gm
-fp
-bC
-bC
-FB
-bC
-fp
-gm
-gm
-vr
-vr
+to
 vr
 Kx
+vr
+Qv
+NC
+gm
+bC
+bC
+GI
+bC
+bC
+fp
+cJ
+bC
+bC
+GI
+bC
+bC
+gm
+NC
+Qv
+vr
+Kx
+vr
+to
 uV
-JW
-JW
 JW
 JW
 JW
@@ -133504,18 +135493,18 @@ MM
 zS
 DV
 Ic
-DV
+vF
 DV
 EK
 Za
 Za
 Za
-Za
-Za
-JW
+AN
+AN
+PJ
 JW
 uT
-uT
+xr
 JW
 JW
 JW
@@ -133847,34 +135836,34 @@ JW
 JW
 JW
 JW
+No
+kQ
 JW
 JW
 JW
-JW
-JW
-JW
-nM
-Kx
-vr
-vr
-vr
-gm
-gm
-fp
+Qv
+Gv
+GI
+bC
+VQ
+GI
 bC
 bC
-FB
-bC
-fp
-gm
-gm
-vr
-vr
-vr
-Kx
-uV
+Hq
+be
+pL
+pL
+rD
+pL
+ND
+rD
+wU
+Qv
 JW
 JW
+JW
+kQ
+No
 JW
 JW
 JW
@@ -134004,9 +135993,9 @@ JW
 JW
 MM
 Bo
-DV
-Iw
-DV
+qt
+DK
+Ub
 Ic
 zH
 Vy
@@ -134349,32 +136338,48 @@ JW
 JW
 JW
 JW
+nM
+to
+vr
+Kx
+vr
+Qv
+NC
+gm
+bC
+bC
+GI
+bC
+bC
+cH
+QQ
+bC
+bC
+GI
+bC
+bC
+gm
+CA
+Qv
+vr
+Kx
+vr
+to
+uV
 JW
 JW
 JW
 JW
 JW
 JW
-xj
-fk
 JW
 JW
 JW
 JW
-fV
-fV
-fV
-zB
-FB
-fV
-fV
-fV
 JW
 JW
 JW
 JW
-xj
-fk
 JW
 JW
 JW
@@ -134482,23 +136487,7 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-Oh
+ay
 ti
 JW
 JW
@@ -134851,34 +136840,34 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-xj
-fk
-JW
+kQ
+kQ
 JW
 JW
 JW
 JW
 fV
+fV
+bC
+bC
+gm
+bC
+bC
+na
 ns
 bC
-FB
 bC
+gm
+bC
+bC
+fV
 fV
 JW
 JW
 JW
 JW
-JW
-xj
-fk
-JW
-JW
+kQ
+kQ
 JW
 JW
 JW
@@ -135021,7 +137010,7 @@ JW
 JW
 JW
 wG
-ur
+RF
 JW
 JW
 JW
@@ -135353,34 +137342,34 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-xj
-fk
+kQ
+kQ
 JW
 JW
 JW
 JW
 JW
 fV
+fV
+fV
+fV
+VQ
 bC
 bC
 FB
 bC
+VQ
+fV
+fV
+fV
 fV
 JW
 JW
 JW
 JW
 JW
-xj
-fk
-JW
-JW
+kQ
+kQ
 JW
 JW
 JW
@@ -135505,9 +137494,9 @@ JW
 uT
 uT
 JW
-JW
-Za
-Za
+PJ
+AN
+AN
 Za
 Cx
 EA
@@ -135515,7 +137504,7 @@ Ps
 Nd
 Nd
 Ps
-RS
+TS
 SZ
 MM
 JW
@@ -135855,34 +137844,34 @@ JW
 JW
 JW
 JW
+No
+kQ
 JW
 JW
 JW
-JW
-JW
-JW
-xj
-fk
 JW
 JW
 JW
 JW
 fV
-fV
-zB
+iS
+iS
+bC
 bC
 FB
-HK
+bC
+bC
+NV
 fV
-fV
 JW
 JW
 JW
 JW
-xj
-fk
 JW
 JW
+JW
+kQ
+No
 JW
 JW
 JW
@@ -136008,8 +137997,8 @@ sy
 sQ
 WS
 WS
-ZD
-uL
+vq
+OW
 ZD
 Cx
 EK
@@ -136357,34 +138346,34 @@ JW
 JW
 JW
 JW
+kQ
+kQ
 JW
 JW
 JW
 JW
-JW
-JW
-eE
-OD
 JW
 JW
 JW
 fV
-fV
-bC
+pT
+pT
 bC
 bC
 FB
 bC
 bC
+Ej
 fV
-fV
 JW
 JW
 JW
-eE
-OD
 JW
 JW
+JW
+JW
+kQ
+kQ
 JW
 JW
 JW
@@ -136510,8 +138499,8 @@ sy
 sQ
 WS
 WS
-ZD
-wy
+vq
+OW
 ZD
 Cz
 Fd
@@ -136859,32 +138848,34 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
+eE
+OD
 JW
 JW
 JW
 JW
 fV
+GI
+GI
 fV
-bC
-bC
+Dt
+iS
 bC
 bC
 FB
 bC
 bC
-bC
+yk
 fV
+GI
+GI
 fV
 JW
 JW
 JW
 JW
+eE
+OD
 JW
 JW
 JW
@@ -137006,14 +138997,12 @@ JW
 JW
 JW
 JW
-JW
-JW
+xr
 uT
-uT
 JW
-JW
-Za
-Za
+PJ
+AN
+AN
 Za
 Za
 Za
@@ -137365,26 +139354,26 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
+fV
+GI
+fV
+fY
 GI
 bC
-oY
-CB
-CB
-CB
-Ji
-zQ
-CB
-QI
+bC
+bC
+bC
+bC
+FB
+bC
+bC
+bC
 bC
 GI
-JW
-JW
+hK
+fV
+GI
+fV
 JW
 JW
 JW
@@ -137521,7 +139510,7 @@ JW
 JW
 Za
 NY
-OO
+Jv
 Rh
 MM
 JW
@@ -137866,28 +139855,28 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-GI
+fV
+fV
+wA
+VQ
 bC
-FB
-ZH
-bC
-dk
-dk
+Of
+oY
+pL
+pL
+pL
+pL
+Yw
+pL
+pL
 hx
-ZH
-FB
+QI
+Of
 bC
-GI
-JW
-JW
-JW
+VQ
+ls
+fV
+fV
 JW
 JW
 JW
@@ -138368,25 +140357,28 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+fV
+fV
+bC
+bC
+bC
 GI
+FB
+dk
 ii
-ZT
-fV
-fV
-fV
-fV
-fV
-fV
-ZT
-ql
+kr
+kr
+kr
+kr
+rW
+zR
+FB
 GI
+bC
+bC
+bC
+fV
+fV
 JW
 JW
 JW
@@ -138511,10 +140503,7 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-wG
+Ut
 ur
 JW
 JW
@@ -138870,28 +140859,28 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
 fV
 fV
+Is
+iW
+Ed
+GI
+FB
+fV
+GI
+GI
+GI
+GI
+GI
+GI
+fV
+FB
+GI
+pb
+pb
+pb
 fV
 fV
-Eq
-Eq
-Eq
-Eq
-fV
-fV
-fV
-fV
-JW
-JW
-JW
 JW
 JW
 JW
@@ -139372,28 +141361,28 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
 fV
-Eq
-Eq
 fV
-JW
-JW
-JW
-JW
+GI
+GI
+GI
 fV
-Eq
-Eq
+LL
 fV
-JW
-JW
-JW
+Yt
+Ry
+hL
+Yt
+Ry
+hL
+fV
+LL
+fV
+GI
+GI
+GI
+fV
+fV
 JW
 JW
 JW
@@ -139875,26 +141864,26 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
 fV
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+Yt
+Ry
+hL
 fV
-JW
-JW
+Td
+fV
+eK
+eK
+eK
+eK
+eK
+eK
+fV
+Td
+fV
+Yt
+Ry
+hL
+fV
 JW
 JW
 JW
@@ -140377,11 +142366,10 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
+fV
+eK
+eK
+eK
 JW
 fV
 JW
@@ -140392,11 +142380,12 @@ JW
 JW
 JW
 JW
-JW
-JW
 fV
 JW
-JW
+eK
+eK
+eK
+fV
 JW
 JW
 JW
@@ -140879,6 +142868,12 @@ JW
 JW
 JW
 JW
+fV
+JW
+JW
+JW
+JW
+UH
 JW
 JW
 JW
@@ -140887,18 +142882,12 @@ JW
 JW
 JW
 JW
+UH
 JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+fV
 JW
 JW
 JW
@@ -141381,6 +143370,7 @@ JW
 JW
 JW
 JW
+UH
 JW
 JW
 JW
@@ -141399,8 +143389,7 @@ JW
 JW
 JW
 JW
-JW
-JW
+UH
 JW
 JW
 JW
@@ -164024,7 +166013,7 @@ Xp
 Xp
 Xp
 mw
-xo
+SI
 Jd
 Wv
 Wv
@@ -164522,7 +166511,7 @@ Wv
 Wv
 Wv
 Jd
-Kc
+Hy
 kA
 Xp
 Xp
@@ -166037,7 +168026,7 @@ Qg
 ry
 Fn
 IX
-oz
+ph
 AR
 At
 WV
@@ -166541,12 +168530,12 @@ qn
 SK
 oz
 oz
-oz
+Ap
 WV
 JW
 JW
 aA
-aA
+Ce
 JW
 JW
 JW
@@ -167043,7 +169032,7 @@ xg
 Ec
 oz
 oz
-oz
+Ap
 SK
 JW
 JW
@@ -167534,7 +169523,7 @@ Wv
 Wv
 Wv
 Jd
-xo
+mW
 md
 jl
 Xp
@@ -167545,7 +169534,7 @@ LA
 OY
 oz
 oz
-oz
+Ap
 SK
 JW
 JW
@@ -168049,10 +170038,10 @@ oz
 oz
 Mk
 SK
-JW
+ws
 JW
 aA
-aA
+Ce
 JW
 JW
 JW
@@ -168549,9 +170538,9 @@ SK
 oz
 oz
 oz
-oz
+uf
 oX
-yF
+Zs
 yF
 vZ
 pH
@@ -168865,12 +170854,12 @@ JW
 fB
 gb
 gb
-gb
+Zd
 YH
 bY
 Zd
-Zd
-Zd
+gb
+gb
 rh
 JW
 JW
@@ -169053,7 +171042,7 @@ lu
 YV
 lu
 SK
-JW
+gV
 JW
 JW
 JW
@@ -169370,9 +171359,9 @@ gb
 gb
 cY
 Te
-Zd
-Zd
-Zd
+gb
+gb
+gb
 Gb
 JW
 JW
@@ -170371,10 +172360,10 @@ JW
 JW
 JW
 JW
-JW
+DI
 Oo
 fG
-JW
+DI
 JW
 JW
 JW
@@ -170386,8 +172375,8 @@ ah
 ah
 oL
 oL
-ah
-ah
+QB
+JV
 Hs
 JW
 JW
@@ -170873,10 +172862,10 @@ JW
 JW
 JW
 JW
-JW
+eI
 Oo
 fG
-JW
+eI
 JW
 JW
 JW
@@ -170889,7 +172878,7 @@ Gn
 Gn
 Gn
 Gn
-ah
+Hr
 Hs
 JW
 JW
@@ -171389,9 +173378,9 @@ Hs
 ah
 Cl
 fo
-ah
-ah
-ah
+XV
+KO
+Xe
 Hs
 JW
 JW
@@ -172393,7 +174382,7 @@ vi
 vi
 XB
 BJ
-vi
+HA
 XB
 vi
 vi
@@ -172895,7 +174884,7 @@ KE
 aa
 aa
 XL
-aa
+Ye
 aa
 aa
 nj
@@ -173395,10 +175384,10 @@ qq
 gU
 jJ
 aj
-lG
-Tw
-Tw
-lG
+Jk
+HO
+JQ
+Jk
 ch
 jJ
 Vh
@@ -173901,7 +175890,7 @@ qq
 kJ
 kJ
 qq
-iK
+wC
 jJ
 Vh
 Zo
@@ -174905,7 +176894,7 @@ kJ
 JW
 JW
 kJ
-iK
+wC
 jJ
 Vh
 Zo
@@ -175390,8 +177379,8 @@ JW
 JW
 JW
 Hn
-Zb
-hz
+IW
+Py
 Og
 TM
 Hn
@@ -175407,7 +177396,7 @@ kJ
 JW
 JW
 kJ
-iK
+wC
 jJ
 om
 RD
@@ -175418,7 +177407,7 @@ RD
 RC
 Em
 Em
-Em
+GD
 bU
 JW
 JW
@@ -175909,7 +177898,7 @@ kJ
 JW
 JW
 kJ
-iK
+wC
 jJ
 Xd
 rH
@@ -176411,7 +178400,7 @@ qq
 JW
 JW
 qq
-iK
+wC
 jJ
 is
 is
@@ -176422,7 +178411,7 @@ dO
 HU
 HU
 HU
-Em
+KC
 dO
 JW
 JW
@@ -176906,7 +178895,7 @@ jJ
 bf
 gj
 gj
-gj
+SE
 HX
 gj
 gj
@@ -176917,14 +178906,14 @@ Kd
 AC
 aa
 aa
-aa
+aI
 Xl
 Nm
 DX
 UT
 GN
-Em
-Em
+kw
+yD
 dO
 JW
 JW
@@ -177419,11 +179408,11 @@ PO
 Sq
 ev
 JK
-ch
+pA
 jJ
 vc
 dO
-HV
+JI
 ZE
 Em
 Em
@@ -177921,7 +179910,7 @@ FJ
 Sx
 FJ
 hV
-iK
+wC
 jJ
 vc
 dO
@@ -178925,7 +180914,7 @@ DG
 Vi
 Tt
 FJ
-iK
+wC
 jJ
 MV
 vi
@@ -179408,14 +181397,14 @@ VO
 Aw
 qq
 ww
-jJ
-aj
+fx
+hZ
 by
 by
 by
 cB
 gj
-Eb
+SE
 gj
 gj
 gj
@@ -179425,9 +181414,9 @@ hV
 QZ
 iy
 Vi
-Tt
+SP
 FJ
-iK
+wC
 th
 aa
 qh
@@ -179946,7 +181935,7 @@ JW
 JW
 JW
 sF
-sF
+Xv
 JW
 JW
 JW
@@ -180429,11 +182418,11 @@ FJ
 fW
 hd
 Vi
-SP
+mh
 hV
 hV
 hV
-iK
+wC
 jJ
 xY
 Sz
@@ -180444,8 +182433,8 @@ Sz
 CM
 CM
 Sz
-JW
-JW
+VS
+DI
 JW
 sF
 sF
@@ -180914,8 +182903,8 @@ Uu
 IK
 zD
 kz
-Qj
-MO
+gk
+LS
 kJ
 JW
 JW
@@ -180930,12 +182919,12 @@ JW
 FJ
 fz
 Bx
-Vi
+OH
 IB
 IV
 xy
 FJ
-iK
+wC
 jJ
 MO
 CM
@@ -180946,7 +182935,7 @@ wd
 Rn
 yJ
 SJ
-qG
+lR
 qG
 qG
 BP
@@ -181413,11 +183402,11 @@ JW
 VO
 Os
 Fy
-kT
+Vl
 qq
 JH
 jJ
-xY
+Vx
 qq
 kJ
 kJ
@@ -181432,18 +183421,18 @@ JW
 hV
 hV
 oM
+Ok
 Vi
-Vi
-Vi
-Tt
+sL
+Zc
 Xi
-iK
+gD
 jJ
 MO
 CM
 gn
 ft
-wg
+Ds
 SU
 qu
 wg
@@ -181919,7 +183908,7 @@ kT
 qq
 Rj
 jJ
-sM
+YD
 GJ
 GJ
 GJ
@@ -181939,7 +183928,7 @@ eP
 Gw
 BK
 FJ
-iK
+wC
 jJ
 xY
 Sz
@@ -181950,8 +183939,8 @@ Sz
 CM
 CM
 Sz
-JW
-JW
+eI
+DI
 JW
 sF
 sF
@@ -182425,9 +184414,9 @@ aa
 aa
 aa
 qh
-MO
+ZS
 Gq
-pW
+qk
 Iy
 fw
 vY
@@ -182441,11 +184430,11 @@ FJ
 FJ
 FJ
 hV
-iK
-jJ
-MO
+bM
+Uz
+EB
 ax
-gn
+nA
 pV
 Ds
 Sz
@@ -182456,7 +184445,7 @@ JW
 JW
 JW
 sF
-sF
+Xv
 JW
 JW
 JW
@@ -182927,7 +184916,7 @@ is
 is
 is
 jJ
-MO
+ZS
 Gq
 XY
 kU
@@ -183429,7 +185418,7 @@ nP
 sS
 La
 jJ
-MO
+ZS
 Gq
 Tg
 kU
@@ -183445,7 +185434,7 @@ iK
 KE
 aa
 aa
-aa
+Ye
 JJ
 MO
 Sz
@@ -183931,7 +185920,7 @@ GW
 Gj
 XO
 jJ
-MO
+ZS
 Ch
 pW
 Et
@@ -183947,9 +185936,13 @@ iK
 jJ
 OU
 Vv
-Vv
+Zu
 xn
 iN
+qq
+zu
+jB
+Hm
 qq
 JW
 JW
@@ -183957,12 +185950,8 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
 Uk
-xu
+aE
 JW
 JW
 JW
@@ -184421,8 +186410,8 @@ JW
 JW
 sF
 sF
-JW
-JW
+eI
+DI
 Gj
 GW
 GW
@@ -184433,10 +186422,10 @@ IM
 GW
 Rj
 jJ
-MO
+ZS
 Ch
 cf
-Kr
+JT
 Kr
 uG
 sj
@@ -184445,18 +186434,18 @@ JW
 JW
 JW
 qq
-Kd
+mG
 jJ
 Mf
 qq
+Iv
 qq
 qq
 qq
+EO
+Hm
+LT
 qq
-JW
-JW
-JW
-JW
 JW
 JW
 JW
@@ -184935,7 +186924,7 @@ zJ
 lH
 Rj
 jJ
-xY
+Vx
 Gq
 Gq
 Fc
@@ -184951,14 +186940,14 @@ iK
 jJ
 vc
 qq
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+yf
+Er
+vC
+Er
+lt
+Hm
+sp
+qq
 JW
 JW
 JW
@@ -185425,8 +187414,8 @@ JW
 JW
 sF
 sF
-JW
-JW
+eI
+DI
 Gj
 GW
 Ug
@@ -185440,10 +187429,10 @@ Qj
 sM
 GJ
 yK
-GJ
+WU
 GJ
 aw
-yK
+sz
 GJ
 GJ
 GJ
@@ -185453,14 +187442,14 @@ QF
 jJ
 vc
 qq
-JW
-JW
-JW
-JW
-JW
-JW
-JW
-JW
+Oi
+Oi
+bt
+bn
+cD
+jB
+NR
+qq
 JW
 JW
 JW
@@ -185939,30 +187928,30 @@ dr
 GW
 Rj
 th
-aa
+Ye
 aa
 aa
 aa
 aa
 XL
+Ye
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+Ye
 FW
 Mf
 GA
 GA
 GA
 GA
-JW
-JW
-JW
-JW
-JW
+Oi
+Oi
+Oi
+Hm
+qq
 JW
 JW
 JW
@@ -186427,7 +188416,7 @@ JW
 JW
 JW
 JW
-Uk
+qX
 xu
 JW
 JW
@@ -186441,30 +188430,30 @@ Gj
 Gj
 uv
 nP
-nP
+ik
 sS
 nP
 La
 is
 is
-is
+oW
 is
 is
 is
 nK
 lG
-Tw
+YN
 Xu
 bz
 Lu
 ac
 dp
 GA
-JW
-JW
-JW
-JW
-JW
+Cy
+el
+Oi
+Hm
+qq
 JW
 JW
 JW
@@ -186949,7 +188938,7 @@ qq
 gM
 Tw
 Tw
-Tw
+Ox
 Tw
 Tw
 Tw
@@ -186962,11 +188951,11 @@ GA
 KG
 Pz
 GA
-JW
-JW
-JW
-JW
-JW
+el
+Vs
+Oi
+Jp
+qq
 JW
 JW
 JW
@@ -187451,7 +189440,7 @@ GA
 kF
 Ay
 sc
-Ay
+EV
 sc
 Ay
 Ay
@@ -187461,14 +189450,14 @@ CN
 TN
 kv
 uk
+qb
 Pz
-NW
 GA
 GA
-JW
-JW
-JW
-JW
+qq
+qq
+LQ
+qq
 JW
 JW
 JW
@@ -187953,7 +189942,7 @@ GA
 RN
 Pz
 DL
-Pz
+qb
 DL
 Pz
 Pz
@@ -187963,14 +189952,14 @@ Pz
 Pz
 Pz
 Pz
-Pz
+qb
 Pz
 Pz
 Zh
 JW
-JW
-JW
-JW
+qq
+EZ
+qq
 JW
 JW
 JW
@@ -188455,7 +190444,7 @@ GA
 rw
 bc
 GS
-Pz
+ZN
 pf
 GC
 bc
@@ -188464,8 +190453,8 @@ Zn
 Pz
 Pz
 Pz
-RK
 Pz
+qb
 bP
 Pz
 Zh
@@ -188964,11 +190953,11 @@ GA
 GA
 GA
 jO
+RK
 Pz
 Pz
+qb
 Pz
-Pz
-iO
 Pz
 Zh
 JW
@@ -189465,13 +191454,13 @@ JW
 JW
 JW
 GA
-pl
-Tx
-zh
-hr
-GA
-GA
-GA
+Pz
+Pz
+Pz
+Pz
+ZN
+FM
+NW
 GA
 JW
 JW
@@ -189967,14 +191956,14 @@ JW
 JW
 JW
 GA
+pl
+Tx
+jC
+hr
 GA
-Zh
-Zh
 GA
 GA
-JW
-JW
-JW
+GA
 JW
 JW
 JW
@@ -190468,12 +192457,12 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
-JW
-JW
+GA
+GA
+Zh
+Zh
+GA
+GA
 JW
 JW
 JW
@@ -196708,7 +198697,7 @@ JW
 JW
 JW
 as
-mL
+RV
 XJ
 RV
 as
@@ -220414,8 +222403,8 @@ JW
 JW
 JW
 JW
-Yy
 JW
+Yy
 JW
 JW
 JW
@@ -220910,15 +222899,15 @@ JW
 JW
 PX
 co
-JW
-JW
-JW
-JW
-JW
-JW
+Tr
+Tr
+Tr
+Tr
+Tr
+Tr
+Tr
 co
 Wn
-JW
 JW
 JW
 JW
@@ -221418,8 +223407,8 @@ JW
 JW
 JW
 JW
-ge
 JW
+ge
 JW
 JW
 JW
@@ -221920,8 +223909,8 @@ JW
 JW
 JW
 JW
-ge
 JW
+ge
 JW
 JW
 JW
@@ -222418,12 +224407,12 @@ JW
 Kk
 JW
 JW
-JW
+vR
 UK
 JW
 JW
-Kk
 JW
+Kk
 JW
 JW
 JW
@@ -222920,12 +224909,12 @@ JW
 Kk
 JW
 JW
-JW
+ge
+ge
 JW
 JW
 JW
 Kk
-JW
 JW
 JW
 JW
@@ -223425,9 +225414,9 @@ Kg
 Kg
 Kg
 Kg
+Kg
 Kk
 Kk
-JW
 JW
 JW
 JW
@@ -223927,9 +225916,9 @@ DO
 GE
 Jf
 if
+hB
 Kk
 Kk
-JW
 JW
 JW
 JW
@@ -224426,12 +226415,12 @@ JW
 Kk
 aJ
 fZ
+VW
 qc
 VW
 LX
 TR
 Kk
-JW
 JW
 JW
 JW
@@ -224929,11 +226918,11 @@ Kk
 oG
 wE
 lq
+zk
 lq
 vE
-gK
+hG
 Kk
-JW
 JW
 JW
 JW
@@ -225431,11 +227420,11 @@ Kg
 Fg
 wE
 Le
+zk
 Le
 vE
 wR
 Kg
-JW
 JW
 JW
 JW
@@ -225933,11 +227922,11 @@ Kg
 Fg
 wE
 Le
+zk
 Le
 vE
 wR
 Kg
-JW
 JW
 JW
 JW
@@ -226435,11 +228424,11 @@ Hu
 oG
 wE
 lq
+zk
 lq
 vE
-gK
+hG
 Kk
-JW
 JW
 JW
 JW
@@ -226927,8 +228916,8 @@ JW
 JW
 JW
 JW
-JW
 Yy
+JW
 JW
 JW
 JW
@@ -226937,12 +228926,12 @@ Kk
 OB
 VW
 Oa
+SF
 Vo
 OX
 hN
 Kk
 Kk
-JW
 JW
 JW
 Yy
@@ -227428,9 +229417,9 @@ JW
 JW
 JW
 JW
-JW
 PX
 co
+Tr
 Tr
 Tr
 Tr
@@ -227439,12 +229428,12 @@ Kk
 Kk
 Kk
 cc
+Kg
 QA
 Kk
 Kk
 Kk
 Kk
-Tr
 Tr
 Tr
 co
@@ -227934,20 +229923,20 @@ JW
 JW
 JW
 JW
-JW
+re
 re
 re
 gH
 gH
 oH
 ER
+Ul
 am
 JZ
 GQ
-kp
+gJ
 vQ
 vQ
-JW
 JW
 JW
 JW
@@ -228435,22 +230424,22 @@ JW
 JW
 JW
 JW
-JW
 re
 re
+nh
 Lz
-qU
 HY
+qU
 oH
 uB
+Sk
 tN
 JZ
 rc
 rc
-Dl
+hn
 vQ
 vQ
-JW
 JW
 JW
 JW
@@ -228937,22 +230926,22 @@ JW
 JW
 JW
 JW
-JW
 re
-Zp
+dN
+qU
 qU
 qU
 qU
 oH
 Xw
+Sk
 XP
 JZ
 rc
 rc
 rc
-EH
+AU
 vQ
-JW
 JW
 JW
 JW
@@ -229439,22 +231428,22 @@ JW
 JW
 JW
 JW
-JW
 oH
-Ab
+qU
+qU
 qU
 qU
 qU
 oH
 Xw
+Sk
 XP
 JZ
 US
 rc
 rc
-Fp
+DQ
 JZ
-JW
 JW
 JW
 JW
@@ -229939,24 +231928,24 @@ JW
 JW
 JW
 JW
-JW
-JW
-XK
+vR
+JB
 oH
-qU
+SL
 qU
 wM
 Ld
+Ld
 Uf
 jm
+ON
 mZ
 ew
 ht
 iE
 rc
-Fp
+NQ
 JZ
-JW
 JW
 JW
 JW
@@ -230441,16 +232430,17 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
+Jn
+Tr
 oH
-qU
+sP
 qU
 mv
 qU
+qU
 yI
 Xw
+Sk
 XP
 Zv
 rc
@@ -230458,7 +232448,6 @@ aR
 rc
 KY
 JZ
-JW
 JW
 JW
 JW
@@ -230945,14 +232934,15 @@ JW
 JW
 JW
 JW
-JW
 oH
 qU
 qU
 mv
 qU
+qU
 oH
 Xw
+Sk
 XP
 JZ
 Bn
@@ -230960,7 +232950,6 @@ aR
 rc
 wl
 JZ
-JW
 JW
 JW
 mS
@@ -231447,22 +233436,22 @@ JW
 JW
 JW
 JW
-JW
 re
-rE
+bH
 qU
 mv
 qU
+qU
 oH
 Xw
+Sk
 XP
 JZ
 Kw
 ZZ
-rc
 XH
 vQ
-JW
+vQ
 JW
 JW
 ge
@@ -231949,23 +233938,23 @@ JW
 JW
 JW
 JW
-JW
 re
 Lf
 Au
 il
-NE
+zZ
+qU
 re
 uB
+Sk
 tN
 vQ
 vQ
 vQ
 vQ
 vQ
-vQ
-JW
-JW
+YL
+YL
 JW
 ge
 JW
@@ -232466,14 +234455,14 @@ Ul
 tC
 Rp
 BU
+tL
 YL
-BU
-JW
+YL
 Dh
 nC
 nC
+nC
 Dh
-JW
 JW
 JW
 JW
@@ -232973,10 +234962,10 @@ BU
 Dh
 Dh
 lV
+aT
 mj
 Dh
 Dh
-JW
 JW
 JW
 JW
@@ -233452,7 +235441,7 @@ JW
 JW
 JW
 JW
-JW
+Fm
 fa
 TT
 TT
@@ -233475,11 +235464,11 @@ Dh
 Dh
 xv
 aH
+Ux
 NH
-xv
+AL
 Dh
 Dh
-JW
 JW
 JW
 JW
@@ -233978,10 +235967,10 @@ Cr
 Yj
 Ux
 Ux
+Ux
 hE
 bp
 Dh
-Tr
 Tr
 Rq
 JW
@@ -234465,7 +236454,7 @@ TT
 TT
 rn
 mV
-yi
+iw
 MW
 Ff
 SX
@@ -234481,9 +236470,9 @@ Ux
 Ux
 Ux
 Ux
+Ux
 dz
 nC
-JW
 JW
 JW
 JW
@@ -234978,14 +236967,14 @@ Cg
 Ul
 am
 Dh
-YU
+gN
+Ux
 Ux
 Ux
 Ux
 Ux
 dz
 nC
-JW
 JW
 JW
 JW
@@ -235460,7 +237449,7 @@ JW
 JW
 JW
 JW
-JW
+Fm
 cn
 TT
 TT
@@ -235472,7 +237461,7 @@ TT
 VD
 yN
 km
-fU
+xM
 nW
 My
 My
@@ -235485,9 +237474,9 @@ LK
 Ux
 Ux
 Ux
+Ux
 dz
 nC
-JW
 JW
 JW
 JW
@@ -235985,16 +237974,16 @@ HI
 VB
 Ux
 Ux
+Ux
 Jq
 yj
-mp
+De
 Dh
 JW
 JW
 JW
 JW
-JW
-wx
+Ri
 JW
 JW
 JW
@@ -236486,17 +238475,17 @@ QK
 HI
 jD
 Ux
+Bg
 Ux
 dz
 Dh
 Dh
 Dh
-id
-JW
+Bt
 ES
 Jt
 VZ
-GX
+wx
 JW
 JW
 JW
@@ -236989,11 +238978,11 @@ nO
 Rr
 Zm
 nQ
+Ux
 dz
 aX
-Ux
+ZC
 aX
-ty
 ty
 uz
 WT
@@ -237491,11 +239480,11 @@ BI
 jD
 cI
 dn
+Ux
 dz
 aX
-Ux
+ZC
 aX
-ty
 ty
 uz
 WT
@@ -237993,16 +239982,16 @@ HI
 jD
 cI
 Ux
+Ux
 dz
 Dh
 Dh
 Dh
-id
-JW
+Bt
 tT
 sR
 uj
-GX
+wx
 JW
 JW
 JW
@@ -238492,19 +240481,19 @@ ED
 Fq
 XP
 HI
-nD
+RO
 qF
 pz
+Ux
 NH
 aT
-Gu
+gB
 Dh
 JW
 JW
 JW
 JW
-JW
-wx
+Ri
 JW
 JW
 JW
@@ -238974,7 +240963,7 @@ JW
 JW
 JW
 JW
-JW
+Fm
 tp
 TT
 TT
@@ -238986,22 +240975,22 @@ TT
 IU
 YO
 Ff
-fU
+xM
 xF
 SM
 SM
 SM
-fU
+Zk
 tN
 Dh
 Dh
 Dh
 YU
 Ux
+Ux
 LK
 hy
 nC
-JW
 JW
 JW
 JW
@@ -239500,10 +241489,10 @@ PL
 dD
 jD
 Ux
+Ux
 LK
 OM
 nC
-JW
 JW
 JW
 JW
@@ -239987,7 +241976,7 @@ TT
 TT
 rn
 mV
-yi
+iw
 Se
 Ff
 zX
@@ -240002,10 +241991,10 @@ PL
 PL
 jD
 Ux
+Ux
 LK
 HB
 nC
-JW
 JW
 JW
 JW
@@ -240504,10 +242493,10 @@ PL
 PL
 RO
 hY
-An
+hY
 kD
+qY
 Dh
-Tr
 Tr
 Rq
 JW
@@ -240982,7 +242971,7 @@ JW
 JW
 JW
 JW
-JW
+Fm
 qO
 TT
 TT
@@ -241005,11 +242994,11 @@ Dh
 Dh
 nC
 nC
+Dh
 nC
 nC
 Dh
 Dh
-JW
 JW
 JW
 JW
@@ -241487,7 +243476,7 @@ JW
 Pb
 qO
 LH
-TE
+TP
 TT
 bL
 TT
@@ -241505,12 +243494,12 @@ xT
 xT
 Dh
 Dh
-on
-iG
-ul
+Ro
 ul
 Dh
-JW
+Ro
+ul
+Dh
 JW
 JW
 JW
@@ -242001,18 +243990,18 @@ tt
 DP
 OS
 LR
-tt
+KI
 MT
 JW
 JW
 Dh
 Dh
-sr
-sr
-sr
-sr
+uo
+uo
 Dh
-JW
+uo
+uo
+Dh
 JW
 JW
 JW
@@ -242498,7 +244487,7 @@ Ka
 ir
 fl
 mf
-aF
+KI
 vx
 Ui
 Jy
@@ -242509,9 +244498,9 @@ JW
 JW
 JW
 JW
+ge
+ug
 JW
-JW
-NU
 JW
 ge
 JW
@@ -243011,8 +245000,8 @@ JW
 JW
 JW
 JW
-JW
-JW
+Jn
+Va
 JW
 JW
 ge
@@ -243495,7 +245484,7 @@ JW
 JW
 JW
 Bv
-Bv
+EJ
 Bv
 es
 Oz
@@ -245507,7 +247496,7 @@ JW
 oo
 oo
 oo
-OI
+zp
 AA
 Kt
 AA
@@ -247012,7 +249001,7 @@ JW
 JW
 JW
 JW
-IP
+bB
 oo
 oo
 Xn
@@ -247021,7 +249010,7 @@ Xn
 Xn
 oo
 oo
-IP
+bB
 JW
 JW
 JW
@@ -247516,11 +249505,11 @@ JW
 JW
 rP
 oo
+dS
+wp
 IP
-IP
-IP
-IP
-IP
+dS
+wp
 IP
 oo
 rP
@@ -248522,7 +250511,7 @@ JW
 oo
 JW
 JW
-JW
+eB
 xH
 JW
 JW
@@ -249024,8 +251013,8 @@ JW
 ge
 JW
 JW
-JW
-JW
+Jn
+Va
 JW
 JW
 ge


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Expand main base ships a little. NT ship expanded mining, medbay, bar. Syndicate ship expanding mining, medbay, bridge, main hallway
Add disposal loop to Fortuna, add disposals section with crusher, expanded fortuna medbay
Move UVB-67 Crew Quarters closer to capture point room, expand capture point room
Fix UVB-67 solars
Add lights to landing pads mapwide
Change interior lights from old light to incandescent lights
Replaced old caution stripe turfs with the better caution stripe decals
Remade NSV Reliant completely
Scattered records around map



