### PR TITLE
Adds the Syndicate Dabbing License

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -921,7 +921,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/dablicense
 	name = "Syndicate Dabbing License"
 	item = /obj/item/card/id/dabbing_license/syndie
-	cost = 4
+	cost = 3
 	desc = "Using all new ID tech this dab license steals the access of anyone you dab on! Also prevents dabbing your arms off."
 	job = list("Staff Assistant")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -918,6 +918,15 @@ This is basically useless for anyone but miners.
 	desc = "A roll of duct tape for makeshift handcuffs. Lets you restrain someone 10 times before being used up."
 	blockedmode = list(/datum/game_mode/revolution)
 
+/datum/syndicate_buylist/traitor/dablicense
+	name = "Syndicate Dabbing License"
+	item = /obj/item/card/id/dabbing_license/syndie
+	cost = 4
+	desc = "Using all new ID tech this dab license steals the access of anyone you dab on! Also prevents dabbing your arms off."
+	job = list("Staff Assistant")
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
+	vr_allowed = 0
+
 /////////////////////////////////////////// Surplus-exclusive items //////////////////////////////////////////////////
 
 /datum/syndicate_buylist/surplus

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -2106,7 +2106,7 @@
 					if(src.reagents) src.reagents.add_reagent("dabs",5)
 
 
-					if(prob(92) && (!src.reagents.has_reagent("extremedabs")))
+					if(prob(92) && (!src.reagents.has_reagent("extremedabs")) || istype(dab_id, /obj/item/card/id/dabbing_license/syndie))
 						dabbify()
 						var/get_dabbed_on = 0
 						if(locate(/mob/living) in range(1, src))
@@ -2120,7 +2120,19 @@
 										M.emote("cry") //You should be ashamed
 									if(dab_id)
 										dab_id.dabbed_on_count++
-
+									if(dab_id.stealsaccess == 1) //takes access and makes the victim a staffie
+										var/obj/item/D = M.wear_id
+										if(istype(D,/obj/item/device/pda2))
+											var/obj/item/device/pda2/P = D
+											if(P.ID_card)
+												D = P.ID_card
+										if(istype(D,/obj/item/card/id))
+											var/obj/item/card/id/their_id = D
+											dab_id.access |= their_id.access
+											their_id.access = get_access("Staff Assistant") // you are now staffie
+											their_id.assignment = "Staff Assistant"
+											their_id.icon_state = "id_civ"
+											boutput(M, "<span class='alert'>You feel empty inside</span>")
 						if(get_dabbed_on == 0)
 							if (src.mind && src.mind.assigned_role == "Clown")
 								message = "<B>[src]</B> [pick("performs a sick dab", "dabs on the haters", "shows everybody [his_or_her(src)] dope dab skills", "performs a wicked dab", "dabs like nobody has dabbed before", "shows everyone how they dab in the circus")]!!!"

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -2129,8 +2129,8 @@
 										if(istype(D,/obj/item/card/id))
 											var/obj/item/card/id/their_id = D
 											dab_id.access |= their_id.access
-											their_id.access = get_access("Staff Assistant") // you are now staffie
-											their_id.assignment = "Staff Assistant"
+											their_id.access = list()
+											their_id.assignment = "Staff Assistant"  // you are now staffie
 											their_id.icon_state = "id_civ"
 											boutput(M, "<span class='alert'>You feel empty inside.</span>")
 						if(get_dabbed_on == 0)

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -2120,7 +2120,7 @@
 										M.emote("cry") //You should be ashamed
 									if(dab_id)
 										dab_id.dabbed_on_count++
-									if(dab_id.stealsaccess == 1) //takes access and makes the victim a staffie
+									if(dab_id.stealsaccess) //takes access and makes the victim a staffie
 										var/obj/item/D = M.wear_id
 										if(istype(D,/obj/item/device/pda2))
 											var/obj/item/device/pda2/P = D

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -2132,7 +2132,7 @@
 											their_id.access = get_access("Staff Assistant") // you are now staffie
 											their_id.assignment = "Staff Assistant"
 											their_id.icon_state = "id_civ"
-											boutput(M, "<span class='alert'>You feel empty inside</span>")
+											boutput(M, "<span class='alert'>You feel empty inside.</span>")
 						if(get_dabbed_on == 0)
 							if (src.mind && src.mind.assigned_role == "Clown")
 								message = "<B>[src]</B> [pick("performs a sick dab", "dabs on the haters", "shows everybody [his_or_her(src)] dope dab skills", "performs a wicked dab", "dabs like nobody has dabbed before", "shows everyone how they dab in the circus")]!!!"

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -206,7 +206,7 @@ GAUNTLET CARDS
 	var/dabbed_on_count = 0
 	var/arm_count = 0
 	var/brain_damage_count = 0
-	var/stealsaccess = 0
+	var/stealsaccess = FALSE
 	New()
 		access = list()
 		..()
@@ -227,7 +227,7 @@ GAUNTLET CARDS
 /obj/item/card/id/dabbing_license/syndie // why did I code this
 	desc = "This card authorizes the person wearing it to perform sick dabs. It seems extra illegal"
 	assignment = "Expert Dabber"
-	stealsaccess = 1
+	stealsaccess = TRUE
 
 /obj/item/card/id/captains_spare/explosive
 	pickup(mob/user)

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -206,6 +206,7 @@ GAUNTLET CARDS
 	var/dabbed_on_count = 0
 	var/arm_count = 0
 	var/brain_damage_count = 0
+	var/stealsaccess = 0
 	New()
 		access = list()
 		..()
@@ -222,6 +223,11 @@ GAUNTLET CARDS
 
 	src.add_fingerprint(user)
 	return
+
+/obj/item/card/id/dabbing_license/syndie // why did I code this
+	desc = "This card authorizes the person wearing it to perform sick dabs. It seems extra illegal"
+	assignment = "Expert Dabber"
+	stealsaccess = 1
 
 /obj/item/card/id/captains_spare/explosive
 	pickup(mob/user)

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -225,7 +225,7 @@ GAUNTLET CARDS
 	return
 
 /obj/item/card/id/dabbing_license/syndie // why did I code this
-	desc = "This card authorizes the person wearing it to perform sick dabs. It seems extra illegal"
+	desc = "This card authorizes the person wearing it to perform sick dabs. It seems extra illegal."
 	assignment = "Expert Dabber"
 	stealsaccess = TRUE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the syndicate dabbing license a 3 tc item for staff assistant traitors. 
When you dab on somebody while wearing the syndie dabbing license their access is copied onto the license while their access is removed and their job is set to a staff assistant. Stealing someone's access will give them a message
The syndie dabbing license also prevents arm removal from dabbing.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Staff Assistants dont have any truly unique traitor items and the thought of a staff assistant dabbing everyone's access away is funny.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)Adds the syndicate dabbing license, a 3 tc traitor item for staff assistants.
```
