### PR TITLE
Consolidate duplicate code for handling radio prefixes on messages, and apply to all languages and accents

### DIFF
--- a/code/datums/language.dm
+++ b/code/datums/language.dm
@@ -49,16 +49,6 @@ var/global/datum/languages/languages = new()
 	var/list/martian_dictionary = list()
 
 	proc/translate(var/message)
-		var/prefix = null
-		if (dd_hasprefix(message, ":lh") || dd_hasprefix(message, ":rh") || dd_hasprefix(message, ":in"))
-			prefix = copytext(message, 1, 4)
-			message = copytext(message, 4)
-		else if (dd_hasprefix(message, ":"))
-			prefix = copytext(message, 1, 3)
-			message = copytext(message, 3)
-		else if (dd_hasprefix(message, ";"))
-			prefix = ";"
-			message = copytext(message, 2)
 		var/list/words = splittext(uppertext(message), " ")
 		var/list/newwords = list()
 		for (var/w in words)
@@ -86,7 +76,7 @@ var/global/datum/languages/languages = new()
 				var/tr = jointext(trl, "")
 				martian_dictionary[w] = tr
 				newwords += tr + suf
-		return prefix + jointext(newwords, " ")
+		return jointext(newwords, " ")
 
 	heard_not_understood(var/orig_message)
 		return translate(orig_message)

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -86,12 +86,9 @@
 		return
 	if (dd_hasprefix(message, "*"))
 		return
-	else if (dd_hasprefix(message, ":lh") || dd_hasprefix(message, ":rh") || dd_hasprefix(message, ":in"))
-		message = copytext(message, 4)
-	else if (dd_hasprefix(message, ":"))
-		message = copytext(message, 3)
-	else if (dd_hasprefix(message, ";"))
-		message = copytext(message, 2)
+
+	var/prefixAndMessage = separate_radio_prefix_and_message(message)
+	message = prefixAndMessage[2]
 
 	if(!src.is_npc)
 		message = gradientText("#3cb5a3", "#124e43", message)

--- a/code/mob/living/critter/martian.dm
+++ b/code/mob/living/critter/martian.dm
@@ -75,12 +75,10 @@
 			return
 		if (dd_hasprefix(message, "*"))
 			return
-		else if (dd_hasprefix(message, ":lh") || dd_hasprefix(message, ":rh") || dd_hasprefix(message, ":in"))
-			message = copytext(message, 4)
-		else if (dd_hasprefix(message, ":"))
-			message = copytext(message, 3)
-		else if (dd_hasprefix(message, ";"))
-			message = copytext(message, 2)
+
+		// Strip the radio prefix (if it exists) and just get the message
+		var/prefixAndMessage = separate_radio_prefix_and_message(message)
+		message = prefixAndMessage[2]
 
 		// martian telepathy to all martians
 		// cirr edit: i have moved this to a proc at the bottom of this file

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -153,12 +153,8 @@
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 	logTheThing("diary", src, null, ": [message]", "say")
 
-	if (dd_hasprefix(message, ":lh") || dd_hasprefix(message, ":rh") || dd_hasprefix(message, ":in"))
-		message = copytext(message, 4)
-	else if (dd_hasprefix(message, ":"))
-		message = copytext(message, 3)
-	else if (dd_hasprefix(message, ";"))
-		message = copytext(message, 2)
+	var/prefixAndMessage = separate_radio_prefix_and_message(message)
+	message = prefixAndMessage[2]
 
 	flock_speak(src, message, src.flock)
 

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -266,6 +266,11 @@ var/obj/item/dummy/click_dummy = new
 #define CLUWNE_NOISE_DELAY 50
 
 /proc/process_accents(var/mob/living/carbon/human/H, var/message)
+	// Separate the radio prefix (if it exists) and message so the accent can't destroy the prefix
+	var/prefixAndMessage = separate_radio_prefix_and_message(message)
+	var/prefix = prefixAndMessage[1]
+	message = prefixAndMessage[2]
+
 	if (!H || !istext(message))
 		return
 
@@ -340,7 +345,7 @@ var/obj/item/dummy/click_dummy = new
 	if (prob(30)) message = replacetext(message, "?", " Eh?")
 #endif
 
-	return message
+	return prefix + message
 
 
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -445,6 +445,25 @@ proc/get_angle(atom/a, atom/b)
 		. = findtext(text, suffix, start, null) //was findtextEx
 
 /**
+ * Given a message, returns a list containing the radio prefix and the message,
+ * so that the message can be manipulated seperately in various functions.
+ */
+/proc/separate_radio_prefix_and_message(var/message)
+	var/prefix = null
+
+	if (dd_hasprefix(message, ":lh") || dd_hasprefix(message, ":rh") || dd_hasprefix(message, ":in"))
+		prefix = copytext(message, 1, 4)
+		message = copytext(message, 4)
+	else if (dd_hasprefix(message, ":"))
+		prefix = copytext(message, 1, 3)
+		message = copytext(message, 3)
+	else if (dd_hasprefix(message, ";"))
+		prefix = ";"
+		message = copytext(message, 2)
+
+	return list(prefix, message)
+
+/**
 	* Given a list, returns a text string representation of the list's contents.
 	*/
 /proc/english_list(var/list/input, nothing_text = "nothing", and_text = " and ", comma_text = ", ", final_comma_text = "," )

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -735,10 +735,16 @@
 	return language
 
 /mob/proc/process_language(var/message, var/forced_language = null)
+	// Separate the radio prefix (if it exists) and message so the language can't destroy the prefix
+	var/prefixAndMessage = separate_radio_prefix_and_message(message)
+	var/prefix = prefixAndMessage[1]
+	message = prefixAndMessage[2]
+
 	var/datum/language/L = languages.language_cache[get_language_id(forced_language)]
 	if (!L)
 		L = languages.language_cache["english"]
-	return L.get_messages(message)
+
+	return prefix + L.get_messages(message)
 
 /mob/proc/get_special_language(var/secure_mode)
 	return null


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a helper function `separate_radio_prefix_and_message` to consolidate duplicate code, and then used this to ensure that languages and accents won't overwrite radio prefixes (as reported in #5182)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
See issue #5182 

This also ensures that when new languages and accents are added in the future, they will automatically have the fix applied to them.