### PR TITLE
Makes toy guns unable to be stashed in gang lockers

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -984,6 +984,9 @@
 
 		//gun score
 		else if (istype(item, /obj/item/gun))
+			if(istype(item, /obj/item/gun/kinetic/foamdartgun))
+				boutput(user, "<span class='alert'><b>You cant stash toy guns in the locker<b></span>")
+				return 0
 			// var/obj/item/gun/gun = item
 			gang.score_gun += round(300)
 			gang.spendable_points += round(300)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so foam dart guns dont work when put in a gang locker


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Toy guns are really easy to obtain and toys so they shouldnt really provide gang points.
