### PR TITLE
hops naval jacket now on every map

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -214,8 +214,6 @@ ABSTRACT_TYPE(/datum/job/command)
 	cant_spawn_as_rev = 1
 	announce_on_join = 1
 
-
-#ifdef SUBMARINE_MAP
 	slot_suit = /obj/item/clothing/suit/armor/hopcoat
 	slot_back = /obj/item/storage/backpack/withO2
 	slot_belt = /obj/item/device/pda2/heads
@@ -223,14 +221,6 @@ ABSTRACT_TYPE(/datum/job/command)
 	slot_foot = /obj/item/clothing/shoes/brown
 	slot_ears = /obj/item/device/radio/headset/command/hop
 	items_in_backpack = list(/obj/item/storage/box/id_kit,/obj/item/device/flash,/obj/item/storage/box/accessimp_kit)
-#else
-	slot_back = /obj/item/storage/backpack/withO2
-	slot_belt = /obj/item/device/pda2/heads
-	slot_jump = /obj/item/clothing/under/suit/hop
-	slot_foot = /obj/item/clothing/shoes/brown
-	slot_ears = /obj/item/device/radio/headset/command/hop
-	items_in_backpack = list(/obj/item/storage/box/id_kit,/obj/item/device/flash,/obj/item/storage/box/accessimp_kit)
-#endif
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[input]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this change removes code so the naval coat the hop has is present and worn at round start (like how the manta jacket is worn at roundstart) on every map.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
hop could use more personality, and the naval jacket is something unique and distinctly hop, it also gives more clothing options for the hop, to express themselves with.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Carsontheking
(*)Hop now wears their manta jacket on all maps
```
