### PR TITLE
Adjust Solar Scaling to match legacy behavior

### DIFF
--- a/_std/machinery.dm
+++ b/_std/machinery.dm
@@ -42,7 +42,7 @@
 #define DATA_TERMINAL_IS_VALID_MASTER(terminal, master) (master && (get_turf(master) == terminal.loc))
 
 #define PROCESSING_TIER_MULTI(target) (1<<(target.current_processing_tier-1)) //! Scalar to behave as if it were running at full speed
-#define MACHINE_LEGACY_SCALE_ADJ (MACHINE_PROC_INTERVAL / ( 3.3 SECONDS )) //! Scalar to achieve pre #743 behavior to account for proc rate change
+#define MACHINE_PROCS_PER_SEC (MACHINE_PROC_INTERVAL / (1 SECOND))
 
 #define PROCESSING_FULL      1
 #define PROCESSING_HALF      2

--- a/_std/machinery.dm
+++ b/_std/machinery.dm
@@ -4,6 +4,8 @@
 //this file is not in defines or macros because this one is kind of a frankenstein
 #define NETWORK_MACHINE_RESET_DELAY 40 //Time (in 1/10 of a second) before we can be manually reset again (machines).
 
+#define MACHINE_PROC_INTERVAL (0.4 SECONDS)
+
 //communications stuff
 #define TRANSMISSION_WIRE	0
 #define TRANSMISSION_RADIO	1
@@ -38,6 +40,9 @@
 #define SHIP_ALERT_BAD 1
 
 #define DATA_TERMINAL_IS_VALID_MASTER(terminal, master) (master && (get_turf(master) == terminal.loc))
+
+#define PROCESSING_TIER_MULTI(target) (1<<(target.current_processing_tier-1)) //! Scalar to behave as if it were running at full speed
+#define MACHINE_LEGACY_SCALE_ADJ (MACHINE_PROC_INTERVAL / ( 3.3 SECONDS )) //! Scalar to achieve pre #743 behavior to account for proc rate change
 
 #define PROCESSING_FULL      1
 #define PROCESSING_HALF      2

--- a/code/datums/controllers/process/machines.dm
+++ b/code/datums/controllers/process/machines.dm
@@ -10,7 +10,7 @@
 
 	setup()
 		name = "Machine"
-		schedule_interval = 0.4 SECONDS
+		schedule_interval = MACHINE_PROC_INTERVAL
 
 		Station_VNet = new /datum/v_space/v_space_network()
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -167,7 +167,7 @@
 
 	if(!obscured)
 		var/sgen = SOLARGENRATE * sunfrac
-		sgen *= 1<<(current_processing_tier-1) // twice the power for half processing, 4 times for quarter etc.
+		sgen *= PROCESSING_TIER_MULTI(src) * MACHINE_LEGACY_SCALE_ADJ
 		add_avail(sgen)
 		if(powernet && control && powernet == control.powernet)
 			control.gen += sgen

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -158,7 +158,9 @@
 
 	sunfrac = cos(p_angle) ** 2
 
-#define SOLARGENRATE 1500
+// Previous SOLARGENRATE was 1500 WATTS processed every 3.3 SECONDS.  This provides 454.54 WATTS every second
+// Adjust accordingly based on machine proc rate
+#define SOLARGENRATE (454.54 * MACHINE_PROCS_PER_SEC)
 
 /obj/machinery/power/solar/process()
 
@@ -167,7 +169,7 @@
 
 	if(!obscured)
 		var/sgen = SOLARGENRATE * sunfrac
-		sgen *= PROCESSING_TIER_MULTI(src) * MACHINE_LEGACY_SCALE_ADJ
+		sgen *= PROCESSING_TIER_MULTI(src)
 		add_avail(sgen)
 		if(powernet && control && powernet == control.powernet)
 			control.gen += sgen


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[bug][balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjust solars scaling by 1/8.25 to match pre #743 as change to task rate was not accounted for in power output.  Most other devices were not impacted as the default tier was adjusted as well causing the rate for an arbitrary piece of machinery to being processed every 3.3 seconds to 3.2 seconds.

This should take solar output to match behavior from 2016-2020.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Introduction of processing buckets to machinery allowed solars to be run less often and then scale appropriately as if it were running at full speed. #743 made larges changes by adding a new bucket but also allowing machinery to run faster than the previous 3.3 second rate.  The adjustment from 3.3 to 0.4 second rate was not accounted for.
Maybe people will stop complaining so much about solars so much.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(+)Reduced power output from solar panels.
```
