### PR TITLE
Overhaul how sechuds' and prodocs' icon adding/removing works.

### DIFF
--- a/code/datums/client_image_group.dm
+++ b/code/datums/client_image_group.dm
@@ -1,3 +1,6 @@
+#define CLIENT_IMAGE_GROUP_ARREST_ICONS "arrest_icons"
+#define CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS "health_mon_icons"
+
 var/global/list/datum/client_image_group/client_image_groups
 
 /datum/client_image_group

--- a/code/global.dm
+++ b/code/global.dm
@@ -60,8 +60,6 @@ var/global
 	force_random_names = 0			// for the pre-roundstart thing
 	force_random_looks = 0			// same as above
 
-	list/health_mon_icons = new/list()
-	list/arrestIconsAll = new/list()
 	list/default_mob_static_icons = list() // new mobs grab copies of these for themselves, or if their chosen type doesn't exist in the list, they generate their own and add it
 	list/mob_static_icons = list() // these are the images that are actually seen by ghostdrones instead of whatever mob
 	list/orbicons = list()

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -394,31 +394,26 @@
 /mob/dead/observer/verb/show_health()
 	set category = "Ghost"
 	set name = "Toggle Health"
-	client.images.Remove(health_mon_icons)
 	if (!health_shown)
 		health_shown = 1
-		if(client?.images)
-			for(var/image/I in health_mon_icons)
-				if (I && src && I.loc != src.loc)
-					client.images.Add(I)
+		get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).add_mob(src)
+		boutput(src, "Health status toggled on.")
 	else
 		health_shown = 0
+		get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_mob(src)
+		boutput(src, "Health status toggled off.")
 
 /mob/dead/observer/verb/show_arrest()
 	set category = "Ghost"
 	set name = "Toggle Arrest Status"
 	if (!arrest_shown)
 		arrest_shown = 1
-		if(client?.images)
-			for(var/image/I in arrestIconsAll)
-				if(I && src && I.loc != src.loc)
-					client.images.Add(I)
+		get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).add_mob(src)
 		boutput(src, "Arrest status toggled on.")
 	else
 		arrest_shown = 0
-		client.images.Remove(arrestIconsAll)
+		get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_mob(src)
 		boutput(src, "Arrest status toggled off.")
-
 
 /mob/dead/observer/verb/ai_laws()
 	set name = "AI Laws"
@@ -441,11 +436,13 @@
 	..()
 
 	if(last_client)
-		health_shown = 0
-		last_client.images.Remove(health_mon_icons)
+		if(health_shown)
+			health_shown = 0
+			get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_mob(src)
 		if(arrest_shown)
 			arrest_shown = 0
-			last_client.images.Remove(arrestIconsAll)
+			get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_mob(src)
+
 
 	if(!src.key && delete_on_logout)
 		//qdel(src)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -196,13 +196,13 @@
 #endif
 
 	health_mon = image('icons/effects/healthgoggles.dmi',src,"100",10)
-	health_mon_icons.Add(health_mon)
+	get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).add_image(health_mon)
 
 	health_implant = image('icons/effects/healthgoggles.dmi',src,"100",10)
-	health_mon_icons.Add(health_implant)
+	get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).add_image(health_implant)
 
 	arrestIcon = image('icons/effects/sechud.dmi',src,null,10)
-	arrestIconsAll.Add(arrestIcon)
+	get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).add_image(arrestIcon)
 
 	src.organHolder = new(src)
 
@@ -509,17 +509,15 @@
 		imp.dispose()
 	src.implant = null
 
-	for(var/client/C)
-		C.images -= list(health_mon, health_implant, arrestIcon)
 	if(health_mon)
+		get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_image(health_mon)
 		health_mon.dispose()
-		health_mon_icons -= health_mon
 	if(health_implant)
+		get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_image(health_implant)
 		health_implant.dispose()
-		health_mon_icons -= health_implant
 	if(arrestIcon)
+		get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_image(arrestIcon)
 		arrestIcon.dispose()
-		arrestIconsAll -= arrestIcon
 
 	src.chest_item = null
 

--- a/code/mob/living/life/hud.dm
+++ b/code/mob/living/life/hud.dm
@@ -61,33 +61,6 @@
 				human_owner.vision.animate_color_mod(rgb(rand(80, 255), rand(80, 255), rand(80, 255)), 15)
 			else
 				human_owner.vision.set_color_mod(rgb(color_mod_r, color_mod_g, color_mod_b))
-
-			if (istype(human_owner.glasses, /obj/item/clothing/glasses/healthgoggles))
-				var/obj/item/clothing/glasses/healthgoggles/G = human_owner.glasses
-				if (human_owner.client && !(G.assigned || G.assigned == human_owner.client))
-					G.assigned = human_owner.client
-					processing_items |= G
-					//G.updateIcons()
-
-			if (istype(human_owner.head, /obj/item/clothing/head/helmet/space/syndicate/specialist/medic))
-				var/obj/item/clothing/head/helmet/space/syndicate/specialist/medic/M = human_owner.head
-				if (human_owner.client && !(M.assigned || M.assigned == human_owner.client))
-					M.assigned = human_owner.client
-					processing_items |= M
-					//G.updateIcons()
-
-			else if (human_owner.organHolder && istype(human_owner.organHolder.left_eye, /obj/item/organ/eye/cyber/prodoc))
-				var/obj/item/organ/eye/cyber/prodoc/G = human_owner.organHolder.left_eye
-				if (human_owner.client && !(G.assigned || G.assigned == human_owner.client))
-					G.assigned = human_owner.client
-					processing_items |= G
-					//G.updateIcons()
-			else if (human_owner.organHolder && istype(human_owner.organHolder.right_eye, /obj/item/organ/eye/cyber/prodoc))
-				var/obj/item/organ/eye/cyber/prodoc/G = human_owner.organHolder.right_eye
-				if (human_owner.client && !(G.assigned || G.assigned == human_owner.client))
-					G.assigned = human_owner.client
-					processing_items |= G
-					//G.updateIcons()
 		else
 			if (owner.druggy)
 				owner.vision.animate_color_mod(rgb(rand(0, 255), rand(0, 255), rand(0, 255)), 15)

--- a/code/modules/robotics/robot/upgrade/prodoc_scanner.dm
+++ b/code/modules/robotics/robot/upgrade/prodoc_scanner.dm
@@ -13,4 +13,3 @@
 	if (..())
 		return
 	get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_mob(user)
-	return

--- a/code/modules/robotics/robot/upgrade/prodoc_scanner.dm
+++ b/code/modules/robotics/robot/upgrade/prodoc_scanner.dm
@@ -4,37 +4,13 @@
 	icon_state = "up-prodoc"
 	drainrate = 5
 
-	var/client/assigned = null
-
-/obj/item/roboupgrade/healthgoggles/process()
-	if (assigned)
-		src.assigned.images.Remove(health_mon_icons)
-		addIcons()
-
-		if (src.loc != assigned.mob)
-			src.assigned.images.Remove(health_mon_icons)
-			src.assigned = null
-
-/obj/item/roboupgrade/healthgoggles/proc/addIcons()
-	if (src.assigned)
-		for (var/image/I in health_mon_icons)
-			if (!I || !I.loc || !src)
-				continue
-			if (I.loc.invisibility && I.loc != src.loc)
-				continue
-			src.assigned.images.Add(I)
-
 /obj/item/roboupgrade/healthgoggles/upgrade_activate(var/mob/living/silicon/robot/user as mob)
 	if (..())
 		return
-	src.assigned = user.client
-	processing_items |= src
+	get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).add_mob(user)
 
 /obj/item/roboupgrade/healthgoggles/upgrade_deactivate(var/mob/living/silicon/robot/user as mob)
 	if (..())
 		return
-	if (src.assigned)
-		src.assigned.images.Remove(health_mon_icons)
-		src.assigned = null
-	processing_items.Remove(src)
+	get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_mob(user)
 	return

--- a/code/modules/robotics/robot/upgrade/sechud_scanner.dm
+++ b/code/modules/robotics/robot/upgrade/sechud_scanner.dm
@@ -4,37 +4,13 @@
 	icon_state = "up-sechud"
 	drainrate = 5
 
-	var/client/assigned = null
-
-	process()
-		if (assigned)
-			src.assigned.images.Remove(arrestIconsAll)
-			addIcons()
-
-			if (src.loc != assigned.mob)
-				src.assigned.images.Remove(arrestIconsAll)
-				src.assigned = null
-
-	proc/addIcons()
-		if (src.assigned)
-			for (var/image/I in arrestIconsAll)
-				if (!I || !I.loc || !src)
-					continue
-				if (I.loc.invisibility && I.loc != src.loc)
-					continue
-				src.assigned.images.Add(I)
-
 	upgrade_activate(var/mob/living/silicon/robot/user as mob)
 		if (..())
 			return
-		src.assigned = user.client
-		processing_items |= src
+		get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).add_mob(user)
 
 	upgrade_deactivate(var/mob/living/silicon/robot/user as mob)
 		if (..())
 			return
-		if (src.assigned)
-			src.assigned.images.Remove(arrestIconsAll)
-			src.assigned = null
-		processing_items.Remove(src)
+		get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_mob(user)
 		return

--- a/code/modules/robotics/robot/upgrade/sechud_scanner.dm
+++ b/code/modules/robotics/robot/upgrade/sechud_scanner.dm
@@ -13,4 +13,3 @@
 		if (..())
 			return
 		get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_mob(user)
-		return

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -163,7 +163,6 @@
 	name = "\improper Security HUD"
 	desc = "Sunglasses with a high tech sheen."
 	icon_state = "sec"
-	var/client/assigned = null
 	color_r = 0.95 // darken a little, kinda red
 	color_g = 0.9
 	color_b = 0.9
@@ -180,37 +179,16 @@
 					H.bioHolder.RemoveEffect("bad_eyesight")
 		return
 
-	process()
-		if (assigned)
-			assigned.images.Remove(arrestIconsAll)
-			addIcons()
-			if (loc != assigned.mob)
-				assigned.images.Remove(arrestIconsAll)
-				assigned = null
-
-	proc/addIcons()
-		if (assigned)
-			for (var/image/I in arrestIconsAll)
-				if (!I || !I.loc || !src)
-					continue
-				if (I.loc.invisibility && I.loc != src.loc)
-					continue
-				else
-					assigned.images.Add(I)
-
 	equipped(var/mob/user, var/slot)
 		..()
 		if (slot == SLOT_GLASSES)
-			assigned = user.client
-			processing_items |= src
+			get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).add_mob(user)
 		return
 
 	unequipped(var/mob/user)
+		if(src.equipped_in_slot == SLOT_GLASSES)
+			get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_mob(user)
 		..()
-		if (assigned)
-			assigned.images.Remove(arrestIconsAll)
-			assigned = null
-		processing_items.Remove(src)
 		return
 
 /obj/item/clothing/glasses/sunglasses/sechud/superhero
@@ -433,7 +411,6 @@
 	desc = "Fitted with an advanced miniature sensor array that allows the user to quickly determine the physical condition of others."
 	icon_state = "prodocs"
 	uses_multiple_icon_states = 1
-	var/client/assigned = null
 	var/scan_upgrade = 0
 	var/health_scan = 0
 	mats = 8
@@ -445,39 +422,16 @@
 		..()
 		setProperty("disorient_resist_eye", 15)
 
-	//proc/updateIcons() //I wouldve liked to avoid this but i dont want to put this inside the mobs life proc as that would be more code.
-	process()
-		if (assigned)
-			assigned.images.Remove(health_mon_icons)
-			addIcons()
-
-			if (loc != assigned.mob)
-				assigned.images.Remove(health_mon_icons)
-				assigned = null
-
-	proc/addIcons()
-		if (assigned)
-			for (var/image/I in health_mon_icons)
-				if (!I || !I.loc || !src)
-					continue
-				if (I.loc.invisibility && I.loc != src.loc)
-					continue
-				else
-					assigned.images.Add(I)
-
 	equipped(var/mob/user, var/slot)
 		..()
 		if (slot == SLOT_GLASSES)
-			assigned = user.client
-		processing_items |= src
+			get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).add_mob(user)
 		return
 
 	unequipped(var/mob/user)
+		if(src.equipped_in_slot == SLOT_GLASSES)
+			get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_mob(user)
 		..()
-		if (assigned)
-			assigned.images.Remove(health_mon_icons)
-			assigned = null
-		processing_items.Remove(src)
 		return
 
 	attackby(obj/item/W as obj, mob/user as mob)

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -177,19 +177,16 @@
 				H.bioHolder.AddEffect("bad_eyesight")
 				SPAWN_DBG(10 SECONDS)
 					H.bioHolder.RemoveEffect("bad_eyesight")
-		return
 
 	equipped(var/mob/user, var/slot)
 		..()
 		if (slot == SLOT_GLASSES)
 			get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).add_mob(user)
-		return
 
 	unequipped(var/mob/user)
 		if(src.equipped_in_slot == SLOT_GLASSES)
 			get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_mob(user)
 		..()
-		return
 
 /obj/item/clothing/glasses/sunglasses/sechud/superhero
 	name = "superhero mask"
@@ -426,13 +423,11 @@
 		..()
 		if (slot == SLOT_GLASSES)
 			get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).add_mob(user)
-		return
 
 	unequipped(var/mob/user)
 		if(src.equipped_in_slot == SLOT_GLASSES)
 			get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_mob(user)
 		..()
-		return
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/device/analyzer/healthanalyzer_upgrade))

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -325,13 +325,11 @@
 				..()
 				if (slot == SLOT_HEAD)
 					get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).add_mob(user)
-				return
 
 			unequipped(var/mob/user)
 				if(src.equipped_in_slot == SLOT_HEAD)
 					get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_mob(user)
 				..()
-				return
 
 		sniper
 			name = "specialist combat cover"
@@ -835,4 +833,3 @@
 		setProperty("heatprot", 15)
 		setProperty("disorient_resist_eye", 8)
 		setProperty("disorient_resist_ear", 8)
-

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -316,50 +316,21 @@
 			item_state = "syndie_specialist"
 			permeability_coefficient = 0.01
 			c_flags = SPACEWEAR | COVERSEYES | COVERSMOUTH | BLOCKCHOKE
-			var/client/assigned = null
 
 			setupProperties()
 				..()
 				setProperty("viralprot", 50)
 
-			process()
-				if (assigned)
-					assigned.images.Remove(health_mon_icons)
-					src.addIcons()
-
-					if (loc != assigned.mob)
-						assigned.images.Remove(health_mon_icons)
-						assigned = null
-
-					//sleep(2 SECONDS)
-				else
-					processing_items.Remove(src)
-
-			proc/addIcons()
-				if (assigned)
-					for (var/image/I in health_mon_icons)
-						if (!I || !I.loc || !src)
-							continue
-						if (I.loc.invisibility && I.loc != src.loc)
-							continue
-						else
-							assigned.images.Add(I)
-
 			equipped(var/mob/user, var/slot)
 				..()
 				if (slot == SLOT_HEAD)
-					assigned = user.client
-					SPAWN_DBG(-1)
-						//updateIcons()
-						processing_items |= src
+					get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).add_mob(user)
 				return
 
 			unequipped(var/mob/user)
+				if(src.equipped_in_slot == SLOT_HEAD)
+					get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_mob(user)
 				..()
-				if (assigned)
-					assigned.images.Remove(health_mon_icons)
-					assigned = null
-					processing_items.Remove(src)
 				return
 
 		sniper

--- a/code/obj/item/organs/eye.dm
+++ b/code/obj/item/organs/eye.dm
@@ -148,7 +148,6 @@
 	desc = "A fancy electronic eye. It has a Security HUD system installed."
 	icon_state = "eye-sec"
 	mats = 7
-	var/client/assigned = null
 	made_from = "pharosium"
 	color_r = 0.975 // darken a little, kinda red
 	color_g = 0.95
@@ -156,45 +155,23 @@
 	change_iris = 0
 
 	process()
-		if (assigned)
-			assigned.images.Remove(arrestIconsAll)
-			if (src.broken)
-				processing_items.Remove(src)
-				return
-			addIcons()
-
-			if (loc != assigned.mob)
-				assigned.images.Remove(arrestIconsAll)
-				assigned = null
-		else
+		if (src.broken)
 			processing_items.Remove(src)
-
-	proc/addIcons()
-		if (assigned)
-			for (var/image/I in arrestIconsAll)
-				if (!I || !I.loc || !src)
-					continue
-				if (I.loc.invisibility && I.loc != src.loc)
-					continue
-				else
-					assigned.images.Add(I)
+			get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_mob(donor)
+			return
 
 	on_transplant(var/mob/M as mob)
 		..()
 		if (src.broken)
 			return
-		if (M.client)
-			src.assigned = M.client
-			SPAWN_DBG(-1)
-				processing_items |= src
+		processing_items |= src
+		get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).add_mob(donor)
 		return
 
 	on_removal()
 		..()
-		if (assigned)
-			assigned.images.Remove(arrestIconsAll)
-			assigned = null
-			processing_items.Remove(src)
+		processing_items.Remove(src)
+		get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_mob(donor)
 		return
 
 /obj/item/organ/eye/cyber/thermal
@@ -282,7 +259,6 @@
 	desc = "A fancy electronic eye. It's fitted with an advanced miniature sensor array that allows you to quickly determine the physical condition of others."
 	icon_state = "eye-prodoc"
 	mats = 7
-	var/client/assigned = null
 	made_from = "pharosium"
 	color_r = 0.925
 	color_g = 1
@@ -291,45 +267,23 @@
 
 	// stolen from original prodocs
 	process()
-		if (assigned)
-			assigned.images.Remove(health_mon_icons)
-			if (src.broken)
-				processing_items.Remove(src)
-				return
-			addIcons()
-
-			if (loc != assigned.mob)
-				assigned.images.Remove(health_mon_icons)
-				assigned = null
-		else
+		if (src.broken)
 			processing_items.Remove(src)
-
-	proc/addIcons()
-		if (assigned)
-			for (var/image/I in health_mon_icons)
-				if (!I || !I.loc || !src)
-					continue
-				if (I.loc.invisibility && I.loc != src.loc)
-					continue
-				else
-					assigned.images.Add(I)
+			get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_mob(donor)
+			return
 
 	on_transplant(var/mob/M as mob)
 		..()
 		if (src.broken)
 			return
-		if (M.client)
-			src.assigned = M.client
-			SPAWN_DBG(-1)
-				processing_items |= src
+		processing_items |= src
+		get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).add_mob(M)
 		return
 
 	on_removal()
 		..()
-		if (assigned)
-			assigned.images.Remove(health_mon_icons)
-			assigned = null
-			processing_items.Remove(src)
+		processing_items.Remove(src)
+		get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_mob(donor)
 		return
 
 /obj/item/organ/eye/cyber/ecto

--- a/code/obj/item/organs/eye.dm
+++ b/code/obj/item/organs/eye.dm
@@ -158,7 +158,6 @@
 		if (src.broken)
 			processing_items.Remove(src)
 			get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_mob(donor)
-			return
 
 	on_transplant(var/mob/M as mob)
 		..()
@@ -166,13 +165,11 @@
 			return
 		processing_items |= src
 		get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).add_mob(donor)
-		return
 
 	on_removal()
 		..()
 		processing_items.Remove(src)
 		get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).remove_mob(donor)
-		return
 
 /obj/item/organ/eye/cyber/thermal
 	name = "thermal imager cybereye"
@@ -270,7 +267,6 @@
 		if (src.broken)
 			processing_items.Remove(src)
 			get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).remove_mob(donor)
-			return
 
 	on_transplant(var/mob/M as mob)
 		..()

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -72,6 +72,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\callback.dm"
 #include "code\datums\changelog.dm"
 #include "code\datums\character_preview.dm"
+#include "code\datums\client_image_group.dm"
 #include "code\datums\commodity.dm"
 #include "code\datums\communications.dm"
 #include "code\datums\computerfiles.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Uses client image groups added in #4789 to overhaul how assigning arrest/health icons to mobs wearing things like sechuds or prodocs works.

Currently, to deal with things like clients logging out/logging in, mobs swapping clients and whatnot processing loops are used to sanity-check constantly for whether the icons need to be added/removed. Invisibility changes are tracked in a similar fashion. This ends up with a lot of lines of repeating code for processing loops for every item that requires that functionality.

This PR instead makes use of signals to handle these events as they happen. It also moves a lot of the responsibility onto the forementioned image groups, drastically cutting down the amount of code required to make use of the icons.

There should be no noticeable difference from a player standpoint and all original functionality has been preserved.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cleaner handling of adding arrest and health icons, with less repetitive code and no necessity of processing loops.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gerhazo
(+)Back-end overhaul to how sechuds and prodocs work. This shouldn't be noticeable from a player standpoint.
```
