### PR TITLE
Metal arms no longer bleed when picking up a rose

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -340,6 +340,9 @@
 			var/ops = text2num(href_list["repair"])
 
 			if (ops == 1 && R.compborg_get_total_damage(1) > 0)
+				if (src.reagents.get_reagent_amount("fuel") < 1)
+					boutput(usr, "<span class='alert'>Not enough welding fuel for repairs.</span>")
+					return
 				var/usage = input(usr, "How much welding fuel do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return
@@ -351,6 +354,9 @@
 					RP.ropart_mend_damage(usage,0)
 				src.reagents.remove_reagent("fuel", usage)
 			else if (ops == 2 && R.compborg_get_total_damage(2) > 0)
+				if (src.cabling < 1)
+					boutput(usr, "<span class='alert'>Not enough wiring for repairs.</span>")
+					return
 				var/usage = input(usr, "How much wiring do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -340,9 +340,6 @@
 			var/ops = text2num(href_list["repair"])
 
 			if (ops == 1 && R.compborg_get_total_damage(1) > 0)
-				if (src.reagents.get_reagent_amount("fuel") < 1)
-					boutput(usr, "<span class='alert'>Not enough welding fuel for repairs.</span>")
-					return
 				var/usage = input(usr, "How much welding fuel do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return
@@ -354,9 +351,6 @@
 					RP.ropart_mend_damage(usage,0)
 				src.reagents.remove_reagent("fuel", usage)
 			else if (ops == 2 && R.compborg_get_total_damage(2) > 0)
-				if (src.cabling < 1)
-					boutput(usr, "<span class='alert'>Not enough wiring for repairs.</span>")
-					return
 				var/usage = input(usr, "How much wiring do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return

--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -421,6 +421,14 @@
 	attack_hand(mob/user as mob)
 		var/mob/living/carbon/human/H = user
 		if(src.thorned)
+			if (H.hand)//gets active arm - left arm is 1, right arm is 0
+				if (istype(H.limbs.l_arm,/obj/item/parts/robot_parts))
+					..()
+					return
+			else
+				if (istype(H.limbs.r_arm,/obj/item/parts/robot_parts))
+					..()
+					return
 			if(istype(H))
 				if(H.gloves)
 					..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[bug - minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If a player picks up a rose using a robotic limb, they no longer bleed from the thorns.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #4995
Robotic arms don't bleed.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Metal arms no longer bleed when picking up a rose.
```
