### PR TITLE
Adds Zooblar Skrippus reference to cleaner bottles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,11 +25,8 @@
 		"editor.rulers": [150]
 	},
 	// Lets you preview .dmi files in the editor
-	"workbench.editorAssociations": [
-		{
-				"filenamePattern": "*.dmi",
-				"viewType": "imagePreview.previewEditor"
-		}
-	],
+	"workbench.editorAssociations": {
+		"*.dmi": "imagePreview.previewEditor"
+	},
 	"gitlens.advanced.blame.customArguments": ["-w"],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,8 +25,11 @@
 		"editor.rulers": [150]
 	},
 	// Lets you preview .dmi files in the editor
-	"workbench.editorAssociations": {
-		"*.dmi": "imagePreview.previewEditor"
-	},
+	"workbench.editorAssociations": [
+		{
+				"filenamePattern": "*.dmi",
+				"viewType": "imagePreview.previewEditor"
+		}
+	],
 	"gitlens.advanced.blame.customArguments": ["-w"],
 }

--- a/code/modules/chemistry/tools/bottles.dm
+++ b/code/modules/chemistry/tools/bottles.dm
@@ -347,9 +347,9 @@
 	amount_per_transfer_from_this = 10
 
 /obj/item/reagent_containers/glass/bottle/cleaner
-	name = "cleaner bottle"
-	desc = "A bottle filled with cleaning fluid."
+	name = "bottle of space cleaner "
+	desc = "This a bottle filled with space cleaner fluid. The label reads 'Poo-Be-Gone! As used by the space-renowned Janitor, Zooblar Skrippus!' There seems to be a cartoonish rendition of woman with golden bangs, thick eyebrows and toothy smile giving a thumbs up in the corner."
 	icon_state = "largebottle-labeled"
-	initial_volume = 50
+	initial_volume = 100
 	initial_reagents = "cleaner"
 	amount_per_transfer_from_this = 10


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a reference to a player character in the form of an ad on cleaner bottles.
Also buffs cleaner bottle capacity from 50 to 100 cus the bottles look pretty big but dont actually have a high capacity.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think its nice to have player references. In this case, its commemorating someone who, as of now, has first place in janitor job XP with 73k points, while the person in second place has 41k, just because its their favourite job and is the only job they play. Also its a very SS13 sounding name.
Would be good to have some player references that arent greifers, like George Melons.

I forgot to specify also that Stush is fine with their character name being used for this.