### PR TITLE
Breaching charge sound and fx

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1189,6 +1189,12 @@ PIPE BOMBS + CONSTRUCTION
 				return
 
 			location.hotspot_expose(700, 125)
+			// NT charge shake
+			if (expl_heavy)
+				for(var/client/C in clients)
+					if(C.mob && (C.mob.z == src.z))
+						shake_camera(C.mob, 8, 24) // remove if this is too laggy
+						C << sound(explosions.distant_sound)
 			playsound(src.loc, pick(sounds_explosion), 75, 1)
 			explosion(src, location, src.expl_devas, src.expl_heavy, src.expl_light, src.expl_flash)
 			new /obj/effects/explosion (src.loc)

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1189,8 +1189,9 @@ PIPE BOMBS + CONSTRUCTION
 				return
 
 			location.hotspot_expose(700, 125)
-
+			playsound(src.loc, pick(sounds_explosion), 75, 1)
 			explosion(src, location, src.expl_devas, src.expl_heavy, src.expl_light, src.expl_flash)
+			new /obj/effects/explosion (src.loc)
 
 			// Breaching charges should be, you know, actually be decent at breaching walls and windows (Convair880).
 			for (var/turf/simulated/wall/W in range(src.expl_range, location))
@@ -1271,7 +1272,7 @@ PIPE BOMBS + CONSTRUCTION
 				qdel(src)
 				return
 
-			playsound(location, "sound/effects/bamf.ogg", 50, 1)
+			playsound(location, "sound/effects/bamf.ogg", 100, 0.5)
 			src.invisibility = 101
 
 			for (var/turf/T in range(src.expl_range, location))

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1189,16 +1189,19 @@ PIPE BOMBS + CONSTRUCTION
 				return
 
 			location.hotspot_expose(700, 125)
-			// NT charge shake
-			if (expl_heavy)
-				for(var/client/C in clients)
-					if(C.mob && (C.mob.z == src.z))
-						shake_camera(C.mob, 8, 24) // remove if this is too laggy
-						C << sound(explosions.distant_sound)
-			playsound(src.loc, pick(sounds_explosion), 75, 1)
-			explosion(src, location, src.expl_devas, src.expl_heavy, src.expl_light, src.expl_flash)
-			new /obj/effects/explosion (src.loc)
 
+			//Explosive effect for breaching charges only
+			if (!(istype(src, /obj/item/breaching_charge/mining)))
+				// NT charge shake
+				if (expl_heavy)
+					for(var/client/C in clients)
+						if(C.mob && (C.mob.z == src.z))
+							shake_camera(C.mob, 8, 24) // remove if this is too laggy
+							C << sound(explosions.distant_sound)
+				playsound(src.loc, pick(sounds_explosion), 75, 1)
+				new /obj/effects/explosion (src.loc)
+
+			explosion(src, location, src.expl_devas, src.expl_heavy, src.expl_light, src.expl_flash)
 			// Breaching charges should be, you know, actually be decent at breaching walls and windows (Convair880).
 			for (var/turf/simulated/wall/W in range(src.expl_range, location))
 				if (W && istype(W) && !location.loc:sanctuary)

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1197,8 +1197,9 @@ PIPE BOMBS + CONSTRUCTION
 					for(var/client/C in clients)
 						if(C.mob && (C.mob.z == src.z))
 							shake_camera(C.mob, 8, 24) // remove if this is too laggy
-							C << sound(explosions.distant_sound)
-				playsound(src.loc, pick(sounds_explosion), 75, 1)
+							playsound(C.mob, explosions.distant_sound, 100, 0)
+				else
+					playsound(src.loc, pick(sounds_explosion), 75, 1)
 				new /obj/effects/explosion (src.loc)
 			else
 				playsound(src.loc, "sound/weapons/flashbang.ogg", 50, 1)

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1198,9 +1198,10 @@ PIPE BOMBS + CONSTRUCTION
 						if(C.mob && (C.mob.z == src.z))
 							shake_camera(C.mob, 8, 24) // remove if this is too laggy
 							playsound(C.mob, explosions.distant_sound, 100, 0)
+							new /obj/effects/explosion (src.loc)
 				else
 					playsound(src.loc, pick(sounds_explosion), 75, 1)
-				new /obj/effects/explosion (src.loc)
+					new/obj/effect/supplyexplosion(src.loc)
 			else
 				playsound(src.loc, "sound/weapons/flashbang.ogg", 50, 1)
 

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1200,6 +1200,8 @@ PIPE BOMBS + CONSTRUCTION
 							C << sound(explosions.distant_sound)
 				playsound(src.loc, pick(sounds_explosion), 75, 1)
 				new /obj/effects/explosion (src.loc)
+			else
+				playsound(src.loc, "sound/weapons/flashbang.ogg", 50, 1)
 
 			explosion(src, location, src.expl_devas, src.expl_heavy, src.expl_light, src.expl_flash)
 			// Breaching charges should be, you know, actually be decent at breaching walls and windows (Convair880).


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an explosion effect and sound to breaching charges.
Gives NT breaching charges a long range explosion sound and screenshake to reflect it's power.
Increase the volume of the thermite charge.

https://user-images.githubusercontent.com/70909958/123425839-86f88780-d5ba-11eb-96b4-5e42aafc7110.mp4

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Despite being a wall clearing explosive breaching charges were surprisingly subtle.
They now have a standard explosion and bang (not a loud, station shaking explosion).
NT Breaching charges will have a loud, station shaking explosion to reflect the fact these are heavy explosives.
Regular mining charges and hacked mining charges used for asteroid mining will act as normal, these already had a flashbang sound,

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Breaching charges now have an explosion effect and sound.
```
