### PR TITLE
Pod Wars | You can no longer pick up enemy armor.

### DIFF
--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -500,6 +500,20 @@
 	desc = "For the inner space commander in you."
 	icon_state = "ntberet_commander"
 	item_state = "ntberet_commander"
+	#ifdef MAP_OVERRIDE_POD_WARS
+	//cant_drop = 1
+	//cant_other_remove = 1
+	//cant_self_remove = 1
+	attack_hand(mob/user)
+		if (get_pod_wars_team_num(user) == team)
+			..()
+		else
+			boutput(user, "<span class='alert'>The headset <b>explodes</b> as you reach out to grab it!</span>")
+			make_fake_explosion(src)
+			user.u_equip(src)
+			src.dropped(user)
+			qdel(src)
+	#endif
 	c_flags = SPACEWEAR
 
 	setupProperties()

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -12,7 +12,7 @@
 	var/seal_hair = 0 // best variable name I could come up with, if 1 it forms a seal with a suit so no hair can stick out
 	block_vision = 0
 	var/path_prot = 1 // protection from airborne pathogens, multiplier for chance to be infected
-
+	var/team_num
 
 	setupProperties()
 		..()
@@ -500,15 +500,13 @@
 	desc = "For the inner space commander in you."
 	icon_state = "ntberet_commander"
 	item_state = "ntberet_commander"
+	team_num = TEAM_NANOTRASEN
 	#ifdef MAP_OVERRIDE_POD_WARS
-	//cant_drop = 1
-	//cant_other_remove = 1
-	//cant_self_remove = 1
 	attack_hand(mob/user)
-		if (get_pod_wars_team_num(user) == team)
+		if (get_pod_wars_team_num(user) == team_num)
 			..()
 		else
-			boutput(user, "<span class='alert'>The headset <b>explodes</b> as you reach out to grab it!</span>")
+			boutput(user, "<span class='alert'>The beret <b>explodes</b> as you reach out to grab it!</span>")
 			make_fake_explosion(src)
 			user.u_equip(src)
 			src.dropped(user)

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -211,10 +211,17 @@
 	item_state = "space_helmet_syndicate"
 	desc = "The standard space helmet of the dreaded Syndicate."
 	item_function_flags = IMMUNE_TO_ACID
+	team_num = TEAM_SYNDICATE
 	#ifdef MAP_OVERRIDE_POD_WARS
-	cant_drop = 1
-	cant_other_remove = 1
-	cant_self_remove = 1
+	attack_hand(mob/user)
+		if (get_pod_wars_team_num(user) == team_num)
+			..()
+		else
+			boutput(user, "<span class='alert'>The space helmet <b>explodes</b> as you reach out to grab it!</span>")
+			make_fake_explosion(src)
+			user.u_equip(src)
+			src.dropped(user)
+			qdel(src)
 	#endif
 
 	setupProperties()
@@ -232,10 +239,17 @@
 		desc = "A terrifyingly tall, black & red cap, typically worn by a Syndicate Nuclear Operative Commander. Maybe they're trying to prove something to the Head of Security?"
 		seal_hair = 0
 		see_face = 1
+		team_num = TEAM_SYNDICATE
 		#ifdef MAP_OVERRIDE_POD_WARS
-		cant_drop = 1
-		cant_other_remove = 1
-		cant_self_remove = 1
+		attack_hand(mob/user)
+			if (get_pod_wars_team_num(user) == team_num)
+				..()
+			else
+				boutput(user, "<span class='alert'>The cap <b>explodes</b> as you reach out to grab it!</span>")
+				make_fake_explosion(src)
+				user.u_equip(src)
+				src.dropped(user)
+				qdel(src)
 		#endif
 
 	specialist
@@ -395,10 +409,17 @@
 	icon_state = "nanotrasen_pilot"
 	item_state = "nanotrasen_pilot"
 	desc = "A space helmet used by certain Nanotrasen pilots."
+	team_num = TEAM_NANOTRASEN
 	#ifdef MAP_OVERRIDE_POD_WARS
-	cant_drop = 1
-	cant_other_remove = 1
-	cant_self_remove = 1
+	attack_hand(mob/user)
+		if (get_pod_wars_team_num(user) == team_num)
+			..()
+		else
+			boutput(user, "<span class='alert'>The space helmet <b>explodes</b> as you reach out to grab it!</span>")
+			make_fake_explosion(src)
+			user.u_equip(src)
+			src.dropped(user)
+			qdel(src)
 	#endif
 
 	setupProperties()

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -211,6 +211,11 @@
 	item_state = "space_helmet_syndicate"
 	desc = "The standard space helmet of the dreaded Syndicate."
 	item_function_flags = IMMUNE_TO_ACID
+	#ifdef MAP_OVERRIDE_POD_WARS
+	cant_drop = 1
+	cant_other_remove = 1
+	cant_self_remove = 1
+	#endif
 
 	setupProperties()
 		..()
@@ -227,6 +232,11 @@
 		desc = "A terrifyingly tall, black & red cap, typically worn by a Syndicate Nuclear Operative Commander. Maybe they're trying to prove something to the Head of Security?"
 		seal_hair = 0
 		see_face = 1
+		#ifdef MAP_OVERRIDE_POD_WARS
+		cant_drop = 1
+		cant_other_remove = 1
+		cant_self_remove = 1
+		#endif
 
 	specialist
 		name = "specialist combat helmet"
@@ -385,6 +395,11 @@
 	icon_state = "nanotrasen_pilot"
 	item_state = "nanotrasen_pilot"
 	desc = "A space helmet used by certain Nanotrasen pilots."
+	#ifdef MAP_OVERRIDE_POD_WARS
+	cant_drop = 1
+	cant_other_remove = 1
+	cant_self_remove = 1
+	#endif
 
 	setupProperties()
 		..()

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -18,6 +18,7 @@
 	w_class = W_CLASS_NORMAL
 	var/restrain_wearer = 0
 	var/bloodoverlayimage = 0
+	var/team_num
 
 
 	setupProperties()
@@ -1063,10 +1064,17 @@
 	item_state = "space_suit_syndicate"
 	desc = "A suit that protects against low pressure environments. Issued to syndicate operatives."
 	contraband = 3
+	team_num = TEAM_SYNDICATE
 	#ifdef MAP_OVERRIDE_POD_WARS
-	cant_drop = 1
-	cant_other_remove = 1
-	cant_self_remove = 1
+	attack_hand(mob/user)
+		if (get_pod_wars_team_num(user) == team_num)
+			..()
+		else
+			boutput(user, "<span class='alert'>The space suit <b>explodes</b> as you reach out to grab it!</span>")
+			make_fake_explosion(src)
+			user.u_equip(src)
+			src.dropped(user)
+			qdel(src)
 	#endif
 	item_function_flags = IMMUNE_TO_ACID
 
@@ -1078,10 +1086,17 @@
 		name = "commander's great coat"
 		icon_state = "commissar_greatcoat"
 		desc = "A fear-inspiring, black-leather great coat, typically worn by a Syndicate Nuclear Operative Commander. So scary even the vacuum of space doesn't dare claim the wearer."
+		team_num = TEAM_SYNDICATE
 		#ifdef MAP_OVERRIDE_POD_WARS
-		cant_drop = 1
-		cant_other_remove = 1
-		cant_self_remove = 1
+		attack_hand(mob/user)
+			if (get_pod_wars_team_num(user) == team_num)
+				..()
+			else
+				boutput(user, "<span class='alert'>The coat <b>explodes</b> as you reach out to grab it!</span>")
+				make_fake_explosion(src)
+				user.u_equip(src)
+				src.dropped(user)
+				qdel(src)
 		#endif
 
 		setupProperties()
@@ -1317,10 +1332,17 @@
 		icon_state = "nanotrasen_pilot"
 		item_state = "nanotrasen_pilot"
 		desc = "A suit that protects against low pressure environments. Issued to nanotrasen pilots."
+		team_num = TEAM_NANOTRASEN
 		#ifdef MAP_OVERRIDE_POD_WARS
-		cant_drop = 1
-		cant_other_remove = 1
-		cant_self_remove = 1
+		attack_hand(mob/user)
+			if (get_pod_wars_team_num(user) == team_num)
+				..()
+			else
+				boutput(user, "<span class='alert'>The space suit <b>explodes</b> as you reach out to grab it!</span>")
+				make_fake_explosion(src)
+				user.u_equip(src)
+				src.dropped(user)
+				qdel(src)
 		#endif
 
 		setupProperties()
@@ -1332,10 +1354,17 @@
 			icon_state = "ntcommander_coat"
 			item_state = "ntcommander_coat"
 			desc = "A fear-inspiring, blue-ish-leather great coat, typically worn by a NanoTrasen Pod Commander. Why does it look like it's been dyed painted blue?"
+			team_num = TEAM_NANOTRASEN
 			#ifdef MAP_OVERRIDE_POD_WARS
-			cant_drop = 1
-			cant_other_remove = 1
-			cant_self_remove = 1
+			attack_hand(mob/user)
+				if (get_pod_wars_team_num(user) == team_num)
+					..()
+				else
+					boutput(user, "<span class='alert'>The coat <b>explodes</b> as you reach out to grab it!</span>")
+					make_fake_explosion(src)
+					user.u_equip(src)
+					src.dropped(user)
+					qdel(src)
 			#endif
 
 			setupProperties()

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1063,6 +1063,11 @@
 	item_state = "space_suit_syndicate"
 	desc = "A suit that protects against low pressure environments. Issued to syndicate operatives."
 	contraband = 3
+	#ifdef MAP_OVERRIDE_POD_WARS
+	cant_drop = 1
+	cant_other_remove = 1
+	cant_self_remove = 1
+	#endif
 	item_function_flags = IMMUNE_TO_ACID
 
 	setupProperties()
@@ -1073,6 +1078,11 @@
 		name = "commander's great coat"
 		icon_state = "commissar_greatcoat"
 		desc = "A fear-inspiring, black-leather great coat, typically worn by a Syndicate Nuclear Operative Commander. So scary even the vacuum of space doesn't dare claim the wearer."
+		#ifdef MAP_OVERRIDE_POD_WARS
+		cant_drop = 1
+		cant_other_remove = 1
+		cant_self_remove = 1
+		#endif
 
 		setupProperties()
 			..()
@@ -1307,6 +1317,11 @@
 		icon_state = "nanotrasen_pilot"
 		item_state = "nanotrasen_pilot"
 		desc = "A suit that protects against low pressure environments. Issued to nanotrasen pilots."
+		#ifdef MAP_OVERRIDE_POD_WARS
+		cant_drop = 1
+		cant_other_remove = 1
+		cant_self_remove = 1
+		#endif
 
 		setupProperties()
 			..()
@@ -1317,6 +1332,11 @@
 			icon_state = "ntcommander_coat"
 			item_state = "ntcommander_coat"
 			desc = "A fear-inspiring, blue-ish-leather great coat, typically worn by a NanoTrasen Pod Commander. Why does it look like it's been dyed painted blue?"
+			#ifdef MAP_OVERRIDE_POD_WARS
+			cant_drop = 1
+			cant_other_remove = 1
+			cant_self_remove = 1
+			#endif
 
 			setupProperties()
 				..()

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -728,12 +728,22 @@
 	desc = "Non-descript, slightly suspicious civilian clothing."
 	icon_state = "syndicate"
 	item_state = "syndicate"
+	#ifdef MAP_OVERRIDE_POD_WARS
+	cant_drop = 1
+	cant_other_remove = 1
+	cant_self_remove = 1
+	#endif
 
 /obj/item/clothing/under/misc/turds
 	name = "NT-SO Jumpsuit"
 	desc = "A Nanotrasen Special Operations jumpsuit."
 	icon_state = "turdsuit"
 	item_state = "turdsuit"
+	#ifdef MAP_OVERRIDE_POD_WARS
+	cant_drop = 1
+	cant_other_remove = 1
+	cant_self_remove = 1
+	#endif
 
 /obj/item/clothing/under/misc/NT
 	name = "nanotrasen jumpsuit"

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -19,6 +19,7 @@
 	burn_output = 800
 	burn_possible = 1
 	health = 50
+	var/team_num
 
 	duration_remove = 6.5 SECONDS
 
@@ -728,10 +729,17 @@
 	desc = "Non-descript, slightly suspicious civilian clothing."
 	icon_state = "syndicate"
 	item_state = "syndicate"
+	team_num = TEAM_SYNDICATE
 	#ifdef MAP_OVERRIDE_POD_WARS
-	cant_drop = 1
-	cant_other_remove = 1
-	cant_self_remove = 1
+	attack_hand(mob/user)
+		if (get_pod_wars_team_num(user) == team_num)
+			..()
+		else
+			boutput(user, "<span class='alert'>The jumpsuit <b>explodes</b> as you reach out to grab it!</span>")
+			make_fake_explosion(src)
+			user.u_equip(src)
+			src.dropped(user)
+			qdel(src)
 	#endif
 
 /obj/item/clothing/under/misc/turds
@@ -739,10 +747,17 @@
 	desc = "A Nanotrasen Special Operations jumpsuit."
 	icon_state = "turdsuit"
 	item_state = "turdsuit"
+	team_num = TEAM_NANOTRASEN
 	#ifdef MAP_OVERRIDE_POD_WARS
-	cant_drop = 1
-	cant_other_remove = 1
-	cant_self_remove = 1
+	attack_hand(mob/user)
+		if (get_pod_wars_team_num(user) == team_num)
+			..()
+		else
+			boutput(user, "<span class='alert'>The jumpsuit <b>explodes</b> as you reach out to grab it!</span>")
+			make_fake_explosion(src)
+			user.u_equip(src)
+			src.dropped(user)
+			qdel(src)
 	#endif
 
 /obj/item/clothing/under/misc/NT


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a feature not dissimilar to what currently happens, in Pod Wars, when you pick up enemy PDAs or radios. That being, it "explodes" then gets deleted.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Disguising as the enemy team is not a good thing, since the antag overlays for your team are notoriously finnicky, and have led to multiple teamkills, both by and to me. Also, in my opinion, you shouldn't be able to do this in the first place, since this is a team vs team PVP mode where you should be able to trust the people who appear to be on your team.

