### PR TITLE
Replaces the syndie donk pockets in the martian ship with normal donk pockets

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -24632,7 +24632,7 @@
 	icon_state = "sideWall";
 	name = "organic wall"
 	},
-/obj/item/storage/box/donkpocket_w_kit,
+/obj/item/storage/box/donkpocket_kit,
 /turf/simulated/floor/plating/damaged3,
 /area/evilreaver/bar)
 "bjr" = (

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -26270,7 +26270,7 @@
 	icon_state = "sideWall";
 	name = "organic wall"
 	},
-/obj/item/storage/box/donkpocket_w_kit,
+/obj/item/storage/box/donkpocket_kit,
 /turf/simulated/floor/plating/damaged3,
 /area/evilreaver/bar)
 "bjr" = (

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -11789,7 +11789,7 @@
 	icon_state = "sideWall";
 	name = "organic wall"
 	},
-/obj/item/storage/box/donkpocket_w_kit,
+/obj/item/storage/box/donkpocket_kit,
 /turf/simulated/floor/plating/damaged3,
 /area/evilreaver/bar)
 "aEU" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Oshan has the martian ship on the station z level and needed to be changed along with the debris one. for consistency.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Antag items in the debris is bad, can't stop people from rushing them every round, and nerfing the items would be a bad solution.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Arthur Holiday
(+)A certain box of syndicate donkpockets on a certain ship now contains normal donk pockets
```
