### PR TITLE
Make c-sabers red for nukies

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -191,6 +191,12 @@ proc/build_syndi_buylist_cache()
 	not_in_crates = 1
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
 
+	run_on_spawn(obj/item/sword/stabby, mob/living/owner, in_surplus_crate=FALSE) //Nukies get red ones
+		if (isnukeop(owner))
+			stabby.light_c.set_color(255, 0, 0)
+			stabby.bladecolor = "R"
+		return
+
 /datum/syndicate_buylist/generic/katana
 	name = "Katana"
 	item = /obj/item/katana_sheath


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so any c-sabers that get spawned by nukies turn red.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
IIRC Gannets wanted to do this, what with the red/black theme they've got going on.