### PR TITLE
Unregister cloak signal

### DIFF
--- a/code/obj/item/device/cloak_device.dm
+++ b/code/obj/item/device/cloak_device.dm
@@ -48,6 +48,7 @@
 		return 1
 
 	proc/deactivate(mob/user as mob)
+		UnregisterSignal(user, COMSIG_CLOAKING_DEVICE_DEACTIVATE)
 		if(src.active && istype(user))
 			user.visible_message("<span class='notice'><b>[user]'s cloak is disrupted!</b></span>")
 		src.active = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an UnregisterSignal call to the cloaking device's deactivate proc.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cloaking device never unregisters it's signal causing a stack trace when activated a second time.