### PR TITLE
Changes the names of haireas for haircuts to match character customization.

### DIFF
--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -87,7 +87,7 @@
 			return 0
 
 	SPAWN_DBG(0)
-		var/list/region = list("First Hairea" = 1, "Second Hairea" = 2, "Third Hairea" = 3)
+		var/list/region = list("Top Hairea" = 3, "Middle Hairea" = 2, "Bottom Hairea" = 1)
 
 		var/which_part = input(user, "Which clump of hair?", "Clump") as null|anything in region
 
@@ -153,7 +153,7 @@
 
 	SPAWN_DBG(0)
 
-		var/list/region = list("First Hairea" = 1, "Second Hairea" = 2, "Third Hairea" = 3)
+		var/list/region = list("Top Hairea" = 3, "Middle Hairea" = 2, "Bottom Hairea" = 1)
 
 		var/which_part = input(user, "Which clump of hair?", "Clump") as null|anything in region
 

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -340,6 +340,9 @@
 			var/ops = text2num(href_list["repair"])
 
 			if (ops == 1 && R.compborg_get_total_damage(1) > 0)
+				if (src.reagents.get_reagent_amount("fuel") < 1)
+					boutput(usr, "<span class='alert'>Not enough welding fuel for repairs.</span>")
+					return
 				var/usage = input(usr, "How much welding fuel do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return
@@ -351,6 +354,9 @@
 					RP.ropart_mend_damage(usage,0)
 				src.reagents.remove_reagent("fuel", usage)
 			else if (ops == 2 && R.compborg_get_total_damage(2) > 0)
+				if (src.cabling < 1)
+					boutput(usr, "<span class='alert'>Not enough wiring for repairs.</span>")
+					return
 				var/usage = input(usr, "How much wiring do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return

--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -340,9 +340,6 @@
 			var/ops = text2num(href_list["repair"])
 
 			if (ops == 1 && R.compborg_get_total_damage(1) > 0)
-				if (src.reagents.get_reagent_amount("fuel") < 1)
-					boutput(usr, "<span class='alert'>Not enough welding fuel for repairs.</span>")
-					return
 				var/usage = input(usr, "How much welding fuel do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return
@@ -354,9 +351,6 @@
 					RP.ropart_mend_damage(usage,0)
 				src.reagents.remove_reagent("fuel", usage)
 			else if (ops == 2 && R.compborg_get_total_damage(2) > 0)
-				if (src.cabling < 1)
-					boutput(usr, "<span class='alert'>Not enough wiring for repairs.</span>")
-					return
 				var/usage = input(usr, "How much wiring do you want to use?", "Docking Station", 0) as num
 				if ((!issilicon(usr) && (get_dist(usr, src) > 1)) || usr.stat)
 					return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the names of the haireas (hair areas) when getting a haircut or shave to match the names for pre-round character customization. 
First hairea becomes bottom hairea
Second hairea becomes  middle hairea
Third hairea becomes top hairea

This matches the associations for character customization.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #4999
Hairea names should be consistent.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Changes the names of haireas for haircuts to match character customization.
```
