### PR TITLE
Beepsky no longer runtimes on death

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -1340,7 +1340,7 @@
 					master.KillPathAndGiveUp(KPAGU_RETURN_TO_GUARD)
 				else
 					master.KillPathAndGiveUp(KPAGU_CLEAR_ALL)
-	
+
 	proc/failchecks()
 		if (!IN_RANGE(master, master.target, 1))
 			return 1
@@ -1389,7 +1389,7 @@
 	onEnd()
 		..()
 		master.baton_charging = 0
-		if(IN_RANGE(master, master.target, 1))
+		if(locate(master) && IN_RANGE(master, master.target, 1))
 			master.baton_attack(master.target, 1)
 		else
 			master.charge_baton()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Beepsky no longer runtimes on death. (Line 1392, secbot.dm, could not locate null.x)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtime bad.

