### PR TITLE
Adds more borg charging stations to Donut 3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -30082,11 +30082,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/quartermaster/office)
-"iCB" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/se)
 "iCK" = (
 /obj/item/reagent_containers/glass/wateringcan{
 	pixel_x = -1;
@@ -58556,6 +58551,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/southeast)
+"qUa" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating/jen,
+/area/station/storage/tech)
 "qUg" = (
 /obj/lattice{
 	dir = 5;
@@ -137118,7 +137117,7 @@ kOm
 wWv
 hqD
 wFv
-xRb
+qUa
 xGu
 ujy
 rdj
@@ -144954,7 +144953,7 @@ nxQ
 wPF
 vfx
 vTC
-iCB
+wZR
 gDk
 rdj
 rdj

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -30082,6 +30082,11 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/quartermaster/office)
+"iCB" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/se)
 "iCK" = (
 /obj/item/reagent_containers/glass/wateringcan{
 	pixel_x = -1;
@@ -31726,9 +31731,9 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/captain)
 "jdI" = (
-/obj/reagent_dispensers/fueltank,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/decal/cleanable/rust/jen,
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating/jen,
 /area/station/science/gen_storage)
 "jdO" = (
@@ -66370,9 +66375,9 @@
 /turf/simulated/floor/green/side,
 /area/station/hallway/primary/west)
 "tlS" = (
-/obj/machinery/portable_atmospherics/pump,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/decal/cleanable/rust/jen,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plating/jen,
 /area/station/science/gen_storage)
 "tlW" = (
@@ -73748,6 +73753,11 @@
 /obj/disposalpipe/trunk,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
+"vvV" = (
+/obj/machinery/recharge_station,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/turf/simulated/floor/plating/airless,
+/area/station/mining/staff_room)
 "vwg" = (
 /obj/wingrille_spawn/auto/tuff,
 /obj/cable{
@@ -78697,6 +78707,14 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
+"wPm" = (
+/obj/machinery/light/emergency{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/orangeblack,
+/area/station/hallway/secondary/exit)
 "wPw" = (
 /obj/stool/chair/comfy/purple{
 	dir = 8
@@ -79645,6 +79663,11 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
+"xbR" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/sw)
 "xbV" = (
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
@@ -110498,7 +110521,7 @@ gBM
 lGw
 eRI
 mLB
-bUO
+xbR
 mQf
 gBM
 hcW
@@ -132800,7 +132823,7 @@ lmX
 lmX
 vob
 kuM
-cjG
+vvV
 xFO
 tgJ
 dCg
@@ -144931,7 +144954,7 @@ nxQ
 wPF
 vfx
 vTC
-wZR
+iCB
 gDk
 rdj
 rdj
@@ -146049,7 +146072,7 @@ fPJ
 jnD
 kNU
 onD
-aIy
+wPm
 qTj
 aIy
 sTL


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 5 more recharging stations to Donut 3, trying to pick locations that are unobtrusive.

New stations are in:
-Mining mineral magnet
-Tech storage, replacing a stool
-Research storage (replacing the second fuel tank)
-Maintenance between disposals and security
-Escape pod room

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While the map has 8 already, they're often tucked into side-rooms (the bathroom stall one, the gym, top of crew lounge) and about 3 of those are around the civ part of the station. The west side of the station only had the one in tool storage, and the southern part had robotics + the bathroom one. Mining gets dedicated borgs sometimes so it's served well to have its own. This should make it easier to find one overall.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Added a few more cyborg recharging stations to Donut 3
```
