### PR TITLE
Heat tanks without fuel

### DIFF
--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -144,14 +144,16 @@
 
 	afterattack(obj/O as obj, mob/user as mob)
 		if ((istype(O, /obj/reagent_dispensers/fueltank) || istype(O, /obj/item/reagent_containers/food/drinks/fueltank)) && get_dist(src,O) <= 1)
-			if (O.reagents.total_volume)
+			if  (!O.reagents.total_volume)
+				boutput(user, "<span class='alert'>The [O.name] is empty!</span>")
+				return
+			if (O.reagents.reagent_list.len == 1 && O.reagents.reagent_list[1] == "fuel")
 				O.reagents.trans_to(src, capacity)
 				src.inventory_counter.update_number(get_fuel())
 				boutput(user, "<span class='notice'>Welder refueled</span>")
 				playsound(src.loc, "sound/effects/zzzt.ogg", 50, 1, -6)
-			else
-				boutput(user, "<span class='alert'>The [O.name] is empty!</span>")
-		else if (src.welding)
+				return
+		if (src.welding)
 			use_fuel(ismob(O) ? 2 : 0.2)
 			if (get_fuel() <= 0)
 				boutput(user, "<span class='notice'>Need more fuel!</span>")

--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -147,8 +147,8 @@
 			if  (!O.reagents.total_volume)
 				boutput(user, "<span class='alert'>The [O.name] is empty!</span>")
 				return
-			if (O.reagents.reagent_list.len == 1 && O.reagents.reagent_list[1] == "fuel")
-				O.reagents.trans_to(src, capacity)
+			if ("fuel" in O.reagents.reagent_list)
+				O.reagents.trans_to(src, capacity, 1, 1, O.reagents.reagent_list.Find("fuel"))
 				src.inventory_counter.update_number(get_fuel())
 				boutput(user, "<span class='notice'>Welder refueled</span>")
 				playsound(src.loc, "sound/effects/zzzt.ogg", 50, 1, -6)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Welding tools only refill from tanks if the tanks contain welding fuel. The behavior is now as follows.

Empty tank - message that the tank is empty
Tank with welding fuel and possibly other chems - refills the welding tool using only the fuel
Tank with other chems without welding fuel and welder is on - heat the container


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5178.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Welding fuel tanks only refill welding tools if they contain welding fuel.
```
