### PR TITLE
Stable mutagen now only copies over some mutant races

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -68,7 +68,7 @@
 	/// Should robots arrest these by default?
 	var/jerk = 0
 	/// Should stable mutagen apply this mutant?
-	var/dna_mutagen_ok = 0
+	var/dna_mutagen_ok = FALSE
 
 	/// This is used for static icons if the mutant isn't built from pieces
 	var/icon = 'icons/effects/genetics.dmi'
@@ -651,7 +651,7 @@
 	voice_override = "bloop"
 	firevuln = 1.5
 	typevulns = list("cut" = 1.25, "stab" = 0.5, "blunt" = 0.75)
-	dna_mutagen_ok = 1
+	dna_mutagen_ok = TRUE
 
 	say_verb()
 		return pick("burbles", "gurgles", "blurbs", "gloops")
@@ -714,7 +714,7 @@
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/flashy/left
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/flashy/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/flashy/left
-	dna_mutagen_ok = 1
+	dna_mutagen_ok = TRUE
 
 
 /datum/mutantrace/virtual
@@ -816,7 +816,7 @@
 	race_mutation = /datum/bioEffect/mutantrace // Most mutants are just another form of lizard, didn't you know?
 	clothing_icon_override = 'icons/mob/lizard_clothes.dmi'
 	color_channel_names = list("Episcutus", "Ventral Aberration", "Sagittal Crest")
-	dna_mutagen_ok = 1
+	dna_mutagen_ok = TRUE
 
 	New(var/mob/living/carbon/human/H)
 		..()
@@ -1121,7 +1121,7 @@
 	special_head = HEAD_SKELETON
 	decomposes = FALSE
 	race_mutation = /datum/bioEffect/mutantrace/skeleton
-	dna_mutagen_ok = 1
+	dna_mutagen_ok = TRUE
 
 	New(var/mob/living/carbon/human/M)
 		..()
@@ -1416,7 +1416,7 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/ithillid/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/ithillid/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HAS_SPECIAL_HAIR | HEAD_HAS_OWN_COLORS | WEARS_UNDERPANTS)
-	dna_mutagen_ok = 1
+	dna_mutagen_ok = TRUE
 
 	say_verb()
 		return "glubs"
@@ -1451,7 +1451,7 @@
 	var/had_tablepass = 0
 	var/table_hide = 0
 	mutant_organs = list("tail" = /obj/item/organ/tail/monkey)
-	dna_mutagen_ok = 1
+	dna_mutagen_ok = TRUE
 
 	New(var/mob/living/carbon/human/M)
 		. = ..()
@@ -1698,7 +1698,7 @@
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_HUMAN_EYES | BUILT_FROM_PIECES | FIX_COLORS | HAS_SPECIAL_HAIR | TORSO_HAS_SKINTONE | WEARS_UNDERPANTS)
 	eye_state = "eyes_roach"
 	typevulns = list("blunt" = 1.66, "crush" = 1.66)
-	dna_mutagen_ok = 1
+	dna_mutagen_ok = TRUE
 
 	New(mob/living/carbon/human/M)
 		. = ..()
@@ -1735,7 +1735,7 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/cat/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/cat/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS | WEARS_UNDERPANTS)
-	dna_mutagen_ok = 1
+	dna_mutagen_ok = TRUE
 
 	New(mob/living/carbon/human/M)
 		. = ..()
@@ -1777,7 +1777,7 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/amphibian/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/amphibian/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
-	dna_mutagen_ok = 1
+	dna_mutagen_ok = TRUE
 
 
 	say_verb()
@@ -2011,7 +2011,7 @@
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_HUMAN_EYES | BUILT_FROM_PIECES | HAS_EXTRA_DETAILS | HAS_OVERSUIT_DETAILS | HAS_SPECIAL_HAIR | HEAD_HAS_OWN_COLORS | WEARS_UNDERPANTS)
 	color_channel_names = list("Horn Detail", "Hoof Detail")
 	eye_state = "eyes-cow"
-	dna_mutagen_ok = 1
+	dna_mutagen_ok = TRUE
 
 	New(var/mob/living/carbon/human/H)
 		..()
@@ -2100,7 +2100,7 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/chicken/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/chicken/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_PARTIAL_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS | TORSO_HAS_SKINTONE | WEARS_UNDERPANTS)
-	dna_mutagen_ok = 1
+	dna_mutagen_ok = TRUE
 
 	emote(var/act, var/voluntary)
 		switch(act)

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -67,8 +67,8 @@
 	var/voice_name = "human"
 	/// Should robots arrest these by default?
 	var/jerk = 0
-	/// Should stable mutagen apply this mutant?
-	var/dna_mutagen_ok = FALSE
+	/// Should stable mutagen not copy from this mutant?
+	var/dna_mutagen_banned = TRUE
 
 	/// This is used for static icons if the mutant isn't built from pieces
 	var/icon = 'icons/effects/genetics.dmi'
@@ -651,7 +651,6 @@
 	voice_override = "bloop"
 	firevuln = 1.5
 	typevulns = list("cut" = 1.25, "stab" = 0.5, "blunt" = 0.75)
-	dna_mutagen_ok = TRUE
 
 	say_verb()
 		return pick("burbles", "gurgles", "blurbs", "gloops")
@@ -714,7 +713,7 @@
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/flashy/left
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/flashy/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/flashy/left
-	dna_mutagen_ok = TRUE
+	dna_mutagen_banned = FALSE
 
 
 /datum/mutantrace/virtual
@@ -816,7 +815,7 @@
 	race_mutation = /datum/bioEffect/mutantrace // Most mutants are just another form of lizard, didn't you know?
 	clothing_icon_override = 'icons/mob/lizard_clothes.dmi'
 	color_channel_names = list("Episcutus", "Ventral Aberration", "Sagittal Crest")
-	dna_mutagen_ok = TRUE
+	dna_mutagen_banned = FALSE
 
 	New(var/mob/living/carbon/human/H)
 		..()
@@ -1121,7 +1120,7 @@
 	special_head = HEAD_SKELETON
 	decomposes = FALSE
 	race_mutation = /datum/bioEffect/mutantrace/skeleton
-	dna_mutagen_ok = TRUE
+	dna_mutagen_banned = FALSE
 
 	New(var/mob/living/carbon/human/M)
 		..()
@@ -1416,7 +1415,7 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/ithillid/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/ithillid/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HAS_SPECIAL_HAIR | HEAD_HAS_OWN_COLORS | WEARS_UNDERPANTS)
-	dna_mutagen_ok = TRUE
+	dna_mutagen_banned = FALSE
 
 	say_verb()
 		return "glubs"
@@ -1451,7 +1450,7 @@
 	var/had_tablepass = 0
 	var/table_hide = 0
 	mutant_organs = list("tail" = /obj/item/organ/tail/monkey)
-	dna_mutagen_ok = TRUE
+	dna_mutagen_banned = FALSE
 
 	New(var/mob/living/carbon/human/M)
 		. = ..()
@@ -1627,6 +1626,7 @@
 	human_compatible = 1
 	uses_human_clothes = 1
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_HUMAN_SKINTONE | HAS_HUMAN_HAIR | HAS_HUMAN_EYES | HAS_NO_HEAD | USES_STATIC_ICON)
+	dna_mutagen_banned = FALSE
 
 
 	New()
@@ -1698,7 +1698,7 @@
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_HUMAN_EYES | BUILT_FROM_PIECES | FIX_COLORS | HAS_SPECIAL_HAIR | TORSO_HAS_SKINTONE | WEARS_UNDERPANTS)
 	eye_state = "eyes_roach"
 	typevulns = list("blunt" = 1.66, "crush" = 1.66)
-	dna_mutagen_ok = TRUE
+	dna_mutagen_banned = FALSE
 
 	New(mob/living/carbon/human/M)
 		. = ..()
@@ -1735,7 +1735,6 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/cat/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/cat/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS | WEARS_UNDERPANTS)
-	dna_mutagen_ok = TRUE
 
 	New(mob/living/carbon/human/M)
 		. = ..()
@@ -1777,7 +1776,6 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/amphibian/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/amphibian/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
-	dna_mutagen_ok = TRUE
 
 
 	say_verb()
@@ -2011,7 +2009,7 @@
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_HUMAN_EYES | BUILT_FROM_PIECES | HAS_EXTRA_DETAILS | HAS_OVERSUIT_DETAILS | HAS_SPECIAL_HAIR | HEAD_HAS_OWN_COLORS | WEARS_UNDERPANTS)
 	color_channel_names = list("Horn Detail", "Hoof Detail")
 	eye_state = "eyes-cow"
-	dna_mutagen_ok = TRUE
+	dna_mutagen_banned = FALSE
 
 	New(var/mob/living/carbon/human/H)
 		..()
@@ -2100,7 +2098,6 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/chicken/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/chicken/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_PARTIAL_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS | TORSO_HAS_SKINTONE | WEARS_UNDERPANTS)
-	dna_mutagen_ok = TRUE
 
 	emote(var/act, var/voluntary)
 		switch(act)

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -67,6 +67,8 @@
 	var/voice_name = "human"
 	/// Should robots arrest these by default?
 	var/jerk = 0
+	/// Should stable mutagen apply this mutant?
+	var/dna_mutagen_ok = 0
 
 	/// This is used for static icons if the mutant isn't built from pieces
 	var/icon = 'icons/effects/genetics.dmi'
@@ -649,6 +651,7 @@
 	voice_override = "bloop"
 	firevuln = 1.5
 	typevulns = list("cut" = 1.25, "stab" = 0.5, "blunt" = 0.75)
+	dna_mutagen_ok = 1
 
 	say_verb()
 		return pick("burbles", "gurgles", "blurbs", "gloops")
@@ -711,6 +714,7 @@
 	l_limb_arm_type_mutantrace = /obj/item/parts/human_parts/arm/mutant/flashy/left
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/flashy/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/flashy/left
+	dna_mutagen_ok = 1
 
 
 /datum/mutantrace/virtual
@@ -812,6 +816,7 @@
 	race_mutation = /datum/bioEffect/mutantrace // Most mutants are just another form of lizard, didn't you know?
 	clothing_icon_override = 'icons/mob/lizard_clothes.dmi'
 	color_channel_names = list("Episcutus", "Ventral Aberration", "Sagittal Crest")
+	dna_mutagen_ok = 1
 
 	New(var/mob/living/carbon/human/H)
 		..()
@@ -1116,6 +1121,7 @@
 	special_head = HEAD_SKELETON
 	decomposes = FALSE
 	race_mutation = /datum/bioEffect/mutantrace/skeleton
+	dna_mutagen_ok = 1
 
 	New(var/mob/living/carbon/human/M)
 		..()
@@ -1410,6 +1416,7 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/ithillid/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/ithillid/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HAS_SPECIAL_HAIR | HEAD_HAS_OWN_COLORS | WEARS_UNDERPANTS)
+	dna_mutagen_ok = 1
 
 	say_verb()
 		return "glubs"
@@ -1444,6 +1451,7 @@
 	var/had_tablepass = 0
 	var/table_hide = 0
 	mutant_organs = list("tail" = /obj/item/organ/tail/monkey)
+	dna_mutagen_ok = 1
 
 	New(var/mob/living/carbon/human/M)
 		. = ..()
@@ -1690,6 +1698,7 @@
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_HUMAN_EYES | BUILT_FROM_PIECES | FIX_COLORS | HAS_SPECIAL_HAIR | TORSO_HAS_SKINTONE | WEARS_UNDERPANTS)
 	eye_state = "eyes_roach"
 	typevulns = list("blunt" = 1.66, "crush" = 1.66)
+	dna_mutagen_ok = 1
 
 	New(mob/living/carbon/human/M)
 		. = ..()
@@ -1726,6 +1735,7 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/cat/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/cat/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS | WEARS_UNDERPANTS)
+	dna_mutagen_ok = 1
 
 	New(mob/living/carbon/human/M)
 		. = ..()
@@ -1767,6 +1777,7 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/amphibian/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/amphibian/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS)
+	dna_mutagen_ok = 1
 
 
 	say_verb()
@@ -2000,6 +2011,7 @@
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_NO_SKINTONE | HAS_HUMAN_EYES | BUILT_FROM_PIECES | HAS_EXTRA_DETAILS | HAS_OVERSUIT_DETAILS | HAS_SPECIAL_HAIR | HEAD_HAS_OWN_COLORS | WEARS_UNDERPANTS)
 	color_channel_names = list("Horn Detail", "Hoof Detail")
 	eye_state = "eyes-cow"
+	dna_mutagen_ok = 1
 
 	New(var/mob/living/carbon/human/H)
 		..()
@@ -2088,6 +2100,7 @@
 	r_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/chicken/right
 	l_limb_leg_type_mutantrace = /obj/item/parts/human_parts/leg/mutant/chicken/left
 	mutant_appearance_flags = (NOT_DIMORPHIC | HAS_PARTIAL_SKINTONE | HAS_NO_EYES | BUILT_FROM_PIECES | HEAD_HAS_OWN_COLORS | TORSO_HAS_SKINTONE | WEARS_UNDERPANTS)
+	dna_mutagen_ok = 1
 
 	emote(var/act, var/voluntary)
 		switch(act)

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1560,7 +1560,7 @@ datum
 						boutput(M, "<span class='notice'>You feel a little [pick("unlike yourself", "out of it", "different", "strange")].</span>")
 					if (progress_timer > 10)
 						M.real_name = M.bioHolder.ownerName
-						if (M.bioHolder?.mobAppearance?.mutant_race)
+						if (M.bioHolder?.mobAppearance?.mutant_race?.dna_mutagen_ok)
 							M.set_mutantrace(M.bioHolder.mobAppearance.mutant_race.type)
 						M.UpdateName()
 					if(ishuman(M))

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1560,7 +1560,7 @@ datum
 						boutput(M, "<span class='notice'>You feel a little [pick("unlike yourself", "out of it", "different", "strange")].</span>")
 					if (progress_timer > 10)
 						M.real_name = M.bioHolder.ownerName
-						if (M.bioHolder?.mobAppearance?.mutant_race?.dna_mutagen_ok)
+						if (M.bioHolder?.mobAppearance?.mutant_race?.dna_mutagen_ok == TRUE)
 							M.set_mutantrace(M.bioHolder.mobAppearance.mutant_race.type)
 						M.UpdateName()
 					if(ishuman(M))

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1554,13 +1554,16 @@ datum
 							src.data = cheating.data
 
 				if (src.data && M.bioHolder && progress_timer <= 10)
-
+					if(istype(src.data, /datum/bioHolder))
+						var/datum/bioHolder/tocopy = data
+						if(tocopy?.mobAppearance?.mutant_race?.dna_mutagen_banned)
+							return ..()
 					M.bioHolder.StaggeredCopyOther(data, progress_timer+=(1 * mult))
 					if (probmult(50) && progress_timer > 7)
 						boutput(M, "<span class='notice'>You feel a little [pick("unlike yourself", "out of it", "different", "strange")].</span>")
 					if (progress_timer > 10)
 						M.real_name = M.bioHolder.ownerName
-						if (M.bioHolder?.mobAppearance?.mutant_race?.dna_mutagen_ok == TRUE)
+						if (M.bioHolder?.mobAppearance?.mutant_race)
 							M.set_mutantrace(M.bioHolder.mobAppearance.mutant_race.type)
 						M.UpdateName()
 					if(ishuman(M))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Used to be that stable mutagen would copy over any race you get blood from, including things like werewolves and shamblers. That's less than ideal, so now I added a var that makes a mutant race valid to SM into!


yass edit: changed behavior of this a bit to make dna mutagen (silently) fail outright when attempting to copy from a banned mutantrace, and changed backend a bit

Currently, you're only able to SM into:
- Lizards
- Cows
- Skeletons
- Roaches
- Chickens
- (Sea)monkeys
- Squids
- Flashies
- Premature clones

Everything else, you'll have to TF into them the hard way.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So apparently you could steal a shambler's blood and then SM into them. Which I think is kinda cool since I'm like 80% sure you need to steal their blood with a syringe or something (Pools of blood dont work last I checked (which was around the time fluids were introduced so iunno?)), but I can see this being abused... somehow.
Also Tarm asked nicely =3


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Superlagg
(*)Stable mutagen now only copies over "normal" mutants, like lizards and skeletons. 
```
