### PR TITLE
fix an error with mulebot speedhacking

### DIFF
--- a/code/modules/robotics/bot/mulebot.dm
+++ b/code/modules/robotics/bot/mulebot.dm
@@ -500,9 +500,9 @@
 			return
 		if(on)
 			SPAWN_DBG(0)
-				var/speed = ((wires & wire_motor1) ? 1:0) + ((wires & wire_motor2) ? 2:0)
-				//boutput(world, "speed: [speed]")
-
+				// speed varies between 1-4 depending on how many wires are cut (and which of the two)
+				var/speed = ((wires & wire_motor1) ? 1:0) + ((wires & wire_motor2) ? 2:0) + 1
+				// both wires results in no speed at all :(
 				var/n_steps = list(0, 12, 7, 6)[speed]
 
 				var/sleep_time = n_steps ? clamp(time_since_last / n_steps, 0.04 SECONDS, 1.5 SECONDS) : 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There was an off-by-one error in the mulebot speed-array, since byond arrays start at 1 rather than 0.
This meant that by default mulebots had speed 7 instead of 6, cutting one of the wires set the speed to 12, the other to 0.
Cutting both set it to runtime.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
good if features work


