### PR TITLE
change the way the right-click interact function operates

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3001,7 +3001,9 @@
 /mob/living/verb/interact_verb(atom/A as mob|obj|turf in view(1))
 	set name = "Pick Up / Left Click"
 	set category = "Local"
-	A.interact(src)
+
+	if(src.client)
+		src.client.Click(A, get_turf(A))
 
 /mob/living/verb/pickup_verb()
 	set name = "Pick Up"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This changes the right click "Pick Up / Left Click" option to trigger a click on the object instead of using the Interact() proc.

Not sure if this could cause any issues due to the click() parameters, but I tested it a bit and did not find any.
I tried
- wrenching components down underwater.
- using an artlab machine.
- using a gun on an object.
- using teleportwand/attackwand artifacts. (Because those use afterattack().)

Seemed to all work fine.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Before you could not do stuff like wrench something down that was underwater, because you would pick the object up and drop the wrench instead.
With this you should now be able to do stuff like put a teleport component into the pool or similar.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) The right click interact option should now hit stuff with held objects instead of dropping the current object and picking the other one up.
```
