### PR TITLE
Allows traitor captains to buy boom boots.

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -486,7 +486,7 @@ This is basically useless for anyone but miners.
 	cost = 12
 	vr_allowed = 0
 	desc = "These big red boots have an explosive step sound. The entire station is sure to want to show you their appreciation."
-	job = list("Clown")
+	job = list("Clown", "Captain")
 	not_in_crates = 1
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows traitor captains to purchase boom boots.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Boom boots are the perfect joke traitor item for caps and its a shame its clown only.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)Traitor captains can buy boom boots
```
