### PR TITLE
Unjerks mutant races

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1391,7 +1391,6 @@
 /datum/mutantrace/ithillid
 	name = "ithillid"
 	icon_state = "squid"
-	jerk = 1
 	override_attack = 0
 	aquatic = 1
 	voice_override = "blub"
@@ -1758,7 +1757,6 @@
 	uses_human_clothes = 1
 	aquatic = 1
 	voice_name = "amphibian"
-	jerk = 1
 	head_offset = 0
 	hand_offset = -3
 	body_offset = -3


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the jerk = 1 var on frog people and squid people


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
SecBots will relentlessly chase and arrest people marked as jerks. Frog people and other races are possible tourist/ambassador alternative races, which most new players pick and end up leaving in the middle of the round because they don't know what to do about it. Also, it makes secbots come off as racist


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Carbadox
(+)Frog and squid people will no longer be targetted by SecBots for simply existing. 
```
