### PR TITLE
Prevents ghoscritters from using manual gas valves

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -1285,6 +1285,7 @@ var/list/ghostcritter_blocked = ghostcritter_blocked_objects()
 	/obj/dummy/chameleon,\
 	/obj/machinery/light,\
 	/obj/machinery/phone,\
+	/obj/machinery/atmospherics/valve,\
 	/obj/machinery/vending,\
 	/obj/machinery/nuclearbomb,\
 	/obj/item/gun/kinetic/airzooka,\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As the title says

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

"Why ghoscritters were allowed to use them the entire time" is a better question
:sheltersweat:


