### PR TITLE
Fixes a corner on Oshan

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -12953,10 +12953,6 @@
 	icon_state = "engine_caution_corners"
 	},
 /area/station/science/teleporter)
-"aEt" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating/random,
-/area/space)
 "aEu" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/clothing/gloves/latex,
@@ -88075,7 +88071,7 @@ clw
 clB
 aDr
 aDr
-ckw
+aDr
 aig
 aEV
 aqn
@@ -88681,7 +88677,7 @@ aig
 aEV
 aEV
 aEV
-aEt
+aEV
 aqn
 aqn
 aqn
@@ -88982,7 +88978,7 @@ cht
 aig
 aEV
 aqn
-aEt
+aqn
 aqn
 aqn
 aqn


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes an extra wingrille & conveyor from a spot in Oshan's inner maint, and places the wingrille in the corner there in the inner maint area.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Neatness