### PR TITLE
Update some "Chemmaster"/"ChemMaster" remnants to "CheMaster"

### DIFF
--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -357,15 +357,15 @@
 		src.add_dialog(usr)
 
 		if (href_list["close"])
-			usr.Browse(null, "window=chem_master;title=Chemmaster 3000")
+			usr.Browse(null, "window=chem_master;title=CheMaster 3000")
 			return
 
 		if (!beaker) return
 		var/datum/reagents/R = beaker.reagents
 
 		if (href_list["analyze"])
-			var/dat = "<TITLE>Chemmaster 3000</TITLE>Chemical infos:<BR><BR>Name:<BR>[href_list["name"]]<BR><BR>Description:<BR>[href_list["desc"]]<BR><BR><BR><A href='?src=\ref[src];main=1'>(Back)</A>"
-			usr.Browse(dat, "window=chem_master;size=575x400;title=Chemmaster 3000")
+			var/dat = "<TITLE>CheMaster 3000</TITLE>Chemical infos:<BR><BR>Name:<BR>[href_list["name"]]<BR><BR>Description:<BR>[href_list["desc"]]<BR><BR><BR><A href='?src=\ref[src];main=1'>(Back)</A>"
+			usr.Browse(dat, "window=chem_master;size=575x400;title=CheMaster 3000")
 			return
 		else if (href_list["isolate"])
 			beaker.reagents.isolate_reagent(href_list["isolate"])
@@ -572,7 +572,7 @@
 			return
 
 		else
-			usr.Browse(null, "window=chem_master;title=Chemmaster 3000")
+			usr.Browse(null, "window=chem_master;title=CheMaster 3000")
 			return
 
 	attack_ai(mob/user as mob)
@@ -602,7 +602,7 @@
 				dat += "<A href='?src=\ref[src];createpatch=1'>Create patch (30 units max)</A><BR>"
 				dat += "<A href='?src=\ref[src];multipatch=1'>Create multiple patches (5 units min)</A> Box: <A href='?src=\ref[src];togglepatchbox=1'>[src.patch_box ? "Yes" : "No"]</A><BR>"
 				dat += "<A href='?src=\ref[src];createampoule=1'>Create ampoule (5 units max)</A>"
-		user.Browse("<TITLE>Chemmaster 3000</TITLE>Chemmaster menu:<BR><BR>[dat]", "window=chem_master;size=575x400;title=Chemmaster 3000")
+		user.Browse("<TITLE>CheMaster 3000</TITLE>CheMaster menu:<BR><BR>[dat]", "window=chem_master;size=575x400;title=CheMaster 3000")
 		onclose(user, "chem_master")
 		return
 

--- a/code/obj/submachine/robotics.dm
+++ b/code/obj/submachine/robotics.dm
@@ -126,7 +126,7 @@
 			..()
 
 /obj/item/robot_chemaster
-	name = "mini-ChemMaster"
+	name = "mini-CheMaster"
 	desc = "A cybernetic tool designed for chemistry cyborgs to do their work with. Use a beaker on it to begin."
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "minichem"
@@ -141,15 +141,15 @@
 			boutput(user, "<span class='alert'>That beaker is empty! There are no reagents for the [src.name] to process!</span>")
 			return
 		if (working)
-			boutput(user, "<span class='alert'>Chemmaster is working, be patient</span>")
+			boutput(user, "<span class='alert'>CheMaster is working, be patient</span>")
 			return
 
 		working = 1
 		var/holder = src.loc
-		var/the_reagent = input("Which reagent do you want to manipulate?","Mini-ChemMaster",null,null) in B.reagents.reagent_list
+		var/the_reagent = input("Which reagent do you want to manipulate?","Mini-CheMaster",null,null) in B.reagents.reagent_list
 		if (src.loc != holder || !the_reagent)
 			return
-		var/action = input("What do you want to do with the [the_reagent]?","Mini-ChemMaster",null,null) in list("Isolate","Purge","Remove One Unit","Remove Five Units","Create Pill","Create Pill Bottle","Create Bottle","Create Patch","Create Ampoule","Do Nothing")
+		var/action = input("What do you want to do with the [the_reagent]?","Mini-CheMaster",null,null) in list("Isolate","Purge","Remove One Unit","Remove Five Units","Create Pill","Create Pill Bottle","Create Bottle","Create Patch","Create Ampoule","Do Nothing")
 		if (src.loc != holder || !action || action == "Do Nothing")
 			working = 0
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There are a couple of places where the game says "Chemmaster" or "ChemMaster" instead of "CheMaster", namely in some of the CheMaster menus and the name and messages for the borg version of the CheMaster. This PR changes them to the modern "CheMaster" form, the form used when you hover over the machine.

Internal name for both machines is the same, so I don't think it should break maps or anything. I tested this to make sure, and all the menus and messages I changed displayed properly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency, basically. 