### PR TITLE
Revert "Adds a intra-round win/death log to an asteroid structure | Pod Wars"

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -5299,10 +5299,6 @@ area/station/security/visitation
 	name = "DORGUN'S GREAT SHIP 10/10"
 	icon_state = "yellow"
 
-/area/pod_wars/spacejunk/memorial_stats
-	name = "Mission Memorial Ruins"
-	icon_state = "yellow"
-
 /area/pod_wars/spacejunk/brightwell
 	name = "LS Brightwell"
 	icon_state = "yellow"

--- a/code/datums/gamemodes/pod_wars.dm
+++ b/code/datums/gamemodes/pod_wars.dm
@@ -381,22 +381,8 @@ ABSTRACT_TYPE(/datum/ore_cluster)
 
 datum/game_mode/pod_wars/proc/do_team_member_death(var/mob/M, var/datum/pod_wars_team/our_team, var/datum/pod_wars_team/enemy_team)
 	our_team.change_points(-1)
-	var/nt_death = world.load_intra_round_value("nt_death")
-	var/sy_death = world.load_intra_round_value("sy_death")
-	if(isnull(nt_death))
-		nt_death = 0
-	if(isnull(sy_death))
-		sy_death = 0
-	if (get_pod_wars_team_num(M) == TEAM_NANOTRASEN)
-		world.save_intra_round_value("nt_death", nt_death + 1)
-	if (get_pod_wars_team_num(M) == TEAM_NANOTRASEN)
-		world.save_intra_round_value("sy_death", sy_death + 1)
 	if (M.mind == our_team.commander)
 		our_team.change_points(-2)
-		if (get_pod_wars_team_num(M) == TEAM_NANOTRASEN)
-			world.save_intra_round_value("nt_death", nt_death + 1)
-		if (get_pod_wars_team_num(M) == TEAM_NANOTRASEN)
-			world.save_intra_round_value("sy_death", sy_death + 1)
 		if (!our_team.first_commander_death)
 			our_team.first_commander_death = 1
 			src.playsound_to_team(our_team, "sound/voice/pod_wars_voices/{PWTN}Commander_Dies{ALTS}.ogg", sound_type=PW_COMMANDER_DIES)
@@ -498,17 +484,6 @@ datum/game_mode/pod_wars/proc/do_team_member_death(var/mob/M, var/datum/pod_wars
 	else
 		winner = team_SY
 		loser = team_NT
-
-	if(winner == team_NT) //putting this in a seperate code block for cleanliness
-		var/value = world.load_intra_round_value("nt_win")
-		if(isnull(value))
-			value = 0
-		world.save_intra_round_value("nt_win", value + 1)
-	else if(winner == team_SY)
-		var/value = world.load_intra_round_value("sy_win")
-		if(isnull(value))
-			value = 0
-		world.save_intra_round_value("sy_win", value + 1)
 
 	// var/text = ""
 	boutput(world, "<FONT size = 3><B>The winner was the [winner.name], commanded by [winner.commander?.current] ([winner.commander?.current?.ckey]):</B></FONT><br>")
@@ -931,100 +906,6 @@ proc/setup_pw_crate_lists()
 	O.icon_state = "explosion"
 	SPAWN_DBG(3.5 SECONDS)
 		qdel(O)
-
-/obj/pod_war_stats_nt/
-	name = "Nanotrasen Mission Log"
-	icon = 'icons/obj/32x64.dmi'
-	icon_state = "memorial_mid" //placeholder, i'm not good at spriting
-	anchored = 1.0
-	opacity = 0
-	density = 1
-
-
-
-	New()
-		..()
-		var/nt_wins = world.load_intra_round_value("nt_win")
-		var/nt_deaths = world.load_intra_round_value("nt_death")
-		if(isnull(nt_wins))
-			nt_wins = 0
-		if(isnull(nt_deaths))
-			nt_deaths = 0
-		var/last_reset_date = world.load_intra_round_value("pod_wars_last_reset")
-		var/last_reset_text = null
-		if(!isnull(last_reset_date))
-			var/days_passed = round((world.realtime - last_reset_date) / (1 DAY))
-			last_reset_text = "<h4>(mission log reset [days_passed] days ago)</h4>"
-		src.desc = "<center><h2><b>Pod Wars Mission Log</b></h2><br> <h3>Nanotrasen Victories: [nt_wins]<br>\nNanotrasen Deaths: [nt_deaths]</h3><br>[last_reset_text]</center>"
-
-	attack_hand(var/mob/user as mob)
-		if (..(user))
-			return
-
-		var/nt_wins = world.load_intra_round_value("nt_win")
-		var/nt_deaths = world.load_intra_round_value("nt_death")
-		if(isnull(nt_wins))
-			nt_wins = 0
-		if(isnull(nt_deaths))
-			nt_deaths = 0
-
-		src.add_dialog(user)
-		user.Browse(src.desc, "title=Mission Log;window=pod_war_stats_[src];size=300x300")
-		onclose(user, "pod_war_stats_[src]")
-		return
-
-/obj/pod_war_stats_sy/
-	name = "Syndicate Mission Log"
-	icon = 'icons/obj/32x64.dmi'
-	icon_state = "memorial_mid" //placeholder, i'm not good at spriting
-	anchored = 1.0
-	opacity = 0
-	density = 1
-
-
-
-	New()
-		..()
-		var/sy_wins = world.load_intra_round_value("sy_win")
-		var/sy_deaths = world.load_intra_round_value("sy_death")
-		if(isnull(sy_wins))
-			sy_wins = 0
-		if(isnull(sy_deaths))
-			sy_deaths = 0
-		var/last_reset_date = world.load_intra_round_value("pod_wars_last_reset")
-		var/last_reset_text = null
-		if(!isnull(last_reset_date))
-			var/days_passed = round((world.realtime - last_reset_date) / (1 DAY))
-			last_reset_text = "<h4>(mission log reset [days_passed] days ago)</h4>"
-		src.desc = "<center><h2><b>Pod Wars Mission Log</b></h2><br> <h3>Syndicate Victories: [sy_wins]<br>\nSyndicate Deaths: [sy_deaths]</h3><br>[last_reset_text]</center>"
-
-	attack_hand(var/mob/user as mob)
-		if (..(user))
-			return
-
-		var/sy_wins = world.load_intra_round_value("sy_win")
-		var/sy_deaths = world.load_intra_round_value("sy_death")
-		if(isnull(sy_wins))
-			sy_wins = 0
-		if(isnull(sy_deaths))
-			sy_deaths = 0
-
-		src.add_dialog(user)
-		user.Browse(src.desc, "title=Mission Log;window=pod_war_stats_[src];size=300x300")
-		onclose(user, "pod_war_stats_[src]")
-		return
-
-/obj/memorial_left
-	name = "Memorial Inscription"
-	desc = "A memorial to those dead, but not forgotten."
-	icon = 'icons/obj/32x64.dmi'
-	icon_state = "memorial_left"
-
-/obj/memorial_right
-	name = "Memorial Inscription"
-	desc = "A memorial to those dead, but not forgotten."
-	icon = 'icons/obj/32x64.dmi'
-	icon_state = "memorial_right"
 
 #undef PW_COMMANDER_DIES
 #undef PW_CRIT_SYSTEM_DESTORYED

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -426,8 +426,6 @@ var/list/admin_verbs = list(
 		/client/proc/toggle_hard_reboot,
 		/client/proc/cmd_modify_respawn_variables,
 		/client/proc/set_nukie_score,
-		/client/proc/set_pod_wars_score,
-		/client/proc/set_pod_wars_deaths,
 
 		/client/proc/player_panel_tgui,
 
@@ -1927,44 +1925,6 @@ var/list/fun_images = list()
 	logTheThing("admin", usr ? usr : src, null, "set nuke ops values to [win_value] wins and [lose_value] loses.")
 	logTheThing("diary", usr ? usr : src, null, "set nuke ops values to [win_value] wins and [lose_value] loses.", "admin")
 	message_admins("[key_name(usr ? usr : src)] set nuke ops values to [win_value] wins and [lose_value] loses.")
-
-/client/proc/set_pod_wars_score()
-	set popup_menu = 0
-	set name = "Set Pod Wars Scoreboard Values"
-	set desc = "Manually assign values to the Pod Wars Nanotrasen/Syndicate wins scoreboard."
-	SET_ADMIN_CAT(ADMIN_CAT_SERVER)
-	admin_only
-
-	var/nt_win_value = input("Enter new Nanotrasen win value.") as num
-	world.save_intra_round_value("nt_win", nt_win_value)
-
-	var/sy_win_value = input("Enter new Syndicate loss value.") as num
-	world.save_intra_round_value("sy_win", sy_win_value)
-
-	world.save_intra_round_value("pod_wars_last_reset", world.realtime)
-
-	logTheThing("admin", usr ? usr : src, null, "set pod war win values to [nt_win_value] Nanotrasen wins and [sy_win_value] Syndicate wins.")
-	logTheThing("diary", usr ? usr : src, null, "set pod war win values to [nt_win_value] Nanotrasen wins and [sy_win_value] Syndicate wins.", "admin")
-	message_admins("[key_name(usr ? usr : src)] set pod war win values to [nt_win_value] Nanotrasen wins and [sy_win_value] Syndicate wins.")
-
-/client/proc/set_pod_wars_deaths()
-	set popup_menu = 0
-	set name = "Set Pod Wars Death Scoreboard Values"
-	set desc = "Manually assign values to the Pod Wars Nanotrasen/Syndicate deaths scoreboard."
-	SET_ADMIN_CAT(ADMIN_CAT_SERVER)
-	admin_only
-
-	var/nt_win_value = input("Enter new Nanotrasen death value.") as num
-	world.save_intra_round_value("nt_death", nt_win_value)
-
-	var/sy_win_value = input("Enter new Syndicate death value.") as num
-	world.save_intra_round_value("sy_death", sy_win_value)
-
-	world.save_intra_round_value("pod_wars_last_reset", world.realtime)
-
-	logTheThing("admin", usr ? usr : src, null, "set pod war death values to [nt_win_value] Nanotrasen deaths and [sy_win_value] Syndicate deaths.")
-	logTheThing("diary", usr ? usr : src, null, "set pod war death values to [nt_win_value] Nanotrasen deaths and [sy_win_value] Syndicate deaths.", "admin")
-	message_admins("[key_name(usr ? usr : src)] set pod war death values to [nt_win_value] Nanotrasen deaths and [sy_win_value] Syndicate deaths.")
 
 
 /mob/verb/admin_interact_verb()

--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -382,9 +382,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
-"bF" = (
-/turf/simulated/floor/black,
-/area/pod_wars/spacejunk/memorial_stats)
 "bG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -1514,11 +1511,6 @@
 /obj/access_spawn/heads,
 /turf/unsimulated/floor/yellow,
 /area/pod_wars/team1/mining)
-"fI" = (
-/turf/simulated/floor/blueblack{
-	dir = 5
-	},
-/area/pod_wars/spacejunk/memorial_stats)
 "fJ" = (
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-M"
@@ -2128,13 +2120,6 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team1/bridge)
-"hS" = (
-/obj/machinery/light/incandescent{
-	dir = 4;
-	icon_state = "tube-empty"
-	},
-/turf/simulated/floor/circuit/off,
-/area/pod_wars/spacejunk/memorial_stats)
 "hT" = (
 /obj/machinery/light/incandescent/netural,
 /obj/table/reinforced/bar/auto,
@@ -3018,14 +3003,6 @@
 	},
 /turf/unsimulated/floor/shuttlebay,
 /area/pod_wars/team2/hangar)
-"lF" = (
-/obj/memorial_right{
-	pixel_x = 3
-	},
-/turf/simulated/floor/blueblack{
-	dir = 8
-	},
-/area/pod_wars/spacejunk/memorial_stats)
 "lG" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/blue/side{
@@ -3139,9 +3116,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/pod_wars/team1/powergen)
-"mb" = (
-/turf/simulated/floor/plating/scorched,
-/area/pod_wars/spacejunk/memorial_stats)
 "mc" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3192,9 +3166,6 @@
 /obj/random_item_spawner/desk_stuff/maybe_few,
 /turf/simulated/floor/plating,
 /area/pod_wars/spacejunk/nancy/warehouse)
-"mp" = (
-/turf/simulated/floor/circuit/off,
-/area/pod_wars/spacejunk/memorial_stats)
 "ms" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
@@ -3264,12 +3235,6 @@
 	},
 /turf/simulated/floor,
 /area/pod_wars/team1/starboardhall)
-"mC" = (
-/obj/machinery/light/incandescent{
-	dir = 4
-	},
-/turf/simulated/floor/airless/circuit,
-/area/pod_wars/spacejunk/memorial_stats)
 "mD" = (
 /obj/cable{
 	d1 = 1;
@@ -3500,10 +3465,6 @@
 /obj/item/plate,
 /turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team1/bar)
-"np" = (
-/obj/pod_war_stats_sy,
-/turf/simulated/floor/airless/circuit,
-/area/pod_wars/spacejunk/memorial_stats)
 "nq" = (
 /obj/item/storage/toilet{
 	dir = 4
@@ -4422,11 +4383,6 @@
 	dir = 4
 	},
 /area/space)
-"qB" = (
-/turf/simulated/floor/blueblack{
-	dir = 4
-	},
-/area/pod_wars/spacejunk/memorial_stats)
 "qC" = (
 /obj/cable{
 	d2 = 8;
@@ -5584,9 +5540,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/pod_wars/spacejunk/reliant/landingpads)
-"uW" = (
-/turf/simulated/wall/asteroid/pod_wars,
-/area/space)
 "uZ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -6258,14 +6211,6 @@
 	tag = "icon-catwalk (WEST)"
 	},
 /area/pod_wars/spacejunk/uvb67/solars)
-"xl" = (
-/obj/memorial_left{
-	pixel_x = -4
-	},
-/turf/simulated/floor/blueblack{
-	dir = 4
-	},
-/area/pod_wars/spacejunk/memorial_stats)
 "xm" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -6918,11 +6863,6 @@
 	dir = 1
 	},
 /area/pod_wars/spacejunk/fstation/crewquarters)
-"zN" = (
-/turf/simulated/floor/blueblack{
-	dir = 1
-	},
-/area/pod_wars/spacejunk/memorial_stats)
 "zO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -7287,9 +7227,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/pod_wars/team2/power)
-"Bk" = (
-/turf/simulated/floor/black/grime,
-/area/pod_wars/spacejunk/memorial_stats)
 "Bl" = (
 /turf/unsimulated/floor/yellow/side{
 	dir = 10
@@ -7863,9 +7800,6 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team1/manufacturing)
-"DD" = (
-/turf/simulated/floor/circuit/off,
-/area/space)
 "DF" = (
 /obj/shrub,
 /turf/unsimulated/floor/blue/side,
@@ -7961,11 +7895,6 @@
 "DV" = (
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/restaurant)
-"DW" = (
-/turf/simulated/floor/blueblack{
-	dir = 10
-	},
-/area/pod_wars/spacejunk/memorial_stats)
 "DX" = (
 /obj/machinery/door/airlock/pyro/glass/med,
 /obj/cable{
@@ -8410,9 +8339,6 @@
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
-"FC" = (
-/turf/simulated/floor/airless/circuit,
-/area/pod_wars/spacejunk/memorial_stats)
 "FD" = (
 /turf/unsimulated/floor/blue/side{
 	dir = 6
@@ -8510,9 +8436,6 @@
 	},
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation)
-"FX" = (
-/turf/simulated/floor/black,
-/area/space)
 "FY" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/purple/side{
@@ -8998,11 +8921,6 @@
 	},
 /turf/space,
 /area/pod_wars/team1/powergen)
-"HQ" = (
-/obj/lattice,
-/obj/lattice,
-/turf/space,
-/area/space)
 "HS" = (
 /obj/machinery/power/furnace,
 /obj/cable{
@@ -9103,9 +9021,6 @@
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
-"Il" = (
-/turf/simulated/wall/auto/reinforced,
-/area/pod_wars/spacejunk/memorial_stats)
 "Ip" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -9891,10 +9806,6 @@
 	},
 /turf/simulated/floor/airless/plating,
 /area/pod_wars/spacejunk/restaurant/landingpads)
-"Li" = (
-/obj/pod_war_stats_nt,
-/turf/simulated/floor/airless/circuit,
-/area/pod_wars/spacejunk/memorial_stats)
 "Lj" = (
 /obj/machinery/light/incandescent/netural,
 /obj/shrub,
@@ -10202,9 +10113,6 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/bar)
-"MD" = (
-/turf/simulated/wall/auto/reinforced,
-/area/space)
 "ME" = (
 /obj/machinery/power/furnace,
 /obj/cable{
@@ -10611,9 +10519,6 @@
 /obj/item/reagent_containers/food/snacks/toastcheese,
 /turf/simulated/floor/yellow,
 /area/pod_wars/spacejunk/restaurant)
-"Om" = (
-/turf/simulated/floor/blueblack,
-/area/pod_wars/spacejunk/memorial_stats)
 "On" = (
 /obj/table/wood/auto,
 /obj/machinery/light/incandescent/netural,
@@ -11253,13 +11158,6 @@
 /obj/disposalpipe/trunk,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/fstation/observatory)
-"QC" = (
-/obj/machinery/light/incandescent{
-	dir = 8;
-	icon_state = "tube-burned"
-	},
-/turf/simulated/floor/airless/circuit,
-/area/pod_wars/spacejunk/memorial_stats)
 "QD" = (
 /turf/unsimulated/floor/yellow/side{
 	dir = 1
@@ -11373,9 +11271,6 @@
 	icon_state = "wall_space"
 	},
 /area/pod_wars/spacejunk/brightwell)
-"Rf" = (
-/turf/simulated/floor/blueblack,
-/area/space)
 "Ri" = (
 /obj/grille/catwalk{
 	dir = 8
@@ -12374,12 +12269,6 @@
 /obj/access_spawn/syndie_shuttle,
 /turf/unsimulated/floor/red,
 /area/pod_wars/team2/bar)
-"UY" = (
-/obj/machinery/light/incandescent{
-	dir = 8
-	},
-/turf/simulated/floor/airless/circuit,
-/area/pod_wars/spacejunk/memorial_stats)
 "Va" = (
 /obj/lattice{
 	dir = 5;
@@ -12773,11 +12662,6 @@
 "Wv" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_11)
-"Wx" = (
-/turf/simulated/floor/blueblack{
-	dir = 8
-	},
-/area/pod_wars/spacejunk/memorial_stats)
 "Wy" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -13302,9 +13186,6 @@
 /obj/lattice,
 /turf/space,
 /area/pod_wars/spacejunk/greatwreck)
-"YA" = (
-/turf/simulated/floor/black/grime,
-/area/space)
 "YB" = (
 /obj/cable{
 	d1 = 4;
@@ -13406,11 +13287,6 @@
 	icon_state = "floor"
 	},
 /area/pod_wars/team2/hangar)
-"YP" = (
-/turf/simulated/floor/blueblack{
-	dir = 9
-	},
-/area/pod_wars/spacejunk/memorial_stats)
 "YR" = (
 /obj/landmark/start{
 	name = "NanoTrasen Pod Pilot"
@@ -91711,13 +91587,13 @@ JW
 JW
 JW
 JW
-uW
 JW
 JW
 JW
 JW
 JW
-uW
+JW
+JW
 JW
 JW
 JW
@@ -92216,10 +92092,10 @@ JW
 JW
 JW
 JW
-uW
 JW
 JW
-uW
+JW
+JW
 JW
 JW
 JW
@@ -92724,7 +92600,7 @@ JW
 JW
 JW
 JW
-YA
+JW
 JW
 JW
 JW
@@ -93218,7 +93094,6 @@ JW
 JW
 JW
 JW
-DD
 JW
 JW
 JW
@@ -93226,9 +93101,10 @@ JW
 JW
 JW
 JW
-co
 JW
-uW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -93717,14 +93593,14 @@ Pf
 Pf
 JW
 JW
-co
-co
 JW
 JW
 JW
 JW
 JW
-DD
+JW
+JW
+JW
 JW
 JW
 JW
@@ -94209,18 +94085,18 @@ JW
 JW
 Pf
 Pf
-Il
-Il
-Il
-Il
-Il
-Il
-Il
-Il
-Il
-Il
-Il
-Il
+Pf
+Pf
+Pf
+Pf
+Pf
+Pf
+Pf
+Pf
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -94711,27 +94587,27 @@ JW
 JW
 Pf
 Pf
-Il
-FC
-UY
-FC
-mp
-FC
-FC
-QC
-mp
-FC
-mp
-Il
-JW
-JW
-co
-co
+Pf
+Pf
+Pf
+Pf
+Pf
+Pf
+Pf
+Pf
 JW
 JW
 JW
 JW
-co
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -95213,29 +95089,29 @@ JW
 JW
 Pf
 Pf
-Il
-mp
-YP
-Wx
-Wx
-lF
-Wx
-Wx
-Bk
-DW
-mp
-Il
+Pf
+Pf
+Pf
+Pf
+Pf
+Pf
+Pf
 JW
 JW
-co
-MD
 JW
 JW
-DD
 JW
-Rf
 JW
-uW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -95715,33 +95591,33 @@ JW
 Pf
 Pf
 Pf
-Il
-FC
-zN
-bF
-bF
-bF
-Bk
-bF
-bF
-Bk
-mp
-co
+Pf
+Pf
+Pf
+Pf
+Pf
 JW
 JW
 JW
 JW
 JW
 JW
-co
 JW
 JW
 JW
 JW
 JW
 JW
-FX
-co
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -96217,16 +96093,10 @@ JW
 Pf
 Pf
 Pf
-Il
-np
-zN
-Bk
-bF
-bF
-bF
-bF
-Bk
-Om
+Pf
+Pf
+Pf
+Pf
 JW
 JW
 JW
@@ -96242,8 +96112,14 @@ JW
 JW
 JW
 JW
-co
-co
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -96719,23 +96595,23 @@ JW
 Pf
 Pf
 Pf
-Il
-Li
-zN
-bF
-Bk
-bF
-Bk
-Bk
-Bk
-co
+Pf
+Pf
+Pf
 JW
 JW
 JW
 JW
 JW
 JW
-MD
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -97221,23 +97097,23 @@ JW
 Pf
 Pf
 Pf
-Il
-FC
-Bk
-bF
-bF
-bF
-bF
-Bk
-mb
+Pf
+Pf
+Pf
 JW
 JW
-MD
 JW
-DD
 JW
-co
-co
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -97723,20 +97599,20 @@ JW
 Pf
 Pf
 Pf
-Il
-mp
-fI
-qB
-qB
-xl
-qB
-qB
-co
-JW
-FX
+Pf
+Pf
+Pf
 JW
 JW
-Rf
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -98225,14 +98101,10 @@ JW
 JW
 Pf
 Pf
-Il
-mp
-mC
-mp
-FC
-mp
-mp
-hS
+Pf
+Pf
+Pf
+Pf
 JW
 JW
 JW
@@ -98246,10 +98118,14 @@ JW
 JW
 JW
 JW
-Rf
 JW
 JW
-FX
+JW
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -98727,14 +98603,11 @@ JW
 JW
 Pf
 Pf
-Il
-Il
-Il
-Il
-Il
-Il
-Il
-Il
+Pf
+Pf
+Pf
+Pf
+Pf
 JW
 JW
 JW
@@ -98742,10 +98615,13 @@ JW
 JW
 JW
 JW
-DD
 JW
 JW
-MD
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -99234,14 +99110,14 @@ Pf
 Pf
 Pf
 Pf
-co
-co
 JW
 JW
 JW
 JW
 JW
-DD
+JW
+JW
+JW
 JW
 JW
 JW
@@ -99736,16 +99612,16 @@ Pf
 Pf
 Pf
 Pf
-co
 JW
 JW
 JW
 JW
-MD
 JW
 JW
 JW
-MD
+JW
+JW
+JW
 JW
 JW
 JW
@@ -100237,21 +100113,21 @@ Pf
 Pf
 JW
 JW
-YA
-YA
-JW
-MD
 JW
 JW
 JW
 JW
 JW
 JW
-Rf
 JW
 JW
 JW
-DD
+JW
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -100742,7 +100618,7 @@ JW
 JW
 JW
 JW
-co
+JW
 JW
 JW
 JW
@@ -101247,13 +101123,13 @@ JW
 JW
 JW
 JW
-MD
 JW
 JW
 JW
 JW
-co
-MD
+JW
+JW
+JW
 JW
 JW
 JW
@@ -101745,11 +101621,6 @@ JW
 JW
 JW
 JW
-DD
-JW
-JW
-JW
-YA
 JW
 JW
 JW
@@ -101761,7 +101632,12 @@ JW
 JW
 JW
 JW
-FX
+JW
+JW
+JW
+JW
+JW
+JW
 JW
 JW
 JW
@@ -102262,8 +102138,8 @@ JW
 JW
 JW
 JW
-co
-HQ
+JW
+JW
 JW
 JW
 JW
@@ -102747,8 +102623,8 @@ JW
 JW
 JW
 JW
-Rf
-co
+JW
+JW
 JW
 JW
 JW
@@ -103257,7 +103133,7 @@ JW
 JW
 JW
 JW
-Rf
+JW
 JW
 JW
 JW
@@ -103756,7 +103632,7 @@ JW
 JW
 JW
 JW
-co
+JW
 JW
 JW
 JW
@@ -104257,8 +104133,8 @@ JW
 JW
 JW
 JW
-FX
-co
+JW
+JW
 JW
 JW
 JW


### PR DESCRIPTION
Reverts goonstation/goonstation#4933 because it doesn't work and there's bugs

```
	if (get_pod_wars_team_num(M) == TEAM_NANOTRASEN)
		world.save_intra_round_value("nt_death", nt_death + 1)
	if (get_pod_wars_team_num(M) == TEAM_NANOTRASEN)
		world.save_intra_round_value("sy_death", sy_death + 1)
```