### PR TITLE
Revert lagcheck removals from Communications.dm

### DIFF
--- a/code/datums/communications.dm
+++ b/code/datums/communications.dm
@@ -109,6 +109,9 @@ datum/radio_frequency
 			signal.channels_passed += "[src.frequency];"
 
 			for(var/obj/device in devices)
+				if(!istype(device))
+					continue
+					
 				if(device != source)
 
 					//MBC : Do checks here and call check_for_jammer_bare instead. reduces proc calls.
@@ -132,7 +135,6 @@ datum/radio_frequency
 			else if (signal)
 				signal.wipe()
 				reusable_signals |= signal
-			LAGCHECK(LAG_MED)
 
 		//assumes that list radio_controller.active_jammers is not null or empty.
 		check_for_jammer(obj/source)

--- a/code/datums/communications.dm
+++ b/code/datums/communications.dm
@@ -125,12 +125,14 @@ datum/radio_frequency
 								device.receive_signal(signal, TRANSMISSION_RADIO, frequency)
 					else
 						device.receive_signal(signal, TRANSMISSION_RADIO, frequency)
+					LAGCHECK(LAG_REALTIME)
 
 			if (!reusable_signals || reusable_signals.len > 10)
 				signal.dispose()
 			else if (signal)
 				signal.wipe()
 				reusable_signals |= signal
+			LAGCHECK(LAG_MED)
 
 		//assumes that list radio_controller.active_jammers is not null or empty.
 		check_for_jammer(obj/source)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Restores lagchecks in Wifi code that were removed 3 months ago
da01962e594f301be6c5cd89c511cc0f3bc2ff66


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pinging high-device-count channels (like doors) causes a lag spike.

Not merging this right away incase smarter-devs have thoughts for improvement.