### PR TITLE
Fixes missing tile & area placement for Cogmap2 Robotics

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -79305,11 +79305,6 @@
 	icon_state = "blue2"
 	},
 /area/station/crew_quarters/arcade/dungeon)
-"pKW" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/space,
-/area/station/medical/robotics)
 "pTS" = (
 /obj/item/storage/wall/random,
 /obj/machinery/vending/janitor,
@@ -115588,7 +115583,7 @@ ciq
 chp
 ciZ
 ckq
-ceC
+coE
 cqn
 cqn
 coG
@@ -117409,7 +117404,7 @@ csd
 csd
 csd
 cAP
-pKW
+wGP
 cDG
 cFB
 ddb


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[Bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes a missing tile beneath a window and the area placement for Cogmap2 robotics

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Missing Tile: It's probably not the best to have exposed space beneath a window, it doesn't cause depressurizations if not messed with though but it still needs to be fixed

Area placement: This area fix will cause radiation storms in robotics to look a bit better, its just a single tile touching NW maints I forgot to hit

