### PR TITLE
Detgadget hat autolights cigarettes

### DIFF
--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -339,6 +339,10 @@
 						M.put_in_hand_or_drop(W) //Put it in their hand
 
 					M.visible_message("<span class='alert'><b>[M]</b>'s hat snaps open and puts \the [W] in [his_or_her(M)] [boop]!</span>")
+					var/obj/item/device/light/zippo/lighter = (locate(/obj/item/device/light/zippo) in src.contents)
+					if (lighter)
+						W.light(M, "<span class='alert'><b>[M]</b>'s hat proceeds to light \the [W] with \the [lighter], whoa.</span>")
+						lighter.firesource_interact()
 			else
 				M.show_text("Requested object missing or nonexistant!", "red")
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a bit to the detgadget hat to try and light a summoned cigarette if you've put a lighter in it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I saw Duke Nukem mention this in discord and thought it'd be neat and silly thing.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)The Detgadget hat will now automatically light requested cigarettes if it can, so you can continue punching crime and drinking uninterrupted.
```
