### PR TITLE
Horizon/XMAS map fixes and cleanup also Kondaru

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -6923,7 +6923,7 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/medical/dome)
 "asA" = (
 /turf/space,
 /area/shuttle/escape/station/cogmap2)
@@ -7171,7 +7171,7 @@
 /obj/machinery/computer/genetics,
 /obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/green,
-/area/space)
+/area/station/medical/dome)
 "ato" = (
 /turf/simulated/floor/purpleblack{
 	dir = 5
@@ -7380,7 +7380,7 @@
 /obj/machinery/genetics_scanner,
 /obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/green,
-/area/space)
+/area/station/medical/dome)
 "atR" = (
 /obj/item/storage/toilet,
 /obj/decal/cleanable/dirt/dirt2,
@@ -8856,7 +8856,8 @@
 /area/station/medical/dome)
 "axs" = (
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Chimpnasium"
+	name = "Chimpnasium";
+	req_access = list(9)
 	},
 /obj/access_spawn/medical,
 /turf/simulated/floor/black,
@@ -10185,7 +10186,7 @@
 /obj/item/aiModule/makeCaptain,
 /obj/random_item_spawner/ai_experimental,
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aBe" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -11535,15 +11536,6 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/east)
-"aEB" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/table/reinforced/auto,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating/random,
-/area/station/storage/tools)
 "aEC" = (
 /obj/table/reinforced/auto,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/northeast,
@@ -11962,7 +11954,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/north)
+/area/station/maintenance/northeast)
 "aFN" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southeast,
 /obj/disposalpipe/segment/morgue{
@@ -12007,7 +11999,7 @@
 /turf/simulated/floor/stairs/dark/wide{
 	dir = 4
 	},
-/area/station/medical/medbay)
+/area/station/maintenance/northeast)
 "aFT" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -12018,7 +12010,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/medical/medbay/lobby)
+/area/station/maintenance/northeast)
 "aFU" = (
 /obj/decal/poster/wallsign/stencil/left/s,
 /obj/decal/poster/wallsign/stencil/right/e,
@@ -12447,7 +12439,7 @@
 /obj/table/reinforced/auto,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/east)
+/area/station/maintenance/east)
 "aHa" = (
 /obj/morgue{
 	dir = 2
@@ -12812,11 +12804,13 @@
 /area/station/maintenance/northeast)
 "aHN" = (
 /obj/machinery/door/airlock/pyro/maintenance{
-	req_access = list(5)
+	req_access = list(9)
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/area/station/medical/research{
+	name = "Genetic Research"
+	})
 "aHO" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency,
@@ -12850,7 +12844,7 @@
 	},
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aHT" = (
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -13474,7 +13468,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/exit)
+/area/station/maintenance/south)
 "aJw" = (
 /obj/machinery/ore_cloud_storage_container,
 /obj/decal/cleanable/dirt,
@@ -15450,7 +15444,7 @@
 /area/station/storage/tech)
 "aOl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aOm" = (
 /obj/cable{
 	d1 = 1;
@@ -16552,9 +16546,7 @@
 /obj/machinery/power/apc/autoname_north,
 /obj/machinery/computer3/luggable,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/info{
-	name = "Net Cafe"
-	})
+/area/station/storage/tech)
 "aQH" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -16605,14 +16597,14 @@
 	tag = ""
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aQM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aQN" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -16626,7 +16618,7 @@
 	text = "NF"
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aQO" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -16634,7 +16626,7 @@
 	},
 /obj/machinery/computer3/terminal/zeta,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aQP" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -16642,7 +16634,7 @@
 	},
 /obj/machinery/networked/radio,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aQQ" = (
 /obj/shrub{
 	dir = 10
@@ -18005,7 +17997,7 @@
 /obj/item/disk/data/floppy/read_only/network_progs,
 /obj/item/disk/data/floppy/read_only/research_progs,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aTH" = (
 /obj/machinery/computer3/generic/med_data,
 /obj/machinery/power/data_terminal,
@@ -18047,7 +18039,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aTJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -18068,7 +18060,7 @@
 /obj/item/disk/data/floppy/read_only/security_progs,
 /obj/item/disk/data/floppy/read_only/terminal_os,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aTL" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -18820,7 +18812,7 @@
 /area/station/mining/staff_room)
 "aVx" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/north)
+/area/station/turret_protected/ai_upload)
 "aVy" = (
 /obj/lattice,
 /obj/cable{
@@ -19352,7 +19344,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aWH" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -19362,7 +19354,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aWI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -19371,7 +19363,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aWJ" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -19385,7 +19377,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aWK" = (
 /obj/machinery/turret{
 	dir = 9
@@ -19394,7 +19386,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aWL" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -19951,9 +19943,6 @@
 "aXN" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
-"aXO" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/medbay/lobby)
 "aXP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/teleporter)
@@ -20136,7 +20125,7 @@
 "aYm" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/vertical,
 /turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/exit)
+/area/station/crew_quarters/pool)
 "aYn" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -20856,7 +20845,7 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aZZ" = (
 /obj/cable{
 	d1 = 4;
@@ -20866,7 +20855,7 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "baa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -20879,7 +20868,7 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "bab" = (
 /obj/machinery/door/airlock/pyro/glass/command{
 	name = "Core"
@@ -20887,12 +20876,12 @@
 /obj/machinery/door/firedoor/pyro,
 /obj/access_spawn/heads,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bac" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "bad" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -22229,14 +22218,14 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcR" = (
 /obj/item/device/radio/intercom/AI,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -22248,10 +22237,10 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcT" = (
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcU" = (
 /obj/table/auto,
 /obj/item/aiModule/freeform,
@@ -22260,7 +22249,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcV" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -23430,13 +23419,13 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfR" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -23453,7 +23442,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfT" = (
 /obj/cable{
 	d1 = 4;
@@ -23465,7 +23454,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfU" = (
 /obj/cable{
 	d1 = 4;
@@ -23478,7 +23467,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfV" = (
 /obj/cable{
 	d1 = 4;
@@ -23494,7 +23483,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfW" = (
 /obj/cable{
 	d1 = 4;
@@ -23521,7 +23510,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfX" = (
 /obj/machinery/turretid{
 	layer = 9.1;
@@ -23536,7 +23525,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/bridge)
 "bfY" = (
 /obj/machinery/light{
 	dir = 1;
@@ -24779,7 +24768,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 10
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24788,7 +24777,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -24802,14 +24791,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biS" = (
 /obj/disposalpipe/segment/transport{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biT" = (
 /obj/table/auto,
 /obj/item/aiModule/oneHuman,
@@ -24819,7 +24808,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 6
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biU" = (
 /obj/machinery/atmospherics/valve,
 /obj/disposalpipe/segment{
@@ -26053,7 +26042,7 @@
 "blJ" = (
 /obj/decal/poster/wallsign/medbay_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "blK" = (
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -31105,7 +31094,7 @@
 	},
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "bzc" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /obj/machinery/light{
@@ -33521,7 +33510,7 @@
 	},
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "bFl" = (
 /obj/machinery/light{
 	dir = 1;
@@ -33690,9 +33679,6 @@
 /area/station/security/detectives_office)
 "bFK" = (
 /obj/stool/chair/red,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -58761,7 +58747,8 @@
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 8;
-	name = "Chimpnasium"
+	name = "Chimpnasium";
+	req_access = list(9)
 	},
 /obj/access_spawn/pathology,
 /turf/simulated/floor/white,
@@ -103544,7 +103531,7 @@ aZY
 bcQ
 bfQ
 biP
-aOl
+aVx
 bov
 bwi
 ePs
@@ -103846,7 +103833,7 @@ aZZ
 bcR
 bfR
 biQ
-aOl
+aVx
 bow
 bwk
 ePs
@@ -104450,7 +104437,7 @@ bab
 bcT
 bfT
 biS
-aOl
+aVx
 boy
 bwk
 ePs
@@ -105054,7 +105041,7 @@ aMf
 aMf
 bfV
 aBd
-aOl
+aVx
 boA
 bwk
 ePs
@@ -105355,8 +105342,8 @@ aWL
 bad
 aMf
 bfW
-aOl
-aOl
+aVx
+aVx
 boB
 bwg
 ePs
@@ -118328,7 +118315,7 @@ aaa
 aaa
 aaa
 aaa
-aVx
+aCg
 aFM
 aHl
 aAZ
@@ -121650,7 +121637,7 @@ aaa
 aaa
 aaa
 aaa
-aIO
+aCg
 aFS
 aHv
 aIO
@@ -121952,7 +121939,7 @@ aaa
 aaa
 aaa
 aaa
-aXO
+aCg
 aFT
 aHw
 aIO
@@ -131913,8 +131900,8 @@ aaa
 aaa
 aaa
 aaa
-asp
-aEB
+arH
+aGZ
 aBx
 asv
 aFi
@@ -132215,7 +132202,7 @@ aaa
 aaa
 aaa
 aaa
-aHQ
+arH
 aGZ
 aBy
 aVS

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -6923,7 +6923,7 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/medical/dome)
+/area/space)
 "asA" = (
 /turf/space,
 /area/shuttle/escape/station/cogmap2)
@@ -7171,7 +7171,7 @@
 /obj/machinery/computer/genetics,
 /obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/green,
-/area/station/medical/dome)
+/area/space)
 "ato" = (
 /turf/simulated/floor/purpleblack{
 	dir = 5
@@ -7380,7 +7380,7 @@
 /obj/machinery/genetics_scanner,
 /obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/green,
-/area/station/medical/dome)
+/area/space)
 "atR" = (
 /obj/item/storage/toilet,
 /obj/decal/cleanable/dirt/dirt2,
@@ -10186,7 +10186,7 @@
 /obj/item/aiModule/makeCaptain,
 /obj/random_item_spawner/ai_experimental,
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "aBe" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -11536,6 +11536,15 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/east)
+"aEB" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/table/reinforced/auto,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating/random,
+/area/station/storage/tools)
 "aEC" = (
 /obj/table/reinforced/auto,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/northeast,
@@ -11954,7 +11963,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/area/station/hallway/secondary/north)
 "aFN" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southeast,
 /obj/disposalpipe/segment/morgue{
@@ -11999,7 +12008,7 @@
 /turf/simulated/floor/stairs/dark/wide{
 	dir = 4
 	},
-/area/station/maintenance/northeast)
+/area/station/medical/medbay)
 "aFT" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -12010,7 +12019,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/maintenance/northeast)
+/area/station/medical/medbay/lobby)
 "aFU" = (
 /obj/decal/poster/wallsign/stencil/left/s,
 /obj/decal/poster/wallsign/stencil/right/e,
@@ -12439,7 +12448,7 @@
 /obj/table/reinforced/auto,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/east)
+/area/station/hallway/secondary/east)
 "aHa" = (
 /obj/morgue{
 	dir = 2
@@ -12808,9 +12817,7 @@
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/plating/random,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/maintenance/northeast)
 "aHO" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency,
@@ -12844,7 +12851,7 @@
 	},
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "aHT" = (
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -13468,7 +13475,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/area/station/hallway/secondary/exit)
 "aJw" = (
 /obj/machinery/ore_cloud_storage_container,
 /obj/decal/cleanable/dirt,
@@ -15444,7 +15451,7 @@
 /area/station/storage/tech)
 "aOl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aOm" = (
 /obj/cable{
 	d1 = 1;
@@ -16546,7 +16553,9 @@
 /obj/machinery/power/apc/autoname_north,
 /obj/machinery/computer3/luggable,
 /turf/simulated/floor/plating/random,
-/area/station/storage/tech)
+/area/station/crew_quarters/info{
+	name = "Net Cafe"
+	})
 "aQH" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -16597,14 +16606,14 @@
 	tag = ""
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aQM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aQN" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -16618,7 +16627,7 @@
 	text = "NF"
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aQO" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -16626,7 +16635,7 @@
 	},
 /obj/machinery/computer3/terminal/zeta,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aQP" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -16634,7 +16643,7 @@
 	},
 /obj/machinery/networked/radio,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aQQ" = (
 /obj/shrub{
 	dir = 10
@@ -17997,7 +18006,7 @@
 /obj/item/disk/data/floppy/read_only/network_progs,
 /obj/item/disk/data/floppy/read_only/research_progs,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aTH" = (
 /obj/machinery/computer3/generic/med_data,
 /obj/machinery/power/data_terminal,
@@ -18039,7 +18048,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aTJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -18060,7 +18069,7 @@
 /obj/item/disk/data/floppy/read_only/security_progs,
 /obj/item/disk/data/floppy/read_only/terminal_os,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aTL" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -18812,7 +18821,7 @@
 /area/station/mining/staff_room)
 "aVx" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload)
+/area/station/hallway/secondary/north)
 "aVy" = (
 /obj/lattice,
 /obj/cable{
@@ -19344,7 +19353,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aWH" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -19354,7 +19363,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aWI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -19363,7 +19372,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aWJ" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -19377,7 +19386,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aWK" = (
 /obj/machinery/turret{
 	dir = 9
@@ -19386,7 +19395,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aWL" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -19943,6 +19952,9 @@
 "aXN" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
+"aXO" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/medical/medbay/lobby)
 "aXP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/teleporter)
@@ -20125,7 +20137,7 @@
 "aYm" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/vertical,
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/pool)
+/area/station/hallway/secondary/exit)
 "aYn" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -20845,7 +20857,7 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aZZ" = (
 /obj/cable{
 	d1 = 4;
@@ -20855,7 +20867,7 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "baa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -20868,7 +20880,7 @@
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "bab" = (
 /obj/machinery/door/airlock/pyro/glass/command{
 	name = "Core"
@@ -20876,12 +20888,12 @@
 /obj/machinery/door/firedoor/pyro,
 /obj/access_spawn/heads,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bac" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "bad" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -22218,14 +22230,14 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bcR" = (
 /obj/item/device/radio/intercom/AI,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bcS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -22237,10 +22249,10 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bcT" = (
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bcU" = (
 /obj/table/auto,
 /obj/item/aiModule/freeform,
@@ -22249,7 +22261,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bcV" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -23419,13 +23431,13 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfR" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -23442,7 +23454,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfT" = (
 /obj/cable{
 	d1 = 4;
@@ -23454,7 +23466,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfU" = (
 /obj/cable{
 	d1 = 4;
@@ -23467,7 +23479,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfV" = (
 /obj/cable{
 	d1 = 4;
@@ -23483,7 +23495,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfW" = (
 /obj/cable{
 	d1 = 4;
@@ -23510,7 +23522,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfX" = (
 /obj/machinery/turretid{
 	layer = 9.1;
@@ -23525,7 +23537,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/bridge)
+/area/station/turret_protected/Zeta)
 "bfY" = (
 /obj/machinery/light{
 	dir = 1;
@@ -24768,7 +24780,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 10
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "biQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24777,7 +24789,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "biR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -24791,14 +24803,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "biS" = (
 /obj/disposalpipe/segment/transport{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "biT" = (
 /obj/table/auto,
 /obj/item/aiModule/oneHuman,
@@ -24808,7 +24820,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 6
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "biU" = (
 /obj/machinery/atmospherics/valve,
 /obj/disposalpipe/segment{
@@ -26042,7 +26054,7 @@
 "blJ" = (
 /obj/decal/poster/wallsign/medbay_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "blK" = (
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -31094,7 +31106,7 @@
 	},
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "bzc" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /obj/machinery/light{
@@ -33510,7 +33522,7 @@
 	},
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "bFl" = (
 /obj/machinery/light{
 	dir = 1;
@@ -103531,7 +103543,7 @@ aZY
 bcQ
 bfQ
 biP
-aVx
+aOl
 bov
 bwi
 ePs
@@ -103833,7 +103845,7 @@ aZZ
 bcR
 bfR
 biQ
-aVx
+aOl
 bow
 bwk
 ePs
@@ -104437,7 +104449,7 @@ bab
 bcT
 bfT
 biS
-aVx
+aOl
 boy
 bwk
 ePs
@@ -105041,7 +105053,7 @@ aMf
 aMf
 bfV
 aBd
-aVx
+aOl
 boA
 bwk
 ePs
@@ -105342,8 +105354,8 @@ aWL
 bad
 aMf
 bfW
-aVx
-aVx
+aOl
+aOl
 boB
 bwg
 ePs
@@ -118315,7 +118327,7 @@ aaa
 aaa
 aaa
 aaa
-aCg
+aVx
 aFM
 aHl
 aAZ
@@ -121637,7 +121649,7 @@ aaa
 aaa
 aaa
 aaa
-aCg
+aIO
 aFS
 aHv
 aIO
@@ -121939,7 +121951,7 @@ aaa
 aaa
 aaa
 aaa
-aCg
+aXO
 aFT
 aHw
 aIO
@@ -131900,8 +131912,8 @@ aaa
 aaa
 aaa
 aaa
-arH
-aGZ
+asp
+aEB
 aBx
 asv
 aFi
@@ -132202,7 +132214,7 @@ aaa
 aaa
 aaa
 aaa
-arH
+aHQ
 aGZ
 aBy
 aVS

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -8857,9 +8857,9 @@
 "axs" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Chimpnasium";
-	req_access = list(9)
+	req_access = null
 	},
-/obj/access_spawn/medical,
+/obj/access_spawn/medlab,
 /turf/simulated/floor/black,
 /area/station/medical/dome)
 "axu" = (
@@ -12813,9 +12813,10 @@
 /area/station/maintenance/northeast)
 "aHN" = (
 /obj/machinery/door/airlock/pyro/maintenance{
-	req_access = list(9)
+	req_access = null
 	},
 /obj/disposalpipe/segment/transport,
+/obj/access_spawn/medlab,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northeast)
 "aHO" = (
@@ -58756,9 +58757,9 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 8;
 	name = "Chimpnasium";
-	req_access = list(9)
+	req_access = null
 	},
-/obj/access_spawn/pathology,
+/obj/access_spawn/medlab,
 /turf/simulated/floor/white,
 /area/station/medical/dome)
 "rHb" = (

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -31554,14 +31554,12 @@
 /area/station/security/detectives_office)
 "bAi" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
-/obj/machinery/door/airlock/pyro/security/alt{
-	id = "detoffice";
-	name = "Detective's Office"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/access_spawn/security,
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Detective's Office"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "bAj" = (
@@ -33695,6 +33693,9 @@
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
 /turf/simulated/floor/carpet/red/standard/edge/south,
 /area/station/security/detectives_office)
 "bFL" = (
@@ -35969,11 +35970,6 @@
 	desc = "The VR representation of a security software package.";
 	require_login = 0;
 	screen = 1
-	},
-/obj/machinery/door_control{
-	id = "detoffice";
-	pixel_x = 24;
-	req_access = list(1)
 	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)

--- a/maps/horizon_xmas.dmm
+++ b/maps/horizon_xmas.dmm
@@ -35054,14 +35054,12 @@
 "bAi" = (
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
-/obj/machinery/door/airlock/pyro/security/alt{
-	id = "detoffice";
+/obj/machinery/door/airlock/pyro/glass{
 	name = "Detective's Office"
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/access_spawn/security,
 /obj/decal/garland,
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
@@ -37613,6 +37611,9 @@
 /obj/stool/chair/red,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
 /turf/simulated/floor/carpet/red/standard/edge/south,
 /area/station/security/detectives_office)
@@ -40456,11 +40457,6 @@
 	desc = "The VR representation of a security software package.";
 	require_login = 0;
 	screen = 1
-	},
-/obj/machinery/door_control{
-	id = "detoffice";
-	pixel_x = 24;
-	req_access = list(1)
 	},
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)

--- a/maps/horizon_xmas.dmm
+++ b/maps/horizon_xmas.dmm
@@ -7977,7 +7977,8 @@
 	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 8;
-	name = "Chimpnasium"
+	name = "Chimpnasium";
+	req_access = list(9)
 	},
 /obj/access_spawn/medical,
 /obj/decal/garland{
@@ -9437,7 +9438,8 @@
 /area/station/medical/dome)
 "axs" = (
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Chimpnasium"
+	name = "Chimpnasium";
+	req_access = list(9)
 	},
 /obj/access_spawn/medical,
 /obj/decal/garland,
@@ -11038,7 +11040,7 @@
 /obj/item/aiModule/makeCaptain,
 /obj/random_item_spawner/ai_experimental,
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aBe" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -12503,15 +12505,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/east)
-"aEB" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/table/reinforced/auto,
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating/random,
-/area/station/storage/tools)
 "aEC" = (
 /obj/disposalpipe/segment/brig,
 /obj/storage/secure/closet/security/equipment,
@@ -12910,7 +12903,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/north)
+/area/station/maintenance/northeast)
 "aFN" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -12958,7 +12951,7 @@
 /turf/simulated/floor/stairs/dark/wide{
 	dir = 4
 	},
-/area/station/medical/medbay)
+/area/station/maintenance/northeast)
 "aFT" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -12969,7 +12962,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/medical/medbay/lobby)
+/area/station/maintenance/northeast)
 "aFU" = (
 /obj/decal/poster/wallsign/stencil/left/s,
 /obj/decal/poster/wallsign/stencil/right/e,
@@ -13438,7 +13431,7 @@
 /obj/table/reinforced/auto,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/east)
+/area/station/maintenance/east)
 "aHa" = (
 /obj/morgue{
 	dir = 2
@@ -13842,11 +13835,13 @@
 /area/station/maintenance/northeast)
 "aHN" = (
 /obj/machinery/door/airlock/pyro/maintenance{
-	req_access = list(5)
+	req_access = list(9)
 	},
 /obj/decal/garland,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/area/station/medical/research{
+	name = "Genetic Research"
+	})
 "aHO" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency,
@@ -13880,7 +13875,7 @@
 	},
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aHT" = (
 /obj/disposalpipe/segment/brig,
 /obj/decal/poster/wallsign/escape_right,
@@ -14571,7 +14566,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/vertical,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/exit)
+/area/station/maintenance/south)
 "aJw" = (
 /obj/machinery/ore_cloud_storage_container,
 /obj/decal/cleanable/dirt,
@@ -14704,7 +14699,7 @@
 /obj/machinery/power/apc/autoname_north,
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/entry)
+/area/station/maintenance/north)
 "aJQ" = (
 /obj/cable{
 	d1 = 2;
@@ -16755,7 +16750,7 @@
 /area/station/storage/tech)
 "aOl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aOm" = (
 /obj/cable{
 	d1 = 1;
@@ -18090,14 +18085,14 @@
 	tag = ""
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aQM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aQN" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -18111,7 +18106,7 @@
 	text = "NF"
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aQO" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -18119,7 +18114,7 @@
 	},
 /obj/machinery/computer3/terminal/zeta,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aQP" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -18127,7 +18122,7 @@
 	},
 /obj/machinery/networked/radio,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aQQ" = (
 /obj/shrub{
 	dir = 10
@@ -19513,7 +19508,7 @@
 /obj/item/disk/data/floppy/read_only/network_progs,
 /obj/item/disk/data/floppy/read_only/research_progs,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aTH" = (
 /obj/machinery/computer3/generic/med_data,
 /obj/machinery/power/data_terminal,
@@ -19555,7 +19550,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aTJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -19578,7 +19573,7 @@
 /obj/item/disk/data/floppy/read_only/security_progs,
 /obj/item/disk/data/floppy/read_only/terminal_os,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aTL" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -20336,7 +20331,7 @@
 /area/station/mining/staff_room)
 "aVx" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/north)
+/area/station/turret_protected/ai_upload)
 "aVy" = (
 /obj/lattice,
 /obj/cable{
@@ -20862,20 +20857,20 @@
 	dir = 5
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aWH" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aWI" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aWJ" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -20886,13 +20881,13 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aWK" = (
 /obj/machinery/turret{
 	dir = 9
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aWL" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -21453,9 +21448,6 @@
 "aXN" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
-"aXO" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/medbay/lobby)
 "aXP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/teleporter)
@@ -21650,7 +21642,7 @@
 "aYm" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/vertical,
 /turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/exit)
+/area/station/crew_quarters/pool)
 "aYn" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -22536,7 +22528,7 @@
 /obj/window/auto/reinforced,
 /obj/decal/xmas_lights,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "aZZ" = (
 /obj/cable{
 	d1 = 4;
@@ -22547,7 +22539,7 @@
 /obj/window/auto/reinforced,
 /obj/decal/xmas_lights,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "baa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -22561,7 +22553,7 @@
 /obj/window/auto/reinforced,
 /obj/decal/xmas_lights,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "bab" = (
 /obj/machinery/door/airlock/pyro/glass/command{
 	name = "Core"
@@ -22570,13 +22562,13 @@
 /obj/access_spawn/heads,
 /obj/decal/garland,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bac" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /obj/decal/wreath,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "bad" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -23899,14 +23891,14 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcR" = (
 /obj/item/device/radio/intercom/AI,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -23918,10 +23910,10 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcT" = (
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcU" = (
 /obj/table/auto,
 /obj/item/aiModule/freeform,
@@ -23930,7 +23922,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcV" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -25316,7 +25308,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfR" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -25325,7 +25317,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -25345,7 +25337,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfT" = (
 /obj/cable{
 	d1 = 4;
@@ -25356,7 +25348,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfU" = (
 /obj/cable{
 	d1 = 4;
@@ -25369,7 +25361,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfV" = (
 /obj/cable{
 	d1 = 4;
@@ -25384,7 +25376,7 @@
 	text = "NF"
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfW" = (
 /obj/cable{
 	d1 = 4;
@@ -25415,7 +25407,7 @@
 	pixel_x = 20
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfX" = (
 /obj/machinery/turretid{
 	layer = 9.1;
@@ -25430,7 +25422,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/bridge)
 "bfY" = (
 /obj/machinery/light{
 	dir = 1;
@@ -26881,13 +26873,13 @@
 /turf/simulated/floor/blueblack{
 	dir = 10
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biQ" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -26898,10 +26890,10 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biS" = (
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biT" = (
 /obj/table/auto,
 /obj/item/aiModule/oneHuman,
@@ -26911,7 +26903,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 6
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biU" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -28198,7 +28190,7 @@
 "blJ" = (
 /obj/decal/poster/wallsign/medbay_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "blK" = (
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -34558,7 +34550,7 @@
 	},
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "bzc" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /obj/machinery/light{
@@ -37415,7 +37407,7 @@
 	},
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload_foyer)
 "bFl" = (
 /obj/disposalpipe/trunk,
 /obj/disposaloutlet{
@@ -37609,9 +37601,6 @@
 /area/station/security/detectives_office)
 "bFK" = (
 /obj/stool/chair/red,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -42361,7 +42350,7 @@
 	},
 /obj/table/auto,
 /obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/glass/bottle/icing,
+/obj/item/reagent_containers/food/drinks/drinkingglass/icing,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
 "bQc" = (
@@ -43762,7 +43751,7 @@
 	desc = "Ew.";
 	name = "meat of questionable origin"
 	},
-/obj/item/reagent_containers/glass/bottle/icing,
+/obj/item/reagent_containers/food/drinks/drinkingglass/icing,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "bSV" = (
@@ -102532,7 +102521,7 @@ aZY
 bcQ
 bfQ
 biP
-aOl
+aVx
 bov
 brA
 btF
@@ -102834,7 +102823,7 @@ aZZ
 bcR
 bfR
 biQ
-aOl
+aVx
 bow
 brB
 btF
@@ -103125,7 +103114,7 @@ aaa
 aaa
 aaa
 aaa
-atE
+aGP
 aJP
 aMc
 aOl
@@ -103438,7 +103427,7 @@ bab
 bcT
 bfT
 biS
-aOl
+aVx
 boy
 brB
 btF
@@ -104042,7 +104031,7 @@ aMf
 aMf
 bfV
 aBd
-aOl
+aVx
 boA
 brB
 btF
@@ -104343,8 +104332,8 @@ aWL
 bad
 aMf
 bfW
-aOl
-aOl
+aVx
+aVx
 boB
 brD
 btF
@@ -117316,7 +117305,7 @@ aaa
 aaa
 aaa
 aaa
-aVx
+aCg
 aFM
 aHl
 aAZ
@@ -120638,7 +120627,7 @@ aaa
 aaa
 aaa
 aaa
-aIO
+aCg
 aFS
 aHv
 aIO
@@ -120940,7 +120929,7 @@ aaa
 aaa
 aaa
 aaa
-aXO
+aCg
 aFT
 aHw
 aIO
@@ -130901,8 +130890,8 @@ aaa
 aaa
 aaa
 aaa
-asp
-aEB
+arH
+aGZ
 aBx
 asv
 aFi
@@ -131203,7 +131192,7 @@ aaa
 aaa
 aaa
 aaa
-aHQ
+arH
 aGZ
 aBy
 aVS

--- a/maps/horizon_xmas.dmm
+++ b/maps/horizon_xmas.dmm
@@ -7978,9 +7978,9 @@
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 8;
 	name = "Chimpnasium";
-	req_access = list(9)
+	req_access = null
 	},
-/obj/access_spawn/medical,
+/obj/access_spawn/medlab,
 /obj/decal/garland{
 	dir = 8;
 	pixel_x = -20
@@ -9439,9 +9439,9 @@
 "axs" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Chimpnasium";
-	req_access = list(9)
+	req_access = null
 	},
-/obj/access_spawn/medical,
+/obj/access_spawn/medlab,
 /obj/decal/garland,
 /turf/simulated/floor/black,
 /area/station/medical/dome)
@@ -13844,9 +13844,10 @@
 /area/station/maintenance/northeast)
 "aHN" = (
 /obj/machinery/door/airlock/pyro/maintenance{
-	req_access = list(9)
+	req_access = null
 	},
 /obj/decal/garland,
+/obj/access_spawn/medlab,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northeast)
 "aHO" = (

--- a/maps/horizon_xmas.dmm
+++ b/maps/horizon_xmas.dmm
@@ -11040,7 +11040,7 @@
 /obj/item/aiModule/makeCaptain,
 /obj/random_item_spawner/ai_experimental,
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "aBe" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -12505,6 +12505,15 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/east)
+"aEB" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/table/reinforced/auto,
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating/random,
+/area/station/storage/tools)
 "aEC" = (
 /obj/disposalpipe/segment/brig,
 /obj/storage/secure/closet/security/equipment,
@@ -12903,7 +12912,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/area/station/hallway/secondary/north)
 "aFN" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -12951,7 +12960,7 @@
 /turf/simulated/floor/stairs/dark/wide{
 	dir = 4
 	},
-/area/station/maintenance/northeast)
+/area/station/medical/medbay)
 "aFT" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -12962,7 +12971,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/maintenance/northeast)
+/area/station/medical/medbay/lobby)
 "aFU" = (
 /obj/decal/poster/wallsign/stencil/left/s,
 /obj/decal/poster/wallsign/stencil/right/e,
@@ -13431,7 +13440,7 @@
 /obj/table/reinforced/auto,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/east)
+/area/station/hallway/secondary/east)
 "aHa" = (
 /obj/morgue{
 	dir = 2
@@ -13839,9 +13848,7 @@
 	},
 /obj/decal/garland,
 /turf/simulated/floor/plating/random,
-/area/station/medical/research{
-	name = "Genetic Research"
-	})
+/area/station/maintenance/northeast)
 "aHO" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency,
@@ -13875,7 +13882,7 @@
 	},
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "aHT" = (
 /obj/disposalpipe/segment/brig,
 /obj/decal/poster/wallsign/escape_right,
@@ -14566,7 +14573,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/vertical,
 /turf/simulated/floor/plating,
-/area/station/maintenance/south)
+/area/station/hallway/secondary/exit)
 "aJw" = (
 /obj/machinery/ore_cloud_storage_container,
 /obj/decal/cleanable/dirt,
@@ -14699,7 +14706,7 @@
 /obj/machinery/power/apc/autoname_north,
 /obj/storage/closet/emergency,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/north)
+/area/station/hallway/secondary/entry)
 "aJQ" = (
 /obj/cable{
 	d1 = 2;
@@ -16750,7 +16757,7 @@
 /area/station/storage/tech)
 "aOl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aOm" = (
 /obj/cable{
 	d1 = 1;
@@ -18085,14 +18092,14 @@
 	tag = ""
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aQM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aQN" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -18106,7 +18113,7 @@
 	text = "NF"
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aQO" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -18114,7 +18121,7 @@
 	},
 /obj/machinery/computer3/terminal/zeta,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aQP" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -18122,7 +18129,7 @@
 	},
 /obj/machinery/networked/radio,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aQQ" = (
 /obj/shrub{
 	dir = 10
@@ -19508,7 +19515,7 @@
 /obj/item/disk/data/floppy/read_only/network_progs,
 /obj/item/disk/data/floppy/read_only/research_progs,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aTH" = (
 /obj/machinery/computer3/generic/med_data,
 /obj/machinery/power/data_terminal,
@@ -19550,7 +19557,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aTJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -19573,7 +19580,7 @@
 /obj/item/disk/data/floppy/read_only/security_progs,
 /obj/item/disk/data/floppy/read_only/terminal_os,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aTL" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -20331,7 +20338,7 @@
 /area/station/mining/staff_room)
 "aVx" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload)
+/area/station/hallway/secondary/north)
 "aVy" = (
 /obj/lattice,
 /obj/cable{
@@ -20857,20 +20864,20 @@
 	dir = 5
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aWH" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aWI" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aWJ" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -20881,13 +20888,13 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aWK" = (
 /obj/machinery/turret{
 	dir = 9
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aWL" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -21448,6 +21455,9 @@
 "aXN" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
+"aXO" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/medical/medbay/lobby)
 "aXP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/teleporter)
@@ -21642,7 +21652,7 @@
 "aYm" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/vertical,
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/pool)
+/area/station/hallway/secondary/exit)
 "aYn" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -22528,7 +22538,7 @@
 /obj/window/auto/reinforced,
 /obj/decal/xmas_lights,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "aZZ" = (
 /obj/cable{
 	d1 = 4;
@@ -22539,7 +22549,7 @@
 /obj/window/auto/reinforced,
 /obj/decal/xmas_lights,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "baa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -22553,7 +22563,7 @@
 /obj/window/auto/reinforced,
 /obj/decal/xmas_lights,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "bab" = (
 /obj/machinery/door/airlock/pyro/glass/command{
 	name = "Core"
@@ -22562,13 +22572,13 @@
 /obj/access_spawn/heads,
 /obj/decal/garland,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bac" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
 /obj/decal/wreath,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "bad" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -23891,14 +23901,14 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bcR" = (
 /obj/item/device/radio/intercom/AI,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bcS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -23910,10 +23920,10 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bcT" = (
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bcU" = (
 /obj/table/auto,
 /obj/item/aiModule/freeform,
@@ -23922,7 +23932,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bcV" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -25308,7 +25318,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfR" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -25317,7 +25327,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -25337,7 +25347,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfT" = (
 /obj/cable{
 	d1 = 4;
@@ -25348,7 +25358,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfU" = (
 /obj/cable{
 	d1 = 4;
@@ -25361,7 +25371,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfV" = (
 /obj/cable{
 	d1 = 4;
@@ -25376,7 +25386,7 @@
 	text = "NF"
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfW" = (
 /obj/cable{
 	d1 = 4;
@@ -25407,7 +25417,7 @@
 	pixel_x = 20
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "bfX" = (
 /obj/machinery/turretid{
 	layer = 9.1;
@@ -25422,7 +25432,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/bridge)
+/area/station/turret_protected/Zeta)
 "bfY" = (
 /obj/machinery/light{
 	dir = 1;
@@ -26873,13 +26883,13 @@
 /turf/simulated/floor/blueblack{
 	dir = 10
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "biQ" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "biR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -26890,10 +26900,10 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "biS" = (
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "biT" = (
 /obj/table/auto,
 /obj/item/aiModule/oneHuman,
@@ -26903,7 +26913,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 6
 	},
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "biU" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -28190,7 +28200,7 @@
 "blJ" = (
 /obj/decal/poster/wallsign/medbay_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/ai_upload)
+/area/station/turret_protected/Zeta)
 "blK" = (
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -34550,7 +34560,7 @@
 	},
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "bzc" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /obj/machinery/light{
@@ -37407,7 +37417,7 @@
 	},
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/black,
-/area/station/turret_protected/ai_upload_foyer)
+/area/station/turret_protected/Zeta)
 "bFl" = (
 /obj/disposalpipe/trunk,
 /obj/disposaloutlet{
@@ -102521,7 +102531,7 @@ aZY
 bcQ
 bfQ
 biP
-aVx
+aOl
 bov
 brA
 btF
@@ -102823,7 +102833,7 @@ aZZ
 bcR
 bfR
 biQ
-aVx
+aOl
 bow
 brB
 btF
@@ -103114,7 +103124,7 @@ aaa
 aaa
 aaa
 aaa
-aGP
+atE
 aJP
 aMc
 aOl
@@ -103427,7 +103437,7 @@ bab
 bcT
 bfT
 biS
-aVx
+aOl
 boy
 brB
 btF
@@ -104031,7 +104041,7 @@ aMf
 aMf
 bfV
 aBd
-aVx
+aOl
 boA
 brB
 btF
@@ -104332,8 +104342,8 @@ aWL
 bad
 aMf
 bfW
-aVx
-aVx
+aOl
+aOl
 boB
 brD
 btF
@@ -117305,7 +117315,7 @@ aaa
 aaa
 aaa
 aaa
-aCg
+aVx
 aFM
 aHl
 aAZ
@@ -120627,7 +120637,7 @@ aaa
 aaa
 aaa
 aaa
-aCg
+aIO
 aFS
 aHv
 aIO
@@ -120929,7 +120939,7 @@ aaa
 aaa
 aaa
 aaa
-aCg
+aXO
 aFT
 aHw
 aIO
@@ -130890,8 +130900,8 @@ aaa
 aaa
 aaa
 aaa
-arH
-aGZ
+asp
+aEB
 aBx
 asv
 aFi
@@ -131192,7 +131202,7 @@ aaa
 aaa
 aaa
 aaa
-arH
+aHQ
 aGZ
 aBy
 aVS

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -10337,11 +10337,9 @@
 	},
 /area/station/security/detectives_office)
 "aBL" = (
-/obj/machinery/door/airlock/pyro/security{
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
-	id = "det_entry";
-	name = "Detective's Office";
-	req_access = null
+	name = "Detective's Office"
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -10349,7 +10347,6 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/access_spawn/forensics,
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "aBM" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [MAPPING] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This cleans up some errors and bugs on both the regular and the XMAS versions of Horizon. Also a wee touchup on Kondaru.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5143
- The detective's receiving office should be open to the public especially if it's going to have a staffie spawn in there (Horizon/Kondaru).
- Only people with genetics access should be able to go into genetics or the monkey dome since both have genetics consoles (Horizon).
- Horizon XMAS was complaining about an invalid obj path which is nice to have fixed.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)eX.n0x
(*)Horizon genetics/monkey dome are completely restricted to geneticists.
(*)Horizon/Kondaru detective receiving office is now open to the general public.
```
