### PR TITLE
Fix cog1 mechanics mail chute

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -58836,8 +58836,8 @@
 /turf/simulated/floor/carpet,
 /area/station/security/main)
 "lYJ" = (
-/obj/machinery/disposal/mail/small/autoname,
 /obj/disposalpipe/trunk/mail,
+/obj/machinery/disposal/mail/small/autoname/mechanics/south,
 /turf/simulated/floor/yellow/side,
 /area/station/engine/elect)
 "lZa" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces cog1's mechanics mail chute with a working subtype, because the subtype just labeled autoname apparently doesn't work right.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #5308 
