### PR TITLE
Frog Flu progresses much slower

### DIFF
--- a/code/modules/medical/diseases/frog_flu.dm
+++ b/code/modules/medical/diseases/frog_flu.dm
@@ -6,7 +6,7 @@
 	associated_reagent = "sheltestgrog"
 	reagentcure = list("robustissin", "coffee")
 	affected_species = list("Human")
-	stage_prob = 4
+	stage_prob = 5
 
 /datum/ailment/disease/frog_flu/stage_act(var/mob/living/affected_mob,var/datum/ailment_data/D)
 	if (..())

--- a/code/modules/medical/diseases/frog_flu.dm
+++ b/code/modules/medical/diseases/frog_flu.dm
@@ -6,7 +6,7 @@
 	associated_reagent = "sheltestgrog"
 	reagentcure = list("robustissin", "coffee")
 	affected_species = list("Human")
-	stage_prob = 15
+	stage_prob = 4
 
 /datum/ailment/disease/frog_flu/stage_act(var/mob/living/affected_mob,var/datum/ailment_data/D)
 	if (..())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For how easy sheltestgrog is to make the effects are much better than the other critter transforming chems. This reduces the stage prob from 15 to 4 which is closer to the other diseases.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sheltestgrog is a bit overpowered in its current state due to how quick it progresses.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)Frog Flu progresses much slower
```
