### PR TITLE
Fix spy organ selection logic

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -585,7 +585,7 @@
 	//Add organs
 	var/list/O = organ_bounties.Copy()
 	var/found_organs = 0;
-	var/organs_length = O.len
+	var/organs_length = length(O)
 	for(var/i=1, (found_organs < organ_bounty_amt) && (i <= organs_length), i++)
 		var/datum/bounty_item/B = new /datum/bounty_item(src)
 		var/list/pair = pick(O)

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -584,7 +584,7 @@
 				valid_spy_thief_targets_by_type[Object.type] = list(Object)
 	//Add organs
 	var/list/O = organ_bounties.Copy()
-	var/found_organs = 0;
+	var/found_organs = 0
 	var/organs_length = length(O)
 	for(var/i=1, (found_organs < organ_bounty_amt) && (i <= organs_length), i++)
 		var/datum/bounty_item/B = new /datum/bounty_item(src)

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -584,7 +584,9 @@
 				valid_spy_thief_targets_by_type[Object.type] = list(Object)
 	//Add organs
 	var/list/O = organ_bounties.Copy()
-	for(var/i=1, i<=organ_bounty_amt && O.len, i++)
+	var/found_organs = 0;
+	var/organs_length = O.len
+	for(var/i=1, (found_organs < organ_bounty_amt) && (i <= organs_length), i++)
 		var/datum/bounty_item/B = new /datum/bounty_item(src)
 		var/list/pair = pick(O)
 		B.item = pair[1]
@@ -593,16 +595,14 @@
 		if (istype(B.item, /obj/item/parts))
 			var/obj/item/parts/P = B.item
 			if (!P || P.qdeled || !P.holder || P.holder.qdeled)
-				// "this seems really stupid"
-				// well, yes; the idea is that this grants a retry
-				// (up to ~4 times) to pick a valid solution
-				// is it dumb? hell yeah. do i care? naaaaah.
-				i -= 0.75
+				// Not found, next organ
+				O -= list(pair)
 				continue
 			B.name = P.holder.real_name + "'s " + P.name
 		B.reveal_area = 1
 		O -= list(pair)
 
+		found_organs++
 		B.bounty_type = BOUNTY_TYPE_ORGAN
 		active_bounties += B
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Spies would not always get four limb bounties despite many valid targets. From testing I believe this to be caused by the retry logic causing it to move ahead one for every four failures. This has been rewritten to not be stinky (probably).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
RNG would result in less bounty targets than intended.