### PR TITLE
adds a size class to the defib

### DIFF
--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -358,6 +358,7 @@ CONTAINS:
 	icon_state = "defib-on"
 	item_state = "defib"
 	pickup_sfx = "sound/items/pickup_defib.ogg"
+	w_class = W_CLASS_TINY
 	var/icon_base = "defib"
 	var/charged = 1
 	var/charge_time = 100


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Bug - Minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the size class of tiny to the defib under modules/medical/surgery_tools.dm
For some reason the size class isn't in the description tho, that needs fixing

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
its weird that it doesn't have a size class, and tiny makes the most sense as all other medical objects are tiny.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Mora
(+)Added a size class for the Defib
```
