### PR TITLE
fix bug where some pod weapons would mess up overlays

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -320,7 +320,7 @@
 				if (src.m_w_system)
 					m_w_system.deactivate()
 					components -= m_w_system
-					if (uses_weapon_overlays)
+					if (uses_weapon_overlays && m_w_system.appearanceString)
 						src.overlays -= image('icons/effects/64x64.dmi', "[m_w_system.appearanceString]")
 					m_w_system.set_loc(src.loc)
 					m_w_system = null
@@ -798,7 +798,7 @@
 					boutput(usr, "Weapons cannot be installed in this ship!")
 					return
 				m_w_system = S
-				if(uses_weapon_overlays)
+				if(uses_weapon_overlays && m_w_system.appearanceString)
 					src.overlays += image('icons/effects/64x64.dmi', "[m_w_system.appearanceString]")
 
 				m_w_system.activate()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Some pod weapons do not have appearanceString set, which leads to their overlays somehow messing up the other overlays.
With this change weapons only add an overlay, if they actually have an appearance set.

We should probably consider adding sprites for these weapons in the future, but this change makes sure that even if a weapon should not have a sprite, it would not mess up the pod appearance.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #5188 