### PR TITLE
Fixed naming of the polysexual jumpsuit in fabs

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2115,7 +2115,7 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	category = "Clothing"
 
 /datum/manufacture/pride_poly
-	name = "Polyamorous Pride Jumpsuit"
+	name = "Polysexual Pride Jumpsuit"
 	item_paths = list("FAB-1")
 	item_amounts = list(4)
 	item_outputs = list(/obj/item/clothing/under/pride/poly)

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -236,7 +236,7 @@
 
 	poly
 		name = "poly pride jumpsuit"
-		desc = "A corporate token of inclusivity, made in a sweatshop. It's based off of the polysexual pride flag."
+		desc = "A corporate token of inclusivity, made in a sweatshop. It's based off of the polysexual pride flag. Previously mistaken for polyamorous in uniform fabricators the responsible employee was promptly terminated under all applicable versions of Space Law."
 		icon_state ="poly"
 		item_state = "poly"
 

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -236,7 +236,7 @@
 
 	poly
 		name = "poly pride jumpsuit"
-		desc = "A corporate token of inclusivity, made in a sweatshop. It's based off of the polysexual pride flag. Previously mistaken for polyamorous in uniform fabricators the responsible employee was promptly terminated under all applicable versions of Space Law."
+		desc = "A corporate token of inclusivity, made in a sweatshop. It's based off of the polysexual pride flag. Previously mistaken for polyamorous in uniform fabricators - the responsible employee was promptly terminated under all applicable versions of Space Law."
 		icon_state ="poly"
 		item_state = "poly"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - TRIVIAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The naming of the polysexual jumpsuit was incorrect in the fabricators so this fixes it. Also adds a tiny joke about it to the jumpsuit itself.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
<img width="402" alt="Screenshot 2021-07-03 233600" src="https://user-images.githubusercontent.com/45720148/124373460-e5c39e00-dc57-11eb-8b7d-6a183dda42d6.png">
<img width="427" alt="Screenshot 2021-07-03 233641" src="https://user-images.githubusercontent.com/45720148/124373462-e78d6180-dc57-11eb-8e4a-faa0c9ddf31a.png">