### PR TITLE
Give every scientist a pen

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -654,6 +654,7 @@ ABSTRACT_TYPE(/datum/job/research)
 	slot_lhan = /obj/item/tank/air
 	slot_ears = /obj/item/device/radio/headset/research
 	slot_eyes = /obj/item/clothing/glasses/spectro
+	slot_poc1 = /obj/item/pen
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a standard black pen to every scientist's starting pocket.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Artifact lab require pens to fill in forms but availability of pens depends upon the map.
Sleepy pens are a common scientist item but even with artifact research typically only 2~ scientists doing that would carry pens making any pen still suspicious.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Every scientist now starts with a pen.
```
