### PR TITLE
Use correct air mixture for sound attenuation

### DIFF
--- a/code/modules/sound/sound.dm
+++ b/code/modules/sound/sound.dm
@@ -46,9 +46,9 @@
 			//if (istype(T, /turf/space))
 			//	return 0 // in space nobody can hear you fart
 		if (T.turf_flags & IS_TYPE_SIMULATED) //danger :)
-			var/turf/simulated/sim_T = T
-			if (sim_T.air)
-				attenuate *= MIXTURE_PRESSURE(sim_T.air) / ONE_ATMOSPHERE
+			var/datum/gas_mixture/air = T.return_air()
+			if (air)
+				attenuate *= MIXTURE_PRESSURE(air) / ONE_ATMOSPHERE
 				attenuate = min(1, max(0, attenuate))
 
 	return attenuate


### PR DESCRIPTION
[bug]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Use correct gas mixture for determining how much to attenuate sounds in a space.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5582