### PR TITLE
Fix constructed mineral magnets breaking fullbright, add magnet action bar for construction

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -56,6 +56,7 @@
 			src.bound_height = 32
 			src.bound_width = 64
 
+#ifndef UNDERWATER_MAP
 /datum/action/bar/icon/magnet_build
 	id = "magnet_build"
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
@@ -109,7 +110,6 @@
 		qdel(mag_parts)
 		owner.visible_message("<span class='notice'>[owner] constructs [magnet]!</span>")
 
-#ifndef UNDERWATER_MAP
 /obj/item/magnet_parts
 	name = "mineral magnet parts"
 	desc = "Used to construct a new magnet on a magnet chassis."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Corrects an issue where constructed mineral magnets would erase the fulbright overlays from space and fail to replace them. Normal magnets are unaffected, they use an area var to the same effect.
* Adds an action bar to constructing the mineral magnet


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* bug fix
* lets players know that they are successfully building the magnet instead of wondering if anything is happening for 24 seconds
* Pod Wars polish

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(+)Constructing mineral magnets now displays an action bar. Corrected constructed magnets breaking fullbright space.
```
