### PR TITLE
Atmos pipes only need 1 weld to repair, add an action bar to atmos pipe repair

### DIFF
--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -392,18 +392,7 @@ obj/machinery/atmospherics/pipe
 					return
 
 				boutput(user, "You start to repair the [src.name].")
-
-				if (do_after(user, 2 SECONDS))
-					ruptured --
-				else
-					boutput(user, "<span class='alert'>You were interrupted!</span>")
-					return
-				if(!ruptured)
-					boutput(user, "You have fully repaired the [src.name].")
-					icon_state = initial_icon_state
-					desc = initial(desc)
-				else boutput(user, "You have partially repaired the [src.name].")
-				return
+				SETUP_GENERIC_ACTIONBAR(user, src, 2 SECONDS, /obj/machinery/atmospherics/pipe/simple/proc/repair_pipe, list(), W.icon, W.icon_state, "You repair the [src.name].", null)
 
 			else if(destroyed && istype(W, /obj/item/rods))
 				var/duration = 15 SECONDS
@@ -413,6 +402,11 @@ obj/machinery/atmospherics/pipe
 				var/datum/action/bar/icon/callback/action_bar = new /datum/action/bar/icon/callback(user, src, duration, /obj/machinery/atmospherics/pipe/simple/proc/reconstruct_pipe,\
 				list(user, S), W.icon, W.icon_state, "[user] finishes working with \the [src].")
 				actions.start(action_bar, user)
+
+		proc/repair_pipe()
+			src.ruptured = 0
+			icon_state = initial_icon_state
+			desc = initial(desc)
 
 		proc/reconstruct_pipe(mob/M, obj/item/rods/R)
 			if(istype(R) && istype(M))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE][QOL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Atmos pipes always repair in one use of a welder rather than sometimes only repairing partially
* adds an action bar for when you repair pipes

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Make repairing the pipes less awful to manage
* action bar modernization

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(+)Repairing ruptured atmos pipes now only ever takes one successful weld, and has an action bar.
```
