### PR TITLE
naval jacket on more naval maps

### DIFF
--- a/_std/mapDefines.dm
+++ b/_std/mapDefines.dm
@@ -7,6 +7,7 @@
 
 #elif defined(MAP_OVERRIDE_CLARION)
 
+#define FLEET_MAP 1
 
 #elif defined(MAP_OVERRIDE_COGMAP)
 

--- a/_std/mapDefines.dm
+++ b/_std/mapDefines.dm
@@ -3,11 +3,11 @@
 
 #elif defined(MAP_OVERRIDE_DESTINY)
 
-#define FLEET_MAP 1
+#define SHIP_MAP 1
 
 #elif defined(MAP_OVERRIDE_CLARION)
 
-#define FLEET_MAP 1
+#define SHIP_MAP 1
 
 #elif defined(MAP_OVERRIDE_COGMAP)
 
@@ -38,11 +38,11 @@
 
 #define UNDERWATER_MAP 1
 #define SCIENCE_PATHO_MAP 1
-#define FLEET_MAP 1
+#define SHIP_MAP 1
 
 #elif defined(MAP_OVERRIDE_HORIZON)
 
-#define FLEET_MAP 1
+#define SHIP_MAP 1
 
 #elif defined(MAP_OVERRIDE_ATLAS)
 
@@ -52,7 +52,7 @@
 #define UNDERWATER_MAP 1
 #define MOVING_SUB_MAP 1
 #define SUBMARINE_MAP 1
-#define FLEET_MAP 1
+#define SHIP_MAP 1
 #define SCIENCE_PATHO_MAP 1
 #elif defined(SPACE_PREFAB_RUNTIME_CHECKING)
 #define RUNTIME_CHECKING 1

--- a/_std/mapDefines.dm
+++ b/_std/mapDefines.dm
@@ -3,6 +3,7 @@
 
 #elif defined(MAP_OVERRIDE_DESTINY)
 
+#define FLEET_MAP 1
 
 #elif defined(MAP_OVERRIDE_CLARION)
 
@@ -36,9 +37,11 @@
 
 #define UNDERWATER_MAP 1
 #define SCIENCE_PATHO_MAP 1
+#define FLEET_MAP 1
 
 #elif defined(MAP_OVERRIDE_HORIZON)
 
+#define FLEET_MAP 1
 
 #elif defined(MAP_OVERRIDE_ATLAS)
 
@@ -48,6 +51,7 @@
 #define UNDERWATER_MAP 1
 #define MOVING_SUB_MAP 1
 #define SUBMARINE_MAP 1
+#define FLEET_MAP 1
 #define SCIENCE_PATHO_MAP 1
 #elif defined(SPACE_PREFAB_RUNTIME_CHECKING)
 #define RUNTIME_CHECKING 1

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -215,7 +215,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	announce_on_join = 1
 
 
-#ifdef SUBMARINE_MAP
+#ifdef FLEET_MAP
 	slot_suit = /obj/item/clothing/suit/armor/hopcoat
 	slot_back = /obj/item/storage/backpack/withO2
 	slot_belt = /obj/item/device/pda2/heads

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -215,7 +215,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	announce_on_join = 1
 
 
-#ifdef FLEET_MAP
+#ifdef SHIP_MAP
 	slot_suit = /obj/item/clothing/suit/armor/hopcoat
 	slot_back = /obj/item/storage/backpack/withO2
 	slot_belt = /obj/item/device/pda2/heads


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
puts the hops naval jacket on oshan, clarion, horizion, and destiny


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
the naval jacket, being the hops only jacket, should be on more maps to give them more options. While other outfits got this treatment, the hops did not. A previous PR i made, saw the hop's coat be added to all maps, however was looked upon less faborably. This PR adds it to more maps, but makes it so its still locked to maps upon which it only makes sense, water based maps, or maps which are ships.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)MozErella
(+)Hops naval jacket appears on more maps.
```
