### PR TITLE
add other organs to surgery artifacts

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -414,6 +414,7 @@
 						src.l_arm.delete()
 					src.l_arm = new /obj/item/parts/human_parts/arm/left/item(src.holder, new new_type(src.holder))
 				src.holder.organs["l_arm"] = src.l_arm
+				src.holder.hud.update_hands()
 				if (show_message)
 					src.holder.show_message("<span class='notice'><b>Your left arm [pick("magically ", "weirdly ", "suddenly ", "grodily ", "")]becomes [src.l_arm]!</b></span>")
 				if (user)
@@ -430,6 +431,7 @@
 						src.r_arm.delete()
 					src.r_arm = new /obj/item/parts/human_parts/arm/right/item(src.holder, new new_type(src.holder))
 				src.holder.organs["r_arm"] = src.r_arm
+				src.holder.hud.update_hands()
 				if (show_message)
 					src.holder.show_message("<span class='notice'><b>Your right arm [pick("magically ", "weirdly ", "suddenly ", "grodily ", "")]becomes [src.r_arm]!</b></span>")
 				if (user)

--- a/code/obj/artifacts/artifact_objects/augmentor.dm
+++ b/code/obj/artifacts/artifact_objects/augmentor.dm
@@ -75,17 +75,17 @@
 			augment = new /datum/artifact_augmentation/borg()
 		// which body parts should be augmented?
 
-		if(prob(35))
+		if(prob(augment.area_chance))
 			augment_location += "limbs"
-		if(prob(35))
+		if(prob(augment.area_chance))
 			augment_location += "eyes"
-		if(prob(25))
+		if(prob(augment.area_chance))
 			augment_location += "organs_1"
-		if(prob(25))
+		if(prob(augment.area_chance))
 			augment_location += "organs_2"
-		if(prob(25))
+		if(prob(augment.area_chance))
 			augment_location += "organs_3"
-		if(prob(25))
+		if(prob(augment.area_chance))
 			augment_location += "organs_4"
 		if(!length(augment_location)) // just to be sure
 			augment_location += "limbs"
@@ -187,6 +187,8 @@
 	var/list/organs_2 = list("pancreas", "liver", "spleen")
 	var/list/organs_3 = list("left_lung", "right_lung", "heart")
 	var/list/organs_4 = list("left_kidney", "right_kidney", "appendix")
+
+	var/area_chance = 25
 
 	New()
 		..()

--- a/code/obj/artifacts/artifact_objects/augmentor.dm
+++ b/code/obj/artifacts/artifact_objects/augmentor.dm
@@ -123,7 +123,9 @@
 			var/replace_action = "appends something else"
 			if(part)
 				if(istype(part, /obj/item/parts)) // LIMBS
-					//var/obj/item/parts/limb = part
+					var/obj/item/parts/old_limb = H.limbs.get_limb(part_loc)
+					if(old_limb)
+						old_limb.remove(FALSE)
 					H.limbs.replace_with(part_loc, part_type, null , 0)
 					H.update_body()
 					remove_action = pick("tears off", "yanks off", "chops off")
@@ -131,6 +133,7 @@
 					ArtifactLogs(user, null, O, "touched by [H.real_name]", "given limb [part] as [part_loc]", 0)
 				else // ORGANS
 					var/obj/item/organ = part
+					H.drop_organ(part_loc)
 					H.receive_organ(organ, part_loc, 0, 1)
 					H.update_body()
 					remove_action = pick("rips out", "tears out", "swiftly removes")

--- a/code/obj/artifacts/artifact_objects/augmentor.dm
+++ b/code/obj/artifacts/artifact_objects/augmentor.dm
@@ -15,7 +15,7 @@
 	deact_text = "closes itself up."
 	react_xray = list(6,75,60,11,"SEGMENTED")
 	var/datum/artifact_augmentation/augment = null
-	var/augment_location = "limb"
+	var/augment_location = list()
 	var/recharge_time = 600
 	var/recharging = 0
 	var/working = 0
@@ -33,7 +33,18 @@
 		"left_eye" = "left eye",
 		"right_eye" = "right eye",
 		"heart" = "heart",
-		"butt" = "butt")
+		"butt" = "butt",
+		"stomach" = "stomach",
+		"intestines" = "intestines",
+		"tail" = "tail",
+		"pancreas" = "pancreas",
+		"liver" = "liver",
+		"spleen" = "spleen",
+		"left_lung" = "left lung",
+		"right_lung" = "right lung",
+		"left_kidney" = "left kidney",
+		"right_kidney" = "right kidney",
+		"appendix" = "appendix")
 
 	// lazy initialiser for augmentation datum cache
 	proc/get_augmentation(var/type)
@@ -62,10 +73,22 @@
 			// we don't have augmentation data!!
 			// backup: instantiate our own borg datum
 			augment = new /datum/artifact_augmentation/borg()
-		// does this augment externally or internally?
-		augment_location = pick("limb", "organ")
-		if(prob(5))
-			augment_location = "all"
+		// which body parts should be augmented?
+
+		if(prob(35))
+			augment_location += "limbs"
+		if(prob(35))
+			augment_location += "eyes"
+		if(prob(25))
+			augment_location += "organs_1"
+		if(prob(25))
+			augment_location += "organs_2"
+		if(prob(25))
+			augment_location += "organs_3"
+		if(prob(25))
+			augment_location += "organs_4"
+		if(!length(augment_location)) // just to be sure
+			augment_location += "limbs"
 
 	effect_touch(var/obj/O,var/mob/living/user)
 		if (..())
@@ -142,10 +165,25 @@
 	var/list/eye = list()
 	var/list/heart = list()
 	var/list/butt = list()
+	var/list/stomach = list()
+	var/list/intestines = list()
+	var/list/tail = list()
+	var/list/pancreas = list()
+	var/list/liver = list()
+	var/list/spleen = list()
+	var/list/left_lung = list() // unlike eyes, there is actually left and right types
+	var/list/right_lung = list()
+	var/list/left_kidney = list()
+	var/list/right_kidney = list()
+	var/list/appendix = list()
 
-	var/list/part_list = list("l_arm", "r_arm", "l_leg", "r_leg", "left_eye", "right_eye", "heart", "butt")
+	var/list/part_list = list()
 	var/list/limbs = list("l_arm", "r_arm", "l_leg", "r_leg")
-	var/list/organs = list("left_eye", "right_eye", "heart", "butt")
+	var/list/eyes = list("left_eye", "right_eye")
+	var/list/organs_1 = list("stomach", "intestines", "butt", "tail")
+	var/list/organs_2 = list("pancreas", "liver", "spleen")
+	var/list/organs_3 = list("left_lung", "right_lung", "heart")
+	var/list/organs_4 = list("left_kidney", "right_kidney", "appendix")
 
 	New()
 		..()
@@ -157,18 +195,42 @@
 		part_list["right_eye"] = eye
 		part_list["heart"] = heart
 		part_list["butt"] = butt
+		part_list["stomach"] = stomach
+		part_list["intestines"] = intestines
+		part_list["tail"] = tail
+		part_list["pancreas"] = pancreas
+		part_list["liver"] = liver
+		part_list["spleen"] = spleen
+		part_list["left_lung"] = left_lung
+		part_list["right_lung"] = right_lung
+		part_list["left_kidney"] = left_kidney
+		part_list["right_kidney"] = right_kidney
+		part_list["appendix"] = appendix
 
 	proc/get_part_target(var/mob/living/carbon/human/H, var/part_category)
 		if(!H) return
 		var/list/available_parts = part_list.Copy()
-		switch(part_category)
-			if("limb")
-				available_parts &= limbs
-			if("organ")
-				available_parts &= organs
-			// else, do nothing (all inclusive!!)
+		var/list/parts = list()
+		for (var/body_area in part_category)
+			switch(body_area)
+				if("limbs")
+					parts += limbs
+				if("eyes")
+					parts += eyes
+				if("organs_1")
+					parts += organs_1
+				if("organs_2")
+					parts += organs_2
+				if("organs_3")
+					parts += organs_3
+				if("organs_4")
+					parts += organs_4
+		available_parts &= parts
 		if(!H.organs)
-			available_parts -= organs
+			available_parts -= organs_1
+			available_parts -= organs_2
+			available_parts -= organs_3
+			available_parts -= organs_4
 		if(!H.limbs)
 			available_parts -= limbs
 		if(available_parts.len <= 0)
@@ -177,10 +239,13 @@
 		var/list/missing_parts = list()
 		var/list/candidates_to_remove = list()
 		for(var/part_loc in available_parts)
+			if(!length(available_parts[part_loc])) // sorry, we do not sell tails here
+				candidates_to_remove += part_loc
+				continue
 			var/obj/item/bodypart = null
 			if(part_loc in limbs)
 				bodypart = H.limbs.get_limb(part_loc)
-			if(part_loc in organs)
+			else
 				bodypart = H.get_organ(part_loc)
 			if(!bodypart)
 				missing_parts += part_loc
@@ -224,6 +289,17 @@
 	eye = list(/obj/item/organ/eye/cyber,/obj/item/organ/eye/cyber/sunglass,/obj/item/organ/eye/cyber/sechud,/obj/item/organ/eye/cyber/thermal,/obj/item/organ/eye/cyber/meson,/obj/item/organ/eye/cyber/spectro,/obj/item/organ/eye/cyber/prodoc,/obj/item/organ/eye/cyber/ecto,/obj/item/organ/eye/cyber/camera,/obj/item/organ/eye/cyber/nightvision,/obj/item/organ/eye/cyber/laser)
 	heart = list(/obj/item/organ/heart/cyber)
 	butt = list(/obj/item/clothing/head/butt/cyberbutt)
+	stomach = list(/obj/item/organ/stomach/cyber)
+	intestines = list(/obj/item/organ/intestines/cyber)
+	tail = list()
+	pancreas = list(/obj/item/organ/pancreas/cyber)
+	liver = list(/obj/item/organ/liver/cyber)
+	spleen = list(/obj/item/organ/spleen/cyber)
+	left_lung = list(/obj/item/organ/lung/cyber/left)
+	right_lung = list(/obj/item/organ/lung/cyber/right)
+	left_kidney = list(/obj/item/organ/kidney/cyber/left)
+	right_kidney = list(/obj/item/organ/kidney/cyber/right)
+	appendix = list(/obj/item/organ/appendix/cyber)
 
 /datum/artifact_augmentation/synth
 	left_arm = list(/obj/item/parts/human_parts/arm/left/synth, /obj/item/parts/human_parts/arm/left/synth/bloom)
@@ -233,3 +309,14 @@
 	eye = list(/obj/item/organ/eye/synth)
 	heart = list(/obj/item/organ/heart/synth)
 	butt = list(/obj/item/clothing/head/butt/synth)
+	stomach = list(/obj/item/organ/stomach/synth)
+	intestines = list(/obj/item/organ/intestines/synth)
+	tail = list()
+	pancreas = list(/obj/item/organ/pancreas/synth)
+	liver = list(/obj/item/organ/liver/synth)
+	spleen = list(/obj/item/organ/spleen/synth)
+	left_lung = list(/obj/item/organ/lung/synth/left)
+	right_lung = list(/obj/item/organ/lung/synth/right)
+	left_kidney = list(/obj/item/organ/kidney/synth/left)
+	right_kidney = list(/obj/item/organ/kidney/synth/right)
+	appendix = list(/obj/item/organ/appendix/synth)

--- a/code/obj/artifacts/artifact_objects/augmentor.dm
+++ b/code/obj/artifacts/artifact_objects/augmentor.dm
@@ -140,7 +140,7 @@
 					replace_action = pick("inserts something else where it was", "places something else inside", "shoves something else in their body")
 					ArtifactLogs(user, null, O, "touched by [H.real_name]", "given organ [part] as [part_loc]", 0)
 
-				T.visible_message("<span class='alert'><b>[O]</b> [remove_action] [H.name]'s [organ_names[part_loc]], pulls it inside and [replace_action]![pick("", "Holy fuck!", "It looks incredibly painful!")]</span>")
+				T.visible_message("<span class='alert'><b>[O]</b> [remove_action] [H.name]'s [organ_names[part_loc]], pulls it inside and [replace_action]! [pick("", "Holy fuck!", "It looks incredibly painful!")]</span>")
 
 			playsound(H.loc, pick(work_sounds), 50, 1, -1)
 			boutput(H, "<span class='alert'><b>[pick("IT HURTS!", "OH GOD!", "JESUS FUCK!")]</b></span>")

--- a/code/obj/artifacts/artifact_objects/augmentor.dm
+++ b/code/obj/artifacts/artifact_objects/augmentor.dm
@@ -122,6 +122,7 @@
 			var/remove_action = "removes"
 			var/replace_action = "appends something else"
 			if(part)
+				src.augment.modify_part(part)
 				if(istype(part, /obj/item/parts)) // LIMBS
 					var/obj/item/parts/old_limb = H.limbs.get_limb(part_loc)
 					if(old_limb)
@@ -286,6 +287,9 @@
 				. = 1
 				return // early interrupt the for loop, we don't need to check further
 
+	proc/modify_part(var/obj/item/bodypart)
+		return
+
 /datum/artifact_augmentation/borg
 	left_arm = list(/obj/item/parts/robot_parts/arm/left/light, /obj/item/parts/robot_parts/arm/left)
 	right_arm = list(/obj/item/parts/robot_parts/arm/right/light, /obj/item/parts/robot_parts/arm/right)
@@ -305,6 +309,11 @@
 	left_kidney = list(/obj/item/organ/kidney/cyber/left)
 	right_kidney = list(/obj/item/organ/kidney/cyber/right)
 	appendix = list(/obj/item/organ/appendix/cyber)
+
+	modify_part(var/obj/item/bodypart)
+		if(istype(bodypart, /obj/item/organ/kidney/cyber))
+			var/obj/item/organ/kidney/cyber/kidney = bodypart
+			kidney.randomize_modifier()
 
 /datum/artifact_augmentation/synth
 	left_arm = list(/obj/item/parts/human_parts/arm/left/synth, /obj/item/parts/human_parts/arm/left/synth/bloom)

--- a/code/obj/item/organs/eye.dm
+++ b/code/obj/item/organs/eye.dm
@@ -358,10 +358,9 @@
 
 	New()
 		..()
-		SPAWN_DBG(0)
-			src.camera = new /obj/machinery/camera(src)
-			src.camera.c_tag = src.camera_tag
-			src.camera.network = src.camera_network
+		src.camera = new /obj/machinery/camera(src)
+		src.camera.c_tag = src.camera_tag
+		src.camera.network = src.camera_network
 
 	on_transplant(var/mob/M as mob)
 		..()

--- a/code/obj/item/organs/kidney.dm
+++ b/code/obj/item/organs/kidney.dm
@@ -7,6 +7,9 @@
 	icon_state = "kidneys"
 	failure_disease = /datum/ailment/disease/kidney_failure
 	var/chem_metabolism_modifier = 1
+	// this is just used for setting them, so I will use the *100 values
+	var/min_chem_metabolism_modifier = 100
+	var/max_chem_metabolism_modifier = 100
 
 	on_life(var/mult = 1)
 		if (!..())
@@ -96,6 +99,14 @@
 		else
 			return 0
 
+	/// sets the chem_metabolism_modifier for this kidney, clamping it to the min and max value and dividing it by 100
+	proc/set_chem_metabolism_modifier(var/new_modifier)
+		src.chem_metabolism_modifier = clamp(new_modifier, src.min_chem_metabolism_modifier, src.max_chem_metabolism_modifier)/100
+
+	/// randomizes the kidneys chem_metabolism_modifier to a value between its min and max
+	proc/randomize_modifier()
+		src.set_chem_metabolism_modifier(rand(src.min_chem_metabolism_modifier, src.max_chem_metabolism_modifier))
+
 /obj/item/organ/kidney/left
 	name = "left kidney"
 	organ_name = "kidney_L"
@@ -132,6 +143,8 @@
 	created_decal = /obj/decal/cleanable/oil
 	edible = 0
 	mats = 6
+	min_chem_metabolism_modifier = 75
+	max_chem_metabolism_modifier = 150
 
 	emag_act(mob/user, obj/item/card/emag/E)
 		. = ..()
@@ -172,8 +185,10 @@
 
 	attackby(obj/item/W, mob/user)
 		if(ispulsingtool(W)) //TODO kyle's robotics configuration console/machine/thing
-			chem_metabolism_modifier = input(user, "Enter a percentage to clock the cyberkidney at, from 75 to 150.", "Organ clocking", "100") as num
-			chem_metabolism_modifier = clamp(chem_metabolism_modifier, 75, 150) / 100
+			var/new_modifier = input(user, \
+			"Enter a percentage to clock the cyberkidney at, from [src.min_chem_metabolism_modifier] to [src.max_chem_metabolism_modifier].",\
+			 "Organ clocking", "100") as num
+			src.set_chem_metabolism_modifier(new_modifier)
 		else
 			. = ..()
 

--- a/code/obj/item/organs/kidney.dm
+++ b/code/obj/item/organs/kidney.dm
@@ -187,7 +187,7 @@
 		if(ispulsingtool(W)) //TODO kyle's robotics configuration console/machine/thing
 			var/new_modifier = input(user, \
 			"Enter a percentage to clock the cyberkidney at, from [src.min_chem_metabolism_modifier] to [src.max_chem_metabolism_modifier].",\
-			 "Organ clocking", "100") as num
+			 "Organ clocking", src.chem_metabolism_modifier*100) as num
 			src.set_chem_metabolism_modifier(new_modifier)
 		else
 			. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that surgery artifacts can also give people organs apart from butts and hearts now.
For this there are now 6 areas
- limbs
- eyes
- stomach, intestines, butt, tail
- pancreas, liver, spleen
- lungs, heart
- kidneys (will also randomize their metabolism modifier), appendix
Any given artifact might be able to replace body parts in any combination of these 6 areas.

I also made it so that body parts that are no longer used are dropped, so you can collect them and sell them for cash.

There was also a runtime for camera eyes, since those were created and then instantly implanted, the SPAWN_DBG delay in the new() of them was too late.
I removed it and they seemed to still work fine? I am not sure why it was there.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it'd be fun!
I tried to kinda spread the good body parts through the 6 groups, so you'll usually get something nice if it's a cyber type artifact.
But usually it will only have 1-3 areas, so hopefully it won't put roboticists out of a job.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+)Surgery type artifacts can now replace all kinds of organs.
```
