### PR TITLE
Fixes a couple improperly formatted logTheThings with paper

### DIFF
--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -239,6 +239,7 @@
 				// the javascript was modified, somehow, outside of
 				// byond.  but right now we are logging it as
 				// the generated html might get beyond this limit
+				logTheThing("debug", src, null, "PAPER: [key_name(ui.user)] writing to paper [name], and overwrote it by [paper_len-PAPER_MAX_LENGTH]")
 			if(paper_len == 0)
 				boutput(ui.user, pick("Writing block strikes again!", "You forgot to write anthing!"))
 			else

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -239,11 +239,9 @@
 				// the javascript was modified, somehow, outside of
 				// byond.  but right now we are logging it as
 				// the generated html might get beyond this limit
-				logTheThing("PAPER: [key_name(ui.user)] writing to paper [name], and overwrote it by [paper_len-PAPER_MAX_LENGTH]")
 			if(paper_len == 0)
 				boutput(ui.user, pick("Writing block strikes again!", "You forgot to write anthing!"))
 			else
-				logTheThing("PAPER: [key_name(ui.user)] writing to paper [name]")
 				if(info != in_paper)
 					boutput(ui.user, "You write on \the [src]!");
 					info = in_paper


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug] [trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
These two logTheThing calls in paper.dm were missing some args, so the entire message was used as the type.
Paper is still logged via TGUI logging, so nothing much is lost by removing the second one outright.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Minor annoyance when viewing logs. 