### PR TITLE
Stop critters accidentally dropping their brains

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -942,7 +942,7 @@
 				mode.team_NT.members -= src.mind
 				mode.team_SY.members -= src.mind
 				message_admins("[src]([src.ckey]) just set DNR and was removed from their team. which was probably [src.mind.special_role]!")
-#else 
+#else
 	if (confirm == "Yes")
 		if (src.mind)
 			src.verbs -= list(/mob/verb/setdnr)
@@ -1047,6 +1047,20 @@
 			continue
 
 		LI += W
+	.= LI
+
+/mob/living/critter/get_unequippable()
+	var/list/obj/item/LI = list()
+
+	for (var/obj/item/W in src)
+		if (src.organHolder)
+			if (istype(W, /obj/item/organ/brain) && src.organHolder.brain == W)
+				continue
+
+		if (istype(W, /obj/item/reagent_containers/food/snacks/bite))
+			continue
+		LI += W
+
 	.= LI
 
 /mob/proc/findname(msg)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -993,19 +993,6 @@
 		if (istype(W, /obj/item/parts) && W:holder == src)
 			continue
 
-		if (istype(W, /obj/item/reagent_containers/food/snacks/bite))
-			continue
-		LI += W
-
-	.= LI
-
-/mob/living/carbon/human/get_unequippable()
-	var/list/obj/item/LI = list()
-
-	for (var/obj/item/W in src)
-		if (istype(W, /obj/item/parts) && W:holder == src)
-			continue
-
 		if(istype(W, /obj/item/implant))
 			continue
 
@@ -1047,20 +1034,6 @@
 			continue
 
 		LI += W
-	.= LI
-
-/mob/living/critter/get_unequippable()
-	var/list/obj/item/LI = list()
-
-	for (var/obj/item/W in src)
-		if (src.organHolder)
-			if (istype(W, /obj/item/organ/brain) && src.organHolder.brain == W)
-				continue
-
-		if (istype(W, /obj/item/reagent_containers/food/snacks/bite))
-			continue
-		LI += W
-
 	.= LI
 
 /mob/proc/findname(msg)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stops mob critters from dropping their brain on `unequip_all` by giving them their own variant of `get_unequippable`.

While this fix is intended to stop spiders dropping theirs when they drain a body, I figured it might as well be a critter mob wide fix just in case.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #1139 
