### PR TITLE
Adds colorful backpacks and satchels to uniform manufacturer

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1853,6 +1853,33 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	create = 1
 	category = "Clothing"
 
+/datum/manufacture/backpack_red
+	name = "Red Backpack"
+	item_paths = list("FAB-1")
+	item_amounts = list(8)
+	item_outputs = list(/obj/item/storage/backpack/red)
+	time = 10 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/backpack_green
+	name = "Green Backpack"
+	item_paths = list("FAB-1")
+	item_amounts = list(8)
+	item_outputs = list(/obj/item/storage/backpack/green)
+	time = 10 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/backpack_blue
+	name = "Blue Backpack"
+	item_paths = list("FAB-1")
+	item_amounts = list(8)
+	item_outputs = list(/obj/item/storage/backpack/blue)
+	time = 10 SECONDS
+	create = 1
+	category = "Clothing"
+
 /datum/manufacture/satchel
 	name = "Satchel"
 	item_paths = list("FAB-1")
@@ -1862,6 +1889,32 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	create = 1
 	category = "Clothing"
 
+/datum/manufacture/satchel_red
+	name = "Red Satchel"
+	item_paths = list("FAB-1")
+	item_amounts = list(8)
+	item_outputs = list(/obj/item/storage/backpack/satchel/red)
+	time = 10 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/satchel_green
+	name = "Green Satchel"
+	item_paths = list("FAB-1")
+	item_amounts = list(8)
+	item_outputs = list(/obj/item/storage/backpack/satchel/green)
+	time = 10 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/satchel_blue
+	name = "Blue Satchel"
+	item_paths = list("FAB-1")
+	item_amounts = list(8)
+	item_outputs = list(/obj/item/storage/backpack/satchel/blue)
+	time = 10 SECONDS
+	create = 1
+	category = "Clothing"
 /datum/manufacture/shoes_brown
 	name = "Brown Shoes"
 	item_paths = list("FAB-1")

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1915,6 +1915,7 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	time = 10 SECONDS
 	create = 1
 	category = "Clothing"
+
 /datum/manufacture/shoes_brown
 	name = "Brown Shoes"
 	item_paths = list("FAB-1")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2377,7 +2377,13 @@
 	/datum/manufacture/hat_orange,
 	/datum/manufacture/hat_tophat,
 	/datum/manufacture/backpack,
-	/datum/manufacture/satchel)
+	/datum/manufacture/backpack_red,
+	/datum/manufacture/backpack_green,
+	/datum/manufacture/backpack_blue,
+	/datum/manufacture/satchel,
+	/datum/manufacture/satchel_red,
+	/datum/manufacture/satchel_green,
+	/datum/manufacture/satchel_blue)
 
 	hidden = list(/datum/manufacture/breathmask,
 	/datum/manufacture/patch,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat][wiki]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds red, green and blue backpacks and satchels to uniform manufacturer.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently they're only available via personal lockers and I often end up claiming all the lockers for myself just to find the satchel I want. I think it's fair to have them printable aswell, since you already can print all kinds of colorful jumpsuits and shoes with uniform manufacturer anyway.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Added colorful backpacks and satchels to uniform manufacturer.
```
