### PR TITLE
manta firedoor and door access fixes

### DIFF
--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -1599,3 +1599,8 @@ exposed to overconfident outbursts on the part of individuals unqualifed to embo
 	desc = "Somebody took whatever was in here."
 	icon_state = "postit-writing"
 	info = {"<h2>IOU</h2>"}
+
+/obj/item/paper/ikea
+	desc = "Somebody took whatever was in here."
+	icon_state = "postit-writing"
+	info = {"<h2>IOU</h2>"}

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -1599,8 +1599,3 @@ exposed to overconfident outbursts on the part of individuals unqualifed to embo
 	desc = "Somebody took whatever was in here."
 	icon_state = "postit-writing"
 	info = {"<h2>IOU</h2>"}
-
-/obj/item/paper/ikea
-	desc = "Somebody took whatever was in here."
-	icon_state = "postit-writing"
-	info = {"<h2>IOU</h2>"}

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -1892,6 +1892,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "agu" = (
@@ -4896,6 +4897,7 @@
 	req_access = null
 	},
 /obj/access_spawn/medical_director,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/head)
 "apl" = (
@@ -5072,6 +5074,9 @@
 	},
 /obj/disposalpipe/segment,
 /obj/storage/closet/medicalclothes,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -11820,6 +11825,8 @@
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access = null
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating/random,
 /area/station/medical/research)
 "aHB" = (
@@ -12944,6 +12951,7 @@
 	icon_state = "1-2"
 	},
 /obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
 "aKz" = (
@@ -17914,6 +17922,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aYX" = (
@@ -18109,6 +18118,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary/blue,
 /area/station/medical/medbay/restroom)
 "aZv" = (
@@ -18433,6 +18443,9 @@
 /area/station/medical/medbay/surgery)
 "bat" = (
 /obj/storage/secure/closet/medical/medicine,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/redwhite{
 	dir = 9
 	},
@@ -18520,6 +18533,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor,
 /area/station/maintenance/upperport)
 "baG" = (
@@ -19479,6 +19493,10 @@
 	dir = 1;
 	icon_state = "line3"
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/greenwhite{
 	dir = 8
 	},
@@ -20118,6 +20136,7 @@
 	req_access = null
 	},
 /obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/surgery/storage)
 "beF" = (
@@ -21673,6 +21692,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "biw" = (
@@ -21686,6 +21706,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "biy" = (
@@ -22379,6 +22400,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "bkm" = (
@@ -23537,6 +23559,7 @@
 	id = "medbay_door"
 	},
 /obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "bmT" = (
@@ -24049,6 +24072,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "boi" = (
@@ -24144,6 +24168,10 @@
 	pixel_y = 11
 	},
 /obj/disposalpipe/segment/mail,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 6
 	},
@@ -24386,6 +24414,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
 "bpb" = (
@@ -24603,6 +24632,7 @@
 /obj/disposalpipe/segment,
 /obj/machinery/door/airlock/pyro/glass,
 /obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "bpF" = (
@@ -24664,6 +24694,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "bpN" = (
@@ -24680,6 +24711,7 @@
 	icon_state = "1-2"
 	},
 /obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/maintenance/upperstarboard)
 "bpQ" = (
@@ -25157,6 +25189,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
 "bqP" = (
@@ -25347,6 +25380,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
 "brl" = (
@@ -25443,6 +25477,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/maint,
 /turf/simulated/floor,
 /area/station/maintenance/upperport)
 "brx" = (
@@ -25743,6 +25778,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
 "bsj" = (
@@ -26091,6 +26127,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/maintenance/upperstarboard)
 "btw" = (
@@ -43229,6 +43266,18 @@
 	},
 /turf/simulated/floor,
 /area/station/construction)
+"tEZ" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor,
+/area/station/hallway/starboardlowerhallway)
 "tHn" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -43954,6 +44003,15 @@
 	dir = 8
 	},
 /area/station/security/interrogation)
+"vot" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor,
+/area/station/hallway/starboardlowerhallway)
 "vqB" = (
 /obj/disposalpipe/segment/mineral{
 	dir = 4
@@ -44878,6 +44936,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"xtM" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/disposalpipe/segment,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor,
+/area/station/hallway/starboardlowerhallway)
 "xuW" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cell_charger,
@@ -97437,7 +97505,7 @@ bmS
 boh
 bhp
 bmt
-bsx
+tEZ
 bsj
 aFO
 aFO
@@ -103476,7 +103544,7 @@ bmd
 bnf
 dFF
 bpz
-bkM
+xtM
 brb
 deY
 nkZ
@@ -108912,7 +108980,7 @@ bli
 bnv
 kWs
 bli
-bkN
+vot
 bsx
 aKB
 buM

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -5077,6 +5077,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/item/crowbar,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -13569,6 +13570,7 @@
 	dir = 4
 	},
 /obj/access_spawn/medical,
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "aMm" = (
@@ -18132,6 +18134,9 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "aZw" = (
@@ -20213,6 +20218,7 @@
 /obj/decal/poster/wallsign/poster_borg{
 	pixel_y = 32
 	},
+/obj/item/crowbar,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "beP" = (
@@ -20241,6 +20247,7 @@
 /obj/item/clothing/suit/bio_suit/paramedic,
 /obj/item/storage/belt/medical,
 /obj/item/clothing/glasses/healthgoggles,
+/obj/item/crowbar,
 /turf/simulated/floor/yellow/checker{
 	dir = 1
 	},
@@ -20680,6 +20687,7 @@
 	dir = 5;
 	icon_state = "line2"
 	},
+/obj/item/crowbar,
 /turf/simulated/floor/yellow/checker{
 	dir = 1
 	},
@@ -40974,6 +40982,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"olu" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/disposalpipe/segment,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor,
+/area/station/hallway/starboardlowerhallway)
 "olF" = (
 /obj/item/raw_material/rock,
 /obj/disposalpipe/trunk,
@@ -43266,18 +43284,6 @@
 	},
 /turf/simulated/floor,
 /area/station/construction)
-"tEZ" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor,
-/area/station/hallway/starboardlowerhallway)
 "tHn" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -43865,6 +43871,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"uTh" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor,
+/area/station/hallway/starboardlowerhallway)
 "uTW" = (
 /obj/machinery/light/incandescent/blueish{
 	dir = 8;
@@ -44003,15 +44021,6 @@
 	dir = 8
 	},
 /area/station/security/interrogation)
-"vot" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor,
-/area/station/hallway/starboardlowerhallway)
 "vqB" = (
 /obj/disposalpipe/segment/mineral{
 	dir = 4
@@ -44936,16 +44945,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
-"xtM" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor,
-/area/station/hallway/starboardlowerhallway)
 "xuW" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cell_charger,
@@ -45223,6 +45222,15 @@
 	},
 /turf/simulated/floor/damaged2,
 /area/station/engine/inner)
+"xTC" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor,
+/area/station/hallway/starboardlowerhallway)
 "xVb" = (
 /obj/machinery/vending/security,
 /obj/machinery/light/incandescent/warm{
@@ -97505,7 +97513,7 @@ bmS
 boh
 bhp
 bmt
-tEZ
+uTh
 bsj
 aFO
 aFO
@@ -103544,7 +103552,7 @@ bmd
 bnf
 dFF
 bpz
-xtM
+olu
 brb
 deY
 nkZ
@@ -108980,7 +108988,7 @@ bli
 bnv
 kWs
 bli
-vot
+xTC
 bsx
 aKB
 buM


### PR DESCRIPTION
## About the PR 
adds some missing firedoors + alarms to medbay hall area on manta; the mirror side of the ship already has these so it seemed unintentional.
ditto on maintenance access spawners on the left side of the ship.
keeps some of the tighter rooms without firedoors; keeps the general medical bay without them too.
tossed some extra crowbars in some of the rooms just in case so it's not possible for the doors to close on people and then have no way out.

## Why's this needed? 
seemed like an oversight. i kept the general medbay lobby open in case there's plasmafires or whatever in the main hall and people end up having to make a mad dash to the shuttle from there.
