### PR TITLE
Allow lights to stick onto unsimulated walls

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -135,7 +135,7 @@
 				var/turf/T = null
 				for (var/dir in cardinal)
 					T = get_step(src,dir)
-					if (istype(T,/turf/simulated/wall) || (locate(/obj/wingrille_spawn) in T) || (locate(/obj/window) in T))
+					if (istype(T,/turf/simulated/wall) || istype(T,/turf/unsimulated/wall) || (locate(/obj/wingrille_spawn) in T) || (locate(/obj/window) in T))
 						var/is_jen_wall = 0 // jen walls' ceilings are narrower, so let's move the lights a bit further inward!
 						if (istype(T, /turf/simulated/wall/auto/jen) || istype(T, /turf/simulated/wall/auto/reinforced/jen))
 							is_jen_wall = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the autoposition feature on lights to work on unsimulated walls.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I'm assuming it was an oversight. "Why would you need lights to snap onto unsimulated walls, anywhere you're using unsimmed stuff will probably have the dirs set manually" line of thinking. Main place the auto position feature not working on unsimulated walls was noticed is on the Pod Wars mode, where the two main base ships use unsimulated walls. When I changed over to use incandescent lights, for different lighting shade, they didn't snap automatically.


I tested the change in some of the z2 azones to make sure no lights were adversely affected and it seems everything was fine, so no azones should have weird lights being messed up. 