### PR TITLE
adds tranqs to armories missing them

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -11599,6 +11599,9 @@
 	pixel_x = -6
 	},
 /obj/machinery/light,
+/obj/item/implantcase/sec{
+	pixel_x = 5
+	},
 /turf/simulated/floor/black,
 /area/station/security/armory)
 "aEE" = (
@@ -37601,7 +37604,21 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/implantcase/sec,
+/obj/item/ammo/bullets/tranq_darts/anti_mutant{
+	pixel_x = -10;
+	pixel_y = -6
+	},
+/obj/item/ammo/bullets/tranq_darts{
+	pixel_x = 10;
+	pixel_y = -6
+	},
+/obj/item/ammo/bullets/tranq_darts{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/gun/kinetic/dart_rifle{
+	pixel_y = -8
+	},
 /turf/simulated/floor/black,
 /area/station/security/armory)
 "bQw" = (

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -15136,6 +15136,15 @@
 	tag = ""
 	},
 /obj/storage/secure/closet/security/armory,
+/obj/item/gun/kinetic/dart_rifle,
+/obj/item/ammo/bullets/tranq_darts,
+/obj/item/ammo/bullets/tranq_darts,
+/obj/item/ammo/bullets/tranq_darts/anti_mutant{
+	pixel_y = 5
+	},
+/obj/item/ammo/bullets/tranq_darts/anti_mutant{
+	pixel_y = 5
+	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "aRq" = (


### PR DESCRIPTION
[mapping][balance]
## About the PR 
adds a tranq gun and 1 set of mutadone darts and 2 sets of halo darts to Manta and Horizon, the only armories missing a tranq.

## Why's this needed? 
the option for security to disable people on stims or with genetic effects is probably nicer than having to use lethals.
matches level of armory equipment available on all other maps.