### PR TITLE
Make syndicate command armor only scan with the syndi device scanner

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1255,6 +1255,7 @@
 	syndicate
 		name = "\improper Syndicate command armor"
 		desc = "An armored space suit, not for your average expendable chumps. No sir."
+		is_syndicate = 1
 		icon_state = "indusred"
 		item_state = "indusred"
 		setupProperties()
@@ -1264,6 +1265,7 @@
 
 		specialist
 			name = "specialist heavy operative combat armor"
+			is_syndicate = 0
 			desc = "A syndicate issue heavy combat dress system, pressurized for space travel and reinforced for greater protection in firefights."
 			icon_state = "syndie_specialist-heavy"
 			item_state = "syndie_specialist-heavy"
@@ -1272,6 +1274,7 @@
 
 	name = "NT-SO heavy operative combat armor"
 	desc = "A Nanotrasen special forces heavy combat dress system, pressurized for space travel and reinforced for greater protection in firefights."
+	is_syndicate = 0
 	icon_state = "ntso_specialist-heavy"
 	item_state = "ntso_specialist-heavy"
 	cant_self_remove = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the syndicate command armor require a syndicate device analyser to scan for blueprints.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The armor can be acquired by non traitors and scanned with a regular analyser to mass produce at a low material cost.
As syndicate equipment (with superior stats to captain armor) this should logically not be able to be scanned with a regular scanner.
NTSO armor can be scanned and mass produced at low cost but this should possibly be addressed through crafting cost changes.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Scanning Syndicate command armor now requires a syndicate device analyser.
```
