### PR TITLE
removes the brighter from crate spawns and replaces it with an Odd Zippo

### DIFF
--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -288,7 +288,7 @@
 							items += /obj/item/clothing/ears/earmuffs/yeti
 							item_amounts += 1
 						if(3)
-							items += /obj/item/device/light/zippo/dan
+							items += /obj/item/device/light/zippo/gold
 							item_amounts += 1
 							items += /obj/item/cigpacket/random
 							item_amounts += rand(2,4)

--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -288,7 +288,7 @@
 							items += /obj/item/clothing/ears/earmuffs/yeti
 							item_amounts += 1
 						if(3)
-							items += /obj/item/device/light/zippo/brighter
+							items += /obj/item/device/light/zippo/dan
 							item_amounts += 1
 							items += /obj/item/cigpacket/random
 							item_amounts += rand(2,4)


### PR DESCRIPTION
[performance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does that.
The brighter continues to exist so that the Brighter Bonanza can be used as a benchmark.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Walking around with it open apparently manages to be one of the laggiest things in the game.