### PR TITLE
Fixes an issue with decorative pots

### DIFF
--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -10,7 +10,7 @@
 		CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 				return 0
 		attackby(obj/item/weapon as obj,mob/user as mob)
-				if(istype(weapon,/obj/item/wrench) || istype(weapon,/obj/item/screwdriver))
+				if((iswrenchingtool(weapon)) || isscrewingtool(weapon))
 						if(!src.anchored)
 								user.visible_message("<b>[user]</b> secures the [src] to the floor!")
 								playsound(src.loc, "sound/items/Screwdriver.ogg", 100, 1)


### PR DESCRIPTION
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes an issue where only screwdrives and wrenches worked on decorative pot bolting, and not multitools.

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Just consistency with tools

