### PR TITLE
The dumb bad fix

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -703,10 +703,21 @@
 
 	onDelete()
 		animate(target) //force-complete the current animation
+		//What I desire, but it's not working.
+		/*
 		target.pixel_x = target_old_pixel_x
 		target.pixel_y = target_old_pixel_y
 		target.transform = target_old_transform
 		target.alpha = target_old_alpha
+		*/
+		
+		target.pixel_x = 0
+		target.pixel_y = 0
+		target.transform = matrix()
+		target.alpha = 255
+
+
+
 		..()
 
 	proc/checkStillValid()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes sprites getting stuck in the squashed-transparent state #5397.
Might also fix #5387? Might make it worse?
I'm not happy with this fix, but other things (like calling the relevant code in `onInterrupt()` wasn't working for me).

I've other solutions in mind that I likely can't make/try tonight.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
[BUG]

