### PR TITLE
Fix #1266 - Antag event spawns on Oshan

### DIFF
--- a/code/WorkInProgress/missile_latejoin.dm
+++ b/code/WorkInProgress/missile_latejoin.dm
@@ -167,4 +167,3 @@ proc/latejoin_missile_spawn(var/mob/character)
 	var/missile_dir = landmarks[LANDMARK_LATEJOIN_MISSILE][T]
 	M.set_loc(T)
 	SPAWN_DBG(0) M.lunch(character, missile_dir)
-	return

--- a/code/WorkInProgress/missile_latejoin.dm
+++ b/code/WorkInProgress/missile_latejoin.dm
@@ -160,3 +160,11 @@ proc/launch_with_missile(atom/movable/thing, turf/target)
 		missile.target = target
 	missile.lunch(thing)
 	return missile
+
+proc/latejoin_missile_spawn(var/mob/character)
+	var/obj/arrival_missile/M = unpool(/obj/arrival_missile)
+	var/turf/T = pick_landmark(LANDMARK_LATEJOIN_MISSILE)
+	var/missile_dir = landmarks[LANDMARK_LATEJOIN_MISSILE][T]
+	M.set_loc(T)
+	SPAWN_DBG(0) M.lunch(character, missile_dir)
+	return

--- a/code/WorkInProgress/missile_latejoin.dm
+++ b/code/WorkInProgress/missile_latejoin.dm
@@ -166,4 +166,5 @@ proc/latejoin_missile_spawn(var/mob/character)
 	var/turf/T = pick_landmark(LANDMARK_LATEJOIN_MISSILE)
 	var/missile_dir = landmarks[LANDMARK_LATEJOIN_MISSILE][T]
 	M.set_loc(T)
-	SPAWN_DBG(0) M.lunch(character, missile_dir)
+	SPAWN_DBG(0)
+		M.lunch(character, missile_dir)

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -349,11 +349,7 @@ mob/new_player
 					starting_loc = pick_landmark(LANDMARK_LATEJOIN, locate(1, 1, 1))
 					character.set_loc(starting_loc)
 			else if (map_settings?.arrivals_type == MAP_SPAWN_MISSILE)
-				var/obj/arrival_missile/M = unpool(/obj/arrival_missile)
-				var/turf/T = pick_landmark(LANDMARK_LATEJOIN_MISSILE)
-				var/missile_dir = landmarks[LANDMARK_LATEJOIN_MISSILE][T]
-				M.set_loc(T)
-				SPAWN_DBG(0) M.lunch(character, missile_dir)
+				latejoin_missile_spawn(character)
 			else if(istype(ticker.mode, /datum/game_mode/battle_royale))
 				var/datum/game_mode/battle_royale/battlemode = ticker.mode
 				if(ticker.round_elapsed_ticks > 3000) // no new people after 5 minutes

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -328,7 +328,7 @@
 		lucky_dude.assigned_role = "MODE"
 		lucky_dude.special_role = role
 		lucky_dude.random_event_special_role = 1
-		//lucky_dude.dnr = 1
+		lucky_dude.dnr = 1
 		if (!(lucky_dude in ticker.mode.Agimmicks))
 			ticker.mode.Agimmicks.Add(lucky_dude)
 		M3.antagonist_overlay_refresh(1, 0)

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -168,7 +168,7 @@
 
 		var/role = null
 		var/objective_path = null
-		var/send_to = 1 // 1: arrival shuttle | 2: wizard shuttle
+		var/send_to = 1 // 1: arrival shuttle/latejoin missile | 2: wizard shuttle | 3: safe start for incorporeal antags
 		var/ASLoc = pick_landmark(LANDMARK_LATEJOIN)
 		var/WSLoc = job_start_locations["wizard"] ? pick(job_start_locations["wizard"]) : null
 		var/failed = 0
@@ -180,6 +180,7 @@
 					M3 = B
 					role = "blob"
 					objective_path = /datum/objective_set/blob
+					send_to = 3
 
 					SPAWN_DBG(0)
 						var/newname = input(B, "You are a Blob. Please choose a name for yourself, it will show in the form: <name> the Blob", "Name change") as text
@@ -199,6 +200,7 @@
 					M3 = F
 					role = "flockmind"
 					//objective_path = /datum/objective_set/blob
+					send_to = 3
 				else
 					failed = 1
 
@@ -208,6 +210,7 @@
 					M3 = W
 					role = "wraith"
 					generate_wraith_objectives(lucky_dude)
+					send_to = 3
 				else
 					failed = 1
 
@@ -325,7 +328,7 @@
 		lucky_dude.assigned_role = "MODE"
 		lucky_dude.special_role = role
 		lucky_dude.random_event_special_role = 1
-		lucky_dude.dnr = 1
+		//lucky_dude.dnr = 1
 		if (!(lucky_dude in ticker.mode.Agimmicks))
 			ticker.mode.Agimmicks.Add(lucky_dude)
 		M3.antagonist_overlay_refresh(1, 0)
@@ -345,13 +348,17 @@
 
 		switch (send_to)
 			if (1)
-				M3.set_loc(ASLoc)
+				if (map_settings?.arrivals_type == MAP_SPAWN_MISSILE)
+					latejoin_missile_spawn(M3)
+				else
+					M3.set_loc(ASLoc)
 			if (2)
 				if (!WSLoc)
 					M3.set_loc(ASLoc)
 				else
 					M3.set_loc(WSLoc)
-
+			if (3)
+				M3.set_loc(ASLoc)
 		//nah
 		/*
 		if (src.centcom_headline && src.centcom_message && random_events.announce_events)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Puts antag event spawns in a late arrival missile instead of throwing them into the ocean.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Vampires were obliterated by spawn location, this should fix https://github.com/goonstation/goonstation/issues/1266