### PR TITLE
Add death confetti purchase

### DIFF
--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -39,6 +39,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 
 	new /datum/bank_purchaseable/critter_respawn,\
 	new /datum/bank_purchaseable/golden_ghost,\
+	new /datum/bank_purchaseable/death_confetti,\
 
 	new /datum/bank_purchaseable/fruithat,\
 	new /datum/bank_purchaseable/hoodie,\
@@ -174,7 +175,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 			name = "Plaid Paint Can"
 			cost = 3000
 			path = /obj/item/paint_can/rainbow/plaid
-		
+
 		crayon_box
 			name = "Crayon Creator"
 			cost = 2500
@@ -468,6 +469,14 @@ var/global/list/persistent_bank_purchaseables =	list(\
 		cost = 1500
 
 		Create(var/mob/M)
+			return 1
+
+	death_confetti
+		name = "Death Confetti"
+		cost = 1000
+
+		Create(var/mob/M)
+			M.AddComponent(/datum/component/death_confetti)
 			return 1
 
 	bp_fjallraven


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a spacebux thing to add the death confetti component you normally only get as a clown.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I figured it'd be fun.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Make the most of a sombre situation with spacebux death confetti!
```
