### PR TITLE
Fix spatial tears runtiming

### DIFF
--- a/code/modules/events/spatial_tear.dm
+++ b/code/modules/events/spatial_tear.dm
@@ -46,8 +46,11 @@
 				src.stabilize()
 				break
 		SPAWN_DBG(duration)
-			STOP_TRACKING
 			qdel(src)
+
+	disposing()
+		STOP_TRACKING
+		..()
 
 	attack_hand(mob/user)
 		if(src.stabilized)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug][runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the `STOP_TRACKING` on spatial tears into `disposing`, which stops it from runtiming on every single segment. They also seem to go away when appropriate now.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I don't know exactly why this fixes it but my guess is that the `SPAWN_DBG` causes the `STOP_TRACKING` to get called from the wrong scope. (That macro looks like a dang hack)

I really just followed the instructions above the tracking defines and it worked. ¯\\\_(ツ)\_/¯

closes #4903
