### PR TITLE
Makes the quantum telescope constructable

### DIFF
--- a/code/WorkInProgress/telescope/quantumTelescope.dm
+++ b/code/WorkInProgress/telescope/quantumTelescope.dm
@@ -29,6 +29,42 @@ TODO: Enforce ping rate limit here as well in case someone futzes with the javas
 	attack_ai(mob/user as mob)
 		return attack_hand(user)
 
+	attackby(obj/item/I as obj, mob/user as mob)
+		if (isscrewingtool(I))
+			playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
+			if (do_after(user, 2 SECONDS))
+				if (src.status & BROKEN)
+					user.show_text("The broken glass falls out.", "blue")
+					var/obj/computerframe/A = new /obj/computerframe(src.loc)
+					if (src.material)
+						A.setMaterial(src.material)
+					var/obj/item/raw_material/shard/glass/G = unpool(/obj/item/raw_material/shard/glass)
+					G.set_loc(src.loc)
+					var/obj/item/circuitboard/telescope/M = new /obj/item/circuitboard/telescope(A)
+					for (var/obj/C in src)
+						C.set_loc(src.loc)
+					A.circuit = M
+					A.state = 3
+					A.icon_state = "3"
+					A.anchored = 1
+					qdel(src)
+				else
+					user.show_text("You disconnect the monitor.", "blue")
+					var/obj/computerframe/A = new /obj/computerframe(src.loc)
+					if (src.material)
+						A.setMaterial(src.material)
+					var/obj/item/circuitboard/telescope/M = new /obj/item/circuitboard/telescope(A)
+					for (var/obj/C in src)
+						C.set_loc(src.loc)
+					A.circuit = M
+					A.state = 4
+					A.icon_state = "4"
+					A.anchored = 1
+					qdel(src)
+		else
+			..()
+		return
+
 	attack_hand(mob/user as mob)
 		if(status & (BROKEN|NOPOWER))
 			return

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -132,6 +132,9 @@
 /obj/item/circuitboard/mining_magnet
 	name = "Circuit board (Mining Magnet Computer)"
 	computertype = "/obj/machinery/computer/magnet"
+/obj/item/circuitboard/telescope
+	name = "Circuit board (Quantum Telescope)"
+	computertype = "/obj/machinery/computer/telescope"
 
 /obj/computerframe/meteorhit(obj/O as obj)
 	qdel(src)

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -20225,6 +20225,7 @@
 /obj/item/circuitboard/powermonitor_smes,
 /obj/item/circuitboard/powermonitor,
 /obj/item/circuitboard/arcade,
+/obj/item/circuitboard/telescope,
 /obj/item/disk/data/tape,
 /obj/item/disk/data/tape/guardbot_tools,
 /turf/simulated/floor/plating,

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -32808,6 +32808,7 @@
 /obj/item/circuitboard/arcade,
 /obj/item/circuitboard/powermonitor_smes,
 /obj/item/circuitboard/genetics,
+/obj/item/circuitboard/telescope,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bqG" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -53035,6 +53035,10 @@
 /area/station/medical/medbay/lobby)
 "cCc" = (
 /obj/rack,
+/obj/item/circuitboard/telescope{
+	pixel_x = -5;
+	pixel_y = 1
+	},
 /obj/item/circuitboard/powermonitor{
 	pixel_x = -5;
 	pixel_y = -3

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -59943,6 +59943,7 @@
 /obj/item/circuitboard/powermonitor_smes,
 /obj/item/circuitboard/operating,
 /obj/item/circuitboard/genetics,
+/obj/item/circuitboard/telescope,
 /turf/simulated/floor/plating,
 /area/station/storage/warehouse)
 "cBl" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -44196,6 +44196,7 @@
 /obj/item/circuitboard/powermonitor_smes,
 /obj/item/circuitboard/operating,
 /obj/item/circuitboard/genetics,
+/obj/item/circuitboard/telescope,
 /obj/cable,
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -42202,6 +42202,10 @@
 	pixel_x = 2;
 	pixel_y = -4
 	},
+/obj/item/circuitboard/telescope{
+	pixel_x = 6;
+	pixel_y = -6
+	},
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -23076,6 +23076,7 @@
 	icon_state = "1-8"
 	},
 /obj/item/circuitboard/genetics,
+/obj/item/circuitboard/telescope,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "bfa" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -52505,6 +52505,7 @@
 /obj/item/circuitboard/genetics,
 /obj/item/circuitboard/bank_data,
 /obj/item/circuitboard/arcade,
+/obj/item/circuitboard/telescope,
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/storage/tech)
 "osY" = (

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -8724,6 +8724,7 @@
 /obj/item/circuitboard/powermonitor,
 /obj/item/circuitboard/arcade,
 /obj/item/circuitboard/tetris,
+/obj/item/circuitboard/telescope,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -15529,6 +15529,7 @@
 /obj/item/circuitboard/powermonitor_smes,
 /obj/item/circuitboard/operating,
 /obj/item/circuitboard/genetics,
+/obj/item/circuitboard/telescope,
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "aKq" = (

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -10013,6 +10013,7 @@
 /obj/item/circuitboard/genetics,
 /obj/item/circuitboard/bank_data,
 /obj/item/circuitboard/arcade,
+/obj/item/circuitboard/telescope,
 /obj/machinery/light/small,
 /turf/simulated/floor/grey/blackgrime,
 /area/station/storage/tech)

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -52349,6 +52349,10 @@
 /area/station/storage/warehouse)
 "bVf" = (
 /obj/rack,
+/obj/item/circuitboard/telescope{
+	pixel_x = 5;
+	pixel_y = 1
+	},
 /obj/item/circuitboard/powermonitor{
 	pixel_x = 5;
 	pixel_y = -3

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -24730,6 +24730,7 @@
 /obj/item/circuitboard/powermonitor_smes,
 /obj/item/circuitboard/operating,
 /obj/item/circuitboard/genetics,
+/obj/item/circuitboard/telescope,
 /obj/decal/cleanable/fungus,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -1963,6 +1963,7 @@
 	},
 /obj/table/auto,
 /obj/decal/cleanable/cobweb2,
+/obj/item/circuitboard/telescope,
 /turf/simulated/floor/grime,
 /area/mining/magnet_control)
 "afN" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the quantum telescope console constructable from console frames in the same way as the teleporter and cloning consoles. Adds a circuit board for constructing it and adds the circuit board to tech storage in each map and the mining outpost.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The telescope console uses the same frame as the other constructable consoles. Being constructable would be consistent with the other consoles in the game. This allows the quantum telescope to be replaced if destroyed or deconstructed and moved by players. The additional telescope circuit board in the mining outpost will require players to build the console themselves before searching for asteroids off-station which seems fitting since the magnet has to be set up as well. Fixes #4519


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Makes the quantum telescope console constructable.
(+)Adds the new quantum telescope circuit board to tech storage and the mining outpost.
```
