### PR TITLE
Fix grave fever symptoms

### DIFF
--- a/code/modules/medical/diseases/vamplague.dm
+++ b/code/modules/medical/diseases/vamplague.dm
@@ -15,17 +15,17 @@
 	var/toxdamage = D.stage * 3
 	var/stuntime = D.stage * 3
 
-	if (probmult(10))
+	if (prob(10))
 		affected_mob.emote(pick("cough","groan", "gasp"))
 		affected_mob.losebreath++
 
-	if (probmult(15))
+	if (prob(15))
 		if (prob(33))
 			boutput(affected_mob, "<span class='alert'>You feel sickly and weak.</span>")
 			affected_mob.changeStatus("slowed", 3 SECONDS)
 		affected_mob.take_toxin_damage(toxdamage)
 
-	if (probmult(10))
+	if (prob(10))
 		boutput(affected_mob, "<span class='alert'>Your joints ache horribly!</span>")
 		affected_mob.changeStatus("weakened", stuntime SECONDS)
 		affected_mob.changeStatus("stunned", stuntime SECONDS)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes grave fever symptoms not triggering. Replaces probmult calls to prob calls as mult was always null. All other diseases I checked used prob instead of probmult already.

After the change, grave fever sends someone untreated into crit after 3-4 minutes. Death a minute or two later.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5454.
