### PR TITLE
Makes syndicate scanner be able to replicate ValuChimp's

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2161,9 +2161,10 @@
 	icon_panel = "standard-panel"
 	// monkey vendor has slightly special broken/etc sprites so it doesn't just inherit the standard set  :)
 	acceptcard = 0
-	mats = 0 // >:I
+	mats = list("MET-1"=5, "CON-1"=5, "viscerite"=20)
 	slogan_list = list("My monkeys are too strong for you, traveler!")
 	slogan_chance = 1
+	is_syndicate = 1
 
 	light_r =1
 	light_g = 0.88


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
At a cost of 5 Met-1 5 Con-1 and 20 viscerite, a new valuchimp can be made using the syndicate scanner.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Offers another unique way for mechanics to kill the station by flooding it with goods.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+) Syndicate scanner can now replicate ValuChimps.
```
