### PR TITLE
Fixes automenders still working when dropped/put away

### DIFF
--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -648,7 +648,7 @@
 		M.apply_to(target,user, multiply, silent = (looped >= 1))
 
 	onEnd()
-		if(get_dist(user, target) > 1 || user == null || target == null || (!isrobot(user) && !user.is_in_hands(M)) || (isrobot(user) && !user.equipped(M)))
+		if(get_dist(user, target) > 1 || user == null || target == null || (!isrobot(user) && !user.is_in_hands(M)) || (isrobot(user) && !user.find_in_hand(M)))
 			..()
 			interrupt(INTERRUPT_ALWAYS)
 			return

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -648,7 +648,7 @@
 		M.apply_to(target,user, multiply, silent = (looped >= 1))
 
 	onEnd()
-		if(get_dist(user, target) > 1 || user == null || target == null)
+		if(get_dist(user, target) > 1 || user == null || target == null || (ishuman(user) && !user.is_in_hands(M)) || (!ishuman(user) && !user.equipped(M)))
 			..()
 			interrupt(INTERRUPT_ALWAYS)
 			return

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -648,7 +648,7 @@
 		M.apply_to(target,user, multiply, silent = (looped >= 1))
 
 	onEnd()
-		if(get_dist(user, target) > 1 || user == null || target == null || (!isrobot(user) && !user.is_in_hands(M)) || (isrobot(user) && !user.find_in_hand(M)))
+		if(get_dist(user, target) > 1 || user == null || target == null || !user.find_in_hand(M))
 			..()
 			interrupt(INTERRUPT_ALWAYS)
 			return

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -648,7 +648,7 @@
 		M.apply_to(target,user, multiply, silent = (looped >= 1))
 
 	onEnd()
-		if(get_dist(user, target) > 1 || user == null || target == null || (ishuman(user) && !user.is_in_hands(M)) || (!ishuman(user) && !user.equipped(M)))
+		if(get_dist(user, target) > 1 || user == null || target == null || (!isrobot(user) && !user.is_in_hands(M)) || (isrobot(user) && !user.equipped(M)))
 			..()
 			interrupt(INTERRUPT_ALWAYS)
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title
In case of humans/mutantraces/critters the automender will work only if it's in your hands
In case of cyborgs, the automender will work if it's in one of the active module slots (switching between tools won't stop it from working)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #5371 

