### PR TITLE
Makes turning off stealth mode set your key back to auto alt key

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -735,6 +735,8 @@ var/list/special_pa_observing_verbs = list(
 	else
 		src.owner:fakekey = null
 		src.owner:stealth_hide_fakekey = 0
+		if (src.auto_alt_key)
+			src.set_alt_key(src.auto_alt_key_name)
 
 	logTheThing("admin", src.owner, null, "has turned stealth mode [src.owner:stealth ? "ON using key \"[src.owner:fakekey]\"" : "OFF"]")
 	logTheThing("diary", src.owner, null, "has turned stealth mode [src.owner:stealth ? "ON using key \"[src.owner:fakekey]\"" : "OFF"]", "admin")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes turning off stealth mode automatically set your key to auto alt key, if you have it turned on as an admin


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Just some minor admin QoL