### PR TITLE
Angry googly eye box for the Cairngorm.

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -2968,9 +2968,7 @@
 "amK" = (
 /obj/table,
 /obj/item/stamp,
-/obj/noticeboard{
-	pixel_y = 32
-	},
+/obj/noticeboard,
 /turf/unsimulated/floor/black,
 /area/hospital)
 "amL" = (
@@ -5098,9 +5096,7 @@
 /turf/unsimulated/floor/white/grime,
 /area/hospital)
 "asU" = (
-/obj/noticeboard{
-	pixel_y = 32
-	},
+/obj/noticeboard,
 /turf/unsimulated/floor/white/grime,
 /area/hospital)
 "asV" = (
@@ -9826,6 +9822,7 @@
 /area/marsoutpost)
 "aIn" = (
 /obj/table/reinforced/auto,
+/obj/item/item_box/googly_eyes/angry,
 /turf/unsimulated/floor/carpet/red/decal/outercross,
 /area/syndicate_station/battlecruiser)
 "aIo" = (
@@ -11536,9 +11533,7 @@
 "aNg" = (
 /obj/table/auto,
 /obj/item/kitchen/food_box/donut_box,
-/obj/noticeboard{
-	pixel_y = 32
-	},
+/obj/noticeboard,
 /turf/unsimulated/floor/specialroom/bar,
 /area/upper_arctic/pod2)
 "aNh" = (
@@ -14236,9 +14231,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/noticeboard{
-	pixel_y = 32
-	},
+/obj/noticeboard,
 /turf/unsimulated/floor/neutral/side{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPING][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cairngorm gets a box of angry googly eyes. A continuation of the "Herb is obsessed with googly eyes" saga.
![image](https://user-images.githubusercontent.com/66253095/119930949-cc2d9780-bfc3-11eb-8cf7-67104e2e4995.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This should cover it.
![image](https://user-images.githubusercontent.com/66253095/119211639-bf5a0100-baf6-11eb-9f35-32fec1f11641.png)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DisturbHerb
(+)A box of angry googly eyes spawns in the Cairngorm. 👀 
```
