### PR TITLE
Touching an artifact with your own robotic arm counts as a silicon touch

### DIFF
--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -454,9 +454,16 @@
 
 	var/datum/artifact/A = src.artifact
 	if (istype(A,/datum/artifact/))
-		if (iscarbon(user))
+		if (ishuman(user))
+			var/mob/living/carbon/human/H = user
+			var/obj/item/parts/arm = H.hand ? H.limbs.l_arm : H.limbs.r_arm
+			if(istype(arm, /obj/item/parts/robot_parts))
+				src.ArtifactStimulus("silitouch", 1)
+			else
+				src.ArtifactStimulus("carbtouch", 1)
+		else if (iscarbon(user))
 			src.ArtifactStimulus("carbtouch", 1)
-		if (issilicon(user))
+		else if (issilicon(user))
 			src.ArtifactStimulus("silitouch", 1)
 		src.ArtifactStimulus("force", 1)
 		user.visible_message("<b>[user.name]</b> touches [src].")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Previously, touching an artifact would only check if you were a carbon-based mob or a silicon mob. You could have your arm replaced by a robot one, and it would still consider it a carbon touch. Now, if you are human, the artifact looks at your active hand and sees if it is a robotic arm, and if so, it considers it a silicon touch.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Since holding a robot arm in your hand to poke an artifact is the standard way to try silicon touch as a scientist, it just makes sense that the same arm is still considered silicon even if it's attached to you.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Jan.antilles
(+)Touching an artifact with your own robotic arm counts as a silicon touch.
```
