### PR TITLE
Kondaru tuneup pass + det office door reversion

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -10337,16 +10337,19 @@
 	},
 /area/station/security/detectives_office)
 "aBL" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	name = "Detective's Office"
-	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	id = "det_entry";
+	name = "Detective's Office";
+	req_access = null
+	},
+/obj/access_spawn/forensics,
 /turf/simulated/floor/wood/two,
 /area/station/security/detectives_office)
 "aBM" = (
@@ -17381,6 +17384,11 @@
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/pathology,
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "aWm" = (
@@ -19886,6 +19894,9 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/horizontal,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/routing/depot)
 "ben" = (
@@ -22677,9 +22688,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/item/device/radio/intercom/medical{
+/obj/submachine/chef_sink/chem_sink{
 	dir = 4;
-	pixel_x = -21
+	pixel_x = -8
 	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
@@ -23090,7 +23101,10 @@
 /area/station/maintenance/west)
 "boR" = (
 /obj/morgue,
-/obj/machinery/light_switch/west,
+/obj/item/device/radio/intercom/medical{
+	dir = 4;
+	pixel_x = -21
+	},
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "boS" = (
@@ -27081,13 +27095,17 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bCw" = (
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/disposalpipe/segment/brig{
-	dir = 8
+/obj/machinery/firealarm{
+	pixel_x = 1;
+	pixel_y = 24
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -27423,17 +27441,12 @@
 /area/station/hallway/primary/south)
 "bDq" = (
 /obj/disposalpipe/segment/brig{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20
-	},
-/obj/machinery/firealarm{
-	pixel_x = 6;
-	pixel_y = 24
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -31582,11 +31595,17 @@
 /area/station/security/secwing)
 "bNK" = (
 /obj/machinery/light/small,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/redblack{
 	dir = 10
 	},
 /area/station/security/secwing)
 "bNL" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/redblack/corner{
 	dir = 4
 	},
@@ -32169,6 +32188,11 @@
 	},
 /area/station/security/secwing)
 "bPk" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -32639,6 +32663,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -33516,7 +33543,6 @@
 	name = "cargo belt - west";
 	operating = 1
 	},
-/obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/airless/grey,
 /area/station/maintenance/southwest)
 "bTG" = (
@@ -36679,6 +36705,7 @@
 /area/station/hangar/medical)
 "ceA" = (
 /obj/morgue,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/morgue)
 "ceB" = (
@@ -42571,6 +42598,9 @@
 "dUS" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/hangar/sec)
 "dUX" = (
@@ -43529,6 +43559,11 @@
 /area/station/science/testchamber)
 "eUm" = (
 /obj/disposalpipe/segment/mail/horizontal,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
 /turf/simulated/floor/neutral/corner{
 	dir = 8
 	},
@@ -44147,6 +44182,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "fCz" = (
@@ -44524,7 +44562,6 @@
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},
-/obj/item/device/radio/intercom,
 /obj/decal/garland/ephemeral{
 	dir = 8;
 	pixel_x = 14
@@ -45112,9 +45149,6 @@
 	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -45484,6 +45518,17 @@
 /area/station/crew_quarters/clown{
 	name = "Clowntainment"
 	})
+"gQt" = (
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/hangar/sec)
 "gQA" = (
 /obj/machinery/disposal,
 /obj/machinery/light{
@@ -45567,9 +45612,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "gTZ" = (
-/obj/decal/poster/wallsign/security_right,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/sw)
+/obj/disposalpipe/segment/brig{
+	dir = 8
+	},
+/obj/item/device/radio/intercom,
+/turf/simulated/floor,
+/area/station/hallway/primary/south)
 "gUz" = (
 /turf/simulated/floor/red/side,
 /area/station/security/secwing)
@@ -49370,9 +49418,6 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/light,
 /turf/simulated/floor/red/side,
 /area/station/security/secwing)
@@ -52529,6 +52574,10 @@
 	name = "autoname - SS13";
 	pixel_y = 20
 	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/sw)
 "ouG" = (
@@ -54984,6 +55033,10 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "rdz" = (
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /obj/machinery/communications_dish{
 	tag = "MAIN_DISH_SS13"
 	},
@@ -61109,11 +61162,16 @@
 	},
 /area/station/routing/security)
 "xuY" = (
-/obj/machinery/light/small,
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/sw)
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4;
+	name = "Cargo Office";
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
+/obj/disposalpipe/segment/horizontal,
+/turf/simulated/floor/orangeblack,
+/area/station/quartermaster/office)
 "xvH" = (
 /obj/machinery/vending/janitor,
 /turf/simulated/floor/darkblue,
@@ -102710,7 +102768,7 @@ xLq
 tnf
 bnT
 bnT
-btb
+bDq
 bnT
 bnT
 bDp
@@ -103317,7 +103375,7 @@ vpD
 vpD
 sJN
 sJN
-bCv
+gTZ
 bDA
 byk
 bGq
@@ -103921,7 +103979,7 @@ ouF
 vpD
 eeR
 sJN
-bDq
+bCv
 bDA
 sdd
 bGr
@@ -104222,7 +104280,7 @@ vpD
 xXb
 eFk
 pzZ
-gTZ
+sJN
 bCv
 bDA
 bxm
@@ -104523,7 +104581,7 @@ jQd
 hhf
 sIi
 fwi
-xuY
+pzZ
 sJN
 fVr
 bDA
@@ -106045,7 +106103,7 @@ bKI
 bXi
 bXi
 bXb
-bXb
+xuY
 bXi
 bXi
 bXi
@@ -116018,7 +116076,7 @@ iTr
 xVN
 gwF
 lgr
-uaU
+gQt
 tSd
 ugs
 uDQ
@@ -122654,7 +122712,7 @@ bKa
 vTU
 bMw
 bPk
-bPk
+bSa
 bQJ
 bSa
 bSa

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -53723,6 +53723,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/testchamber)
+"pKT" = (
+/obj/machinery/drainage,
+/turf/simulated/floor/sanitary/white,
+/area/station/medical/morgue)
 "pLb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -96709,7 +96713,7 @@ oGg
 aZm
 baC
 bbC
-bGb
+pKT
 bGb
 ceH
 bfZ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Another set of changes and fixes for Kondaru, including an inspection pass over infrastructure.

- Undoes the change made to the detective's office in #5148 by returning to the front door being detective-only and openable using a button behind the desk. The door is intended to be opaque and access-locked in order to provide protection and (when combined with the blinds) privacy to clients, and it is not easy for someone to be trapped in the foyer area as there's a disposal chute readily available.
- Changed the arrangement of wall objects by the southwest hallway junction to increase the amount of open wall space, and relocated a wall light in associated maintenance. This change significantly improves QoL when taking over that section of maintenance using construction, as a contiguous three-tile span along the south side is now easily renovated.
- Introduced a sink to the west wall of the Morgue, relocating some other wall objects elsewhere in the room. A drain has also been added in the vicinity.
- Fixed several instances of missing or orphaned electrical cables and disposal pipes, most notably an absent segment in the brig pipe connecting to the escape hallway, an absent segment in the disposal pipe from QM, and a bit of missing wire along the connection to one of the two comm dishes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Further improves the usability of Kondaru.

Opted for a major changelog entry because of the Detective's office reversion, as the PR that originally made that change also received a major entry.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(*)Kondaru detective's office front door is once again detective-only with remote open. Also made maintenance near the Foundry more construction-friendly and added a sink/drain to the Morgue.
```
