### PR TITLE
Vending machine/manufacturer/seed fabricator hacking QOL

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -441,9 +441,9 @@
 			else
 				boutput(user, "<span class='notice'>[bicon(W)] Regular electrical response received from access panel.</span>")
 		return
-	else if (ispulsingtool(W))
-		return src.attack_hand(user)
-
+	else if (src.panel_open && (issnippingtool(W) || ispulsingtool(W)))
+		src.attack_hand(user)
+		return
 	else if (ispryingtool(W))
 		if (src.status & BROKEN) //if the vendor is broken
 			//action bar is defined at the end of these procs

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1036,6 +1036,10 @@
 			user.visible_message("<span class='notice'>[user] loads [W] into the [src].</span>", "<span class='notice'>You load [W] into the [src].</span>")
 			src.load_item(W,user)
 
+		else if (src.panelopen && (issnippingtool(W) || ispulsingtool(W)))
+			src.attack_hand(user)
+			return
+
 		else if(scan_card(W))
 			return
 

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -1288,6 +1288,8 @@
 				src.panelopen = 0
 			boutput(user, "You [src.panelopen ? "open" : "close"] the maintenance panel.")
 			src.updateUsrDialog()
+		else if (src.panelopen && (issnippingtool(W) || ispulsingtool(W)))
+			src.attack_hand(user)
 		else ..()
 
 	proc/isWireColorCut(var/wireColor)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds attack_hand call to wirecutters/multitool interaction for seed fabricators, manufacturers and vending machines, if the  device panel is open.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It makes more sense than having to switch to empty hand while holding the tool in another hand to attempt hacking.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)You can now click a vending machine/manufactuer/seed fabricator with wirecutters/multitool to access the hacking menu, if the panel is open.
```
