### PR TITLE
Sandwich stuff

### DIFF
--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -531,6 +531,7 @@
 			return null
 
 		var/obj/item/reagent_containers/food/snacks/sandwich/customSandwich = new /obj/item/reagent_containers/food/snacks/sandwich (ourCooker)
+		customSandwich.heal_amt = 1 // no filling yet, so less than regular sandwich
 		customSandwich.reagents = new /datum/reagents(100)
 		customSandwich.reagents.my_atom = customSandwich
 
@@ -601,6 +602,8 @@
 					var/obj/transformedFilling = image(snack.icon, snack.icon_state)
 					transformedFilling.transform = matrix(0.75, MATRIX_SCALE)
 					fillingColors += transformedFilling
+
+				customSandwich.heal_amt += snack.heal_amt
 
 				qdel(snack)
 

--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -603,7 +603,8 @@
 					transformedFilling.transform = matrix(0.75, MATRIX_SCALE)
 					fillingColors += transformedFilling
 
-				customSandwich.heal_amt += snack.heal_amt
+				// spread the total healing left for the added food among the sandwich bites
+				customSandwich.heal_amt += snack.heal_amt * snack.amount / customSandwich.amount
 
 				qdel(snack)
 

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -387,12 +387,12 @@ table#cooktime a#start {
 			src.recipes += new /datum/cookingrecipe/sandwich_mb(src)
 			src.recipes += new /datum/cookingrecipe/sandwich_egg(src)
 			src.recipes += new /datum/cookingrecipe/sandwich_bm(src)
-			//src.recipes += new /datum/cookingrecipe/sandwich_m_h(src)
-			//src.recipes += new /datum/cookingrecipe/sandwich_m_m(src)
-			//src.recipes += new /datum/cookingrecipe/sandwich_m_s(src)
-			//src.recipes += new /datum/cookingrecipe/sandwich_c(src)
-			//src.recipes += new /datum/cookingrecipe/sandwich_p_h(src)
-			//src.recipes += new /datum/cookingrecipe/sandwich_p(src)
+			src.recipes += new /datum/cookingrecipe/sandwich_m_h(src)
+			src.recipes += new /datum/cookingrecipe/sandwich_m_m(src)
+			src.recipes += new /datum/cookingrecipe/sandwich_m_s(src)
+			src.recipes += new /datum/cookingrecipe/sandwich_c(src)
+			src.recipes += new /datum/cookingrecipe/sandwich_p_h(src)
+			src.recipes += new /datum/cookingrecipe/sandwich_p(src)
 			src.recipes += new /datum/cookingrecipe/sandwich_custom(src)
 			src.recipes += new /datum/cookingrecipe/onionchips(src)
 			src.recipes += new /datum/cookingrecipe/mint_chutney(src)
@@ -578,7 +578,7 @@ table#cooktime a#start {
 				// Enforce GIGO and prevent infinite reuse
 				var/contentsok = 1
 				for(var/obj/item/I in src.contents)
-					if(istype(I, /obj/item/reagent_containers/food/snacks/yuck))
+					if(istype(I, /obj/item/reagent_containers/food/snacks/yuck))c
 						contentsok = 0
 						break
 					if(istype(I, /obj/item/reagent_containers/food/snacks/yuckburn))

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -578,7 +578,7 @@ table#cooktime a#start {
 				// Enforce GIGO and prevent infinite reuse
 				var/contentsok = 1
 				for(var/obj/item/I in src.contents)
-					if(istype(I, /obj/item/reagent_containers/food/snacks/yuck))c
+					if(istype(I, /obj/item/reagent_containers/food/snacks/yuck))
 						contentsok = 0
 						break
 					if(istype(I, /obj/item/reagent_containers/food/snacks/yuckburn))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lots of people report having issues with making some of the sandwich types. Apparently the recipes for those had been disabled, so they turned into custom sandwiches instead?

But it doesn't really make sense, because then you have stuff like two slices of bread with a jar of peanut butter between them, which doesn't really make sense.

Also, those custom sandwiches would not heal or restore hunger, since people were using the oven settings for the sandwich they actually wanted to make. (For instance, 6 for PB sandwich, instead of 12 for custom sandwich.) The wrong settings caused the heal_amt (and by extension the hunger restore) to be set to 0.

Also, for custom sandwiches, this makes it so that custom sandwiches also combine the total healing amount of their bonus ingredients.
For instance: 1 sloppy joe (5 bites x 2 heal = 10) + 1 fries (6 bites x 1 heal = 6) combines to 16 heal. A custom sandwich has 4 bites, thus you would get a heal_amt of 16/4 = 4. To this, 1 is added for the sandwich bread, resulting in a total heal_amt of 5 for this sandwich, with 4 bites.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People were really confused because the stuff on the wiki was not giving them the sandwich they wanted, and the resulting custom sandwiches were not healing them or restoring hunger.
Also, they looked kind of bad for some ingredients. (For instance, peanut butter jars.)

I think an increased healing amount (and by extension more hunger restore) for custom sandwiches would encourage people to seek out the kitchen/bar instead of eating vendor food or drinking chicken soup, in a similar way that stews already do.
The healing should not be too strong, since you could just eat the ingredients instead to get the same effect, and healing is capped anyway, especially for non-survivalists.
Also, the amount of food you could put into a sandwich is capped at 6 already, since only 8 total pieces of food can fit into an oven.

If this is deemed too strong, we could instead change it so that the added food would increase the amount of bites of the resulting sandwich instead, but I think it'd be fine this way.

fixes #4320
fixes #4208
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+)Custom sandwiches now combine the healing and hunger restore of their ingredients.
```
