### PR TITLE
N.A.R.C.S. deployers can be scanned by Syndicate Analyzers

### DIFF
--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -546,6 +546,9 @@
 	health = 125
 	icon_tag = "nt"
 	quick_deploy_fuel = 0
+	mats = list("INS-1"=10, "CON-1"=10, "CRY-1"=3, "MET-2"=2)
+	is_syndicate = 1
+	
 
 	spawn_turret(var/direct)
 		var/obj/deployable_turret/riot/turret = new /obj/deployable_turret/riot(src.loc,direction=direct)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
N.A.R.C.S. deployers can now be scanned by people using the syndicate device analyzer.
Its cost is as follows: "INS-1"=10, "CON-1"=10, "CRY-1"=3, "MET-2"=2)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I thought it'd be interesting, without being too easy to do, since you'll have to break into the armory and a secure locker to get to a N.A.R.C.S. deployer.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)NARCS can now be scanned by a Syndicate Device Analyzer.
```
