### PR TITLE
PDAs get some form of writing implement by default

### DIFF
--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -914,7 +914,7 @@
 			src.UpdateOverlays(null, "pen")
 			return
 
-	proc/insert_pen(var/obj/item/insertedPen, mob/user)
+	proc/insert_pen(obj/item/insertedPen, mob/user)
 		if (!istype(insertedPen))
 			return
 		if (user)

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -199,6 +199,7 @@
 
 	forensic
 		icon_state = "pda-s"
+		setup_default_pen = /obj/item/clothing/mask/cigarette
 		setup_default_cartridge = /obj/item/disk/data/cartridge/forensic
 		mailgroups = list(MGD_SECURITY,MGD_PARTY)
 		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CRISIS, MGA_TRACKING)

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -44,7 +44,7 @@
 	var/linkbg_color = "#565D4B"
 	var/graphic_mode = 0
 
-	var/setup_default_pen = pick(/obj/item/pen,/obj/item/pen/pencil,/obj/item/pen/marker/random) //PDAs contain writing implements by default
+	var/setup_default_pen = /obj/item/pen //PDAs can contain writing implements by default
 	var/setup_default_cartridge = null //Cartridge contains job-specific programs
 	var/setup_drive_size = 32 //PDAs don't have much work room at all, really.
 	// 2020 zamu update: 24 -> 32
@@ -912,10 +912,9 @@
 				src.pen.set_loc(T)
 			src.pen = null
 			src.UpdateOverlays(null, "pen")
-			boutput(user, "<span class='notice'>You eject [insertedPen] from [src].</span>")
 			return
 
-	proc/insert_pen(obj/item/insertedPen, mob/user)
+	proc/insert_pen(var/obj/item/insertedPen, mob/user)
 		if (!istype(insertedPen))
 			return
 		if (user)

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -44,6 +44,7 @@
 	var/linkbg_color = "#565D4B"
 	var/graphic_mode = 0
 
+	var/setup_default_pen = pick(/obj/item/pen,/obj/item/pen/pencil,/obj/item/pen/marker/random) //PDAs contain writing implements by default
 	var/setup_default_cartridge = null //Cartridge contains job-specific programs
 	var/setup_drive_size = 32 //PDAs don't have much work room at all, really.
 	// 2020 zamu update: 24 -> 32
@@ -98,18 +99,21 @@
 /obj/item/device/pda2
 	captain
 		icon_state = "pda-c"
+		setup_default_pen = /obj/item/pen/fancy
 		setup_default_cartridge = /obj/item/disk/data/cartridge/captain
 		setup_drive_size = 32
 		mailgroups = list(MGD_COMMAND,MGD_PARTY)
 
 	heads
 		icon_state = "pda-h"
+		setup_default_pen = /obj/item/pen/fancy
 		setup_default_cartridge = /obj/item/disk/data/cartridge/head
 		setup_drive_size = 32
 		mailgroups = list(MGD_COMMAND,MGD_PARTY)
 
 	hos
 		icon_state = "pda-hos"
+		setup_default_pen = /obj/item/pen/fancy
 		setup_default_cartridge = /obj/item/disk/data/cartridge/hos
 		setup_default_module = /obj/item/device/pda_module/alert
 		setup_drive_size = 32
@@ -118,6 +122,7 @@
 
 	ntso
 		icon_state = "pda-nt"
+		setup_default_pen = /obj/item/pen/fancy
 		setup_default_cartridge = /obj/item/disk/data/cartridge/hos //hos cart gives access to manifest compared to regular sec cart, useful for NTSO
 		setup_default_module = /obj/item/device/pda_module/alert
 		setup_drive_size = 32
@@ -126,6 +131,7 @@
 
 	ai
 		icon_state = "pda-h"
+		setup_default_pen = null // ai don't need no pens
 		setup_default_cartridge = /obj/item/disk/data/cartridge/ai
 		ejectable_cartridge = 0
 		setup_drive_size = 1024
@@ -143,6 +149,7 @@
 
 	cyborg
 		icon_state = "pda-h"
+		setup_default_pen = null // you don't even have hands
 		setup_default_cartridge = /obj/item/disk/data/cartridge/cyborg
 		ejectable_cartridge = 0
 		setup_drive_size = 1024
@@ -153,12 +160,14 @@
 
 	research_director
 		icon_state = "pda-rd"
+		setup_default_pen = /obj/item/pen/fancy
 		setup_default_cartridge = /obj/item/disk/data/cartridge/research_director
 		setup_drive_size = 32
 		mailgroups = list(MGD_SCIENCE,MGD_COMMAND,MGD_PARTY)
 
 	medical_director
 		icon_state = "pda-md"
+		setup_default_pen = /obj/item/pen/fancy
 		setup_default_cartridge = /obj/item/disk/data/cartridge/medical_director
 		setup_drive_size = 32
 		mailgroups = list(MGD_MEDRESEACH,MGD_MEDBAY,MGD_COMMAND,MGD_PARTY)
@@ -208,6 +217,7 @@
 	clown
 		icon_state = "pda-clown"
 		desc = "A portable microcomputer by Thinktronic Systems, LTD. The surface is coated with polytetrafluoroethylene and banana drippings."
+		setup_default_pen = /obj/item/pen/crayon/random
 		setup_default_cartridge = /obj/item/disk/data/cartridge/clown
 		event_handler_flags = USE_HASENTERED | USE_FLUID_ENTER
 
@@ -336,6 +346,19 @@
 		src.net_id = format_net_id("\ref[src]")
 
 		radio_controller?.add_object(src, "[frequency]")
+
+		if (src.setup_default_pen)
+			src.pen = new src.setup_default_pen(src)
+			if(istype(src.pen, /obj/item/clothing/mask/cigarette))
+				src.UpdateOverlays(image(src.icon, "cig"), "pen")
+			else if(istype(src.pen, /obj/item/pen/crayon))
+				var/image/pen_overlay = image(src.icon, "crayon")
+				pen_overlay.color = pen.color
+				src.UpdateOverlays(pen_overlay, "pen")
+			else if(istype(src.pen, /obj/item/pen/pencil))
+				src.UpdateOverlays(image(src.icon, "pencil"), "pen")
+			else
+				src.UpdateOverlays(image(src.icon, "pen"), "pen")
 
 		if (src.setup_default_cartridge)
 			src.cartridge = new src.setup_default_cartridge(src)
@@ -888,6 +911,7 @@
 				src.pen.set_loc(T)
 			src.pen = null
 			src.UpdateOverlays(null, "pen")
+			boutput(user, "<span class='notice'>You eject [insertedPen] from [src].</span>")
 			return
 
 	proc/insert_pen(obj/item/insertedPen, mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
PDAs, by default, will start with a pen in its pen slot. Some jobs have differing writing utensils, as follows.

- Head roles get fancy pens, fancy shmancy.
- Silicons don't get any writing utensils, they don't even have hands.
- The Detective starts with a cigarette in their PDA. Ha.
- The Clown gets a randomly coloured crayon.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I like pens.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DisturbHerb
(+)(Most) PDAs will start with writing utensils in them by default.
```
