### PR TITLE
Removes inquisitor gas mask from QM crates

### DIFF
--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -1433,7 +1433,6 @@
 						/obj/item/clothing/mask/balaclava,
 						/obj/item/clothing/mask/spiderman,
 						/obj/item/clothing/mask/horse_mask,
-						/obj/item/clothing/mask/gas/inquis,
 						/obj/item/clothing/mask/gas/plague,
 						/obj/item/clothing/mask/skull,
 						/obj/item/clothing/mask/niccage,


### PR DESCRIPTION
[Removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As the title says this will lower the variety of masks available for QM, but the mask didn't even have a worn sprite so it doesn't matter?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The gas mask lacks a worn state and will appear invisible when worn. It shouldn't be gettable by players for that reason.
