### PR TITLE
Prevents wasting reagents when pouring into a nearly full container

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -204,20 +204,10 @@
 			boutput(user, "<span class='alert'>[A] is full!</span>") // Notify the user, then exit the process.
 			return
 
-		var/T //Placeholder for total volume transferred
-
-		if ((A.reagents.total_volume + src.reagents.total_volume) > A.reagents.maximum_volume) // Check to make sure that both containers content's combined won't overfill the destination container.
-			T = (A.reagents.maximum_volume - A.reagents.total_volume) // Dump only what fills up the destination container.
-			logTheThing("combat", user, null, "transfers chemicals from [src] [log_reagents(src)] to [A] at [log_loc(A)].") // This wasn't logged. Call before trans_to (Convair880).
-			src.reagents.trans_to(A, T) // Dump the amount of reagents.
-			boutput(user, "<span class='notice'>You transfer [T] units into [A].</span>") // Tell the user they did a thing.
-			return
-		else
-			T = src.reagents.total_volume // Just make T the whole dang amount then.
-			logTheThing("combat", user, null, "transfers chemicals from [src] [log_reagents(src)] to [A] at [log_loc(A)].") // Ditto (Convair880).
-			src.reagents.trans_to(A, T) // Dump it all!
-			boutput(user, "<span class='notice'>You transfer [T] units into [A].</span>")
-			return
+		logTheThing("combat", user, null, "transfers chemicals from [src] [log_reagents(src)] to [A] at [log_loc(A)].") // Ditto (Convair880).
+		var/T = src.reagents.trans_to(A, src.reagents.total_volume) // Dump it all!
+		boutput(user, "<span class='notice'>You transfer [T] units into [A].</span>")
+		return
 
 /atom/proc/signal_event(var/event) // Right now, we only signal our container
 	if(src.loc)

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -274,6 +274,7 @@ datum
 				target.reagents = new
 
 			var/datum/reagents/target_reagents = target.reagents
+			amount = min(amount, target_reagents.maximum_volume - target_reagents.total_volume)
 
 			if (do_fluid_react && issimulatedturf(target))
 				var/turf/simulated/T = target

--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -177,7 +177,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 					boutput(user, "<span class='notice'>You splash all of the solution onto [target].</span>")
 					target.visible_message("<span class='alert'><b>[user.name]</b> splashes the [src.name]'s contents onto [target.name]!</span>")
 				else
-					boutput(user, "<span class='notice'>You apply [src.amount_per_transfer_from_this] units of the solution to [target].</span>")
+					boutput(user, "<span class='notice'>You apply [min(src.amount_per_transfer_from_this,src.reagents.total_volume)] units of the solution to [target].</span>")
 					target.visible_message("<span class='alert'><b>[user.name]</b> applies some of the [src.name]'s contents to [target.name].</span>")
 				var/mob/living/MOB = target
 				logTheThing("combat", user, MOB, "splashes [src] onto [constructTarget(MOB,"combat")] [log_reagents(src)] at [log_loc(MOB)].") // Added location (Convair880).

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -340,6 +340,9 @@
 			var/ops = text2num(href_list["repair"])
 
 			if (ops == 1 && R.compborg_get_total_damage(1) > 0)
+				if (src.reagents.get_reagent_amount("fuel") < 1)
+					boutput(usr, "<span class='alert'>Not enough welding fuel for repairs.</span>")
+					return
 				var/usage = input(usr, "How much welding fuel do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return
@@ -351,6 +354,9 @@
 					RP.ropart_mend_damage(usage,0)
 				src.reagents.remove_reagent("fuel", usage)
 			else if (ops == 2 && R.compborg_get_total_damage(2) > 0)
+				if (src.cabling < 1)
+					boutput(usr, "<span class='alert'>Not enough wiring for repairs.</span>")
+					return
 				var/usage = input(usr, "How much wiring do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -340,9 +340,6 @@
 			var/ops = text2num(href_list["repair"])
 
 			if (ops == 1 && R.compborg_get_total_damage(1) > 0)
-				if (src.reagents.get_reagent_amount("fuel") < 1)
-					boutput(usr, "<span class='alert'>Not enough welding fuel for repairs.</span>")
-					return
 				var/usage = input(usr, "How much welding fuel do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return
@@ -354,9 +351,6 @@
 					RP.ropart_mend_damage(usage,0)
 				src.reagents.remove_reagent("fuel", usage)
 			else if (ops == 2 && R.compborg_get_total_damage(2) > 0)
-				if (src.cabling < 1)
-					boutput(usr, "<span class='alert'>Not enough wiring for repairs.</span>")
-					return
 				var/usage = input(usr, "How much wiring do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the trans_to proc to check if the amount of reagents to be transferred is more than the remaining room in the target container. In that case, only enough to fill the container is transferred. This will impact hyposprays which will no longer waste whitelisted chemicals when topped off.

Also fixes a message to correctly indicate the amount of reagents transferred.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Chemicals disappearing while topping off containers is probably a bug.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Reagents will no longer be wasted when topping off reagent containers.
```
