### PR TITLE
Tweak clown shoe slip

### DIFF
--- a/code/datums/components/tripsalot.dm
+++ b/code/datums/components/tripsalot.dm
@@ -10,22 +10,15 @@
 
 
 /datum/component/wearertargeting/tripsalot/proc/tripalot(mob/living/carbon/human/H, last_turf, direct)
-	if (prob(1) && prob(50) && !H.lying)
-		if(istype(H.head, /obj/item/clothing/head))
-			if(istype(H.head, /obj/item/clothing/head/helmet))
-				boutput(H, "<span class='alert'>You stumble and fall to the ground. Thankfully, that helmet protected you.</span>")
-				H.changeStatus("weakened", 1.2 SECONDS)
-				H.slip()
-			else if(prob(70))
-				boutput(H, "<span class='alert'>You stumble and fall to the ground. Thankfully, that hat protected you.</span>")
-				H.changeStatus("weakened", 1.2 SECONDS)
-				H.slip()
-			else
-				boutput(H, "<span class='alert'>You stumble and hit your head.</span>")
-				H.changeStatus("weakened", 1.2 SECONDS)
-				H.slip()
-		else
-			boutput(H, "<span class='alert'>You stumble and hit your head.</span>")
-			H.changeStatus("weakened", 2 SECONDS)
-			H.slip()
-			H.stuttering = max(rand(0,3), H.stuttering)
+	if (prob(0.5) && !H.lying)
+		if (!GET_COOLDOWN(H, "clown_trip"))
+			if (H.slip())
+				ON_COOLDOWN(H, "clown_trip", rand(30,60) SECONDS)
+				if(istype(H.head, /obj/item/clothing/head))
+					if(istype(H.head, /obj/item/clothing/head/helmet))
+						boutput(H, "<span class='alert'>You stumble and fall to the ground. Thankfully, that helmet protected you.</span>")
+					else
+						boutput(H, "<span class='alert'>You stumble and fall to the ground. Thankfully, that hat protected you.</span>")
+				else
+					boutput(H, "<span class='alert'>You stumble and hit your head.</span>")
+					H.stuttering = max(H.stuttering, 4)

--- a/code/datums/components/tripsalot.dm
+++ b/code/datums/components/tripsalot.dm
@@ -13,7 +13,7 @@
 	if (prob(0.5) && !H.lying)
 		if (!GET_COOLDOWN(H, "clown_trip"))
 			if (H.slip())
-				ON_COOLDOWN(H, "clown_trip", rand(30,60) SECONDS)
+				ON_COOLDOWN(H, "clown_trip", 6 SECONDS)
 				if(istype(H.head, /obj/item/clothing/head))
 					if(istype(H.head, /obj/item/clothing/head/helmet))
 						boutput(H, "<span class='alert'>You stumble and fall to the ground. Thankfully, that helmet protected you.</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors tripsalot to ignore walking and have a cooldown for clown comfort.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Why was this stacking two probabilities?
Removed weakened as I could not find any difference before/after in testing except for the weaken seemed to make the laydown be unreliable. Slip handles a knockdown fine.
I found the stuttering to be almost impossible to notice so changed it have a higher minimum.

Current behavior has no control for the clown and just RNG slips them. Now the clown can at least exercise the option to walk and know they won't slip three times in 20 seconds due to RNG.
Clowns would just avoid the shoes instead of deal with it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Allow walking in clown shoes without slipping and added a cooldown to prevent chain slips.
```