### PR TITLE
Prevents dropping borg items on the material processor

### DIFF
--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -239,7 +239,7 @@
 
 		var/obj/item/W = O
 
-		if(W in user)
+		if(W in user && !W.cant_drop)
 			user.u_equip(W)
 			W.set_loc(src.loc)
 			W.dropped()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug allowing borgs to drop inventory items by dragging them onto the material processor. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5015. No more sticky borg tools.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Fixes borgs dropping items on the material processor.
```
