### PR TITLE
Slight mini-bible buffs

### DIFF
--- a/code/obj/item/storage/bible.dm
+++ b/code/obj/item/storage/bible.dm
@@ -191,7 +191,16 @@ var/global/list/bible_contents = list()
 	name = "O.C. Bible"
 	desc = "For when you don't want the good book to take up too much space in your life."
 	icon_state = "minibible"
+	item_state = null
 	w_class = W_CLASS_SMALL
+
+	farty_heresy(mob/user) //fuk u always die
+		if(!user || user.loc != src.loc)
+			return 0
+		user.visible_message("<span class='alert'>[user] farts on the bible.<br><b>A mysterious force smites [user]!</b></span>")
+		logTheThing("combat", user, null, "farted on [src] at [log_loc(src)] last touched by <b>[src.fingerprintslast ? src.fingerprintslast : "unknown"]</b>.")
+		user.gib()
+		return 0
 
 /obj/item/storage/bible/hungry
 	name = "hungry bible"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does two things with mini-bibles:
-Makes it so it doesn't have inhands
-Makes the thing gib farters indescriminately

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The mini-bible is intended to be a stealthy/bait-and-switch trick, and very noticable inhands don't help with that.
While it doesn't make a lot of sense to differentiate farting on regular vs mini-bibles, atheists should balance-wise probably not be immune to a traitor item. 

(EDIT: Looking at the wiki page the inhands were unintentional? Guess you could call it a bugfix then :P)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Miniature bibles are no longer visible in-hand, nor will they spare atheists.
```
