### PR TITLE
Deconstruct destruction

### DIFF
--- a/_std/defines/construction.dm
+++ b/_std/defines/construction.dm
@@ -43,5 +43,5 @@
 #define DECON_BUILT 128
 /// can only be deconstructed if access required is null
 #define DECON_ACCESS 256
-/// item will be destroyed and remade on re-deployment
+/// item will be saved by path instead of stored in the frame
 #define DECON_DESTRUCT 512

--- a/_std/defines/construction.dm
+++ b/_std/defines/construction.dm
@@ -43,3 +43,5 @@
 #define DECON_BUILT 128
 /// can only be deconstructed if access required is null
 #define DECON_ACCESS 256
+/// item will be destroyed and remade on re-deployment
+#define DECON_DESTRUCT 512

--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -874,11 +874,14 @@
 		playsound(user.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		user.visible_message("<B>[user.name]</B> deconstructs [target].")
 
-
 		var/obj/item/electronics/frame/F = new(get_turf(target))
 		F.name = "[target.name] frame"
-		F.deconstructed_thing = target
-		O.set_loc(F)
+		if(O.deconstruct_flags & DECON_DESTRUCT)
+			F.store_type = O.type
+			qdel(O)
+		else
+			F.deconstructed_thing = target
+			O.set_loc(F)
 		F.viewstat = 2
 		F.secured = 2
 		F.icon_state = "dbox_big"

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -100,6 +100,7 @@
 
 		..()
 
+
 /obj/machinery/networked/storage
 	name = "Databank"
 	desc = "A networked data storage device."
@@ -108,7 +109,7 @@
 	icon_state = "tapedrive0"
 	device_tag = "PNET_DATA_BANK"
 	mats = 12
-	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL | DECON_DESTRUCT
 	var/base_icon_state = "tapedrive"
 	var/bank_id = null //Unique Identifier for this databank.
 	var/locked = 1
@@ -1362,7 +1363,7 @@
 	device_tag = "PNET_PR6_RADIO"
 	//var/freq = 1219
 	mats = 8
-	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_MULTITOOL | DECON_DESTRUCT
 	var/list/frequencies = list()
 	var/datum/radio_frequency/radio_connection
 	var/transmission_range = 100 //How far does our signal reach?
@@ -1690,7 +1691,7 @@
 	desc = "A networked printer.  It's designed to print."
 	anchored = 1
 	density = 1
-	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WIRECUTTERS | DECON_MULTITOOL
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_WIRECUTTERS | DECON_MULTITOOL | DECON_DESTRUCT
 	icon_state = "printer0"
 	device_tag = "PNET_PRINTDEVC"
 	mats = 6
@@ -2153,6 +2154,7 @@
 	anchored = 1
 	density = 1
 	icon_state = "scanner0"
+	deconstruct_flags = DECON_DESTRUCT
 	//device_tag = "PNET_SCANDEVC"
 	var/scanning = 0 //Are we scanning RIGHT NOW?
 	var/obj/item/scanned_thing //Ideally, this would be a paper or photo.
@@ -3392,6 +3394,7 @@
 	//Don't forget to give devices unique device_tag values of the form "PNET_XXXXXXXXX"
 	device_tag = "PNET_TEST_APPT" //This is the device tag used to interface with the mainframe GTPIO driver.
 	mats = 8
+	deconstruct_flags = DECON_DESTRUCT
 
 	power_usage = 200
 	var/dragload = 0 // can we click-drag a machinery-type artifact into this machine?

--- a/code/modules/networks/computer3/mainframe2/telesci.dm
+++ b/code/modules/networks/computer3/mainframe2/telesci.dm
@@ -56,6 +56,7 @@ proc/is_teleportation_allowed(var/turf/T)
 	desc = "Stand on this to have your wildest dreams come true!"
 	device_tag = "PNET_S_TELEPAD"
 	plane = PLANE_NOSHADOW_BELOW
+	deconstruct_flags = DECON_DESTRUCT
 	var/recharging = 0
 	var/realx = 0
 	var/realy = 0
@@ -807,6 +808,7 @@ proc/is_teleportation_allowed(var/turf/T)
 	device_tag = "SRV_TERMINAL"
 	timeout = 10
 	mats = 14
+	deconstruct_flags = DECON_DESTRUCT
 	var/xtarget = 0
 	var/ytarget = 0
 	var/ztarget = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[QOL] [BUGFIX]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a deconstruct flag DECON_DESTRUCT that saves the path of the item when deconstructed instead of the original item.
This flag is added to basically all of the network equipment for the mainframe and the telescience equipment, so that it can actually connect to a terminal when re-deployed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Usually the best solution to a problem is also the easiest.
Also Matheus needs this for firelocks and light switches and stuff.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Penny
(+)Networked equipment can finally now be re-deployed onto new data terminals
```
