### PR TITLE
Civilian Cyborg Module now uses the correct sprite

### DIFF
--- a/code/modules/robotics/robot/module/civilian.dm
+++ b/code/modules/robotics/robot/module/civilian.dm
@@ -1,6 +1,7 @@
 /obj/item/robot_module/civilian
 	name = "civilian cyborg module"
 	desc = "A module suitable for many of the menial tasks covered by the civilian department."
+	icon_state = "civilian"
 	mod_hudicon = "civilian"
 	included_cosmetic = /datum/robot_cosmetic/civilian
 	included_tools = /datum/robot/module_tool_creator/recursive/module/civilian


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Very tiny fix, I noticed that civilian cyborg modules came out of the module rewriter looking blank, despite there being a sprite for them. This just corrects this. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not sure if it was removed on purpose or just an oversight, but it did lead to some confusion ingame during a couple of rounds I observed over time.
