### PR TITLE
Fixes an issue where npcs could keep moving while stunned or knocked out

### DIFF
--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -640,9 +640,10 @@
 	. = ..()
 	if(!src.ai_active)
 		return
-	if(src.ai_state == AI_FLEEING && ai_incapacitated())
-		src.ai_state = AI_PASSIVE
-		walk_away(src, null)
+	if(ai_incapacitated())
+		walk(src, null)
+		if(src.ai_state == AI_FLEEING)
+			src.ai_state = AI_PASSIVE
 
 
 /mob/living/carbon/human/proc/ai_pickupstuff()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. This does not prevent them from moving while prone (provided that they're not stunned or knocked out), which is consistent with the behavior of player characters.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes https://github.com/goonstation/goonstation/issues/5376

