### PR TITLE
Fixes build_fields

### DIFF
--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -369,7 +369,7 @@
 /obj/item/paper/proc/build_fields(var/length)
 	var/pixel_width = (14 + (12 * (length-1)))
 	src.field_counter++
-	return {"\[<input type="text" style="font:'12x Georgia';color:'null';min-width:[pixel_width]px;max-width:[pixel_width]px;" id="paperfield_3" maxlength=[length] size=[length] />\]"}
+	return {"\[<input type="text" style="font:'12x Georgia';color:'null';min-width:[pixel_width]px;max-width:[pixel_width]px;" id="paperfield_[field_counter]" maxlength=[length] size=[length] />\]"}
 
 
 /obj/item/paper/thermal


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Presumably fixes the problem where build_fields didn't work correct. Such as input in the first field overwriting all the other fields and inputs in the other field being wiped after saving. It is currently only used in Yacht dice sheet, thus breaking it.
It worked correct in the test server, with more than one instances of the yacht dice sheet in the game.
But it may be not the optimal code or/and cause an error. Feedbacks would be appreciated in that case!
![564](https://user-images.githubusercontent.com/67675401/125194971-7d477300-e28e-11eb-9733-a482056fc261.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
To fix the bug, Time to finally have dice fun! Also could be used for future materials.