### PR TITLE
let guardbuddies rack the riotgun

### DIFF
--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -1236,6 +1236,9 @@
 			burst--
 			if (burst)
 				sleep(5)	// please dont fuck anything up
+			if(istype(budgun, /obj/item/gun/kinetic/riotgun))
+				var/obj/item/gun/kinetic/riotgun/RG = budgun
+				RG.rack(src)
 		ON_COOLDOWN(src, "buddy_refire_delay", src.gunfire_cooldown)
 		return 1
 

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -687,13 +687,17 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 			src.update_icon()
 			src.casings_to_eject = 0
 
-
-
 	attack_self(mob/user as mob)
 		..()
+		src.rack(user)
+
+	proc/rack(var/atom/movable/user)
+		var/mob/mob_user = null
+		if(ismob(user))
+			mob_user = user
 		if (!src.racked_slide) //Are we racked?
 			if (src.ammo.amount_left == 0)
-				boutput(user, "<span class ='notice'>You are out of shells!</span>")
+				boutput(mob_user, "<span class ='notice'>You are out of shells!</span>")
 				update_icon()
 			else
 				src.racked_slide = TRUE
@@ -703,7 +707,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 					animate(icon_state = "shotty[gilded ? "-golden" : ""]")
 				else
 					update_icon() // Slide already open? Just close the slide
-				boutput(user, "<span class='notice'>You rack the slide of the shotgun!</span>")
+				boutput(mob_user, "<span class='notice'>You rack the slide of the shotgun!</span>")
 				playsound(user.loc, "sound/weapons/shotgunpump.ogg", 50, 1)
 				src.casings_to_eject = 0
 				if (src.ammo.amount_left < 8) // Do not eject shells if you're racking a full "clip"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This lets guardbuddies rack the riotgun, so they can actually use it.

For this I move some stuff around in the riotgun code, so that a non-mob can rack the gun too without problems.

If we ever make more rackable guns, i assume we'll do this in a more general way!
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Buddies should be able to use guns nicely!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) Buddies should be able to rack the riot shotgun now.
```
