### PR TITLE
Laying neon now matches user orientation

### DIFF
--- a/code/obj/item/neon_lining.dm
+++ b/code/obj/item/neon_lining.dm
@@ -172,22 +172,17 @@
 		return
 
 	else
-		var/dirn
-
-		if (user.loc == F)
-			dirn = user.dir			//If laying on the tile we're on, lay in the direction we're facing.
-		else
-			dirn = get_dir(F, user)
+		var/dirn = user.dir
 
 		var/obj/neon_lining/C = new /obj/neon_lining(F, src)
-		if (dirn == 2)
-			C.lining_rotation = 1
-		else if (dirn == 4)
-			C.lining_rotation = 2
-		else if (dirn == 8)
-			C.lining_rotation = 3
-		else
+		if (dirn == SOUTH)
 			C.lining_rotation = 0
+		else if (dirn == EAST)
+			C.lining_rotation = 3
+		else if (dirn == WEST)
+			C.lining_rotation = 1
+		else //NORTH
+			C.lining_rotation = 2
 		boutput(user, "You set some neon lining on the floor.")
 		C.lining_color = lining_item_color
 		C.add_fingerprint(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Laying neon now matches user orientation. There was code for placing it while the user was resting, but there's no way to hold the cable during.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The old placement-to-orientation was nonsense. Seemed to be a code-typo born from magic-numbers.


![image](https://user-images.githubusercontent.com/9563541/123750551-92260e80-d86b-11eb-8d8a-9ad02f500b07.png)
(I tested it)

[FIX][QOL]