### PR TITLE
Buff cursed clown mask

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -493,7 +493,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/clown_mask
 	name = "Clown Mask"
 	item = /obj/item/clothing/mask/gas/syndie_clown
-	cost = 5
+	cost = 3
 	vr_allowed = 0
 	desc = "A clown mask haunted by the souls of those who honked before. Only true clowns should attempt to wear this. It also functions like a gas mask."
 	job = list("Clown")

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -493,7 +493,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/clown_mask
 	name = "Clown Mask"
 	item = /obj/item/clothing/mask/gas/syndie_clown
-	cost = 3
+	cost = 4
 	vr_allowed = 0
 	desc = "A clown mask haunted by the souls of those who honked before. Only true clowns should attempt to wear this. It also functions like a gas mask."
 	job = list("Clown")

--- a/code/modules/medical/diseases/clowning_around.dm
+++ b/code/modules/medical/diseases/clowning_around.dm
@@ -73,7 +73,7 @@
 				playsound(affected_mob.loc, "sound/musical_instruments/Bikehorn_1.ogg", 50, 1)
 
 			if(prob(10))
-				if(!affected_mob:wear_mask || ((affected_mob:wear_mask != null) && !istype(affected_mob:wear_mask, /obj/item/clothing/mask/clown_hat)))
+				if(!affected_mob:wear_mask || (!istype(affected_mob:wear_mask, /obj/item/clothing/mask/clown_hat)) && (!istype(affected_mob:wear_mask, /obj/item/clothing/mask/gas/syndie_clown)))
 					var/c = affected_mob:wear_mask
 					if((affected_mob:wear_mask != null) && !istype(affected_mob:wear_mask, /obj/item/clothing/mask/clown_hat))
 						affected_mob.u_equip(c)
@@ -100,7 +100,7 @@
 					return
 #endif
 			if(prob(10))
-				if(!affected_mob:wear_mask || ((affected_mob:wear_mask != null) && !istype(affected_mob:wear_mask, /obj/item/clothing/mask/clown_hat)))
+				if(!affected_mob:wear_mask || (!istype(affected_mob:wear_mask, /obj/item/clothing/mask/clown_hat)) && (!istype(affected_mob:wear_mask, /obj/item/clothing/mask/gas/syndie_clown)))
 					var/c = affected_mob:wear_mask
 					if((affected_mob:wear_mask != null) && !istype(affected_mob:wear_mask, /obj/item/clothing/mask/clown_hat))
 						affected_mob.u_equip(c)

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -308,6 +308,7 @@
 				src.victim.change_misstep_chance(25)
 				src.victim.emote("scream")
 				src.victim.TakeDamage("head",0,15,0,DAMAGE_BURN)
+				src.victim.reagents.add_reagent("rainbow fluid", 10)
 				src.victim.changeStatus("stunned", 2.5 SECONDS)
 				processing_items.Add(src)
 

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -336,6 +336,21 @@
 			if (prob(60))
 				src.victim.emote("laugh")
 
+	attack_hand(var/mob/user)
+		if (user.mind.assigned_role == "Clown" && istraitor(user))
+			return ..()
+		else
+			if (ishuman(user))
+				var/mob/living/carbon/human/U = user
+				if(!U.wear_mask)
+					U.equip_if_possible(src,U.slot_wear_mask)
+					message_admins("[key_name(U)] picked up a cursed clown mask ([src]).")
+					logTheThing("combat", U, null, "picked up a cursed clown mask ([src]) at [log_loc(U)].")
+				else
+					return ..()
+			else
+				return ..()
+
 	afterattack(atom/target, mob/user, reach, params)
 		if ( reach <= 1 && user.mind && user.mind.assigned_role == "Clown" && istraitor(user) && istype(user,/mob/living/carbon/human) && istype(target,/mob/living/carbon/human) )
 			var/mob/living/carbon/human/U = user
@@ -347,7 +362,6 @@
 
 				// If we don't empty out that slot first, it could blip the mask out of existence
 				T.drop_from_slot(T.wear_mask)
-
 				T.equip_if_possible(src,T.slot_wear_mask)
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT][WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduces cursed clown mask from 5TC to 4TC.
Cursed clown mask now injects victim with rainbow fluid.
Cursed clown mask attaches to anyone who touches it without a mask.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
According to the last traitor pick stats the cursed clown mask was the 89th picked item (out of 97) and the least picked clown item (although chameleon bomb is missing from the list?).
The mask costs 5TC for a relatively "so what" item. While it does have an instant two second stun on touch if you attack a victims head while holding it the effects are overall not particularly significant for a 5 cost:
- Instant equip on victims, even if wearing a mask, when attacked with the mask by a traitor clown
- 25% misstep chance (this does not seem to work properly?)
- 15 head BURN damage
- 2.5 second stun
Per process loop
- 45% chance of 3 head BURN damage
- 20% chance of 3 brain damage
- 10% chance of 2 second stun
- 10% chance of 4 second slow
- 60% chance of laughing

New additions:
- Instant placement on victims who touch the mask if they are not wearing a mask
- 10 units of rainbow fluid

This change adds some trap utility to the mask (although the description still clues in the observant) and increases it's inconvenience to the victim through rainbow fluid. The victim does not drop their held equipment, it does not stop the victim speaking normally and takes 3+ minutes to kill.
Rainbow fluid is thematic and increases the disabling effects of the mask slightly but is not particularly quick or inconvenient until it rolls replacing your uniform slot and can be cured by spaceacillin which is in every med vendor and injected by medbots. 10u of rainbow fluid is used as 5u was unreliable. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Cursed clown mask is now 4TC, infects the victim with rainbow fluid (Clowning Around disease) and latches on to anyone (other than traitor clowns) not wearing a mask when they touch it.
(+)Clowning Around disease will no longer replace cursed clown masks.
```
