### PR TITLE
Adds food processor + mixer to fortuna, NT Base, and Syndicate base

### DIFF
--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -7425,7 +7425,7 @@
 "BL" = (
 /obj/wingrille_spawn/crystal/full,
 /turf/unsimulated/floor/plating,
-/area/space)
+/area/pod_wars/team2/bar)
 "BM" = (
 /obj/machinery/r_door_control/podbay/t2d1/new_walls/west,
 /turf/unsimulated/floor/shuttlebay,
@@ -12333,9 +12333,6 @@
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/fstation/computercore)
-"Vd" = (
-/turf/unsimulated/wall/auto/reinforced/supernorn,
-/area/space)
 "Ve" = (
 /obj/table/auto,
 /obj/machinery/recharger{
@@ -182244,7 +182241,7 @@ JW
 JW
 JW
 JW
-JW
+Fh
 Fh
 Fh
 Fh
@@ -182743,8 +182740,8 @@ JW
 JW
 JW
 JW
-JW
-JW
+Fh
+Fh
 Fh
 Fh
 Fh
@@ -183243,10 +183240,10 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
+Fh
+Fh
+Fh
+Fh
 Fh
 Fh
 Fh
@@ -183745,10 +183742,10 @@ JW
 JW
 JW
 JW
-JW
-JW
-JW
-JW
+Fh
+Fh
+Fh
+Fh
 Fh
 Fh
 Fh
@@ -242487,7 +242484,7 @@ zX
 fN
 UX
 zX
-tt
+xT
 xT
 xT
 Dh
@@ -246506,7 +246503,7 @@ mm
 nG
 hA
 oo
-Vd
+oo
 JW
 JW
 JW

--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -2029,6 +2029,12 @@
 "hz" = (
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation/secdock)
+"hA" = (
+/obj/machinery/vending/kitchen{
+	req_access_txt = null
+	},
+/turf/unsimulated/floor/specialroom/bar,
+/area/pod_wars/team2/power)
 "hB" = (
 /turf/unsimulated/floor/red/side{
 	dir = 10
@@ -2387,6 +2393,13 @@
 /obj/machinery/vending/cola/blue,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
+"jc" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1;
+	pixel_y = -4
+	},
+/turf/unsimulated/floor/specialroom/bar,
+/area/pod_wars/team1/bar)
 "jf" = (
 /obj/machinery/computer/announcement{
 	name = "Nanotrasen Announcement Computer";
@@ -3161,6 +3174,10 @@
 	dir = 10
 	},
 /area/pod_wars/team2/mining)
+"mm" = (
+/obj/machinery/chem_dispenser/soda,
+/turf/unsimulated/floor/specialroom/bar,
+/area/pod_wars/team2/power)
 "mo" = (
 /obj/storage/crate,
 /obj/random_item_spawner/desk_stuff/maybe_few,
@@ -3526,6 +3543,11 @@
 	dir = 4
 	},
 /area/pod_wars/team1/bridge)
+"nG" = (
+/obj/machinery/chem_dispenser/alcohol,
+/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/turf/unsimulated/floor/specialroom/bar,
+/area/pod_wars/team2/power)
 "nH" = (
 /obj/grille/catwalk{
 	dir = 1
@@ -4729,6 +4751,11 @@
 	},
 /turf/space,
 /area/pod_wars/team2/power)
+"rR" = (
+/obj/table/reinforced/bar/auto,
+/obj/submachine/mixer,
+/turf/unsimulated/floor/specialroom/bar,
+/area/pod_wars/team1/bar)
 "rS" = (
 /obj/machinery/shuttle/engine/propulsion{
 	dir = 8;
@@ -5618,10 +5645,6 @@
 	dir = 10
 	},
 /area/pod_wars/spacejunk/restaurant)
-"vn" = (
-/obj/machinery/chem_dispenser/soda,
-/turf/unsimulated/floor/specialroom/bar,
-/area/pod_wars/team2/bar)
 "vo" = (
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_28)
@@ -5649,6 +5672,12 @@
 	dir = 4
 	},
 /area/pod_wars/team2/central_hallway)
+"vt" = (
+/obj/submachine/foodprocessor{
+	dir = 1
+	},
+/turf/unsimulated/floor/specialroom/bar,
+/area/pod_wars/team2/bar)
 "vu" = (
 /obj/grille/catwalk{
 	dir = 5;
@@ -6294,6 +6323,8 @@
 /turf/unsimulated/floor/white,
 /area/pod_wars/team1/medbay)
 "xy" = (
+/obj/submachine/mixer,
+/obj/table/auto,
 /turf/simulated/floor/green/side{
 	dir = 10
 	},
@@ -7391,6 +7422,10 @@
 	dir = 6
 	},
 /area/pod_wars/spacejunk/fstation/mess)
+"BL" = (
+/obj/wingrille_spawn/crystal/full,
+/turf/unsimulated/floor/plating,
+/area/space)
 "BM" = (
 /obj/machinery/r_door_control/podbay/t2d1/new_walls/west,
 /turf/unsimulated/floor/shuttlebay,
@@ -10203,8 +10238,9 @@
 	},
 /area/pod_wars/spacejunk/miningoutpost)
 "MT" = (
-/obj/wingrille_spawn/crystal/full,
-/turf/unsimulated/floor/plating,
+/obj/table/reinforced/bar/auto,
+/obj/submachine/mixer,
+/turf/unsimulated/floor/specialroom/bar,
 /area/pod_wars/team2/bar)
 "MU" = (
 /turf/simulated/floor/green/side{
@@ -11869,6 +11905,7 @@
 	},
 /area/pod_wars/team2/central_hallway)
 "Tt" = (
+/obj/submachine/foodprocessor,
 /turf/simulated/floor/green/side,
 /area/pod_wars/spacejunk/fstation/mess)
 "Tu" = (
@@ -12296,6 +12333,9 @@
 	},
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/fstation/computercore)
+"Vd" = (
+/turf/unsimulated/wall/auto/reinforced/supernorn,
+/area/space)
 "Ve" = (
 /obj/table/auto,
 /obj/machinery/recharger{
@@ -12680,6 +12720,11 @@
 	dir = 1
 	},
 /area/pod_wars/spacejunk/uvb67/central)
+"WC" = (
+/obj/machinery/light/incandescent/netural,
+/obj/submachine/foodprocessor,
+/turf/unsimulated/floor/specialroom/bar,
+/area/pod_wars/team1/bar)
 "WG" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -12948,12 +12993,6 @@
 /obj/machinery/manufacturer/medical/pod_wars,
 /turf/unsimulated/floor/white,
 /area/pod_wars/team2/medbay)
-"XI" = (
-/obj/machinery/vending/kitchen{
-	req_access_txt = null
-	},
-/turf/unsimulated/floor/specialroom/bar,
-/area/pod_wars/team2/bar)
 "XJ" = (
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/dorgun)
@@ -13020,11 +13059,6 @@
 /obj/landmark/start/latejoin,
 /turf/simulated/floor/purple,
 /area/pod_wars/spacejunk/fstation/crewquarters)
-"XZ" = (
-/obj/machinery/chem_dispenser/alcohol,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
-/turf/unsimulated/floor/specialroom/bar,
-/area/pod_wars/team2/bar)
 "Ya" = (
 /obj/storage/secure/closet/fridge,
 /obj/item/reagent_containers/food/snacks/ingredient/cheese,
@@ -53298,7 +53332,7 @@ no
 wB
 Xt
 yx
-yx
+jc
 Tc
 wX
 mB
@@ -53793,7 +53827,7 @@ JW
 kn
 Mt
 Fk
-dX
+WC
 yx
 IC
 eV
@@ -55300,7 +55334,7 @@ JW
 JW
 Fk
 Fk
-yx
+rR
 hT
 dt
 yx
@@ -242453,7 +242487,7 @@ zX
 fN
 UX
 zX
-xT
+tt
 xT
 xT
 Dh
@@ -244964,9 +244998,9 @@ Jy
 Zl
 tt
 tt
-od
+tt
 MT
-JW
+BL
 JW
 ge
 ug
@@ -245467,8 +245501,8 @@ RW
 tt
 tt
 tt
-MT
-JW
+vt
+BL
 JW
 Jn
 Va
@@ -245966,11 +246000,11 @@ bl
 tt
 DP
 ua
-vn
-XZ
-XI
-MT
-JW
+tt
+tt
+tt
+od
+BL
 JW
 JW
 JW
@@ -246468,11 +246502,11 @@ va
 oo
 oo
 oo
+mm
+nG
+hA
 oo
-oo
-oo
-oo
-JW
+Vd
 JW
 JW
 JW
@@ -246969,8 +247003,8 @@ BQ
 PB
 kt
 LM
-AA
-AA
+oo
+oo
 oo
 oo
 oo


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? --> 
Name explains it all, allows the chef to make more recipes. I had to change the layout of the syndicate kitchen a fair bit, layout of all the other kitchens are mostly the same. This pr also expands an asteroid west of syndicate base northwards, as to prevent a straight one way path. This prevents being able to easily chairflip over to UVB.
![image](https://user-images.githubusercontent.com/73148980/126205052-96dae5d7-327f-4593-afeb-6b2a194299e7.png)
![image](https://user-images.githubusercontent.com/73148980/126205067-06fc22d1-7218-432b-ab87-87a068a29654.png)
![image](https://user-images.githubusercontent.com/73148980/126205080-c8b15d5a-972a-4b85-8412-92f497a166c1.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. --> 
I just want to grill. 

