### PR TITLE
Fix %target% messages for custom critters

### DIFF
--- a/code/obj/critter/critter_parent.dm
+++ b/code/obj/critter/critter_parent.dm
@@ -108,6 +108,7 @@
 		if (!message || !length(message))
 			return
 		var/msg = replacetext(message, "%src%", "<b>[src]</b>")
+		msg = replacetext(msg, "%target%", "[target]")
 		msg = replacetext(msg, "[constructTarget(target,"combat")]", "[target]")
 		src.visible_message("<span class='alert'>[msg]</span>")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes admin spawned custom critters not replacing %target% messages with the name of the target.
I doubt think this is the ideal solution.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If an admin uses custom critters chat is full of "xyz attacks %target%!"