### PR TITLE
Fix large headband/headset combo sprites

### DIFF
--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -1338,6 +1338,7 @@ ABSTRACT_TYPE(/obj/item/clothing/head/headband)
 			H.name = src.name
 			H.icon_state = src.icon_state
 			H.wear_image_icon = src.wear_image_icon
+			H.wear_image = src.wear_image
 			H.desc = "Aww, cute and fuzzy. Someone has taped a radio headset onto the headband."
 			qdel(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes an image reference on radio/headband combining code which made some of the resulting headsets (the large ones in `bighat.dmi`) invisible on your mob.

(They were displaying right on severed heads though, which makes me wonder if we need `wear_image` at all but that's not for this PR)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I put my headset in antlers and then got sad