### PR TITLE
Cleans beepsky-baton non-recharging

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -41,8 +41,6 @@
 	var/cost_cyborg = 500 // Battery charge to drain when user is a cyborg.
 	var/uses_charges = 1 // Does it deduct charges when used? Distinct from...
 	var/uses_electricity = 1 // Does it use electricity? Certain interactions don't work with a wooden baton.
-	///if rechargers can charge the baton (if applicable)
-	var/chargeable = 1
 	var/status = 1 //1 is on, 0 is off
 
 	var/stun_normal_weakened = 15
@@ -203,7 +201,7 @@
 		return
 
 	proc/charge(var/amt)
-		if(src.cell && chargeable)
+		if(src.cell)
 			return src.cell.charge(amt)
 		else
 			//No cell. Tell anything trying to charge it.
@@ -473,9 +471,11 @@
 /obj/item/baton/beepsky
 	name = "securitron stun baton"
 	desc = "A stun baton that's been modified to be used more effectively by security robots. There's a small parallel port on the bottom of the handle."
-	chargeable = 0
 	can_swap_cell = 0
 	cell_type = /obj/item/ammo/power_cell
+
+	charge(var/amt)
+		return -1 //no
 
 /obj/item/baton/stamina
 	stamina_based_stun = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[cleanliness][nitpicking]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Re-does the baton non-recharging from 47808ebf7f2ed5290396860c356396aefa4b0053 by overriding the beepsky baton charge proc so rechargers reject it instead of a using a new variable.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Using existing systems cleanly good, unnecessary variables mildly bad.
