### PR TITLE
Fix health & forensic scanners getting false positives on bullets

### DIFF
--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -410,7 +410,7 @@
 
 		if (H.implant && H.implant.len > 0)
 			var/wounds = null
-			for (var/obj/item/implant/I in H)
+			for (var/obj/item/implant/I in H.implant)
 				if (istype(I, /obj/item/implant/projectile))
 					wounds ++
 			if (wounds)

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -108,7 +108,7 @@
 
 			var/bad_stuff = 0
 			if (L.implant && L.implant.len > 0)
-				for (var/obj/item/implant/I in L)
+				for (var/obj/item/implant/I in L.implant)
 					if (istype(I, /obj/item/implant/projectile))
 						bad_stuff ++
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the health analyzer and forensic scanner only scan for foreign objects within `implant`.
(For those curious, the bug this fixes occurs if you have a non-bullet implant in you when getting scanned, since at that point implant isn't empty but line 111 checks all your contents.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #4929 
