### PR TITLE
Fixes magic missiles occasionally orbiting their targets

### DIFF
--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -708,9 +708,13 @@ ABSTRACT_TYPE(/datum/projectile/special)
 		if(istype(O) && !(hit in O.hitlist))
 			if(ismob(hit))
 				var/mob/M = hit
-				if(iswizard(M) || M.traitHolder?.hasTrait("training_chaplain") || ON_COOLDOWN(M, "magic_missiled", 1 SECOND))
+				if(iswizard(M) || M.traitHolder?.hasTrait("training_chaplain"))
 					boutput(M, "The magic missile passes right through you!")
 					. = TRUE
+				else if(ON_COOLDOWN(M, "magic_missiled", 1 SECOND))
+					boutput(M, "The magic missile passes right through you, not wishing to add insult to injury!")
+					. = TRUE
+					O.targets -= M //Stop tracking whoever we hit to prevent the projectiles orbiting them
 
 			if(isobj(hit) || (isturf(hit) && !hit.density))
 				. = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently if a magic missile collides with someone it's tracking while the `magic_missiled` cooldown is in effect, the missile will harmlessly pass back and forth over them until the person moves or is moved far enough away. This makes it so missiles striking their target while the cooldown is in effect instead fly past, preventing them from doing the weird orbit pattern thing.

Also added a slight message variant if you're hit while the cooldown is in effect to make it clearer to the victim why some missiles are hitting and some aren't.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
https://user-images.githubusercontent.com/67879783/122428518-d0a3fb00-cf46-11eb-874f-99936cb4e4e9.mp4
