### PR TITLE
Separetes sleeper agent from traitor in antag preferences

### DIFF
--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -24,6 +24,7 @@ datum/preferences
 	var/employment_note
 
 	var/be_traitor = 0
+	var/be_sleeper = 0
 	var/be_syndicate = 0
 	var/be_spy = 0
 	var/be_gangleader = 0
@@ -847,6 +848,7 @@ datum/preferences
 				radio_music_volume = 50
 				use_click_buffer = 0
 				be_traitor = 0
+				be_sleeper = 0
 				be_syndicate = 0
 				be_spy = 0
 				be_gangleader = 0
@@ -1261,6 +1263,7 @@ datum/preferences
 		if (jobban_isbanned(user, "Syndicate"))
 			HTML += "You are banned from playing antagonist roles."
 			src.be_traitor = 0
+			src.be_sleeper = 0
 			src.be_syndicate = 0
 			src.be_spy = 0
 			src.be_gangleader = 0
@@ -1277,6 +1280,7 @@ datum/preferences
 
 			HTML += {"
 			<a href="byond://?src=\ref[src];preferences=1;b_traitor=1" class="[src.be_traitor ? "yup" : "nope"]">[crap_checkbox(src.be_traitor)] Traitor</a>
+			<a href="byond://?src=\ref[src];preferences=1;b_sleeper=1" class="[src.be_sleeper ? "yup" : "nope"]">[crap_checkbox(src.be_sleeper)] Sleeper Agent</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_syndicate=1" class="[src.be_syndicate ? "yup" : "nope"]">[crap_checkbox(src.be_syndicate)] Nuclear Operative</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_spy=1" class="[src.be_spy ? "yup" : "nope"]">[crap_checkbox(src.be_spy)] Spy/Thief</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_gangleader=1" class="[src.be_gangleader ? "yup" : "nope"]">[crap_checkbox(src.be_gangleader)] Gang Leader</a>
@@ -1482,6 +1486,11 @@ datum/preferences
 
 		if (link_tags["b_traitor"])
 			src.be_traitor = !( src.be_traitor)
+			src.SetChoices(user)
+			return
+
+		if (link_tags["b_sleeper"])
+			src.be_sleeper = !( src.be_sleeper)
 			src.SetChoices(user)
 			return
 

--- a/code/datums/savefile.dm
+++ b/code/datums/savefile.dm
@@ -83,6 +83,7 @@
 		F["[profileNum]_job_prefs_3"] << src.jobs_low_priority
 		F["[profileNum]_job_prefs_4"] << src.jobs_unwanted
 		F["[profileNum]_be_traitor"] << src.be_traitor
+		F["[profileNum]_be_sleeper"] << src.be_sleeper
 		F["[profileNum]_be_syndicate"] << src.be_syndicate
 		F["[profileNum]_be_spy"] << src.be_spy
 		F["[profileNum]_be_gangleader"] << src.be_gangleader
@@ -247,6 +248,7 @@
 		F["[profileNum]_job_prefs_3"] >> src.jobs_low_priority
 		F["[profileNum]_job_prefs_4"] >> src.jobs_unwanted
 		F["[profileNum]_be_traitor"] >> src.be_traitor
+		F["[profileNum]_be_sleeper"] << src.be_sleeper
 		F["[profileNum]_be_syndicate"] >> src.be_syndicate
 		F["[profileNum]_be_spy"] >> src.be_spy
 		F["[profileNum]_be_gangleader"] >> src.be_gangleader

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -175,7 +175,7 @@
 				if (Hs.frequency == frequency)
 					listeners += H
 					boutput(H, "<span class='notice'>A peculiar noise intrudes upon the radio frequency of your [Hs].</span>")
-					if (H.client && !checktraitor(H) && (H.client.preferences.be_traitor || src.override_player_pref))
+					if (H.client && !checktraitor(H) && (H.client.preferences.be_sleeper || src.override_player_pref))
 						var/datum/job/J = find_job_in_controller_by_string(H?.mind.assigned_role)
 						if (J.allow_traitors)
 							candidates.Add(H)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] --> [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so you can decide not to be a sleeper agent candidate while still being able to be a traitor candidate.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People in the forumns/discord asked for it, makes sense for me, they aren't really the same.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Arthur Holiday
(+)Sleeper agent and traitor antag preferences are now separated 

```
