### PR TITLE
change how manufacturers select cable materials

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -620,22 +620,8 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	modify_output(var/obj/machinery/manufacturer/M, var/atom/A,var/list/materials)
 		..()
 		var/obj/item/cable_coil/coil = A
-		var/min_cond = 1
-		var/max_cond = 0
-		var/min_cond_mat = null
-		var/max_cond_mat = null
-		for (var/pattern in materials)
-			var/datum/material/cand = getMaterial(materials[pattern])
-			if (!cand)
-				continue
-			if (cand.getProperty("electrical") < min_cond)
-				min_cond = cand.getProperty("electrical")
-				min_cond_mat = cand
-			else if (cand.getProperty("electrical") > max_cond)
-				max_cond = cand.getProperty("electrical")
-				max_cond_mat = cand
-		coil.setInsulator(min_cond_mat)
-		coil.setConductor(max_cond_mat)
+		coil.setInsulator(getMaterial(materials["INS-1"]))
+		coil.setConductor(getMaterial(materials["CON-1"]))
 		return 1
 
 /datum/manufacture/RCD


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Before now, manufacturers seemed to get both the insulative material and the conductive material and then check which of the two had the higher conductivity and which the lower one.
It would then choose the more conductive one as conductor and the less conductive one as insulator.
If the conductor didn't have more than 0 conductivity it wouldn't be used, and if the insulator had more than 1 conductivity it would also not be used.
Neither of these checks seem to make any sense, since the overlying system already only lets materials which are INS-1 (<47 conductivity) and materials which are CON-1 (>50 conductivity) through.
So basically, all it did was unnecessary checks and making sure that no insulator that had the conductivity stat actually set could be used.

When a material (usually the insulator) was deemed unusable, it would just not set it, which would replace it with the default synthrubber, magically conjuring the rubber out of thin air, which totally makes sense.


Anyway, I changed it so that it just uses the conductive material as conductive material and the insulative material as insulative material, which seems to work fine?
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- fixes #4943 
- bee wool insulation
- wendigo hide insulation
- etc