### PR TITLE
Fixes baton toggling not working at low power

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -938,13 +938,6 @@ This is basically useless for anyone but miners.
 	desc = "An experimental laser design with a self-charging cerenkite battery."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
-/datum/syndicate_buylist/surplus/riotbaton
-	name = "Riot Baton"
-	item = /obj/item/baton/classic
-	cost = 5
-	desc = "An old riot baton."
-	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
-
 /datum/syndicate_buylist/surplus/breachingT
 	name = "Thermite Breaching Charge"
 	item = /obj/item/breaching_charge/thermite

--- a/code/mob/living/critter/misc.dm
+++ b/code/mob/living/critter/misc.dm
@@ -53,7 +53,7 @@
 		else
 			if (istype(W, /obj/item/baton))
 				var/obj/item/baton/B = W
-				if (B.can_stun(1, 1, user) == 1)
+				if (B.can_stun(1, user) == 1)
 					user.visible_message("<span class='combat'><b>[user] shocks [src] with [B]!</b></span>", "<span class='combat'><b>While your baton passes through, [src] appears damaged!</b></span>")
 					B.process_charges(-1, user)
 

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -408,8 +408,6 @@
 			qdel(src)
 		else if (istype(W, /obj/item/baton))
 			var/obj/item/baton/baton = W
-			if (!baton.uses_electricity)
-				..()
 			if (baton.is_active) //baton is on
 				if (user.a_intent != "harm")
 					if (user.traitHolder.hasTrait("training_security"))

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -410,7 +410,7 @@
 			var/obj/item/baton/baton = W
 			if (!baton.uses_electricity)
 				..()
-			if (baton.status == 1) //baton is on
+			if (baton.is_active) //baton is on
 				if (user.a_intent != "harm")
 					if (user.traitHolder.hasTrait("training_security"))
 						playsound(src, "sound/impact_sounds/Energy_Hit_3.ogg", 30, 1, -1) //bit quieter than a baton hit

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -208,25 +208,6 @@
 	desc = "A little security robot, apparently carved out of a pumpkin.  He looks...spooky?"
 	icon = 'icons/misc/halloween.dmi'
 
-/obj/machinery/bot/secbot/brute
-	name = "Komisarz Beepinarska"
-	desc = "This little security robot seems to have a particularly large chip on its... shoulder? ...head?"
-	our_baton_type = /obj/item/baton/classic
-	loot_baton_type = /obj/item/baton/classic
-	stun_type = "harm_classic"
-	emagged = 2
-	control_freq = 0
-
-	demag()
-		//Nope
-		return
-
-/obj/machinery/bot/secbot/stamina_test
-	name = "test secbot"
-	desc = "stamina test"
-	our_baton_type = /obj/item/baton/stamina
-	loot_baton_type = /obj/item/baton/stamina
-
 /obj/item/secbot_assembly
 	name = "helmet/signaler assembly"
 	desc = "Some sort of bizarre assembly."
@@ -566,8 +547,6 @@
 
 			// No need for unnecessary hassle, just make it ignore charges entirely for the time being.
 			if (src.our_baton && istype(src.our_baton))
-				if (src.our_baton.uses_electricity == 0)
-					src.our_baton.uses_electricity = 1
 				if (src.our_baton.uses_charges != 0)
 					src.our_baton.uses_charges = 0
 			else

--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -534,7 +534,7 @@
 		// Not charged when dropped (ran on Beepsky's internal battery or whatever).
 		if (istype(loot_baton_type, /obj/item/baton)) // Now we can drop *any* baton!
 			var/obj/item/baton/B = new loot_baton_type(Tsec)
-			B.status = 0
+			B.is_active = FALSE
 			B.process_charges(-INFINITY)
 			if (src.is_beepsky == IS_BEEPSKY_AND_HAS_HIS_SPECIAL_BATON || src.is_beepsky == IS_NOT_BEEPSKY_BUT_HAS_HIS_SPECIAL_BATON)	// Holding Beepsky's baton doesnt make you him, but it does mean you're holding his baton
 				B.name = "Beepsky's stun baton"
@@ -1340,7 +1340,7 @@
 					master.KillPathAndGiveUp(KPAGU_RETURN_TO_GUARD)
 				else
 					master.KillPathAndGiveUp(KPAGU_CLEAR_ALL)
-	
+
 	proc/failchecks()
 		if (!IN_RANGE(master, master.target, 1))
 			return 1

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -280,7 +280,7 @@
 
 	if(istype(W,/obj/item/baton))
 		var/obj/item/baton/BAT = W
-		if (BAT.can_stun(1, 1, user) == 1)
+		if (BAT.can_stun(1, user) == 1)
 			src.ArtifactStimulus("force", BAT.force)
 			src.ArtifactStimulus("elec", 1500)
 			playsound(src.loc, "sound/impact_sounds/Energy_Hit_3.ogg", 100, 1)

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -1007,7 +1007,7 @@
 		else
 			if (istype(W, /obj/item/baton))
 				var/obj/item/baton/B = W
-				if (B.can_stun(1, 1, user) == 1)
+				if (B.can_stun(1, user) == 1)
 					user.visible_message("<span class='combat'><b>[user] shocks the [src.name] with [B]!</b></span>", "<span class='combat'><b>While your baton passes through, the [src.name] appears damaged!</b></span>")
 					B.process_charges(-1, user)
 					src.health--

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -302,14 +302,14 @@
 
 		switch (user.a_intent)
 			if ("harm")
-				if (src.status == 0 || (src.status != 0 && src.can_stun() == 0))
+				if (!src.is_active || (src.is_active && src.can_stun() == 0))
 					playsound(src, "swing_hit", 50, 1, -1)
 					..()
 				else
 					src.do_stun(user, M, "failed_harm", 1)
 
 			else
-				if (src.status == 0 || (src.status != 0 && src.can_stun() == 0))
+				if (!src.is_active || (src.is_active && src.can_stun() == 0))
 					src.do_stun(user, M, "failed_stun", 1)
 				else
 					src.do_stun(user, M, "stun", 2)

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -78858,7 +78858,7 @@
 	flipped = 1;
 	force = 15;
 	name = "\improper Harmbaton of Porter Starboard";
-	status = 0
+	is_active = 0
 	},
 /obj/machinery/light/incandescent/warm/very{
 	dir = 4


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There was an issue where batons couldn't be turned ***off*** if the power cell capacity was between 0 and 25 PU, and it would then state that the baton doesn't have enough power to turn ***on*** (despite already being on). This fixes that.
The behavior where batons can't be turned on when it's turned off is still there (and that was the original intention afaik).


HOHOHOHO i'm hijacking this PR to remove police batons and non-stamina-based batons to really get some cleanliness in there! - yass

Also I renamed `status` to be more descriptive since it's just a binary value.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug fix

Clean up da code - yass

```changelog
(u)Tarmunora
(+)Removes police baton
```

