### PR TITLE
Fix chest item runtime

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3064,8 +3064,6 @@
 	if(!(src.chest_item && (src.chest_item in src.contents)))
 		return
 	src.show_text("You grunt and squeeze <B>[src.chest_item]</B> in your chest.")
-	SPAWN_DBG(0) //might sleep/input/etc, and we don't want to hold anything up
-		src.chest_item.attack_self(src)
 	if (src.chest_item_sewn == 0 || istype(src.chest_item, /obj/item/cloaking_device))	// If item isn't sewn in, poop it onto the ground. No fartcloaks allowed
 		// Item object is pooped out
 		if (istype(src.chest_item, /obj/item/))
@@ -3102,7 +3100,7 @@
 			if (cutOffButt)
 				src.TakeDamage("chest", 15, 0, 0, src.chest_item.hit_type)
 				take_bleeding_damage(src, src, 15)
-				src.show_text("<span class='alert'><B>[src.chest_item] cut your butt off on the way out!</B></span>")
+				src.show_text("<span class='alert'><B>[src.chest_item] cuts your butt off on the way out!</B></span>")
 				src.organHolder.drop_organ("butt")
 		// Other object is pooped out
 		else
@@ -3116,7 +3114,10 @@
 		// Make copy of item on ground
 		var/obj/item/outChestItem = src.chest_item
 		outChestItem.set_loc(get_turf(src))
+		src.chest_item.attack_self(src)
 		src.chest_item = null
+		return
+	src.chest_item.attack_self(src)
 
 /mob/living/carbon/human/attackby(obj/item/W, mob/M)
 	if (src.parry_or_dodge(M))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[runtime][trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a runtime on farting out chest items, where the spawn would try to run after nulling `chest_item`. Instead I just put the `attack_self` at the very end where the only thing it could hold up is nulling one's `chest_item`, which probably won't be an issue unless someone is specifically farting out and inserting multiple items while on an operating table. Doubt that'll happen in practice.

Also fixes a grammar issue on one of the strings (since almost all debutting chest items are singular).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
ew runtimes and eeeeeew grammar