### PR TITLE
Cyborg module selection color fix

### DIFF
--- a/code/modules/robotics/robot/module/chemistry.dm
+++ b/code/modules/robotics/robot/module/chemistry.dm
@@ -12,4 +12,4 @@
 	ches_mod = "Lab Coat"
 	fx = list(0, 0, 255)
 	painted = 1
-	paint = list(0, 0, 100)
+	paint = "#000064"

--- a/code/modules/robotics/robot/module/civilian.dm
+++ b/code/modules/robotics/robot/module/civilian.dm
@@ -10,4 +10,4 @@
 /datum/robot_cosmetic/civilian
 	fx = list(255, 0, 0)
 	painted = 1
-	paint = list(0, 0, 0)
+	paint = "#000000"

--- a/code/modules/robotics/robot/module/construction_worker.dm
+++ b/code/modules/robotics/robot/module/construction_worker.dm
@@ -10,4 +10,4 @@
 /datum/robot_cosmetic/construction
 	fx = list(0,240,160)
 	painted = 1
-	paint = list(0,120,80)
+	paint = "#007850"

--- a/code/modules/robotics/robot/module/engineering.dm
+++ b/code/modules/robotics/robot/module/engineering.dm
@@ -12,4 +12,4 @@
 /datum/robot_cosmetic/engineering
 	fx = list(255, 255, 0)
 	painted = 1
-	paint = list(130, 150, 0)
+	paint = "#829600"

--- a/code/modules/robotics/robot/module/medical.dm
+++ b/code/modules/robotics/robot/module/medical.dm
@@ -14,4 +14,4 @@
 	ches_mod = "Medical Insignia"
 	fx = list(0, 255, 0)
 	painted = 1
-	paint = list(150, 150, 150)
+	paint = "#969696"

--- a/code/modules/robotics/robot/module/mining.dm
+++ b/code/modules/robotics/robot/module/mining.dm
@@ -13,4 +13,4 @@
 	head_mod = "Hard Hat"
 	fx = list(0, 255, 255)
 	painted = 1
-	paint = list(130, 90, 0)
+	paint = "#825A00"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the default colors associated with different modules to be hex values rather than RGB lists.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The code expects hex values and throws a runtime error each time a player chooses their initial module before defaulting to white. This change corrects the initial values to their hex equivalents.


