### PR TITLE
artguns can't point blank when not activated

### DIFF
--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -280,6 +280,11 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 						user.l_hand:shoot(target_turf,get_turf(user), user, rand(-5,5), rand(-5,5))
 
 
+	if (src.artifact && istype(src.artifact, /datum/artifact))
+		var/datum/artifact/art_gun = src.artifact
+		if (!art_gun.activated)
+			return
+
 	if (!canshoot())
 		if (!silenced)
 			M.visible_message("<span class='alert'><B>[user] tries to shoot [user == M ? "[him_or_her(user)]self" : M] with [src] point-blank, but it was empty!</B></span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I decided against overriding canshoot() in artguns, since that would make them output the text that it is "empty", which would not be accurate. Maybe in the future we could make it so that part returns a custom text dependant on gun, but that seemed out of scope.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #4947 