### PR TITLE
Fixing a glass table no longer makes you put the glass sheets on it

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -700,6 +700,7 @@
 					if (S.material)
 						src.setMaterial(S.material)
 					src.repair()
+					return
 			else
 				return ..()
 

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -700,7 +700,7 @@
 					if (S.material)
 						src.setMaterial(S.material)
 					src.repair()
-					return
+				return
 			else
 				return ..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR prevents putting glass sheets on a glass table when fixing it

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Dealing with yet another minor annoyance
