### PR TITLE
Radbow no longer shows impact effect

### DIFF
--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -766,6 +766,7 @@ datum/projectile/tele_bolt
 
 datum/projectile/rad_bolt
 	impact_range = 0
+	ie_type = null // Probably not the best way to make sure these don't generate an impact effect but oh well.
 
 datum/projectile/wavegun
 	impact_range = 4

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -766,7 +766,6 @@ datum/projectile/tele_bolt
 
 datum/projectile/rad_bolt
 	impact_range = 0
-	ie_type = null // Probably not the best way to make sure these don't generate an impact effect but oh well.
 
 datum/projectile/wavegun
 	impact_range = 4

--- a/code/modules/projectiles/radbolt.dm
+++ b/code/modules/projectiles/radbolt.dm
@@ -36,3 +36,5 @@ toxic - poisons
 	window_pass = 1
 	//no visible message upon bullet_act and no armor block message
 	silentshot = 1
+	//Prevent impact effect
+	ie_type = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that the rad crossbow doesn't show an impact effect.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5060 and a stealth weapon probably shouldn't leave a small explosion at the impact site.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)eX.n0x
(+)Radbow no longer shows an impact effect.
```
