### PR TITLE
Remove random head pieces from gibs proc

### DIFF
--- a/code/procs/gibs.dm
+++ b/code/procs/gibs.dm
@@ -8,8 +8,6 @@
 
 	// NORTH
 	gib = make_cleanable( /obj/decal/cleanable/blood/gibs,location)
-	if (prob(30))
-		gib.icon_state = "gibup1"
 	gib.streak_cleanable(NORTH)
 	gib.diseases += diseases
 	gib.blood_DNA = blood_DNA
@@ -19,8 +17,6 @@
 
 	// SOUTH
 	gib = make_cleanable( /obj/decal/cleanable/blood/gibs,location)
-	if (prob(30))
-		gib.icon_state = "gibdown1"
 	gib.streak_cleanable(SOUTH)
 	gib.diseases += diseases
 	gib.blood_DNA = blood_DNA


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[REWORK]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the 30% chance to use body gibs in the gib() proc.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Upper torso with a head show up in regular gibs, which are used for things like Rathens Secret.
By default these two pieces are not used unless a headgibs variable is set. Why would we include these at 30% chance? This just results in confusing body pieces that look like someone was fully gibbed.