### PR TITLE
Fix manufacturer not ejecting bucket, slight container code update

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -707,16 +707,14 @@
 					return
 
 			if (href_list["ejectbeaker"])
-				var/obj/item/reagent_containers/glass/beaker/B = locate(href_list["ejectbeaker"])
-				if (!istype(B,/obj/item/reagent_containers/glass/))
-					return
-				src.beaker.set_loc(get_output_location(B,1))
+				if (src.beaker)
+					src.beaker.set_loc(get_output_location(beaker,1))
 				src.beaker = null
 
 			if (href_list["transto"])
 				// reagents are going into beaker
-				var/obj/item/reagent_containers/glass/beaker/B = locate(href_list["transto"])
-				if (!istype(B,/obj/item/reagent_containers/glass/beaker/))
+				var/obj/item/reagent_containers/glass/B = locate(href_list["transto"])
+				if (!istype(B,/obj/item/reagent_containers/glass/))
 					return
 				var/howmuch = input("Transfer how much to [B]?","[src.name]",B.reagents.maximum_volume - B.reagents.total_volume) as null|num
 				if (!howmuch || !B || B != src.beaker )
@@ -725,8 +723,8 @@
 
 			if (href_list["transfrom"])
 				// reagents are being drawn from beaker
-				var/obj/item/reagent_containers/glass/beaker/B = locate(href_list["transfrom"])
-				if (!istype(B,/obj/item/reagent_containers/glass/beaker/))
+				var/obj/item/reagent_containers/glass/B = locate(href_list["transfrom"])
+				if (!istype(B,/obj/item/reagent_containers/glass/))
 					return
 				var/howmuch = input("Transfer how much from [B]?","[src.name]",B.reagents.total_volume) as null|num
 				if (!howmuch)

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -708,7 +708,7 @@
 
 			if (href_list["ejectbeaker"])
 				var/obj/item/reagent_containers/glass/beaker/B = locate(href_list["ejectbeaker"])
-				if (!istype(B,/obj/item/reagent_containers/glass/beaker/))
+				if (!istype(B,/obj/item/reagent_containers/glass/))
 					return
 				src.beaker.set_loc(get_output_location(B,1))
 				src.beaker = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor][cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The ejection code for manufacturers required a beaker to be inserted but the machines accepted any `obj/item/reagent_containers/glass/` (which has some really weird subtypes but that's another matter). I kinda just removed the check because dumping the container isn't a place where type-checks are all that helpful.

A couple of nearby html code things have been altered to also not expect beakers specifically. I don't feel like allowing a somewhat broader selection of insertable reagent things is that big of a deal (especially since the whole system has no use AFAIK).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #5490. AFAIK nothing in manufacturers ever needs a reagent but if we wanted them to, it'd be neat if things work.