### PR TITLE
Fixes lead wall auto-connection list

### DIFF
--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -687,8 +687,8 @@ ABSTRACT_TYPE(turf/unsimulated/wall/auto/lead)
 	flags = ALWAYS_SOLID_FLUID | IS_PERSPECTIVE_FLUID
 	connect_overlay = 1
 	connect_diagonal = 1
-	connects_to = list(/turf/unsimulated/wall/auto/lead,
-	 /obj/machinery/door, /obj/window, /turf/unsimulated/wall/, /turf/simulated/wall/false_wall/, /turf/unsimulated/wall/setpieces/leadwindow)
+	connects_to = list(/turf/unsimulated/wall/auto/lead, /obj/machinery/door, /obj/window, /turf/unsimulated/wall/, /turf/simulated/wall/false_wall/,
+	/turf/unsimulated/wall/setpieces/leadwindow, /turf/simulated/wall/false_wall/centcom)
 	connects_with_overlay = list(/obj/machinery/door, /obj/window)
 
 /turf/unsimulated/wall/auto/lead/blue


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug-minor] [secret]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a false wall to the connects_to list for the auto lead wall. This way normal auto lead walls will know to connect to the correct type of false walls.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A certain false wall became much more visible due to surrounding walls not connecting to it. This fixes the walls so the false wall is well-hidden again. The specific false wall is related to secret content.



