### PR TITLE
Adds RecordTrak scanners as a redeemable utility in Security weapons vendors

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -116,6 +116,7 @@
 		materiel_stock += new/datum/materiel/utility/firstaidsec
 		materiel_stock += new/datum/materiel/utility/nightvisiongoggles
 		materiel_stock += new/datum/materiel/utility/riotrounds
+		materiel_stock += new/datum/materiel/utility/prisonerscanner
 		materiel_stock += new/datum/materiel/assistant/basic
 
 	vended(var/atom/A)
@@ -292,6 +293,10 @@
 	path = /obj/item/ammo/bullets/pbr
 	description = "One case of 40mm Riot Rounds, totalling 2 shots, for the Riot Launcher."
 
+/datum/materiel/utility/prisonerscanner
+	name = "RecordTrak Scannner"
+	path = /obj/item/device/prisoner_scanner
+	description = "A device used to scan in prisoners and update their security records."
 /datum/materiel/assistant/basic
 	name = "Assistant"
 	path = /obj/item/storage/belt/security/assistant

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -297,6 +297,7 @@
 	name = "RecordTrak Scannner"
 	path = /obj/item/device/prisoner_scanner
 	description = "A device used to scan in prisoners and update their security records."
+
 /datum/materiel/assistant/basic
 	name = "Assistant"
 	path = /obj/item/storage/belt/security/assistant


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
RecordTrak scanners are now available from the Security weapons vendors as a utility. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hopefully this'll encourage their use and at least there's a way of actually obtaining them. Maybe. Figured it'd be good since #5073.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DisturbHerb
(*)RecordTrak scanners are now available from Security weapons vendors.
```
