### PR TITLE
makes frogs and ithillids not jerks

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1356,7 +1356,7 @@
 	name = "hunter"
 	icon_state = "hunter"
 	human_compatible = 0
-	jerk = 1
+	jerk = 0
 	override_attack = 0
 	mutant_folder = 'icons/mob/hunter.dmi'
 	special_head = HEAD_HUNTER //heh
@@ -1391,7 +1391,7 @@
 /datum/mutantrace/ithillid
 	name = "ithillid"
 	icon_state = "squid"
-	jerk = 1
+	jerk = 0
 	override_attack = 0
 	aquatic = 1
 	voice_override = "blub"

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1758,7 +1758,7 @@
 	uses_human_clothes = 1
 	aquatic = 1
 	voice_name = "amphibian"
-	jerk = 1
+	jerk = 0
 	head_offset = 0
 	hand_offset = -3
 	body_offset = -3

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1356,7 +1356,7 @@
 	name = "hunter"
 	icon_state = "hunter"
 	human_compatible = 0
-	jerk = 0
+	jerk = 1
 	override_attack = 0
 	mutant_folder = 'icons/mob/hunter.dmi'
 	special_head = HEAD_HUNTER //heh


### PR DESCRIPTION
[qol]
## About the PR
Makes it so buddies won't harrass ithillids (squid people) or frogs anymore

## Why's this needed? 
It seems kind of off that ithillids are heckled by buddies for no reason other than that they're ithillids. No other non-antag mutantrace types obtainable through normal means by players in the game (except maybe grey?) have the variable toggled on, not even ones from chems or azones!
Diplomats can also round-start as ithillids so it's not always necessarily a choice to play as this particular mutantrace that is a jerk, versus as a skeleton or blobperson or something.
I'd understand if this is rejected since it's maybe meant as a funny joke in reference to other content like mindflayers or something; I just thought it maybe makes more sense and fits better with the treatment of other roundstart mutantraces on the server.