### PR TITLE
Fix SWORD targeting mobs in arrivals

### DIFF
--- a/_std/macros/area.dm
+++ b/_std/macros/area.dm
@@ -1,2 +1,5 @@
 /// Returns the area of a passed atom
 #define get_area(x) (isarea(x) ? x : get_step(x, 0)?.loc)
+
+/// Returns true if this area is considered part of arrivals. Otherwise false.
+#define IS_ARRIVALS(x) (istype(x, /area/shuttle/arrival/station) || istype(x, /area/station/crewquarters/cryotron) || istype(x, /area/station/hallway/secondary/oshan_arrivals))

--- a/code/modules/events/syndicate_retribution.dm
+++ b/code/modules/events/syndicate_retribution.dm
@@ -5,9 +5,7 @@
 	required_elapsed_round_time = 40 MINUTES
 	weight = 88
 
-#ifdef RP_MODE
-	disabled = 1
-#endif
+ 	disabled = 1
 
 	event_effect(var/source,var/turf/T,var/delay,var/duration)
 		..()

--- a/code/modules/events/syndicate_retribution.dm
+++ b/code/modules/events/syndicate_retribution.dm
@@ -5,7 +5,9 @@
 	required_elapsed_round_time = 40 MINUTES
 	weight = 88
 
+#ifdef RP_MODE
 	disabled = 1
+#endif
 
 	event_effect(var/source,var/turf/T,var/delay,var/duration)
 		..()

--- a/code/modules/events/syndicate_retribution.dm
+++ b/code/modules/events/syndicate_retribution.dm
@@ -5,7 +5,7 @@
 	required_elapsed_round_time = 40 MINUTES
 	weight = 88
 
- 	disabled = 1
+	disabled = 1
 
 	event_effect(var/source,var/turf/T,var/delay,var/duration)
 		..()

--- a/code/obj/critter/sword.dm
+++ b/code/obj/critter/sword.dm
@@ -1,4 +1,5 @@
 #define SWORD_ATTACKING_RANGE 4
+#define IS_ARRIVALS(x) (istype(x, /area/shuttle/arrival/station) || istype(x, /area/station/crewquarters/cryotron) || istype(x, /area/station/hallway/secondary/oshan_arrivals))
 /* ================================================== */
 /* --- Syndicate Weapon: Orion Retribution Device --- */
 /* ================================================== */
@@ -188,6 +189,9 @@
 
 		return ai_think()
 
+	filter_target(var/mob/living/M)
+		return is_valid_target(M)
+
 	ai_think()
 		if(mode)
 			switch(task)
@@ -199,10 +203,8 @@
 					seek_target()
 					if (!src.target) src.task = "wandering"
 				if("chasing")
-					if (src.frustration >= rand(16,32))
-						src.target = null
-						src.last_found = TIME
-						src.frustration = 0
+					if (src.frustration >= rand(16,32) || !is_valid_target(src.target))
+						clear_target()
 						src.task = "thinking"
 						walk_to(src,0)
 					if (src.target)
@@ -227,6 +229,7 @@
 											tile_purge(OV.loc.x,OV.loc.y,3)
 
 							for (var/turf/simulated/wall/WT in range(2,get_center()))
+								if(IS_ARRIVALS(WT.loc)) continue
 								leavescan(WT, 1)
 								new /obj/item/raw_material/scrap_metal(WT)
 								if(prob(50))
@@ -248,17 +251,18 @@
 
 					else src.task = "thinking"
 				if("attacking")
-					if (!IN_RANGE(get_center(), src.target, SWORD_ATTACKING_RANGE) || (src.target:loc != src.target_lastloc))
+					if(!is_valid_target(src.target))
+						src.task = "thinking"
+						src.attacking = 0
+					else if (!IN_RANGE(get_center(), src.target, SWORD_ATTACKING_RANGE) || (src.target:loc != src.target_lastloc))
 						src.task = "chasing"
 					else if (IN_RANGE(get_center(), src.target, SWORD_ATTACKING_RANGE))
 						var/mob/living/carbon/M = src.target
 						if (!src.attacking) CritterAttack(src.target)
 						if(M != null)
 							if (M.health <= 0)
+								clear_target()
 								src.task = "thinking"
-								src.target = null
-								src.last_found = TIME
-								src.frustration = 0
 								src.attacking = 0
 							else
 								ability_selection()
@@ -420,12 +424,12 @@
 				if (1)	//N
 					var/turf/T = locate(src.loc.x + 1,src.loc.y + 3,src.loc.z)
 					for (var/mob/living/M in T)
-						if (isintangible(M)) continue
+						if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 						M.changeStatus("stunned", 2 SECONDS)
 						M.changeStatus("weakened", 4 SECONDS)
 					for(increment = -1; increment <= 1; increment++)
 						for(var/mob/living/M in locate(src.loc.x + 1 + increment,src.loc.y + 4,src.loc.z))
-							if (isintangible(M)) continue
+							if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 							M.changeStatus("stunned", 2 SECONDS)
 							M.changeStatus("weakened", 4 SECONDS)
 							M.throw_at(T, 3, 1)
@@ -433,12 +437,12 @@
 				if (4)	//E
 					var/turf/T = locate(src.loc.x + 3,src.loc.y + 1,src.loc.z)
 					for (var/mob/living/M in T)
-						if (isintangible(M)) continue
+						if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 						M.changeStatus("stunned", 2 SECONDS)
 						M.changeStatus("weakened", 4 SECONDS)
 					for(increment = -1; increment <= 1; increment++)
 						for(var/mob/living/M in locate(src.loc.x + 4,src.loc.y + 1 + increment,src.loc.z))
-							if (isintangible(M)) continue
+							if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 							M.changeStatus("stunned", 2 SECONDS)
 							M.changeStatus("weakened", 4 SECONDS)
 							M.throw_at(T, 3, 1)
@@ -446,12 +450,12 @@
 				if (2)	//S
 					var/turf/T = locate(src.loc.x + 1,src.loc.y - 1,src.loc.z)
 					for (var/mob/living/M in T)
-						if (isintangible(M)) continue
+						if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 						M.changeStatus("stunned", 2 SECONDS)
 						M.changeStatus("weakened", 4 SECONDS)
 					for(increment = -1; increment <= 1; increment++)
 						for(var/mob/living/M in locate(src.loc.x + 1 + increment,src.loc.y - 2,src.loc.z))
-							if (isintangible(M)) continue
+							if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 							M.changeStatus("stunned", 2 SECONDS)
 							M.changeStatus("weakened", 4 SECONDS)
 							M.throw_at(T, 3, 1)
@@ -459,12 +463,12 @@
 				if (8)	//W
 					var/turf/T = locate(src.loc.x - 1,src.loc.y + 1,src.loc.z)
 					for (var/mob/living/M in T)
-						if (isintangible(M)) continue
+						if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 						M.changeStatus("stunned", 2 SECONDS)
 						M.changeStatus("weakened", 4 SECONDS)
 					for(increment = -1; increment <= 1; increment++)
 						for(var/mob/living/M in locate(src.loc.x - 2,src.loc.y + 1 + increment,src.loc.z))
-							if (isintangible(M)) continue
+							if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 							M.changeStatus("stunned", 2 SECONDS)
 							M.changeStatus("weakened", 4 SECONDS)
 							M.throw_at(T, 3, 1)
@@ -564,7 +568,7 @@
 
 		SPAWN_DBG(1 SECOND)
 			for (var/mob/living/M in range(5,get_center()))
-				if (isintangible(M)) continue
+				if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 				random_brute_damage(M, 16)
 				random_burn_damage(M, 16)
 
@@ -609,11 +613,11 @@
 					src.pixel_y -= 4
 				sleep(5)
 			for (var/mob/living/M in range(3,get_center()))
-				if (isintangible(M)) continue
+				if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 				random_brute_damage(M, 60)
 			tile_purge(src.loc.x + 1,src.loc.y + 1,1)
 			for (var/mob/living/M in get_center())
-				if (isintangible(M)) continue
+				if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 				if(prob(69))								//Nice.
 					M.gib()
 				else
@@ -649,19 +653,19 @@
 
 		SPAWN_DBG(0.2 SECONDS)
 			for (var/mob/living/M in range(3,get_center()))
-				if(isintangible(M)) continue
+				if(isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 				random_burn_damage(M, (current_heat_level / 5))
 				M.changeStatus("burning", 4 SECONDS)
 
 		SPAWN_DBG(0.4 SECONDS)
 			for (var/mob/living/M in range(3,get_center()))
-				if(isintangible(M)) continue
+				if(isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 				random_burn_damage(M, (current_heat_level / 4))
 				M.changeStatus("burning", 6 SECONDS)
 
 		SPAWN_DBG(0.6 SECONDS)
 			for (var/mob/living/M in range(3,get_center()))
-				if(isintangible(M)) continue
+				if(isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 				random_burn_damage(M, (current_heat_level / 3))
 				M.changeStatus("burning", 8 SECONDS)
 
@@ -712,6 +716,7 @@
 		walk_towards(src, src.target)
 		walk(src,0)
 		for (var/mob/B in range(3,get_center()))
+			if(IS_ARRIVALS(get_area(B))) continue
 			random_burn_damage(B, 30)
 		icon = 'icons/misc/retribution/SWORD/abilities.dmi'
 		icon_state = "destructiveFlight"
@@ -763,7 +768,7 @@
 				step(src, src.dir)
 				sleep(0.1 SECONDS)
 			for (var/mob/living/M in range(3,get_center()))
-				if(isintangible(M)) continue
+				if(isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 				random_brute_damage(M, 60)
 			past_destructive_rotation = src.dir
 
@@ -823,6 +828,8 @@
 //-MISCELLANEOUS-//
 
 	proc/tile_purge(var/point_x, var/point_y, var/dam_type)	//A helper proc for Linear Purge, Destructive Leap and Destructive Flight.
+		if(IS_ARRIVALS(get_area(locate(point_x,point_y,src.z)))) return
+
 		for (var/mob/living/M in locate(point_x,point_y,src.z))
 			if(isintangible(M)) continue
 			if(!dam_type)
@@ -880,7 +887,7 @@
 		glow.plane = PLANE_SELFILLUM
 		src.UpdateOverlays(glow, "glow")
 		command_announcement("<br><b><span class='alert'>An unidentified long-range beacon has been detected near the station. Await further instructions.</span></b>", "Alert", "sound/vox/alert.ogg")
-		SPAWN_DBG(2 MINUTES)
+		SPAWN_DBG(5 SECONDS)
 			command_announcement("<br><b><span class='alert'>The station is under siege by the Syndicate-made object detected earlier. Survive any way possible.</span></b>", "Alert", "sound/vox/alert.ogg")
 			transformation(0)
 
@@ -889,4 +896,17 @@
 		var/turf/center_tile = get_step(get_turf(src), NORTHEAST)
 		return center_tile
 
+	proc/is_valid_target(var/target)
+		var/mob/living/M = target
+		if(!istype(M) || IS_ARRIVALS(get_area(M)))
+			return FALSE
+		return TRUE
+
+	proc/clear_target()
+		src.target = null
+		src.last_found = TIME
+		src.frustration = 0
+		return
+
 #undef SWORD_ATTACKING_RANGE
+#undef IS_ARRIVALS

--- a/code/obj/critter/sword.dm
+++ b/code/obj/critter/sword.dm
@@ -887,7 +887,7 @@
 		glow.plane = PLANE_SELFILLUM
 		src.UpdateOverlays(glow, "glow")
 		command_announcement("<br><b><span class='alert'>An unidentified long-range beacon has been detected near the station. Await further instructions.</span></b>", "Alert", "sound/vox/alert.ogg")
-		SPAWN_DBG(5 SECONDS)
+		SPAWN_DBG(2 MINUTES)
 			command_announcement("<br><b><span class='alert'>The station is under siege by the Syndicate-made object detected earlier. Survive any way possible.</span></b>", "Alert", "sound/vox/alert.ogg")
 			transformation(0)
 

--- a/code/obj/critter/sword.dm
+++ b/code/obj/critter/sword.dm
@@ -1,5 +1,4 @@
 #define SWORD_ATTACKING_RANGE 4
-#define IS_ARRIVALS(x) (istype(x, /area/shuttle/arrival/station) || istype(x, /area/station/crewquarters/cryotron) || istype(x, /area/station/hallway/secondary/oshan_arrivals))
 /* ================================================== */
 /* --- Syndicate Weapon: Orion Retribution Device --- */
 /* ================================================== */
@@ -909,4 +908,3 @@
 		return
 
 #undef SWORD_ATTACKING_RANGE
-#undef IS_ARRIVALS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- No longer targets mobs in arrivals area.
- Clears active target if the target enters arrivals area.
- Abilities cannot affect any mobs, turfs or objects in arrivals area.
- Re-enables the SWORD event on non-RP.

Tested semi-extensively on a number of maps with NPCs. Even if I tried to lure SWORD into arrivals it would sort of naturally move away from there (since it clears targets entering arrivals) by engaging distant targets.

It's worth mentioning that people that are in an arrivals area are _completely_ immune to all of its abilities. This has some potential for cheesing it but I think the chances of this being successful are very low due to the new targeting behavior.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
resolves https://github.com/goonstation/goonstation/issues/5289
