### PR TITLE
Triples vamp "retreat to coffin" projectile max speed

### DIFF
--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -636,7 +636,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	icon_state = "vamp_travel"
 	auto_find_targets = 0
 	max_speed = 6
-	start_speed = 0.5
+	start_speed = 0.1
 
 
 	shot_sound = "sound/effects/mag_phase.ogg"

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -635,7 +635,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	name = "mysterious mystery mist"
 	icon_state = "vamp_travel"
 	auto_find_targets = 0
-	max_speed = 2
+	max_speed = 5
 	start_speed = 0.1
 
 

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -635,8 +635,8 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	name = "mysterious mystery mist"
 	icon_state = "vamp_travel"
 	auto_find_targets = 0
-	max_speed = 5
-	start_speed = 0.1
+	max_speed = 6
+	start_speed = 0.5
 
 
 	shot_sound = "sound/effects/mag_phase.ogg"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The 'recall to coffin' ability kinda sucks right now because people can follow you with relative ease. This makes it nice and speedy so you have some time to escape, even if your pursuers get a general idea of where you are.
Also, MBC's request.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
see above

```changelog
(u)Asche
(+)Made the vampire "Retreat to Coffin" ability a lot speedier
```
