### PR TITLE
Allows cyborgs and AI to see packet sniffer device output and set filters

### DIFF
--- a/code/modules/networks/computer3/sniffer.dm
+++ b/code/modules/networks/computer3/sniffer.dm
@@ -15,7 +15,9 @@
 	var/list/packet_data = list()
 	var/max_logs = 8
 
-	attack_ai()
+	attack_ai(mob/user as mob)
+		if(mode)
+			src.interacted(user)
 		return
 
 	attack_hand(mob/user as mob)
@@ -85,21 +87,23 @@
 	Topic(href, href_list)
 		..()
 
-		if (usr.contents.Find(src) || usr.contents.Find(src.master) || (istype(src.loc, /turf) && get_dist(src, usr) <= 1))
+		if (!issilicon(usr))
+			if (!usr.contents.Find(src) && !usr.contents.Find(src.master) && !(istype(src.loc, /turf) && get_dist(src, usr) <= 1))
+				return
 			if (usr.stat || usr.restrained())
 				return
 
 			src.add_fingerprint(usr)
-			src.add_dialog(usr)
+		src.add_dialog(usr)
 
-			if(href_list["filtid"])
-				var/t = input(usr, "Please enter new filter net id", src.name, src.filter_id) as text
+		if(href_list["filtid"])
+			var/t = input(usr, "Please enter new filter net id", src.name, src.filter_id) as text
 				if (!t)
 					src.filter_id = null
 					src.updateIntDialog()
 					return
 
-				if (!in_interact_range(src, usr) || usr.stat || usr.restrained())
+				if (!issilicon && (!in_interact_range(src, usr) || usr.stat || usr.restrained()))
 					return
 
 				if(length(t) != 8 || !is_hex(t))

--- a/code/modules/networks/computer3/sniffer.dm
+++ b/code/modules/networks/computer3/sniffer.dm
@@ -88,7 +88,7 @@
 		..()
 
 		if (!issilicon(usr) && !isAIeye(usr))
-			if (!usr.contents.Find(src) && !usr.contents.Find(src.master) && !(istype(src.loc, /turf) && get_dist(src, usr) <= 1))
+			if (!(src in usr.contents) && !(src.master in usr.contents) && !(istype(src.loc, /turf) && IN_RANGE(src, usr, 1))
 				return
 			if (usr.stat || usr.restrained())
 				return

--- a/code/modules/networks/computer3/sniffer.dm
+++ b/code/modules/networks/computer3/sniffer.dm
@@ -103,8 +103,9 @@
 				src.updateIntDialog()
 				return
 
-			if (!issilicon(usr) && !isAIeye(usr) && (!in_interact_range(src, usr) || usr.stat || usr.restrained()))
-				return
+			if (!issilicon(usr) && !isAIeye(usr))//Only check range for organics
+				if (!in_interact_range(src, usr) || usr.stat || usr.restrained())
+					return
 
 			if(length(t) != 8 || !is_hex(t))
 				src.filter_id = null

--- a/code/modules/networks/computer3/sniffer.dm
+++ b/code/modules/networks/computer3/sniffer.dm
@@ -87,7 +87,7 @@
 	Topic(href, href_list)
 		..()
 
-		if (!issilicon(usr))
+		if (!issilicon(usr) && !isAIeye(usr))
 			if (!usr.contents.Find(src) && !usr.contents.Find(src.master) && !(istype(src.loc, /turf) && get_dist(src, usr) <= 1))
 				return
 			if (usr.stat || usr.restrained())
@@ -98,23 +98,21 @@
 
 		if(href_list["filtid"])
 			var/t = input(usr, "Please enter new filter net id", src.name, src.filter_id) as text
-				if (!t)
-					src.filter_id = null
-					src.updateIntDialog()
-					return
+			if (!t)
+				src.filter_id = null
+				src.updateIntDialog()
+				return
 
-				if (!issilicon && (!in_interact_range(src, usr) || usr.stat || usr.restrained()))
-					return
+			if (!issilicon(usr) && !isAIeye(usr) && (!in_interact_range(src, usr) || usr.stat || usr.restrained()))
+				return
 
-				if(length(t) != 8 || !is_hex(t))
-					src.filter_id = null
-					src.updateIntDialog()
-					return
+			if(length(t) != 8 || !is_hex(t))
+				src.filter_id = null
+				src.updateIntDialog()
+				return
 
-				src.filter_id = t
-
+			src.filter_id = t
 			src.updateIntDialog()
-			return
 
 		return
 

--- a/code/modules/networks/computer3/sniffer.dm
+++ b/code/modules/networks/computer3/sniffer.dm
@@ -88,7 +88,7 @@
 		..()
 
 		if (!issilicon(usr) && !isAIeye(usr))
-			if (!(src in usr.contents) && !(src.master in usr.contents) && !(istype(src.loc, /turf) && IN_RANGE(src, usr, 1))
+			if (!(src in usr.contents) && !(src.master in usr.contents) && !(istype(src.loc, /turf) && IN_RANGE(src, usr, 1)))
 				return
 			if (usr.stat || usr.restrained())
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug-minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This allows cyborgs and AI to view the output of the activated packet sniffer device and set the netid filtering.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5159


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Borgs and AI can now see packet sniffer device output and set filters.
```
