### PR TITLE
Highlight Manta mining station on trench map

### DIFF
--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -60,7 +60,7 @@
 					else if (T.name == "trench floor" || T.name == "\proper space")
 						turf_color = "empty"
 					else
-						if (T.loc && (T.loc.type == /area/shuttle/sea_elevator || T.loc.type == /area/shuttle/sea_elevator/lower))
+						if (T.loc && (T.loc.type == /area/shuttle/sea_elevator || T.loc.type == /area/shuttle/sea_elevator/lower || T.loc.type == /area/prefab/sea_mining))
 							turf_color = "station"
 						else
 							turf_color = "other"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the Manta mining station use the NT Asset highlight on the trench map.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's an NT Asset and should be identified as such, makes the trench map easier to use. Without this the highlight isn't used at all on Manta.

![image](https://user-images.githubusercontent.com/70909958/125160228-b6d78b80-e173-11eb-8d65-b9526fd0c6eb.png)