### PR TITLE
APC hacking QoL

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -473,6 +473,9 @@ var/zapLimiter = 0
 			boutput(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"]")
 			updateicon()
 
+	else if (wiresexposed && (issnippingtool(W) || ispulsingtool(W)))
+		src.attack_hand(user)
+
 	else if (issilicon(user))
 		if (istype(W, /obj/item/robojumper))
 			var/mob/living/silicon/S = user


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

A follow-up to #5413, on @alexeric123's request. Now you can also click the APC with wirecutters/multitool to open the hacking panel, if wires are exposed

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

More quality of life stuff good

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)You can now click the APC with wirecutters/multitool to open the hacking panel, if wires are exposed.
```
