### PR TITLE
Implement turf blocked_dirs flag, update checkTurfPassable for astar, add blocked_dirs info overlay

### DIFF
--- a/_std/defines/obj.dm
+++ b/_std/defines/obj.dm
@@ -7,6 +7,8 @@
 #define NO_ARM_ATTACH 			 (1<<1)
 /// access gun can reprog
 #define CAN_REPROGRAM_ACCESS (1<<2)
+/// this object only blocks things in certain directions, e.g. railings, thindows
+#define HAS_DIRECTIONAL_BLOCKING (1<<3)
 
 /// At which alpha do opague objects become see-through?
 #define MATERIAL_ALPHA_OPACITY 190

--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -136,7 +136,7 @@
 	if(T.density || !T.pathable) // simplest case
 		return FALSE
 	// if a source turf was included check for directional blocks between the two turfs
-	if (source && T.blocked_dirs || source.blocked_dirs)
+	if (source && (T.blocked_dirs || source.blocked_dirs))
 		var/direction = get_dir(source, T)
 
 		// do either of these turfs explicitly block entry or exit to the other?

--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -190,13 +190,13 @@
 				continue // we already handled these above with the blocked_dirs
 			if (istype(A, /obj/overlay) || istype(A, /obj/effects)) continue
 		if (heuristic) // Only use a custom hueristic if we were passed one
-			. = min(., call(heuristic)(A, source, heuristic_args))
+			. = min(., call(heuristic)(A, heuristic_args))
 			if (!.) // early return if we encountered a failing atom
 				return
 		else if (A.density)
 			return FALSE // not a special case, so this is a blocking object
 
-/proc/hueristic_IsPassableMob(atom/A, turf/source, mob/M)
+/proc/hueristic_IsPassableMob(atom/A, mob/M)
 	. = FALSE
 	if (!A.density) // Not dense? Don't care!
 		return TRUE

--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -145,7 +145,7 @@
 			return FALSE
 
 		// is it time for combo checks?
-		if (direction in ordinal) // fuck.
+		if (direction in ordinal) // ordinal? That complicates things...
 			if (source?.blocked_dirs && T.blocked_dirs)
 				// check for "wall" blocks
 				// ex. trying to move NE source blocking north exit and destination (T) blocking south entry
@@ -164,7 +164,7 @@
 						return FALSE // entry to dest blocked by corners
 					else if (HAS_FLAG(corner_2.blocked_dirs, turn(direction, 135)))
 						// check for "wall" blocks
-						// ex. trying to move NE with C1 blocking south entry and C2 blocking north exit forming a wall
+						// ex. trying to move NE with C1 blocking south entry and C2 blocking north exit
 						return FALSE
 				if (HAS_FLAG(corner_1.blocked_dirs, turn(direction, -135)))
 					if (HAS_FLAG(corner_2.blocked_dirs, turn(direction, 135)))

--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -144,7 +144,6 @@
 		else if (source && HAS_FLAG(source.blocked_dirs, direction))
 			return FALSE
 
-		// is it time for combo checks?
 		if (direction in ordinal) // ordinal? That complicates things...
 			if (source?.blocked_dirs && T.blocked_dirs)
 				// check for "wall" blocks

--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -135,7 +135,8 @@
 	. = TRUE
 	if(T.density || !T.pathable) // simplest case
 		return FALSE
-	if (T.blocked_dirs || source?.blocked_dirs)
+	// if a source turf was included check for directional blocks between the two turfs
+	if (source && T.blocked_dirs || source.blocked_dirs)
 		var/direction = get_dir(source, T)
 
 		// do either of these turfs explicitly block entry or exit to the other?
@@ -145,7 +146,7 @@
 			return FALSE
 
 		if (direction in ordinal) // ordinal? That complicates things...
-			if (source?.blocked_dirs && T.blocked_dirs)
+			if (source.blocked_dirs && T.blocked_dirs)
 				// check for "wall" blocks
 				// ex. trying to move NE source blocking north exit and destination (T) blocking south entry
 				if (HAS_FLAG(source.blocked_dirs, turn(direction, 45)) && HAS_FLAG(T.blocked_dirs, turn(direction, -135)))
@@ -179,7 +180,7 @@
 				else if (HAS_FLAG(corner_2.blocked_dirs, turn(direction, 45)) && HAS_FLAG(T.blocked_dirs, turn(direction, 135)))
 					return FALSE
 			// entry blocked by an object in source and in one or more of the corners
-			if (source?.blocked_dirs && (corner_1.blocked_dirs || corner_2.blocked_dirs))
+			if (source.blocked_dirs && (corner_1.blocked_dirs || corner_2.blocked_dirs))
 				if (HAS_FLAG(corner_1.blocked_dirs, turn(direction, -135)) && HAS_FLAG(source.blocked_dirs, turn(direction, -45)))
 					return FALSE
 				else if (HAS_FLAG(corner_2.blocked_dirs, turn(direction, 135)) && HAS_FLAG(source.blocked_dirs, turn(direction, 45)))
@@ -187,7 +188,8 @@
 	for(var/atom/A in T.contents)
 		if (isobj(A))
 			var/obj/O = A
-			if (HAS_FLAG(O.object_flags, HAS_DIRECTIONAL_BLOCKING))
+			// only skip if we did the source check, otherwise fall back to normal density checks
+			if (source && HAS_FLAG(O.object_flags, HAS_DIRECTIONAL_BLOCKING))
 				continue // we already handled these above with the blocked_dirs
 			if (istype(A, /obj/overlay) || istype(A, /obj/effects)) continue
 		if (heuristic) // Only use a custom hueristic if we were passed one

--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -147,7 +147,8 @@
 		// is it time for combo checks?
 		if (direction in ordinal) // fuck.
 			if (source?.blocked_dirs && T.blocked_dirs)
-				// check for blocks caused by alternating opposing blocks (like moving NE with source blocking North entry and destination blocking South exit forming a wall)
+				// check for "wall" blocks
+				// ex. trying to move NE source blocking north exit and destination (T) blocking south entry
 				if (HAS_FLAG(source.blocked_dirs, turn(direction, 45)) && HAS_FLAG(T.blocked_dirs, turn(direction, -135)))
 					return FALSE
 				else if (HAS_FLAG(source.blocked_dirs, turn(direction, -45)) && HAS_FLAG(T.blocked_dirs, turn(direction, 135)))
@@ -158,17 +159,18 @@
 
 			// check for potential blocks form the two corners
 			if (corner_1.blocked_dirs && corner_2.blocked_dirs)
-				// entry to dest blocked by corners
-				if (HAS_FLAG(corner_1.blocked_dirs, turn(direction, -45)) && HAS_FLAG(corner_2.blocked_dirs, turn(direction, 45)))
-					return FALSE
-				// exit from source blocked by corners
-				else if (HAS_FLAG(corner_1.blocked_dirs, turn(direction, -135)) && HAS_FLAG(corner_2.blocked_dirs, turn(direction, 135)))
-					return FALSE
-				// check for blocks caused by corners with alternating opposing blocks (like moving NE with one blocking North exit and the other South entry forming a wall)
-				else if (HAS_FLAG(corner_1.blocked_dirs, turn(direction, -45)) && HAS_FLAG(corner_2.blocked_dirs, turn(direction, 135)))
-					return FALSE
-				else if (HAS_FLAG(corner_1.blocked_dirs, turn(direction, -135)) && HAS_FLAG(corner_2.blocked_dirs, turn(direction, 45)))
-					return FALSE
+				if (HAS_FLAG(corner_1.blocked_dirs, turn(direction, -45)))
+					if (HAS_FLAG(corner_2.blocked_dirs, turn(direction, 45)))
+						return FALSE // entry to dest blocked by corners
+					else if (HAS_FLAG(corner_2.blocked_dirs, turn(direction, 135)))
+						// check for "wall" blocks
+						// ex. trying to move NE with C1 blocking south entry and C2 blocking north exit forming a wall
+						return FALSE
+				if (HAS_FLAG(corner_1.blocked_dirs, turn(direction, -135)))
+					if (HAS_FLAG(corner_2.blocked_dirs, turn(direction, 135)))
+						return FALSE // exit from source blocked by corners
+					else if (HAS_FLAG(corner_2.blocked_dirs, turn(direction, 45)))
+						return FALSE // "wall" block
 
 			// we got past the combinations of the two corners ok, but what about the corners combined with the source and destination?
 			// entry blocked by an object in destination and in one or more of the corners

--- a/code/modules/admin/diagnostics.dm
+++ b/code/modules/admin/diagnostics.dm
@@ -825,6 +825,16 @@ proc/debug_map_apc_count(delim,zlim)
 		GetInfo(var/turf/theTurf, var/image/debugoverlay/img)
 			img.app.color = theTurf.checkinghasentered ? "#0f0" : "#f00"
 
+	blocked_dirs
+		name = "has blocked dirs"
+		help = "Green = yes."
+		GetInfo(var/turf/theTurf, var/image/debugoverlay/img)
+			if (theTurf.blocked_dirs)
+				img.app.overlays = list(src.makeText(theTurf.blocked_dirs))
+				img.app.color = "#0000ff"
+			else
+				img.app.alpha = 0
+
 	checkinghasproximity
 		name = "checkinghasproximity"
 		help = "Green = yes."

--- a/code/modules/admin/diagnostics.dm
+++ b/code/modules/admin/diagnostics.dm
@@ -826,8 +826,8 @@ proc/debug_map_apc_count(delim,zlim)
 			img.app.color = theTurf.checkinghasentered ? "#0f0" : "#f00"
 
 	blocked_dirs
-		name = "has blocked dirs"
-		help = "Green = yes."
+		name = "blocked dirs"
+		help = "Displays dir flags of blocked turf exits"
 		GetInfo(var/turf/theTurf, var/image/debugoverlay/img)
 			if (theTurf.blocked_dirs)
 				img.app.overlays = list(src.makeText(theTurf.blocked_dirs))

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -25,10 +25,9 @@
 
 	New()
 		. = ..()
-		SPAWN_DBG(0) // needs a chance to set dir apparently
-			if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
-				var/turf/T = get_turf(src)
-				T?.UpdateDirBlocks()
+		if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
+			var/turf/T = get_turf(src)
+			T?.UpdateDirBlocks()
 		src.update_access_from_txt()
 
 	Move(NewLoc, direct)
@@ -50,6 +49,12 @@
 			old_loc?.UpdateDirBlocks()
 		else
 			. = ..()
+
+	set_dir(new_dir)
+		. = ..()
+		if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
+			var/turf/T = get_turf(src)
+			T?.UpdateDirBlocks()
 
 	proc/setHealth(var/value)
 		var/prevHealth = _health

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -23,6 +23,34 @@
 	var/_health = 100
 	var/_max_health = 100
 
+	New()
+		. = ..()
+		SPAWN_DBG(0) // needs a chance to set dir apparently
+			if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
+				var/turf/T = get_turf(src)
+				T?.UpdateDirBlocks()
+		src.update_access_from_txt()
+
+	Move(NewLoc, direct)
+		if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
+			var/turf/old_loc = get_turf(src)
+			. = ..()
+			var/turf/T = get_turf(NewLoc)
+			T?.UpdateDirBlocks()
+			old_loc?.UpdateDirBlocks()
+		else
+			. = ..()
+
+	set_loc(newloc)
+		if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
+			var/turf/old_loc = get_turf(src)
+			. = ..()
+			var/turf/T = get_turf(newloc)
+			T?.UpdateDirBlocks()
+			old_loc?.UpdateDirBlocks()
+		else
+			. = ..()
+
 	proc/setHealth(var/value)
 		var/prevHealth = _health
 		_health = min(value, _max_health)

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -537,6 +537,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	has_panel = 0
 	has_crush = 0
 	layer = 3.5
+	object_flags = BOTS_DIRBLOCK | CAN_REPROGRAM_ACCESS | HAS_DIRECTIONAL_BLOCKING
 
 	bumpopen(mob/user as mob)
 		if (src.density)

--- a/code/obj/railing.dm
+++ b/code/obj/railing.dm
@@ -9,6 +9,7 @@
 	color = "#ffffff"
 	flags = FPRINT | USEDELAY | ON_BORDER
 	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
+	object_flags = HAS_DIRECTIONAL_BLOCKING
 	dir = SOUTH
 	custom_suicide = 1
 	var/broken = 0

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -694,6 +694,7 @@
 	dir = 5
 	health_multiplier = 2
 	//deconstruct_time = 20
+	object_flags = 0 // so they don't inherit the HAS_DIRECTIONAL_BLOCKING flag from thindows
 	flags = FPRINT | USEDELAY | ON_BORDER | ALWAYS_SOLID_FLUID | IS_PERSPECTIVE_FLUID
 
 	var/mod = null

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -8,6 +8,7 @@
 	dir = 5 //full tile
 	flags = FPRINT | USEDELAY | ON_BORDER | ALWAYS_SOLID_FLUID
 	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
+	object_flags = HAS_DIRECTIONAL_BLOCKING
 	text = "<font color=#aaf>#"
 	var/health = 30
 	var/health_max = 30

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -12,9 +12,6 @@
  * To not affect requirements, this should be null.
  */
 /obj/var/req_access_txt = null
-/obj/New()
-	..()
-	src.update_access_from_txt()
 /*
  * Override all access requirements if user is an administrator
  */

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -43,6 +43,8 @@
 	var/tmp/checkingcanpass = 0 // "" how many implement canpass()
 	var/tmp/checkinghasentered = 0 // "" hasproximity as well as items with a mat that hasproximity
 	var/tmp/checkinghasproximity = 0
+	/// directions of this turf being blocked by directional blocking objects. So we don't need to loop through the entire contents
+	var/tmp/blocked_dirs = 0
 	var/wet = 0
 	throw_unlimited = 0 //throws cannot stop on this tile if true (also makes space drift)
 
@@ -133,6 +135,12 @@
 		else
 			src.intact = FALSE
 			src.layer = PLATING_LAYER
+
+	proc/UpdateDirBlocks()
+		src.blocked_dirs = 0
+		for (var/obj/O in src.contents)
+			if (HAS_FLAG(O.object_flags, HAS_DIRECTIONAL_BLOCKING))
+				ADD_FLAG(src.blocked_dirs, O.dir)
 
 /obj/overlay/tile_effect
 	name = ""
@@ -524,6 +532,7 @@
 	var/old_checkingexit = src.checkingexit
 	var/old_checkingcanpass = src.checkingcanpass
 	var/old_checkinghasentered = src.checkinghasentered
+	var/old_blocked_dirs = src.blocked_dirs
 	var/old_checkinghasproximity = src.checkinghasproximity
 
 #ifdef ATMOS_PROCESS_CELL_STATS_TRACKING
@@ -596,6 +605,7 @@
 	new_turf.checkingexit = old_checkingexit
 	new_turf.checkingcanpass = old_checkingcanpass
 	new_turf.checkinghasentered = old_checkinghasentered
+	new_turf.blocked_dirs = old_blocked_dirs
 	new_turf.checkinghasproximity = old_checkinghasproximity
 
 #ifdef ATMOS_PROCESS_CELL_STATS_TRACKING


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* implements `blocked_dirs` flag on turfs to keep track of what directions the turf is blocking exit and entry from. This saves us from having to do numerous loops later on for the same information
* `blocked_dirs` is updated anytime an `obj` with the `HAS_DIRECTIONAL_BLOCKING` flag is moved, created, destroyed, etc. to keep it accurate
* A new info overlay has been added `blocked dirs` that will visually display the dir flags of a turfs blocked exits
* `/proc/checkTurfPassable` used mainly by our 2 astar is now capable of handling thin object blocking using the `blocked_dirs` flag.
* windoors, windows, and railings have been marked with the `HAS_DIRECTIONAL_BLOCKING` flag

example of testing the new astar pathing
![image](https://user-images.githubusercontent.com/33204415/122829330-de45e180-d2b4-11eb-80c8-20ddde00bcb7.png)
visualization of many different scenarios that should be properly handled by the changes (does not list all combos I am aware, but it should still handle them)
![image](https://user-images.githubusercontent.com/33204415/122829613-37157a00-d2b5-11eb-946a-6d2ba3929c05.png)
example of info overlay in use
![image](https://user-images.githubusercontent.com/33204415/122830641-a049bd00-d2b6-11eb-9bab-dbfb27debef5.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Allow astar pathing to handle thing object blocking
* Let chickens eat feed next to fences and otherwise path around them

```changelog
(u)Sovexe
(+)Made changes to pathfinding procs to resolve the chicken fence issues.
```
