### PR TITLE
Fixes csaber glowstick light not updating properly

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -311,8 +311,8 @@
 		else
 			user.visible_message("<b>[user]</b> loads a glowstick into [src].")
 			loaded_glowstick = W
-			user.u_equip(W)
 			W.set_loc(src)
+			user.u_equip(W)
 			var/datum/component/holdertargeting/simple_light/light_c = src.GetComponent(/datum/component/holdertargeting/simple_light)
 			switch(src.loaded_glowstick.color_name)
 				if("red")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There was an issue where the csaber glowstick light would remain attached to the user mob after pulling the glowstick out of the csaber. This fixes that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug fix
