### PR TITLE
fix small bug with artifact analysis forms

### DIFF
--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -27,14 +27,15 @@
 		if(A.type_name == src.artifactType)
 			lastAnalysis++
 
-		// check if trigger is one of the correct ones
-		for(var/datum/artifact_trigger/T as anything in A.triggers)
-			if(T.type_name == src.artifactTriggers)
-				lastAnalysis++
-				break
-		// if a trigger would e redundant, let's just say it's cool!
-		if(!length(A.triggers) || A.automatic_activation)
+		// if a trigger would be redundant, let's just say it's cool!
+		if(A.automatic_activation)
 			lastAnalysis++
+		else
+			// check if trigger is one of the correct ones
+			for(var/datum/artifact_trigger/T as anything in A.triggers)
+				if(T.type_name == src.artifactTriggers)
+					lastAnalysis++
+					break
 
 		// ok, let's make a name
 		// start with obscured name


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If an artifact was of an automatically activated type, you would just get a point by default since it was redundant, but some of those artifact types still generate triggers, so if you got those correctly as well, you would be up to 133.33% correct in your artifact analysis.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
no fun allowed