### PR TITLE
Fixes Donut 3 armory airlocks, adds a blind switch to RD's office

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -8641,7 +8641,6 @@
 /area/station/security/brig/south_side)
 "chE" = (
 /obj/machinery/door/airlock/pyro/glass/security{
-	aiControlDisabled = 1;
 	req_access = null
 	},
 /obj/access_spawn/security,
@@ -9737,7 +9736,6 @@
 /area/station/hallway/primary/east)
 "czj" = (
 /obj/machinery/door/airlock/pyro/glass/security{
-	aiControlDisabled = 1;
 	req_access = null
 	},
 /obj/firedoor_spawn,
@@ -25476,7 +25474,6 @@
 /area/station/engine/engineering)
 "hjG" = (
 /obj/machinery/door/airlock/pyro/glass/security{
-	aiControlDisabled = 1;
 	req_access = null
 	},
 /obj/firedoor_spawn,
@@ -28759,19 +28756,19 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "igr" = (
+/obj/access_spawn/hos,
 /obj/machinery/door/airlock/pyro/glass/security{
 	aiControlDisabled = 1;
 	req_access = null
 	},
 /obj/firedoor_spawn,
-/obj/access_spawn/hos,
 /obj/machinery/secscanner,
-/obj/decal/mule/dropoff,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/decal/mule/dropoff,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
@@ -45719,6 +45716,7 @@
 /area/station/medical/asylum/kitchen)
 "noB" = (
 /obj/machinery/door/airlock/pyro/glass/security{
+	aiControlDisabled = 1;
 	dir = 4;
 	req_access = null
 	},
@@ -57023,7 +57021,7 @@
 "qxk" = (
 /obj/machinery/door/airlock/pyro/security/alt{
 	aiControlDisabled = 1;
-	req_access_txt = null
+	req_access = null
 	},
 /obj/access_spawn/hos,
 /obj/firedoor_spawn,
@@ -57033,8 +57031,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/decal/mule/dropoff,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe,
+/obj/decal/mule/dropoff,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "qxz" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -8641,6 +8641,7 @@
 /area/station/security/brig/south_side)
 "chE" = (
 /obj/machinery/door/airlock/pyro/glass/security{
+	aiControlDisabled = 1;
 	req_access = null
 	},
 /obj/access_spawn/security,
@@ -9736,6 +9737,7 @@
 /area/station/hallway/primary/east)
 "czj" = (
 /obj/machinery/door/airlock/pyro/glass/security{
+	aiControlDisabled = 1;
 	req_access = null
 	},
 /obj/firedoor_spawn,
@@ -25474,6 +25476,7 @@
 /area/station/engine/engineering)
 "hjG" = (
 /obj/machinery/door/airlock/pyro/glass/security{
+	aiControlDisabled = 1;
 	req_access = null
 	},
 /obj/firedoor_spawn,
@@ -28757,6 +28760,7 @@
 /area/station/medical/medbay/cloner)
 "igr" = (
 /obj/machinery/door/airlock/pyro/glass/security{
+	aiControlDisabled = 1;
 	req_access = null
 	},
 /obj/firedoor_spawn,
@@ -45727,7 +45731,7 @@
 	},
 /obj/decal/mule/dropoff,
 /turf/simulated/floor/black,
-/area/station/turret_protected/armory_outside)
+/area/station/ai_monitored/armory)
 "noC" = (
 /obj/machinery/light/incandescent/harsh,
 /obj/cable{
@@ -51351,7 +51355,7 @@
 	},
 /obj/decal/mule/dropoff,
 /turf/simulated/floor/black,
-/area/station/ai_monitored/armory)
+/area/station/security/hos)
 "oXO" = (
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/west)
@@ -57017,9 +57021,12 @@
 /turf/simulated/floor/white,
 /area/station/crewquarters/fuq3)
 "qxk" = (
-/obj/machinery/door/airlock/pyro/security/alt,
-/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/security/alt{
+	aiControlDisabled = 1;
+	req_access_txt = null
+	},
 /obj/access_spawn/hos,
+/obj/firedoor_spawn,
 /obj/machinery/secscanner,
 /obj/cable{
 	d1 = 1;
@@ -62280,6 +62287,7 @@
 /area/station/medical/medbay/lobby)
 "rXe" = (
 /obj/machinery/light/incandescent/netural,
+/obj/blind_switch/area/west,
 /turf/simulated/floor/circuit/purple,
 /area/station/crew_quarters/hor)
 "rXg" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -56947,9 +56947,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
 "qwT" = (
-/obj/blind_switch/area/west{
-	name = "Blind switch"
-	},
+/obj/blind_switch/area/west,
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/bathroom)
 "qxb" = (
@@ -62287,9 +62285,7 @@
 /area/station/medical/medbay/lobby)
 "rXe" = (
 /obj/machinery/light/incandescent/netural,
-/obj/blind_switch/area/west{
-	name = "Blind switch"
-	},
+/obj/blind_switch/area/west,
 /turf/simulated/floor/circuit/purple,
 /area/station/crew_quarters/hor)
 "rXg" = (
@@ -83507,9 +83503,7 @@
 "yid" = (
 /obj/machinery/manufacturer/uniform,
 /obj/disposalpipe/segment/mail,
-/obj/blind_switch/area/west{
-	name = "Blind switch"
-	},
+/obj/blind_switch/area/west,
 /turf/simulated/floor/white/checker,
 /area/station/medical/medbay/cloner)
 "yie" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -56947,7 +56947,9 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
 "qwT" = (
-/obj/blind_switch/area/west,
+/obj/blind_switch/area/west{
+	name = "Blind switch"
+	},
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/bathroom)
 "qxb" = (
@@ -62285,7 +62287,9 @@
 /area/station/medical/medbay/lobby)
 "rXe" = (
 /obj/machinery/light/incandescent/netural,
-/obj/blind_switch/area/west,
+/obj/blind_switch/area/west{
+	name = "Blind switch"
+	},
 /turf/simulated/floor/circuit/purple,
 /area/station/crew_quarters/hor)
 "rXg" = (
@@ -83503,7 +83507,9 @@
 "yid" = (
 /obj/machinery/manufacturer/uniform,
 /obj/disposalpipe/segment/mail,
-/obj/blind_switch/area/west,
+/obj/blind_switch/area/west{
+	name = "Blind switch"
+	},
 /turf/simulated/floor/white/checker,
 /area/station/medical/medbay/cloner)
 "yie" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

-Makes AI unable to access armory/outer turret control room airlocks
-Changes the armory area slightly, previously armory auth console gave out access to HoS office, but not into the outer turret control room which was a bit weird
-Adds a blind switch to RD's office

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
 
Fixes #5400 
Fixes #5401 