### PR TITLE
Lock ruck kits separately

### DIFF
--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -600,7 +600,7 @@
 		if (S.item_mats && src.olde)
 			dat += " * <A href='?src=\ref[src];op=\ref[S];tp=done'>Frame</A>"
 		else if (S.blueprint)
-			if ((!itemlocked && hide_allowed) || src.olde)
+			if (!itemlocked || src.olde)
 				dat += " * <A href='?src=\ref[src];op=\ref[S];tp=blueprint'>Blueprint</A>"
 			else
 				dat += " * Blueprint Disabled"

--- a/code/datums/controllers/mechanic_controls.dm
+++ b/code/datums/controllers/mechanic_controls.dm
@@ -20,7 +20,6 @@ var/datum/mechanic_controller/mechanic_controls
 	var/item_type = ""
 	var/list/item_mats
 	var/finish_time = 0
-	var/locked = FALSE
 	var/datum/manufacture/mechanics/blueprint = null
 
 	proc


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX] [QOL] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Being able to lock items from every kit in the universe is a debilitating power, players are put in a weird scenario where the only solution is stealing AA is the only option if command decides to completely lock down the kit.

I brought this up in #4959

This also fixes an href exploit, where users could craft a link to print locked blueprints

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

There's some ideas of other stuff we could be doing here to add to the antag versus command dynamic, like

- blueprints uploaded via packets (PDA) are on every kit
- blueprints uploaded by device scanners aren't shared
- new ruck kits don't have blueprints, not even packet (PDA) ones

But the fact that command can shut the creation of anything and everything, everywhere is a singular atomic concern so it's the only thing in this PR
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
```
(u)Penny
(+)Ruck kit blueprints are now locked by command per-kit
```
