### PR TITLE
Pod Wars | Enemy Blasters can no longer be used by point-blanking, also updates shooting procs. | Version 2

### DIFF
--- a/code/datums/gamemodes/pod_wars/pw_weapons.dm
+++ b/code/datums/gamemodes/pod_wars/pw_weapons.dm
@@ -17,9 +17,7 @@
 	shoot(var/target,var/start,var/mob/user)
 		if (canshoot())
 			if (team_num)
-				if (team_num == 1 && user?.mind?.special_role == "NanoTrasen")
-					return ..(target, start, user)
-				else if (team_num == 2 && user?.mind?.special_role == "Syndicate")
+				if (team_num == get_pod_wars_team_num(user))
 					return ..(target, start, user)
 				else
 					boutput(user, "<span class='alert'>You don't have to right DNA to fire this weapon!</span><br>")
@@ -28,6 +26,19 @@
 					return
 			else
 				return ..(target, start, user)
+
+	shoot_point_blank(mob/M, mob/user)
+		if (canshoot())
+			if (team_num)
+				if (team_num == get_pod_wars_team_num(user))
+					return ..(M, user)
+				else
+					boutput(user, "<span class='alert'>You don't have to right DNA to fire this weapon!</span><br>")
+					playsound(get_turf(user), "sound/machines/buzz-sigh.ogg", 20, 1)
+
+					return
+			else
+				return ..(M, user)
 
 	disposing()
 		indicator_display = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You used to be able to point-blank people with blasters that aren't your teams. I then fixed it with PR #4928 , but then the files were split up as of [this commit](https://github.com/Zonespace27/goonstation/commit/39ac373288a1bd5819ba1056783cdd93d19317d8), and Kyle put the old, broken version back in. This PR fixes it, again.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fixes good.