### PR TITLE
Adds the purple hairbow to the Clothing Booth

### DIFF
--- a/code/modules/vending/clothingbooth_items.dm
+++ b/code/modules/vending/clothingbooth_items.dm
@@ -81,6 +81,10 @@ ABSTRACT_TYPE(/datum/clothingbooth_item/accessory/hbow)
 	navy
 		name = "Navy Hair Bow"
 		path = /obj/item/clothing/head/hairbow/navy
+	
+	purple
+		name = "Purple Hair Bow"
+		path = /obj/item/clothing/head/hairbow/purple
 
 	shinyblack
 		name = "Shiny Black Hair Bow"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug-minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When the hairbows were changed to an abstract type while being added to the clothing booth, the purple one was missed. This just re-adds it. The item and sprite are already present.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sometimes you want to wear a hairbow and you want it to be purple.

