### PR TITLE
Makes the laser rifle require more difficult materials.

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1061,7 +1061,7 @@
 	uses_multiple_icon_states = 1
 	force = 5.0
 	muzzle_flash = "muzzle_flash_plaser"
-	is_syndicate = TRUE
+	mats = list("MET-3"=7, "CRY-1"=13, "POW-2"=10)
 
 	New()
 		..()

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1061,6 +1061,7 @@
 	uses_multiple_icon_states = 1
 	force = 5.0
 	muzzle_flash = "muzzle_flash_plaser"
+	is_syndicate = TRUE
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the predator laser rifle require more difficult materials.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Laser rifles are powerful enough to justify needing more difficult materials due to the laser rifle itself and the extremely powerful power cell it comes with.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)Laser Rifles now require more difficult materials.
```
