### PR TITLE
Remove borg emag failure chance

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -962,22 +962,17 @@
 			if (src.opened && user) boutput(user, "You must close the cover to swipe an ID card.")
 			else if (src.wiresexposed && user) boutput(user, "<span class='alert'>You need to get the wires out of the way.</span>")
 			else
-				sleep (6)
-				if (prob(50))
-					if (user)
-						boutput(user, "You emag [src]'s interface.")
-					src.visible_message("<font color=red><b>[src]</b> buzzes oddly!</font>")
-					src.emagged = 1
-					src.handle_robot_antagonist_status("emagged", 0, user)
-					if(src.syndicate)
-						src.antagonist_overlay_refresh(1, 1)
-					SPAWN_DBG(0)
-						update_appearance()
-					return 1
-				else
-					if (user)
-						boutput(user, "You fail to [ locked ? "unlock" : "lock"] [src]'s interface.")
-					return 0
+				if (user)
+					boutput(user, "You emag [src]'s interface.")
+				src.visible_message("<font color=red><b>[src]</b> buzzes oddly!</font>")
+				src.emagged = 1
+				src.handle_robot_antagonist_status("emagged", 0, user)
+				if(src.syndicate)
+					src.antagonist_overlay_refresh(1, 1)
+				SPAWN_DBG(0)
+					update_appearance()
+				return 1
+			return 0
 
 	emp_act()
 		vision.noise(60)

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -969,8 +969,7 @@
 				src.handle_robot_antagonist_status("emagged", 0, user)
 				if(src.syndicate)
 					src.antagonist_overlay_refresh(1, 1)
-				SPAWN_DBG(0)
-					update_appearance()
+				update_appearance()
 				return 1
 			return 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the 50% chance for emagging borgs to fail.
Also removes a `sleep` from the code there that I didn't understand what it was for.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
EMAGs don't have a chance to fail for other things, and RNG seems out of place here. It's not even a credible obstacle for people who know about it, since you can just spam several clicks and chances are one'll go through!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Emagging cyborgs no longer randomly fails.
```
