### PR TITLE
Actually killer tomatoes

### DIFF
--- a/code/obj/critter/plants.dm
+++ b/code/obj/critter/plants.dm
@@ -104,6 +104,9 @@
 	name_the_meat = 0
 	death_text = "%src% messily splatters into a puddle of tomato sauce!"
 	chase_text = "viciously lunges at"
+	atk_brute_amt = 4
+	crit_brute_amt = 6
+	crit_chance = 10
 	meat_type = /obj/item/reagent_containers/food/snacks/plant/tomato/incendiary
 	generic = 0
 
@@ -133,7 +136,7 @@
 	ChaseAttack(mob/M)
 		..()
 		if (prob(20)) M.changeStatus("stunned", 2 SECONDS)
-		random_brute_damage(M, rand(2,5),1)
+		random_brute_damage(M, rand(4,6),1)
 
 	CritterAttack(mob/M)
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds atk_brute_amt of 4, crit_brute_amt of 6 and 10% crit_chance to killer tomatos.
Raises charge damage to be a range from atk_brute_amt to crit_brute_amt.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Killer tomatos didn't have their damage variables set and were doing default (1) damage on bite. Due to typical uniform armor of 1 melee this meant they only did damage when charging and 1 damage (reduced from 2 by armor) on crit.
For reference a space pig does 4 regular damage and 8 crit.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Killer tomatoes now actually do damage (4-6) when biting you.
```
