### PR TITLE
remove check that made reclaimer only work on some materials

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -789,7 +789,7 @@
 				var/obj/item/wizard_crystal/wc = M
 				wc.setMaterial(getMaterial(wc.assoc_material),0,0,1,0)
 
-			if (!istype(M.material) || !(M.material.material_flags & MATERIAL_CRYSTAL) && !(M.material.material_flags & MATERIAL_METAL) && !(M.material.material_flags & MATERIAL_RUBBER))
+			if (!istype(M.material))
 				M.set_loc(src.loc)
 				src.reject = 1
 				continue


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Portable reclaimers only work on crystal, metal, and rubber.
Now they work on all raw material pieces.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's just kind of annoying and some people have expressed confusion about it.
And I don't really think there is any game balance reason for it.
