### PR TITLE
Broken APC examine text + actionbars

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -407,14 +407,8 @@ var/zapLimiter = 0
 					else
 						boutput(user, "<span class='alert'>Not enough cable! <I>(Requires four pieces)</I></span>")
 						return
-					if(!do_after(user, 100))
-						return
-					theCoil.use(4)
-					boutput(user, "You repair the autotransformer.")
-					playsound(src.loc, "sound/items/Deconstruct.ogg", 50, 1)
-
-					src.repair_status = 2
-
+					SETUP_GENERIC_ACTIONBAR(user, src, 10 SECONDS, /obj/machinery/power/apc/proc/fix_wiring,\
+					list(theCoil, user), W.icon, W.icon_state, null, null)
 					return
 				if (2)
 					boutput(user, "The autotransformer is already in good condition, it just needs tuning.")
@@ -430,11 +424,8 @@ var/zapLimiter = 0
 					boutput(user, "<span class='alert'>You must repair the autotransformer's windings prior to tuning it.</span>")
 				if (2)
 					boutput(user, "You begin to carefully tune the autotransformer.  This might take a little while.")
-					if (!do_after(user, 6 SECONDS))
-						return
-					boutput(user, "You tune the autotransformer.")
-					playsound(src.loc, "sound/items/Ratchet.ogg", 50, 1)
-					src.repair_status = 3
+					SETUP_GENERIC_ACTIONBAR(user, src, 6 SECONDS, /obj/machinery/power/apc/proc/fix_autotransformer,\
+					list(user), W.icon, W.icon_state, null, null)
 				else
 					boutput(user, "The autotransformer is already tuned.")
 
@@ -538,6 +529,17 @@ var/zapLimiter = 0
 				updateicon()
 			else
 				boutput(user, "<span class='alert'>Access denied.</span>")
+
+/obj/machinery/power/apc/proc/fix_wiring(obj/item/W, mob/user)
+	W.change_stack_amount(-4)
+	boutput(user, "You repair the autotransformer.")
+	playsound(src.loc, "sound/items/Deconstruct.ogg", 50, 1)
+	src.repair_status = 2
+
+/obj/machinery/power/apc/proc/fix_autotransformer(mob/user)
+	boutput(user, "You tune the autotransformer.")
+	playsound(src.loc, "sound/items/Ratchet.ogg", 50, 1)
+	src.repair_status = 3
 
 
 /obj/machinery/power/apc/attack_ai(mob/user)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -196,6 +196,17 @@ var/zapLimiter = 0
 	. = ..()
 
 	if(status & BROKEN)
+		switch(repair_status)
+			if(0)
+				. += "<br>It's completely busted! It seems you need to use a screwdriver and disconnect the control board first, to begin the repair process.</br>"
+			if(1)
+				. += "<br>The control board has been disconnected. The autotransformer's wiring is all messed up! You need to grab some cables and fix it.</br>"
+			if(2)
+				. += "<br>The control panel is disconnected and the autotransformer seems to be in a good condition. You just need to tune it with a wrench now.</br>"
+			if(3)
+				. += "<br>The autotransformer seems to be working fine now. The next step is resetting the control board with a multitool.</br>"
+			if(4)
+				. += "<br>The autotransformer is working fine and the control board has been reset! Now you just need to reconnect it with a screwdriver, to finish the repair process.</br>"
 		return
 
 	if(user && !user.stat)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -541,7 +541,6 @@ var/zapLimiter = 0
 	playsound(src.loc, "sound/items/Ratchet.ogg", 50, 1)
 	src.repair_status = 3
 
-
 /obj/machinery/power/apc/attack_ai(mob/user)
 	if (src.aidisabled && !src.wiresexposed)
 		boutput(user, "AI control for this APC interface has been disabled.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds examine text with a hint for each step of fixing the broken APC + actionbars for all the steps that require the player to stand still for a few seconds.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently there is no way to learn how to fix the APC without mentorhelp or using the wiki, so having it exaplained in the form of examine text is good. Also actionbars are always nicer than do_after.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)You can now examine the broken APC to learn how to fix it. Also added actionbars for all the APC fixing steps that require the player to stand still.
```
