### PR TITLE
Fix dissolved headwear runtime

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -825,7 +825,7 @@ datum
 								else
 									H.visible_message("<span class='alert>The blueish acidic substance slides off \the [D] harmlessly.</span>", "<span class='alert'>Your [H.head] protects you from the acid!</span>")
 								melted = 1
-							if (!(H?.head.c_flags & SPACEWEAR))
+							if (!(H.head?.c_flags & SPACEWEAR))
 								if (H.wear_mask)
 									var/obj/item/clothing/mask/K = H.wear_mask
 									if (!(K.item_function_flags & IMMUNE_TO_ACID))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][RUNTIME]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
pacid (fluorosulfuric acid) tried to check vars on head after a qdel, leading to a runtime if you had a hat but no mask. As line 797 is correct this was probably a typo.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtime.