### PR TITLE
Removes the disposal chute prompt window on empty satchels/boxes

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -106,7 +106,6 @@
 					S.hud.remove_object(O)
 				user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
 				return
-			if (isnull(action)) return
 		var/obj/item/magtractor/mag
 		if (istype(I.loc, /obj/item/magtractor))
 			mag = I.loc

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -79,7 +79,7 @@
 			return
 		if (istype(I, /obj/item/handheld_vacuum))
 			return
-		if (istype(I,/obj/item/satchel/))
+		if (istype(I,/obj/item/satchel/) && I.contents.len)
 			var/action = input(user, "What do you want to do with the satchel?") in list("Empty it into the Chute","Place it in the Chute","Never Mind")
 			if (!action || action == "Never Mind") return
 			if (get_dist(src,user) > 1)
@@ -91,7 +91,7 @@
 				S.satchel_updateicon()
 				user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
 				return
-		if (istype(I,/obj/item/storage/))
+		if (istype(I,/obj/item/storage/) && I.contents.len)
 			var/action = input(user, "What do you want to do with [I]?") as null|anything in list("Empty it into the chute","Place it in the Chute")
 			if (!in_interact_range(src, user))
 				boutput(user, "<span class='alert'>You need to be closer to the chute to do that.</span>")

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -80,9 +80,10 @@
 		if (istype(I, /obj/item/handheld_vacuum))
 			return
 		if (istype(I,/obj/item/satchel/) && I.contents.len)
-			var/action = input(user, "What do you want to do with the satchel?") in list("Empty it into the Chute","Place it in the Chute","Never Mind")
-			if (!action || action == "Never Mind") return
-			if (get_dist(src,user) > 1)
+			var/action = input(user, "What do you want to do with the satchel?") in list("Place it in the Chute","Empty it into the Chute","Never Mind")
+			if (!action || action == "Never Mind")
+				return
+			if (!in_interact_range(src, user))
 				boutput(user, "<span class='alert'>You need to be closer to the chute to do that.</span>")
 				return
 			if (action == "Empty it into the Chute")
@@ -92,7 +93,9 @@
 				user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
 				return
 		if (istype(I,/obj/item/storage/) && I.contents.len)
-			var/action = input(user, "What do you want to do with [I]?") as null|anything in list("Empty it into the chute","Place it in the Chute")
+			var/action = input(user, "What do you want to do with [I]?") as null|anything in list("Place it in the Chute","Empty it into the chute","Never Mind")
+			if (!action || action == "Never Mind")
+				return
 			if (!in_interact_range(src, user))
 				boutput(user, "<span class='alert'>You need to be closer to the chute to do that.</span>")
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR removes the "empty the contents/place into the chute" window that pops up upon inserting the box/satchel into the disposal unit, if they're empty.
Also swaps the empty/place options per BatElite's request and makes the code a tiny bit better

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Just fixing another minor annoyance I have with the game

