### PR TITLE
Scannable name fixes

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -216,24 +216,27 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	.= ..()
 
 /obj/machinery/door/airlock/command
+	name = "command airlock"
 	icon = 'icons/obj/doors/Doorcom.dmi'
 	req_access = list(access_heads)
 
 /obj/machinery/door/airlock/security
+	name = "security airlock"
 	icon = 'icons/obj/doors/Doorsec.dmi'
 	req_access = list(access_security)
 
 /obj/machinery/door/airlock/engineering
-	name = "Engineering"
+	name = "engineering airlock"
 	icon = 'icons/obj/doors/Dooreng.dmi'
 	req_access = list(access_engineering)
 
 /obj/machinery/door/airlock/medical
+	name = "medical airlock"
 	icon = 'icons/obj/doors/doormed.dmi'
 	req_access = list(access_medical)
 
 /obj/machinery/door/airlock/maintenance
-	name = "Maintenance Access"
+	name = "maintenance airlock"
 	icon = 'icons/obj/doors/Doormaint.dmi'
 	req_access = list(access_maint_tunnels)
 
@@ -282,18 +285,22 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	visible = 0
 
 /obj/machinery/door/airlock/glass/command
+		name = "command airlock"
 		icon = 'icons/obj/doors/Doorcom-glass.dmi'
 		req_access = list(access_heads)
 
 /obj/machinery/door/airlock/glass/engineering
+		name = "command airlock"
 		icon = 'icons/obj/doors/Dooreng-glass.dmi'
 		req_access = list(access_engineering)
 
 /obj/machinery/door/airlock/glass/medical
+		name = "medical airlock"
 		icon = 'icons/obj/doors/Doormed-glass.dmi'
 		req_access = list(access_medical)
 
 /obj/machinery/door/airlock/classic
+	name = "classic airlock"
 	icon = 'icons/obj/doors/Doorclassic.dmi'
 	sound_airlock = 'sound/machines/airlock.ogg'
 	operation_time = 10
@@ -314,7 +321,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	welded_icon_state = "2_welded"
 
 /obj/machinery/door/airlock/pyro/command
-	name = "Command Airlock"
+	name = "command airlock"
 	icon_state = "com_closed"
 	icon_base = "com"
 	req_access = list(access_heads)
@@ -348,7 +355,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 
 
 /obj/machinery/door/airlock/pyro/security
-	name = "Security Airlock"
+	name = "security airlock"
 	icon_state = "sec_closed"
 	icon_base = "sec"
 	req_access = list(access_security)
@@ -361,7 +368,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/engineering
-	name = "Engineering Airlock"
+	name = "engineering airlock"
 	icon_state = "eng_closed"
 	icon_base = "eng"
 	req_access = list(access_engineering)
@@ -374,7 +381,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/medical
-	name = "Medical Airlock"
+	name = "medical airlock"
 	icon_state = "research_closed"
 	icon_base = "research"
 	req_access = list(access_medical)
@@ -401,6 +408,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/mining
+	name = "mining airlock"
 	icon_state = "mining_closed"
 	icon_base = "mining"
 	panel_icon_state = "2_panel_open"
@@ -408,7 +416,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/maintenance
-	name = "maintenance access"
+	name = "maintenance airlock"
 	icon_state = "maint_closed"
 	icon_base = "maint"
 	req_access = list(access_maint_tunnels)
@@ -463,46 +471,55 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	req_access_txt = "2"
 
 /obj/machinery/door/airlock/pyro/glass/command
+	name = "command airlock"
 	icon_state = "com_glass_closed"
 	icon_base = "com_glass"
 	req_access = list(access_heads)
 
 /obj/machinery/door/airlock/pyro/glass/engineering
+	name = "engineering airlock"
 	icon_state = "eng_glass_closed"
 	icon_base = "eng_glass"
 	req_access = list(access_engineering)
 
 /obj/machinery/door/airlock/pyro/glass/security //Shitty Azungar recolor, no need to thank me.
+	name = "security airlock"
 	icon_state = "sec_glass_closed"
 	icon_base = "sec_glass"
 	req_access = list(access_security)
 
 /obj/machinery/door/airlock/pyro/glass/med
+	name = "medical airlock"
 	icon_state = "med_glass_closed"
 	icon_base = "med_glass"
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/sci
+	name = "research airlock"
 	icon_state = "sci_glass_closed"
 	icon_base = "sci_glass"
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/toxins
+	name = "toxins airlock"
 	icon_state = "toxins_glass_closed"
 	icon_base = "toxins_glass"
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/mining
+	name = "mining airlock"
 	icon_state = "mining_glass_closed"
 	icon_base = "mining_glass"
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/glass/botany
+	name = "botany airlock"
 	icon_state = "botany_glass_closed"
 	icon_base = "botany_glass"
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/classic
+	name = "old airlock"
 	icon_state = "old_closed"
 	icon_base = "old"
 	panel_icon_state = "old_panel_open"
@@ -542,6 +559,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	layer = 3.5
 
 /obj/machinery/door/airlock/pyro/sci_alt
+	name = "research airlock"
 	icon_state = "sci_closed"
 	icon_base = "sci"
 	panel_icon_state = "2_panel_open"
@@ -549,6 +567,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/toxins_alt
+	name = "toxins airlock"
 	icon_state = "toxins2_closed"
 	icon_base = "toxins2"
 	panel_icon_state = "2_panel_open"
@@ -567,6 +586,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fgen_welded"
 
 	command
+		name = "command airlock"
 		icon_state = "com_closed"
 		icon_base = "com"
 		req_access = list(access_heads)
@@ -577,6 +597,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fcom_welded"
 
 	security
+		name = "security airlock"
 		icon_state = "sec_closed"
 		icon_base = "sec"
 		req_access = list(access_security)
@@ -587,6 +608,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fsec_welded"
 
 	engineering
+		name = "engineering airlock"
 		icon_state = "eng_closed"
 		icon_base = "eng"
 		req_access = list(access_engineering)
@@ -597,6 +619,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "feng_welded"
 
 	medical
+		name = "medical airlock"
 		icon_state = "med_closed"
 		icon_base = "med"
 		req_access = list(access_medical)
@@ -607,6 +630,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fmed_welded"
 
 	morgue
+		name = "morgue airlock"
 		icon_state = "morg_closed"
 		icon_base = "morg"
 		req_access = list(access_morgue)
@@ -617,6 +641,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fmorg_welded"
 
 	chemistry
+		name = "chemistry airlock"
 		icon_state = "chem_closed"
 		icon_base = "chem"
 		req_access = list(access_research)
@@ -627,6 +652,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fchem_welded"
 
 	toxins
+		name = "toxins airlock"
 		icon_state = "tox_closed"
 		icon_base = "tox"
 		req_access = list(access_research)
@@ -637,6 +663,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "ftox_welded"
 
 	maintenance
+		name = "maintenance airlock"
 		icon_state = "maint_closed"
 		icon_base = "maint"
 		welded_icon_state = "maint_welded"
@@ -656,6 +683,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fgen_welded"
 
 	command
+		name = "glass command airlock"
 		icon_state = "tcom_closed"
 		icon_base = "tcom"
 		req_access = list(access_heads)
@@ -666,6 +694,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fcom_welded"
 
 	security
+		name = "glass security airlock"
 		icon_state = "tsec_closed"
 		icon_base = "tsec"
 		req_access = list(access_security)
@@ -676,6 +705,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fsec_welded"
 
 	engineering
+		name = "glass engineering airlock"
 		icon_state = "teng_closed"
 		icon_base = "teng"
 		req_access = list(access_engineering)
@@ -686,6 +716,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "feng_welded"
 
 	medical
+		name = "glass medical airlock"
 		icon_state = "tmed_closed"
 		icon_base = "tmed"
 		req_access = list(access_medical)
@@ -696,6 +727,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fmed_welded"
 
 	morgue
+		name = "glass morgue airlock"
 		icon_state = "tmorg_closed"
 		icon_base = "tmorg"
 		req_access = list(access_morgue)
@@ -706,6 +738,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fmorg_welded"
 
 	chemistry
+		name = "glass chemistry airlock"
 		icon_state = "tchem_closed"
 		icon_base = "tchem"
 		req_access = list(access_research)
@@ -716,6 +749,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "fchem_welded"
 
 	toxins
+		name = "glass toxins airlock"
 		icon_state = "ttox_closed"
 		icon_base = "ttox"
 		req_access = list(access_research)
@@ -726,6 +760,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		welded_icon_state = "ftox_welded"
 
 	maintenance
+		name = "glass maintenance airlock"
 		icon_state = "tmaint_closed"
 		icon_base = "tmaint"
 		welded_icon_state = "tmaint_welded"

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -300,7 +300,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		req_access = list(access_medical)
 
 /obj/machinery/door/airlock/classic
-	name = "classic airlock"
+	name = "large airlock"
 	icon = 'icons/obj/doors/Doorclassic.dmi'
 	sound_airlock = 'sound/machines/airlock.ogg'
 	operation_time = 10

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -510,7 +510,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	operation_time = 10
 
 /obj/machinery/door/airlock/pyro/glass/windoor
-	name = "counter window"
+	name = "thin glass airlock"
 	icon_state = "windoor_closed"
 	icon_base = "windoor"
 	panel_icon_state = "windoor"

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -290,7 +290,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 		req_access = list(access_heads)
 
 /obj/machinery/door/airlock/glass/engineering
-		name = "command airlock"
+		name = "engineering airlock"
 		icon = 'icons/obj/doors/Dooreng-glass.dmi'
 		req_access = list(access_engineering)
 

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -314,7 +314,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	welded_icon_state = "2_welded"
 
 /obj/machinery/door/airlock/pyro/command
-	name = "Command"
+	name = "Command Airlock"
 	icon_state = "com_closed"
 	icon_base = "com"
 	req_access = list(access_heads)
@@ -348,7 +348,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 
 
 /obj/machinery/door/airlock/pyro/security
-	name = "Security"
+	name = "Security Airlock"
 	icon_state = "sec_closed"
 	icon_base = "sec"
 	req_access = list(access_security)
@@ -361,7 +361,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/engineering
-	name = "Engineering"
+	name = "Engineering Airlock"
 	icon_state = "eng_closed"
 	icon_base = "eng"
 	req_access = list(access_engineering)
@@ -374,6 +374,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	req_access = null
 
 /obj/machinery/door/airlock/pyro/medical
+	name = "Medical Airlock"
 	icon_state = "research_closed"
 	icon_base = "research"
 	req_access = list(access_medical)

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -510,6 +510,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	operation_time = 10
 
 /obj/machinery/door/airlock/pyro/glass/windoor
+	name = "counter window"
 	icon_state = "windoor_closed"
 	icon_base = "windoor"
 	panel_icon_state = "windoor"

--- a/code/obj/machinery/phone.dm
+++ b/code/obj/machinery/phone.dm
@@ -322,7 +322,7 @@
 		holder = user
 
 /obj/machinery/phone/wall
-	name = "phone"
+	name = "wall phone"
 	icon = 'icons/obj/machines/phones.dmi'
 	desc = "A landline phone. In space. Where there is no land. Hmm."
 	icon_state = "wallphone"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Looking for mech scannable items that have identical names, so far we've got

wall phones "phone" -> "wall phone"
windooors "glass airlock" -> "thin glass airlock"

Research/Command/Engineering airlocks -> "department airlock"

Trying to find any of these that exist so please let me know if you know or find any

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Manufacturers and rucks don't have icons at the moment, you can now scan items with the same name in #4989, and you can load items with the same name into manufacturers in #5033 , and this makes it possible to tell them apart in both

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

Nah
