### PR TITLE
Adds a single stalactite to Biodome

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -81045,6 +81045,11 @@
 	icon_state = "diagonalWall3"
 	},
 /area/diner/tug)
+"rPr" = (
+/obj/map/light/graveyard,
+/obj/decal/stalagtite,
+/turf/unsimulated/floor/cave,
+/area/catacombs)
 "rQC" = (
 /obj/decal/stage_edge/dojo,
 /obj/decal/stone_lamp{
@@ -139972,7 +139977,7 @@ bnW
 aTs
 aaa
 boz
-boP
+rPr
 bpp
 boz
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL] [Secret]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds one stalactite to the room behind the alchemy circle, allowing it to be traversed by a whip, with the caveat of it being a one way trip across, forcing the person to have a port-a-sci to get out, or similar.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It bugged me that this coffin was _mostly_ unobtainable, forcing you to use things like the obsidian crown to get across. 
<img width="295" alt="Screenshot 2021-06-04 082503" src="https://user-images.githubusercontent.com/41448081/120825938-bf063080-c50e-11eb-8ae8-6895d73d8da3.png">
^ This is the room, with the normal lighting removed, with the stalactite being pointed at.



