### PR TITLE
Fix light grenade emptying borgs

### DIFF
--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -726,7 +726,7 @@ PIPE BOMBS + CONSTRUCTION
 								W.layer = HUD_LAYER
 						else
 							qdel(W)
-				else
+				else if (!issilicon(user)) //borgs could drop all their tools/internal items trying to pull one
 					user.unequip_all()
 
 				for (var/mob/N in viewers(user, null))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[major]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes light grenades not have borgs (or silicons in general) drop their stuff if they try to pull one.

Old light grenades (which I've never seen) are unaffected but it looks like those only unequip clothing & light grenades, neither of which are borg-specific.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #5343
