### PR TITLE
Volume settings popup changes

### DIFF
--- a/code/modules/sound/playsound.dm
+++ b/code/modules/sound/playsound.dm
@@ -155,7 +155,8 @@ var/global/admin_sound_channel = 1014 //Ranges from 1014 to 1024
 	var/channel_id = audio_channel_name_to_id[channel_name]
 	if(isnull(channel_id))
 		alert(usr, "Invalid channel.")
-	var/vol = input("Goes from 0-100. Default is [getDefaultVolume(channel_id) * 100]", "[channel_name] Volume", src.getRealVolume(channel_id) * 100) as num
+	var/vol = input("Goes from 0-100. Default is [getDefaultVolume(channel_id) * 100]\n[src.getVolumeChannelDescription(channel_id)]", \
+	 "[capitalize(channel_name)] Volume", src.getRealVolume(channel_id) * 100) as num
 	vol = max(0,min(vol,100))
 	src.setVolume(channel_id, vol/100 )
 	boutput(usr, "<span class='notice'>You have changed [channel_name] Volume to [vol].</span>")

--- a/code/modules/sound/sound.dm
+++ b/code/modules/sound/sound.dm
@@ -78,7 +78,7 @@ var/global/list/default_channel_volumes = list(1, 1, 0.1, 0.5, 0.5, 1, 1)
 /client/proc/getVolumeDescriptions()
 	return list("This will affect all sounds.", "Most in-game audio will use this channel.", "Ambient background music in various areas will use this channel.", "Any music played from the radio station", "Any music or sounds played by admins.", "Screams and farts.", "Mentor PM notification sound.")
 
-// Get the friendly description for a specific sound channel.
+/// Get the friendly description for a specific sound channel.
 /client/proc/getVolumeChannelDescription(channel)
 	// +1 since master channel is 0, while byond arrays start at 1
 	return getVolumeDescriptions()[channel+1]

--- a/code/modules/sound/sound.dm
+++ b/code/modules/sound/sound.dm
@@ -72,7 +72,7 @@ var/global/list/default_channel_volumes = list(1, 1, 0.1, 0.5, 0.5, 1, 1)
 
 /// Returns the default volume for a channel, unattenuated for the master channel (0-1)
 /client/proc/getDefaultVolume(channel)
-	return volumes[channel + 1]
+	return default_channel_volumes[channel + 1]
 
 /// Returns a list of friendly descriptions for available sound channels
 /client/proc/getVolumeDescriptions()

--- a/code/modules/sound/sound.dm
+++ b/code/modules/sound/sound.dm
@@ -76,7 +76,12 @@ var/global/list/default_channel_volumes = list(1, 1, 0.1, 0.5, 0.5, 1, 1)
 
 /// Returns a list of friendly descriptions for available sound channels
 /client/proc/getVolumeDescriptions()
-	return list("Most in-game audio will use this channel.", "Ambient background music in various areas will use this channel.", "Any music played from the radio station", "Any music or sounds played by admins.", "Screams and farts.", "Mentor PM notification sound.")
+	return list("This will affect all sounds.", "Most in-game audio will use this channel.", "Ambient background music in various areas will use this channel.", "Any music played from the radio station", "Any music or sounds played by admins.", "Screams and farts.", "Mentor PM notification sound.")
+
+// Get the friendly description for a specific sound channel.
+/client/proc/getVolumeChannelDescription(channel)
+	// +1 since master channel is 0, while byond arrays start at 1
+	return getVolumeDescriptions()[channel+1]
 
 /// Returns the volume to set /sound/var/volume to for the given channel(so 0-100)
 /client/proc/getVolume(id)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- The default volume displayed is now the actual default volume for the channel.
- The radio channel name in the title of the popup is now also capitalized, so it's not "radio Volume" or whatever.
- It now displays a friendly description of the channel as well, which I found in the code. 
- (I also added one for the master channel.)
![image](https://user-images.githubusercontent.com/35579460/122360066-64c98e80-cf56-11eb-9db5-04ad2fbe07ad.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #5176 
So people will have more of an idea which channels affect what.
(And because we already had the friendly descriptors and it seemed a pity not to use them?
