### PR TITLE
removes sechud eye from random prosthetics crates

### DIFF
--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -1097,8 +1097,7 @@
 	/obj/item/parts/robot_parts/leg/right/treads,
 	/obj/item/parts/robot_parts/leg/left/treads,
 	/obj/item/organ/eye/cyber/prodoc,
-	/obj/item/organ/eye/cyber/nightvision,
-	/obj/item/organ/eye/cyber/sechud)
+	/obj/item/organ/eye/cyber/nightvision)
 
 /obj/random_item_spawner/critter
 	name = "random critter spawner"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -30,6 +30,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // BEGIN_INCLUDE
+#include "_std\compatibility.dm"
 #include "code\area.dm"
 #include "code\atom.dm"
 #include "code\base_lighting.dm"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -30,7 +30,6 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // BEGIN_INCLUDE
-#include "_std\compatibility.dm"
 #include "code\area.dm"
 #include "code\atom.dm"
 #include "code\base_lighting.dm"


### PR DESCRIPTION
[balance][removal]

## About the PR 
the riveting conclusion to the series:

cargo crates 4: muerte del globo ocular

removes sechud cybereyes from the random prosthetics crates in cargo.

## Why's this needed? 
traitor item; also available from doc; also katzen and gannets just made the process of obtaining sechud eyes as a traitor/organ dealer Very Cool so i don't want people to short-circuit that effort.