### PR TITLE
fix cog1 power grid monitoring  computer and re-add interdictor crate

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -34502,11 +34502,11 @@
 /turf/simulated/floor/plating/jen,
 /area/station/engine/power)
 "bJk" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
 /obj/cable,
 /obj/machinery/power/apc/autoname_south,
+/obj/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/engine/power)
 "bJl" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -33715,10 +33715,7 @@
 /obj/cable/brown{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/monitor{
-	dir = 4;
-	name = "Station Power Grid Monitoring"
-	},
+/obj/storage/secure/crate/eng/interdictor,
 /turf/simulated/floor,
 /area/station/engine/power)
 "bHm" = (
@@ -54567,6 +54564,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/core)
+"dZY" = (
+/obj/stool/chair/yellow{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/engine/engineering)
 "ebe" = (
 /obj/item/device/radio/intercom/cargo{
 	dir = 8
@@ -55480,6 +55486,18 @@
 /obj/decal/xmas_lights/ephemeral,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
+"fDa" = (
+/obj/landmark/start{
+	name = "Engineer"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/engine/engineering)
 "fDy" = (
 /obj/landmark/gps_waypoint,
 /obj/decal/tile_edge/stripe/big{
@@ -56618,6 +56636,7 @@
 /obj/item/device/radio/intercom/engineering{
 	dir = 1
 	},
+/obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "hCk" = (
@@ -62833,9 +62852,6 @@
 	dir = 5
 	},
 /obj/cable/brown{
-	icon_state = "4-8"
-	},
-/obj/cable/brown{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
@@ -63371,12 +63387,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria)
 "tSs" = (
-/obj/machinery/disposal/mail{
-	mail_tag = "engineering";
-	mailgroup = "engineer";
-	message = "1";
-	name = "mail chute-'Engineering'"
-	},
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
@@ -63388,9 +63398,7 @@
 	can_rupture = 0;
 	dir = 10
 	},
-/obj/cable/brown{
-	icon_state = "4-8"
-	},
+/obj/machinery/disposal/mail/autoname/engineering,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -64802,14 +64810,18 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/reagent_dispensers/watertank/fountain,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 6
 	},
+/obj/machinery/power/data_terminal,
 /obj/cable/brown{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
+/obj/cable/brown{
+	icon_state = "0-8"
+	},
+/obj/machinery/computer/atmosphere/pumpcontrol,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -65150,10 +65162,10 @@
 /area/station/security/main)
 "xpg" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/atmosphere/pumpcontrol,
-/obj/cable/brown{
-	icon_state = "0-8"
+/obj/cable{
+	icon_state = "0-2"
 	},
+/obj/machinery/power/monitor,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -114434,8 +114446,8 @@ bEo
 rEe
 bsN
 xpg
-bHr
-bIo
+dZY
+fDa
 bJu
 bMc
 jbi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

![image](https://user-images.githubusercontent.com/13049028/124245732-1c24e000-dad5-11eb-876c-be3a73e9d1db.png)

Some fixes from my cog1 change, moves the grid computer to the control room and adds an interdiction crate back to the power room

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Obligatory tweaks after a mapping change


