### PR TITLE
Fix #5333

### DIFF
--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -434,6 +434,7 @@ A Flamethrower in various states of assembly
 		var/obj/item/device/igniter/I = W
 		if (!( I.status ))
 			return
+		user.show_message("<span class='notice'>You put the igniter in place, it still needs to be firmly attached.</span>", 1)
 		var/obj/item/assembly/weld_rod/S = src
 		var/obj/item/assembly/w_r_ignite/R = new /obj/item/assembly/w_r_ignite( user )
 		R.welder = S.welder
@@ -554,11 +555,10 @@ A Flamethrower in various states of assembly
 	var/fuel = "_no_fuel"
 	if(src.fueltank)
 		fuel = "_fuel"
-	src.icon_state = "flamethrower_oxy[fuel]"
 	var/oxy = "_no_oxy"
 	if(src.gastank)
 		oxy = "_oxy"
-	src.icon_state = "flamethrower[oxy]_fuel"
+	src.icon_state = "flamethrower[oxy][fuel]"
 
 	src.updateSelfDialog()
 	SPAWN_DBG(0.5 SECONDS)

--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -418,6 +418,7 @@ A Flamethrower in various states of assembly
 		var/turf/T = src.loc
 		if (ismob(T))
 			T = T.loc
+		user.show_message("<span class='notice'>You remove the rod from the welding tool.</span>", 1)
 		src.welder.set_loc(T)
 		src.rod.set_loc(T)
 		src.welder.master = null
@@ -466,6 +467,7 @@ A Flamethrower in various states of assembly
 		var/turf/T = src.loc
 		if (ismob(T))
 			T = T.loc
+		user.show_message("<span class='notice'>You disassemble the [src.name]</span>", 1)
 		src.welder.set_loc(T)
 		src.rod.set_loc(T)
 		src.igniter.set_loc(T)
@@ -552,13 +554,7 @@ A Flamethrower in various states of assembly
 	if (src.fueltank)
 		src.inventory_counter.update_percent(src.fueltank.reagents.total_volume, src.fueltank.reagents.maximum_volume)
 
-	var/fuel = "_no_fuel"
-	if(src.fueltank)
-		fuel = "_fuel"
-	var/oxy = "_no_oxy"
-	if(src.gastank)
-		oxy = "_oxy"
-	src.icon_state = "flamethrower[oxy][fuel]"
+	src.icon_state = "flamethrower[src.gastank ? "_oxy" : "_no_oxy"][src.fueltank ? "_fuel" : "_no_fuel"]"
 
 	src.updateSelfDialog()
 	SPAWN_DBG(0.5 SECONDS)

--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -122,6 +122,7 @@
 			if (src.loc != user)
 				boutput(user, "<span class='alert'>You need to be holding [src] to work on it!</span>")
 				return
+			boutput(user, "<span class='notice'>You attach the rod to the welding tool.</span>")
 			var/obj/item/rods/R = new /obj/item/rods
 			R.amount = 1
 			var/obj/item/rods/S = W


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix https://github.com/goonstation/goonstation/issues/5333
Adds a bit of feedback about the construction/deconstruction actions.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Icon is bugged.
Other steps have messages, helps players understand constructing the flamethrower.