### PR TITLE
Fix burning item tracking

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -490,6 +490,7 @@
 		processing_items.Add(src)
 
 /obj/item/proc/combust_ended()
+	STOP_TRACKING_CAT(TR_CAT_BURNING_ITEMS)
 	processing_items.Remove(src)
 	burning = null
 	firesource = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes items that stop burning set their tracking properly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #5206 - poor firebots