### PR TITLE
Fix mines not apply effect and not updating UI in real time

### DIFF
--- a/code/obj/item/device/timer.dm
+++ b/code/obj/item/device/timer.dm
@@ -65,9 +65,9 @@
 		last_tick = TIME
 
 		if (!src.master)
-			src.updateDialog()
+			src.updateSelfDialog()
 		else
-			src.master.updateDialog()
+			src.master.updateSelfDialog()
 
 	else
 		// If it's not timing, reset the icon so it doesn't look like it's still about to go off.
@@ -105,7 +105,10 @@
 		return
 
 	if ((src in user) || (src.master && (src.master in user)) || (get_dist(src, user) <= 1 && istype(src.loc, /turf)) || src.is_detonator_trigger())
-		src.add_dialog(user)
+		if (!src.master)
+			src.add_dialog(user)
+		else
+			src.master.add_dialog(user)
 		var/second = src.time % 60
 		var/minute = (src.time - second) / 60
 		var/detonator_trigger = src.is_detonator_trigger()
@@ -117,7 +120,10 @@
 		onclose(user, "timer")
 	else
 		user.Browse(null, "window=timer")
-		src.remove_dialog(user)
+		if (!src.master)
+			src.remove_dialog(user)
+		else
+			src.master.remove_dialog(user)
 
 	return
 
@@ -138,7 +144,10 @@
 		return
 	var/can_use_detonator = src.is_detonator_trigger() && !src.timing
 	if (can_use_detonator || (src in usr) || (src.master && (src.master in usr)) || in_interact_range(src, usr) && istype(src.loc, /turf))
-		src.add_dialog(usr)
+		if (!src.master)
+			src.add_dialog(usr)
+		else
+			src.master.add_dialog(usr)
 		if (href_list["time"])
 			src.timing = text2num(href_list["time"])
 			if(timing)
@@ -168,13 +177,16 @@
 
 		if (href_list["close"])
 			usr.Browse(null, "window=timer")
-			src.remove_dialog(usr)
+			if (!src.master)
+				src.remove_dialog(usr)
+			else
+				src.master.remove_dialog(usr)
 			return
 
 		if (!src.master)
-			src.updateDialog()
+			src.updateSelfDialog()
 		else
-			src.master.updateDialog()
+			src.master.updateSelfDialog()
 
 		src.add_fingerprint(usr)
 	else

--- a/code/obj/item/mine.dm
+++ b/code/obj/item/mine.dm
@@ -173,15 +173,11 @@
 			return mobs
 
 		var/turf/T = get_turf(src)
-		if (T && istype(T))
-			for (var/mob/living/L in T.contents)
-				if (!istype(L) || isintangible(L) || iswraith(L))
-					continue
 
-		if (radius > 0)
-			for (var/mob/living/L2 in range(src, radius))
-				if (!istype(L2) || isintangible(L2) || iswraith(L2))
-					continue
+		for (var/mob/living/L in range(radius,T))
+			if (isintangible(L) || iswraith(L))
+				continue
+			mobs += L
 
 		return mobs
 


### PR DESCRIPTION
[BUG]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The PR fixes two bugs: 
1. Bug in `get_mobs_on_turf` proc that always resulted it returning an empty mob list. Caused stun and rad mines to not apply effects to mobs caught in the blast radius.
2. Bug with the timer that resulted in the timers not updating their UI when either pressing a UI element, or when in-progress.

Fixes #4926

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stun and rad mines are currently duds. Also having the UI update in real time would cut down on confusion.

This code change should also make it so other items that use the timer UI (e.x. beaker / pipebomb timer assemblies, standalone timers, etc.) have responsive UI as well.

A similar change should be added to `prox_sensor.dm`, however I'm planning on doing that in a follow-up PR once my method in `timer.dm` has been reviewed.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Blackrep
(+)Fixed stun and radiation mines not applying their effects on people caught in their blast radiuses.
```
