### PR TITLE
Update telescience computer UI for AI eyes

### DIFF
--- a/code/modules/networks/computer3/mainframe2/telesci.dm
+++ b/code/modules/networks/computer3/mainframe2/telesci.dm
@@ -1002,7 +1002,7 @@ proc/is_teleportation_allowed(var/turf/T)
 				else
 					src.attack_hand(M)
 
-		if (issilicon(usr))
+		if (issilicon(usr) || isAIeye(usr))
 			if (!(usr in nearby))
 				if (usr.using_dialog_of(src))
 					if (updateReadout)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a presumed oversight on the telescience comp so that it updates for users who are AI eyes regardless of distance (like it does for silicons)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I have no UI updates and I must AI nerd