### PR TITLE
Allows orange shoes to be made into jet boots, minor cleanup

### DIFF
--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -148,29 +148,28 @@
 	uses_multiple_icon_states = 1
 	desc = "Shoes, now in prisoner orange! Can be made into shackles."
 
+	attack_self(mob/user as mob)
+		if (src.chained)
+			src.chained = null
+			src.cant_self_remove = 0
+			new /obj/item/handcuffs(get_turf(user))
+			src.name = "orange shoes"
+			src.icon_state = "orange"
+			src.desc = "Shoes, now in prisoner orange! Can be made into shackles."
+
+	attackby(H as obj, loc)
+		if (istype(H, /obj/item/handcuffs) && !src.chained)
+			qdel(H)
+			src.chained = 1
+			src.cant_self_remove = 1
+			src.name = "shackles"
+			src.desc = "Used to restrain prisoners."
+			src.icon_state = "orange1"
+		..()
+
 /obj/item/clothing/shoes/pink
 	name = "pink shoes"
 	icon_state = "pink"
-
-/obj/item/clothing/shoes/orange/attack_self(mob/user as mob)
-	if (src.chained)
-		src.chained = null
-		src.cant_self_remove = 0
-		new /obj/item/handcuffs(get_turf(user))
-		src.name = "orange shoes"
-		src.icon_state = "orange"
-		src.desc = "Shoes, now in prisoner orange! Can be made into shackles."
-	return
-
-/obj/item/clothing/shoes/orange/attackby(H as obj, loc)
-	if (istype(H, /obj/item/handcuffs) && !src.chained)
-		qdel(H)
-		src.chained = 1
-		src.cant_self_remove = 1
-		src.name = "shackles"
-		src.desc = "Used to restrain prisoners."
-		src.icon_state = "orange1"
-	return
 
 /obj/item/clothing/shoes/magnetic
 	name = "magnetic shoes"


### PR DESCRIPTION
[cleanliness] [trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Orange shoes didn't call their parents. The shoe family is distraught.
Also moves the orange shoe procs to a decent spot, so pink shoes are no longer just... hanging out in the middle. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prettier code is nice.
A certain type of shoes not working for jet boots is unintuitive and dumb.

