### PR TITLE
Fix hat blacklist

### DIFF
--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -13,12 +13,17 @@
 	block_vision = 0
 	var/path_prot = 1 // protection from airborne pathogens, multiplier for chance to be infected
 	var/team_num
+	var/blocked_from_petasusaphilic = FALSE //Replacing the global blacklist
 
 	setupProperties()
 		..()
 		setProperty("coldprot", 10)
 		setProperty("heatprot", 5)
 		setProperty("meleeprot_head", 1)
+
+proc/filter_trait_hats(var/type)
+	var/obj/item/clothing/head/coolhat = type
+	return !initial(coolhat.blocked_from_petasusaphilic)
 
 /obj/item/clothing/head/red
 	desc = "A knit cap in red."
@@ -891,6 +896,7 @@
 	wear_image_icon = 'icons/mob/bighat.dmi'
 	icon_state = "tophat"
 	w_class = W_CLASS_BULKY
+	blocked_from_petasusaphilic = TRUE
 
 /obj/item/clothing/head/bighat/syndicate
 	name = "syndicate hat"
@@ -1458,6 +1464,7 @@ ABSTRACT_TYPE(/obj/item/clothing/head/barrette)
 	wear_image_icon = 'icons/mob/head.dmi'
 	icon_state = "barrette-blue"
 	item_state = "barrette-blue"
+	blocked_from_petasusaphilic = TRUE
 	w_class = W_CLASS_TINY
 	throwforce = 0
 

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -213,6 +213,7 @@
 	desc = "The standard space helmet of the dreaded Syndicate."
 	item_function_flags = IMMUNE_TO_ACID
 	team_num = TEAM_SYNDICATE
+	blocked_from_petasusaphilic = TRUE
 	#ifdef MAP_OVERRIDE_POD_WARS
 	attack_hand(mob/user)
 		if (get_pod_wars_team_num(user) == team_num)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -600,7 +600,7 @@
 	else if (src.traitHolder && src.traitHolder.hasTrait("loyalist"))
 		trinket = new/obj/item/clothing/head/NTberet(src)
 	else if (src.traitHolder && src.traitHolder.hasTrait("petasusaphilic"))
-		var/picked = pick(concrete_typesof(/obj/item/clothing/head) - hat_blacklist)
+		var/picked = pick(filtered_concrete_typesof(/obj/item/clothing/head, /proc/filter_trait_hats))
 		trinket = new picked(src)
 	else if (src.traitHolder && src.traitHolder.hasTrait("conspiracytheorist"))
 		trinket = new/obj/item/clothing/head/tinfoil_hat
@@ -781,10 +781,3 @@ var/list/trinket_safelist = list(/obj/item/basketball,/obj/item/instrument/bikeh
 /obj/item/toy/plush/small/bee, /obj/item/paper/book/from_file/the_trial, /obj/item/paper/book/from_file/deep_blue_sea, /obj/item/clothing/suit/bedsheet/cape/red, /obj/item/disk/data/cartridge/clown,
 /obj/item/clothing/mask/cigarette/cigar, /obj/item/device/light/sparkler, /obj/item/toy/sponge_capsule, /obj/item/reagent_containers/food/snacks/plant/pear, /obj/item/reagent_containers/food/snacks/donkpocket/honk/warm,
 /obj/item/seed/alien)
-
-
-
-////////////////////////////////////
-// hat blacklist for trinket hats //
-////////////////////////////////////
-var/list/hat_blacklist = typesof(/obj/item/clothing/head/bighat, /obj/item/clothing/head/helmet/space/syndicate, /obj/item/clothing/head/barrette)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -787,4 +787,4 @@ var/list/trinket_safelist = list(/obj/item/basketball,/obj/item/instrument/bikeh
 ////////////////////////////////////
 // hat blacklist for trinket hats //
 ////////////////////////////////////
-var/list/hat_blacklist = list(typesof(/obj/item/clothing/head/bighat, /obj/item/clothing/head/helmet/space/syndicate, /obj/item/clothing/head/barrette))
+var/list/hat_blacklist = typesof(/obj/item/clothing/head/bighat, /obj/item/clothing/head/helmet/space/syndicate, /obj/item/clothing/head/barrette)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the hat blacklist being ~~a list of a list~~ a thing and does the same functionality via a var on hats.

To test I spawned a total of 300 hats with the same logic petasusaphilic has and didn't see any blacklisted hats.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #5553