### PR TITLE
makes it so golem deaths create smoke again

### DIFF
--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -679,8 +679,7 @@
 		..()
 
 		src.visible_message("<span class='combat'><b>[src]</b> bursts into a puff of smoke!</span>")
-		var/datum/chemical_reaction/smoke/thesmoke = new
-		thesmoke.on_reaction(src.reagents, 12)
+		src.reagents.smoke_start(12)
 		invisibility = 100
 		SPAWN_DBG(5 SECONDS)
 			qdel(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The change that made smoke powder not work in closed containers affected golems, since those instantiated a smoke powder reaction and then called it.

Instead they now call the smoke proc on their reagent container directly.