### PR TITLE
Allows CE to purchase the Syndicate Device Analyzer

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -642,7 +642,7 @@ This is basically useless for anyone but miners.
 	cost = 4
 	vr_allowed = 0
 	desc = "The shell of a standard Nanotrasen mechanic's analyzer with cutting-edge Syndicate internals. This baby can scan almost anything!"
-	job = list("Mechanic")
+	job = list("Mechanic", "Chief Engineer")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/stimulants


### PR DESCRIPTION
## About the PR 
Allows the CE to purchase the Syndicate Device Analyzer


## Why's this needed? 
It feels sensible for the CE, the manager of the mechanics, to have access to the syndicate device analyzer, and it could create interesting gameplay. The scanner requires a level of setup and discretion, similar to the mindslave cloning module which is available to Medical directors, doctors, and geneticists.  It also allows for contraband in the ruck kit to cast suspicion on both mechanics and the CE, which i think could create interesting situations.


## Changelog

```changelog
(u)COOLVAPE
(+)Allows CE to purchase the Syndicate Device Analyzer
```
