### PR TITLE
implement ai disposing

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -171,6 +171,9 @@
 		if (src.is_npc)
 			src.registered_area?.registered_mob_critters -= src
 			src.registered_area = null
+		if (ai)
+			qdel(ai)
+			ai = null
 		..()
 
 	///enables mob ai that was disabled by a hibernation task


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][RUNTIME] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Resolves an issue caused when mob ai attempts to handle the stamina updates of disposed mobs

if a `/mob/living/critter` has an `ai` object calls `qdel` and clears the reference on the mob


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
File | Life.dm
-- | --
Line | 570
Error | bad index
```dm
proc name: handle stamina updates (/mob/living/handle_stamina_updates)
  source file: Life.dm,570
  usr: null
  src: the dragon (/mob/living/critter/dragon/ai_controlled)
  src.loc: null
  call stack:
the dragon (/mob/living/critter/dragon/ai_controlled): handle stamina updates()
Mob AI (/datum/controller/process/mob_ai): doWork()
Mob AI (/datum/controller/process/mob_ai): process()
/datum/controller/processSched... (/datum/controller/processScheduler): runProcess(Mob AI (/datum/controller/process/mob_ai), 0.8)
```

