### PR TITLE
Nerfs Rathen's Secret and Magic Missile spells

### DIFF
--- a/code/modules/events/gimmick/bigfart.dm
+++ b/code/modules/events/gimmick/bigfart.dm
@@ -91,7 +91,8 @@
 			ThrowRandom(B, dist = 6, speed = 1)
 		H.visible_message("<span class='alert'><b>[H]</b>'s [magical ? "arse" : "ass"] tears itself away from \his body[magical ? " in a magical explosion" : null]!</span>",\
 		"<span class='alert'>[changer ? "Our" : "Your"] [magical ? "arse" : "ass"] tears itself away from [changer ? "our" : "your"] body[magical ? " in a magical explosion" : null]!</span>")
-		H.changeStatus("weakened", 2 SECONDS)
+		if (!magical)
+			H.changeStatus("weakened", 2 SECONDS)
 		severed_something = TRUE
 		H.force_laydown_standup()
 
@@ -157,9 +158,7 @@
 		boutput(H, "<span class='notification'>[changer ? "We" : "You"] hear an otherworldly force let out a short, disappointed cluck at [changer ? "our" : "your"] lack of an arse.</span>")
 	H.visible_message("<span class='alert'>[is_bot ? "Oily chunks of twisted shrapnel" : "Wadded hunks of blood and gore"] burst out of where <b>[H]</b>'s [magical ? "arse" : "ass"] used to be!</span>",\
 	"<span class='alert'>[nobutt_phrase[assmagic]]</span>")
-	if(magical)
-		H.changeStatus("weakened", 1 DECI SECOND)
-	else
+	if(!magical)
 		H.changeStatus("weakened", 3 SECONDS)
 	H.force_laydown_standup()
 	if(!severed_something)

--- a/code/modules/events/gimmick/bigfart.dm
+++ b/code/modules/events/gimmick/bigfart.dm
@@ -93,8 +93,8 @@
 		"<span class='alert'>[changer ? "Our" : "Your"] [magical ? "arse" : "ass"] tears itself away from [changer ? "our" : "your"] body[magical ? " in a magical explosion" : null]!</span>")
 		if (!magical)
 			H.changeStatus("weakened", 2 SECONDS)
+			H.force_laydown_standup()
 		severed_something = TRUE
-		H.force_laydown_standup()
 
 	/// If that didn't work, try severing a limb or tail
 	else if (!is_bot && prob(limbloss_prob)) // It'll try to sever an arm, then a leg, then an arm, then a leg
@@ -160,7 +160,7 @@
 	"<span class='alert'>[nobutt_phrase[assmagic]]</span>")
 	if(!magical)
 		H.changeStatus("weakened", 3 SECONDS)
-	H.force_laydown_standup()
+		H.force_laydown_standup()
 	if(!severed_something)
 		H.emote("scream")
 

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -698,7 +698,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	max_speed = 2
 	goes_through_walls = 0 // It'll stop homing when it hits something, then go bouncy
 	var/max_bounce_count = 3 // putting the I in ICEE BEEYEM
-	var/weaken_length = 5 SECONDS
+	var/weaken_length = 4 SECONDS
 	var/slam_text = "The magic missile SLAMS into you!"
 	var/hit_sound = 'sound/effects/mag_magmisimpact_bounce.ogg'
 	var/cat_sound = 'sound/voice/animal/cat.ogg'
@@ -752,7 +752,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	min_speed = 2
 	max_speed = 2
 	max_bounce_count = 2 // putting the Y in ICEE BEEYEM
-	weaken_length = 3 SECONDS
+	weaken_length = 2 SECONDS
 	slam_text = "The magic missile bumps into you!"
 
 /datum/projectile/special/homing/orbiter


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ADD TO WIKI] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes weakened from Rathen's Secret spell.
Changes weakened time on Magic Missile from 5 to 4. (3 to 2 on the weak projectile.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Recently, Rathen's Secret has been picked extremely often due to how well it synergizes with Magic Missile and with good reason. Nearly every wizard round, at least one wizard would pick this combo and search for players, then use Rathen's followed by Magic Missile. This would nearly always put all nearby players in a 6 second unavoidable stun which could be swiftly followed up with one of the other spells, such as Prismatic Spray, Empower, Polymorph, Clown's Revenge, etc. This makes it extremely easy for just one wizard to slowly kill a majority of the station with little to no counterplay. This PR aims to remove this broken combo by turning Rathen's into a damage-focused spell instead of a stun as well as slightly decreasing how long you're stunned for after getting hit by Magic Missile so it isn't as much as a free kill every time it's cast.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Lythine
(*)Rathen's Secret no longer weakens. Magic Missile's weaken time slightly shortened.
```
