### PR TITLE
Fixes observers being affected by mass drivers and cargo routers

### DIFF
--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -46,7 +46,7 @@
 		playsound(src, "sound/effects/pump.ogg",50, 1)
 		SPAWN_DBG(0.3 SECONDS)
 			for(var/atom/movable/AM in src.loc)
-				if(AM.anchored || AM == src || isobserver(AM)) continue
+				if(AM.anchored || AM == src || isobserver(AM) || isintangible(AM)) continue
 				if(trash && AM.delivery_destination != "Disposals")
 					AM.delivery_destination = "Disposals"
 				step(AM,src.dir)
@@ -80,7 +80,7 @@
 		if(!operating && !driver_operating)
 			var/drive = 0
 			for(var/atom/movable/M in src.loc)
-				if(M == src || M.anchored || isobserver(M)) continue
+				if(M == src || M.anchored || isobserver(M) || isintangible(M)) continue
 				drive = 1
 				break
 			if(drive) activate()
@@ -125,7 +125,7 @@
 
 	proc/get_next_dir()
 		for(var/atom/movable/AM in src.loc)
-			if(AM.anchored || AM == src || isobserver(AM)) continue
+			if(AM.anchored || AM == src || isobserver(AM) || isintangible(AM)) continue
 			if(AM.delivery_destination)
 				if(destinations.Find(AM.delivery_destination))
 					return destinations[AM.delivery_destination]
@@ -150,7 +150,7 @@
 
 		SPAWN_DBG(0.3 SECONDS)
 			for(var/atom/movable/AM2 in src.loc)
-				if(AM2.anchored || AM2 == src || isobserver(AM2)) continue
+				if(AM2.anchored || AM2 == src || isobserver(AM2) || isintangible(AM2)) continue
 				step(AM2,src.dir)
 
 			driver = (locate(/obj/machinery/mass_driver) in get_step(src,src.dir))
@@ -174,7 +174,7 @@
 		if(!operating && !driver_operating)
 			var/drive = 0
 			for(var/atom/movable/M in src.loc)
-				if(M == src || M.anchored || isobserver(M)) continue
+				if(M == src || M.anchored || isobserver(M) || isintangible(M)) continue
 				drive = 1
 				break
 			if(drive) activate()

--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -46,7 +46,7 @@
 		playsound(src, "sound/effects/pump.ogg",50, 1)
 		SPAWN_DBG(0.3 SECONDS)
 			for(var/atom/movable/AM in src.loc)
-				if(AM.anchored || AM == src) continue
+				if(AM.anchored || AM == src || isobserver(AM)) continue
 				if(trash && AM.delivery_destination != "Disposals")
 					AM.delivery_destination = "Disposals"
 				step(AM,src.dir)
@@ -80,7 +80,7 @@
 		if(!operating && !driver_operating)
 			var/drive = 0
 			for(var/atom/movable/M in src.loc)
-				if(M == src || M.anchored) continue
+				if(M == src || M.anchored || isobserver(M)) continue
 				drive = 1
 				break
 			if(drive) activate()
@@ -125,7 +125,7 @@
 
 	proc/get_next_dir()
 		for(var/atom/movable/AM in src.loc)
-			if(AM.anchored || AM == src) continue
+			if(AM.anchored || AM == src || isobserver(AM)) continue
 			if(AM.delivery_destination)
 				if(destinations.Find(AM.delivery_destination))
 					return destinations[AM.delivery_destination]
@@ -150,7 +150,7 @@
 
 		SPAWN_DBG(0.3 SECONDS)
 			for(var/atom/movable/AM2 in src.loc)
-				if(AM2.anchored || AM2 == src) continue
+				if(AM2.anchored || AM2 == src || isobserver(AM2)) continue
 				step(AM2,src.dir)
 
 			driver = (locate(/obj/machinery/mass_driver) in get_step(src,src.dir))
@@ -174,7 +174,7 @@
 		if(!operating && !driver_operating)
 			var/drive = 0
 			for(var/atom/movable/M in src.loc)
-				if(M == src || M.anchored) continue
+				if(M == src || M.anchored || isobserver(M)) continue
 				drive = 1
 				break
 			if(drive) activate()

--- a/code/obj/machinery/mass_driver.dm
+++ b/code/obj/machinery/mass_driver.dm
@@ -19,7 +19,7 @@
 	var/O_limit
 	var/atom/target = get_edge_target_turf(src, src.dir)
 	for(var/atom/movable/O in src.loc)
-		if(O.anchored || isobserver(O)) continue
+		if(O.anchored || isobserver(O) || isintangible(O)) continue
 		O_limit++
 		if(O_limit >= 20)
 			for(var/mob/M in hearers(src, null))

--- a/code/obj/machinery/mass_driver.dm
+++ b/code/obj/machinery/mass_driver.dm
@@ -19,13 +19,13 @@
 	var/O_limit
 	var/atom/target = get_edge_target_turf(src, src.dir)
 	for(var/atom/movable/O in src.loc)
-		if(!O.anchored)
-			O_limit++
-			if(O_limit >= 20)
-				for(var/mob/M in hearers(src, null))
-					boutput(M, "<span class='notice'>The mass driver lets out a screech, it mustn't be able to handle any more items.</span>")
-				break
-			use_power(500)
-			O.throw_at(target, drive_range * src.power, src.power)
+		if(O.anchored || isobserver(O)) continue
+		O_limit++
+		if(O_limit >= 20)
+			for(var/mob/M in hearers(src, null))
+				boutput(M, "<span class='notice'>The mass driver lets out a screech, it mustn't be able to handle any more items.</span>")
+			break
+		use_power(500)
+		O.throw_at(target, drive_range * src.power, src.power)
 	flick("mass_driver1", src)
 	return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Observers (including the AI eye) are no longer affected by mass drivers and cargo routers, including the mass driver loader.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugfix
fixes https://github.com/goonstation/goonstation/issues/5100