### PR TITLE
Announce players entering cryogenic storage

### DIFF
--- a/code/WorkInProgress/cryospawn.dm
+++ b/code/WorkInProgress/cryospawn.dm
@@ -145,6 +145,9 @@
 				if (L.client)
 					L.addOverlayComposition(/datum/overlayComposition/blinded)
 					L.updateOverlaysClient(L.client)
+				for (var/obj/machinery/computer/announcement/A as anything in machine_registry[MACHINES_ANNOUNCEMENTS])
+					if (!A.status && A.announces_arrivals)
+						A.announce_departure(L)
 				return 1
 
 		stored_mobs += L
@@ -157,6 +160,9 @@
 		if (L.client)
 			L.addOverlayComposition(/datum/overlayComposition/blinded)
 			L.updateOverlaysClient(L.client)
+		for (var/obj/machinery/computer/announcement/A as anything in machine_registry[MACHINES_ANNOUNCEMENTS])
+			if (!A.status && A.announces_arrivals)
+				A.announce_departure(L)
 		if (ishuman(L))
 			var/mob/living/carbon/human/H = L
 			if (H.sims)

--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -15,6 +15,7 @@
 	var/arrival_announcements_enabled = 1
 	var/say_language = "english"
 	var/arrivalalert = "$NAME has signed up as $JOB."
+	var/departurealert = "$NAME the $JOB has entered cryogenic storage."
 	var/obj/item/device/radio/intercom/announcement_radio = null
 	var/voice_message = "broadcasts"
 	var/voice_name = "Announcement Computer"
@@ -202,6 +203,18 @@
 			src.announcement_radio = new(src)
 
 		var/message = replacetext(replacetext(replacetext(src.arrivalalert, "$STATION", "[station_name()]"), "$JOB", person.mind.assigned_role), "$NAME", person.real_name)
+		message = replacetext(replacetext(replacetext(message, "$THEY", "[he_or_she(person)]"), "$THEM", "[him_or_her(person)]"), "$THEIR", "[his_or_her(person)]")
+
+		var/list/messages = process_language(message)
+		src.announcement_radio.talk_into(src, messages, 0, src.name, src.say_language)
+		logTheThing("station", src, null, "ANNOUNCES: [message]")
+		return 1
+
+	proc/announce_departure(var/mob/living/person)
+		if (!src.announcement_radio)
+			src.announcement_radio = new(src)
+
+		var/message = replacetext(replacetext(replacetext(src.departurealert, "$STATION", "[station_name()]"), "$JOB", person.mind.assigned_role), "$NAME", person.real_name)
 		message = replacetext(replacetext(replacetext(message, "$THEY", "[he_or_she(person)]"), "$THEM", "[him_or_her(person)]"), "$THEIR", "[his_or_her(person)]")
 
 		var/list/messages = process_language(message)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Announcement computer gives a message when a player enters cryogenic storage.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Helps players to know that someone has left the game.