### PR TITLE
Fix eyes remaining after decapitation 

### DIFF
--- a/code/mob/living/carbon/human/procs/update_icon.dm
+++ b/code/mob/living/carbon/human/procs/update_icon.dm
@@ -690,6 +690,8 @@
 		UpdateOverlays(null, "hair_special_two", 1, 1)
 		UpdateOverlays(null, "hair_special_three", 1, 1)
 
+		UpdateOverlays(null, "eyes", 1, 1)
+
 
 /mob/living/carbon/human/update_burning_icon(var/force_remove=0, var/datum/statusEffect/simpledot/burning/B = 0)
 	if (!B)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes update_icon.dm - update_face() to clear eyes if head is null.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If you get decapitated right now you still have eyes.