### PR TITLE
Add Janitor alert to Crisis Alerts

### DIFF
--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -689,7 +689,8 @@ Code:
 				dat += "<center>Please select alert type:<br>"
 				dat += "<a href='?src=\ref[src];alert=1'>Medical Alert</a><br>"
 				dat += "<a href='?src=\ref[src];alert=2'>Engineering Alert</a><br>"
-				dat += "<a href='?src=\ref[src];alert=3'>Security Alert</a>"
+				dat += "<a href='?src=\ref[src];alert=3'>Security Alert</a><br>"
+				dat += "<a href='?src=\ref[src];alert=4'>Janitor Alert</a>"
 
 		else
 			dat += "<center><b>Please confirm: <a href='?src=\ref[src];confirm=y'>Y</a> / <a href='?src=\ref[src];confirm=n'>N</a></b></center>"
@@ -724,8 +725,10 @@ Code:
 				mailgroup = MGD_MEDBAY
 			if (2)
 				mailgroup = MGO_ENGINEER
-			if (3 to INFINITY)
+			if (3)
 				mailgroup = MGD_SECURITY
+			if (4 to INFINITY)
+				mailgroup = MGO_JANITOR
 
 		var/datum/signal/signal = get_free_signal()
 		signal.source = src.master

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -686,11 +686,13 @@ Code:
 				dat += "Alert Sent -- Please wait for a response.<br>Additional alerts will be available shortly."
 
 			else
-				dat += "<center>Please select alert type:<br>"
-				dat += "<a href='?src=\ref[src];alert=1'>Medical Alert</a><br>"
-				dat += "<a href='?src=\ref[src];alert=2'>Engineering Alert</a><br>"
-				dat += "<a href='?src=\ref[src];alert=3'>Security Alert</a><br>"
-				dat += "<a href='?src=\ref[src];alert=4'>Janitor Alert</a>"
+				dat += {"
+				<center>Please select alert type:<br>
+				<a href='?src=\ref[src];alert=1'>Medical Alert</a><br>
+				<a href='?src=\ref[src];alert=2'>Engineering Alert</a><br>
+				<a href='?src=\ref[src];alert=3'>Security Alert</a><br>
+				<a href='?src=\ref[src];alert=4'>Janitor Alert</a>
+				"}
 
 		else
 			dat += "<center><b>Please confirm: <a href='?src=\ref[src];confirm=y'>Y</a> / <a href='?src=\ref[src];confirm=n'>N</a></b></center>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][INPUT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add's a Janitor Alert to the crisis alerts on the PDA.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When you need a janitor in an emergency!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Added crisis alert for janitors to the PDA, let them know of a big mess!
```
