### PR TITLE
Ozy ghostdrone factory solar fake objects

### DIFF
--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -18107,7 +18107,13 @@
 /turf/simulated/floor/neutral,
 /area/station/crew_quarters/market)
 "fch" = (
-/obj/machinery/power/solar,
+/obj/decal/fakeobjects{
+	density = 1;
+	desc = "A solar electrical generator.";
+	icon = 'icons/obj/power.dmi';
+	icon_state = "solar_panel";
+	name = "solar panel"
+	},
 /turf/simulated/floor/airless/solar,
 /area/ghostdrone_factory)
 "fcl" = (
@@ -31768,7 +31774,13 @@
 /turf/simulated/floor,
 /area/station/security/equipment)
 "iJi" = (
-/obj/machinery/power/tracker,
+/obj/decal/fakeobjects{
+	density = 1;
+	desc = "A strange solar tracker. You can't tell if it's operating.";
+	icon = 'icons/obj/power.dmi';
+	icon_state = "tracker";
+	name = "solar tracker"
+	},
 /turf/simulated/floor/airless/solar,
 /area/ghostdrone_factory)
 "iJo" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Replaces solar panels and tracker on the improved Ozy ghostdrone factory with fake objects, eliminating some unnecessary machines and preventing a minor runtime when the tracker would attempt to operate despite nothing to track for.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Keeps Ozy clean in the event it's hauled out for an event, population surge or performance test.
