### PR TITLE
Removes all instances of the abstract candy parent and fixes several recipes

### DIFF
--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -813,7 +813,7 @@
 /datum/cookingrecipe/cookie_jaffa
 	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie
 	item2 = /obj/item/reagent_containers/food/snacks/plant/orange
-	item3 = /obj/item/reagent_containers/food/snacks/candy
+	item3 = /obj/item/reagent_containers/food/snacks/candy/regular
 	cookbonus = 4
 	output = /obj/item/reagent_containers/food/snacks/cookie/jaffa
 
@@ -883,7 +883,7 @@
 	item1 = /obj/item/reagent_containers/food/snacks/cookie/chocolate_chip
 	amt1 = 2
 	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
-	item3 = /obj/item/reagent_containers/food/snacks/candy
+	item3 = /obj/item/reagent_containers/food/snacks/candy/regular
 	cookbonus = 6
 	output = /obj/item/reagent_containers/food/snacks/moon_pie/chocolate
 
@@ -1100,8 +1100,8 @@
 
 /datum/cookingrecipe/pie_chocolate
 	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/candy
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/butter
+	item2 = /obj/item/reagent_containers/food/snacks/candy/regular
+	item3 = /obj/item/reagent_containers/food/snacks/ingredient/butter
 	cookbonus = 10
 	output = /obj/item/reagent_containers/food/snacks/pie/chocolate
 
@@ -1233,7 +1233,7 @@
 
 /datum/cookingrecipe/cake_chocolate
 	item1 = /obj/item/reagent_containers/food/snacks/cake_batter
-	item2 = /obj/item/reagent_containers/food/snacks/candy
+	item2 = /obj/item/reagent_containers/food/snacks/candy/regular
 	cookbonus = 14
 	output = /obj/item/reagent_containers/food/snacks/cake/chocolate
 

--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -905,7 +905,7 @@ table#cooktime a#start {
 				if (/obj/item/reagent_containers/food/snacks/condiment/cream)
 					new/obj/item/reagent_containers/food/snacks/ingredient/butter(src.loc)
 					qdel( P )
-				if (/obj/item/reagent_containers/food/snacks/candy)
+				if (/obj/item/reagent_containers/food/snacks/candy/regular)
 					new/obj/item/reagent_containers/food/snacks/condiment/chocchips(src.loc)
 					qdel( P )
 				if (/obj/item/reagent_containers/food/snacks/plant/corn)

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -90,7 +90,7 @@
 /area/station/engine/monitoring)
 "aam" = (
 /obj/table/reinforced/bar/auto,
-/obj/item/reagent_containers/food/snacks/candy,
+/obj/item/reagent_containers/food/snacks/candy/regular,
 /obj/item/reagent_containers/food/snacks/candy/nougat,
 /obj/item/reagent_containers/food/snacks/candy/chocolate,
 /turf/simulated/floor/carpet/green/fancy/narrow/eastwest,
@@ -3036,7 +3036,7 @@
 	},
 /area/station/catwalk/south)
 "bnF" = (
-/obj/item/reagent_containers/food/snacks/candy,
+/obj/item/reagent_containers/food/snacks/candy/regular,
 /turf/space,
 /area/space)
 "bnQ" = (
@@ -14943,7 +14943,7 @@
 /area/station/science/lab)
 "gjW" = (
 /obj/table/glass/auto,
-/obj/item/reagent_containers/food/snacks/candy,
+/obj/item/reagent_containers/food/snacks/candy/regular,
 /obj/item/reagent_containers/food/snacks/burger{
 	pixel_x = 2;
 	pixel_y = 10
@@ -37378,7 +37378,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "qbM" = (
-/obj/item/reagent_containers/food/snacks/candy,
+/obj/item/reagent_containers/food/snacks/candy/regular,
 /turf/simulated/floor/airless/blackwhite,
 /area/abandonedship{
 	name = "Crashed Limo"
@@ -38333,17 +38333,17 @@
 /obj/item/reagent_containers/food/drinks/noodlecup,
 /obj/item/reagent_containers/food/drinks/noodlecup,
 /obj/item/reagent_containers/food/drinks/noodlecup,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy,
-/obj/item/reagent_containers/food/snacks/candy,
+/obj/item/reagent_containers/food/snacks/candy/regular,
+/obj/item/reagent_containers/food/snacks/candy/regular,
+/obj/item/reagent_containers/food/snacks/candy/regular,
+/obj/item/reagent_containers/food/snacks/candy/regular,
+/obj/item/reagent_containers/food/snacks/candy/regular,
+/obj/item/reagent_containers/food/snacks/candy/regular,
+/obj/item/reagent_containers/food/snacks/candy/regular,
+/obj/item/reagent_containers/food/snacks/candy/regular,
+/obj/item/reagent_containers/food/snacks/candy/regular,
+/obj/item/reagent_containers/food/snacks/candy/regular,
+/obj/item/reagent_containers/food/snacks/candy/regular,
 /obj/item/reagent_containers/food/snacks/chips,
 /obj/item/reagent_containers/food/snacks/chips,
 /obj/item/reagent_containers/food/snacks/chips,
@@ -43517,7 +43517,7 @@
 	name = "Ringside Hallway"
 	})
 "szL" = (
-/obj/item/reagent_containers/food/snacks/candy,
+/obj/item/reagent_containers/food/snacks/candy/regular,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "szP" = (
@@ -55713,7 +55713,7 @@
 /obj/item/parts/robot_parts/head,
 /obj/item/parts/robot_parts/arm/left,
 /obj/item/parts/robot_parts/arm/right,
-/obj/item/reagent_containers/food/snacks/candy,
+/obj/item/reagent_containers/food/snacks/candy/regular,
 /obj/item/reagent_containers/food/snacks/ingredient/pepperoni_log,
 /obj/item/pen/pencil,
 /obj/cable{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The abstract candy parent was a requirement for several recipes and showed up on wrestle map. This has been replaced with the 'regular' candy bar which is a concrete child type using the same icon and description

Also fixes a mislabeled variable that broke the chocolate pie recipe.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5391. On most maps, the abstract parent is impossible to get, so the recipes are impossible to perform.
