### PR TITLE
Removes Synth-O-Matic modules from traders

### DIFF
--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -624,8 +624,11 @@
 		/datum/commodity/junk,
 		/datum/commodity/diner,
 		/datum/commodity/bodyparts,
-		/datum/commodity/medical,
-		/datum/commodity/synthmodule)
+		/datum/commodity/medical)
+
+		#ifdef CREATE_PATHOGENS //Don't need this when there's no pathology
+		commercetypes += /datum/commodity/synthmodule
+		#endif
 
 		var/list/selltypes = typesof(pick(commercetypes))
 		var/list/buytypes = typesof(pick(commercetypes))
@@ -833,13 +836,13 @@
 				src.goods_sell += new /datum/commodity/medical/firstaidC(src)
 				src.goods_sell += new /datum/commodity/medical/injectorPent(src)
 				src.goods_sell += new /datum/commodity/medical/injectorPerf(src)
+				#ifdef CREATE_PATHOGENS //PATHOLOGY REMOVAL
 				src.goods_sell += new /datum/commodity/synthmodule/bacteria(src)
 				src.goods_sell += new /datum/commodity/synthmodule/virii(src)
 				src.goods_sell += new /datum/commodity/synthmodule/fungi(src)
 				src.goods_sell += new /datum/commodity/synthmodule/parasite(src)
 				src.goods_sell += new /datum/commodity/synthmodule/gmcell(src)
 				src.goods_sell += new /datum/commodity/synthmodule/vaccine(src)
-				#ifdef CREATE_PATHOGENS //PATHOLOGY REMOVAL
 				src.goods_sell += new /datum/commodity/pathogensample(src)
 				#endif
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL] [Removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Synth-O-Matic modules, both from D.O.C. and random merchant traders, are now dependent on the define CREATE_PATHOGENS to be enabled.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pathology's disabled, and the synth-o-matic is functionally inert currently. This removes them from the merchant pool, and thus clears up space for other merchants that could reasonably have a use.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Synth-O-Matic modules are no longer sold by merchants.
```