### PR TITLE
Fix selling stacked items to NPC traders

### DIFF
--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -322,10 +322,9 @@
 					doing_a_thing = 1
 					src.temp = pick(src.successful_sale_dialogue) + "<BR>"
 					src.temp += "<BR><A href='?src=\ref[src];sell=1'>OK</A>"
-					var/price = tradetype.price * src.sellitem.amount
+					account.fields["current_money"] += tradetype.price * src.sellitem.amount
 					qdel (src.sellitem)
 					src.sellitem = null
-					account.fields["current_money"] += price
 					src.add_fingerprint(usr)
 					src.updateUsrDialog()
 					doing_a_thing = 0

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -322,9 +322,10 @@
 					doing_a_thing = 1
 					src.temp = pick(src.successful_sale_dialogue) + "<BR>"
 					src.temp += "<BR><A href='?src=\ref[src];sell=1'>OK</A>"
+					var/price = tradetype.price * src.sellitem.amount
 					qdel (src.sellitem)
 					src.sellitem = null
-					account.fields["current_money"] += tradetype.price
+					account.fields["current_money"] += price
 					src.add_fingerprint(usr)
 					src.updateUsrDialog()
 					doing_a_thing = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes selling stacked items to NPC traders. The income received is now multiplied by the number of items in the stack.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stacked items were selling as if they were single items. Fixes #5396.
