### PR TITLE
Multi action bars

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -375,6 +375,8 @@ var/datum/action_controller/actions
 	onDelete()
 		if (owner)
 			owner.overlays -= icon_image
+		if (icon_on_target && place_to_put_bar)
+			place_to_put_bar.overlays -= icon_image
 		if (icon_image)
 			del(icon_image)
 		..()

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -137,8 +137,10 @@ var/datum/action_controller/actions
 	var/color_active = "#4444FF"
 	var/color_success = "#00CC00"
 	var/color_failure = "#CC0000"
-	var/atom/movable/place_to_put_bar = null // By default the bar is put on the owner, define this on the progress bar as the place you want to put it on.
-	var/bar_on_owner = TRUE // In case we want the owner to have no visible action bar but still want to make the bar.
+	/// By default the bar is put on the owner, define this on the progress bar as the place you want to put it on.
+	var/atom/movable/place_to_put_bar = null
+	/// In case we want the owner to have no visible action bar but still want to make the bar.
+	var/bar_on_owner = TRUE
 
 	onStart()
 		..()
@@ -358,7 +360,8 @@ var/datum/action_controller/actions
 	var/icon_x_off = 0
 	var/image/icon_image
 	var/icon_plane = PLANE_HUD + 2
-	var/icon_on_target = TRUE // Is the icon also on the target if we have one?
+	/// Is the icon also on the target if we have one?
+	var/icon_on_target = TRUE
 
 	onStart()
 		..()

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -157,8 +157,6 @@ var/datum/action_controller/actions
 				A.vis_contents += bar
 				A.vis_contents += border
 			if (place_to_put_bar)
-				bar.on_target = 1
-				border.on_target = 1
 				place_to_put_bar.vis_contents += bar
 				place_to_put_bar.vis_contents += border
 
@@ -1135,7 +1133,6 @@ var/datum/action_controller/actions
 	name = ""
 	desc = ""
 	mouse_opacity = 0
-	var/on_target = FALSE
 
 /obj/actions/bar
 	icon_state = "bar"

--- a/code/obj/item/table_rack_parts.dm
+++ b/code/obj/item/table_rack_parts.dm
@@ -485,10 +485,11 @@ RACK PARTS
 
 /datum/action/bar/icon/furniture_deconstruct
 	id = "furniture_deconstruct"
-	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED
 	duration = 50
 	icon = 'icons/ui/actions.dmi'
 	icon_state = "working"
+	icon_on_target = FALSE
 
 	var/obj/the_furniture
 	var/obj/item/the_tool
@@ -497,6 +498,7 @@ RACK PARTS
 		..()
 		if (O)
 			the_furniture = O
+			place_to_put_bar = O
 		if (tool)
 			the_tool = tool
 			icon = the_tool.icon


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] --> [FEATURE] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the option to have action bars on the target, along with a few things to tweak with how those action bars look. 

Removes INTERRUPT_ACT and INTERRUPT_ACTION from chair deconstruction along with making the action bars show on top of the chairs by using the customization options I talked about earlier, so players can deconstruct more than 1 at a time. Here is how it looks:

![Captura de Tela (328)](https://user-images.githubusercontent.com/74429191/124307355-1a433700-db3e-11eb-9405-ee693fea7076.png)

other action bars should show no differences. giving other stuff multi action bars in the future should also be super easy.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes deconstructing multiple stuff look better 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Arthur Holiday
(+)You can now deconstruct multiple chairs at a time.
```
