### PR TITLE
Door health nerf

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1542,7 +1542,7 @@ obj/item/whetstone
 	two_handed = 1
 	click_delay = 30
 
-	force = 25 //this number is multiplied by 4 when attacking doors.
+	force = 30 //this number is multiplied by 4 when attacking doors.
 	stamina_damage = 60
 	stamina_cost = 30
 

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -157,8 +157,8 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	var/welded_icon_state = "welded"
 
 	explosion_resistance = 2
-	health = 1200
-	health_max = 1200
+	health = 600
+	health_max = 600
 
 	var/ai_no_access = 0 //This is the dumbest var.
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
@@ -325,8 +325,8 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	icon_state = "com_closed"
 	icon_base = "com"
 	req_access = list(access_heads)
-	health = 1600
-	health_max = 1600
+	health = 800
+	health_max = 800
 
 /obj/machinery/door/airlock/pyro/command/alt
 	icon_state = "com2_closed"

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -536,6 +536,8 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	sound_airlock = 'sound/machines/windowdoor.ogg'
 	has_panel = 0
 	has_crush = 0
+	health = 500
+	health_max = 500
 	layer = 3.5
 	object_flags = BOTS_DIRBLOCK | CAN_REPROGRAM_ACCESS | HAS_DIRECTIONAL_BLOCKING
 

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -30,8 +30,8 @@
 	var/has_crush = 1 //flagged to true when the door has a secret admirer. also if the var == 1 then the door doesn't have the ability to crush items.
 	var/close_trys = 0
 
-	var/health = 600
-	var/health_max = 600
+	var/health = 400
+	var/health_max = 400
 	var/hitsound = "sound/impact_sounds/Generic_Hit_Heavy_1.ogg"
 	var/knocksound = 'sound/impact_sounds/Door_Metal_Knock_1.ogg' //knock knock
 

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -291,15 +291,13 @@
 
 	if (src.isblocked() == 1)
 		if (src.density && !src.operating && I)
+			if (I.tool_flags & TOOL_CHOPPING)
+				src.take_damage(I.force*4, user)
+			else
+				src.take_damage(I.force, user)
 			user.lastattacked = src
 			attack_particle(user,src)
 			playsound(src.loc, src.hitsound , 50, 1, pitch = 1.6)
-			src.take_damage(I.force, user)
-			if (I.tool_flags & TOOL_CHOPPING)
-				user.lastattacked = src
-				attack_particle(user,src)
-				playsound(src.loc, src.hitsound , 50, 1, pitch = 1.6)
-				src.take_damage(I.force*4, user)
 			..()
 
 		return
@@ -394,11 +392,11 @@
 			if(prob(25))
 				qdel(src)
 			else
-				take_damage(health_max/2)
+				take_damage(health_max/4)
 		if(3.0)
 			if(prob(80))
 				elecflash(src,power=2)
-			take_damage(health_max/6)
+			take_damage(health_max/12)
 
 /obj/machinery/door/proc/break_me_complitely()
 	set waitfor = 0
@@ -454,15 +452,15 @@
 
 	switch(P.proj_data.damage_type)
 		if(D_KINETIC)
-			take_damage(damage * 3)
+			take_damage(round(damage * 1.5))
 		if(D_PIERCING)
-			take_damage(damage * 4)
-		if(D_ENERGY)
 			take_damage(damage * 2)
-		if(D_BURNING)
+		if(D_ENERGY)
 			take_damage(damage)
-		if(D_RADIOACTIVE)
+		if(D_BURNING)
 			take_damage(damage/2)
+		if(D_RADIOACTIVE)
+			take_damage(damage/4)
 	return
 
 /obj/machinery/door/proc/update_icon(var/toggling = 0)

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -392,11 +392,11 @@
 			if(prob(25))
 				qdel(src)
 			else
-				take_damage(health_max/4)
+				take_damage(health_max/2)
 		if(3.0)
 			if(prob(80))
 				elecflash(src,power=2)
-			take_damage(health_max/12)
+			take_damage(health_max/6)
 
 /obj/machinery/door/proc/break_me_complitely()
 	set waitfor = 0

--- a/code/obj/machinery/door/window.dm
+++ b/code/obj/machinery/door/window.dm
@@ -13,6 +13,8 @@
 	var/base_state = "left"
 	visible = 0
 	flags = ON_BORDER
+	health = 500
+	health_max = 500
 	opacity = 0
 	brainloss_stumble = 1
 	autoclose = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][WIKI][FEEDBACK]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduce door health by around 50%.
Scales explosive, radiation, fire and projectile damage to match previous behavior.
Tidies weird cutting tool code that actually caused 5x damage. Buffs breaching hammer slightly to compensate.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Recommended by MBC to reduce door health by around 70%. Went with 50% for simplicity.
Doors are incredibly strong. It takes 5-6 hits (15 seconds approx) of a Breaching Hammer to get through the flimsiest door and 12 hits (35 seconds approx) to get through command doors. This is with a dedicated, two handed tool that does 125 damage to doors!
The next strongest common melee weapon, a baseball bat, takes 50 hits to break a standard door, with most doors actually being pyro doors with 1200 health.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Made doors half as strong, you can now break them this century. Explosive/fire/projectile scaling is adjusted so it will still take the same number of bullets to destroy a door.
```
