### PR TITLE
chages arrivals area designation on some maps to prevent being affected by blowouts

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -1848,11 +1848,14 @@ ABSTRACT_TYPE(/area/station/hallway/secondary)
 	name = "Main Hallway"
 	icon_state = "entry"
 
+/area/station/hallway/secondary/oshan_arrivals
+	name = "Oshan Arrivals"
+	icon_state = "blue"
+	do_not_irradiate = 1
+
 /area/station/hallway/secondary/shuttle
 	name = "Shuttle Bay"
 	icon_state = "shuttle3"
-
-
 
 /area/station/mailroom
 	name = "Mailroom"
@@ -2228,6 +2231,7 @@ ABSTRACT_TYPE(/area/station/crew_quarters/radio)
 /area/station/crewquarters/cryotron
 	name ="Cryogenic Crew Storage"
 	icon_state = "blue"
+	do_not_irradiate = 1
 
 ABSTRACT_TYPE(/area/station/com_dish)
 /area/station/com_dish

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -30,6 +30,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // BEGIN_INCLUDE
+#include "_std\compatibility.dm"
 #include "code\area.dm"
 #include "code\atom.dm"
 #include "code\base_lighting.dm"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -30,7 +30,6 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // BEGIN_INCLUDE
-#include "_std\compatibility.dm"
 #include "code\area.dm"
 #include "code\atom.dm"
 #include "code\base_lighting.dm"

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -2128,25 +2128,19 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/orangeblack,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aeE" = (
 /obj/cryotron{
 	layer = 3.9
 	},
 /turf/simulated/floor/black,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aeF" = (
 /obj/landmark{
 	name = "JoinLate"
 	},
 /turf/simulated/floor/black,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aeG" = (
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/entry{
@@ -2156,9 +2150,7 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aeK" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -2461,23 +2453,17 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "afg" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "afi" = (
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "afj" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -2486,17 +2472,13 @@
 /turf/simulated/floor/caution/misc{
 	dir = 8
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "afk" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "afl" = (
 /obj/machinery/computer/airbr/emergency_shuttle{
 	density = 0;
@@ -2508,9 +2490,7 @@
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "afm" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -2519,9 +2499,7 @@
 /turf/simulated/floor/caution/misc{
 	dir = 4
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "afn" = (
 /obj/airbridge_controller{
 	id = "merchant_N";
@@ -2679,9 +2657,7 @@
 	})
 "afM" = (
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "afO" = (
 /obj/machinery/light{
 	dir = 4;
@@ -2690,9 +2666,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "afP" = (
 /obj/machinery/light_switch/south{
 	pixel_y = 28
@@ -2999,23 +2973,17 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ago" = (
 /obj/stool/bench/yellow/auto,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "agp" = (
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "agq" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -3323,9 +3291,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "agI" = (
 /obj/machinery/disposal/mail/small{
 	dir = 8
@@ -3336,9 +3302,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "agJ" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -3522,44 +3486,34 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "agW" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "agX" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/stool/bench/yellow/auto,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "agY" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "agZ" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aha" = (
 /obj/machinery/disposal/small{
 	dir = 8
@@ -3570,9 +3524,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ahb" = (
 /turf/space,
 /area/shuttle/merchant_shuttle/right_station/destiny)
@@ -3773,24 +3725,18 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ahs" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aht" = (
 /obj/table/auto,
 /obj/item/decoration/ashtray,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ahu" = (
 /obj/machinery/light{
 	dir = 8;
@@ -4184,9 +4130,7 @@
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ahT" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -4194,26 +4138,20 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ahU" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ahV" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ahW" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -4228,9 +4166,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ahX" = (
 /obj/window/reinforced/north,
 /turf/simulated/floor/white/checker{
@@ -4414,9 +4350,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aip" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -4425,9 +4359,7 @@
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aiq" = (
 /obj/machinery/computer/airbr/emergency_shuttle{
 	density = 0;
@@ -4439,9 +4371,7 @@
 /turf/simulated/floor/caution/northsouth{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "air" = (
 /obj/airbridge_controller{
 	id = "merchant_S";
@@ -4807,42 +4737,30 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 10
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aiR" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/orangeblack/side,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aiS" = (
 /obj/machinery/vending/cola/blue,
 /turf/simulated/floor/orangeblack/side,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aiT" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/orangeblack/side,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aiU" = (
 /obj/stool/bench/yellow/auto,
 /turf/simulated/floor/orangeblack/side,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aiV" = (
 /obj/machinery/light/emergency,
 /obj/stool/bench/yellow/auto,
 /turf/simulated/floor/orangeblack/side{
 	dir = 6
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aiW" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
@@ -5245,14 +5163,10 @@
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/space,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ajs" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ajt" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -19115,9 +19029,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "aMs" = (
 /obj/disposalpipe/junction{
 	dir = 8
@@ -44455,6 +44367,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"ciN" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crewquarters/cryotron)
 "ciQ" = (
 /obj/noticeboard/persistent{
 	name = "Chapel persistent notice board";
@@ -45713,6 +45629,9 @@
 	},
 /turf/simulated/floor/black,
 /area/station/maintenance/central)
+"fNK" = (
+/turf/simulated/floor/black,
+/area/station/crewquarters/cryotron)
 "fNN" = (
 /obj/securearea{
 	desc = "Boxing ring and fitness equipment.";
@@ -45848,9 +45767,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "gdA" = (
 /obj/disposalpipe/segment/food,
 /obj/machinery/computer/riotgear{
@@ -46633,9 +46550,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 5
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "ipm" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -47503,9 +47418,7 @@
 /turf/simulated/floor/orangeblack/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "kAg" = (
 /obj/cable{
 	d1 = 4;
@@ -48230,9 +48143,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "mBl" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -49648,9 +49559,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "qSy" = (
 /turf/simulated/floor/caution/north,
 /area/station/security/main)
@@ -49877,9 +49786,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 9
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "rBs" = (
 /obj/machinery/light_switch/east{
 	dir = 4
@@ -50344,9 +50251,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "sOp" = (
 /obj/machinery/light{
 	dir = 8;
@@ -50374,9 +50279,7 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "sVC" = (
 /obj/stool/chair/comfy/blue{
 	dir = 4
@@ -50663,9 +50566,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry{
-	name = "Entry Hallway"
-	})
+/area/station/crewquarters/cryotron)
 "tPW" = (
 /obj/item/device/radio/beacon,
 /obj/disposalpipe/segment,
@@ -51113,6 +51014,9 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
+"uTK" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crewquarters/cryotron)
 "uXZ" = (
 /obj/table/reinforced/auto,
 /obj/item/reagent_containers/food/snacks/cake/chocolate/gateau,
@@ -87922,16 +87826,16 @@ acw
 acc
 adK
 acc
-aCN
-aCN
+ciN
+ciN
 gar
-aCN
-aCN
-aCN
-aCN
+ciN
+ciN
+ciN
+ciN
 ahS
-aCN
-aCN
+ciN
+ciN
 ajs
 ajH
 akk
@@ -88950,7 +88854,7 @@ abF
 adg
 xzR
 acc
-aeG
+fNK
 afg
 tPK
 afM
@@ -89721,17 +89625,17 @@ aaI
 abH
 aaU
 abF
-abg
+uTK
 afj
-abg
-aCN
-aCN
-aCN
-aCN
-abg
+uTK
+ciN
+ciN
+ciN
+ciN
+uTK
 afj
 aMr
-abg
+uTK
 ajI
 ajI
 ajI
@@ -89980,12 +89884,12 @@ aaI
 abH
 aeJ
 afk
-aCN
+ciN
 aay
 aay
 aay
 aay
-aCN
+ciN
 aip
 aeJ
 abH
@@ -90235,14 +90139,14 @@ aaa
 aay
 aay
 aay
-aCN
+ciN
 afl
 ajr
 agq
 agJ
 agJ
 agq
-aCN
+ciN
 aiq
 ajr
 aay
@@ -90492,16 +90396,16 @@ aaa
 aaa
 aaa
 aay
-abg
+uTK
 afm
-abg
+uTK
 aay
 aaa
 aaa
 aay
-abg
+uTK
 afm
-abg
+uTK
 aay
 aaa
 aay

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -590,6 +590,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/entry{
 	name = "Entry Hallway"
@@ -600,6 +603,10 @@
 	pixel_x = 10
 	},
 /obj/machinery/computer/stockexchange,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/entry{
 	name = "Entry Hallway"

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -4371,7 +4371,7 @@
 /area/station/hallway/primary/central)
 "asc" = (
 /turf/simulated/floor/carpet/blue/standard/edge/west,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "asg" = (
 /obj/wingrille_spawn/reinforced,
 /obj/cable{
@@ -4531,7 +4531,7 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/carpet/blue/standard/narrow/east,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "asF" = (
 /obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
@@ -7662,7 +7662,7 @@
 	},
 /obj/table/round/auto,
 /turf/simulated/floor/darkblue/checker,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "aFX" = (
 /obj/decal/tile_edge/line/blue{
 	icon_state = "line1"
@@ -10387,7 +10387,7 @@
 /area/station/hallway/primary/west)
 "aSR" = (
 /turf/simulated/floor/carpet/blue/standard,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "aSU" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/external,
@@ -11393,7 +11393,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/sw,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "aXB" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
@@ -12549,7 +12549,7 @@
 "beT" = (
 /obj/forcefield/energyshield/perma,
 /turf/simulated/floor/stairs/medical/wide/other,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "beU" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -13024,7 +13024,7 @@
 	layer = 3.9
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/nw,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "bhT" = (
 /obj/decal/tile_edge/line/black{
 	dir = 10;
@@ -15441,7 +15441,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "bvV" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5
@@ -17208,7 +17208,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "bFn" = (
 /obj/decal/tile_edge/line/red{
 	dir = 4;
@@ -19909,7 +19909,7 @@
 /area/station/security/equipment)
 "cUy" = (
 /turf/simulated/floor/carpet/blue/standard/innercorner/east,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "cUC" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 4;
@@ -22905,7 +22905,7 @@
 /area/station/crew_quarters/lounge/starboard)
 "eql" = (
 /turf/simulated/floor/carpet/blue/standard/edge/se,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "equ" = (
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
@@ -24287,7 +24287,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "eQz" = (
 /obj/storage/secure/closet/engineering/mechanic,
 /obj/decal/tile_edge/line/black{
@@ -27089,7 +27089,7 @@
 /area/station/crew_quarters/quartersC)
 "gfZ" = (
 /turf/simulated/floor/carpet/blue/standard/edge/south,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "ggS" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
@@ -35192,7 +35192,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "kDO" = (
 /obj/disposalpipe/trunk{
 	dir = 1
@@ -36893,7 +36893,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "lCc" = (
 /obj/table/auto,
 /obj/item/pen/crayon/rainbow,
@@ -39572,7 +39572,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/gannets/glass,
 /turf/simulated/floor/wood,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "nbl" = (
 /obj/decal/tile_edge/line/blue{
 	color = "#485e81";
@@ -43613,7 +43613,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "pim" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -44229,7 +44229,7 @@
 	name = "Station Intercom"
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/ne,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "pCF" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -45947,7 +45947,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "qzc" = (
 /obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
@@ -49197,7 +49197,7 @@
 	explosion_resistance = 20;
 	name = "very reinforced wall"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "smP" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51138,7 +51138,7 @@
 	explosion_resistance = 20;
 	name = "very reinforced wall"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "tnE" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -53352,7 +53352,7 @@
 "uyz" = (
 /obj/forcefield/energyshield/perma,
 /turf/simulated/floor/stairs/medical/wide,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "uyP" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -53785,7 +53785,7 @@
 "uIi" = (
 /obj/landmark/start/latejoin,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "uIs" = (
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
@@ -55821,7 +55821,7 @@
 	explosion_resistance = 20;
 	name = "very reinforced wall"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "vNb" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 5
@@ -57203,7 +57203,7 @@
 /area/station/maintenance/southwest)
 "wAa" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "wAi" = (
 /obj/lattice,
 /obj/warp_beacon{
@@ -60183,7 +60183,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/entry)
+/area/station/crewquarters/cryotron)
 "ybu" = (
 /obj/decal/tile_edge/line/black{
 	dir = 9;

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -9321,7 +9321,7 @@
 	},
 /obj/machinery/light/small/floor/warm,
 /turf/simulated/floor/darkpurple/side,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "avI" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 8
@@ -9630,7 +9630,7 @@
 "awx" = (
 /obj/machinery/bot/cleanbot,
 /turf/simulated/floor/darkpurple/side,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "awy" = (
 /obj/cable{
 	d1 = 4;
@@ -9671,7 +9671,7 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor/shuttlebay,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "awB" = (
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/blue,
@@ -18099,7 +18099,7 @@
 /turf/simulated/floor/darkpurple/side{
 	dir = 4
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "aRl" = (
 /obj/machinery/disposal_pipedispenser/mobile{
 	dir = 4
@@ -19830,7 +19830,7 @@
 	},
 /obj/machinery/light/small/floor/warm,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "aWg" = (
 /obj/stool/bed,
 /obj/item/device/radio/electropack,
@@ -35661,7 +35661,7 @@
 "bJY" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bJZ" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/firedoor_spawn,
@@ -35669,19 +35669,19 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/delivery,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bKa" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bKb" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bKc" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bKd" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/radio/lab)
@@ -36176,22 +36176,22 @@
 /obj/disposalpipe/segment/mail,
 /obj/machinery/vending/cola/blue,
 /turf/simulated/floor/black/corner,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bLv" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bLw" = (
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bLx" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/black/corner{
 	dir = 4
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bLy" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/kitchen/food_box/donut_box{
@@ -36539,7 +36539,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bMF" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -36550,7 +36550,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bMG" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -36558,7 +36558,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bMH" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/matchbook,
@@ -37045,11 +37045,11 @@
 /turf/simulated/floor/black/corner{
 	dir = 8
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bNS" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bNT" = (
 /obj/shrub{
 	dir = 10
@@ -37057,7 +37057,7 @@
 /turf/simulated/floor/black/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bNU" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/clipboard,
@@ -37395,14 +37395,14 @@
 /area/station/maintenance/south)
 "bOS" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bOT" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bOU" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Arrivals"
@@ -37416,7 +37416,7 @@
 /obj/firedoor_spawn,
 /obj/forcefield/energyshield/perma,
 /turf/simulated/floor/delivery,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bOV" = (
 /obj/wingrille_spawn/auto,
 /obj/disposalpipe/segment/mail{
@@ -37424,7 +37424,7 @@
 	},
 /obj/forcefield/energyshield/perma,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bOW" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -37435,13 +37435,13 @@
 /obj/firedoor_spawn,
 /obj/forcefield/energyshield/perma,
 /turf/simulated/floor/delivery,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bOX" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bOY" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -37786,7 +37786,7 @@
 /turf/simulated/floor/darkpurple/side{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bPR" = (
 /obj/table/glass/auto,
 /obj/shrub{
@@ -37808,7 +37808,7 @@
 /turf/simulated/floor/darkpurple/side{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bPS" = (
 /obj/machinery/light/incandescent/warm,
 /obj/cable{
@@ -37819,7 +37819,7 @@
 /turf/simulated/floor/darkpurple/side{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bPT" = (
 /obj/cable{
 	d1 = 1;
@@ -37834,7 +37834,7 @@
 /turf/simulated/floor/caution/corner/misc{
 	dir = 6
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bPU" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37853,7 +37853,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/caution/south,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bPV" = (
 /obj/cable{
 	d1 = 2;
@@ -37863,13 +37863,13 @@
 /turf/simulated/floor/caution/corner/misc{
 	dir = 10
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bPW" = (
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/darkpurple/side{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bPX" = (
 /obj/table/glass/auto,
 /obj/shrub{
@@ -37889,7 +37889,7 @@
 /turf/simulated/floor/darkpurple/side{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bPY" = (
 /obj/storage/closet/emergency,
 /obj/item/tank/emergency_oxygen,
@@ -37900,7 +37900,7 @@
 /turf/simulated/floor/darkpurple/side{
 	dir = 1
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bPZ" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right,
@@ -38295,12 +38295,12 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bQU" = (
 /turf/simulated/floor/caution/east{
 	dir = 8
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bQV" = (
 /obj/table/glass/auto,
 /obj/cable{
@@ -38315,13 +38315,13 @@
 /turf/simulated/floor/darkblue{
 	dir = 10
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bQW" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/west,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bQX" = (
 /obj/table/wood,
 /obj/item/storage/box/cutlery,
@@ -38810,26 +38810,26 @@
 /turf/simulated/floor/darkblue{
 	dir = 10
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bSb" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/caution/west,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bSc" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bSd" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/navbeacon/tour/oshan/tour1,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bSe" = (
 /obj/machinery/light/small/floor/greenish,
 /turf/simulated/floor/plating/random,
@@ -39225,15 +39225,15 @@
 /turf/simulated/floor/darkblue{
 	dir = 10
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bTd" = (
 /obj/machinery/navbeacon/tour/oshan/tour0,
 /turf/simulated/floor/caution/west,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bTe" = (
 /obj/forcefield/energyshield/perma,
 /turf/simulated/floor/shuttlebay,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bTf" = (
 /turf/simulated/floor/stairs/wood/wide{
 	dir = 8
@@ -39676,7 +39676,7 @@
 /area/skeleton_trader)
 "bUf" = (
 /turf/space/fluid,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bUg" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -39727,10 +39727,10 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/crowbar,
 /turf/simulated/floor/darkpurple/side,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bUn" = (
 /turf/simulated/floor/darkpurple/side,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bUo" = (
 /obj/item/caution{
 	desc = "Caution! Construction Zone!";
@@ -39741,7 +39741,7 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /turf/simulated/floor/darkpurple/side,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bUp" = (
 /obj/machinery/drainage/big,
 /turf/simulated/floor,
@@ -39756,7 +39756,7 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /turf/simulated/floor/darkpurple/side,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bUr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/radio/bathroom)
@@ -40147,12 +40147,12 @@
 /turf/simulated/floor/darkpurple/side{
 	dir = 8
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bVq" = (
 /turf/simulated/floor/darkpurple/side{
 	dir = 4
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bVr" = (
 /obj/item/device/radio/beacon,
 /obj/cable{
@@ -40161,7 +40161,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bVs" = (
 /obj/item/seed/alien/rocks,
 /obj/item/seed/alien/rocks,
@@ -40494,7 +40494,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bWn" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/trackimp_kit2,
@@ -41110,10 +41110,10 @@
 "bXI" = (
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/shuttlebay,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bXJ" = (
 /turf/simulated/floor/shuttlebay,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bXK" = (
 /obj/decal/cleanable/dirt,
 /obj/item/weldingtool,
@@ -41211,7 +41211,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/shuttlebay,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bYa" = (
 /obj/machinery/light/incandescent/blueish,
 /turf/simulated/floor/plating/random,
@@ -41230,7 +41230,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "bYd" = (
 /obj/cable{
 	d1 = 2;
@@ -43554,7 +43554,7 @@
 "cfs" = (
 /obj/landmark/start/latejoin,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/oshan_arrivals)
 "cft" = (
 /obj/cable{
 	d1 = 1;


### PR DESCRIPTION
## About the PR 
changes the arrivals area designations on destiny and clarion to the "cryotron" area and sets this area to `do_not_irradiate`. this means arrivals in atlas, manta, kondaru, destiny, and clarion won't be exposed to radiation instantly upon joining the round. this is consistent with the behavior of areas zoned as "arrivals shuttle" on cog1, cog2, donut 3, and horizon.

this also creates a new instance of an arrivals area specifically for oshan because it was previously zoned as the "entry hall", which is an area type used on cog1, cog2, and others for un-protected areas immediately around arrivals but not necessarily arrivals itself. i felt re-using the "cryoton" area name would be misleading for oshan since that's not all that's there/the primary way that latejoins emerge into a round.


## Why's this needed? 
consistent behavior across all maps and hopefully better player experiences for latejoining or new players who might not know any better about which maps they would otherwise need to sit out radstorms/run into the nearest locker on.