### PR TITLE
Disarm nerfs the sequel

### DIFF
--- a/_std/defines/stamina.dm
+++ b/_std/defines/stamina.dm
@@ -23,9 +23,9 @@
 /// How much grabbing someone costs.
 #define STAMINA_GRAB_COST 25
 /// How much disarming someone costs.
-#define STAMINA_DISARM_COST 10
+#define STAMINA_DISARM_COST 30
 /// Stamina damage of disarming someone with bare hands.
-#define STAMINA_DISARM_DMG 20
+#define STAMINA_DISARM_DMG 10
 /// How much flipping / suplexing costs.
 #define STAMINA_FLIP_COST 25
 /// Base chance of landing a critical hit to stamina.

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1235,15 +1235,17 @@
 			actions.stopId("magpickerhold", src)
 
 //throw the dropped item
-/mob/proc/drop_item_throw()
-	var/obj/item/W = src.equipped()
-	if (src.drop_item())
+/mob/proc/drop_item_throw(obj/item/W)
+	if(!W)
+		W = src.equipped()
+	if (src.drop_item(W))
 		var/turf/T = get_edge_target_turf(src, pick(alldirs))
 		W.throw_at(T,rand(0,5),1)
 
-/mob/proc/drop_item_throw_dir(dir)
-	var/obj/item/W = src.equipped()
-	if (src.drop_item())
+/mob/proc/drop_item_throw_dir(dir, obj/item/W)
+	if(!W)
+		W = src.equipped()
+	if (src.drop_item(W))
 		var/turf/T = get_edge_target_turf(src, dir)
 		W.throw_at(T,7,1)
 

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -340,7 +340,7 @@
 	msgs.clear(target)
 	msgs.valid = 1
 	msgs.disarm = 1
-	var/item/I
+	var/obj/item/I
 	var/def_zone = null
 	if (zone_sel)
 		def_zone = zone_sel.selecting
@@ -351,7 +351,7 @@
 			if("r_arm")
 				I = target.r_hand
 			else
-				I = target.equipped
+				I = target.equipped()
 	else
 		def_zone = "All"
 		msgs.affecting = def_zone

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -340,11 +340,18 @@
 	msgs.clear(target)
 	msgs.valid = 1
 	msgs.disarm = 1
-
+	var/item/I
 	var/def_zone = null
 	if (zone_sel)
 		def_zone = zone_sel.selecting
 		msgs.affecting = def_zone
+		switch(zone_sel)
+			if("l_arm")
+				I = target.l_hand
+			if("r_arm")
+				I = target.r_hand
+			else
+				I = target.equipped
 	else
 		def_zone = "All"
 		msgs.affecting = def_zone
@@ -359,7 +366,6 @@
 		msgs.played_sound = 'sound/impact_sounds/Generic_Shove_1.ogg'
 		msgs.base_attack_message = "<span class='alert'><B>[src] rolls [target] backwards[DISARM_WITH_ITEM_TEXT]!</B></span>"
 		msgs.disarm_RNG_result = "shoved"
-		var/obj/item/I = target.equipped()
 		if (I && I.temp_flags & IS_LIMB_ITEM)
 			msgs.disarm_RNG_result = "attack_self_with_item_shoved"
 
@@ -419,7 +425,6 @@
 		msgs.base_attack_message = "<span class='alert'><B>[src] shoves [target] to the ground[DISARM_WITH_ITEM_TEXT]!</B></span>"
 		msgs.played_sound = 'sound/impact_sounds/Generic_Shove_1.ogg'
 		msgs.disarm_RNG_result = "shoved_down"
-		var/obj/item/I = target.equipped()
 		if (I && I.temp_flags & IS_LIMB_ITEM)
 			msgs.disarm_RNG_result = "attack_self_with_item_shoved_down"
 
@@ -427,7 +432,6 @@
 
 	if (is_shove) return msgs
 
-	var/obj/item/I = target.equipped()
 	if (I)
 		var/disarm_item_prob = 37 * lerp(clamp(200 - target_stamina, 0, 100)/100, 1, 0.5)
 		if (target.check_block() && !(HAS_MOB_PROPERTY(target, PROP_CANTMOVE)))

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -429,7 +429,7 @@
 
 	var/obj/item/I = target.equipped()
 	if (I)
-		var/disarm_item_prob = 37
+		var/disarm_item_prob = 37 * lerp(clamp(200 - target_stamina, 0, 100)/100, 1, 0.5)
 		if (target.check_block() && !(HAS_MOB_PROPERTY(target, PROP_CANTMOVE)))
 			disarm_item_prob = 5
 

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -340,18 +340,12 @@
 	msgs.clear(target)
 	msgs.valid = 1
 	msgs.disarm = 1
-	var/obj/item/I
+	msgs.disarm_RNG_result = list()
+	var/list/obj/item/items = target.equipped_list()
 	var/def_zone = null
 	if (zone_sel)
 		def_zone = zone_sel.selecting
 		msgs.affecting = def_zone
-		switch(zone_sel)
-			if("l_arm")
-				I = target.l_hand
-			if("r_arm")
-				I = target.r_hand
-			else
-				I = target.equipped()
 	else
 		def_zone = "All"
 		msgs.affecting = def_zone
@@ -365,10 +359,8 @@
 	if (target.lying == 1) //roll lying bodies
 		msgs.played_sound = 'sound/impact_sounds/Generic_Shove_1.ogg'
 		msgs.base_attack_message = "<span class='alert'><B>[src] rolls [target] backwards[DISARM_WITH_ITEM_TEXT]!</B></span>"
-		msgs.disarm_RNG_result = "shoved"
-		if (I && I.temp_flags & IS_LIMB_ITEM)
-			msgs.disarm_RNG_result = "attack_self_with_item_shoved"
-
+		msgs.disarm_RNG_result |= "shoved"
+		msgs.disarm_RNG_result |= "handle_item_arm"
 		return msgs
 
 	var/damage = rand(base_damage_low, base_damage_high) * extra_damage
@@ -411,7 +403,7 @@
 		msgs.played_sound = 'sound/impact_sounds/Generic_Shove_1.ogg'
 		if (prob((stampart + 70) * mult))
 			msgs.base_attack_message = "<span class='alert'><B>[src] shoves [target] backwards[DISARM_WITH_ITEM_TEXT]!</B></span>"
-			msgs.disarm_RNG_result = "shoved"
+			msgs.disarm_RNG_result |= "shoved"
 
 	if (prob((stampart + 5) * mult))
 		if (ishuman(src))
@@ -424,52 +416,70 @@
 					return msgs
 		msgs.base_attack_message = "<span class='alert'><B>[src] shoves [target] to the ground[DISARM_WITH_ITEM_TEXT]!</B></span>"
 		msgs.played_sound = 'sound/impact_sounds/Generic_Shove_1.ogg'
-		msgs.disarm_RNG_result = "shoved_down"
-		if (I && I.temp_flags & IS_LIMB_ITEM)
-			msgs.disarm_RNG_result = "attack_self_with_item_shoved_down"
+		msgs.disarm_RNG_result |= "shoved_down"
+		msgs.disarm_RNG_result |= "drop_item"
+		msgs.disarm_RNG_result |= "handle_item_arm"
 
 		return msgs
 
 	if (is_shove) return msgs
+	var/disarm_prob = 37 * lerp(clamp(200 - target_stamina, 0, 100)/100, 1, 0.5) * mult
+	message_admins("[disarm_prob]")
+	var/disarm_success = prob(disarm_prob)
+	if (target.check_block() && !(HAS_MOB_PROPERTY(target, PROP_CANTMOVE)) && prob(80))
+		disarm_success = 0
+	var/list/obj/item/limbs = list()
+	var/list/obj/item/loose = list()
+	var/list/obj/item/fixed_in_place = list()
+	if (ishuman(src))
+		var/mob/living/carbon/human/H2 = src
+		for (var/uid in H2.pathogens)
+			var/datum/pathogen/P = H2.pathogens[uid]
+			var/ret = P.ondisarm(target, 1)
+			if (!ret)
+				disarm_success = 0
+				break
+	if(length(items))
+		var/multi = length(items) > 1
+		for(var/obj/item/I in items)
+			if(I.two_handed)
+				multi = 1
 
-	if (I)
-		var/disarm_item_prob = 37 * lerp(clamp(200 - target_stamina, 0, 100)/100, 1, 0.5)
-		if (target.check_block() && !(HAS_MOB_PROPERTY(target, PROP_CANTMOVE)))
-			disarm_item_prob = 5
 
-		if (I.temp_flags & IS_LIMB_ITEM)
-			if (prob(disarm_item_prob * mult))
-				msgs.base_attack_message = "<span class='alert'><B>[src] shoves [I.loc] and forces [target]'s to hit themselves[DISARM_WITH_ITEM_TEXT]!</B></span>"
-				msgs.played_sound = 'sound/impact_sounds/Generic_Shove_1.ogg'
-				msgs.disarm_RNG_result = "attack_self_with_item"
+			if (I.temp_flags & IS_LIMB_ITEM)
+				limbs |= I.loc
+				if(disarm_success)
+					msgs.disarm_RNG_result |= "handle_item_arm"
+			else if (I.cant_other_remove)
+				fixed_in_place |= I
 			else
-				msgs.base_attack_message = "<span class='alert'><B>[src] shoves at [I.loc][DISARM_WITH_ITEM_TEXT]!</B></span>"
-				msgs.played_sound = 'sound/impact_sounds/Generic_Swing_1.ogg'
+				loose |= I
+				if(disarm_success)
+					msgs.disarm_RNG_result |= "drop_item"
 
-		else if (I.cant_other_remove)
-			msgs.played_sound = 'sound/impact_sounds/Generic_Swing_1.ogg'
-			msgs.base_attack_message = "<span class='alert'><B>[src] vainly tries to knock [I] out of [target]'s hand[DISARM_WITH_ITEM_TEXT]!</B></span>"
-			msgs.show_self.Add("<span class='alert'>Something is binding [I] to [target]. You won't be able to disarm [him_or_her(target)].</span>")
-			msgs.show_target.Add("<span class='alert'>Something is binding [I] to you. It cannot be knocked out of your hands.</span>")
+#define ONE_OR_SOME(_mylist, _what) (length(_mylist) > 1 ? "multiple [_what]" : "[_mylist[1]]")
 
-		else if (prob(disarm_item_prob * mult))
-			if (ishuman(src))
-				var/mob/living/carbon/human/H2 = src
-				for (var/uid in H2.pathogens)
-					var/datum/pathogen/P = H2.pathogens[uid]
-					var/ret = P.ondisarm(target, 1)
-					if (!ret)
-						msgs.base_attack_message = "<span class='alert'><B>[src] tries to knock [I] out of [target]'s hand[DISARM_WITH_ITEM_TEXT]!</B></span>"
-						return msgs
-			msgs.base_attack_message = "<span class='alert'><B>[src] knocks [I] out of [target]'s hand[DISARM_WITH_ITEM_TEXT]!</B></span>"
+		if(disarm_success)
 			msgs.played_sound = 'sound/impact_sounds/Generic_Shove_1.ogg'
-			msgs.disarm_RNG_result = "drop_item"
+			if(length(limbs))
+				msgs.base_attack_message = "<span class='alert'><B>[src] shoves [ONE_OR_SOME(limbs, "item limbs")][DISARM_WITH_ITEM_TEXT] and forces [target] to hit [himself_or_herself(target)]!</B></span>"
+			else if(length(loose))
+				msgs.base_attack_message = "<span class='alert'><B>[src] knocks [ONE_OR_SOME(loose, "items")] out of [target]'s hand[multi?"s":""][DISARM_WITH_ITEM_TEXT]!</B></span>"
 		else
-			msgs.base_attack_message = "<span class='alert'><B>[src] tries to knock [I] out of [target]'s hand[DISARM_WITH_ITEM_TEXT]!</B></span>"
 			msgs.played_sound = 'sound/impact_sounds/Generic_Swing_1.ogg'
+			if(length(limbs))
+				msgs.base_attack_message = "<span class='alert'><B>[src] shoves at [ONE_OR_SOME(limbs, "item limbs")][DISARM_WITH_ITEM_TEXT]!</B></span>"
+			else if(length(loose))
+				msgs.base_attack_message = "<span class='alert'><B>[src] tries to knock [ONE_OR_SOME(loose, "items")] out of [target]'s hand[multi?"s":""][DISARM_WITH_ITEM_TEXT]!</B></span>"
+
+			else if(length(fixed_in_place))
+				msgs.base_attack_message = "<span class='alert'><B>[src] vainly tries to knock [ONE_OR_SOME(fixed_in_place, "items")] out of [target]'s hand[multi?"s":""][DISARM_WITH_ITEM_TEXT]!</B></span>"
+				msgs.show_self.Add("<span class='alert'>Something is binding [ONE_OR_SOME(fixed_in_place, "items")] to [target]. You won't be able to disarm [him_or_her(target)].</span>")
+				msgs.show_target.Add("<span class='alert'>Something is binding [ONE_OR_SOME(fixed_in_place, "items")] to you. It cannot be knocked out of your hands.</span>")
 	else
 		msgs.base_attack_message = "<span class='alert'><B>[src] shoves [target][DISARM_WITH_ITEM_TEXT]!</B></span>"
 		msgs.played_sound = 'sound/impact_sounds/Generic_Shove_1.ogg'
+#undef ONE_OR_SOME
 
 	return msgs
 
@@ -945,51 +955,43 @@
 			if (owner.traitHolder && !owner.traitHolder.hasTrait("glasscannon"))
 				owner.process_stamina(STAMINA_DISARM_COST)
 
-			if (!isnull(src.disarm_RNG_result))
-				switch (src.disarm_RNG_result)
-					if ("drop_item")
-						target.deliver_move_trigger("bump")
-						target.drop_item_throw()
+			if (length(src.disarm_RNG_result))
+				if ("drop_item" in src.disarm_RNG_result)
+					target.deliver_move_trigger("bump")
+					for(var/obj/item/I in target.equipped_list())
+						if(!(I.temp_flags & IS_LIMB_ITEM))
+							target.drop_item_throw(I)
 
-					if ("attack_self_with_item", "attack_self_with_item_shoved_down", "attack_self_with_item_shoved")
-						var/obj/item/I = target.equipped()
-						if (I)
-							var/old_zone_sel = 0
-							if (target.zone_sel) //attack the zone of the attacker
-								old_zone_sel = target.zone_sel.selecting
-								if (owner.zone_sel)
-									target.zone_sel.selecting = owner.zone_sel.selecting
-							var/prev_intent = target.a_intent
-							target.a_intent = INTENT_HARM
+				if ("handle_item_arm" in src.disarm_RNG_result)
+					for(var/obj/item/I in target.equipped_list())
+						if(!(I.temp_flags & IS_LIMB_ITEM))
+							continue
 
-							target.attackby(I, target)
+						var/old_zone_sel = 0
+						if (target.zone_sel) //attack the zone of the attacker
+							old_zone_sel = target.zone_sel.selecting
+							if (owner.zone_sel)
+								target.zone_sel.selecting = owner.zone_sel.selecting
+						var/prev_intent = target.a_intent
+						target.a_intent = INTENT_HARM
 
-							target.a_intent = prev_intent
-							if (old_zone_sel)
-								target.zone_sel.selecting = old_zone_sel
+						target.attackby(I, target)
 
-							if (prob(20))
-								I.attack_self(target)
+						target.a_intent = prev_intent
+						if (old_zone_sel)
+							target.zone_sel.selecting = old_zone_sel
 
-							//SORRY
-							if (src.disarm_RNG_result == "attack_self_with_item_shoved_down")
-								target.changeStatus("weakened", 1 SECONDS)
-								target.force_laydown_standup()
-							if (src.disarm_RNG_result == "attack_self_with_item_shoved")
-								step_away(target, owner, 1)
-								target.OnMove(owner)
+						if (prob(20))
+							I.attack_self(target)
 
-					if ("shoved_down")
-						target.deliver_move_trigger("pushdown")
-						if (prob(50))
-							target.drop_item()
-						else
-							target.drop_item_throw()
-						target.changeStatus("weakened", 2 SECONDS)
-						target.force_laydown_standup()
-					if ("shoved")
-						step_away(target, owner, 1)
-						target.OnMove(owner)
+
+				if ("shoved_down" in src.disarm_RNG_result)
+					target.deliver_move_trigger("pushdown")
+					target.changeStatus("weakened", 2 SECONDS)
+					target.force_laydown_standup()
+				if ("shoved" in src.disarm_RNG_result)
+					step_away(target, owner, 1)
+					target.OnMove(owner)
 			else
 				target.deliver_move_trigger("bump")
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Instead of dramatically changing the mechanics of disarm (#5309), which seemed to be poorly received, lets see if mainly numbers tweaks are taken better:
* disarm stam cost 10 -> 30
* disarm stam damage 20 -> 10 
* Disarm chance scaled down to 50% of current (18.5%) at targets with 200 or more stamina, and linerally scaled to current value (37%) on targets with 100 or less. Disarm chances on blocks is reduced by 80% (multiplicative)
* Disarm targets all held items at once


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stam costs: Make disarm less spammable as a main action in a brawl

Disarm stamina scaling: Make disarm less useful in a first-strike scenario, as well as less useful against ranged weapons (which typically do not use stamina) - numbers here might want poking

Arm targeting -> hand targeting:
* No other mechanic in this game, afaik, cares about what active hand slot someone *else* is using at any given time, 
* Additionally, there is no feedback that a player has swapped hands or indication of which hand a player has as their active hand at any given time (until they attack/you attempt a disarm)

Together, this makes for a feature that is unintuitive and nigh-impossible to play around, as suddenly your disarm attacks stop working with exactly zero indication that anything in the situation has changed. Letting players target a specific hand for disarms will help alleviate that element, while still leaving inventory management as a way to reduce chance of weapon loss (pocket, bag, move *weapon* to other hand [which would trigger a change in the inhand sprite for the item as well as changing examine text, giving some feedback as to why disarms stop working])

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Tarmunora
(*)Disarm changes. See minor changes for details. To be reverted by Sat, July 3 for further review
(+)disarm stam cost 10 -> 30
(+)disarm stam damage 20 -> 10 
(+)Disarm chance scaled down to 50% of current (18.5%) at targets with 200 or more stamina, and linerally scaled to current value (37%) on targets with 100 or less. Disarm chances on blocks is reduced by 80% (multiplicative)
(+)Disarm targets all held items at once
```
