### PR TITLE
Fixes to reagent extractor

### DIFF
--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -987,29 +987,13 @@
 
 		else if (istype(W,/obj/item/satchel/hydro))
 			var/obj/item/satchel/S = W
-
 			var/loadcount = 0
-			if (src.autoextract)
-				if (!src.extract_to)
-					boutput(user, "<span class='alert'>You must first select an extraction target if you want items to be automatically extracted.</span>")
-					return
-
+			if (src.autoextract && !src.extract_to)
+				boutput(user, "<span class='alert'>You must first select an extraction target if you want items to be automatically extracted.</span>")
+				return
 			for (var/obj/item/I in S.contents)
-				if (src.autoextract)
-					if (src.extract_to.reagents.total_volume >= src.extract_to.reagents.maximum_volume)
-						boutput(user, "<span class='alert'>The auto-extraction target is full.</span>")
-						break
-				for(var/check_path in src.allowed)
-					if(istype(I, check_path))
-						if (src.autoextract)
-							src.doExtract(I)
-							qdel(I)
-						else
-							I.set_loc(src)
-							src.ingredients += I
-						loadcount++
-						break
-
+				if (src.canExtract(I) && (src.tryLoading(I, user)))
+					loadcount++
 			if (!loadcount)
 				boutput(user, "<span class='alert'>No items were loaded from the satchel!</span>")
 			else if (src.autoextract)
@@ -1022,33 +1006,16 @@
 			src.updateUsrDialog()
 
 		else
-			var/proceed = 0
-			for(var/check_path in src.allowed)
-				if(istype(W, check_path))
-					proceed = 1
-					break
-			if (!proceed)
+			if (!src.canExtract(W))
 				boutput(user, "<span class='alert'>The extractor cannot accept that!</span>")
 				return
 
-			if (src.autoextract)
-				if (!src.extract_to)
-					boutput(user, "<span class='alert'>You must first select an extraction target if you want items to be automatically extracted.</span>")
-					return
-				if (src.extract_to.reagents.total_volume == src.extract_to.reagents.maximum_volume)
-					boutput(user, "<span class='alert'>The extraction target is full.</span>")
-					return
-
+			if (!src.tryLoading(W, user)) return
 			boutput(user, "<span class='notice'>You add [W] to the machine!</span>")
+
 			user.u_equip(W)
 			W.dropped()
 
-			if (src.autoextract)
-				src.doExtract(W)
-				qdel(W)
-			else
-				W.set_loc(src)
-				src.ingredients += W
 			src.update_icon()
 			src.updateUsrDialog()
 			return
@@ -1056,33 +1023,19 @@
 	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 		if (istype(O, /obj/item/reagent_containers/glass/) || istype(O, /obj/item/reagent_containers/food/drinks/) || istype(O, /obj/item/satchel/hydro))
 			return src.attackby(O, user)
-		var/proceed = 0
-		for (var/check_path in src.allowed)
-			if (istype(O, check_path))
-				proceed = 1
-				break
-		if (!proceed) ..()
+		if (!src.canExtract(O)) ..()
 		else
-			if (src.autoextract)
-				if (!src.extract_to)
-					boutput(user, "<span class='alert'>You must first select an extraction target if you want items to be automatically extracted.</span>")
-					return
+			if (src.autoextract && !src.extract_to)
+				boutput(user, "<span class='alert'>You must first select an extraction target if you want items to be automatically extracted.</span>")
+				return
 			user.visible_message("<span class='notice'>[user] begins quickly stuffing [O.name] into [src]!</span>")
 			var/staystill = user.loc
 			for (var/obj/item/P in view(1,user))
 				if (user.loc != staystill) break
 				if (P.type == O.type)
-					if (src.autoextract)
-						if (src.extract_to.reagents.total_volume >= src.extract_to.reagents.maximum_volume)
-							boutput(user, "<span class='alert'>The auto-extraction target is full.</span>")
-							break
-						src.doExtract(P)
-						qdel(P)
-						sleep(0.2 SECONDS)
-					else
-						P.set_loc(src)
-						src.ingredients.Add(P)
-						sleep(0.2 SECONDS)
+					if (!src.tryLoading(P, user))
+						break
+					sleep(0.2 SECONDS)
 				else continue
 			boutput(user, "<span class='notice'>You finish stuffing items into [src]!</span>")
 		src.update_icon()
@@ -1123,6 +1076,29 @@
 
 	I.reagents.trans_to(src.extract_to, I.reagents.total_volume)
 	src.update_icon()
+
+/obj/submachine/chem_extractor/proc/canExtract(O)
+	for(var/check_path in src.allowed)
+		if(istype(O, check_path))
+			return TRUE
+	return FALSE
+
+/obj/submachine/chem_extractor/proc/tryLoading(var/obj/item/O, var/mob/user as mob)
+	// Pre: make sure that the item type can be extracted
+	if (src.autoextract)
+		if (!src.extract_to)
+			boutput(user, "<span class='alert'>You must first select an extraction target if you want items to be automatically extracted.</span>")
+			return FALSE
+		if (src.extract_to.reagents.total_volume >= src.extract_to.reagents.maximum_volume)
+			boutput(user, "<span class='alert'>The auto-extraction target is full.</span>")
+			return FALSE
+		src.doExtract(O)
+		qdel(O)
+		return TRUE
+	else
+		O.set_loc(src)
+		src.ingredients += O
+		return TRUE
 
 /obj/submachine/seed_vendor
 	name = "Seed Fabricator"

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -1004,13 +1004,12 @@
 						if (src.autoextract)
 							src.doExtract(I)
 							qdel(I)
-							loadcount++
-							break
 						else
 							I.set_loc(src)
 							src.ingredients += I
-							loadcount++
-							break
+						loadcount++
+						break
+
 			if (!loadcount)
 				boutput(user, "<span class='alert'>No items were loaded from the satchel!</span>")
 			else if (src.autoextract)

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -1071,10 +1071,10 @@
 	src.update_icon()
 
 /obj/submachine/chem_extractor/proc/canExtract(O)
+	. = FALSE
 	for(var/check_path in src.allowed)
 		if(istype(O, check_path))
 			return TRUE
-	return FALSE
 
 /obj/submachine/chem_extractor/proc/tryLoading(var/obj/item/O, var/mob/user as mob)
 	// Pre: make sure that the item type can be extracted

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -988,9 +988,6 @@
 		else if (istype(W,/obj/item/satchel/hydro))
 			var/obj/item/satchel/S = W
 			var/loadcount = 0
-			if (src.autoextract && !src.extract_to)
-				boutput(user, "<span class='alert'>You must first select an extraction target if you want items to be automatically extracted.</span>")
-				return
 			for (var/obj/item/I in S.contents)
 				if (src.canExtract(I) && (src.tryLoading(I, user)))
 					loadcount++
@@ -1025,16 +1022,12 @@
 			return src.attackby(O, user)
 		if (!src.canExtract(O)) ..()
 		else
-			if (src.autoextract && !src.extract_to)
-				boutput(user, "<span class='alert'>You must first select an extraction target if you want items to be automatically extracted.</span>")
-				return
 			user.visible_message("<span class='notice'>[user] begins quickly stuffing [O.name] into [src]!</span>")
 			var/staystill = user.loc
 			for (var/obj/item/P in view(1,user))
 				if (user.loc != staystill) break
 				if (P.type == O.type)
-					if (!src.tryLoading(P, user))
-						break
+					if (!src.tryLoading(P, user)) break
 					sleep(0.2 SECONDS)
 				else continue
 			boutput(user, "<span class='notice'>You finish stuffing items into [src]!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug] [QoL] [feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes dragging and dropping extractable items into the extractor not working (prior to this the items were destroyed). Also adds support for autoextraction to both drag and drop and hydroponics produce satchel.
Fixes #5457

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)vocalpocal
(+)Regent extractor auto-extract now works with produce satchels and drag and drop
```
