### PR TITLE
Allows latejoin antags in spy thief gamemode

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -8,9 +8,8 @@
 	name = "spy_thief"
 	config_tag = "spy_theft"
 
-	//maybe not??
-	//latejoin_antag_compatible = 1
-	//latejoin_antag_roles = list("spy_thief")
+	latejoin_antag_compatible = 1
+	latejoin_antag_roles = list("traitor")
 	var/const/waittime_l = 600	// Minimum after round start to send threat information to printer
 	var/const/waittime_h = 1800	// Maximum after round start to send threat information to printer
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR turns on latejoin antag events in spy thief gamemode, allowing players to join as traitors. (Not spy thieves, since latejoining as a spy, in my opinion, would suck, as roundstart spies would have a huge advantage over latejoin ones)

The change also allows sleeper agent events to happen, since it's tied to latejoin_antag_compatible aswell.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Many people find spy thief rounds incredibly slow-paced, which I agree about. Introducing latejoin traitors and sleeper agents will hopefully spice it up a little.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Added latejoin traitor and sleeper agent spawn events to spy thief gamemode.
```
