### PR TITLE
Makes the Item Slot Machine unable to be scanned

### DIFF
--- a/code/z_adventurezones/space_casino.dm
+++ b/code/z_adventurezones/space_casino.dm
@@ -11,7 +11,7 @@
 	name = "Item Slot Machine"
 	desc = "A slot machine that produces items rather than money. Somehow."
 	icon_state = "slotsitem-off"
-	//mats = 50
+	mats = null
 	var/uses = 0
 	icon_base = "slotsitem"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR 

Makes the Item Slot Machine unable to be scanned.

## Why's this needed? 

An admin told me to do this in the original PR that added it and I did it wrong. Whoops
