### PR TITLE
Add Donut 2 Nuke Plant Sites

### DIFF
--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -89,6 +89,17 @@
 			"the artifact lab" = list(/area/station/science/artifact),
 			"the robotics lab" = list(/area/station/medical/robotics))
 
+		else if (ismap ("DONUT2"))
+			target_locations = list("the bridge" = list(/area/station/bridge),
+			"the chapel" = list(/area/station/chapel/sanctuary),
+			"the medbay" = list(/area/station/medical/medbay),
+			"the genetic lab" = list(/area/station/medical/research),
+			"the public tool storage" = list(/area/station/storage/tools),
+			"the brig" = list(/area/station/security/brig),
+			"the cargo bay(QM)" = list(/area/station/quartermaster/office),
+			"the hydroponics bay(Botany)" = list(/area/station/hydroponics/bay))
+
+
 		else // COG1
 			target_locations = list("the main security room" = list(/area/station/security/main),
 			"the central research sector hub" = list(/area/station/science/lobby),


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds some nuke plant sites to donut 2 so it doesn't try to pull an area that doesn't exist

Plant sites:
Chapel
Medbay
Genetics
Tool Storage (the one to the right of atmos)
Brig
QM
Botany
