### PR TITLE
some small barbery tweaks

### DIFF
--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -4,6 +4,12 @@
 #define TOOLMODE_DEACTIVATED SOUTH // points the thing to its default direction when not-tool
 #define TOOLMODE_ACTIVATED WEST // flips around the grip to point this way when tool
 
+// hairea options
+#define BOTTOM_DETAIL 1
+#define MIDDLE_DETAIL 2
+#define TOP_DETAIL 3
+#define ALL_HAIR 4
+
 /datum/component/toggle_tool_use
 /datum/component/toggle_tool_use/Initialize()
 	if(!istype(parent, /obj/item))
@@ -616,3 +622,8 @@
 #undef BARBERY_FAILURE
 #undef TOOLMODE_DEACTIVATED
 #undef TOOLMODE_ACTIVATED
+
+#undef BOTTOM_DETAIL
+#undef MIDDLE_DETAIL
+#undef TOP_DETAIL
+#undef ALL_HAIR

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -105,7 +105,7 @@
 			return
 
 		if(region[which_part] != ALL_HAIR)
-			var/list/customization_types = /datum/customization_style/none + concrete_typesof(/datum/customization_style/hair) + concrete_typesof(/datum/customization_style/eyebrows)
+			var/list/customization_types = list(/datum/customization_style/none) + concrete_typesof(/datum/customization_style/hair) + concrete_typesof(/datum/customization_style/eyebrows)
 			var/new_style = select_custom_style(customization_types, user)
 
 			if (!new_style)
@@ -180,7 +180,7 @@
 			return
 
 		if (region[which_part] != ALL_HAIR)
-			var/list/facehair = /datum/customization_style/none + concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache)
+			var/list/facehair = list(/datum/customization_style/none) + concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache)
 			var/new_style = select_custom_style(facehair, user)
 
 			if (!new_style)

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -106,7 +106,7 @@
 			return
 
 		if(region[which_part] != ALL_HAIR)
-			var/list/customization_types = concrete_typesof(/datum/customization_style)-concrete_typesof(/datum/customization_style/biological)
+			var/list/customization_types = concrete_typesof(/datum/customization_style/hair) + concrete_typesof(/datum/customization_style/eyebrows) + /datum/customization_style/none
 			var/new_style = select_custom_style(customization_types, user)
 
 			if (!new_style) // I'd prefer not to go through all of the hair styles and rank them based on hairiness

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -94,9 +94,9 @@
 
 	SPAWN_DBG(0)
 		var/list/region = list(
-			"Bottom Hairea ([M.bioHolder.mobAppearance.customization_first.name])" = BOTTOM_DETAIL,
-			"Middle Hairea ([M.bioHolder.mobAppearance.customization_second.name])" = MIDDLE_DETAIL,
-			"Top Hairea ([M.bioHolder.mobAppearance.customization_third.name])" = TOP_DETAIL,
+			"Top Detail ([M.bioHolder.mobAppearance.customization_third.name])" = TOP_DETAIL,
+			"Middle Detail ([M.bioHolder.mobAppearance.customization_second.name])" = MIDDLE_DETAIL,
+			"Bottom Detail ([M.bioHolder.mobAppearance.customization_first.name])" = BOTTOM_DETAIL,
 			"Create Wig" = ALL_HAIR)
 
 		var/which_part = input(user, "Which clump of hair?", "Clump") as null|anything in region
@@ -169,9 +169,9 @@
 	SPAWN_DBG(0)
 
 		var/list/region = list(
-			"Bottom Hairea ([M.bioHolder.mobAppearance.customization_first.name])" = BOTTOM_DETAIL,
-			"Middle Hairea ([M.bioHolder.mobAppearance.customization_second.name])" = MIDDLE_DETAIL,
-			"Top Hairea ([M.bioHolder.mobAppearance.customization_third.name])" = TOP_DETAIL,
+			"Top Detail ([M.bioHolder.mobAppearance.customization_third.name])" = TOP_DETAIL,
+			"Middle Detail ([M.bioHolder.mobAppearance.customization_second.name])" = MIDDLE_DETAIL,
+			"Bottom Detail ([M.bioHolder.mobAppearance.customization_first.name])" = BOTTOM_DETAIL,
 			"Create Wig" = ALL_HAIR)
 
 		var/which_part = input(user, "Which clump of hair?", "Clump") as null|anything in region

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -539,11 +539,11 @@ ABSTRACT_TYPE(/datum/action/bar/barber)
 					M, "<span class='notice'>[user] [cuts] your hair.</span>",\
 					user, "<span class='notice'>You [cut] [M]'s hair.</span>")
 					switch(which_part)
-						if (1)
+						if (BOTTOM_DETAIL)
 							M.bioHolder.mobAppearance.customization_first = new_style
-						if (2)
+						if (MIDDLE_DETAIL)
 							M.bioHolder.mobAppearance.customization_second = new_style
-						if (3)
+						if (TOP_DETAIL)
 							M.bioHolder.mobAppearance.customization_third = new_style
 
 		M.set_clothing_icon_dirty() // why the fuck is hair updated in clothing

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -153,6 +153,9 @@
 			M.organHolder.head.update_icon()
 		return ATTACK_PRE_DONT_ATTACK // gottem
 
+	if(istype(AH.customization_first,/datum/customization_style/none) && istype(AH.customization_second,/datum/customization_style/none) && istype(AH.customization_third,/datum/customization_style/none))
+		boutput(user, "<span class='alert'>There is nothing to cut!</span>")
+		non_murderous_failure = BARBERY_FAILURE
 
 	if(!mutant_barber_fluff(M, user, "shave"))
 		non_murderous_failure = BARBERY_FAILURE

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -93,10 +93,11 @@
 			return 0
 
 	SPAWN_DBG(0)
-		var/list/region = list("Bottom Hairea" = BOTTOM_DETAIL, "Middle Hairea" = MIDDLE_DETAIL, "Top Hairea" = TOP_DETAIL, "Full Shave" = ALL_HAIR)
-		region[BOTTOM_DETAIL] += " ([M.bioHolder.mobAppearance.customization_first.name])"
-		region[MIDDLE_DETAIL] += " ([M.bioHolder.mobAppearance.customization_second.name])"
-		region[TOP_DETAIL] += " ([M.bioHolder.mobAppearance.customization_third.name])"
+		var/list/region = list(
+			"Bottom Hairea ([M.bioHolder.mobAppearance.customization_first.name])" = BOTTOM_DETAIL,
+			"Middle Hairea ([M.bioHolder.mobAppearance.customization_second.name])" = MIDDLE_DETAIL,
+			"Top Hairea ([M.bioHolder.mobAppearance.customization_third.name])" = TOP_DETAIL,
+			"Create Wig" = ALL_HAIR)
 
 		var/which_part = input(user, "Which clump of hair?", "Clump") as null|anything in region
 
@@ -112,9 +113,9 @@
 				boutput(user, "Never mind.") // So I guess it'll be on the honor system for now not to give balding folk rockin' 'fros
 				return
 
-			actions.start(new/datum/action/bar/barber/haircut(M, user, get_barbery_conditions(M, user), new_style, which_part), user)
+			actions.start(new/datum/action/bar/barber/haircut(M, user, get_barbery_conditions(M, user), new_style, region[which_part]), user)
 		else
-			actions.start(new/datum/action/bar/barber/haircut(M, user, get_barbery_conditions(M, user), null, which_part), user)
+			actions.start(new/datum/action/bar/barber/haircut(M, user, get_barbery_conditions(M, user), null, region[which_part]), user)
 	return ATTACK_PRE_DONT_ATTACK
 
 /datum/component/barber/proc/do_shave(var/obj/item/thing, mob/living/carbon/human/M as mob, mob/living/carbon/human/user as mob)
@@ -165,10 +166,11 @@
 
 	SPAWN_DBG(0)
 
-		var/list/region = list("Bottom Hairea" = 1, "Middle Hairea" = 2, "Top Hairea" = 3, "Full Shave" = 4)
-		region[1] += " ([M.bioHolder.mobAppearance.customization_first.name])"
-		region[2] += " ([M.bioHolder.mobAppearance.customization_second.name])"
-		region[3] += " ([M.bioHolder.mobAppearance.customization_third.name])"
+		var/list/region = list(
+			"Bottom Hairea ([M.bioHolder.mobAppearance.customization_first.name])" = BOTTOM_DETAIL,
+			"Middle Hairea ([M.bioHolder.mobAppearance.customization_second.name])" = MIDDLE_DETAIL,
+			"Top Hairea ([M.bioHolder.mobAppearance.customization_third.name])" = TOP_DETAIL,
+			"Create Wig" = ALL_HAIR)
 
 		var/which_part = input(user, "Which clump of hair?", "Clump") as null|anything in region
 
@@ -176,13 +178,16 @@
 			boutput(user, "Never mind.")
 			return
 
-		var/list/facehair = concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache) + /datum/customization_style/none
-		var/new_style = select_custom_style(facehair, user)
+		if (which_part != ALL_HAIR)
+			var/list/facehair = concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache) + /datum/customization_style/none
+			var/new_style = select_custom_style(facehair, user)
 
-		if (!new_style) // otherwise it alternates between non-functional and fucking useless
-			boutput(user, "Never mind.")
-			return
-		actions.start(new/datum/action/bar/barber/shave(M, user, get_barbery_conditions(M, user), new_style, region[which_part]), user)
+			if (!new_style) // otherwise it alternates between non-functional and fucking useless
+				boutput(user, "Never mind.")
+				return
+			actions.start(new/datum/action/bar/barber/shave(M, user, get_barbery_conditions(M, user), new_style, region[which_part]), user)
+		else
+			actions.start(new/datum/action/bar/barber/shave(M, user, get_barbery_conditions(M, user), null, region[which_part]), user)
 
 	return ATTACK_PRE_DONT_ATTACK
 

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -124,6 +124,7 @@
 
 	var/non_murderous_failure = 0
 	var/mob/living/carbon/human/H = M
+	var/datum/appearanceHolder/AH = M.bioHolder.mobAppearance
 	if(ishuman(M) && ((H.head && H.head.c_flags & COVERSEYES) || (H.wear_mask && H.wear_mask.c_flags & COVERSEYES) || (H.glasses && H.glasses.c_flags & COVERSEYES)))
 		// you can't stab someone in the eyes wearing a mask!
 		boutput(user, "<span class='notice'>You're going to need to remove that mask/helmet/glasses first.</span>")

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -102,15 +102,13 @@
 		var/which_part = input(user, "Which clump of hair?", "Clump") as null|anything in region
 
 		if (!which_part)
-			boutput(user, "Never mind.")
 			return
 
 		if(region[which_part] != ALL_HAIR)
 			var/list/customization_types = concrete_typesof(/datum/customization_style/hair) + concrete_typesof(/datum/customization_style/eyebrows) + /datum/customization_style/none
 			var/new_style = select_custom_style(customization_types, user)
 
-			if (!new_style) // I'd prefer not to go through all of the hair styles and rank them based on hairiness
-				boutput(user, "Never mind.") // So I guess it'll be on the honor system for now not to give balding folk rockin' 'fros
+			if (!new_style)
 				return
 
 			actions.start(new/datum/action/bar/barber/haircut(M, user, get_barbery_conditions(M, user), new_style, region[which_part]), user)
@@ -179,15 +177,13 @@
 		var/which_part = input(user, "Which clump of hair?", "Clump") as null|anything in region
 
 		if (!which_part)
-			boutput(user, "Never mind.")
 			return
 
 		if (region[which_part] != ALL_HAIR)
 			var/list/facehair = concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache) + /datum/customization_style/none
 			var/new_style = select_custom_style(facehair, user)
 
-			if (!new_style) // otherwise it alternates between non-functional and fucking useless
-				boutput(user, "Never mind.")
+			if (!new_style)
 				return
 			actions.start(new/datum/action/bar/barber/shave(M, user, get_barbery_conditions(M, user), new_style, region[which_part]), user)
 		else

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -105,7 +105,7 @@
 			boutput(user, "Never mind.")
 			return
 
-		if(which_part != ALL_HAIR)
+		if(region[which_part] != ALL_HAIR)
 			var/list/customization_types = concrete_typesof(/datum/customization_style)-concrete_typesof(/datum/customization_style/biological)
 			var/new_style = select_custom_style(customization_types, user)
 
@@ -178,7 +178,7 @@
 			boutput(user, "Never mind.")
 			return
 
-		if (which_part != ALL_HAIR)
+		if (region[which_part] != ALL_HAIR)
 			var/list/facehair = concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache) + /datum/customization_style/none
 			var/new_style = select_custom_style(facehair, user)
 

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -180,7 +180,7 @@
 			return
 
 		if (region[which_part] != ALL_HAIR)
-			var/list/facehair = list(/datum/customization_style/none) + concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache)
+			var/list/facehair = list(/datum/customization_style/none) + concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache) + concrete_typesof(/datum/customization_style/sideburns)
 			var/new_style = select_custom_style(facehair, user)
 
 			if (!new_style)
@@ -570,7 +570,7 @@ ABSTRACT_TYPE(/datum/action/bar/barber)
 	cutting = "shaving"
 
 	getHairStyles()
-		return concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache)
+		return concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache) + concrete_typesof(/datum/customization_style/sideburns)
 
 #undef HAIRCUT
 #undef SHAVE

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -105,7 +105,7 @@
 			return
 
 		if(region[which_part] != ALL_HAIR)
-			var/list/customization_types = concrete_typesof(/datum/customization_style/hair) + concrete_typesof(/datum/customization_style/eyebrows) + /datum/customization_style/none
+			var/list/customization_types = /datum/customization_style/none + concrete_typesof(/datum/customization_style/hair) + concrete_typesof(/datum/customization_style/eyebrows)
 			var/new_style = select_custom_style(customization_types, user)
 
 			if (!new_style)
@@ -180,7 +180,7 @@
 			return
 
 		if (region[which_part] != ALL_HAIR)
-			var/list/facehair = concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache) + /datum/customization_style/none
+			var/list/facehair = /datum/customization_style/none + concrete_typesof(/datum/customization_style/beard) + concrete_typesof(/datum/customization_style/moustache)
 			var/new_style = select_custom_style(facehair, user)
 
 			if (!new_style)

--- a/code/datums/components/barber.dm
+++ b/code/datums/components/barber.dm
@@ -565,7 +565,7 @@ ABSTRACT_TYPE(/datum/action/bar/barber)
 	cutting = "cutting"
 
 	getHairStyles()
-		return concrete_typesof(/datum/customization_style)-concrete_typesof(/datum/customization_style/biological)
+		return concrete_typesof(/datum/customization_style/hair) + concrete_typesof(/datum/customization_style/eyebrows)
 
 /datum/action/bar/barber/shave
 	id = "shave"

--- a/code/obj/ToSplit/barber_shop.dm
+++ b/code/obj/ToSplit/barber_shop.dm
@@ -237,35 +237,18 @@
 		if(passed_dye_roll)
 			switch(bottle.hair_group)
 				if(BOTTOM_DETAIL)
-					if(is_barber || prob(60))
-						M.bioHolder.mobAppearance.customization_first_color = bottle.customization_first_color
-					else
-						boutput(M, "<span class='alert'>Oh no, you dyed the wrong thing!</span> Maybe they won't notice?")
-						if(prob(50))
-							M.bioHolder.mobAppearance.customization_second_color = bottle.customization_first_color
-						else
-							M.bioHolder.mobAppearance.customization_third_color = bottle.customization_first_color
-
 				if(MIDDLE_DETAIL)
-					if(is_barber || prob(60))
-						M.bioHolder.mobAppearance.customization_second_color = bottle.customization_first_color
-					else
-						boutput(M, "<span class='alert'>Oh no, you dyed the wrong thing!</span> Maybe they won't notice?")
-						if(prob(50))
-							M.bioHolder.mobAppearance.customization_first_color = bottle.customization_first_color
-						else
-							M.bioHolder.mobAppearance.customization_third_color = bottle.customization_first_color
-
 				if(TOP_DETAIL)
-					if(is_barber || prob(60))
-						M.bioHolder.mobAppearance.customization_third_color = bottle.customization_first_color
-					else
+					if(!is_barber && prob(25))
 						boutput(M, "<span class='alert'>Oh no, you dyed the wrong thing!</span> Maybe they won't notice?")
-						if(prob(50))
-							M.bioHolder.mobAppearance.customization_second_color = bottle.customization_first_color
-						else
+						bottle.hair_group = pick(list(BOTTOM_DETAIL, MIDDLE_DETAIL, TOP_DETAIL) - bottle.hair_group)
+					switch(bottle.hair_group)
+						if(BOTTOM_DETAIL)
 							M.bioHolder.mobAppearance.customization_first_color = bottle.customization_first_color
-
+						if(MIDDLE_DETAIL)
+							M.bioHolder.mobAppearance.customization_second_color = bottle.customization_first_color
+						if(TOP_DETAIL)
+							M.bioHolder.mobAppearance.customization_third_color = bottle.customization_first_color
 				if(ALL_HAIR)
 					if(src.uses_left < 3)
 						boutput(M, "<span class='notice'>This dyejob's going to need a full bottle!</span>")

--- a/code/obj/ToSplit/barber_shop.dm
+++ b/code/obj/ToSplit/barber_shop.dm
@@ -294,8 +294,8 @@
 				src.uses_left = 0
 				src.icon_state= "dye-e"
 			else if(src.uses_left > 1 && is_barber && bottle.hair_group != ALL_HAIR)
-				boutput(user, "Hey, there's still some dye left in the bottle! Looks about ")
 				src.uses_left --
+				boutput(user, "Hey, there's still some dye left in the bottle! Looks about [get_english_num(src.uses_left)] third\s full!")
 			else
 				boutput(user, "You used the whole bottle!")
 				src.uses_left = 0

--- a/code/obj/ToSplit/barber_shop.dm
+++ b/code/obj/ToSplit/barber_shop.dm
@@ -1,10 +1,13 @@
 #define HAIRCUT 1
 #define SHAVE 2
-#define HAIR_1 1
-#define HAIR_2 2
-#define HAIR_3 3
+
+// hairea options
+#define BOTTOM_DETAIL 1
+#define MIDDLE_DETAIL 2
+#define TOP_DETAIL 3
 #define ALL_HAIR 4
 #define EYES 5
+
 #define HAIR_1_FUCKED 1
 #define HAIR_2_FUCKED 2
 #define HAIR_3_FUCKED 4
@@ -130,12 +133,12 @@
 		src.hair_group = hair_group >= 5 ? 1 : hair_group + 1
 		var/which_part
 		switch (hair_group)
-			if (HAIR_1)
-				which_part = "first group of hair"
-			if (HAIR_2)
+			if (BOTTOM_DETAIL)
+				which_part = "bottom group of hair"
+			if (MIDDLE_DETAIL)
 				which_part = "middle group of hair"
-			if (HAIR_3)
-				which_part = "last group of hair"
+			if (TOP_DETAIL)
+				which_part = "top group of hair"
 			if (ALL_HAIR)
 				which_part = "entire coiffure"
 			if (EYES)
@@ -233,7 +236,7 @@
 
 		if(passed_dye_roll)
 			switch(bottle.hair_group)
-				if(HAIR_1)
+				if(BOTTOM_DETAIL)
 					if(is_barber || prob(60))
 						M.bioHolder.mobAppearance.customization_first_color = bottle.customization_first_color
 					else
@@ -243,7 +246,7 @@
 						else
 							M.bioHolder.mobAppearance.customization_third_color = bottle.customization_first_color
 
-				if(HAIR_2)
+				if(MIDDLE_DETAIL)
 					if(is_barber || prob(60))
 						M.bioHolder.mobAppearance.customization_second_color = bottle.customization_first_color
 					else
@@ -253,7 +256,7 @@
 						else
 							M.bioHolder.mobAppearance.customization_third_color = bottle.customization_first_color
 
-				if(HAIR_3)
+				if(TOP_DETAIL)
 					if(is_barber || prob(60))
 						M.bioHolder.mobAppearance.customization_third_color = bottle.customization_first_color
 					else
@@ -278,7 +281,7 @@
 					result_msg2 ="<span class='notice'>You dump the [src] in [M]'s eyes.</span>"
 					result_msg3 ="<span class='alert'>[user] dumps the [src] into your eyes!</span>"
 					if(user.mind.assigned_role == "Barber")
-						SPAWN_DBG(20)
+						SPAWN_DBG(2 SECONDS)
 							boutput(M, "Huh, that actually didn't hurt that much. What a great [pick("barber", "stylist", "bangmangler")]!")
 					else
 						M.emote("scream", 0)
@@ -426,9 +429,9 @@
 
 // Barber stuff
 
-#undef HAIR_1
-#undef HAIR_2
-#undef HAIR_3
+#undef BOTTOM_DETAIL
+#undef MIDDLE_DETAIL
+#undef TOP_DETAIL
 #undef ALL_HAIR
 #undef EYES
 #undef HAIR_1_FUCKED

--- a/code/obj/ToSplit/barber_shop.dm
+++ b/code/obj/ToSplit/barber_shop.dm
@@ -236,9 +236,7 @@
 
 		if(passed_dye_roll)
 			switch(bottle.hair_group)
-				if(BOTTOM_DETAIL)
-				if(MIDDLE_DETAIL)
-				if(TOP_DETAIL)
+				if(BOTTOM_DETAIL, MIDDLE_DETAIL, TOP_DETAIL)
 					if(!is_barber && prob(25))
 						boutput(M, "<span class='alert'>Oh no, you dyed the wrong thing!</span> Maybe they won't notice?")
 						bottle.hair_group = pick(list(BOTTOM_DETAIL, MIDDLE_DETAIL, TOP_DETAIL) - bottle.hair_group)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The haireas are now referred to by their level, and they also have the current active hair style noted.
I also added a new option to make a wig, since before when you tried to remove the hair in one hairea, it would always shave all three haireas completely.
![image](https://user-images.githubusercontent.com/35579460/120963243-801be900-c761-11eb-872d-fe7ec70753ea.png)

Instead of scissors being able to make any hair/beard/eyebrow/makeup style they are now only allowed to make hairstyles and eyebrow styles, since it made razors kind of redundant?
Razors can still make beard and moustache styles.
For makeup changes you'll need to do something else. (Especially since we already have the lipstick item in the game.)

Razors now also check if the person actually has hair before allowing you to change what that hair looks like.

Added a missing snipping noise for when the haircut actually succeeds.

Dyeing specific haireas now has a 75% chance to succeed. 
(60% seemed kind of low to me, since you'd might actually need to dye up to three haireas, and there is no way to improve the chance of that check except for being a barber.)

There was some missing text about how much hair dye remains in the bottle.

Some general cleanliness stuff mainly to try to reduce the amount of code duplication. (Though there is still plenty.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- fixes #4999 
- more clarity about which part of the hair you are changing
- meaningful reasons to use both scissors AND razors
- missing sounds and text bad
- code duplication bad