### PR TITLE
Removes the taser the HoS gets on roundstart

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -252,6 +252,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	receives_security_disk = 1
 	receives_badge = 1
 	recieves_implant = /obj/item/implant/health/security/anti_mindslave
+	items_in_backpack = list(/obj/item/device/flash)
 
 
 #ifdef SUBMARINE_MAP

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -280,9 +280,6 @@ ABSTRACT_TYPE(/datum/job/command)
 	slot_eyes = /obj/item/clothing/glasses/sunglasses/sechud
 #endif
 
-	items_in_backpack = list(/obj/item/gun/energy/taser_gun)
-
-
 	New()
 		..()
 		src.access = get_access("Head of Security")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BALANCE] [WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes the taser the HoS gets when they spawn.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The taser is unneeded if they want to, they can get one by using a token from the armory, they already spawn with a token too and because taking down an HoS is already hard enough without their extra taser.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Arthur Holiday
(+)The Head of Security does not get a taser at roundstart anymore.
```
