### PR TITLE
Remove rollerskate noslip

### DIFF
--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -1524,7 +1524,6 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves/ring)
 /obj/item/clothing/shoes/rollerskates
 	name = "rollerskates"
 	desc = "A pair of rollerskates, invented when experimental teleportation technology fused a pair of tacky boots and a shopping cart."
-	c_flags = NOSLIP
 	icon_state = "rollerskates"
 
 /obj/item/clothing/under/gimmick/itsyourcousin


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the noslip flag from rollerskates.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Turns out you can get these for 200 in a costume box from the clown vendor, when noslips are meant to be fairly uncommon.
(I've not seen anyone else pick up on this, so practically this only stops my own bullshit)