### PR TITLE
Transmissions to Central Command now play the announcement sound

### DIFF
--- a/code/modules/networks/computer3/comm_dish.dm
+++ b/code/modules/networks/computer3/comm_dish.dm
@@ -80,7 +80,8 @@
 				src.link.post_signal(src, signal)
 
 		transmit_to_centcom(var/title, var/message, var/user)
-			command_alert(message, title, override_big_title="Transmission to Central Command")
+			var/sound_to_play = "sound/misc/announcement_1.ogg"
+			command_alert(message, title, sound_to_play, override_big_title="Transmission to Central Command")
 			message_admins("[user ? user : "Someone"] sent a message to Central Command:<br>[title]<br><br>[message]")
 			var/ircmsg[] = new()
 			ircmsg["msg"] = "[user ? user : "Unknown"] sent a message to Central Command:\n**[title]**\n[message]"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added argument `sound_to_play` to the `command_alert` call in the `transmit_to_centcom` proc. The sound it plays is `sound/misc/announcement_1.ogg`, like all other station announcements.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It just feels... right.