### PR TITLE
Fixed time stamps on paper.

### DIFF
--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -273,7 +273,7 @@
 	var/obj/O = user.equipped()
 	var/time_type = istype(O, /obj/item/stamp/clown) ? "HONK O'CLOCK" : "SHIFT TIME"
 	var/T = ""
-	T = time_type + ": [time2text(world.timeofday, "DDD DD MMM, hh:mm:ss")]"
+	T = time_type + ": [time2text(world.timeofday, "DD MMM 2053, hh:mm:ss")]"
 
 	// TODO: change this awful array name & stampAssetType
 	var/stamp_assets = list(

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -273,7 +273,7 @@
 	var/obj/O = user.equipped()
 	var/time_type = istype(O, /obj/item/stamp/clown) ? "HONK O'CLOCK" : "SHIFT TIME"
 	var/T = ""
-	T = time_type + ": [time2text(ticker.round_elapsed_ticks, "hh:mm:ss")]"
+	T = time_type + ": [time2text(world.timeofday, "DDD DD MMM, hh:mm:ss")]"
 
 	// TODO: change this awful array name & stampAssetType
 	var/stamp_assets = list(


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][TRIVIAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Paper stamps now properly stamp down the appropriate local time, rather than whatever the heck was happening before. It also now prints the date as well, for the flex. Fixes #4166.
![image](https://user-images.githubusercontent.com/66253095/125950797-64058b4d-8570-4b1f-acfd-9bdd6fe92f30.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Weirdness bad.