### PR TITLE
Moves Cog1 uniform manufacturer to a public area

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -7709,9 +7709,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
 "avL" = (
-/obj/shrub{
-	dir = 6
-	},
+/obj/machinery/manufacturer/uniform,
 /turf/simulated/floor/neutral/side{
 	dir = 10
 	},
@@ -21047,14 +21045,13 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/vehicle/segway,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bbW" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/manufacturer/personnel,
+/obj/vehicle/segway,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bbX" = (
@@ -21076,7 +21073,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/machinery/manufacturer/uniform,
+/obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/black,
 /area/station/security/checkpoint)
 "bbZ" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -21045,13 +21045,14 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/vehicle/segway,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bbW" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/vehicle/segway,
+/obj/machinery/manufacturer/personnel,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads)
 "bbX" = (
@@ -21073,7 +21074,7 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/machinery/manufacturer/personnel,
+/obj/machinery/manufacturer/uniform,
 /turf/simulated/floor/black,
 /area/station/security/checkpoint)
 "bbZ" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a uniform manufacturer to crew quarters, next to clothing booth.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I'm pretty sure all the maps except cog1 have public access uniform manufacturers. It'd be nice to have it public on cog1 aswell.
