### PR TITLE
Changes Some Medbay Tiling

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -22557,9 +22557,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 6
-	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "aTy" = (
 /obj/cable{
@@ -22624,18 +22622,14 @@
 	location = "tour13";
 	name = "tour beacon - medbay"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 10
-	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "aTD" = (
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 5
-	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "aTF" = (
 /obj/cable{
@@ -23341,9 +23335,7 @@
 	location = "medbay_lobby";
 	name = "bot navigation beacon"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 9
-	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "aVc" = (
 /obj/disposalpipe/segment{

--- a/maps/clarion_xmas_2020.dmm
+++ b/maps/clarion_xmas_2020.dmm
@@ -15297,12 +15297,12 @@
 	},
 /obj/table/reinforced/auto,
 /obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/drinks/drinkingglass/icing,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "aBw" = (
 /obj/table/reinforced/auto,
 /obj/item/reagent_containers/food/snacks/breadloaf,
-/obj/item/reagent_containers/glass/bottle/icing,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "aBx" = (
@@ -24710,9 +24710,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 6
-	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "aTy" = (
 /obj/cable{
@@ -24793,18 +24791,14 @@
 	location = "tour13";
 	name = "tour beacon - medbay"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 10
-	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "aTD" = (
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 5
-	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "aTE" = (
 /obj/cable{
@@ -25627,9 +25621,7 @@
 	location = "medbay_lobby";
 	name = "bot navigation beacon"
 	},
-/turf/simulated/floor/redwhite{
-	dir = 9
-	},
+/turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "aVc" = (
 /obj/disposalpipe/segment{

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -6851,18 +6851,18 @@
 	},
 /area/station/medical/medbay)
 "apT" = (
-/obj/decal/tile_edge/line/red{
-	dir = 6;
-	icon_state = "line1"
-	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/decal/tile_edge/line/blue{
+	dir = 6;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "apU" = (
-/obj/decal/tile_edge/line/red{
+/obj/decal/tile_edge/line/blue{
 	dir = 10;
 	icon_state = "line1"
 	},
@@ -7415,23 +7415,19 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "ari" = (
-/obj/decal/tile_edge/line/red{
-	dir = 6;
-	icon_state = "line1"
-	},
 /obj/disposalpipe/segment,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/decal/tile_edge/line/blue{
+	dir = 6;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "arj" = (
-/obj/decal/tile_edge/line/red{
-	dir = 6;
-	icon_state = "line2"
-	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
@@ -7441,10 +7437,14 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/decal/tile_edge/line/blue{
+	dir = 6;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "ark" = (
-/obj/decal/tile_edge/line/red{
+/obj/decal/tile_edge/line/blue{
 	dir = 10;
 	icon_state = "line2"
 	},
@@ -7936,28 +7936,28 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "ass" = (
-/obj/decal/tile_edge/line/red{
+/obj/disposalpipe/segment,
+/obj/decal/tile_edge/line/blue{
 	dir = 5;
 	icon_state = "line1"
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
 /area/station/medical/medbay)
 "ast" = (
-/obj/decal/tile_edge/line/red{
-	dir = 5;
-	icon_state = "line2"
-	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/decal/tile_edge/line/blue{
+	dir = 5;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "asu" = (
-/obj/decal/tile_edge/line/red{
+/obj/decal/tile_edge/line/blue{
 	dir = 9;
 	icon_state = "line2"
 	},
@@ -8487,18 +8487,18 @@
 	},
 /area/station/medical/medbay)
 "atJ" = (
-/obj/decal/tile_edge/line/red{
-	dir = 5;
-	icon_state = "line1"
-	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/decal/tile_edge/line/blue{
+	dir = 5;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "atK" = (
-/obj/decal/tile_edge/line/red{
+/obj/decal/tile_edge/line/blue{
 	dir = 9;
 	icon_state = "line1"
 	},

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -7293,18 +7293,18 @@
 	},
 /area/station/medical/medbay)
 "apT" = (
-/obj/decal/tile_edge/line/red{
-	dir = 6;
-	icon_state = "line1"
-	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/decal/tile_edge/line/blue{
+	dir = 6;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "apU" = (
-/obj/decal/tile_edge/line/red{
+/obj/decal/tile_edge/line/blue{
 	dir = 10;
 	icon_state = "line1"
 	},
@@ -7831,23 +7831,19 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "ari" = (
-/obj/decal/tile_edge/line/red{
-	dir = 6;
-	icon_state = "line1"
-	},
 /obj/disposalpipe/segment,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/decal/tile_edge/line/blue{
+	dir = 6;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "arj" = (
-/obj/decal/tile_edge/line/red{
-	dir = 6;
-	icon_state = "line2"
-	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
@@ -7857,17 +7853,21 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/decal/tile_edge/line/blue{
+	dir = 6;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "ark" = (
-/obj/decal/tile_edge/line/red{
+/obj/decal/tile_edge/line/blue{
 	dir = 10;
 	icon_state = "line2"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "arl" = (
-/obj/decal/tile_edge/line/red{
+/obj/decal/tile_edge/line/blue{
 	dir = 10;
 	icon_state = "line1"
 	},
@@ -8335,28 +8335,28 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "ass" = (
-/obj/decal/tile_edge/line/red{
+/obj/disposalpipe/segment,
+/obj/decal/tile_edge/line/blue{
 	dir = 5;
 	icon_state = "line1"
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
 /area/station/medical/medbay)
 "ast" = (
-/obj/decal/tile_edge/line/red{
-	dir = 5;
-	icon_state = "line2"
-	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/decal/tile_edge/line/blue{
+	dir = 5;
+	icon_state = "line2"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "asu" = (
-/obj/decal/tile_edge/line/red{
+/obj/decal/tile_edge/line/blue{
 	dir = 9;
 	icon_state = "line2"
 	},
@@ -8374,7 +8374,7 @@
 	},
 /area/research_outpost/toxins)
 "asw" = (
-/obj/decal/tile_edge/line/red{
+/obj/decal/tile_edge/line/blue{
 	dir = 9;
 	icon_state = "line1"
 	},
@@ -8878,10 +8878,6 @@
 	},
 /area/station/medical/medbay)
 "atJ" = (
-/obj/decal/tile_edge/line/red{
-	dir = 5;
-	icon_state = "line1"
-	},
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
@@ -8889,15 +8885,19 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/decal/tile_edge/line/blue{
+	dir = 5;
+	icon_state = "line1"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "atK" = (
-/obj/decal/tile_edge/line/red{
-	dir = 9;
-	icon_state = "line1"
-	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/decal/tile_edge/line/blue{
+	dir = 9;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
@@ -27217,7 +27217,7 @@
 /area/station/crew_quarters/kitchen)
 "blr" = (
 /obj/table/auto,
-/obj/item/reagent_containers/glass/bottle/icing,
+/obj/item/reagent_containers/food/drinks/drinkingglass/icing,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
 "bls" = (


### PR DESCRIPTION
[mapping]

## About the PR 
Replaces some medbay decals and tiles with blue crosses.

## Why's this needed?
The discussion/question about what qualifies as usable medbay imagery comes up often enough that I'd rather just change these and have it not be a problem anymore.