### PR TITLE
Fixes clothing booth breaking when the occupant is teleported out

### DIFF
--- a/code/modules/vending/clothingbooth.dm
+++ b/code/modules/vending/clothingbooth.dm
@@ -173,10 +173,6 @@ var/list/clothingbooth_items = list()
 		return
 	if(!(user in range(1,src)))
 		return
-	if((src.open == 0) && !(locate(/mob) in src))//Booth is closed but no one is inside
-		src.set_open(1)
-		user.visible_message("<span class='alert'>You pull back the curtain to find... the booth empty. How strange.</span>")
-		return
 	if((src.open == 1)&&(!user.stat))
 		user.set_loc(src.loc)
 		src.set_open(0)
@@ -208,3 +204,6 @@ var/list/clothingbooth_items = list()
 
 		else
 			boutput(user, "<span class='alert'>Someone is already working up the nerve to pull the ouccupant out.</span>")
+
+/obj/machinery/clothingbooth/Exited(mob/user as mob)
+	src.set_open(1)

--- a/code/modules/vending/clothingbooth.dm
+++ b/code/modules/vending/clothingbooth.dm
@@ -205,5 +205,5 @@ var/list/clothingbooth_items = list()
 		else
 			boutput(user, "<span class='alert'>Someone is already working up the nerve to pull the ouccupant out.</span>")
 
-/obj/machinery/clothingbooth/Exited(mob/user as mob)
+/obj/machinery/clothingbooth/Exited()
 	src.set_open(1)

--- a/code/modules/vending/clothingbooth.dm
+++ b/code/modules/vending/clothingbooth.dm
@@ -173,6 +173,10 @@ var/list/clothingbooth_items = list()
 		return
 	if(!(user in range(1,src)))
 		return
+	if((src.open == 0) && !(locate(/mob) in src))//Booth is closed but no one is inside
+		src.set_open(1)
+		user.visible_message("<span class='alert'>You pull back the curtain to find... the booth empty. How strange.</span>")
+		return
 	if((src.open == 1)&&(!user.stat))
 		user.set_loc(src.loc)
 		src.set_open(0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If the person using a clothing booth is teleported out for any reason, the clothing booth resets to its open state.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5552. When a recaller artifact pulled someone out of the clothing booth, it prevented it from being used again.
