### PR TITLE
Removes overly loud "creepy sound" triggers on-station

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -384,7 +384,7 @@ ABSTRACT_TYPE(/area) // don't instantiate this directly dummies, use /area/space
 	proc/pickAmbience()
 		switch(src.name)
 			if ("Chapel") sound_fx_1 = pick('sound/ambience/station/Chapel_FemaleChoir.ogg','sound/ambience/station/Chapel_ChoirTwoNote1.ogg','sound/ambience/station/Chapel_ChoirTwoNote2.ogg','sound/ambience/station/Chapel_HighFemaleSolo.ogg')
-			if ("Morgue") sound_fx_1 = pick('sound/ambience/station/Station_SpookyAtmosphere1.ogg','sound/ambience/station/Station_SpookyAtmosphere2.ogg')
+			//if ("Morgue") sound_fx_1 = pick('sound/ambience/station/Station_SpookyAtmosphere1.ogg','sound/ambience/station/Station_SpookyAtmosphere2.ogg') // spooky shouldn't mean overly loud wailing, replace with something lowkey
 			if ("Jazz Lounge") sound_fx_1 = 'sound/ambience/station/JazzLounge1.ogg'
 			if ("Zen Garden") sound_fx_1 = pick('sound/ambience/station/ZenGarden1.ogg','sound/ambience/station/ZenGarden2.ogg')
 			//if ("Engine Control") sound_fx_1 = pick(ambience_engine)
@@ -396,7 +396,7 @@ ABSTRACT_TYPE(/area) // don't instantiate this directly dummies, use /area/space
 			if ("Biodome South") sound_fx_1 = pick('sound/ambience/nature/Biodome_Bugs.ogg', 'sound/ambience/nature/Biodome_Birds1.ogg', 'sound/ambience/nature/Biodome_Birds2.ogg', 'sound/ambience/nature/Biodome_Monkeys.ogg')
 			if ("Caves") sound_fx_1 = pick('sound/ambience/nature/Cave_Bugs.ogg', 'sound/ambience/nature/Cave_Rumbling.ogg', 'sound/ambience/nature/Cave_Wind1.ogg', 'sound/ambience/nature/Cave_Wind2.ogg', 'sound/ambience/nature/Cave_Drips.ogg')
 			if ("Glacial Abyss") sound_fx_1 = pick('sound/ambience/nature/Glacier_DeepRumbling1.ogg','sound/ambience/nature/Glacier_DeepRumbling1.ogg', 'sound/ambience/nature/Glacier_DeepRumbling1.ogg', 'sound/ambience/nature/Glacier_IceCracking.ogg', 'sound/ambience/nature/Glacier_DeepRumbling1.ogg', 'sound/ambience/nature/Glacier_Scuttling.ogg')
-			if ("AI Satellite Core") sound_fx_1 = pick('sound/ambience/station/Station_SpookyAtmosphere1.ogg','sound/ambience/station/Station_SpookyAtmosphere2.ogg')
+			//if ("AI Satellite Core") sound_fx_1 = pick('sound/ambience/station/Station_SpookyAtmosphere1.ogg','sound/ambience/station/Station_SpookyAtmosphere2.ogg') // same as above
 			if ("The Blind Pig") sound_fx_1 = pick('sound/ambience/spooky/TheBlindPig.ogg','sound/ambience/spooky/TheBlindPig2.ogg')
 			if ("M. Fortuna's House of Fortune") sound_fx_1 = 'sound/ambience/spooky/MFortuna.ogg'
 			#ifdef SUBMARINE_MAP

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -10864,7 +10864,6 @@
 /turf/space,
 /area/space)
 "Ar" = (
-/obj/creepy_sound_trigger,
 /turf/simulated/wall/false_wall/reinforced,
 /area/station/quartermaster/office)
 "As" = (
@@ -12137,7 +12136,7 @@
 /area/station/science/chemistry)
 "DR" = (
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Research Wing";
+	name = "Research Wing"
 	},
 /obj/access_spawn/research,
 /obj/firedoor_spawn,

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -2025,7 +2025,6 @@
 /area/station/crew_quarters/clown)
 "age" = (
 /obj/decal/cleanable/dirt,
-/obj/creepy_sound_trigger,
 /obj/item/bananapeel,
 /obj/cable{
 	icon_state = "1-2"
@@ -5316,7 +5315,6 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/creepy_sound_trigger,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -19272,13 +19270,6 @@
 "aXE" = (
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/east)
-"aXF" = (
-/obj/creepy_sound_trigger,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aXG" = (
 /obj/disposalpipe/trunk{
@@ -122557,7 +122548,7 @@ aTN
 aVb
 bcg
 aXN
-aXF
+bbH
 aYP
 baE
 bbG

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -53589,7 +53589,6 @@
 "uDz" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/decal/cleanable/dirt,
-/obj/creepy_sound_trigger,
 /obj/item/bananapeel,
 /obj/machinery/door/airlock/gannets/maintenance,
 /obj/cable{

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -3936,7 +3936,6 @@
 /area/station/hallway/primary/west)
 "aOO" = (
 /obj/decal/cleanable/dirt,
-/obj/creepy_sound_trigger,
 /turf/simulated/floor/sanitary/blue,
 /area/station/medical/asylum/bathroom)
 "aOR" = (
@@ -23067,7 +23066,6 @@
 	desc = "What the fuck is blocking this thing up, and more importantly why does it have so much water?!";
 	name = "ungodly clogged toilet"
 	},
-/obj/creepy_sound_trigger,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "gwX" = (
@@ -72287,10 +72285,6 @@
 	},
 /turf/simulated/floor/wood/six,
 /area/station/library)
-"uXr" = (
-/obj/creepy_sound_trigger,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/north)
 "uXw" = (
 /obj/railing/orange,
 /obj/decal/cleanable/dirt/jen,
@@ -78557,7 +78551,6 @@
 /turf/simulated/floor/wood/two,
 /area/station/crew_quarters/bathroom)
 "wNq" = (
-/obj/creepy_sound_trigger,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
 "wNv" = (
@@ -127077,7 +127070,7 @@ cWr
 brv
 xvR
 cWr
-uXr
+jnB
 jnB
 ixW
 tOJ

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -38193,7 +38193,6 @@
 /turf/simulated/floor/engine/vacuum,
 /area/research_outpost/indigo_rye)
 "cjg" = (
-/obj/creepy_sound_trigger,
 /obj/cable{
 	d1 = 1;
 	d2 = 2;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR and why it's needed!<!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
These sound triggers (the one you'll recognize is the extremely loud weee wooo one just south of the chapel on Cog1) are rather out of place in the station. They trigger every time you enter a specific area, and one of the sounds used is a minute(!) long, which continues on well past the time you've spent in the area. Aside from them being overly loud, they don't really do anything except jumpscare people new to the station, and aren't connected to any important event. Note: ghosts also activate these triggers.

Going forward I'd like overt environmental ambiance to actually be connected to things caused by players rather than existing for the sake of it. Soft background ambiance like some of the other classic and excellent audio used already is great for the station, but loud jumpscares are not. This PR doesn't touch any triggers off of station z-levels.