### PR TITLE
Removes Nugget Mode from Prison Loafers

### DIFF
--- a/code/WorkInProgress/recycling/disposal.dm
+++ b/code/WorkInProgress/recycling/disposal.dm
@@ -838,7 +838,6 @@
 	name = "disciplinary loaf processor"
 	desc = "A pipe segment designed to convert detritus into a nutritionally-complete meal for inmates."
 	icon_state = "pipe-loaf0"
-	var/nugget_mode = 0
 	mats = 100
 	is_syndicate = 1
 	var/is_doing_stuff = FALSE
@@ -886,111 +885,60 @@
 				estein.set_loc(H)
 				goto StopLoafing
 
-			if (nugget_mode)
-				var/obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget/current_nugget
-				var/list/new_nuggets = list()
-				for (var/atom/movable/newIngredient in H)
-					if(istype(newIngredient, /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget))
-						continue
-					if (!current_nugget)
-						current_nugget = new /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget(src)
-						new_nuggets += current_nugget
 
-					current_nugget.name = "[newIngredient] nugget"
-					current_nugget.desc = "A breaded wad of [newIngredient.name], far too processed to have a more specific label than 'nugget.'"
+			var/obj/item/reagent_containers/food/snacks/prison_loaf/newLoaf = new /obj/item/reagent_containers/food/snacks/prison_loaf(src)
+			for (var/atom/movable/newIngredient in H)
 
-					if (isliving(newIngredient))
-						playsound(src.loc, pick("sound/impact_sounds/Slimy_Splat_1.ogg","sound/impact_sounds/Liquid_Slosh_1.ogg","sound/impact_sounds/Wood_Hit_1.ogg","sound/impact_sounds/Slimy_Hit_3.ogg","sound/impact_sounds/Slimy_Hit_4.ogg","sound/impact_sounds/Flesh_Stab_1.ogg"), 50, 1)
-						var/mob/living/poorSoul = newIngredient
-						if (issilicon(poorSoul))
-							current_nugget.reagents.add_reagent("oil",10)
-							current_nugget.reagents.add_reagent("silicon",10)
-							current_nugget.reagents.add_reagent("iron",10)
-						else
-							current_nugget.reagents.add_reagent("bloodc",10) // heh
-							current_nugget.reagents.add_reagent("ectoplasm",10)
-
-						if(!isdead(poorSoul))
-							poorSoul:emote("scream")
-						sleep(0.5 SECONDS)
-						poorSoul.ghostize()
-
-					if (newIngredient.reagents)
-						var/anItem = isitem(newIngredient)
-						while (length(new_nuggets) < 50 && (newIngredient.reagents.total_volume > 0 || (anItem && newIngredient:w_class--)))
-							newIngredient.reagents.trans_to(current_nugget, current_nugget.reagents.maximum_volume)
-							if (current_nugget.reagents.total_volume >= current_nugget.reagents.maximum_volume)
-								current_nugget = new /obj/item/reagent_containers/food/snacks/ingredient/meat/mysterymeat/nugget(src)
-
-								current_nugget.name = "[newIngredient] nugget"
-								current_nugget.desc = "A breaded wad of [newIngredient.name], far too processed to have a more specific label than 'nugget.'"
-
-								new_nuggets += current_nugget
-
-					qdel(newIngredient)
-					LAGCHECK(LAG_MED)
-
-				for (var/obj/O in new_nuggets)
-					O.set_loc(H)
-					LAGCHECK(LAG_MED)
-
-				sleep(length(new_nuggets))
-
-			else
-				var/obj/item/reagent_containers/food/snacks/prison_loaf/newLoaf = new /obj/item/reagent_containers/food/snacks/prison_loaf(src)
-
-				for (var/atom/movable/newIngredient in H)
-
-					LAGCHECK(LAG_MED)
+				LAGCHECK(LAG_MED)
 
 
 
-					if (newIngredient.reagents)
-						newIngredient.reagents.trans_to(newLoaf, 1000)
+				if (newIngredient.reagents)
+					newIngredient.reagents.trans_to(newLoaf, 1000)
 
-					if (istype(newIngredient, /obj/item/reagent_containers/food/snacks/prison_loaf))
-						var/obj/item/reagent_containers/food/snacks/prison_loaf/otherLoaf = newIngredient
-						newLoaf.loaf_factor += otherLoaf.loaf_factor * 1.2
-						newLoaf.loaf_recursion = otherLoaf.loaf_recursion + 1
-						otherLoaf = null
+				if (istype(newIngredient, /obj/item/reagent_containers/food/snacks/prison_loaf))
+					var/obj/item/reagent_containers/food/snacks/prison_loaf/otherLoaf = newIngredient
+					newLoaf.loaf_factor += otherLoaf.loaf_factor * 1.2
+					newLoaf.loaf_recursion = otherLoaf.loaf_recursion + 1
+					otherLoaf = null
 
-					else if (isliving(newIngredient))
-						playsound(src.loc, pick("sound/impact_sounds/Slimy_Splat_1.ogg","sound/impact_sounds/Liquid_Slosh_1.ogg","sound/impact_sounds/Wood_Hit_1.ogg","sound/impact_sounds/Slimy_Hit_3.ogg","sound/impact_sounds/Slimy_Hit_4.ogg","sound/impact_sounds/Flesh_Stab_1.ogg"), 50, 1)
-						var/mob/living/poorSoul = newIngredient
-						if (issilicon(poorSoul))
-							newLoaf.reagents.add_reagent("oil",10)
-							newLoaf.reagents.add_reagent("silicon",10)
-							newLoaf.reagents.add_reagent("iron",10)
-						else
-							newLoaf.reagents.add_reagent("bloodc",10) // heh
-							newLoaf.reagents.add_reagent("ectoplasm",10)
-
-						if(ishuman(newIngredient))
-							newLoaf.loaf_factor += (newLoaf.loaf_factor / 5) + 50 // good god this is a weird value
-						else
-							newLoaf.loaf_factor += (newLoaf.loaf_factor / 10) + 50
-						if(!isdead(poorSoul))
-							poorSoul:emote("scream")
-						sleep(0.5 SECONDS)
-						poorSoul.death()
-						if (poorSoul.mind || poorSoul.client)
-							poorSoul.ghostize()
-					else if (isitem(newIngredient))
-						var/obj/item/I = newIngredient
-						newLoaf.loaf_factor += I.w_class * 5
-						I = null
+				else if (isliving(newIngredient))
+					playsound(src.loc, pick("sound/impact_sounds/Slimy_Splat_1.ogg","sound/impact_sounds/Liquid_Slosh_1.ogg","sound/impact_sounds/Wood_Hit_1.ogg","sound/impact_sounds/Slimy_Hit_3.ogg","sound/impact_sounds/Slimy_Hit_4.ogg","sound/impact_sounds/Flesh_Stab_1.ogg"), 50, 1)
+					var/mob/living/poorSoul = newIngredient
+					if (issilicon(poorSoul))
+						newLoaf.reagents.add_reagent("oil",10)
+						newLoaf.reagents.add_reagent("silicon",10)
+						newLoaf.reagents.add_reagent("iron",10)
 					else
-						newLoaf.loaf_factor++
+						newLoaf.reagents.add_reagent("bloodc",10) // heh
+						newLoaf.reagents.add_reagent("ectoplasm",10)
 
-					H.contents -= newIngredient
-					newIngredient.set_loc(null)
-					newIngredient = null
+					if(ishuman(newIngredient))
+						newLoaf.loaf_factor += (newLoaf.loaf_factor / 5) + 50 // good god this is a weird value
+					else
+						newLoaf.loaf_factor += (newLoaf.loaf_factor / 10) + 50
+					if(!isdead(poorSoul))
+						poorSoul:emote("scream")
+					sleep(0.5 SECONDS)
+					poorSoul.death()
+					if (poorSoul.mind || poorSoul.client)
+						poorSoul.ghostize()
+				else if (isitem(newIngredient))
+					var/obj/item/I = newIngredient
+					newLoaf.loaf_factor += I.w_class * 5
+					I = null
+				else
+					newLoaf.loaf_factor++
 
-					//LAGCHECK(LAG_MED)
-					qdel(newIngredient)
+				H.contents -= newIngredient
+				newIngredient.set_loc(null)
+				newIngredient = null
 
-				newLoaf.update()
-				newLoaf.set_loc(H)
+				//LAGCHECK(LAG_MED)
+				qdel(newIngredient)
+
+			newLoaf.update()
+			newLoaf.set_loc(H)
 
 			StopLoafing:
 
@@ -1023,27 +971,11 @@
 
 		return P
 
-	/*welded()
-
-		/*var/obj/disposalconstruct/C = new (src.loc)
-		C.ptype = 10
-		C.set_dir(dir)
-		C.update()
-
-		qdel(src)*/
-
-		src.visible_message("<span class='alert'>[src] emits a weird noise!</span>")
-
-		src.nugget_mode = !src.nugget_mode
-		src.update()
-		return*/
-
+	welded()
+		return //can't let them unweld the loafer
 	update()
 		..()
-		if (nugget_mode)
-			src.name = "disciplinary nugget processor"
-		else
-			src.name = initial(src.name)
+		src.name = initial(src.name)
 
 #define MAXIMUM_LOAF_STATE_VALUE 10
 

--- a/code/WorkInProgress/recycling/disposal.dm
+++ b/code/WorkInProgress/recycling/disposal.dm
@@ -1023,7 +1023,7 @@
 
 		return P
 
-	welded()
+	/*welded()
 
 		/*var/obj/disposalconstruct/C = new (src.loc)
 		C.ptype = 10
@@ -1036,7 +1036,7 @@
 
 		src.nugget_mode = !src.nugget_mode
 		src.update()
-		return
+		return*/
 
 	update()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Removal] [Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes nugget mode from loafers.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There's an issue with nuggeting high-tier loaves in succession that manages to crash the server for a period of time, before making the server slow down to, conservatively, 1 in game second every 30 real.
Twenty or so minutes ago from writing this, I accidentally welded the wrong pipe on my loafer, and managed to do as mentioned above, which isn't ideal, to say the least.

Also, I'm not sure what the point of nuggets are in the prison loafer, since you don't make 3 nuggets for 1 loaf now.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(*)Prison Loafers no longer have nugget mode.
```
