### PR TITLE
Fix number-based mats processing

### DIFF
--- a/code/datums/controllers/mechanic_controls.dm
+++ b/code/datums/controllers/mechanic_controls.dm
@@ -15,7 +15,7 @@ var/datum/mechanic_controller/mechanic_controls
 				S.mats = M.Copy()
 				MC = M.Copy()
 			else
-				S.mats = MC
+				MC = M
 			S.item_mats = MC
 			S.create_partslist(MC)
 			S.create_blueprint(MC)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a borked assignment that prevented number-based `mats` scans (AKA anything not specifying its materials) from using their proper amount.

(For anyone looking at that block of code and worrying about `M` potentially being garbage, `create_partslist` and `create_blueprint` are written to handle non-number inputs.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #5419
closes #5346 
