### PR TITLE
Fix airlock prying sound

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1415,8 +1415,8 @@ About the new airlock wires panel:
 	else if (src.arePowerSystemsOn())
 		boutput(usr, "<span class='alert'>You try to pry [src]  open, but it won't budge! The power of \the [src] must be disabled first.</span>")
 
-		if(!ON_COOLDOWN(src, "playsound", 1.5 SECONDS))
-			playsound(src, 'sound/machines/airlock_pry.ogg', 35, 1)
+	if(!ON_COOLDOWN(src, "playsound", 1.5 SECONDS))
+		playsound(src, 'sound/machines/airlock_pry.ogg', 35, 1)
 
 	return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Virva accidentally put the playsound for crowbarring a door on the wrong level of indentation in https://github.com/goonstation/goonstation/commit/f7b1fb219f6f19d4ae427a90029e2bb0bfb6bca5, this fixes that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #4955