### PR TITLE
Make welding fuel toxic

### DIFF
--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -727,7 +727,7 @@ datum
 					M.changeStatus("burning", 2 SECONDS * mult)
 				if((M.health > 20) && (prob(33)))
 					M.take_toxin_damage(1 * mult)
-				if(probmult(4))
+				if(probmult(1))
 					M.visible_message("<span class='alert'>[M] pukes all over \himself.</span>", "<span class='alert'>You puke all over yourself!</span>")
 					M.vomit()
 				..()

--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -656,6 +656,7 @@ datum
 			transparency = 230
 			viscosity = 0.2
 			minimum_reaction_temperature = T0C + 200
+			depletion_rate = 0.6
 
 			var/max_radius = 7
 			var/min_radius = 0
@@ -724,8 +725,6 @@ datum
 					M = holder.my_atom
 				if(istype(M, /mob/living/) && M.getStatusDuration("burning"))
 					M.changeStatus("burning", 2 SECONDS * mult)
-				if(holder.has_reagent("welding fuel"))
-					holder.remove_reagent("welding fuel", 1 * mult)
 				if((M.health > 20) && (probmult(33)))
 					M.take_toxin_damage(1 * mult)
 				if(probmult(4))

--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -725,7 +725,7 @@ datum
 					M = holder.my_atom
 				if(istype(M, /mob/living/) && M.getStatusDuration("burning"))
 					M.changeStatus("burning", 2 SECONDS * mult)
-				if((M.health > 20) && (probmult(33)))
+				if((M.health > 20) && (prob(33)))
 					M.take_toxin_damage(1 * mult)
 				if(probmult(4))
 					M.visible_message("<span class='alert'>[M] pukes all over \himself.</span>", "<span class='alert'>You puke all over yourself!</span>")

--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -720,10 +720,17 @@ datum
 				return 1
 
 			on_mob_life(var/mob/M, var/mult = 1)
-
-				var/mob/living/L = M
-				if(istype(L) && L.getStatusDuration("burning"))
-					L.changeStatus("burning", 2 SECONDS * mult)
+				if (!M)
+					M = holder.my_atom
+				if(istype(M, /mob/living/) && M.getStatusDuration("burning"))
+					M.changeStatus("burning", 2 SECONDS * mult)
+				if(holder.has_reagent("welding fuel"))
+					holder.remove_reagent("welding fuel", 1 * mult)
+				if((M.health > 20) && (probmult(33)))
+					M.take_toxin_damage(1 * mult)
+				if(probmult(4))
+					M.visible_message("<span class='alert'>[M] pukes all over \himself.</span>", "<span class='alert'>You puke all over yourself!</span>")
+					M.vomit()
 				..()
 
 			on_plant_life(var/obj/machinery/plantpot/P)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes welding fuel a toxic substance. Refactors code slightly to resemble medical chemicals.
Now drains slightly faster from your body and does a low level of toxin damage above 20 health, occasionally making you vomit.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You can drink 300 units of welding fuel as if it was water. It's supposed to be Acetylene which is very not good for you.
Now it's mildly toxic, it shouldn't have any value as a poison considering it's available in huge quantities.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Welding fuel is now slightly toxic.
```
