### PR TITLE
Add ref and JSON inputs to various var input prompts

### DIFF
--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -2291,7 +2291,7 @@ Returns:
 		var/list/listargs = list()
 
 		for(var/i=0, i<argnum, i++)
-			var/class = input("Type of Argument #[i]","Variable Type", null) in list("text","num","type","reference","mob reference", "icon","file", "*triggering object*","cancel")
+			var/class = input("Type of Argument #[i]","Variable Type", null) in list("text","num","type","json","ref","reference","mob reference", "icon","file", "*triggering object*","cancel")
 			switch(class)
 				if("-cancel-")
 					return
@@ -2307,6 +2307,15 @@ Returns:
 
 				if("type")
 					listargs += input("Enter type:","Type", null) in typesof(/obj,/mob,/area,/turf)
+
+				if("json")
+					listargs += list(json_decode(input("Enter json:") as null|text))
+
+				if ("ref")
+					var/input = input("Enter ref:") as null|text
+					var/ref_target = locate(input)
+					if (!ref_target) ref_target = locate("\[[input]\]")
+					listargs += ref_target
 
 				if("reference")
 					listargs += input("Select reference:","Reference", null) as mob|obj|turf|area in world

--- a/code/modules/admin/debug.dm
+++ b/code/modules/admin/debug.dm
@@ -203,7 +203,7 @@ var/global/debug_messages = 0
 		var/list/listargs = list()
 
 		for(var/i=0, i<argnum, i++)
-			var/class = input("Type of Argument #[i]","Variable Type", null) in list("text","num","type","reference","mob reference","reference atom at current turf","icon","file","-cancel-")
+			var/class = input("Type of Argument #[i]","Variable Type", null) in list("text","num","type","json","ref","reference","mob reference","reference atom at current turf","icon","file","-cancel-")
 			switch(class)
 				if("-cancel-")
 					return
@@ -216,6 +216,15 @@ var/global/debug_messages = 0
 
 				if("type")
 					listargs += input("Enter type:","Type", null) in null|typesof(/obj,/mob,/area,/turf)
+
+				if("json")
+					listargs += list(json_decode(input("Enter json:") as null|text))
+
+				if ("ref")
+					var/input = input("Enter ref:") as null|text
+					var/target = locate(input)
+					if (!target) target = locate("\[[input]\]")
+					listargs += target
 
 				if("reference")
 					listargs += input("Select reference:","Reference", null) as null|mob|obj|turf|area in world
@@ -343,7 +352,7 @@ var/global/debug_messages = 0
 	if (!argnum)
 		return listargs
 	for (var/i=0, i<argnum, i++)
-		var/class = input("Type of Argument #[i]","Variable Type", null) as null|anything in list("text","num","type","ref","reference","mob reference","reference atom at current turf","icon","color","file","the turf of which you are on top of right now")
+		var/class = input("Type of Argument #[i]","Variable Type", null) as null|anything in list("text","num","type","json","ref","reference","mob reference","reference atom at current turf","icon","color","file","the turf of which you are on top of right now")
 		if(!class)
 			break
 		switch(class)
@@ -362,6 +371,9 @@ var/global/debug_messages = 0
 					var/match = get_one_match(typename, /datum, use_concrete_types = FALSE)
 					if (match)
 						listargs += match
+
+			if("json")
+				listargs += list(json_decode(input("Enter json:") as null|text))
 
 			if ("ref")
 				var/input = input("Enter ref:") as null|text

--- a/code/modules/admin/modifyvariables.dm
+++ b/code/modules/admin/modifyvariables.dm
@@ -39,7 +39,7 @@
 
 /client/proc/mod_list_add_ass(var/list/L, var/index) //haha
 	var/class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-	"num", "type", "reference", "mob reference", "turf by coordinates", "reference picker", "new instance of a type", "icon", "file", "color")
+	"num", "type", "json", "ref", "reference", "mob reference", "turf by coordinates", "reference picker", "new instance of a type", "icon", "file", "color")
 
 	if (!class)
 		return
@@ -59,6 +59,15 @@
 
 		if ("type")
 			var_value = input("Enter type:","Type") in null|typesof(/obj,/mob,/area,/turf)
+
+		if("json")
+			var_value = json_decode(input("Enter json:") as null|text)
+
+		if ("ref")
+			var/input = input("Enter ref:") as null|text
+			var/target = locate(input)
+			if (!target) target = locate("\[[input]\]")
+			var_value = target
 
 		if ("reference")
 			var_value = input("Select reference:","Reference") as null|mob|obj|turf|area in world
@@ -115,7 +124,7 @@
 
 /client/proc/mod_list_add(var/list/L)
 	var/class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-	"num", "type", "reference", "mob reference", "turf by coordinates", "reference picker", "new instance of a type", "icon", "file", "color")
+	"num", "type", "json", "type", "reference", "mob reference", "turf by coordinates", "reference picker", "new instance of a type", "icon", "file", "color")
 
 	if (!class)
 		return
@@ -135,6 +144,15 @@
 
 		if ("type")
 			var_value = input("Enter type:","Type") in null|typesof(/obj,/mob,/area,/turf)
+
+		if("json")
+			var_value = json_decode(input("Enter json:") as null|text)
+
+		if ("ref")
+			var/input = input("Enter ref:") as null|text
+			var/target = locate(input)
+			if (!target) target = locate("\[[input]\]")
+			var_value = target
 
 		if ("reference")
 			var_value = input("Select reference:","Reference") as null|mob|obj|turf|area in world
@@ -185,12 +203,16 @@
 
 	if (!var_value) return
 
-	switch(alert("Would you like to associate a var with the list entry?",,"Yes","No"))
-		if("Yes")
-			L += var_value
-			L[var_value] = mod_list_add_ass(L, var_value) //haha
-		if("No")
-			L += var_value
+	if (islist(var_value))
+		//embed the list inside rather than combining the two
+		L += list(var_value)
+	else
+		switch(alert("Would you like to associate a var with the list entry?",,"Yes","No"))
+			if("Yes")
+				L += var_value
+				L[var_value] = mod_list_add_ass(L, var_value) //haha
+			if("No")
+				L += var_value
 
 
 /client/proc/mod_list(var/list/L)
@@ -297,7 +319,7 @@
 			boutput(usr, "If a direction, direction is: [dir]")
 
 	var/class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-		"num","type","reference","mob reference","turf by coordinates","reference picker","new instance of a type", "icon","file","color","list","number","edit referenced object", default == "associated" ? "associated" : null, "(DELETE FROM LIST)","restore to default")
+		"num","type","json","ref","reference","mob reference","turf by coordinates","reference picker","new instance of a type", "icon","file","color","list","number","edit referenced object", default == "associated" ? "associated" : null, "(DELETE FROM LIST)","restore to default")
 
 	if(!class)
 		return
@@ -335,6 +357,15 @@
 				var/match = get_one_match(typename, /datum, use_concrete_types = FALSE)
 				if (match)
 					L[variable_index] = match
+
+		if("json")
+			L[variable_index] = json_decode(input("Enter json:") as null|text)
+
+		if ("ref")
+			var/input = input("Enter ref:") as null|text
+			var/target = locate(input)
+			if (!target) target = locate("\[[input]\]")
+			L[variable_index] = target
 
 		if("reference")
 			L[variable_index] = input("Select reference:","Reference",\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds ref and JSON inputs to several input prompts that did not have them, creating lists / associated lists, proc call adventure object args, and proc call argument props
* In some cases the JSON input gets wrapped in `list()` - this is to embed the list within another to avoid adding them together

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Required for more advanced admin gimmicks
* Using ref values makes my life easier for complex var editing and proc calling ingame
* ![image](https://user-images.githubusercontent.com/33204415/126012707-c1d22422-5248-4745-8afd-dd9c1d77136b.png)
