### PR TITLE
Allows the ID computer to save and apply custom jobs to ID cards

### DIFF
--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -77,7 +77,7 @@ GAUNTLET CARDS
 	flags = FPRINT | TABLEPASS | ATTACK_SELF_DELAY
 	click_delay = 0.4 SECONDS
 	wear_layer = MOB_BELT_LAYER
-	var/access = list()
+	var/list/access = list()
 	var/registered = null
 	var/assignment = null
 	var/title = null
@@ -180,7 +180,7 @@ GAUNTLET CARDS
 		assignment = "NanoTrasen Pilot"
 		access = list(access_heads)
 		team = 1
-			
+
 		commander
 			name = "NanoTrasen Commander"
 			assignment = "NanoTrasen Commander"

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -353,21 +353,21 @@
 			else
 				src.custom1_name = src.modify.assignment
 			src.custom1_list = src.modify.access.Copy()
-			src.custom1_list -= 37 //prevent saving armory access
+			src.custom1_list -= access_maxsec //prevent saving armory access
 		else if (slot == "custom2")
 			if (!src.modify.assignment)
 				src.custom2_name = "Custom 2"
 			else
 				src.custom2_name = src.modify.assignment
 			src.custom2_list = src.modify.access.Copy()
-			src.custom2_list -= 37 //prevent saving armory access
+			src.custom2_list -= access_maxsec //prevent saving armory access
 		else
 			if (!src.modify.assignment)
 				src.custom3_name = "Custom 3"
 			else
 				src.custom3_name = src.modify.assignment
 			src.custom3_list = src.modify.access.Copy()
-			src.custom3_list -= 37 //prevent saving armory access
+			src.custom3_list -= access_maxsec //prevent saving armory access
 	if (href_list["apply"])
 		var/slot = href_list["apply"]
 		if (slot == "custom1")

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -90,7 +90,7 @@
 			var/list/civilianjobs = list("Staff Assistant", "Bartender", "Chef", "Botanist", "Rancher", "Chaplain", "Janitor", "Clown")
 			var/list/maintainencejobs = list("Engineer", "Mechanic", "Miner", "Quartermaster")
 			var/list/researchjobs = list("Scientist", "Medical Doctor", "Geneticist", "Roboticist", "Pathologist")
-			var/list/securityjobs = list("Security Officer", "Security Assistant", "Detective")
+			var/list/securityjobs = list("Security Officer", "Detective")
 			var/list/commandjobs = list("Head of Personnel", "Chief Engineer", "Research Director", "Medical Director", "Captain")
 
 			body += "<br><br><u>Jobs</u>"

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -14,6 +14,7 @@
 	var/list/custom1_list = list()
 	var/list/custom2_list = list()
 	var/list/custom3_list = list()
+	var/list/banned_access_list = list(access_maxsec,access_syndicate_shuttle,access_owlerymaint,access_owlerysec,access_owlerycommand,access_syndicate_4,access_syndicate_8,access_syndicate_16,access_syndicate_32,access_syndicate_64,access_syndicate_128,access_syndicate_256,access_syndicate_512,access_polariscargo,access_polarisimportant,access_contrabandpermit,access_syndicate_commander,access_retention_blue,access_retention_green,access_retention_yellow,access_retention_orange,access_retention_red,access_retention_black)
 	req_access = list(access_change_ids)
 	desc = "A computer that allows an authorized user to change the identification of other ID cards."
 
@@ -353,21 +354,21 @@
 			else
 				src.custom1_name = src.modify.assignment
 			src.custom1_list = src.modify.access.Copy()
-			src.custom1_list -= access_maxsec //prevent saving armory access
+			src.custom1_list -= banned_access_list //prevent saving armory access
 		else if (slot == "custom2")
 			if (!src.modify.assignment)
 				src.custom2_name = "Custom 2"
 			else
 				src.custom2_name = src.modify.assignment
 			src.custom2_list = src.modify.access.Copy()
-			src.custom2_list -= access_maxsec //prevent saving armory access
+			src.custom2_list -= banned_access_list //prevent saving armory access
 		else
 			if (!src.modify.assignment)
 				src.custom3_name = "Custom 3"
 			else
 				src.custom3_name = src.modify.assignment
 			src.custom3_list = src.modify.access.Copy()
-			src.custom3_list -= access_maxsec //prevent saving armory access
+			src.custom3_list -= banned_access_list //prevent saving armory access
 	if (href_list["apply"])
 		var/slot = href_list["apply"]
 		if (slot == "custom1")

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -346,8 +346,6 @@
 			if (newcolour == "green")
 				src.modify.icon_state = "id_com"
 	if (href_list["save"])
-		if (src.modify.assignment == "Head of Security")
-			return
 		var/slot = href_list["save"]
 		if (slot == "custom1")
 			if (!src.modify.assignment)

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -356,18 +356,18 @@
 			src.custom1_list -= 37 //prevent saving armory access
 		else if (slot == "custom2")
 			if (!src.modify.assignment)
-				src.custom1_name = "Custom 2"
+				src.custom2_name = "Custom 2"
 			else
 				src.custom2_name = src.modify.assignment
 			src.custom2_list = src.modify.access.Copy()
-			src.custom1_list -= 37 //prevent saving armory access
+			src.custom2_list -= 37 //prevent saving armory access
 		else
 			if (!src.modify.assignment)
 				src.custom3_name = "Custom 3"
 			else
 				src.custom3_name = src.modify.assignment
 			src.custom3_list = src.modify.access.Copy()
-			src.custom1_list -= 37 //prevent saving armory access
+			src.custom3_list -= 37 //prevent saving armory access
 	if (href_list["apply"])
 		var/slot = href_list["apply"]
 		if (slot == "custom1")

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -8,6 +8,12 @@
 	var/mode = 0.0
 	var/printing = null
 	var/list/scan_access = null
+	var/custom1_name = "Custom 1"
+	var/custom2_name = "Custom 2"
+	var/custom3_name = "Custom 3"
+	var/list/custom1_list = list()
+	var/list/custom2_list = list()
+	var/list/custom3_list = list()
 	req_access = list(access_change_ids)
 	desc = "A computer that allows an authorized user to change the identification of other ID cards."
 
@@ -83,7 +89,7 @@
 			var/list/civilianjobs = list("Staff Assistant", "Bartender", "Chef", "Botanist", "Rancher", "Chaplain", "Janitor", "Clown")
 			var/list/maintainencejobs = list("Engineer", "Mechanic", "Miner", "Quartermaster")
 			var/list/researchjobs = list("Scientist", "Medical Doctor", "Geneticist", "Roboticist", "Pathologist")
-			var/list/securityjobs = list("Security Officer", "Detective")
+			var/list/securityjobs = list("Security Officer", "Security Assistant", "Detective")
 			var/list/commandjobs = list("Head of Personnel", "Chief Engineer", "Research Director", "Medical Director", "Captain")
 
 			body += "<br><br><u>Jobs</u>"
@@ -106,6 +112,11 @@
 			body += "<br>Command:"
 			for(var/job in commandjobs)
 				body += " <a href='?src=\ref[src];assign=[job];colour=green'>[replacetext(job, " ", "&nbsp")]</a>"
+
+			body += "<br>Custom:"
+			body += " [src.custom1_name] <a href='?src=\ref[src];save=custom1'>save</a> <a href='?src=\ref[src];apply=custom1'>apply</a>"
+			body += " [src.custom2_name] <a href='?src=\ref[src];save=custom2'>save</a> <a href='?src=\ref[src];apply=custom2'>apply</a>"
+			body += " [src.custom3_name] <a href='?src=\ref[src];save=custom3'>save</a> <a href='?src=\ref[src];apply=custom3'>apply</a>"
 
 			//Change access to individual areas
 			body += "<br><br><u>Access</u>"
@@ -334,6 +345,37 @@
 				src.modify.icon_state = "id_sec"
 			if (newcolour == "green")
 				src.modify.icon_state = "id_com"
+	if (href_list["save"])
+		var/slot = href_list["save"]
+		if (slot == "custom1")
+			if (!src.modify.assignment)
+				src.custom1_name = "Custom 1"
+			else
+				src.custom1_name = src.modify.assignment
+			src.custom1_list = src.modify.access.Copy()
+		else if (slot == "custom2")
+			if (!src.modify.assignment)
+				src.custom1_name = "Custom 2"
+			else
+				src.custom2_name = src.modify.assignment
+			src.custom2_list = src.modify.access.Copy()
+		else
+			if (!src.modify.assignment)
+				src.custom3_name = "Custom 3"
+			else
+				src.custom3_name = src.modify.assignment
+			src.custom3_list = src.modify.access.Copy()
+	if (href_list["apply"])
+		var/slot = href_list["apply"]
+		if (slot == "custom1")
+			src.modify.assignment = src.custom1_name
+			src.modify.access = src.custom1_list.Copy()
+		else if (slot == "custom2")
+			src.modify.assignment = src.custom2_name
+			src.modify.access = src.custom2_list.Copy()
+		else
+			src.modify.assignment = src.custom3_name
+			src.modify.access = src.custom3_list.Copy()
 	if (src.modify)
 		src.modify.name = "[src.modify.registered]'s ID Card ([src.modify.assignment])"
 	if (src.eject)

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -8,13 +8,15 @@
 	var/mode = 0.0
 	var/printing = null
 	var/list/scan_access = null
-	var/custom1_name = "Custom 1"
-	var/custom2_name = "Custom 2"
-	var/custom3_name = "Custom 3"
-	var/list/custom1_list = list()
-	var/list/custom2_list = list()
-	var/list/custom3_list = list()
-	var/list/banned_access_list = list(access_maxsec,access_syndicate_shuttle,access_owlerymaint,access_owlerysec,access_owlerycommand,access_syndicate_4,access_syndicate_8,access_syndicate_16,access_syndicate_32,access_syndicate_64,access_syndicate_128,access_syndicate_256,access_syndicate_512,access_polariscargo,access_polarisimportant,access_contrabandpermit,access_syndicate_commander,access_retention_blue,access_retention_green,access_retention_yellow,access_retention_orange,access_retention_red,access_retention_black)
+	var/list/custom_names = list("Custom 1", "Custom 2", "Custom 3")
+	var/custom_access_list = list(list(),list(),list())
+	var/list/civilian_access_list = list(access_morgue, access_maint_tunnels, access_chapel_office, access_tech_storage, access_bar, access_janitor, access_crematorium, access_kitchen, access_hydro, access_ranch)
+	var/list/engineering_access_list = list(access_external_airlocks, access_construction, access_engineering, access_engineering_storage, access_engineering_power, access_engineering_engine, access_engineering_mechanic, access_engineering_atmos, access_engineering_control)
+	var/list/supply_access_list = list(access_hangar, access_cargo, access_supply_console, access_mining, access_mining_shuttle, access_mining_outpost)
+	var/list/research_access_list = list(access_medical, access_tox, access_tox_storage, access_medlab, access_medical_lockers, access_research, access_robotics, access_chemistry, access_pathology)
+	var/list/security_access_list = list(access_security, access_brig, access_forensics_lockers, access_maxsec, access_securitylockers, access_carrypermit, access_contrabandpermit)
+	var/list/command_access_list = list(access_research_director, access_emergency_storage, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_heads, access_captain, access_engineering_chief, access_medical_director, access_head_of_personnel, access_ghostdrone)
+	var/list/allowed_access_list
 	req_access = list(access_change_ids)
 	desc = "A computer that allows an authorized user to change the identification of other ID cards."
 
@@ -22,6 +24,10 @@
 	light_r =0.7
 	light_g = 1
 	light_b = 0.1
+
+/obj/machinery/computer/card/New()
+	..()
+	src.allowed_access_list = civilian_access_list + engineering_access_list + supply_access_list + research_access_list + command_access_list + security_access_list - access_maxsec
 
 
 /obj/machinery/computer/card/console_upper
@@ -115,31 +121,19 @@
 				body += " <a href='?src=\ref[src];assign=[job];colour=green'>[replacetext(job, " ", "&nbsp")]</a>"
 
 			body += "<br>Custom:"
-			body += " [src.custom1_name] <a href='?src=\ref[src];save=custom1'>save</a> <a href='?src=\ref[src];apply=custom1'>apply</a>"
-			body += " [src.custom2_name] <a href='?src=\ref[src];save=custom2'>save</a> <a href='?src=\ref[src];apply=custom2'>apply</a>"
-			body += " [src.custom3_name] <a href='?src=\ref[src];save=custom3'>save</a> <a href='?src=\ref[src];apply=custom3'>apply</a>"
+			for (var/i = 1, i <= custom_names.len, i++)
+				body += " [src.custom_names[i]] <a href='?src=\ref[src];save=[i]'>save</a> <a href='?src=\ref[src];apply=[i]'>apply</a>"
 
 			//Change access to individual areas
 			body += "<br><br><u>Access</u>"
 
 			//Organised into sections
 			var/civilian_access = list("<br>Staff:")
-			var/list/civilian_access_list = list(access_morgue, access_maint_tunnels, access_chapel_office, access_tech_storage, access_bar, access_janitor, access_crematorium, access_kitchen, access_hydro, access_ranch)
 			var/engineering_access = list("<br>Engineering:")
-			/* Conor12: I removed some unused accesses as the page is large enough, add these if they ever get used:
-			3 (access_armory). Replaced by HoS-exclusive access_maxsec.
-			21 (access_all_personal_lockers). Current personal lockers don't have a master key.
-			36 (access_mail)
-			42 (access_engineering_eva)*/
-			var/list/engineering_access_list = list(access_external_airlocks, access_construction, access_engineering, access_engineering_storage, access_engineering_power, access_engineering_engine, access_engineering_mechanic, access_engineering_atmos, access_engineering_control)
 			var/supply_access = list("<br>Supply:")
-			var/list/supply_access_list = list(access_hangar, access_cargo, access_supply_console, access_mining, access_mining_shuttle, access_mining_outpost)
 			var/research_access = list("<br>Science and Medical:")
-			var/list/research_access_list = list(access_medical, access_tox, access_tox_storage, access_medlab, access_medical_lockers, access_research, access_robotics, access_chemistry, access_pathology)
 			var/security_access = list("<br>Security:")
-			var/list/security_access_list = list(access_security, access_brig, access_forensics_lockers, access_maxsec, access_securitylockers, access_carrypermit, access_contrabandpermit)
 			var/command_access = list("<br>Command:")
-			var/list/command_access_list = list(access_research_director, access_emergency_storage, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_heads, access_captain, access_engineering_chief, access_medical_director, access_head_of_personnel, access_ghostdrone)
 
 			for(var/A in access_name_lookup)
 				if(access_name_lookup[A] in src.modify.access)
@@ -347,39 +341,18 @@
 			if (newcolour == "green")
 				src.modify.icon_state = "id_com"
 	if (href_list["save"])
-		var/slot = href_list["save"]
-		if (slot == "custom1")
-			if (!src.modify.assignment)
-				src.custom1_name = "Custom 1"
-			else
-				src.custom1_name = src.modify.assignment
-			src.custom1_list = src.modify.access.Copy()
-			src.custom1_list -= banned_access_list //prevent saving armory access
-		else if (slot == "custom2")
-			if (!src.modify.assignment)
-				src.custom2_name = "Custom 2"
-			else
-				src.custom2_name = src.modify.assignment
-			src.custom2_list = src.modify.access.Copy()
-			src.custom2_list -= banned_access_list //prevent saving armory access
+		var/slot = text2num(href_list["save"])
+		if (!src.modify.assignment)
+			src.custom_names[slot] = "Custom [slot]"
 		else
-			if (!src.modify.assignment)
-				src.custom3_name = "Custom 3"
-			else
-				src.custom3_name = src.modify.assignment
-			src.custom3_list = src.modify.access.Copy()
-			src.custom3_list -= banned_access_list //prevent saving armory access
+			src.custom_names[slot] = src.modify.assignment
+		src.custom_access_list[slot] = src.modify.access.Copy()
+		src.custom_access_list[slot] &= allowed_access_list //prevent saving non-allowed accesses
 	if (href_list["apply"])
-		var/slot = href_list["apply"]
-		if (slot == "custom1")
-			src.modify.assignment = src.custom1_name
-			src.modify.access = src.custom1_list.Copy()
-		else if (slot == "custom2")
-			src.modify.assignment = src.custom2_name
-			src.modify.access = src.custom2_list.Copy()
-		else
-			src.modify.assignment = src.custom3_name
-			src.modify.access = src.custom3_list.Copy()
+		var/slot = text2num(href_list["apply"])
+		src.modify.assignment = src.custom_names[slot]
+		var/list/selected_access_list = src.custom_access_list[slot]
+		src.modify.access = selected_access_list.Copy()
 	if (src.modify)
 		src.modify.name = "[src.modify.registered]'s ID Card ([src.modify.assignment])"
 	if (src.eject)

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -346,6 +346,8 @@
 			if (newcolour == "green")
 				src.modify.icon_state = "id_com"
 	if (href_list["save"])
+		if (src.modify.assignment == "Head of Security")
+			return
 		var/slot = href_list["save"]
 		if (slot == "custom1")
 			if (!src.modify.assignment)
@@ -353,18 +355,21 @@
 			else
 				src.custom1_name = src.modify.assignment
 			src.custom1_list = src.modify.access.Copy()
+			src.custom1_list -= 37 //prevent saving armory access
 		else if (slot == "custom2")
 			if (!src.modify.assignment)
 				src.custom1_name = "Custom 2"
 			else
 				src.custom2_name = src.modify.assignment
 			src.custom2_list = src.modify.access.Copy()
+			src.custom1_list -= 37 //prevent saving armory access
 		else
 			if (!src.modify.assignment)
 				src.custom3_name = "Custom 3"
 			else
 				src.custom3_name = src.modify.assignment
 			src.custom3_list = src.modify.access.Copy()
+			src.custom1_list -= 37 //prevent saving armory access
 	if (href_list["apply"])
 		var/slot = href_list["apply"]
 		if (slot == "custom1")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds three slots for custom jobs on the menu of the ID card computer. Each saves the job name and access list and can apply it to other cards with the press of a button. Save a job by setting the name and access and hitting save then it can be applied to future cards.

![image](https://user-images.githubusercontent.com/22460970/122517023-be6ca000-cfcc-11eb-8cba-c6e1408a51b7.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It was requested on the forums https://forum.ss13.co/showthread.php?tid=16609 
It saves the HoP time when trying to give the same access level out multiple times or lets the HoP easily build and distribute custom jobs and access levels.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Adds custom job save slots to the ID card computer.
```
