### PR TITLE
Peeing in toilets has been fixed, alongside minor cleaning-up.

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1795,7 +1795,6 @@
 
 					else
 						var/obj/item/storage/toilet/toilet = locate() in src.loc
-						var/obj/item/reagent_containers/glass/beaker = locate() in src.loc
 
 						if (toilet && (src.buckled != null))
 							if (src.urine >= 1)

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1797,18 +1797,17 @@
 						var/obj/item/storage/toilet/toilet = locate() in src.loc
 						var/obj/item/reagent_containers/glass/beaker = locate() in src.loc
 
-						if (src.urine < 1)
+						if (toilet && (src.buckled != null))
+							if (src.urine >= 1)
+								for (var/obj/item/storage/toilet/T in src.loc)
+									message = pick("<B>[src]</B> unzips [his_or_her(src)] pants and pees in the toilet.", "<B>[src]</B> empties [his_or_her(src)] bladder.", "<span class='notice'>Ahhh, sweet relief.</span>")
+									src.urine = 0
+									T.clogged += 0.10
+									break
+							else
+								message = "<B>[src]</B> unzips [his_or_her(src)] pants but, try as [he_or_she(src)] might, [he_or_she(src)] can't pee in the toilet!"
+						else if (src.urine < 1)
 							message = "<B>[src]</B> pees [himself_or_herself(src)] a little bit."
-						else if (toilet && (src.buckled != null) && (src.urine >= 2))
-							for (var/obj/item/storage/toilet/T in src.loc)
-								message = pick("<B>[src]</B> unzips [his_or_her(src)] pants and pees in the toilet.", "<B>[src]</B> empties [his_or_her(src)] bladder.", "<span class='notice'>Ahhh, sweet relief.</span>")
-								src.urine = 0
-								T.clogged += 0.10
-								break
-						else if (beaker && (src.urine >= 1))
-							message = pick("<B>[src]</B> unzips [his_or_her(src)] pants, takes aim, and pees in the beaker.", "<B>[src]</B> takes aim and pees in the beaker!", "<B>[src]</B> fills the beaker with pee!")
-							beaker.reagents.add_reagent("urine", src.urine * 4)
-							src.urine = 0
 						else
 							src.urine--
 							src.urinate()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
[QOL]

NOTE: This has nothing to do with recent discussion surrounding urination as a mechanic. This fixes a long-standing bug with peeing in toilets.

For whatever reason, having a `urine` value of 1 to 2 would make you piss on the floor even if you were buckled on the toilet if you tried to pee. This PR fixes... that. The toilet peeing threshold has now been reduced to 1 or above, meaning that drinking 25u out of a glass will allow you to pee in a toilet. This does not present any obvious changes to game balance.

Some bits of code which would end up being handled by the `urinate()` proc have been removed for... brevity? Readability? Who knows. I don't want to think about piss anymore.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug bad. Bug in my pee worse. Dear god, just let me pee in a sanitary manner.