### PR TITLE
Remakes Cogmap2 Robotics to be more open to the hallway and increase interaction

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -53524,8 +53524,6 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
 "cmV" = (
-/obj/table/auto,
-/obj/random_item_spawner/tools,
 /obj/cable,
 /obj/machinery/power/apc{
 	areastring = "Medbay Lobby";
@@ -53533,6 +53531,7 @@
 	name = "W APC";
 	pixel_x = -24
 	},
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "cmW" = (
@@ -54399,7 +54398,6 @@
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "coH" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Robotics";
 	req_access_txt = "29"
@@ -54409,6 +54407,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "coI" = (
@@ -55105,47 +55105,35 @@
 	},
 /area/station/medical/robotics)
 "cqp" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 8
 	},
-/turf/simulated/floor/caution/corner/sw,
+/turf/simulated/floor/blueblack{
+	dir = 1
+	},
 /area/station/medical/robotics)
 "cqq" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/caution/corner/sw,
+/area/station/medical/robotics)
+"cqr" = (
 /obj/machinery/computer/robot_module_rewriter,
 /obj/machinery/ai_status_display{
 	pixel_y = 28
 	},
 /turf/simulated/floor/caution/south,
 /area/station/medical/robotics)
-"cqr" = (
+"cqs" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "corner_east"
 	},
 /area/station/medical/robotics)
-"cqs" = (
-/obj/storage/secure/closet/medical/anesthetic,
-/turf/simulated/floor/blueblack{
-	dir = 1
-	},
-/area/station/medical/robotics)
 "cqt" = (
-/obj/table/reinforced/auto,
-/obj/item/weldingtool,
-/obj/item/weldingtool,
-/obj/item/storage/wall/random,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/helmet/welding,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/computer3/generic/med_data,
+/obj/cable,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/blueblack{
 	dir = 5
 	},
@@ -55155,17 +55143,14 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
 	pixel_x = -24
 	},
 /obj/cable{
-	icon_state = "0-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
@@ -55808,24 +55793,33 @@
 	},
 /area/station/medical/medbay/lobby)
 "csb" = (
-/obj/machinery/manufacturer/robotics,
-/turf/simulated/floor/caution/corner/ne{
-	dir = 1
+/obj/decal/tile_edge/stripe/big,
+/obj/surgery_tray,
+/obj/item/bandage,
+/obj/item/bandage,
+/obj/item/bandage,
+/obj/item/hemostat,
+/obj/item/hemostat,
+/obj/item/suture{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/device/analyzer/healthanalyzer,
+/turf/simulated/floor/blueblack{
+	dir = 10
 	},
 /area/station/medical/robotics)
 "csc" = (
-/obj/landmark/start{
-	name = "Cyborg"
-	},
-/turf/simulated/floor/black,
+/obj/decal/tile_edge/stripe/big,
+/turf/simulated/floor/blueblack,
 /area/station/medical/robotics)
 "csd" = (
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "cse" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/decal/tile_edge/stripe/big,
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
@@ -55836,15 +55830,13 @@
 	name = "Robotics Storage";
 	req_access_txt = "29"
 	},
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "csg" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/grille/steel,
+/obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "csh" = (
@@ -55855,6 +55847,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "csj" = (
@@ -56403,25 +56396,18 @@
 /obj/item/scalpel,
 /obj/item/circular_saw{
 	pixel_x = 3;
-	pixel_y = 12
+	pixel_y = -11
 	},
 /obj/item/circular_saw{
 	pixel_x = 3;
-	pixel_y = 12
+	pixel_y = -12
 	},
-/obj/item/suture,
-/obj/item/clothing/mask/surgical_shield,
-/obj/item/clothing/mask/surgical_shield,
-/turf/simulated/floor/caution/east{
-	dir = 8
+/obj/item/scissors/surgical_scissors{
+	pixel_x = -10;
+	pixel_y = 5
 	},
-/area/station/medical/robotics)
-"ctv" = (
-/obj/stool/chair/office,
-/obj/landmark/start{
-	name = "Roboticist"
-	},
-/turf/simulated/floor/black,
+/obj/item/scissors/surgical_scissors,
+/turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "ctw" = (
 /obj/machinery/light{
@@ -56429,23 +56415,13 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/submachine/cargopad/robotics,
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
 /area/station/medical/robotics)
 "ctx" = (
 /obj/machinery/portable_reclaimer,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "cty" = (
@@ -56469,13 +56445,13 @@
 	},
 /obj/item/circular_saw,
 /obj/decal/cleanable/cobweb,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/firstaid/regular,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
 	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plating,
 /area/station/medical/robotics)
 "ctA" = (
@@ -57050,32 +57026,42 @@
 	dir = 4
 	},
 /area/station/catwalk/south)
-"cuO" = (
-/obj/machinery/optable{
-	id = "robotics"
-	},
-/turf/simulated/floor/black,
-/area/station/medical/robotics)
 "cuP" = (
-/obj/machinery/light_switch/east,
-/obj/machinery/computer3/generic/med_data{
-	dir = 8
+/obj/table/auto,
+/obj/decal/tile_edge/stripe/big{
+	dir = 1
 	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/storage/belt/utility{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/device/multitool{
+	pixel_x = 8;
+	pixel_y = -14
+	},
+/obj/item/device/multitool{
+	pixel_x = 8;
+	pixel_y = -14
+	},
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
 /area/station/medical/robotics)
 "cuQ" = (
-/obj/window/auto/reinforced,
-/obj/grille/steel,
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/disposal/mail/small{
+	dir = 1;
+	mail_tag = "robotics";
+	mailgroup = "robotics";
+	mailgroup2 = null;
+	message = "1";
+	name = "mail chute-'Robotics'"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/robotics)
 "cuR" = (
 /obj/disposalpipe/segment{
@@ -57690,27 +57676,33 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/robotics)
 "cwo" = (
-/obj/machinery/manufacturer/robotics,
-/obj/machinery/light,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "corner_east"
+/obj/table/auto,
+/obj/item/clothing/glasses/healthgoggles{
+	pixel_y = 16
 	},
+/obj/item/clothing/mask/surgical{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/clothing/gloves/latex{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/obj/item/clothing/mask/surgical_shield{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "cwp" = (
-/obj/storage/crate,
-/obj/item/sheet/steel/fullstack,
-/obj/item/sheet/steel/fullstack,
-/obj/item/storage/box/cablesbox,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/turf/simulated/floor/black,
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/saline,
+/turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "cwq" = (
 /obj/grille/catwalk{
@@ -57727,6 +57719,23 @@
 	},
 /area/station/catwalk/south)
 "cwr" = (
+/obj/table/auto,
+/obj/item/reagent_containers/glass/oilcan{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/glass/oilcan{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/clothing/head/helmet/welding{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/welding{
+	pixel_x = 6;
+	pixel_y = 3
+	},
 /turf/simulated/floor/blueblack/corner{
 	dir = 8
 	},
@@ -57739,40 +57748,9 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/disposalpipe/trunk/mail/south,
-/obj/machinery/disposal/mail/autoname/medbay/robotics,
-/turf/simulated/floor/blueblack{
-	dir = 1
-	},
-/area/station/medical/robotics)
-"cwt" = (
-/obj/machinery/power/data_terminal,
 /obj/table/auto,
-/obj/cable,
-/obj/machinery/networked/printer{
-	name = "Printer - Robotics";
-	pixel_y = 5;
-	print_id = "Robotics"
-	},
-/turf/simulated/floor/blueblack{
-	dir = 1
-	},
-/area/station/medical/robotics)
-"cwu" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/turf/simulated/floor/blueblack{
-	dir = 1
-	},
-/area/station/medical/robotics)
-"cwv" = (
-/obj/table/reinforced/auto,
-/obj/item/reagent_containers/glass/oilcan,
-/obj/item/reagent_containers/glass/oilcan,
+/obj/machinery/cell_charger,
+/obj/item/cell/supercell/charged,
 /obj/item/storage/wall/medical{
 	dir = 1;
 	pixel_y = 32
@@ -57781,14 +57759,51 @@
 	dir = 1
 	},
 /area/station/medical/robotics)
+"cwt" = (
+/obj/disposalpipe/trunk/mail/south,
+/turf/simulated/floor/blueblack{
+	dir = 1
+	},
+/area/station/medical/robotics)
+"cwu" = (
+/obj/disposalpipe/trunk,
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/obj/machinery/disposal/small{
+	dir = 1;
+	layer = 32;
+	pixel_y = 32
+	},
+/turf/simulated/floor/blueblack{
+	dir = 1
+	},
+/area/station/medical/robotics)
+"cwv" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/blueblack{
+	dir = 5
+	},
+/area/station/medical/robotics)
 "cww" = (
 /obj/disposalpipe/segment/mail/bent/east,
-/turf/simulated/wall/auto/supernorn,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Robot Depot";
+	req_access_txt = "29"
+	},
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating,
 /area/station/science/bot_storage)
 "cwx" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/machinery/light_switch/west,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "cwy" = (
@@ -58344,13 +58359,25 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/robotics)
 "cxP" = (
-/obj/submachine/cargopad/robotics,
-/turf/simulated/floor/black,
+/obj/decal/tile_edge/stripe{
+	dir = 9;
+	icon_state = "xtra_bigstripe-corner2";
+	tag = ""
+	},
+/turf/simulated/floor/blueblack/corner{
+	dir = 1
+	},
 /area/station/medical/robotics)
 "cxQ" = (
-/obj/disposalpipe/segment/mail/vertical,
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/black,
+/obj/storage/secure/closet/medical/anesthetic,
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/turf/simulated/floor/blueblack{
+	dir = 9
+	},
 /area/station/medical/robotics)
 "cxR" = (
 /obj/disposalpipe/segment{
@@ -58363,22 +58390,17 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/black,
+/obj/machinery/manufacturer/robotics,
+/turf/simulated/floor/blueblack{
+	dir = 4
+	},
 /area/station/medical/robotics)
 "cxT" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Robot Depot";
-	req_access_txt = "29"
-	},
 /obj/disposalpipe/segment/mail/vertical,
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
-	},
-/turf/simulated/floor/delivery,
+/turf/simulated/wall/auto/supernorn,
 /area/station/science/bot_storage)
 "cxU" = (
 /obj/disposalpipe/junction{
@@ -58386,6 +58408,7 @@
 	icon_state = "pipe-j2"
 	},
 /obj/landmark/gps_waypoint,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "cxV" = (
@@ -59016,6 +59039,9 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/transport,
+/obj/submachine/ATM{
+	pixel_y = 32
+	},
 /turf/simulated/floor{
 	icon_state = "carpetN"
 	},
@@ -59026,9 +59052,6 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/decal/poster/wallsign/poster_nt{
-	pixel_y = 28
-	},
 /turf/simulated/floor{
 	icon_state = "carpetNE"
 	},
@@ -59038,70 +59061,47 @@
 	pixel_y = 24;
 	text = "NF"
 	},
-/obj/stool/chair{
-	dir = 4
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "bot2"
 	},
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
-"czq" = (
-/obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro{
+"czr" = (
+/obj/landmark/start{
+	name = "Cyborg"
+	},
+/obj/decal/tile_edge/stripe{
+	dir = 10;
+	icon_state = "xtra_bigstripe-corner2";
+	tag = ""
+	},
+/turf/simulated/floor/blueblack/corner{
 	dir = 4
 	},
-/obj/machinery/door/window/westright{
-	name = "Robotics";
-	req_access_txt = "29"
-	},
-/obj/item/clipboard,
-/obj/item/paper_bin,
-/obj/item/pen/marker/red,
-/obj/item/pen/marker/blue,
-/obj/item/pen,
-/obj/item/staple_gun/red,
-/turf/simulated/floor/black,
-/area/station/medical/robotics)
-"czr" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
-/obj/stool/chair/office{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Roboticist"
-	},
-/turf/simulated/floor/black,
 /area/station/medical/robotics)
 "czs" = (
-/obj/disposalpipe/segment/mail/bent/north,
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "xtra_bigstripe-corner2";
+	tag = ""
+	},
+/obj/landmark/start{
+	name = "Cyborg"
+	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "czt" = (
-/obj/disposalpipe/segment/mail/horizontal,
+/obj/disposalpipe/segment/mail/bent/north,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "czu" = (
-/obj/stool/chair/office{
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Roboticist"
-	},
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "czv" = (
 /obj/disposalpipe/segment/mail/horizontal,
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 8
-	},
+/obj/machinery/manufacturer/robotics,
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
@@ -59115,6 +59115,10 @@
 /area/station/science/bot_storage)
 "czx" = (
 /obj/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "czy" = (
@@ -59699,57 +59703,86 @@
 	},
 /area/station/catwalk/south)
 "cAK" = (
-/turf/simulated/floor{
-	icon_state = "carpetE"
+/obj/landmark/start{
+	name = "Cyborg"
 	},
-/area/station/medical/medbay/lobby)
+/obj/decal/tile_edge/stripe/big,
+/turf/simulated/floor/blueblack,
+/area/station/medical/robotics)
 "cAL" = (
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "cAM" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/pyro{
-	dir = 4
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
 	},
-/obj/machinery/door/window/westleft{
-	name = "Robotics";
-	req_access_txt = "29"
-	},
-/obj/machinery/cashreg,
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
+/obj/random_item_spawner/desk_stuff/few,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "cAN" = (
 /turf/simulated/floor/blueblack,
 /area/station/medical/robotics)
 "cAO" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor/blueblack,
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
+/turf/simulated/floor/blueblack{
+	dir = 8
+	},
 /area/station/medical/robotics)
 "cAP" = (
-/obj/machinery/manufacturer/robotics,
+/obj/table/auto,
+/obj/item/robot_module{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/robot_module{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/robot_module{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/robot_module{
+	pixel_x = 8;
+	pixel_y = 9
+	},
 /turf/simulated/floor/blueblack,
 /area/station/medical/robotics)
 "cAQ" = (
-/obj/table/auto,
-/obj/item/suture,
-/obj/item/suture,
-/obj/item/suture,
-/obj/item/bandage,
-/obj/item/bandage,
-/obj/item/bandage,
-/obj/item/hemostat,
-/obj/item/hemostat,
+/obj/storage/crate,
+/obj/item/sheet/steel/fullstack,
+/obj/item/sheet/steel/fullstack,
+/obj/item/storage/box/cablesbox,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/machinery/light,
 /turf/simulated/floor/blueblack,
 /area/station/medical/robotics)
 "cAR" = (
-/obj/iv_stand,
-/turf/simulated/floor/blueblack,
+/obj/stool/chair/office{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Roboticist"
+	},
+/turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "cAS" = (
-/obj/machinery/optable{
-	id = "robotics"
+/obj/stool/chair/office,
+/obj/landmark/start{
+	name = "Roboticist"
 	},
-/obj/machinery/light,
 /turf/simulated/floor/blueblack,
 /area/station/medical/robotics)
 "cAT" = (
@@ -60347,20 +60380,26 @@
 	},
 /area/station/medical/medbay/lobby)
 "cCl" = (
-/turf/simulated/floor{
-	icon_state = "carpetSE"
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
 	},
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "cCm" = (
-/obj/decal/poster/wallsign/escape_right,
-/turf/simulated/wall/auto/supernorn,
+/obj/table/reinforced/auto,
+/obj/machinery/cashreg,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
 /area/station/medical/robotics)
 "cCn" = (
-/obj/machinery/door/firedoor/pyro,
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Robotics Lab";
 	req_access_txt = "29"
 	},
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/medical/robotics)
 "cCo" = (
@@ -60948,14 +60987,6 @@
 	icon_state = "Stairs_wide"
 	},
 /area/station/medical/medbay/lobby)
-"cDF" = (
-/obj/submachine/ATM{
-	pixel_y = 32
-	},
-/turf/simulated/floor/blue/side{
-	dir = 1
-	},
-/area/station/medical/medbay/lobby)
 "cDG" = (
 /turf/simulated/floor/blue/side{
 	dir = 1
@@ -60968,12 +60999,10 @@
 	},
 /area/station/medical/medbay/lobby)
 "cDJ" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 9.1;
-	pixel_y = 21
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "bot2"
 	},
-/obj/machinery/light_switch/north,
 /turf/simulated/floor/blue/side{
 	dir = 1
 	},
@@ -61017,6 +61046,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/stairs{
 	dir = 4;
 	icon_state = "Stairs_wide"
@@ -71705,17 +71735,7 @@
 /turf/simulated/floor/redwhite,
 /area/station/medical/cdc)
 "daZ" = (
-/obj/table/reinforced/auto,
-/obj/item/scalpel,
-/obj/item/circular_saw{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/machinery/light,
-/obj/item/paper/book/from_file/medical_surgery_guide,
-/turf/simulated/floor/black,
+/turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "dba" = (
 /turf/simulated/floor/redwhite,
@@ -72175,15 +72195,8 @@
 	},
 /area/station/quartermaster/office)
 "dce" = (
-/obj/table/reinforced/auto,
-/obj/item/circular_saw{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/obj/item/scalpel,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/paper/book/from_file/medical_surgery_guide,
+/obj/machinery/portable_reclaimer,
+/obj/machinery/light_switch/east,
 /turf/simulated/floor/blueblack{
 	dir = 6
 	},
@@ -73215,7 +73228,10 @@
 /area/station/maintenance/south)
 "des" = (
 /obj/machinery/drainage,
-/turf/simulated/floor/black,
+/obj/machinery/optable{
+	id = "robotics"
+	},
+/turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "det" = (
 /obj/cable{
@@ -73456,13 +73472,13 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/checkpoint/cargo)
 "deW" = (
-/obj/decal/poster/wallsign/teaparty{
-	pixel_y = 32
+/obj/decal/tile_edge/stripe{
+	dir = 5;
+	icon_state = "xtra_bigstripe-corner2";
+	tag = ""
 	},
-/turf/simulated/floor/blue/side{
-	dir = 1
-	},
-/area/station/medical/medbay/lobby)
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "deX" = (
 /obj/table/auto,
 /obj/bedsheetbin,
@@ -74549,19 +74565,23 @@
 /area/station/crew_quarters/market)
 "dhq" = (
 /obj/table/auto,
-/obj/machinery/cell_charger,
-/obj/item/crowbar,
-/obj/item/cell/supercell/charged,
-/obj/item/device/prox_sensor,
-/obj/item/staple_gun,
-/obj/item/device/multitool{
-	pixel_x = -7;
-	pixel_y = 1
+/obj/item/suture{
+	pixel_x = 2;
+	pixel_y = 7
 	},
-/obj/item/hand_labeler,
-/turf/simulated/floor/caution/east{
-	dir = 8
+/obj/item/staple_gun{
+	pixel_x = 5;
+	pixel_y = -2
 	},
+/obj/item/suture{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/staple_gun{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "dhr" = (
 /obj/machinery/magnet_chassis{
@@ -78507,6 +78527,13 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"fVa" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "gcY" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
@@ -78544,6 +78571,15 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/ai_monitored/storage/eva)
+"hbJ" = (
+/obj/stool/chair/office,
+/obj/landmark/start{
+	name = "Roboticist"
+	},
+/turf/simulated/floor/blueblack{
+	dir = 10
+	},
+/area/station/medical/robotics)
 "hlO" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -78619,6 +78655,18 @@
 	icon_state = "blue1"
 	},
 /area/station/crew_quarters/arcade/dungeon)
+"hLE" = (
+/obj/table/reinforced/auto,
+/obj/item/clipboard,
+/obj/item/paper_bin,
+/obj/item/pen/marker/red,
+/obj/item/pen/marker/blue,
+/obj/item/pen,
+/obj/machinery/door/airlock/pyro/glass/windoor,
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "hNh" = (
 /obj/cable{
 	d1 = 4;
@@ -78799,6 +78847,15 @@
 	},
 /turf/simulated/floor/bot,
 /area/station/storage/emergency)
+"jAK" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	dir = 8
+	},
+/obj/access_spawn/robotics,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "jNp" = (
 /obj/item/paper/book/from_file/monster_manual_revised,
 /turf/simulated/wall/asteroid,
@@ -78867,6 +78924,11 @@
 	},
 /turf/simulated/floor/plating/scorched,
 /area/station/garden/owlery)
+"ltA" = (
+/obj/landmark/gps_waypoint,
+/obj/disposalpipe/segment/mail/vertical,
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "luy" = (
 /obj/machinery/light{
 	dir = 1;
@@ -79095,6 +79157,11 @@
 	dir = 4
 	},
 /area/station/ranch)
+"nSx" = (
+/turf/simulated/floor/blueblack{
+	dir = 8
+	},
+/area/station/medical/robotics)
 "ojq" = (
 /obj/stool/chair/office{
 	dir = 4
@@ -79132,6 +79199,13 @@
 	},
 /turf/simulated/floor/bot,
 /area/station/storage/emergency)
+"olE" = (
+/obj/decal/tile_edge/stripe{
+	dir = 6;
+	icon_state = "bot2"
+	},
+/turf/simulated/floor/specialroom/medbay,
+/area/station/medical/medbay/lobby)
 "oxp" = (
 /obj/submachine/chicken_incubator,
 /obj/item/reagent_containers/food/snacks/ingredient/egg{
@@ -79171,6 +79245,10 @@
 /obj/random_item_spawner/tools,
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
+"pbL" = (
+/obj/decal/poster/wallsign/escape_right,
+/turf/simulated/wall/auto/supernorn,
+/area/station/science/bot_storage)
 "pdE" = (
 /obj/machinery/chem_master{
 	dir = 4
@@ -79227,6 +79305,11 @@
 	icon_state = "blue2"
 	},
 /area/station/crew_quarters/arcade/dungeon)
+"pKW" = (
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/turf/space,
+/area/station/medical/robotics)
 "pTS" = (
 /obj/item/storage/wall/random,
 /obj/machinery/vending/janitor,
@@ -79244,6 +79327,17 @@
 "qfX" = (
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"qja" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 9.1;
+	pixel_y = 21
+	},
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/blue/side{
+	dir = 1
+	},
+/area/station/medical/medbay/lobby)
 "qmv" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/arcade/dungeon)
@@ -79255,6 +79349,19 @@
 	dir = 8
 	},
 /area/station/ranch)
+"qEw" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/blueblack{
+	dir = 9
+	},
+/area/station/medical/robotics)
 "qGS" = (
 /obj/storage/cart/mechcart{
 	desc = "A big rolling supply cart equipped for handling hull breaches.";
@@ -79436,6 +79543,12 @@
 	icon_state = "blue5"
 	},
 /area/station/crew_quarters/arcade/dungeon)
+"sHS" = (
+/obj/landmark/start{
+	name = "Cyborg"
+	},
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "sLX" = (
 /obj/stool/chair{
 	dir = 1
@@ -79824,6 +79937,11 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
+"wGP" = (
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/turf/simulated/floor/black,
+/area/station/medical/robotics)
 "wSb" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -115470,7 +115588,7 @@ ciq
 chp
 ciZ
 ckq
-cmW
+ceC
 cqn
 cqn
 coG
@@ -115773,15 +115891,15 @@ chp
 cjc
 ckq
 coE
-coE
+cxQ
 csb
 ctu
 dhq
 cwo
 coE
 czo
-cAK
-cCl
+cAC
+cCe
 cDA
 cFx
 cGP
@@ -116077,12 +116195,12 @@ cks
 coF
 cqo
 csc
-csd
-csd
-csd
+daZ
+cAR
+daZ
 coE
 czp
-cAL
+olE
 cAL
 cDA
 cFy
@@ -116379,13 +116497,13 @@ ckq
 coE
 cqp
 csc
-csd
+daZ
 des
 cwp
-coE
-czq
+wGP
 cAM
-coE
+jAK
+wGP
 cDE
 cFz
 cGR
@@ -116678,17 +116796,17 @@ cit
 chp
 cje
 ckq
-coE
+csg
 cqq
-csc
-ctv
-cuO
+cAK
 daZ
-coE
-czr
-cAN
-coE
-cDF
+daZ
+daZ
+qEw
+nSx
+hbJ
+hLE
+cDJ
 cFA
 dcE
 cIi
@@ -116980,17 +117098,17 @@ chp
 chp
 cjf
 cku
-coG
+coE
 cqr
-csc
-csd
-csd
-csd
+czr
+cAO
+cAO
+cAO
 cxP
 csd
-cAO
+cAN
 cCm
-cDG
+cDJ
 cFB
 ddq
 cIi
@@ -117284,15 +117402,15 @@ cjg
 ckq
 coG
 cqs
-csd
-csd
-csd
+czs
+cCl
+deW
 csd
 csd
 csd
 cAP
-coE
-deW
+pKW
+cDG
 cFB
 ddb
 cIi
@@ -117892,8 +118010,8 @@ csf
 coE
 coE
 cws
-cxQ
-czs
+sHS
+csd
 cAN
 cCn
 cDG
@@ -118190,15 +118308,15 @@ cjd
 ckq
 coE
 cqu
-csg
+csh
 ctx
 cuQ
 cwt
-csd
+ltA
 czt
-cAR
+cAN
 coE
-cDG
+qja
 cFB
 cGW
 cIj
@@ -118494,12 +118612,12 @@ coH
 cqv
 csh
 cty
-coG
+coE
 cwu
 cxR
 czu
 cAS
-coE
+fVa
 cDJ
 cFB
 cGX
@@ -118801,7 +118919,7 @@ cwv
 cxS
 czv
 dce
-coE
+wGP
 cDK
 cFB
 cGY
@@ -119707,7 +119825,7 @@ cwy
 cxV
 czy
 cAW
-coI
+pbL
 cDN
 cFE
 cHb


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR entirely reworks cog2's robotics to be more efficient and increase player interaction.

The changes can be seen in these images and below:

SDMM View:
![Cog2-robot-1](https://user-images.githubusercontent.com/75814831/121789672-be703880-cba5-11eb-8abf-917add8498d7.PNG)

Player View:
![Cog2-robot-2](https://user-images.githubusercontent.com/75814831/121789673-c039fc00-cba5-11eb-85f3-24d174b4003e.PNG)

Ghost View:
![Cog2-robot-3](https://user-images.githubusercontent.com/75814831/121789676-c16b2900-cba5-11eb-8368-8a559d3368a9.PNG)

Video Exploration:
![Cog2-Robot-Video](https://user-images.githubusercontent.com/75814831/121789707-127b1d00-cba6-11eb-97a3-2f62defaadc4.mp4)




## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This is needed because, while Cog2 has the best robotics imo, it has the flaw of being closed off to the public hallway, decreasing player interaction. I also made the department as a whole more efficient after studying how robotics expands for many rounds.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Yellow-Mushroom
(*)Reworks Cogmap2's robotics to increase player interaction
```
