### PR TITLE
Restrict CARL

### DIFF
--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -139,11 +139,9 @@
 		///////Generate Purchase List//
 		///////////////////////////////
 		var/list/goods_for_purchase = goods_sell.Copy()
-		message_admins("Illegal [illegal] - Mind: [usr.mind.special_role]")
 		// Illegal goods for syndicate traitors
 		if (illegal)
 			if(usr.mind && (usr.mind.special_role == "traitor" || usr.mind.special_role == "spy_thief" || usr.mind.special_role == "nukeop" ||	usr.mind.special_role == "sleeper agent" || usr.mind.special_role == "hard-mode traitor" ||	usr.mind.special_role == "omnitraitor"))
-				message_admins("Adding illegal goods")
 				goods_for_purchase += goods_illegal
 		if (href_list["purchase"])
 			src.temp =buy_dialogue + "<HR><BR>"

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -13,6 +13,8 @@
 	var/hiketolerance = 20 //How much they will tolerate price hike
 	var/list/droplist = null //What the merchant will drop upon their death
 	var/list/goods_sell = new/list() //What products the trader sells
+	var/illegal = 0 // maybe trading with illegal bots could flag the user's criminal record for smuggling
+	var/goods_illegal = list() // Illegal goods
 	var/list/goods_buy = new/list() //what products the merchant buys
 	var/list/shopping_cart = new/list() //What has been bought
 	var/obj/item/sell = null //Item to sell
@@ -136,9 +138,16 @@
 		///////////////////////////////
 		///////Generate Purchase List//
 		///////////////////////////////
+		var/list/goods_for_purchase = goods_sell.Copy()
+		message_admins("Illegal [illegal] - Mind: [usr.mind.special_role]")
+		// Illegal goods for syndicate traitors
+		if (illegal)
+			if(usr.mind && (usr.mind.special_role == "traitor" || usr.mind.special_role == "spy_thief" || usr.mind.special_role == "nukeop" ||	usr.mind.special_role == "sleeper agent" || usr.mind.special_role == "hard-mode traitor" ||	usr.mind.special_role == "omnitraitor"))
+				message_admins("Adding illegal goods")
+				goods_for_purchase += goods_illegal
 		if (href_list["purchase"])
 			src.temp =buy_dialogue + "<HR><BR>"
-			for(var/datum/commodity/N in goods_sell)
+			for(var/datum/commodity/N in goods_for_purchase)
 				// Have to send the type instead of a reference to the obj because it would get caught by the garbage collector. oh well.
 				src.temp += {"<A href='?src=\ref[src];doorder=\ref[N]'><B><U>[N.comname]</U></B></A><BR>
 				<B>Cost:</B> [N.price] Credits<BR>
@@ -169,7 +178,7 @@
 					quantity = 50
 
 				////////////
-				var/datum/commodity/P = locate(href_list["doorder"]) in goods_sell
+				var/datum/commodity/P = locate(href_list["doorder"]) in goods_for_purchase
 
 				if(P)
 					if(shopping_cart.len + quantity > 50)
@@ -200,7 +209,7 @@
 
 			var/askingprice= input(usr, "Please enter your asking price.", "Haggle", 0) as null|num
 			if(askingprice)
-				var/datum/commodity/N = locate(href_list["haggleb"]) in goods_sell
+				var/datum/commodity/N = locate(href_list["haggleb"]) in goods_for_purchase
 				if(N)
 					if(patience == N.haggleattempts)
 						src.temp = "[src.name] becomes angry and won't trade anymore."
@@ -732,7 +741,6 @@
 	picture = "robot.png"
 	trader_area = "/area/turret_protected/robot_trade_outpost"
 	var/productset = 0 // 0 is robots and salvage, 1 is podparts and drugs, 2 is produce. 3 is syndicate junk, 4 is medical stuff
-	var/illegal = 0 // maybe trading with illegal bots could flag the user's criminal record for smuggling
 	angrynope = "Unable to process request."
 	whotext = "I am a trading unit. I have been authorized to engage in trade with you."
 
@@ -787,22 +795,23 @@
 				src.goods_buy += new /datum/commodity/produce/special/glowfruit(src)
 
 			if(3) // syndicate bot
+				src.illegal = 1
 				var/carlsell = rand(1,10)
-				src.goods_sell += new /datum/commodity/contraband/command_suit(src)
-				src.goods_sell += new /datum/commodity/contraband/swatmask(src)
+				src.goods_illegal += new /datum/commodity/contraband/command_suit(src)
+				src.goods_illegal += new /datum/commodity/contraband/swatmask(src)
 				if (carlsell <= 2)
-					src.goods_sell += new /datum/commodity/contraband/radiojammer(src)
+					src.goods_illegal += new /datum/commodity/contraband/radiojammer(src)
 				if (carlsell >= 3 && carlsell <= 5)
-					src.goods_sell += new /datum/commodity/contraband/stealthstorage(src)
+					src.goods_illegal += new /datum/commodity/contraband/stealthstorage(src)
 				if (carlsell >= 6 && carlsell <= 8)
-					src.goods_sell += new /datum/commodity/contraband/voicechanger(src)
+					src.goods_illegal += new /datum/commodity/contraband/voicechanger(src)
 				if (carlsell == 9) // if it rolls 10, then none of the three are sold
-					src.goods_sell += new /datum/commodity/contraband/radiojammer(src)
-					src.goods_sell += new /datum/commodity/contraband/stealthstorage(src)
-					src.goods_sell += new /datum/commodity/contraband/voicechanger(src)
+					src.goods_illegal += new /datum/commodity/contraband/radiojammer(src)
+					src.goods_illegal += new /datum/commodity/contraband/stealthstorage(src)
+					src.goods_illegal += new /datum/commodity/contraband/voicechanger(src)
+				src.goods_illegal += new /datum/commodity/contraband/birdbomb(src)
 				src.goods_sell += new /datum/commodity/contraband/spy_sticker_kit(src)
 				src.goods_sell += new /datum/commodity/contraband/disguiser(src)
-				src.goods_sell += new /datum/commodity/contraband/birdbomb(src)
 				src.goods_sell += new /datum/commodity/contraband/flare(src)
 				src.goods_sell += new /datum/commodity/contraband/eguncell_highcap(src)
 				src.goods_sell += new /datum/commodity/podparts/cloak(src)

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -796,7 +796,7 @@
 				src.illegal = 1
 				var/carlsell = rand(1,10)
 				src.goods_illegal += new /datum/commodity/contraband/command_suit(src)
-				src.goods_illegal += new /datum/commodity/contraband/swatmask(src)
+				src.goods_illegal += new /datum/commodity/contraband/disguiser(src)
 				if (carlsell <= 2)
 					src.goods_illegal += new /datum/commodity/contraband/radiojammer(src)
 				if (carlsell >= 3 && carlsell <= 5)
@@ -808,8 +808,8 @@
 					src.goods_illegal += new /datum/commodity/contraband/stealthstorage(src)
 					src.goods_illegal += new /datum/commodity/contraband/voicechanger(src)
 				src.goods_illegal += new /datum/commodity/contraband/birdbomb(src)
+				src.goods_sell += new /datum/commodity/contraband/swatmask(src)
 				src.goods_sell += new /datum/commodity/contraband/spy_sticker_kit(src)
-				src.goods_sell += new /datum/commodity/contraband/disguiser(src)
 				src.goods_sell += new /datum/commodity/contraband/flare(src)
 				src.goods_sell += new /datum/commodity/contraband/eguncell_highcap(src)
 				src.goods_sell += new /datum/commodity/podparts/cloak(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
C.A.R.L will now restrict some of his stock to syndicate operatives.
Roles are : traitor, spy_thief, nukeop, sleeper agent, hard-mode traitor, omnitraitor.
This prevents non antags and non syndicate antags like wizards, gang members, changelings, vampires from buying syndicate contraband.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Players have reliable methods for making money, visiting C.A.R.L and buying some of his unique contraband regardless of possession of an agent card or antagonist status.
Rather than close off the listening post or C.A.R.L entirely this just keeps his good stuff for actual syndicate agents, i.e traitors, sleepers, spy thieves and nuke operatives.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)C.A.R.L at the listening post now restricts his best contraband to syndicate agents.
```