### PR TITLE
Makes patting someone down always damage you if your gloves aren't fire resistant

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -31,24 +31,23 @@
 		src.shake_awake(M)
 
 /mob/proc/help_put_out_fire(var/mob/living/M)
-	M.update_burning(-1.2)
 	playsound(M.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1, 0 , 0.7)
 	src.visible_message("<span class='notice'>[src] pats down [M] wildly, trying to put out the fire!</span>")
-	var/glove_protection = FALSE
 
-	if (ishuman(src)) // glove heat resistance check
+	if (ishuman(src))
 		var/mob/living/carbon/human/H = src
 		var/obj/item/clothing/gloves/G = H.gloves
-		if (G && G.hasProperty("heatprot"))
-			if (G.getProperty("heatprot") >= 7)
-				glove_protection = 1
-				boutput(src, "<span class='notice'>Your [G] protect you from the flames!</span>")
-
-	if (!glove_protection)
-		if (ishuman(src))
-			src.TakeDamage(prob(50) ? "l_arm" : "r_arm", 0, rand(1,2))
+		if (G && G.hasProperty("heatprot") && (G.getProperty("heatprot") >= 7))
+			M.update_burning(-2.5)
+			boutput(H, "<span class='notice'>Your [G] protect you from the flames!</span>")
 		else
-			src.TakeDamage("All", 0, rand(1,2))
+			M.update_burning(-1.2)
+			H.TakeDamage(prob(50) ? "l_arm" : "r_arm", 0, rand(1,2))
+			playsound(src, "sound/impact_sounds/burn_sizzle.ogg", 30, 1)
+			boutput(src, "<span class='alert'>Your hands burn from patting the flames!</span>")
+	else
+		M.update_burning(-1.2)
+		src.TakeDamage("All", 0, rand(1,2))
 		playsound(src, "sound/impact_sounds/burn_sizzle.ogg", 30, 1)
 		boutput(src, "<span class='alert'>Your hands burn from patting the flames!</span>")
 

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -34,13 +34,21 @@
 	M.update_burning(-1.2)
 	playsound(M.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1, 0 , 0.7)
 	src.visible_message("<span class='notice'>[src] pats down [M] wildly, trying to put out the fire!</span>")
+	var/glove_protection = FALSE
 
-	if (prob(50))
+	if (ishuman(src)) // glove heat resistance check
+		var/mob/living/carbon/human/H = src
+		var/obj/item/clothing/gloves/G = H.gloves
+		if (G && G.hasProperty("heatprot"))
+			if (G.getProperty("heatprot") >= 7)
+				glove_protection = 1
+				boutput(src, "<span class='notice'>Your [G] protect you from the flames!</span>")
+
+	if (!glove_protection)
 		if (ishuman(src))
 			src.TakeDamage(prob(50) ? "l_arm" : "r_arm", 0, rand(1,2))
 		else
 			src.TakeDamage("All", 0, rand(1,2))
-
 		playsound(src, "sound/impact_sounds/burn_sizzle.ogg", 30, 1)
 		boutput(src, "<span class='alert'>Your hands burn from patting the flames!</span>")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BALANCE] [WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes patting someone who is on fire check for your glove's heatprot, if it is equal to or higher than 7 you are safe, and the pats are more effective. the only gloves that will be safe are black gloves, swat gloves and some matsci ones depending on how you make them. also removes the 50% chance for it to not damage you at all.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Helps make different gloves more unique, more things for the player to think about when making a choice is good
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Arthur Holiday
(+)If your gloves have atleast 7% heat resistance, patting out people on fire won't damage you and you will be 2x more effective at it
```
