### PR TITLE
Add disaster custom shuttles to all maps

### DIFF
--- a/assets/maps/shuttles/cog1/cog1-disaster.dmm
+++ b/assets/maps/shuttles/cog1/cog1-disaster.dmm
@@ -1,0 +1,550 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"cg" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"ch" = (
+/obj/machinery/computer/shuttle/embedded/south,
+/obj/stool/chair/comfy/shuttle/pilot,
+/obj/decal/skeleton{
+	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body7"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"cv" = (
+/obj/decal/cleanable/vomit,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/cogmap)
+"cx" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"dr" = (
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/cogmap)
+"ed" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"es" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"gq" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"hf" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/cogmap)
+"hF" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"hJ" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"hY" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-M"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"iY" = (
+/obj/decal/cleanable/machine_debris{
+	icon_state = "gib7"
+	},
+/obj/decal/cleanable/oil,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"kk" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/cogmap)
+"kA" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"kO" = (
+/obj/machinery/sleeper/compact,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"lc" = (
+/obj/decal/cleanable/paper,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/cogmap)
+"mM" = (
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/cogmap)
+"nf" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"nq" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/cogmap)
+"nz" = (
+/turf/simulated/shuttle/wall/cockpit{
+	dir = 1
+	},
+/area/shuttle/escape/centcom/cogmap)
+"pC" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"qj" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 9;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"ri" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"rj" = (
+/obj/stool/chair/comfy/shuttle/red,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"rV" = (
+/obj/stool/chair/comfy/shuttle,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/cogmap)
+"sr" = (
+/obj/stool/chair/comfy/shuttle/red,
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"tG" = (
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/cogmap)
+"vr" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-R"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"vJ" = (
+/obj/item/storage/wall/emergency{
+	dir = 8
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"vK" = (
+/obj/decal/cleanable/blood/gibs{
+	icon_state = "gib2"
+	},
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/cogmap)
+"vL" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "alt_heater-L"
+	},
+/obj/window/reinforced/south,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"xe" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"xg" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"xs" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"xZ" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/radio,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"yv" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"zB" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 5;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"zJ" = (
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/cogmap)
+"Er" = (
+/obj/critter/crunched,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/cogmap)
+"EZ" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"FZ" = (
+/obj/machinery/light/small/floor,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"IX" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Jd" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "15"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Ke" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"KJ" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"KN" = (
+/obj/lattice{
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"LU" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"OB" = (
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"OJ" = (
+/obj/stool/chair/comfy/shuttle/red,
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/cogmap)
+"PF" = (
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/cogmap)
+"Tq" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body8";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"Ve" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body3";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"VM" = (
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/cogmap)
+"VO" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"WX" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/decal/cleanable/vomit,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"WZ" = (
+/obj/stool/chair/comfy/shuttle,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"XV" = (
+/obj/machinery/door/airlock/pyro/security{
+	name = "Secure Transport"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"Yh" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 10;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"Yp" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/cogmap)
+"Yq" = (
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"Yu" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap)
+"YO" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+"Zz" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap)
+
+(1,1,1) = {"
+gq
+xs
+Ke
+Ke
+Ke
+Jd
+KJ
+IX
+VM
+Zz
+Zz
+Ke
+pC
+KN
+LU
+LU
+LU
+"}
+(2,1,1) = {"
+qj
+vr
+Zz
+OJ
+sr
+cx
+Yq
+YO
+VM
+VM
+WZ
+hF
+Yp
+Zz
+pC
+nf
+nf
+"}
+(3,1,1) = {"
+Yh
+hY
+Zz
+sr
+FZ
+XV
+PF
+WZ
+VM
+cv
+VM
+kk
+VM
+xZ
+VO
+pC
+KN
+"}
+(4,1,1) = {"
+zB
+vL
+Zz
+rj
+nq
+cx
+Yq
+rV
+WZ
+VM
+Er
+VM
+VM
+zJ
+ed
+cx
+kA
+"}
+(5,1,1) = {"
+nf
+EZ
+Ke
+vJ
+VM
+Er
+VM
+Yq
+VM
+VM
+vK
+Tq
+VM
+lc
+ch
+cx
+nz
+"}
+(6,1,1) = {"
+qj
+vr
+Zz
+mM
+VM
+VM
+yv
+WZ
+OB
+OB
+xg
+WZ
+cx
+hf
+ed
+cx
+kA
+"}
+(7,1,1) = {"
+Yh
+hY
+VM
+VM
+VM
+iY
+Ve
+WZ
+tG
+tG
+OB
+WX
+Zz
+xe
+cg
+es
+KN
+"}
+(8,1,1) = {"
+zB
+vL
+VM
+VM
+kO
+cx
+dr
+ri
+Yq
+WZ
+WZ
+ri
+Yp
+Zz
+es
+nf
+nf
+"}
+(9,1,1) = {"
+gq
+Yu
+VM
+Ke
+Ke
+Jd
+KJ
+hJ
+Zz
+Zz
+Zz
+Ke
+es
+KN
+LU
+LU
+LU
+"}

--- a/assets/maps/shuttles/cog2/cog2-disaster.dmm
+++ b/assets/maps/shuttles/cog2/cog2-disaster.dmm
@@ -1,0 +1,813 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"as" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"bl" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"bv" = (
+/obj/item/storage/wall/medical{
+	pixel_z = -1
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"bw" = (
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/cogmap2)
+"dw" = (
+/obj/decal/cleanable/machine_debris{
+	icon_state = "gib7"
+	},
+/obj/decal/cleanable/oil,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"eY" = (
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"fa" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"fC" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"hD" = (
+/obj/stool/chair/comfy/shuttle/green{
+	dir = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/cogmap2)
+"ie" = (
+/turf/unsimulated/floor/stairs{
+	icon_state = "Stairs_wide"
+	},
+/area/centcom)
+"ii" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "4"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"ir" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/cogmap2)
+"km" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"kK" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"kS" = (
+/obj/indestructible/shuttle_corner,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"lu" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"mW" = (
+/obj/decal/cleanable/robot_debris,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"on" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"oy" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/obj/decal/cleanable/blood/splatter,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"qi" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/cogmap2)
+"qz" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"rz" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"rJ" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/cogmap2)
+"sc" = (
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/cogmap2)
+"sy" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"tw" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"tS" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"tW" = (
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"uP" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/cogmap2)
+"vX" = (
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/cogmap2)
+"wj" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/decal/cleanable/vomit,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"wA" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"wS" = (
+/obj/item/storage/wall/emergency{
+	pixel_y = 4;
+	pixel_z = -5
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"xH" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/cogmap2)
+"xJ" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"xT" = (
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/cogmap2)
+"yc" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/cogmap2)
+"yj" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"zi" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/cogmap2)
+"zX" = (
+/turf/unsimulated/floor/stairs{
+	dir = 1;
+	icon_state = "Stairs2_wide"
+	},
+/area/centcom)
+"Aq" = (
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/cogmap2)
+"CG" = (
+/obj/machinery/light/small/floor,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"Da" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"Db" = (
+/turf/unsimulated/wall{
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"Dj" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"DG" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"DY" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/cogmap2)
+"Ex" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/cogmap2)
+"Fy" = (
+/obj/machinery/door/airlock/pyro/medical{
+	dir = 4;
+	name = "First-Aid Station";
+	opacity = 0
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"FJ" = (
+/obj/decal/cleanable/paper,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/cogmap2)
+"Gp" = (
+/turf/unsimulated/floor/stairs{
+	dir = 1;
+	icon_state = "Stairs_wide"
+	},
+/area/centcom)
+"He" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"Hp" = (
+/turf/unsimulated/floor/stairs{
+	icon_state = "Stairs2_wide"
+	},
+/area/centcom)
+"HD" = (
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"HU" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body3";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/cogmap2)
+"HX" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"If" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/cogmap2)
+"Ii" = (
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/cogmap2)
+"Jl" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/cogmap2)
+"Jz" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"Kv" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/cogmap2)
+"KD" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/blood/splatter,
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"KG" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"Lt" = (
+/turf/simulated/shuttle/wall/cockpit,
+/area/shuttle/escape/centcom/cogmap2)
+"LJ" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/cogmap2)
+"LV" = (
+/turf/unsimulated/wall{
+	dir = 1;
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"Mw" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Om" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"OG" = (
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Secure Transport";
+	opacity = 0
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"OT" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "15"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Pt" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body8";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter,
+/obj/decal/cleanable/vomit,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/cogmap2)
+"Qj" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/cogmap2)
+"RS" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"Sh" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/decal/cleanable/vomit,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/cogmap2)
+"St" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"Vb" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"Vr" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/obj/decal/skeleton,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"Vt" = (
+/obj/stool/chair/comfy/shuttle/green{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/cogmap2)
+"VN" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"WY" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"Xc" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"Xr" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"XB" = (
+/obj/machinery/computer/shuttle/embedded/east,
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 4
+	},
+/obj/decal/cleanable/molten_item,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/cogmap2)
+"XN" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+"XZ" = (
+/obj/machinery/light/small/floor,
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"Yc" = (
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"YS" = (
+/obj/critter/crunched,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/cogmap2)
+"ZJ" = (
+/obj/grille/steel,
+/obj/window/auto/reinforced,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/cogmap2)
+"ZN" = (
+/obj/item/storage/wall/fire{
+	pixel_z = -1
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/cogmap2)
+
+(1,1,1) = {"
+wA
+yj
+tw
+tw
+tw
+yj
+yj
+tw
+tw
+yj
+wA
+"}
+(2,1,1) = {"
+wA
+kS
+ZJ
+tW
+eY
+sc
+sc
+tW
+eY
+kK
+wA
+"}
+(3,1,1) = {"
+tw
+XN
+lu
+He
+Vr
+sc
+sc
+qi
+zi
+XN
+tw
+"}
+(4,1,1) = {"
+ii
+bv
+Vt
+fa
+hD
+sc
+sy
+XZ
+oy
+XN
+ii
+"}
+(5,1,1) = {"
+Ex
+OT
+Xr
+Fy
+sc
+YS
+Xr
+OG
+Xr
+OT
+on
+"}
+(6,1,1) = {"
+wA
+ZN
+Sh
+HU
+sc
+sc
+Da
+as
+wj
+XN
+wA
+"}
+(7,1,1) = {"
+wA
+Jz
+yc
+sc
+sc
+Da
+Da
+ir
+Qj
+Jz
+wA
+"}
+(8,1,1) = {"
+Db
+wS
+qz
+FJ
+St
+Jz
+VN
+Aq
+DY
+Mw
+LV
+"}
+(9,1,1) = {"
+ie
+Dj
+KD
+Yc
+fC
+Yc
+mW
+Yc
+tS
+Dj
+zX
+"}
+(10,1,1) = {"
+Hp
+Dj
+as
+Vb
+bw
+xH
+sc
+vX
+xT
+Dj
+Gp
+"}
+(11,1,1) = {"
+Db
+DG
+HX
+HX
+Yc
+sc
+sc
+Kv
+Da
+Mw
+LV
+"}
+(12,1,1) = {"
+wA
+Jz
+uP
+Jl
+rJ
+YS
+FJ
+sc
+Da
+Jz
+wA
+"}
+(13,1,1) = {"
+wA
+Jz
+Ii
+Ii
+HX
+sc
+sc
+sc
+sc
+sc
+wA
+"}
+(14,1,1) = {"
+wA
+Mw
+RS
+If
+Jl
+HD
+Da
+sc
+sc
+sc
+wA
+"}
+(15,1,1) = {"
+wA
+Ex
+OT
+Jz
+Xr
+dw
+Xr
+Jz
+OT
+on
+wA
+"}
+(16,1,1) = {"
+wA
+rz
+Jz
+KG
+Xc
+CG
+Pt
+bl
+Jz
+rz
+wA
+"}
+(17,1,1) = {"
+wA
+Om
+Ex
+RS
+LJ
+XB
+km
+WY
+on
+Om
+wA
+"}
+(18,1,1) = {"
+wA
+Om
+wA
+Ex
+Xr
+Xr
+Xr
+on
+wA
+Om
+wA
+"}
+(19,1,1) = {"
+wA
+Om
+wA
+rz
+xJ
+Lt
+xJ
+rz
+wA
+Om
+wA
+"}

--- a/assets/maps/shuttles/destiny/destiny_disaster.dmm
+++ b/assets/maps/shuttles/destiny/destiny_disaster.dmm
@@ -1,0 +1,770 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ap" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/destiny)
+"ba" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/blood/splatter,
+/obj/decal/cleanable/machine_debris{
+	icon_state = "gib7"
+	},
+/obj/decal/cleanable/oil,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/destiny)
+"bw" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/destiny)
+"bR" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"cp" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"cB" = (
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/destiny)
+"cE" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"dL" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/machine_debris,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"dX" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/destiny)
+"dY" = (
+/obj/decal/skeleton,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"ew" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"eY" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/skeleton{
+	desc = "The remains of some poor cosmonaut fellow.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body9";
+	name = "corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"ff" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/vomit,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"fI" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"ip" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"iM" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"jg" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/destiny)
+"jz" = (
+/obj/table/reinforced/auto,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"jL" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/destiny)
+"kW" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/dirt,
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"lp" = (
+/obj/stool/chair/comfy/shuttle,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/destiny)
+"lL" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"mc" = (
+/obj/decal/cleanable/dirt,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/destiny)
+"md" = (
+/obj/decal/skeleton,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/decal/cleanable/machine_debris{
+	icon_state = "gib7"
+	},
+/obj/decal/cleanable/oil,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"mn" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"mZ" = (
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/destiny)
+"nU" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/destiny)
+"oI" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"pa" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"qc" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt/dirt5,
+/obj/decal/cleanable/dirt/dirt5,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/destiny)
+"qO" = (
+/obj/decal/cleanable/paper,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/destiny)
+"rO" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"sm" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"so" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 6
+	},
+/obj/item/storage/toolbox/emergency,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"ss" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
+	},
+/area/shuttle/escape/centcom/destiny)
+"sy" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body3";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"tV" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"tW" = (
+/obj/table/reinforced/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"uy" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/destiny)
+"wj" = (
+/obj/machinery/shuttle/engine/propulsion{
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"zb" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/destiny)
+"zB" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"zO" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Am" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Au" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"AZ" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt5,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Bh" = (
+/obj/machinery/computer/shuttle/embedded/north,
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 1
+	},
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/destiny)
+"DZ" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"Gt" = (
+/turf/simulated/shuttle/wall/cockpit{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/destiny)
+"GI" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Hf" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Hr" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/destiny)
+"Hy" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"HI" = (
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Jf" = (
+/obj/decal/skeleton{
+	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body7"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Lq" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"LH" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/destiny)
+"Nq" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/destiny)
+"Om" = (
+/obj/decal/cleanable/machine_debris{
+	icon_state = "gib7"
+	},
+/obj/decal/cleanable/oil,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/destiny)
+"On" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/destiny)
+"Oz" = (
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/destiny)
+"OZ" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/destiny)
+"PH" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/destiny)
+"PR" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/destiny)
+"PY" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/destiny)
+"QL" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/destiny)
+"Se" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom/destiny)
+"SC" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/destiny)
+"SG" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/destiny)
+"TR" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body8";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Um" = (
+/turf/simulated/wall/auto/shuttle,
+/area/shuttle/escape/centcom/destiny)
+"UP" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/destiny)
+"Vb" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt5,
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/destiny)
+"VV" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"We" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/destiny)
+"Wz" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Xj" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Xk" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Xl" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"XJ" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/destiny)
+"Yk" = (
+/obj/critter/crunched,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/destiny)
+"Yt" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"Yv" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/destiny)
+"YA" = (
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/destiny)
+
+(1,1,1) = {"
+pa
+pa
+pa
+Lq
+sm
+QL
+zO
+Hf
+Hf
+Hf
+zO
+cB
+Se
+PH
+PH
+PH
+zB
+mn
+"}
+(2,1,1) = {"
+mn
+mn
+sm
+Hf
+On
+lp
+HI
+OZ
+Xj
+eY
+cB
+cB
+Nq
+zb
+uy
+Am
+oI
+wj
+"}
+(3,1,1) = {"
+Lq
+sm
+Yt
+jz
+Hf
+tV
+YA
+VV
+Vb
+nU
+cB
+dL
+md
+mc
+kW
+mZ
+Hy
+wj
+"}
+(4,1,1) = {"
+PR
+Um
+Xk
+SG
+Nq
+jg
+Jf
+AZ
+Yk
+cB
+cB
+We
+Nq
+tW
+qO
+LH
+Xl
+wj
+"}
+(5,1,1) = {"
+Gt
+Um
+Bh
+ff
+ba
+Yv
+YA
+Oz
+cB
+cB
+cB
+cB
+bw
+Yk
+cB
+PH
+ss
+mn
+"}
+(6,1,1) = {"
+PR
+Um
+dX
+ip
+Nq
+SC
+YA
+qO
+cB
+qc
+cB
+cB
+cB
+cB
+ew
+GI
+oI
+wj
+"}
+(7,1,1) = {"
+Lq
+cp
+Wz
+so
+Hf
+bR
+cE
+UP
+Au
+sy
+cB
+cB
+Om
+Oz
+lL
+ap
+Hy
+wj
+"}
+(8,1,1) = {"
+mn
+mn
+cp
+Hf
+On
+lp
+dY
+rO
+Hr
+fI
+XJ
+iM
+Nq
+TR
+jL
+PY
+Xl
+wj
+"}
+(9,1,1) = {"
+pa
+pa
+pa
+Lq
+cp
+Se
+zO
+Hf
+Hf
+Hf
+zO
+Se
+QL
+PH
+PH
+PH
+DZ
+mn
+"}

--- a/assets/maps/shuttles/donut2/donut2_disaster.dmm
+++ b/assets/maps/shuttles/donut2/donut2_disaster.dmm
@@ -1,0 +1,754 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ah" = (
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut2)
+"aI" = (
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Secure Transport";
+	opacity = 0
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"bz" = (
+/obj/machinery/light/small/floor,
+/obj/decal/cleanable/machine_debris,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut2)
+"bW" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"cr" = (
+/obj/item/storage/wall/emergency{
+	pixel_y = 4
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/donut2)
+"dh" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "15"
+	},
+/area/shuttle/escape/centcom/donut2)
+"ed" = (
+/turf/simulated/shuttle/wall/cockpit{
+	dir = 4;
+	layer = 50
+	},
+/area/shuttle/escape/centcom/donut2)
+"fM" = (
+/obj/item/storage/wall/fire,
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/donut2)
+"fW" = (
+/obj/critter/crunched,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/donut2)
+"gm" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"gI" = (
+/turf/unsimulated/wall{
+	dir = 1;
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"iy" = (
+/obj/machinery/sleeper/compact,
+/obj/decal/skeleton{
+	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body7"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"jA" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"lk" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"mi" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut2)
+"ou" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut2)
+"oL" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"oU" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"ra" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut2)
+"ri" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"rU" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/decal/skeleton{
+	desc = "The remains of some poor cosmonaut fellow.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body9";
+	name = "corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"tm" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"uw" = (
+/obj/decal/skeleton,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"vY" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/donut2)
+"wf" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut2)
+"xR" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"xS" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"xV" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
+	},
+/area/shuttle/escape/centcom/donut2)
+"ye" = (
+/obj/decal/cleanable/molten_item,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/donut2)
+"Ck" = (
+/obj/item/storage/wall/medical{
+	pixel_z = -1
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/donut2)
+"CD" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"DA" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/donut2)
+"DO" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/radio,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"Em" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/donut2)
+"EF" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"FK" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"Gb" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "8"
+	},
+/area/shuttle/escape/centcom/donut2)
+"Gd" = (
+/obj/indestructible/invisible_block,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"HA" = (
+/obj/machinery/sleeper/compact,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut2)
+"HV" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"HZ" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"If" = (
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"Io" = (
+/turf/unsimulated/wall{
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadcap"
+	},
+/area/centcom)
+"Is" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut2)
+"JM" = (
+/obj/decal/cleanable/blood/splatter,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"JS" = (
+/obj/machinery/computer/shuttle/embedded/west,
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 8
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body8";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"KD" = (
+/obj/decal/cleanable/paper,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/donut2)
+"La" = (
+/obj/decal/cleanable/machine_debris{
+	icon_state = "gib7"
+	},
+/obj/decal/cleanable/oil,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"LM" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"Ns" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light/small/floor,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut2)
+"NJ" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut2)
+"NM" = (
+/obj/indestructible/shuttle_corner,
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"Oc" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/paper,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut2)
+"Od" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"OL" = (
+/obj/stool/chair/comfy/shuttle/green{
+	dir = 8
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"Pf" = (
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut2)
+"Po" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut2)
+"Pz" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/donut2)
+"PK" = (
+/obj/machinery/light/small/floor,
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut2)
+"QK" = (
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/donut2)
+"Rq" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/donut2)
+"Si" = (
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/donut2)
+"TD" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut2)
+"TE" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"Uv" = (
+/obj/decal/cleanable/molten_item,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut2)
+"Vz" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"VV" = (
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"Wb" = (
+/obj/machinery/light/small/floor,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut2)
+"Wf" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut2)
+"Wn" = (
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut2)
+"Wu" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"WE" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"Xk" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/donut2)
+"XL" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut2)
+"XU" = (
+/obj/machinery/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+"Yz" = (
+/turf/unsimulated/floor/stairs{
+	dir = 1
+	},
+/area/centcom)
+"YA" = (
+/turf/unsimulated/floor/stairs,
+/area/centcom)
+"Zb" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut2)
+
+(1,1,1) = {"
+Od
+Od
+Od
+Od
+Gd
+ed
+Gd
+Od
+Od
+Od
+Od
+"}
+(2,1,1) = {"
+Od
+Od
+Od
+NM
+Em
+Em
+Em
+LM
+Od
+Od
+Od
+"}
+(3,1,1) = {"
+Od
+Od
+NM
+CD
+WE
+JS
+ra
+HZ
+LM
+Od
+Od
+"}
+(4,1,1) = {"
+Od
+Od
+vY
+DO
+NJ
+bz
+XL
+gm
+vY
+Od
+Od
+"}
+(5,1,1) = {"
+Od
+NM
+dh
+Vz
+Em
+La
+Em
+Vz
+dh
+LM
+Od
+"}
+(6,1,1) = {"
+Od
+Pz
+CD
+FK
+Zb
+ye
+Rq
+TE
+QK
+QK
+Od
+"}
+(7,1,1) = {"
+Io
+Xk
+TD
+Ns
+QK
+uw
+QK
+QK
+QK
+QK
+gI
+"}
+(8,1,1) = {"
+YA
+xS
+VV
+KD
+QK
+QK
+fW
+QK
+ah
+xS
+Yz
+"}
+(9,1,1) = {"
+Io
+cr
+Zb
+mi
+QK
+QK
+QK
+wf
+TE
+Pz
+gI
+"}
+(10,1,1) = {"
+Od
+Vz
+tm
+Si
+QK
+QK
+QK
+QK
+TE
+Vz
+Od
+"}
+(11,1,1) = {"
+Od
+Vz
+TE
+QK
+QK
+QK
+TE
+Pf
+Oc
+Vz
+Od
+"}
+(12,1,1) = {"
+Io
+fM
+ou
+QK
+QK
+QK
+xV
+Uv
+rU
+Pz
+gI
+"}
+(13,1,1) = {"
+YA
+QK
+QK
+fW
+QK
+Is
+EF
+JM
+VV
+xS
+Yz
+"}
+(14,1,1) = {"
+Io
+QK
+QK
+QK
+QK
+QK
+TE
+Wn
+TE
+Pz
+gI
+"}
+(15,1,1) = {"
+NM
+dh
+Em
+La
+QK
+QK
+Em
+aI
+Em
+dh
+LM
+"}
+(16,1,1) = {"
+Gb
+Ck
+OL
+PK
+QK
+QK
+DA
+Wb
+Wu
+vY
+Gb
+"}
+(17,1,1) = {"
+HV
+vY
+HA
+lk
+iy
+vY
+Wu
+Wu
+Po
+vY
+HV
+"}
+(18,1,1) = {"
+Od
+Wf
+xR
+ri
+oU
+Gb
+XU
+jA
+bW
+oL
+Od
+"}
+(19,1,1) = {"
+Od
+If
+HV
+HV
+HV
+If
+HV
+HV
+HV
+If
+Od
+"}

--- a/assets/maps/shuttles/donut3/donut3-disaster.dmm
+++ b/assets/maps/shuttles/donut3/donut3-disaster.dmm
@@ -1,0 +1,1027 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom/donut3)
+"ak" = (
+/obj/machinery/door/airlock/pyro/glass/command,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"ar" = (
+/obj/item/storage/wall/medical{
+	dir = 4;
+	pixel_x = -32;
+	pixel_z = -1
+	},
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/donut3)
+"aA" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"cH" = (
+/obj/decal/cleanable/paper,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/donut3)
+"dc" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut3)
+"dq" = (
+/obj/decal/skeleton{
+	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body7"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"eO" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"fK" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
+/turf/space,
+/area/shuttle/escape/centcom/donut3)
+"fM" = (
+/obj/machinery/light,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"fW" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"gp" = (
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter,
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut3)
+"gS" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"he" = (
+/obj/machinery/shuttle/engine/propulsion{
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut3)
+"hP" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body3";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"iq" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"iz" = (
+/obj/machinery/door/airlock/pyro/medical/alt,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/donut3)
+"iJ" = (
+/obj/machinery/door/airlock/pyro/security,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"iU" = (
+/obj/item/storage/wall/emergency{
+	pixel_y = 32
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"jm" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"jK" = (
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"kJ" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/decal/cleanable/dirt/dirt2,
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"lC" = (
+/obj/decal/cleanable/machine_debris,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut3)
+"lD" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut3)
+"lS" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"lT" = (
+/obj/machinery/light/small/floor,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"lX" = (
+/obj/decal/cleanable/dirt/jen,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut3)
+"nf" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"nz" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"nT" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"pE" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut3)
+"ql" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"qS" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"ra" = (
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut3)
+"ri" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut3)
+"rt" = (
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"rX" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"sm" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0;
+	icon_state = "7"
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"tJ" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-L"
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/escape/centcom/donut3)
+"uh" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body3";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"uD" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"vl" = (
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"vs" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/donut3)
+"wQ" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"wZ" = (
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"xC" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/decal/skeleton{
+	desc = "The remains of some poor cosmonaut fellow.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body9";
+	name = "corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"xK" = (
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut3)
+"yh" = (
+/obj/machinery/door/airlock/pyro/glass,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut3)
+"yW" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "8"
+	},
+/area/shuttle/escape/centcom/donut3)
+"zi" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut3)
+"zx" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/escape/centcom/donut3)
+"zY" = (
+/obj/decal/cleanable/dirt/dirt3,
+/obj/decal/skeleton,
+/obj/decal/cleanable/blood/splatter,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"AF" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/machine_debris{
+	icon_state = "gib7"
+	},
+/obj/decal/cleanable/oil,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Be" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Cb" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"Ce" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Cg" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Cu" = (
+/obj/table/auto,
+/obj/mug_rack{
+	pixel_x = -26;
+	pixel_y = 4
+	},
+/obj/machinery/coffeemaker{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/machinery/light,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"DH" = (
+/obj/decal/cleanable/dirt/jen,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"DN" = (
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/donut3)
+"DS" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Et" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 9.1;
+	pixel_x = -10
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Ez" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Fh" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "4"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Fq" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"FE" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"FS" = (
+/obj/machinery/light,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"Gf" = (
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/donut3)
+"HB" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/obj/indestructible/shuttle_corner{
+	dir = 0;
+	icon_state = "7"
+	},
+/turf/unsimulated/floor/shuttle,
+/area/shuttle/escape/centcom/donut3)
+"HR" = (
+/obj/machinery/computer/announcement,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"If" = (
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut3)
+"Ix" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut3)
+"IW" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Jq" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	layer = 9.1;
+	pixel_x = 10
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"JW" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Kb" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/obj/decal/skeleton,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Kc" = (
+/obj/machinery/computer/shuttle,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"Lb" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"Lh" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"LF" = (
+/obj/critter/crunched,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/donut3)
+"LR" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"LS" = (
+/obj/decal/skeleton,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"Nh" = (
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater"
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Nr" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/decal/cleanable/dirt/jen,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"NW" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/donut3)
+"Og" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/donut3)
+"Oi" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/donut3)
+"OX" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body8";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut3)
+"OZ" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 7
+	},
+/obj/item/device/radio{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Qy" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
+	},
+/turf/simulated/floor/plating/airless,
+/area/shuttle/escape/centcom/donut3)
+"QT" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut3)
+"Rg" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/donut3)
+"RB" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/donut3)
+"Sk" = (
+/obj/item/storage/wall/fire{
+	pixel_y = 32
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"Ss" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Sx" = (
+/obj/stool/chair/comfy/shuttle/green{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"SS" = (
+/obj/table/auto,
+/obj/item/kitchen/food_box/donut_box,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"TP" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"UW" = (
+/obj/stool/chair/comfy/shuttle/brown,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/donut3)
+"VV" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut3)
+"VW" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Wb" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"Xb" = (
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/donut3)
+"Xf" = (
+/obj/item/reagent_containers/food/snacks/donut/custom/frosted{
+	desc = "IT HIM, IT REALLY HIM";
+	name = "smol donut"
+	},
+/obj/reagent_dispensers/cleanable/ants,
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"XE" = (
+/obj/stool/chair/comfy/shuttle,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/donut3)
+"Yh" = (
+/obj/decal/skeleton,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/donut3)
+"YN" = (
+/obj/machinery/sleeper/compact{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 21
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"YQ" = (
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/donut3)
+"Zf" = (
+/obj/decal/cleanable/dirt/dirt2,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/donut3)
+"Zi" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/donut3)
+
+(1,1,1) = {"
+Wb
+Wb
+Wb
+Wb
+RB
+DS
+DS
+Ez
+Ez
+DS
+DS
+Xb
+Xb
+Xb
+ql
+sm
+Nh
+he
+Wb
+"}
+(2,1,1) = {"
+Cb
+Cb
+qS
+RB
+VW
+wQ
+jm
+OX
+nT
+Lh
+Et
+Xb
+Xb
+Xb
+Og
+JW
+aa
+QT
+Wb
+"}
+(3,1,1) = {"
+Wb
+Wb
+Wb
+vs
+Be
+xK
+Yh
+xK
+Gf
+Xb
+Zf
+Xb
+Xb
+Xb
+Xb
+aA
+JW
+tJ
+he
+"}
+(4,1,1) = {"
+qS
+RB
+DS
+Rg
+UW
+VV
+DH
+cH
+Xb
+LF
+DN
+nz
+iJ
+Xb
+jK
+If
+IW
+Qy
+he
+"}
+(5,1,1) = {"
+RB
+VW
+zi
+yW
+xC
+DH
+Xb
+Xb
+Xb
+Xb
+jK
+hP
+Fh
+Gf
+wZ
+Ss
+eO
+zx
+he
+"}
+(6,1,1) = {"
+DS
+XE
+lX
+ak
+YQ
+FS
+DS
+DS
+DS
+Xb
+Xb
+lS
+Cg
+ql
+ql
+ql
+HB
+ri
+Wb
+"}
+(7,1,1) = {"
+DS
+HR
+gp
+Fh
+Sk
+Lb
+DS
+Xf
+Wb
+Xb
+Xb
+DN
+yh
+ra
+lD
+Cu
+vs
+Wb
+Wb
+"}
+(8,1,1) = {"
+DS
+Kc
+zY
+yW
+iU
+Ce
+DS
+Wb
+Wb
+Xb
+Xb
+cH
+Xb
+Xb
+Sx
+SS
+vs
+Wb
+Wb
+"}
+(9,1,1) = {"
+DS
+Nr
+LR
+AF
+lC
+fM
+DS
+DS
+DS
+DS
+Oi
+Xb
+LF
+ql
+ql
+ql
+NW
+QT
+Wb
+"}
+(10,1,1) = {"
+dc
+TP
+OZ
+Fh
+rX
+LS
+jm
+uh
+iq
+jm
+Xb
+Xb
+Xb
+Xb
+ar
+ra
+Zi
+tJ
+he
+"}
+(11,1,1) = {"
+qS
+dc
+DS
+Rg
+kJ
+If
+lT
+YQ
+xK
+Xb
+Xb
+Xb
+iz
+Xb
+Xb
+dq
+pE
+Qy
+he
+"}
+(12,1,1) = {"
+Wb
+Wb
+Wb
+vs
+rX
+vl
+jK
+Ix
+Fq
+Xb
+FE
+FE
+Fh
+Xb
+Gf
+Kb
+uD
+fK
+he
+"}
+(13,1,1) = {"
+Cb
+Cb
+qS
+dc
+TP
+Jq
+FE
+gS
+rt
+FE
+fW
+FE
+vs
+YN
+nf
+uD
+NW
+ri
+Wb
+"}
+(14,1,1) = {"
+Wb
+Wb
+Wb
+Wb
+dc
+DS
+DS
+Ez
+Ez
+DS
+DS
+ql
+NW
+ql
+ql
+NW
+Nh
+he
+Wb
+"}

--- a/assets/maps/shuttles/manta/manta_disaster.dmm
+++ b/assets/maps/shuttles/manta/manta_disaster.dmm
@@ -1,0 +1,732 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"df" = (
+/obj/machinery/shuttle/engine/heater/seaheater_middle,
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"dY" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"er" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/manta)
+"et" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/manta)
+"eu" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"fo" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/skeleton,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/manta)
+"fs" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body3";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"fu" = (
+/turf/unsimulated/wall{
+	dir = 4;
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadwindow_1";
+	name = "window";
+	opacity = 0
+	},
+/area/centcom)
+"fH" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/jen,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/manta)
+"gx" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"gQ" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/manta)
+"hE" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/radio,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"jj" = (
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-L"
+	},
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"jq" = (
+/obj/machinery/door/airlock/pyro/medical,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"jz" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"jM" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"lg" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/manta)
+"lK" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"nB" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"oY" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/manta)
+"qC" = (
+/obj/critter/crunched,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/manta)
+"qW" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/manta)
+"sb" = (
+/turf/unsimulated/wall/setpieces/leadwall{
+	dir = 5
+	},
+/area/centcom)
+"sz" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/manta)
+"sG" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"sL" = (
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-R"
+	},
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"tp" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/manta)
+"tH" = (
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/manta)
+"tO" = (
+/obj/table/auto,
+/obj/item/storage/firstaid/oxygen{
+	pixel_x = -6
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = 2
+	},
+/obj/item/storage/firstaid/brute{
+	pixel_x = 9
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"uE" = (
+/turf/space/fluid,
+/area/centcom)
+"vc" = (
+/obj/machinery/light/small/floor,
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/manta)
+"wC" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"wW" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"xH" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/jen,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"yl" = (
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 1
+	},
+/obj/decal/skeleton{
+	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body7"
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/manta)
+"yR" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/manta)
+"AF" = (
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/manta)
+"AL" = (
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"AM" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/manta)
+"Bn" = (
+/obj/indestructible/shuttle_corner,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"BT" = (
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/manta)
+"Cd" = (
+/obj/decal/cleanable/machine_debris{
+	icon_state = "gib7"
+	},
+/obj/decal/cleanable/oil,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/manta)
+"CC" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/manta)
+"Dt" = (
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"Dx" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"Dy" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"DW" = (
+/obj/decal/cleanable/paper,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/manta)
+"HV" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt,
+/obj/decal/cleanable/dirt/jen,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/manta)
+"Il" = (
+/obj/machinery/shuttle/engine/heater{
+	icon_state = "alt_heater-M"
+	},
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"IJ" = (
+/obj/machinery/computer/shuttle,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"IR" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/manta)
+"Ji" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"Jj" = (
+/obj/machinery/shuttle/engine/propulsion/sea_propulsion,
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"JA" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"KM" = (
+/turf/unsimulated/wall/setpieces/leadwall{
+	dir = 6
+	},
+/area/centcom)
+"LV" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/manta)
+"MK" = (
+/obj/machinery/shuttle/engine/propulsion{
+	icon_state = "alt_propulsion"
+	},
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"Nu" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"NN" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/manta)
+"Oj" = (
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/manta)
+"OO" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"Pb" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"Pd" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"PZ" = (
+/turf/unsimulated/wall/setpieces/leadwall{
+	dir = 9
+	},
+/area/centcom)
+"Qj" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/manta)
+"QE" = (
+/obj/indestructible/shuttle_corner,
+/turf/space/fluid,
+/area/shuttle/escape/centcom/manta)
+"Rv" = (
+/obj/machinery/light/small/floor,
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"RD" = (
+/turf/unsimulated/wall{
+	icon = 'icons/misc/worlds.dmi';
+	icon_state = "leadwall"
+	},
+/area/centcom)
+"RQ" = (
+/obj/decal/cleanable/machine_debris{
+	icon_state = "gib7"
+	},
+/obj/decal/cleanable/oil,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"Tn" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/manta)
+"Tp" = (
+/obj/decal/cleanable/machine_debris,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/manta)
+"TN" = (
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/manta)
+"Uq" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/manta)
+"VK" = (
+/obj/machinery/light/small/floor,
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/manta)
+"Ww" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom/manta)
+"XK" = (
+/obj/stool/chair/comfy/shuttle/green,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"XR" = (
+/obj/machinery/light/small/floor,
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body8";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/manta)
+"XY" = (
+/turf/unsimulated/wall/setpieces/leadwall{
+	dir = 10
+	},
+/area/centcom)
+"Yw" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/manta)
+"YO" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/manta)
+"Zh" = (
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/manta)
+
+(1,1,1) = {"
+uE
+uE
+uE
+uE
+uE
+QE
+Pd
+Pd
+et
+Cd
+tH
+et
+Dx
+sb
+RD
+RD
+XY
+"}
+(2,1,1) = {"
+AL
+QE
+Ww
+et
+et
+oY
+Nu
+fo
+Tn
+tH
+Tp
+tO
+JA
+Dx
+uE
+uE
+fu
+"}
+(3,1,1) = {"
+AL
+Pd
+Nu
+gx
+Pd
+Pb
+gQ
+Uq
+tH
+qC
+tH
+AF
+XK
+JA
+df
+Jj
+sb
+"}
+(4,1,1) = {"
+AL
+Pd
+Zh
+LV
+Pd
+Pb
+yR
+HV
+tH
+tH
+jq
+CC
+VK
+XK
+JA
+Dx
+AL
+"}
+(5,1,1) = {"
+Pd
+Pd
+XR
+eu
+IR
+YO
+TN
+DW
+tH
+fH
+IR
+Dt
+BT
+sz
+XK
+jj
+MK
+"}
+(6,1,1) = {"
+Pd
+IJ
+yl
+AM
+RQ
+qW
+Qj
+Tp
+tH
+xH
+lg
+et
+et
+et
+et
+Il
+MK
+"}
+(7,1,1) = {"
+Pd
+Pd
+Rv
+Ji
+Oj
+Pb
+tH
+tH
+tH
+xH
+Zh
+Dy
+tp
+TN
+lK
+sL
+MK
+"}
+(8,1,1) = {"
+AL
+Pd
+TN
+Yw
+Pd
+wW
+NN
+tH
+tH
+tH
+qC
+tH
+DW
+fs
+Bn
+jz
+AL
+"}
+(9,1,1) = {"
+AL
+Pd
+wC
+hE
+Pd
+OO
+dY
+OO
+AM
+tH
+tH
+tH
+lK
+Bn
+df
+Jj
+PZ
+"}
+(10,1,1) = {"
+AL
+jM
+oY
+et
+et
+Ww
+wC
+er
+sG
+vc
+IR
+lK
+Bn
+jz
+uE
+uE
+fu
+"}
+(11,1,1) = {"
+uE
+uE
+uE
+uE
+uE
+jM
+Pd
+Pd
+et
+nB
+oY
+et
+jz
+PZ
+RD
+RD
+KM
+"}

--- a/assets/maps/shuttles/sealab/oshan-disaster.dmm
+++ b/assets/maps/shuttles/sealab/oshan-disaster.dmm
@@ -1,0 +1,811 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/item/storage/wall/medical{
+	dir = 4
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"cs" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "14"
+	},
+/area/shuttle/escape/centcom/sealab)
+"cH" = (
+/obj/decal/cleanable/machine_debris,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"dy" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/obj/decal/skeleton,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"el" = (
+/obj/item/storage/wall/fire{
+	dir = 4;
+	pixel_z = -4
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"ew" = (
+/obj/decal/cleanable/rust,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"ez" = (
+/obj/table/auto,
+/obj/random_item_spawner/med_kit,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"eX" = (
+/obj/landmark/load_prefab_shuttledmm/sealab,
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"ig" = (
+/obj/machinery/door/airlock/pyro/external,
+/obj/forcefield/energyshield/perma,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"ih" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "11"
+	},
+/area/shuttle/escape/centcom/sealab)
+"js" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"jN" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-L"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"lc" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "10"
+	},
+/area/shuttle/escape/centcom/sealab)
+"li" = (
+/obj/table/reinforced/auto,
+/obj/item/device/radio,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"ll" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"mR" = (
+/obj/stool/chair/comfy/shuttle/green,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"nC" = (
+/obj/decal/cleanable/vomit,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"nT" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"ou" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "2"
+	},
+/area/shuttle/escape/centcom/sealab)
+"tn" = (
+/turf/unsimulated/outdoors/grass,
+/area/centcom/outside)
+"ty" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"tX" = (
+/turf/unsimulated/floor/plating/damaged2,
+/area/shuttle/escape/centcom/sealab)
+"un" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "7"
+	},
+/area/shuttle/escape/centcom/sealab)
+"va" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "13"
+	},
+/area/shuttle/escape/centcom/sealab)
+"vP" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/obj/decal/cleanable/blood/gibs{
+	icon_state = "gib2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"wQ" = (
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/sealab)
+"xA" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/sealab)
+"xC" = (
+/obj/decal/cleanable/machine_debris,
+/obj/decal/cleanable/dirt,
+/obj/machinery/drainage/big,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"xL" = (
+/obj/decal/cleanable/vomit,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/sealab)
+"yA" = (
+/obj/decal/skeleton,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/sealab)
+"yC" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/regular,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"yP" = (
+/obj/stool/chair/comfy/shuttle/green{
+	dir = 1
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body3";
+	name = "decomposed corpse"
+	},
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"zv" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-R"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"BZ" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/sealab)
+"Cs" = (
+/obj/decal/cleanable/blood/splatter,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Cv" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/sealab)
+"Cw" = (
+/obj/machinery/door/airlock/pyro/command,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Da" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"DV" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/decal/skeleton{
+	desc = "The remains of the captain of this, uh, part of station. Not sure if all of the station parts are from the same place.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body7"
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Fh" = (
+/obj/machinery/light/small/floor,
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Fq" = (
+/obj/decal/cleanable/blood/gibs,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/sealab)
+"Fw" = (
+/obj/indestructible/shuttle_corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/sealab)
+"Gg" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"GF" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/obj/decal/skeleton{
+	desc = "The remains of some poor cosmonaut fellow.";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body9";
+	name = "corpse"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"GQ" = (
+/obj/machinery/drainage/big,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"IN" = (
+/obj/machinery/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "alt_propulsion"
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"Jg" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "5"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Ji" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "alt_heater-M"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Jj" = (
+/obj/machinery/light/small/floor,
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/sealab)
+"Kp" = (
+/obj/indestructible/shuttle_corner{
+	dir = 0
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"LK" = (
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/sealab)
+"LP" = (
+/obj/machinery/door/airlock/pyro/command,
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/sealab)
+"Mh" = (
+/obj/decal/cleanable/machine_debris{
+	icon_state = "gib7"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Mu" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/sealab)
+"MB" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "4"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Nu" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body8";
+	name = "decomposed corpse"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Ok" = (
+/obj/decal/cleanable/paper,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Ov" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"OM" = (
+/obj/machinery/computer/shuttle{
+	dir = 4;
+	icon_state = "turret1"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Pe" = (
+/obj/item/storage/wall/emergency{
+	dir = 8
+	},
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "3"
+	},
+/area/shuttle/escape/centcom/sealab)
+"PF" = (
+/obj/decal/cleanable/dirt,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"PG" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Rw" = (
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Rx" = (
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Secure Transport";
+	opacity = 0
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"RD" = (
+/obj/wingrille_spawn/auto,
+/turf/unsimulated/floor/shuttle{
+	dir = 8
+	},
+/area/shuttle/escape/centcom/sealab)
+"RR" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/sealab)
+"RX" = (
+/obj/indestructible/shuttle_corner{
+	dir = 1
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"Sh" = (
+/obj/stool/chair/comfy/shuttle/red{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Sm" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "12"
+	},
+/area/shuttle/escape/centcom/sealab)
+"SN" = (
+/obj/machinery/light/small/floor,
+/turf/unsimulated/floor/plating/scorched,
+/area/shuttle/escape/centcom/sealab)
+"SO" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor2"
+	},
+/obj/machinery/drainage/big,
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/sealab)
+"ST" = (
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/sealab)
+"TC" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"TS" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/toolbox/emergency,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"TT" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/sealab)
+"Uh" = (
+/turf/unsimulated/floor/plating/damaged3,
+/area/shuttle/escape/centcom/sealab)
+"UI" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "6"
+	},
+/area/shuttle/escape/centcom/sealab)
+"UJ" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/outdoors/grass,
+/area/shuttle/escape/centcom/sealab)
+"UM" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/sealab)
+"US" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Vg" = (
+/obj/indestructible/shuttle_corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"VM" = (
+/obj/critter/crunched,
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/sealab)
+"Wh" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "1"
+	},
+/area/shuttle/escape/centcom/sealab)
+"Wj" = (
+/obj/decal/skeleton{
+	desc = "Eugh, the stench is horrible!";
+	icon = 'icons/misc/hstation.dmi';
+	icon_state = "body1";
+	name = "decomposed corpse";
+	pixel_y = 4
+	},
+/turf/unsimulated/floor/void,
+/area/shuttle/escape/centcom/sealab)
+"Wl" = (
+/obj/stool/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/decal/skeleton,
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"WR" = (
+/obj/machinery/door/airlock/pyro/medical{
+	dir = 4;
+	name = "First-Aid Station";
+	opacity = 0
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"WY" = (
+/obj/machinery/sleeper/compact{
+	dir = 8
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"Xf" = (
+/obj/stool/chair/comfy/shuttle/pilot{
+	dir = 8
+	},
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"XO" = (
+/turf/unsimulated/floor/plating/damaged1,
+/area/shuttle/escape/centcom/sealab)
+"Yl" = (
+/obj/stool/chair/comfy/shuttle/brown{
+	dir = 4
+	},
+/turf/unsimulated/floor/plating,
+/area/shuttle/escape/centcom/sealab)
+"YU" = (
+/turf/simulated/wall/auto/shuttle{
+	icon_state = "15"
+	},
+/area/shuttle/escape/centcom/sealab)
+
+(1,1,1) = {"
+tn
+tn
+tn
+IN
+IN
+IN
+tn
+tn
+tn
+IN
+IN
+IN
+tn
+tn
+eX
+"}
+(2,1,1) = {"
+IN
+Kp
+Wh
+jN
+Ji
+zv
+aa
+un
+aa
+jN
+Ji
+zv
+ou
+nT
+IN
+"}
+(3,1,1) = {"
+MB
+Sm
+mR
+Uh
+xL
+Rw
+yP
+Sm
+Mu
+GF
+wQ
+Sh
+Sh
+Sm
+Sm
+"}
+(4,1,1) = {"
+RX
+va
+ez
+WY
+Rw
+LK
+Rw
+ST
+Cv
+wQ
+SN
+Rw
+Ov
+cs
+UJ
+"}
+(5,1,1) = {"
+Kp
+YU
+Gg
+Gg
+WR
+Gg
+ST
+ST
+ST
+ST
+Rx
+Gg
+Gg
+YU
+nT
+"}
+(6,1,1) = {"
+cs
+Vg
+TC
+Nu
+Mh
+TC
+ST
+yA
+UM
+BZ
+Rw
+ST
+Wl
+ty
+va
+"}
+(7,1,1) = {"
+js
+TC
+UM
+Rw
+Uh
+tX
+XO
+ST
+Uh
+Rw
+nC
+ST
+VM
+ST
+js
+"}
+(8,1,1) = {"
+Sm
+TC
+TC
+tX
+UI
+js
+Gg
+Pe
+Gg
+js
+Jg
+Rw
+ST
+VM
+Sm
+"}
+(9,1,1) = {"
+ig
+XO
+Cs
+ew
+Sm
+yC
+Yl
+OM
+vP
+li
+Sm
+Rw
+XO
+Fq
+ig
+"}
+(10,1,1) = {"
+js
+xC
+Rw
+ew
+Cw
+Ok
+Uh
+SO
+PG
+Mh
+LP
+Rw
+Rw
+GQ
+js
+"}
+(11,1,1) = {"
+ig
+tX
+tX
+Rw
+Sm
+TS
+dy
+Xf
+xA
+Rw
+XO
+Rw
+XO
+Rw
+ig
+"}
+(12,1,1) = {"
+Sm
+Rw
+ST
+PF
+lc
+js
+Gg
+el
+Uh
+PF
+PF
+Uh
+Rw
+RR
+Sm
+"}
+(13,1,1) = {"
+js
+ST
+VM
+ST
+Rw
+TC
+TC
+ll
+Rw
+XO
+PF
+cH
+Rw
+US
+RD
+"}
+(14,1,1) = {"
+cs
+Fw
+ST
+Wj
+ST
+ST
+Rw
+Rw
+Uh
+TT
+XO
+Rw
+US
+Da
+va
+"}
+(15,1,1) = {"
+RX
+YU
+Fw
+ST
+ST
+VM
+Jj
+US
+Fh
+US
+US
+DV
+Da
+YU
+UJ
+"}
+(16,1,1) = {"
+tn
+RX
+ih
+Gg
+js
+js
+js
+Pe
+js
+js
+js
+Gg
+ih
+UJ
+tn
+"}

--- a/code/datums/prefab_shuttles.dm
+++ b/code/datums/prefab_shuttles.dm
@@ -52,6 +52,8 @@ var/list/prefab_shuttles = list()
 		prefab_path = "assets/maps/shuttles/cog1/cog1-syndicate.dmm"
 	zen
 		prefab_path = "assets/maps/shuttles/cog1/cog1-zenshuttle.dmm"
+	disaster
+		prefab_path = "assets/maps/shuttles/cog1/cog1-disaster.dmm"
 
 /datum/prefab_shuttle/cog2
 	prefab_path = "assets/maps/shuttles/cog2/cog2_default.dmm"
@@ -59,10 +61,15 @@ var/list/prefab_shuttles = list()
 
 	martian
 		prefab_path = "assets/maps/shuttles/cog2/cog2_martian.dmm"
+	disaster
+		prefab_path = "assets/maps/shuttles/cog2/cog2-disaster.dmm"
 
 /datum/prefab_shuttle/manta
 	prefab_path = "assets/maps/shuttles/manta/manta_default.dmm"
 	landmark = LANDMARK_SHUTTLE_MANTA
+
+	disaster
+		prefab_path = "assets/maps/shuttles/manta/manta_disaster.dmm"
 
 /datum/prefab_shuttle/sealab
 	prefab_path = "assets/maps/shuttles/sealab/oshan_default.dmm"
@@ -72,10 +79,15 @@ var/list/prefab_shuttles = list()
 		prefab_path = "assets/maps/shuttles/sealab/oshan-meat.dmm"
 	minisubs
 		prefab_path = "assets/maps/shuttles/sealab/oshan-minisubs.dmm"
+	disaster
+		prefab_path = "assets/maps/shuttles/sealab/oshan-disaster.dmm"
 
 /datum/prefab_shuttle/donut2
 	prefab_path = "assets/maps/shuttles/donut2/donut2_default.dmm"
 	landmark = LANDMARK_SHUTTLE_DONUT2
+
+	disaster
+		prefab_path = "assets/maps/shuttles/donut2/donut2_disaster.dmm"
 
 /datum/prefab_shuttle/donut3
 	prefab_path = "assets/maps/shuttles/donut3/donut3_default.dmm"
@@ -83,7 +95,12 @@ var/list/prefab_shuttles = list()
 
 	cave
 		prefab_path = "assets/maps/shuttles/donut3/donut3-cave.dmm"
+	disaster
+		prefab_path = "assets/maps/shuttles/donut3/donut3-disaster.dmm"
 
 /datum/prefab_shuttle/destiny
 	prefab_path = "assets/maps/shuttles/destiny/destiny_default.dmm"
 	landmark = LANDMARK_SHUTTLE_DESTINY
+
+	disaster
+		prefab_path = "assets/maps/shuttles/destiny/destiny_disaster.dmm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[mapping] [feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds custom disaster themed shuttles to each map for admins to spawn and use.

![disshuttlecog1](https://user-images.githubusercontent.com/71185626/123900583-eb0aab00-d92e-11eb-9212-618113e7968a.png)
![disshuttlecog2](https://user-images.githubusercontent.com/71185626/123900584-eba34180-d92e-11eb-9ed8-5c716111e899.png)
![disshuttledestiny](https://user-images.githubusercontent.com/71185626/123900586-eba34180-d92e-11eb-855a-e6278e4b1b2c.png)
![disshuttledonut2](https://user-images.githubusercontent.com/71185626/123900588-ec3bd800-d92e-11eb-9bf3-8cfbd667891b.png)
![disshuttledonut3](https://user-images.githubusercontent.com/71185626/123900589-ec3bd800-d92e-11eb-9c9f-a355e9e52781.png)
![disshuttlemanta](https://user-images.githubusercontent.com/71185626/123900590-ec3bd800-d92e-11eb-8010-15024988edf6.png)
![disshuttleoshan](https://user-images.githubusercontent.com/71185626/123900591-ec3bd800-d92e-11eb-85d5-a366986e01a5.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More custom shuttles good. Themed shuttles for disaster mode is more good.
