### PR TITLE
Makes it possible to resist out of straightjackets

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1097,7 +1097,36 @@ var/datum/action_controller/actions
 					O.show_message("<span class='alert'><B>[H] manages to remove the shackles!</B></span>", 1)
 				H.show_text("You successfully remove the shackles.", "blue")
 
+/datum/action/bar/private/icon/straightjacket_removal //This is used when you try to resist out of a straightjacket.
+	duration = 90 SECONDS
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
+	id = "straightjacket"
+	icon = 'icons/obj/clothing/overcoats/item_suit.dmi'
+	icon_state = "straight_jacket"
 
+	New(var/dur)
+		duration = dur
+		..()
+
+	onStart()
+		..()
+		owner.visible_message("<span class='alert'><B>[owner] attempts to remove the straightjacket!</B></span>")
+
+	onInterrupt(var/flag)
+		..()
+		boutput(owner, "<span class='alert'>Your attempt to remove your straightjacket was interrupted!</span>")
+
+	onEnd()
+		..()
+		if(owner != null && ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			if (H.wear_suit)
+				var/obj/item/clothing/suit/straight_jacket = H.wear_suit
+				H.u_equip(straight_jacket)
+				straight_jacket.set_loc(H.loc)
+				H.update_clothing()
+				H.visible_message("<span class='alert'><B>[H] attempts to remove the straightjacket!</B></span>")
+				boutput(H, "<span class='notice'>You successfully remove your straightjacket.</span>")
 //CLASSES & OBJS
 
 /obj/actions //These objects are mostly used for the attached_objs var on mobs to attach progressbars to mobs.

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2571,6 +2571,14 @@
 			if (src.handcuffs:material) //This is a bit hacky.
 				src.handcuffs:material:triggerOnAttacked(src.handcuffs, src, src, src.handcuffs)
 			actions.start(new/datum/action/bar/private/icon/handcuffRemoval(calcTime), src)
+
+	if (src.wear_suit.restrain_wearer)
+	//handle werewolf/borg arm/ling/hulk interactions - do that later
+	//ok everything after this assumes we are a Normal Human With No Powers
+		src.last_resist = world.time + 100
+		var/time = 90 SECONDS
+		boutput(src, "<span class='alert'>You attempt to remove your straightjacket. (This will take around 90 seconds and you need to stand still)</span>")
+		actions.start(new/datum/action/bar/private/icon/straightjacket_removal(time), src)
 	return 0
 
 /mob/living/carbon/human/proc/spidergib()


### PR DESCRIPTION
[wiki][balance]

## About the PR 
Makes it possible to resist out of straightjackets with a 90 second actionbar that can be interrupted by moving, being moved, acting, and being stunned (all the same flags as handcuffs and shackles).

## Why's this needed? 
There's no way to resist out of straightjackets on your own currently; I think every other method of restraining someone has the ability to resist out of it, whether it's handcuffs or the PortABrig, so I think straightjackets should have that ability too. 
I think the 90 seconds is accomodating for whatever legitimate uses someone might have for using a straightjacket on someone, but if the agreed decision is that they're too weird to have in the game or that handcuffs and the PortABrig are really meant to be the tools used for that, I'd be open to removing the straightjacket outright.


## Changelog
```changelog
(u)Asche & Nefarious6th
(+)You can now resist out of a straightjacket by pressing resist and holding very still for 90 seconds.
```