### PR TITLE
removes hunter mask from cargo clothing crate

### DIFF
--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -1425,8 +1425,7 @@
 	icon_state = "rand_mask"
 	min_amt2spawn = 5
 	max_amt2spawn = 10
-	items2spawn = list(/obj/item/clothing/mask/hunter,
-						/obj/item/clothing/mask/owl_mask,
+	items2spawn = list(/obj/item/clothing/mask/owl_mask,
 						/obj/item/clothing/mask/smile,
 						/obj/item/clothing/mask/batman,
 						/obj/item/clothing/mask/clown_hat,


### PR DESCRIPTION
[removal][balance]
## About the PR 
removes the unique hunter mask from the masquerade cargo crate.

## Why's this needed? 
requested.
masks in the cargo crate are all unique cosmetics, and the hunter mask gives some decent benefits like IR, NV and voice changing that have, to my knowledge, been fixed up, making this a very good mask that doesn't make much sense in the context of just cosmetic apparel.