### PR TITLE
remove syndie scanner from zone, adds security robot blueprint

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -123,6 +123,14 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	create = 1
 	frame_path = /obj/machinery/ai_status_display
 
+/datum/manufacture/mechanics/gunbot
+	name = "Security Robot"
+	item_paths = list("POW-1","MET-2","CON-1")
+	item_amounts = list(1,10,10,10)
+	frame_path = /obj/critter/gunbot/heavy
+	time = 15 SECONDS
+	create = 1
+
 /*
 /datum/manufacture/iron
 	// purely a test

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -642,7 +642,6 @@ This is basically useless for anyone but miners.
 	cost = 4
 	vr_allowed = 0
 	desc = "The shell of a standard Nanotrasen mechanic's analyzer with cutting-edge Syndicate internals. This baby can scan almost anything!"
-	not_in_crates = 1
 	job = list("Mechanic")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
 

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1892,6 +1892,7 @@
 	icon_state = "blueprint"
 	item_state = "sheet"
 	var/datum/manufacture/blueprint = null
+	var/override_name_desc = 1
 
 
 
@@ -1915,9 +1916,9 @@
 		if (!src.blueprint)
 			qdel(src)
 			return 0
-
-		src.name = "Manufacturer Blueprint: [src.blueprint.name]"
-		src.desc = "This blueprint will allow a manufacturer unit to build a [src.blueprint.name]"
+		if(src.override_name_desc)
+			src.name = "Manufacturer Blueprint: [src.blueprint.name]"
+			src.desc = "This blueprint will allow a manufacturer unit to build a [src.blueprint.name]"
 
 		src.pixel_x = rand(-4,4)
 		src.pixel_y = rand(-4,4)
@@ -2001,6 +2002,16 @@
 	icon = 'icons/obj/writing.dmi'
 	icon_state = "interdictor_blueprint"
 	blueprint = /datum/manufacture/interdictor_rod_sigma
+
+/******************** Phaser Drone *******************/
+/obj/item/paper/manufacturer_blueprint/gunbot
+	name = "Security Robot blueprint"
+	icon = 'icons/obj/electronics.dmi'
+	info = "<h3>AP-Class Security Robot</h3><i>A schematic blueprint for a security robot, modified to fit a station-grade manufacturer.</i>"
+	icon_state = "blueprint"
+	item_state = "sheet"
+	blueprint = /datum/manufacture/mechanics/gunbot
+	override_name_desc = 0
 
 // Fabricator Defines
 

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -20753,8 +20753,9 @@
 /area/drone)
 "bmq" = (
 /obj/table/reinforced/auto,
-/obj/item/electronics/scanner/syndicate,
+/obj/item/electronics/scanner,
 /obj/item/electronics/soldering,
+/obj/item/paper/manufacturer_blueprint/gunbot,
 /turf/unsimulated/floor/red/side{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes mechanic-unique syndicate device analyzer from adventure zone, adds a (frame) blueprint for the security robots guarding the area in its place


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having it there makes it too common for people to be scanning and mass-producing nukes/drones/etc.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Tarmunora
(+)Replaced a certain syndicate device analyzer with a certain specific manufacturing blueprint
(+)Added syndicate device analyzers to surplus crate pool
```
