### PR TITLE
instrument player components can now pick which note they play

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -2914,7 +2914,7 @@
 		if (length(sounds) > 1 && index > 0 && index <= length(sounds))
 			unReady(delay)
 			flick("comp_instrument1", src)
-			playsound(get_turf(src), sounds[signum], volume, 0)
+			playsound(get_turf(src), sounds[index], volume, 0)
 		else if (signum &&((signum >= 0.1 && signum <= 2) || (signum <= -0.1 && signum >= -2) || pitchUnlocked))
 			var/mod_delay = delay
 			if(abs(signum) < 1)

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -2910,7 +2910,12 @@
 		if (level == 2 || !isReady() || !instrument) return
 		LIGHT_UP_HOUSING
 		var/signum = text2num(input.signal)
-		if (signum &&((signum >= 0.1 && signum <= 2) ||(signum <= -0.1 && signum >= -2) || pitchUnlocked))
+		var/index = round(signum)
+		if (length(sounds) > 1 && index > 0 && index <= length(sounds))
+			unReady(delay)
+			flick("comp_instrument1", src)
+			playsound(get_turf(src), sounds[signum], volume, 0)
+		else if (signum &&((signum >= 0.1 && signum <= 2) || (signum <= -0.1 && signum >= -2) || pitchUnlocked))
 			var/mod_delay = delay
 			if(abs(signum) < 1)
 				mod_delay /= abs(signum)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This let's instruments play the corresponding note when they get a proper index as "play" signal input.
If the input is not a valid index, it will still play a randomly selected sound as before.
I round the input, so you can no longer change the pitch of random instrument notes. (I don't think this is a very useful feature, seeing as the notes are random, why would you want to pick the pitch?)

You can still pick the pitch for items that only have one sound as before. (butts, clown shoes, horns, etc.)

Not sure if there is a better way to handle the different inputs for pitch vs different inputs for notes.
Maybe I should make two different inputs for instrument player components, "Player (Pitch)" and "Play (Note)"?
Please let me know what you think, I don't really do much mechanics!
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It just makes sense.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+)Instrument player components can now choose which note to play via their input.
```
