### PR TITLE
Hotboxing is now admin logged.

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -494,9 +494,9 @@
 						hotbox_count = hotbox_count + 1
 						if (hotbox_count == 5) //number is up for debate, 5 seemed like a good starting place
 							if (hotbox_item)
-								message_admins("([src]) was set on fire along with multiple other plants at [log_loc(src)] by item ([hotbox_item]). Last touched by: [hotbox_item.fingerprintslast ? "[hotbox_item.fingerprintslast]" : "*null*"].")
+								message_admins("([src]) was set on fire on the same turf as multiple other plants at [log_loc(src)] by item ([hotbox_item]). Last touched by: [hotbox_item.fingerprintslast ? "[hotbox_item.fingerprintslast]" : "*null*"].")
 							else
-								message_admins("([src]) was set on fire along with multiple other plants at [log_loc(src)].")
+								message_admins("([src]) was set on fire on the same turf as multiple other plants at [log_loc(src)].")
 		if (src.burn_output >= 1000)
 			UpdateOverlays(image('icons/effects/fire.dmi', "2old"),"burn_overlay")
 		else

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -554,7 +554,6 @@
 					firesource = I
 					break
 			src.combust(firesource)
-			src.combust()
 	if (src.material)
 		src.material.triggerTemp(src, temperature)
 	..() // call your fucking parents

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -475,7 +475,7 @@
 /obj/item/proc/equipment_click(atom/source, atom/target, params, location, control, origParams, slot) //Called through hand_range_attack on items the mob is wearing that have HAS_EQUIP_CLICK in flags.
 	return 0
 
-/obj/item/proc/combust(obj/item/W as obj) // cogwerks- flammable items project
+/obj/item/proc/combust(obj/item/W) // cogwerks- flammable items project
 	if(processing_items.Find(src)) //processing items cant be lit on fire to avoid weird bugs
 		return
 	if (!src.burning)
@@ -488,11 +488,11 @@
 				var/list/hotbox_plants = list()
 				for (var/obj/item/plant/P in get_turf(src))
 					hotbox_plants += P
-					if (length(hotbox_plants) == 5) //number is up for debate, 5 seemed like a good starting place
-						if (W && W.firesource)
-							message_admins("([src]) was set on fire on the same turf as at least ([length(hotbox_plants)]) other plants at [log_loc(src)] by item ([W]). Last touched by: [W.fingerprintslast ? "[W.fingerprintslast]" : "*null*"].")
-						else
-							message_admins("([src]) was set on fire on the same turf as at least ([length(hotbox_plants)]) other plants at [log_loc(src)].")
+				if (length(hotbox_plants) >= 5) //number is up for debate, 5 seemed like a good starting place
+					if (W?.firesource)
+						message_admins("([src]) was set on fire on the same turf as at least ([length(hotbox_plants)]) other plants at [log_loc(src)] by item ([W]). Last touched by: [W.fingerprintslast ? "[W.fingerprintslast]" : "*null*"].")
+					else
+						message_admins("([src]) was set on fire on the same turf as at least ([length(hotbox_plants)]) other plants at [log_loc(src)].")
 		if (src.burn_output >= 1000)
 			UpdateOverlays(image('icons/effects/fire.dmi', "2old"),"burn_overlay")
 		else
@@ -548,10 +548,12 @@
 /obj/item/temperature_expose(datum/gas_mixture/air, temperature, volume)
 	if (src.burn_possible && !src.burning)
 		if ((temperature > T0C + src.burn_point) && prob(5))
+			var/obj/item/firesource = null
 			for (var/obj/item/I in get_turf(src))
 				if (I.firesource)
-					src.combust(I)
+					firesource = I
 					break
+			src.combust(firesource)
 			src.combust()
 	if (src.material)
 		src.material.triggerTemp(src, temperature)

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)fri jul 9 21
+(u)Zonespace
+(*)Hotboxes are now logged, showing the turf, the fire source, and the last person to touch it.
 (t)tue may 25 21
 (u)Virva, Yass, Sord, Kyle
 (*)Add a new admin gimmick game mode called Pod Wars. It's like NT vs Syndicate with two small bases on either side and control points to capture.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds hotbox adminlogging.
If a plant is lit on fire with at least four other plants on the same turf, this will be logged along with the source of the fire, and the last person to touch the fire source. To prevent log spam, it's on a thirty second cooldown.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hotboxes can be very destructive, and the knowledge of when it happens, along with the (potential) culprit's name, should help admins figure out who hotboxed that Omega Weed on the shuttle.

