### PR TITLE
Blacklists lupine regen from mutini

### DIFF
--- a/code/modules/medical/genetics/bioEffects/beneficial.dm
+++ b/code/modules/medical/genetics/bioEffects/beneficial.dm
@@ -293,6 +293,7 @@
 	msgLose = "You feel more comfortable in your own skin."
 	heal_per_tick = 2
 	regrow_prob = 50
+	acceptable_in_mutini = 0 // fun is banned
 
 	OnAdd()
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Blacklists werewolf regeneration from mutini mutations.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lupine regen makes the affected person a werewolf which lasts after the mutini effect fades. Mutini is meant for fun bursts of crazy mutations not gaining antag powers.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)You can no longer become a werewolf through mutini.
```
