### PR TITLE
Disrupt cloak on chairflip

### DIFF
--- a/code/datums/abilities/generic.dm
+++ b/code/datums/abilities/generic.dm
@@ -124,6 +124,7 @@
 			var/mob/living/M = hit_atom
 
 			playsound(src.loc, "sound/impact_sounds/Flesh_Break_1.ogg", 75, 1)
+			SEND_SIGNAL(src, COMSIG_CLOAKING_DEVICE_DEACTIVATE)
 			if (prob(25))
 				M.emote("scream")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Hitting someone from a chairflip will disrupt your cloak.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Other physical attacks disrupt cloaks. Wrestlers could chain cloaked flips easily.