### PR TITLE
Makes personal locker backpacks/satchels random colours

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -9,11 +9,17 @@
 	name = "personal locker"
 	desc = "The first card swiped gains control."
 	personal = 1
-	spawn_contents = list(/obj/item/storage/backpack,
-	/obj/item/storage/backpack/satchel,
-	/obj/item/device/radio/signaler,
+	spawn_contents = list(/obj/item/device/radio/signaler,
 	/obj/item/pen,
 	/obj/item/device/radio/headset)
+
+	make_my_stuff() //Let's spawn the backpack/satchel in random colours!
+		. = ..()
+		if (. == 1) //if we've not spawned stuff before
+			var/backwear = pick(/obj/item/storage/backpack,/obj/item/storage/backpack/blue,/obj/item/storage/backpack/red,/obj/item/storage/backpack/green)
+			new backwear(src)
+			backwear = pick(/obj/item/storage/backpack/satchel,/obj/item/storage/backpack/satchel/blue,/obj/item/storage/backpack/satchel/red,/obj/item/storage/backpack/satchel/green)
+			new backwear(src)
 
 /obj/storage/secure/closet/personal/empty
 	spawn_contents = list()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes personal lockers pick their backpacks and satchels from Walp's grey, red, green and blue variants. Brown is excluded because that's a spacebux thing.
![afbeelding](https://user-images.githubusercontent.com/31984217/121445072-05391500-c991-11eb-80c9-97c285ddc4fb.png)
Both are picked individually, so colours might not match.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes the various backpack colours available and adds something interesting to a often ignored locker type.

I think having some of the more or less inconsequential things like these be random and maybe a bit obscure is more fun than putting everything in the clothing booth or similar.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)The backpacks and satchels in personal lockers now come in a small variety of random colours!
```
