### PR TITLE
Starstone value reduction

### DIFF
--- a/code/modules/economy/traders/gragg.dm
+++ b/code/modules/economy/traders/gragg.dm
@@ -155,5 +155,5 @@
 /datum/commodity/trader/gragg/starstone
 	comname = "Rare star-shaped jewel"
 	comtype = /obj/item/raw_material/starstone
-	price_boundary = list(500000,4500000)
+	price_boundary = list(200000,350000)
 	possible_names = list("WANT BUY PALE BLUE STAR-SHAPED GEMSTONE. EXTREMELY RARE. SELL TO ME IF FIND.")

--- a/code/modules/economy/traders/gragg.dm
+++ b/code/modules/economy/traders/gragg.dm
@@ -155,5 +155,5 @@
 /datum/commodity/trader/gragg/starstone
 	comname = "Rare star-shaped jewel"
 	comtype = /obj/item/raw_material/starstone
-	price_boundary = list(250000,350000)
+	price_boundary = list(300000,450000)
 	possible_names = list("WANT BUY PALE BLUE STAR-SHAPED GEMSTONE. EXTREMELY RARE. SELL TO ME IF FIND.")

--- a/code/modules/economy/traders/gragg.dm
+++ b/code/modules/economy/traders/gragg.dm
@@ -155,5 +155,5 @@
 /datum/commodity/trader/gragg/starstone
 	comname = "Rare star-shaped jewel"
 	comtype = /obj/item/raw_material/starstone
-	price_boundary = list(200000,350000)
+	price_boundary = list(250000,350000)
 	possible_names = list("WANT BUY PALE BLUE STAR-SHAPED GEMSTONE. EXTREMELY RARE. SELL TO ME IF FIND.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT][WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduces starstone sell value range to 300,000-450,000.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You can reliably get 1-2 from the mineral magnet every single round in 10-15~ minutes. With a value 500k-4.5 million this can easily cover cargo for the entire round.
Cargo is already expected to be profitable without starstones so a reduction shouldn't make life any harder for them while still being a substantial budget boost.