### PR TITLE
Pod Wars | Commanders of both sides now have APC access.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2720,7 +2720,7 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 			no_jobban_from_this_job = 0
 			high_priority_job = 1
 			cant_allocate_unwanted = 1
-			access = list(access_heads, access_captain, access_medical, access_medical_lockers)
+			access = list(access_heads, access_captain, access_medical, access_medical_lockers, access_engineering_power)
 
 			slot_head = /obj/item/clothing/head/NTberet/commander
 			slot_suit = /obj/item/clothing/suit/space/nanotrasen/pilot/commander
@@ -2760,7 +2760,7 @@ ABSTRACT_TYPE(/datum/job/special/pod_wars)
 			no_jobban_from_this_job = 0
 			high_priority_job = 1
 			cant_allocate_unwanted = 1
-			access = list(access_syndicate_shuttle, access_syndicate_commander, access_medical, access_medical_lockers)
+			access = list(access_syndicate_shuttle, access_syndicate_commander, access_medical, access_medical_lockers, access_engineering_power)
 
 			slot_head = /obj/item/clothing/head/helmet/space/syndicate/commissar_cap
 			slot_suit = /obj/item/clothing/suit/space/syndicate/commissar_greatcoat


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL] [Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pod Wars commanders now get APC access.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
EMPing an APC can cause it to turn off. Currently, no role has access to APCs. Now, this PR gives access, to remedy the issue. To prevent mass grief, only commanders have APC access.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->