### PR TITLE
Changing Minimum and Maximum times for the nuclear charge

### DIFF
--- a/_std/defines/computer.dm
+++ b/_std/defines/computer.dm
@@ -11,3 +11,6 @@
 
 #define COMP_HIDDEN 0
 #define COMP_ALLACC 511
+
+#define MIN_NUKE_TIME 120
+#define MAX_NUKE_TIME 600

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1036,13 +1036,7 @@
 
 
 #define DISARM_CUTOFF 10 //Can't disarm past this point! OH NO!
-//#define NUKE_ALERT_ONE 540 //Points where the nuke alerts the station
-//#define NUKE_ALERT_TWO 480
-//#define NUKE_ALERT_THREE 420
-//#define NUKE_ALERT_FOUR 360
-//#define NUKE_ALERT_FIVE 300
-//#define NUKE_ALERT_SIX 240
-//#define NUKE_ALERT_SIX 180
+
 	mats = list("POW-3" = 27, "MET-3" = 25, "CON-2" = 13, "DEN-3" = 15) //haha this is a bad idea
 	deconstruct_flags = DECON_NONE
 	is_syndicate = 1 //^ Agreed
@@ -1067,8 +1061,6 @@
 	attack_hand(mob/user as mob)
 		if(..() || status & NOPOWER)
 			return
-
-		src.add_dialog(user)
 
 		var/dat = "<html><head><title>Nuclear Charge</title></head><body>"
 

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1219,7 +1219,8 @@
 //					SPAWN_DBG(0.3 SECONDS)
 //						src.post_status(target, "command","term_disconnect")
 //					return
-
+#define MIN_NUKE_TIME 120
+#define MAX_NUKE_TIME 600
 				if(src.host_id && src.host_id != target)
 					return
 
@@ -1262,7 +1263,7 @@
 						if(isnull(thetime))
 							src.post_status(target,"command","term_message","data","command=status&status=noparam&session=[sessionid]")
 							return
-						thetime = max( min(thetime,600), 120)
+						thetime = clamp(thetime, MIN_NUKE_TIME, MAX_NUKE_TIME)
 						src.time = thetime
 						src.post_status(target,"command","term_message","data","command=status&status=success&session=[sessionid]")
 						return
@@ -1294,7 +1295,7 @@
 							return
 
 						src.timing = 0
-						src.time = max(src.time,30) //so we don't have some jerk letting it tick down to 11 and then saving it for later.
+						src.time = max(src.time,MIN_NUKE_TIME) //so we don't have some jerk letting it tick down to 11 and then saving it for later.
 						src.icon_state = "net_nuke0"
 						src.post_status(target,"command","term_message","data","command=status&status=success&session=[sessionid]")
 						//World announcement.

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1143,9 +1143,6 @@
 				src.detonate()
 				return
 			if(src.time == DISARM_CUTOFF)
-				src.icon_state = "net_nuke2"
-				boutput(world, "<span class='alert'><b>[src.time] seconds until nuclear charge detonation.</b></span>")
-			if(src.time == DISARM_CUTOFF)
 				world << sound('sound/misc/airraid_loop_short.ogg')
 			if(src.time <= DISARM_CUTOFF)
 				src.icon_state = "net_nuke2"

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1029,7 +1029,7 @@
 	desc = "A nuclear charge used as a self-destruct device. Uh oh!"
 	device_tag = "PNET_NUCCHARGE"
 	var/timing = 0
-	var/time = 60
+	var/time = 180
 	power_usage = 120
 
 	var/status_display_freq = "1435"
@@ -1262,7 +1262,7 @@
 						if(isnull(thetime))
 							src.post_status(target,"command","term_message","data","command=status&status=noparam&session=[sessionid]")
 							return
-						thetime = max( min(thetime,440), 30)
+						thetime = max( min(thetime,600), 120)
 						src.time = thetime
 						src.post_status(target,"command","term_message","data","command=status&status=success&session=[sessionid]")
 						return

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1036,7 +1036,13 @@
 
 
 #define DISARM_CUTOFF 10 //Can't disarm past this point! OH NO!
-
+//#define NUKE_ALERT_ONE 540 //Points where the nuke alerts the station
+//#define NUKE_ALERT_TWO 480
+//#define NUKE_ALERT_THREE 420
+//#define NUKE_ALERT_FOUR 360
+//#define NUKE_ALERT_FIVE 300
+//#define NUKE_ALERT_SIX 240
+//#define NUKE_ALERT_SIX 180
 	mats = list("POW-3" = 27, "MET-3" = 25, "CON-2" = 13, "DEN-3" = 15) //haha this is a bad idea
 	deconstruct_flags = DECON_NONE
 	is_syndicate = 1 //^ Agreed
@@ -1145,6 +1151,9 @@
 				src.detonate()
 				return
 			if(src.time == DISARM_CUTOFF)
+				src.icon_state = "net_nuke2"
+				boutput(world, "<span class='alert'><b>[src.time] seconds until nuclear charge detonation.</b></span>")
+			if(src.time == DISARM_CUTOFF)
 				world << sound('sound/misc/airraid_loop_short.ogg')
 			if(src.time <= DISARM_CUTOFF)
 				src.icon_state = "net_nuke2"
@@ -1219,8 +1228,7 @@
 //					SPAWN_DBG(0.3 SECONDS)
 //						src.post_status(target, "command","term_disconnect")
 //					return
-#define MIN_NUKE_TIME 120
-#define MAX_NUKE_TIME 600
+
 				if(src.host_id && src.host_id != target)
 					return
 

--- a/code/modules/networks/computer3/mainframe2/os_drivers.dm
+++ b/code/modules/networks/computer3/mainframe2/os_drivers.dm
@@ -1064,7 +1064,7 @@
 				if (!isnum(data["time"]))
 					return ESIG_GENERIC
 
-				var/newtime = max(0, min(data["time"], MAX_NUKE_TIME))
+				var/newtime = clamp("time", 0, MAX_NUKE_TIME)
 
 				var/sessionid = "[world.timeofday%100][rand(0,9)]"
 				message_device("command=settime&time=[newtime]&session=[sessionid]")

--- a/code/modules/networks/computer3/mainframe2/os_drivers.dm
+++ b/code/modules/networks/computer3/mainframe2/os_drivers.dm
@@ -1064,7 +1064,7 @@
 				if (!isnum(data["time"]))
 					return ESIG_GENERIC
 
-				var/newtime = max(0, min(data["time"], 600))
+				var/newtime = max(0, min(data["time"], MAX_NUKE_TIME))
 
 				var/sessionid = "[world.timeofday%100][rand(0,9)]"
 				message_device("command=settime&time=[newtime]&session=[sessionid]")
@@ -1255,7 +1255,7 @@
 			if ("time")
 				if (initlist.len >= 2)
 					var/newtime = text2num(initlist[2])
-					if (isnum(newtime) && (newtime <= 600) && (newtime >= 120))
+					if (isnum(newtime) && (newtime <= MAX_NUKE_TIME) && (newtime >= MIN_NUKE_TIME))
 						var/success = signal_program( 1, list("command"=DWAINE_COMMAND_DMSG,"target"=driver_id,"dcommand"="settime","time"=newtime))
 						switch(success)
 							if (ESIG_SUCCESS)
@@ -1266,9 +1266,9 @@
 								message_user("Error: Could not associate with charge driver.")
 
 					else
-						message_user("Error: Invalid time argument supplied (Must be between 120 and 600).")
+						message_user("Error: Invalid time argument supplied (Must be between [MIN_NUKE_TIME] and [MAX_NUKE_TIME]).")
 				else
-					message_user("Error: No time argument supplied (Must be between 120 and 600).")
+					message_user("Error: No time argument supplied (Must be between [MIN_NUKE_TIME] and [MAX_NUKE_TIME]).")
 
 
 			else

--- a/code/modules/networks/computer3/mainframe2/os_drivers.dm
+++ b/code/modules/networks/computer3/mainframe2/os_drivers.dm
@@ -1064,7 +1064,7 @@
 				if (!isnum(data["time"]))
 					return ESIG_GENERIC
 
-				var/newtime = max(0, min(data["time"], 440))
+				var/newtime = max(0, min(data["time"], 600))
 
 				var/sessionid = "[world.timeofday%100][rand(0,9)]"
 				message_device("command=settime&time=[newtime]&session=[sessionid]")
@@ -1255,7 +1255,7 @@
 			if ("time")
 				if (initlist.len >= 2)
 					var/newtime = text2num(initlist[2])
-					if (isnum(newtime) && (newtime <= 440) && (newtime >= 30))
+					if (isnum(newtime) && (newtime <= 600) && (newtime >= 120))
 						var/success = signal_program( 1, list("command"=DWAINE_COMMAND_DMSG,"target"=driver_id,"dcommand"="settime","time"=newtime))
 						switch(success)
 							if (ESIG_SUCCESS)
@@ -1266,9 +1266,9 @@
 								message_user("Error: Could not associate with charge driver.")
 
 					else
-						message_user("Error: Invalid time argument supplied (Must be between 30 and 440).")
+						message_user("Error: Invalid time argument supplied (Must be between 120 and 600).")
 				else
-					message_user("Error: No time argument supplied (Must be between 30 and 440).")
+					message_user("Error: No time argument supplied (Must be between 120 and 600).")
 
 
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This changes the nuclear charge's (the one activated using nukeman) minimum and maximum time from 30 and 440 to 120 and 600 seconds respectively. It also sets the default time to 180 seconds. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This is because setting off a nuke on a 30 second timer is currently near impossible to defuse, and people deserve a chance to deal with it. It also increases the maximum time to give you a little more wiggle room if you want to rp a bomb threat without it accidentally going off. Its maximum time would also end up being equal to the nuclear operatives gamemode's nuke timer, for consistency's sake.


## Changelog

<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)AmazingDragons
(+)Changes the minimum, maximum, and default times (in seconds) on the nuclear charge to 120, 600, and 180 respectively.
```