### PR TITLE
Fix for issue #4494: Sheaths should be visible above overcoats

### DIFF
--- a/_std/defines/layer.dm
+++ b/_std/defines/layer.dm
@@ -30,8 +30,9 @@
 #define MOB_HAIR_LAYER2 	(MOB_OVERLAY_BASE-6)
 #define MOB_GLASSES_LAYER	(MOB_OVERLAY_BASE-7)
 #define MOB_BACK_LAYER 		(MOB_OVERLAY_BASE-8)
-#define MOB_OVERSUIT_LAYER1 (MOB_OVERLAY_BASE-8.7)	// For mutant oversuit (de)tails when facing north
-#define MOB_OVERSUIT_LAYER2 (MOB_OVERLAY_BASE-8.8)	// If we have another one
+#define MOB_OVERSUIT_LAYER1 (MOB_OVERLAY_BASE-8.6)	// For mutant oversuit (de)tails when facing north
+#define MOB_OVERSUIT_LAYER2 (MOB_OVERLAY_BASE-8.7)	// If we have another one
+#define MOB_SHEATH_LAYER 	(MOB_OVERLAY_BASE-8.8)
 #define MOB_BACK_LAYER_SATCHEL  (MOB_OVERLAY_BASE-8.9)  // For satchels so they don't show over a tail or something
 #define MOB_ARMOR_LAYER 	(MOB_OVERLAY_BASE-9)
 #define MOB_HAND_LAYER2 	(MOB_OVERLAY_BASE-10) 	// gloves

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1193,6 +1193,7 @@
 	desc = "It can clean a bloodied katana, and also allows for easier storage of a katana"
 	icon = 'icons/obj/items/weapons.dmi'
 	icon_state = "katana_sheathed"
+	wear_layer = MOB_SHEATH_LAYER
 	uses_multiple_icon_states = 1
 	inhand_image_icon = 'icons/mob/inhand/hand_weapons.dmi'
 	item_state = "sheathedhand"


### PR DESCRIPTION
## About the PR
Adds a new mob layer for sheaths that sits just above satchels.

## Why's this needed?
Sheaths currently display under overcoats (see issue #4494), but they needed a new layer as they couldn't be placed on the same layer as satchels (because they are sometimes on the same hip).

## Changelog
```changelog
(u)Sasskp
(+)Added new layer for sheaths so they appear above overcoats
```

Sheath worn **without** an overcoat:
![no_coat_plus_sheath](https://user-images.githubusercontent.com/5334580/122664980-eb48cf00-d1e7-11eb-91b5-d09cbe8253f5.PNG)

Some of the sheaths worn **with** an overcoat:
![coat_plus_reverse_sheath](https://user-images.githubusercontent.com/5334580/122664978-ea17a200-d1e7-11eb-8f0f-3ed4d8e354f1.PNG)
![coat_plus_sheath](https://user-images.githubusercontent.com/5334580/122664979-eab03880-d1e7-11eb-9410-b8ab8350a1cd.PNG)
![space_suit_plus_sheath](https://user-images.githubusercontent.com/5334580/122664981-eb48cf00-d1e7-11eb-8193-f9864ae86569.PNG)
![syndicate_sheath](https://user-images.githubusercontent.com/5334580/122664984-ec79fc00-d1e7-11eb-9613-fb9bc228235e.PNG)

Sheath worn on the same hip as a satchel, with an overcoat:
![standard_katana_with_satchel](https://user-images.githubusercontent.com/5334580/122664983-ebe16580-d1e7-11eb-92bc-c28161b55cf7.PNG)

