### PR TITLE
fix a runtime with recaller artifacts

### DIFF
--- a/code/obj/artifacts/artifact_objects/recaller.dm
+++ b/code/obj/artifacts/artifact_objects/recaller.dm
@@ -26,7 +26,7 @@
 
 		O.ArtifactFaultUsed(user)
 		SPAWN_DBG(src.recall_delay)
-			if (user && src.activated && !user.hibernating) //Wire note: Fix for Cannot execute null.visible message()
+			if (user && src.activated && !user.hibernating && !user.disposed) //Wire note: Fix for Cannot execute null.visible message()
 				user.visible_message("<span class='alert'><b>[user]</b> is suddenly pulled through space!</span>")
 				playsound(user.loc, "sound/effects/mag_warp.ogg", 50, 1, -1)
 				var/turf/T = get_turf(O)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Recalled terrible disposed entities from beyond the void.
Any form of interacting with them, be it bumping, examining, grabbing, etc., resulted in terrible runtimes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
runtimes bad