### PR TITLE
EMP proof nuke

### DIFF
--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -275,11 +275,6 @@
 		src.take_damage(power)
 		return
 
-	emp_act()
-		src.take_damage(rand(25,35))
-		if (armed && det_time)
-			det_time += rand(-300,600)
-
 	meteorhit()
 		src.take_damage(rand(30,60))
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the nuclear bomb immune to EMP.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nukies can purchase EMP grenades that are effective against sec equipment but cause a surprising amount of damage to their own bomb. The only EMP for security is Pulse Rifle EMP mode, very rarely used against the nuke.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Nuclear bomb is now EMP proof.
```
