### PR TITLE
Increases the random antag even frequency

### DIFF
--- a/code/datums/controllers/event_controls.dm
+++ b/code/datums/controllers/event_controls.dm
@@ -17,7 +17,7 @@ var/datum/event_controller/random_events
 	var/minor_event_cycle_count = 0
 
 	var/list/antag_spawn_events = list()
-	var/alive_antags_threshold = 0.06
+	var/alive_antags_threshold = 0.2
 	var/list/player_spawn_events = list()
 	var/dead_players_threshold = 0.3
 	var/spawn_events_begin = 23 MINUTES

--- a/code/datums/controllers/event_controls.dm
+++ b/code/datums/controllers/event_controls.dm
@@ -17,7 +17,11 @@ var/datum/event_controller/random_events
 	var/minor_event_cycle_count = 0
 
 	var/list/antag_spawn_events = list()
+#ifdef RP_MODE
+	var/alive_antags_threshold = 0.06
+#else
 	var/alive_antags_threshold = 0.1
+#endif
 	var/list/player_spawn_events = list()
 	var/dead_players_threshold = 0.3
 	var/spawn_events_begin = 23 MINUTES

--- a/code/datums/controllers/event_controls.dm
+++ b/code/datums/controllers/event_controls.dm
@@ -17,7 +17,7 @@ var/datum/event_controller/random_events
 	var/minor_event_cycle_count = 0
 
 	var/list/antag_spawn_events = list()
-	var/alive_antags_threshold = 0.2
+	var/alive_antags_threshold = 0.1
 	var/list/player_spawn_events = list()
 	var/dead_players_threshold = 0.3
 	var/spawn_events_begin = 23 MINUTES


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR (hopefully) increases the random antag event frequency by changing the alive antag threshold value from 6% to 10% (meaning, if less than 10% of the alive crew are antags, the event has a chance to trigger, if other requirements are met)

The change is exclusive to non RP servers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It was actually suggested by mbc, and also, in my opinion, random antag events are currently too rare and I often find myself triggering them manually, if the round feels too slow. With the variety of antag critters we have, I think the change will benefit the game, influencing the round dynamics more often and giving dead players a chance to participate in the round again.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Increased the random antag event frequency on non-RP servers.
```
