### PR TITLE
Improves the Space Law 1st edition book

### DIFF
--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -272,8 +272,7 @@ Custom Books
 				var/hos = (istype(user.head, /obj/item/clothing/head/hosberet) || istype(user.head, /obj/item/clothing/head/hos_hat))
 				if(hos)
 					var/mob/living/carbon/human/H = hit_atom
-					H.say("[pick("Alright, fine, ", "I confess that I ")][pick("nabbed ", "stole ", "klepped ", "grabbed ")]the [pick("Head of Security's ", "Captain's ", "Head of Personnel's ", "Chief Engineer's ", "Research Director's ", "Heisenbee's ")] [pick("hair brush!", "shoes!", "stuffed animal!", "spare uniform!", "bedsheets!", "hat!", "trophy!", "glasses!", "fizzy lifting drink!", "ID card!")]")
-					playsound(H.loc, "swing_hit", 50, 1)
+					H.say("[pick("Alright, fine, I ", "I confess that I ", "I confess! I ", "Okay, okay, I admit that I ")][pick("nabbed ", "stole ", "klepped ", "grabbed ", "thieved ", "pilfered ")]the [pick("Head of Security's ", "Captain's ", "Head of Personnel's ", "Chief Engineer's ", "Research Director's ", "Heisenbee's ", "Science Department's ", "Mining Team's ", "Quartermaster's ")] [pick("hair brush!", "shoes!", "stuffed animal!", "spare uniform!", "bedsheets!", "hat!", "trophy!", "glasses!", "fizzy lifting drink!", "ID card!")]")
 				prob_clonk = min(prob_clonk + 5, 40)
 				SPAWN_DBG(2 SECONDS)
 					prob_clonk = max(prob_clonk - 5, 0)

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -271,7 +271,7 @@ Custom Books
 				var/mob/living/carbon/human/user = usr
 				var/mob/living/carbon/human/H = hit_atom
 				var/hos = (istype(user.head, /obj/item/clothing/head/hosberet) || istype(user.head, /obj/item/clothing/head/hos_hat))
-				if(hos && !GET_COOLDOWN(H, "spacelaw_confession"))
+				if(hos && !ON_COOLDOWN(H, "spacelaw_confession", 10 SECONDS))
 					H.say("[pick("Alright, fine, I ", "I confess that I ", "I confess! I ", "Okay, okay, I admit that I ")][pick("nabbed ", "stole ", "klepped ", "grabbed ", "thieved ", "pilfered ")]the [pick("Head of Security's ", "Captain's ", "Head of Personnel's ", "Chief Engineer's ", "Research Director's ", "Science Department's ", "Mining Team's ", "Quartermaster's ")] [pick("hair brush!", "shoes!", "stuffed animal!", "spare uniform!", "bedsheets!", "hat!", "trophy!", "glasses!", "fizzy lifting drink!", "ID card!")]")
 				prob_clonk = min(prob_clonk + 5, 40)
 				SPAWN_DBG(2 SECONDS)

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -272,8 +272,7 @@ Custom Books
 				var/mob/living/carbon/human/H = hit_atom
 				var/hos = (istype(user.head, /obj/item/clothing/head/hosberet) || istype(user.head, /obj/item/clothing/head/hos_hat))
 				if(hos && !GET_COOLDOWN(H, "spacelaw_confession"))
-					H.say("[pick("Alright, fine, I ", "I confess that I ", "I confess! I ", "Okay, okay, I admit that I ")][pick("nabbed ", "stole ", "klepped ", "grabbed ", "thieved ", "pilfered ")]the [pick("Head of Security's ", "Captain's ", "Head of Personnel's ", "Chief Engineer's ", "Research Director's ", "Heisenbee's ", "Science Department's ", "Mining Team's ", "Quartermaster's ")] [pick("hair brush!", "shoes!", "stuffed animal!", "spare uniform!", "bedsheets!", "hat!", "trophy!", "glasses!", "fizzy lifting drink!", "ID card!")]")
-					ON_COOLDOWN(H, "spacelaw_confession", 10 SECONDS)
+					H.say("[pick("Alright, fine, I ", "I confess that I ", "I confess! I ", "Okay, okay, I admit that I ")][pick("nabbed ", "stole ", "klepped ", "grabbed ", "thieved ", "pilfered ")]the [pick("Head of Security's ", "Captain's ", "Head of Personnel's ", "Chief Engineer's ", "Research Director's ", "Science Department's ", "Mining Team's ", "Quartermaster's ")] [pick("hair brush!", "shoes!", "stuffed animal!", "spare uniform!", "bedsheets!", "hat!", "trophy!", "glasses!", "fizzy lifting drink!", "ID card!")]")
 				prob_clonk = min(prob_clonk + 5, 40)
 				SPAWN_DBG(2 SECONDS)
 					prob_clonk = max(prob_clonk - 5, 0)

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -271,7 +271,7 @@ Custom Books
 				var/mob/living/carbon/human/user = usr
 				var/mob/living/carbon/human/H = hit_atom
 				var/hos = (istype(user.head, /obj/item/clothing/head/hosberet) || istype(user.head, /obj/item/clothing/head/hos_hat))
-				if(hos && !GET_COOLDOWN(H, "spacelaw_confession")
+				if(hos && !GET_COOLDOWN(H, "spacelaw_confession"))
 					H.say("[pick("Alright, fine, I ", "I confess that I ", "I confess! I ", "Okay, okay, I admit that I ")][pick("nabbed ", "stole ", "klepped ", "grabbed ", "thieved ", "pilfered ")]the [pick("Head of Security's ", "Captain's ", "Head of Personnel's ", "Chief Engineer's ", "Research Director's ", "Heisenbee's ", "Science Department's ", "Mining Team's ", "Quartermaster's ")] [pick("hair brush!", "shoes!", "stuffed animal!", "spare uniform!", "bedsheets!", "hat!", "trophy!", "glasses!", "fizzy lifting drink!", "ID card!")]")
 					ON_COOLDOWN(H, "spacelaw_confession", 10 SECONDS)
 				prob_clonk = min(prob_clonk + 5, 40)

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -269,10 +269,11 @@ Custom Books
 		else
 			if(ishuman(hit_atom))
 				var/mob/living/carbon/human/user = usr
+				var/mob/living/carbon/human/H = hit_atom
 				var/hos = (istype(user.head, /obj/item/clothing/head/hosberet) || istype(user.head, /obj/item/clothing/head/hos_hat))
-				if(hos)
-					var/mob/living/carbon/human/H = hit_atom
+				if(hos && !GET_COOLDOWN(H, "spacelaw_confession")
 					H.say("[pick("Alright, fine, I ", "I confess that I ", "I confess! I ", "Okay, okay, I admit that I ")][pick("nabbed ", "stole ", "klepped ", "grabbed ", "thieved ", "pilfered ")]the [pick("Head of Security's ", "Captain's ", "Head of Personnel's ", "Chief Engineer's ", "Research Director's ", "Heisenbee's ", "Science Department's ", "Mining Team's ", "Quartermaster's ")] [pick("hair brush!", "shoes!", "stuffed animal!", "spare uniform!", "bedsheets!", "hat!", "trophy!", "glasses!", "fizzy lifting drink!", "ID card!")]")
+					ON_COOLDOWN(H, "spacelaw_confession", 10 SECONDS)
 				prob_clonk = min(prob_clonk + 5, 40)
 				SPAWN_DBG(2 SECONDS)
 					prob_clonk = max(prob_clonk - 5, 0)

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -234,7 +234,7 @@ Custom Books
 
 	density = 0
 	opacity = 0
-	anchored = 1
+	anchored = 0
 
 	icon = 'icons/obj/items/weapons.dmi'
 	icon_state = "lawbook"
@@ -272,12 +272,8 @@ Custom Books
 				var/hos = (istype(user.head, /obj/item/clothing/head/hosberet) || istype(user.head, /obj/item/clothing/head/hos_hat))
 				if(hos)
 					var/mob/living/carbon/human/H = hit_atom
-					H.changeStatus("stunned", 2 SECONDS)
-					H.changeStatus("weakened", 2 SECONDS)
-					H.force_laydown_standup()
-					//H.paralysis++
+					H.say("[pick("Alright, fine, ", "I confess that I ")][pick("nabbed ", "stole ", "klepped ", "grabbed ")]the [pick("Head of Security's ", "Captain's ", "Head of Personnel's ", "Chief Engineer's ", "Research Director's ", "Heisenbee's ")] [pick("hair brush!", "shoes!", "stuffed animal!", "spare uniform!", "bedsheets!", "hat!", "trophy!", "glasses!", "fizzy lifting drink!", "ID card!")]")
 					playsound(H.loc, "swing_hit", 50, 1)
-					usr.say("I AM THE LAW!")
 				prob_clonk = min(prob_clonk + 5, 40)
 				SPAWN_DBG(2 SECONDS)
 					prob_clonk = max(prob_clonk - 5, 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Unanchors the Space Law 1st edition book, in addition to reworking it near-completely.
Previously, it stunned for two seconds when thrown at someone (assuming you could unanchor it in the first place).
Now, when someone is hit with the book, they are forced to say a funny confession (e.g. "I confess! I nabbed the Research Director's shoes!")


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The old 1st edition Space Law book had a habit of getting stuck in backpacks due to its anchoring, and overall was very unintuitive. This should hopefully add some humor to an overall very bland item.

