### PR TITLE
Adds mutadone to Cairngorm medbay

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -62397,6 +62397,7 @@
 /obj/item/reagent_containers/glass/beaker/large/antitox,
 /obj/item/reagent_containers/glass/beaker/large/epinephrine,
 /obj/item/clothing/gloves/latex,
+/obj/item/storage/pill_bottle/mutadone,
 /turf/unsimulated/floor/redwhite{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a pill bottle of mutadone to the Cairngorm medbay.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Operatives spawning with the random genetics trait sometimes become radioactive and inflect the whole team with mutations. This is a means to solve that issue without raiding the station medbay.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gannets
(+)Added a pill bottle of mutadone to the Cairngorm medbay.
```
