### PR TITLE
Pod Wars | On RP, pod fabricators now have handcuffs.

### DIFF
--- a/code/datums/gamemodes/pod_wars/pw_manufacturing_.dm
+++ b/code/datums/gamemodes/pod_wars/pw_manufacturing_.dm
@@ -12,6 +12,9 @@
 		/obj/item/material_piece/molitz
 	)
 	available = list(
+		#ifdef RP_MODE
+		/datum/manufacture/pod_wars/handcuffs
+		#endif
 		/datum/manufacture/pod_wars/barricade,
 		/datum/manufacture/pod_wars/energy_concussion_grenade,
 		/datum/manufacture/pod_wars/energy_frag_grenade,
@@ -346,6 +349,16 @@
 	item_amounts = list(5, 5, 5)
 	item_outputs = list(/obj/item/old_grenade/energy_frag)
 	time = 1 SECONDS
+	create = 1
+	category = "Weapon"
+
+/datum/manufacture/pod_wars/handcuffs
+	
+	name = "Handcuffs"
+	item_paths = list("MET-1")
+	item_amounts = list(5)
+	item_outputs = list(/obj/item/handcuffs)
+	time = 2 SECONDS
 	create = 1
 	category = "Weapon"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL] [Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pod fabricators now have handcuffs, costing 5 metal and taking 0.7 seconds on speed 3 to make.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Multiple times on RP, someone was taken hostage, and everyone just relied on the honor system for the hostage to not just run around. This should fix it, by allowing more effective hostage taking. 
This feature is only on RP because, on main, this would just be used to fuck people over more when spacing them, instead of their intended purpose.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(*)In Pod Wars, pod fabricators can now produce handcuffs on RP.
```
