### PR TITLE
Fixes eyepatch behavior

### DIFF
--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -337,24 +337,15 @@
 	attackby(obj/item/W as obj, mob/user as mob)
 		if ((isscrewingtool(W) || istype(W, /obj/item/pen)) && !pinhole)
 			if( equipper && equipper.glasses == src )
-				var/obj/item/organ/eye/theEye = equipper.drop_organ((block_eye == "L") ? "left_eye" : "right_eye")
-				if(theEye)
+				var/obj/item/organ/eye/theEye = equipper.drop_organ((src.icon_state == "eyepatch-L") ? "left_eye" : "right_eye")
+				pinhole = 1
+				block_eye = null
+				appearance_flags |= RESET_COLOR
+				if(!theEye)
 					user.show_message("<span class='alert'>Um. Wow. Thats kinda grode.<span>")
 					return ..()
 				theEye.appearance_flags |= RESET_COLOR
-				appearance_flags |= RESET_COLOR
-				W.underlays += theEye
-				W.underlays += src
-				pinhole = 1
-				block_eye = null
-				equipper.u_equip(src)
-				theEye.set_loc(W)
-				src.set_loc(W)
-				equipper = null
-				user.show_message("<span class='alert'>You stab a hole in [src].  Unfortunately, you also stab a hole in your [theEye] and when you pull [W] away your eye comes with it!!</span>")
-
-				W.name_prefix("eye")
-				W.UpdateName()
+				user.show_message("<span class='alert'>You stab a hole in [src].  Unfortunately, you also stab a hole in your eye and when you pull [W] away your eye comes with it!!</span>")
 				return
 			else
 				pinhole = 1
@@ -367,7 +358,7 @@
 		return ..()
 	attack_self(mob/user)
 
-		if (src.block_eye == "R")
+		if (src.icon_state == "eyepatch-R")
 			src.block_eye = "L"
 		else
 			src.block_eye = "R"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG-minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes eyepatch behavior. Poking out an eye now also pierces the eyepatch. Eyepatches with pinholes can now be flipped. Description text correctly matches the action.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5282. Poking yourself in the eye should also pierce the eyepatch. There were descriptions for this action that were only reachable if you did not have an eye. The descriptions are now appropriate for if the player does or does not have an eye already.
