### PR TITLE
Fix chem grenades remaining equipped after in-hand detonation

### DIFF
--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -170,6 +170,7 @@
 			if (src && !src.disposed)
 				a = get_area(src)
 				if(a.sanctuary) return
+				user.u_equip(src)
 				explode()
 
 	proc/explode()

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -170,7 +170,7 @@
 			if (src && !src.disposed)
 				a = get_area(src)
 				if(a.sanctuary) return
-				if(user && user.equipped() == src)
+				if(user?.equipped() == src)
 					user.u_equip(src)
 				explode()
 

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -170,7 +170,8 @@
 			if (src && !src.disposed)
 				a = get_area(src)
 				if(a.sanctuary) return
-				user.u_equip(src)
+				if(user && user.equipped() == src)
+					user.u_equip(src)
 				explode()
 
 	proc/explode()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Chem grenades were equipped and invisible for a short while after in-hand detonation. Now they're not.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugfix
