### PR TITLE
Reworks the snow suit

### DIFF
--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1022,13 +1022,6 @@
 		..()
 		setProperty("space_movespeed", 1.5)
 
-	snow // bleh whatever!!!
-		name = "snow suit"
-		desc = "A thick padded suit that protects against extreme cold temperatures."
-		icon_state = "snowcoat"
-		item_state = "snowcoat"
-		rip = -1
-
 /obj/item/clothing/suit/space/emerg/proc/ripcheck(var/mob/user)
 	if(rip >= 36 && rip != -1 && prob(10))  //upped from rip >= 14 by Buttes
 		boutput(user, "<span class='alert'>The emergency suit tears off!</span>")
@@ -1626,3 +1619,21 @@
 			. = "It's your war medal, you remember when you got this for saving a man's life during the war."
 		else
 			. = "It's the HoS's old war medal, you heard they got it for their acts of heroism in the war."
+
+/obj/item/clothing/suit/snow
+	name = "snow suit"
+	desc = "A thick padded suit that protects against extreme cold temperatures."
+	icon = 'icons/obj/clothing/overcoats/item_suit_hazard.dmi'
+	wear_image_icon = 'icons/mob/overcoats/worn_suit_hazard.dmi'
+	inhand_image_icon = 'icons/mob/inhand/overcoat/hand_suit_hazard.dmi'
+	icon_state = "snowcoat"
+	item_state = "snowcoat"
+	body_parts_covered = TORSO|LEGS|ARMS
+
+	setupProperties()
+		..()
+		setProperty("coldprot", 50)
+		setProperty("heatprot", 10)
+		setProperty("meleeprot", 3)
+		setProperty("rangedprot", 0.5)
+		setProperty("movespeed", 0.5)

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1637,3 +1637,4 @@
 		setProperty("meleeprot", 3)
 		setProperty("rangedprot", 0.5)
 		setProperty("movespeed", 0.5)
+		setProperty("disorient_resist", 15)

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -15130,9 +15130,9 @@
 	on = 0;
 	pixel_x = -24
 	},
-/obj/item/clothing/suit/space/emerg/snow,
-/obj/item/clothing/suit/space/emerg/snow,
-/obj/item/clothing/suit/space/emerg/snow,
+/obj/item/clothing/suit/snow,
+/obj/item/clothing/suit/snow,
+/obj/item/clothing/suit/snow,
 /obj/item/tank/air,
 /obj/item/tank/air,
 /obj/item/tank/air,


### PR DESCRIPTION
[Balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks the snow suit into a generic suit item, removes the space proofness, and reworks the stats to be not an exact copy of the emergency space suit.

Original:
> Cold = 50%
Heat = 20%
Viral = 50%
Melee = -3
Ranged = .5
Space Movespeed = 1.5


New:
> Cold = 50%
Heat = 10%
Melee = -3
Ranged = .5
Movespeed = .5
Disorient Resitance - 15%

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The snow suit is a very undesirable piece of equipment due to it's incredibly slow speed and it does not read as a space suit. This makes it a more unique clothing item that is more distinct from a space suit.

## Changelog

```changelog
(u)DimWhat
(+)Removed the space proofness of the snow suit and altered its stats.
```
