### PR TITLE
Makes Player vending machines be deleted after deconstruction

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1760,7 +1760,7 @@
 			else
 				var/datum/material/M = getMaterial("steel")
 				A.setMaterial(M)
-				qdel(src)
+			qdel(src)
 		else
 			setFrameState("UNWRENCHED")
 			CRASH("Invalid state \"[state]\" set in [src] construction process at [log_loc(src)]")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the machine be deleted when you deconstruct it with a welder, instead of it staying there.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Infinite metal sheets are crashing the metal sheet market also, fixes #5184 