### PR TITLE
Swaps CE RCD on Clarion for RCDC

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -36231,7 +36231,7 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 1
 	},
-/obj/storage/crate/rcd,
+/obj/storage/crate/rcd/CE,
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "fblue2"

--- a/maps/clarion_xmas_2020.dmm
+++ b/maps/clarion_xmas_2020.dmm
@@ -39230,7 +39230,7 @@
 	layer = 3.5;
 	pixel_y = 24
 	},
-/obj/storage/crate/rcd,
+/obj/storage/crate/rcd/CE,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;

--- a/maps/horizon_xmas.dmm
+++ b/maps/horizon_xmas.dmm
@@ -51757,7 +51757,7 @@
 	},
 /area/station/crew_quarters/ce)
 "cjs" = (
-/obj/storage/crate/rcd,
+/obj/storage/crate/rcd/CE,
 /obj/item/clothing/shoes/magnetic,
 /obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/yellowblack,

--- a/maps/unused/clarion_xmas_2018.dmm
+++ b/maps/unused/clarion_xmas_2018.dmm
@@ -40887,7 +40887,7 @@
 	layer = 3.5;
 	pixel_y = 24
 	},
-/obj/storage/crate/rcd,
+/obj/storage/crate/rcd/CE,
 /obj/cable{
 	icon_state = "4-8";
 	d1 = 4;

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -26694,7 +26694,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/lobby)
 "lnT" = (
-/obj/storage/crate/rcd,
+/obj/storage/crate/rcd/CE,
 /obj/item/device/radio/intercom/engineering{
 	pixel_y = 28
 	},


### PR DESCRIPTION
[mapping][bug - minor]

## About the PR
Swaps the RCD crate on Clarion for the CE RCDC crate.

## Why's this needed? 
Engineers can have a little airlock customization. As a treat.