### PR TITLE
Changes the material costs of the nuclear charge

### DIFF
--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1037,7 +1037,7 @@
 
 #define DISARM_CUTOFF 10 //Can't disarm past this point! OH NO!
 
-	mats = 80 //haha this is a bad idea
+	mats = list("POW-3"=113, "MET-3" = 134, "CON-2" = 117, "DEN-3" = 142) //haha this is a bad idea
 	deconstruct_flags = DECON_NONE
 	is_syndicate = 1 //^ Agreed
 

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1037,7 +1037,7 @@
 
 #define DISARM_CUTOFF 10 //Can't disarm past this point! OH NO!
 
-	mats = list("POW-3"=113, "MET-3" = 134, "CON-2" = 117, "DEN-3" = 142) //haha this is a bad idea
+	mats = list("POW-3" = 27, "MET-3" = 25, "CON-2" = 13, "DEN-3" = 15) //haha this is a bad idea
 	deconstruct_flags = DECON_NONE
 	is_syndicate = 1 //^ Agreed
 


### PR DESCRIPTION
[Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Alters the material costs of a nuclear charge from 80 generic materials to a more complex recipe which is:
27 Extreme Power Source
25 Dense Metal
13 High Energy Conductor
15 Extremely Dense Crystalline Matter

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A nuclear charge is about the size of a canbomb. You shouldn't be able to fabricate something like that without some effort in my opinion.

## Changelog

```changelog
(u)DimWhat
(*) Made fabricating a nuclear charge take more difficult materials
```
