### PR TITLE
Lit trick cigarrettes will destroy a PDA if placed inside one.

### DIFF
--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -339,6 +339,11 @@
 		else
 			logTheThing("bombing", src.fingerprintslast, null, "A trick cigarette explodes at [log_loc(src)]. Last touched by [src.fingerprintslast ? "[src.fingerprintslast]" : "*null*"].")
 
+		if (istype(src.loc,/obj/item/device/pda2))
+			var/obj/item/device/pda2/pda = src.loc
+			if (pda.ID_card) //let's not destroy IDs
+				pda.ID_card.set_loc(tlocation)
+			qdel(pda)//Destroy PDA if in one
 		qdel(src)
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lit trick cigarettes placed into a PDA will now destroy the PDA when they explode and drop the ID on the ground.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5444.
