### PR TITLE
Makes more things deconstructable + a few deconstruction adjustments

### DIFF
--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -457,10 +457,11 @@
 		icon_state = "weld"
 
 		execute(atom/target, mob/user)
-			for (var/obj/item/weldingtool/W in user.equipped_list())
-				if(W.try_weld(user, 2))
-					user.show_text("You weld [target] carefully.", "blue")
-					return ..()
+			for (var/obj/item/I in user.equipped_list())
+				if (isweldingtool(I))
+					if (I:try_weld(user, 2))
+						user.show_text("You weld [target] carefully.", "blue")
+						return ..()
 
 	pry
 		name = "Pry"

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -390,6 +390,8 @@
 	src.wire_HTML = jointext(html_parts, "")
 
 /obj/machinery/vending/attackby(obj/item/W as obj, mob/user as mob)
+	if (istype(W,/obj/item/electronics/scanner) || istype(W,/obj/item/deconstructor)) // So people don't end up making the vending machines fall on them when they try to scan/deconstruct it
+		return
 	if (istype(W, /obj/item/spacecash))
 		if (src.pay)
 			src.credit += W.amount

--- a/code/obj/item/instruments.dm
+++ b/code/obj/item/instruments.dm
@@ -116,6 +116,7 @@
 	note_time = 200
 	affect_fun = 15 // a little higher, why not?
 	module_research = list("audio" = 14) // I don't think this is even relevant without being able to pick up the thing and also the research thing isn't even enabled atm but well. why not?
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH
 
 	attack_hand(mob/user as mob)
 		src.add_fingerprint(user)

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -763,6 +763,7 @@
 	anchored = 0
 	density = 1
 	event_handler_flags = NO_MOUSEDROP_QOL
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR
 	var/active = 0
 	var/reject = 0
 	var/insufficient = 0

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -763,7 +763,6 @@
 	anchored = 0
 	density = 1
 	event_handler_flags = NO_MOUSEDROP_QOL
-	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR
 	var/active = 0
 	var/reject = 0
 	var/insufficient = 0

--- a/code/obj/kitchenspike.dm
+++ b/code/obj/kitchenspike.dm
@@ -7,6 +7,7 @@
 	anchored = 1
 	var/meat = 0
 	var/occupied = 0
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR
 
 /obj/kitchenspike/attackby(obj/item/grab/G as obj, mob/user as mob)
 	if(!istype(G, /obj/item/grab))

--- a/code/obj/machinery/drone_recharger.dm
+++ b/code/obj/machinery/drone_recharger.dm
@@ -13,6 +13,7 @@
 	var/mob/living/silicon/ghostdrone/occupant = null
 	var/transition = 0 //For when closing
 	event_handler_flags = USE_HASENTERED | USE_FLUID_ENTER
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_MULTITOOL
 
 	New()
 		..()

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -94,6 +94,7 @@
 	anchored = 0
 	density = 1
 	mats = 2
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR
 	flags = NOSPLASH
 	processing_tier = PROCESSING_SIXTEENTH
 	machine_registry_idx = MACHINES_PLANTPOTS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[FEATURE] [QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes big instruments such as the jukebox, portable material reclaimers, the kitchen monkey spike, drone rechargers and botany plant pots all deconstructable makes it so that when you hit a vending machine with a decon tool or a device analyzer it doesn't hit the machine, also makes it so the decon tool menu welder option looks for a tool with the weld flag instead of a welding tool.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Deconstructing stuff is cool, taking the risk of a vending machine falling on my head every time I want to decon one is funny but annoying, and the omnitool welder should work on the decon menu.