### PR TITLE
Fixes blowout event maint access bug and potential errors

### DIFF
--- a/code/modules/events/blowout.dm
+++ b/code/modules/events/blowout.dm
@@ -52,10 +52,9 @@
 				N.flash(3 SECONDS)
 
 	#ifndef UNDERWATER_MAP
-			for (var/turf/space/S in world)
+			for (var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 				LAGCHECK(LAG_LOW)
-				if (S.z == Z_LEVEL_STATION)
-					S.color = src.space_color
+				S.color = src.space_color
 	#endif
 
 			world << siren
@@ -92,10 +91,9 @@
 			command_alert("All radiation alerts onboard [station_name(1)] have been cleared. You may now leave the tunnels freely. Maintenance doors will regain their normal access requirements shortly.", "All Clear")
 
 	#ifndef UNDERWATER_MAP
-			for (var/turf/space/S in world)
+			for (var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
 				LAGCHECK(LAG_LOW)
-				if (S.z == Z_LEVEL_STATION)
-					S.color = null
+				S.color = null
 	#endif
 			for (var/mob/N in mobs)
 				N.flash(3 SECONDS)
@@ -107,5 +105,5 @@
 					continue
 				if (!(istype(A, /obj/machinery/door/airlock/maintenance) || istype(A, /obj/machinery/door/airlock/pyro/maintenance) || istype(A, /obj/machinery/door/airlock/gannets/maintenance) || istype(A, /obj/machinery/door/airlock/gannets/glass/maintenance)))
 					continue
-				if (isnull(A.req_access))
+				if (access_maint_tunnels in initial(A.req_access))
 					A.req_access = list(access_maint_tunnels)

--- a/code/modules/events/blowout.dm
+++ b/code/modules/events/blowout.dm
@@ -25,7 +25,8 @@
 					continue
 				if (!(istype(A, /obj/machinery/door/airlock/maintenance) || istype(A, /obj/machinery/door/airlock/pyro/maintenance) || istype(A, /obj/machinery/door/airlock/gannets/maintenance) || istype(A, /obj/machinery/door/airlock/gannets/glass/maintenance)))
 					continue
-				A.req_access = null
+				if (access_maint_tunnels in A.req_access)
+					A.req_access = null
 
 			sleep(actualtime)
 
@@ -55,8 +56,6 @@
 				LAGCHECK(LAG_LOW)
 				if (S.z == Z_LEVEL_STATION)
 					S.color = src.space_color
-				else
-					break
 	#endif
 
 			world << siren
@@ -97,8 +96,6 @@
 				LAGCHECK(LAG_LOW)
 				if (S.z == Z_LEVEL_STATION)
 					S.color = null
-				else
-					break
 	#endif
 			for (var/mob/N in mobs)
 				N.flash(3 SECONDS)
@@ -107,7 +104,8 @@
 
 			for_by_tcl(A, /obj/machinery/door/airlock)
 				if (A.z != Z_LEVEL_STATION)
-					break
+					continue
 				if (!(istype(A, /obj/machinery/door/airlock/maintenance) || istype(A, /obj/machinery/door/airlock/pyro/maintenance) || istype(A, /obj/machinery/door/airlock/gannets/maintenance) || istype(A, /obj/machinery/door/airlock/gannets/glass/maintenance)))
 					continue
-				A.req_access = list(access_maint_tunnels)
+				if (isnull(A.req_access))
+					A.req_access = list(access_maint_tunnels)

--- a/code/modules/events/blowout.dm
+++ b/code/modules/events/blowout.dm
@@ -52,9 +52,10 @@
 				N.flash(3 SECONDS)
 
 	#ifndef UNDERWATER_MAP
-			for (var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
+			for (var/turf/space/S in world)
 				LAGCHECK(LAG_LOW)
-				S.color = src.space_color
+				if (S.z == Z_LEVEL_STATION)
+					S.color = src.space_color
 	#endif
 
 			world << siren
@@ -91,9 +92,10 @@
 			command_alert("All radiation alerts onboard [station_name(1)] have been cleared. You may now leave the tunnels freely. Maintenance doors will regain their normal access requirements shortly.", "All Clear")
 
 	#ifndef UNDERWATER_MAP
-			for (var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
+			for (var/turf/space/S in world)
 				LAGCHECK(LAG_LOW)
-				S.color = null
+				if (S.z == Z_LEVEL_STATION)
+					S.color = null
 	#endif
 			for (var/mob/N in mobs)
 				N.flash(3 SECONDS)
@@ -105,5 +107,5 @@
 					continue
 				if (!(istype(A, /obj/machinery/door/airlock/maintenance) || istype(A, /obj/machinery/door/airlock/pyro/maintenance) || istype(A, /obj/machinery/door/airlock/gannets/maintenance) || istype(A, /obj/machinery/door/airlock/gannets/glass/maintenance)))
 					continue
-				if (access_maint_tunnels in initial(A.req_access))
+				if (isnull(A.req_access))
 					A.req_access = list(access_maint_tunnels)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [CLEANLINESS] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes it so that when the blowout event occurs, it only messes with the access levels of doors that have maint access as well rather than doors that just happen to be maintenance-style doors. It also fixes some potential issues that could crop up later on by making sure that the loops for checking things don't end prematurely.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5104
Also fixes whatever other doors get caught in the check.
Plus preventing possible future errors is nice.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)eX.n0x, Sovexe, & ZeWaka
(+)The rad blowout event no longer changes access levels on non-maintenance doors.
```
