### PR TITLE
Renames Epilepsy Mutation

### DIFF
--- a/code/modules/medical/genetics/bioEffects/harmful.dm
+++ b/code/modules/medical/genetics/bioEffects/harmful.dm
@@ -189,10 +189,10 @@
 					applied = 0
 		return
 
-/datum/bioEffect/epilepsy
-	name = "Epilepsy"
-	desc = "Causes damage to the subject's brain structure, resulting in occasional seizures from brain misfires."
-	id = "epilepsy"
+/datum/bioEffect/stupefaction
+	name = "Stupefaction"
+	desc = "Causes damage to the subject's brain structure, occassionally utterly stupefying and stunning them."
+	id = "stupefaction"
 	effectType = EFFECT_TYPE_DISABILITY
 	isBad = 1
 	probability = 66
@@ -208,9 +208,8 @@
 		if (isdead(owner))
 			return
 		if (probmult(1) && !owner.getStatusDuration("paralysis"))
-			owner:visible_message("<span class='alert'><B>[owner] starts having a seizure!</span>", "<span class='alert'>You have a seizure!</span>")
+			owner:visible_message("<span class='alert'><B>[owner] looks totally stupefied!</span>", "<span class='alert'>You feel totally stupefied!</span>")
 			owner.setStatus("paralysis", max(owner.getStatusDuration("paralysis"), 20))
-			owner:make_jittery(100)
 		return
 
 /datum/bioEffect/thermal_vuln

--- a/code/modules/medical/genetics/combo_recipes.dm
+++ b/code/modules/medical/genetics/combo_recipes.dm
@@ -70,10 +70,6 @@
 	required_effects = list("accent_chav","accent_tommy")
 	result = /datum/bioEffect/coprolalia
 
-/datum/geneticsrecipe/epilepsy
-	required_effects = list("bad_eyesight","flashy")
-	result = /datum/bioEffect/epilepsy
-
 /datum/geneticsrecipe/blind
 	required_effects = list("bad_eyesight","narcolepsy")
 	result = /datum/bioEffect/blind
@@ -316,10 +312,6 @@
 
 /datum/geneticsrecipe/flashy_two
 	required_effects = list("glowy","chameleon")
-	result = /datum/bioEffect/mutantrace/flashy
-
-/datum/geneticsrecipe/flashy_three // Discovered
-	required_effects = list("glowy","epilepsy")
 	result = /datum/bioEffect/mutantrace/flashy
 
 /datum/geneticsrecipe/lizard


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Renames the epilepsy mutation to stupefaction, removes the combo recipes that no longer would make sense due to this. (Two combos, one where you make epilepsy by combining the flashy mutation with poor eyesight, and one where you make flashy by combining epilepsy with glowy. Not anticipating these will be missed if they've been used at all.). Mutation no longer makes your sprite jittery as well. Same mechanical effect otherwise.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I think the implementation of epilepsy in our game is pretty dang ableist and insensitive, and I don't like it! It's been around forever and I wouldn't attribute it existing to maliciousness at all, to be clear, I just don't think it belongs in this game. Epilepsy is a really serious and traumatic condition, and I think the way it's portrayed in-game as a 'gene that stuns you every now and then for a few seconds' is really negative and inaccurate, it's a harmful simplification. Overall I don't think we have the ability to tackle representing the condition with the tact and seriousness it deserves, as our game will naturally incur a lot of levity since it's a fairly silly game, and I don't feel very comfortable personally with the way it exists in-game. I feel these negatives far outweigh the positives keeping the name has, specifically that it's a fairly recognizable name. 

My issue with it is fixed quite cleanly with a rename, though I'm sure there's people who'd rather just axe it (since it's really just a mutation that stuns you for a few seconds very rarely.) Stupefaction (pronounced stoop-eh-faction) refers to being stupefied or stunned by something. I think it'd pass as a term for genetics, though if somebody has a better name I'm open to ideas. The point isn't really to rework a kinda bad mutation moreso as it is to just change the name. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flaborized
(+)Renamed the epilepsy mutation to 'Stupefaction'.
```
