### PR TITLE
Mechanics can set access requirements of constructed airlocks

### DIFF
--- a/code/obj/item/device/accessgun.dm
+++ b/code/obj/item/device/accessgun.dm
@@ -216,4 +216,3 @@
 		boutput(user, "<span class='notice'>You clear the access requirements loaded in the [src]</span>")
 		scanned_access = null
 		icon_state = initial(icon_state)
-		return

--- a/code/obj/item/device/accessgun.dm
+++ b/code/obj/item/device/accessgun.dm
@@ -185,22 +185,27 @@
 	New()
 		scanned_access = list()
 		req_access = list()
+		. = ..()
 
 	afterattack(obj/target, mob/user, reach, params)
 		var/obj/machinery/door/airlock/door_reqs = target
-		if(istype(door_reqs) && (target.deconstruct_flags & DECON_BUILT))
-			if (!isnull(scanned_access))
-				boutput(user, "<span class='notice'>[src] has no access requirements loaded!</span>"
-			if (!length(door_reqs.req_access))
-				. = ..()
-			else
-				boutput(user, "<span class='notice'>[src] cannot reprogram [door_reqs.name], access requirements already set.</span>")
-		else if (istype(door_reqs))
-			scanned_access = door_reqs.req_access
-			icon_state = "accessgun-x"
-			boutput(user, "<span class='notice'>[src] scans the access requirements of [door_reqs.name].</span>")
-		else
+		if (!istype(door_reqs))
 			. = ..()
+			return
+		if(target.deconstruct_flags & DECON_BUILT)
+			if (isnull(scanned_access))
+				boutput(user, "<span class='notice'>[src] has no access requirements loaded!</span>")
+				return
+			if (length(door_reqs.req_access))
+				boutput(user, "<span class='notice'>[src] cannot reprogram [door_reqs.name], access requirements already set.</span>")
+				return
+			. = ..()
+			return
+
+		scanned_access = door_reqs.req_access
+		icon_state = "accessgun-x"
+		boutput(user, "<span class='notice'>[src] scans the access requirements of [door_reqs.name].</span>")
+
 
 	reprogram(obj/O,mob/user)
 		if (!isnull(scanned_access))

--- a/code/obj/item/device/accessgun.dm
+++ b/code/obj/item/device/accessgun.dm
@@ -1,5 +1,5 @@
 /obj/item/device/accessgun
-	name = "access-pro"
+	name = "Access Pro"
 	desc = "This device can reprogram electronic access requirements. It will copy the permissions of any inserted ID. Activate it in-hand while empty to change between AND/OR modes"
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "accessgun"
@@ -175,7 +175,7 @@
 			boutput(owner, "<span class='alert'>Access change of [O] interrupted!</span>")
 		..()
 
-/obj/item/device/accessgun/meh
+/obj/item/device/accessgun/lite
 	name = "Access Lite"
 	desc = "A device that sets the access requirments of newly constructed airlocks to one scanned from an existing airlock."
 	req_access = list()
@@ -196,7 +196,7 @@
 		else
 			. = ..()
 
-	reprogram(var/obj/O,var/mob/user)
+	reprogram(obj/O,mob/user)
 		if (!isnull(scanned_access))
 			O.set_access_list(scanned_access)
 		playsound(src, "sound/machines/reprog.ogg", 70, 1)

--- a/code/obj/item/device/accessgun.dm
+++ b/code/obj/item/device/accessgun.dm
@@ -185,6 +185,8 @@
 	afterattack(obj/target, mob/user, reach, params)
 		var/obj/machinery/door/airlock/door_reqs = target
 		if(istype(door_reqs) && (target.deconstruct_flags & DECON_BUILT))
+			if (!isnull(scanned_access))
+				boutput(user, "<span class='notice'>[src] has no access requirements loaded!</span>"
 			if (!length(door_reqs.req_access))
 				. = ..()
 			else

--- a/code/obj/item/device/accessgun.dm
+++ b/code/obj/item/device/accessgun.dm
@@ -178,9 +178,13 @@
 /obj/item/device/accessgun/lite
 	name = "Access Lite"
 	desc = "A device that sets the access requirments of newly constructed airlocks to one scanned from an existing airlock."
-	req_access = list()
+	req_access = null
 	ID_card = 1
-	var/list/scanned_access = list()
+	var/list/scanned_access = null
+
+	New()
+		scanned_access = list()
+		req_access = list()
 
 	afterattack(obj/target, mob/user, reach, params)
 		var/obj/machinery/door/airlock/door_reqs = target

--- a/code/obj/item/device/accessgun.dm
+++ b/code/obj/item/device/accessgun.dm
@@ -9,6 +9,7 @@
 	flags = FPRINT | TABLEPASS | ONBELT
 	mats = 14
 	var/obj/item/card/id/ID_card = null
+	var/list/scanned_access = list()
 	req_access = list(access_change_ids,access_engineering_chief)
 	var/mode = 0 //0 AND, 1 OR
 
@@ -174,3 +175,14 @@
 		if (O && owner)
 			boutput(owner, "<span class='alert'>Access change of [O] interrupted!</span>")
 		..()
+
+/obj/item/device/accessgun/meh
+	name = "Access Lite"
+	req_access = list()
+	afterattack(obj/target, mob/user, reach, params)
+		var/obj/machinery/door/airlock/door_reqs = target
+		if(istype(door_reqs)target.deconstruct_flags & DECON_BUILT)
+			. = ..()
+		else
+
+			boutput(user, "<span class='notice'>[src] cannot burn programmed doors.</span>")

--- a/code/obj/item/device/accessgun.dm
+++ b/code/obj/item/device/accessgun.dm
@@ -110,19 +110,23 @@
 			boutput(user, "<span class='notice'>[src] can't reprogram this.</span>")
 			return
 
-		if (O.object_flags & CAN_REPROGRAM_ACCESS)
-			if (istype(target,/obj/machinery/door))
-				var/obj/machinery/door/D = target
-				if (D.cant_emag || isrestrictedz(D.z))
-					playsound(src, 'sound/machines/airlock_deny.ogg', 35, 1, 0, 2)
-					boutput(user, "<span class='notice'>[src] can't reprogram this.</span>")
-					return
-
-			actions.start(new/datum/action/bar/icon/access_reprog(O,src), user)
-		else
+		if (is_restricted(O, user))
 			playsound(src, 'sound/machines/airlock_deny.ogg', 35, 1, 0, 2)
 			boutput(user, "<span class='notice'>[src] can't reprogram this.</span>")
+			return
 
+		actions.start(new/datum/action/bar/icon/access_reprog(O,src), user)
+
+
+	proc/is_restricted(obj/O)
+		. = FALSE
+		if (!(O.object_flags & CAN_REPROGRAM_ACCESS))
+			. = TRUE
+			return
+		if (istype(O,/obj/machinery/door))
+			var/obj/machinery/door/D = O
+			if (D.cant_emag || isrestrictedz(D.z))
+				. = TRUE
 
 
 	proc/reprogram(var/obj/O,var/mob/user)
@@ -194,14 +198,19 @@
 			return
 		if(target.deconstruct_flags & DECON_BUILT)
 			if (isnull(scanned_access))
-				boutput(user, "<span class='notice'>[src] has no access requirements loaded!</span>")
+				playsound(src, 'sound/machines/airlock_deny.ogg', 35, 1, 0, 2)
+				boutput(user, "<span class='notice'>[src] has no access requirements loaded.</span>")
 				return
 			if (length(door_reqs.req_access))
+				playsound(src, 'sound/machines/airlock_deny.ogg', 35, 1, 0, 2)
 				boutput(user, "<span class='notice'>[src] cannot reprogram [door_reqs.name], access requirements already set.</span>")
 				return
 			. = ..()
 			return
-
+		if(is_restricted(door_reqs))
+			playsound(src, 'sound/machines/airlock_deny.ogg', 35, 1, 0, 2)
+			boutput(user, "<span class='notice'>[src] can't scan [door_reqs.name]</span>")
+			return
 		scanned_access = door_reqs.req_access
 		icon_state = "accessgun-x"
 		boutput(user, "<span class='notice'>[src] scans the access requirements of [door_reqs.name].</span>")

--- a/code/obj/item/device/accessgun.dm
+++ b/code/obj/item/device/accessgun.dm
@@ -177,7 +177,7 @@
 
 /obj/item/device/accessgun/lite
 	name = "Access Lite"
-	desc = "A device that sets the access requirments of newly constructed airlocks to one scanned from an existing airlock."
+	desc = "A device that sets the access requirments of newly constructed airlocks to ones scanned from an existing airlock."
 	req_access = null
 	ID_card = 1
 	var/list/scanned_access = null

--- a/code/obj/item/device/accessgun.dm
+++ b/code/obj/item/device/accessgun.dm
@@ -198,17 +198,17 @@
 			return
 		if(target.deconstruct_flags & DECON_BUILT)
 			if (isnull(scanned_access))
-				playsound(src, 'sound/machines/airlock_deny.ogg', 35, 1, 0, 2)
+				playsound(src, "sound/machines/airlock_deny.ogg", 35, 1, 0, 2)
 				boutput(user, "<span class='notice'>[src] has no access requirements loaded.</span>")
 				return
 			if (length(door_reqs.req_access))
-				playsound(src, 'sound/machines/airlock_deny.ogg', 35, 1, 0, 2)
+				playsound(src, "sound/machines/airlock_deny.ogg", 35, 1, 0, 2)
 				boutput(user, "<span class='notice'>[src] cannot reprogram [door_reqs.name], access requirements already set.</span>")
 				return
 			. = ..()
 			return
 		if(is_restricted(door_reqs))
-			playsound(src, 'sound/machines/airlock_deny.ogg', 35, 1, 0, 2)
+			playsound(src, "sound/machines/airlock_deny.ogg", 35, 1, 0, 2)
 			boutput(user, "<span class='notice'>[src] can't scan [door_reqs.name]</span>")
 			return
 		scanned_access = door_reqs.req_access

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -203,6 +203,8 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 			var/area/station/A = get_area(src)
 			src.name = A.name
 		src.net_access_code = rand(1, NET_ACCESS_OPTIONS)
+		if(deconstruct_flags & DECON_BUILT)
+			req_access = list()
 		START_TRACKING
 
 	disposing()
@@ -510,6 +512,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	operation_time = 10
 
 /obj/machinery/door/airlock/pyro/glass/windoor
+	name = "thin glass airlock"
 	icon_state = "windoor_closed"
 	icon_base = "windoor"
 	panel_icon_state = "windoor"

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -515,6 +515,7 @@
 	name = "\improper Mechanic's locker"
 	req_access = list(access_engineering_mechanic)
 	spawn_contents = list(/obj/item/storage/toolbox/electrical,
+	/obj/item/device/accessgun/lite,
 	/obj/item/clothing/suit/wintercoat/engineering,
 	/obj/item/storage/box/clothing/mechanic,
 	/obj/item/clothing/gloves/yellow,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

![image](https://user-images.githubusercontent.com/13049028/121014731-26aabe80-c74f-11eb-8add-62cdc3a24129.png)
![image](https://user-images.githubusercontent.com/13049028/121014774-32968080-c74f-11eb-89e8-3e82135d42a0.png)
![image](https://user-images.githubusercontent.com/13049028/121014816-4215c980-c74f-11eb-869b-020ee7a08477.png)
![image](https://user-images.githubusercontent.com/13049028/121025522-177d3e00-c75a-11eb-8a57-35ed33bdd1b2.png)

Constructed airlocks now spawn with no access requirements.
Mechanics can set the access requirements of newly constructed airlocks with the new Access Lite, found in their lockers.

It is able to scan existing airlocks and set the access requirements of constructed airlocks, but only once, any edits require getting the HOP just like before.

Restricted airlocks cannot be scanned.

I also adjust the name of the access-pro, for consistency.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Airlocks spawned with their "default" access list which half the time wasn't what you wanted, given access lists.
This makes constructing any airlock actually useful.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Penny
(*)Mechanics can now set the access requirements of newly constructed airlocks- find the new Access Lite in your secure lockers to try it out!
```
