### PR TITLE
Rockbox free purchase fix

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -801,7 +801,7 @@
 
 					////////////
 
-					if(OCD.amount >= quantity)
+					if(OCD.amount >= quantity && quantity > 0)
 						var/subtotal = round(price * quantity)
 						var/sum_taxes = round(taxes * quantity)
 						var/rockbox_fees = (!rockbox_globals.rockbox_premium_purchased ? rockbox_globals.rockbox_standard_fee : 0) * quantity
@@ -843,7 +843,10 @@
 						else
 							src.temp = {"You don't have enough dosh, bucko.<BR>"}
 					else
-						src.temp = {"I don't have that many for sale, champ.<BR>"}
+						if(quantity > 0)
+							src.temp = {"I don't have that many for sale, champ.<BR>"}
+						else
+							src.temp = {"Enter some actual valid number, you doofus!<BR>"}
 				else
 					src.temp = {"That card doesn't have an account anymore, you might wanna get that checked out.<BR>"}
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes a bug that lets you buy rockbox ores for free

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Closes #5187 

