### PR TITLE
Fixes incorrect lizard skintone in preview windows 

### DIFF
--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -230,7 +230,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 		e_offset_y = toCopy.e_offset_y
 		e_color_original = toCopy.e_color_original
 
-		s_tone = toCopy.s_tone_original // *usually* we want to have a normal skintone by default. *usually*
+		s_tone = toCopy.s_tone
 		s_tone_original = toCopy.s_tone_original
 
 		underwear = toCopy.underwear


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes a line that deals with copying a mob's appearance.  It used to copy the mob's original (human) skin color, now it copies the mob's actual skin color.  This allows the preview windows in the pregame customization menu and the clothing booth to display the correct skin colors for lizards.

As described in https://github.com/goonstation/goonstation/issues/4193 currently the proper skin color will be displayed only when the window is first loaded, after any input it will revert to a human skintone, making lizard customization very tedious.

I've tested some other areas this change could possibly impact, including changing to/from various mutant races, changing to/from various antagonists, delimbing/healing, and transplanting limbs to and from other humans.  I didn't see any anomalies.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently customizing a lizard character involves reloading the menu many times to see your changes, which makes lizards everywhere weep.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)KoboldCommando
(+)Fixed incorrect lizard skin colors in preview windows
```
