### PR TITLE
Ditch old AI traitor string

### DIFF
--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -124,7 +124,7 @@
 //	O.laws_object = ticker.centralized_ai_laws
 //	O.current_law_set = O.laws_object
 	ticker.centralized_ai_laws.show_laws(O)
-	boutput(O, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
+	boutput(O, "<b>These laws may be changed by other players.</b>")
 
 	O.verbs += /mob/living/silicon/ai/proc/ai_call_shuttle
 	O.verbs += /mob/living/silicon/ai/proc/show_laws_verb


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the line implying the AI can change their laws if they're the traitor from the "you are the AI and these are your laws!" thing.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AIs rolling traitor hasn't been a thing in game since ancient times AFAIK, no need to keep having this holdover show up every time.