### PR TITLE
Remove playable pests from agimmicks

### DIFF
--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -59,21 +59,25 @@
 		if (candidates.len)
 			var/list/EV = list()
 
-			EV += landmarks[LANDMARK_PESTSTART]
-			EV += landmarks[LANDMARK_MONKEY]
-			EV += landmarks[LANDMARK_BLOBSTART]
-			EV += landmarks[LANDMARK_KUDZUSTART]
+			if (length(landmarks[LANDMARK_PESTSTART]))
+				EV += landmarks[LANDMARK_PESTSTART]
+			if (length(landmarks[LANDMARK_MONKEY]))
+				EV += landmarks[LANDMARK_MONKEY]
+			if (length(landmarks[LANDMARK_BLOBSTART]))
+				EV += landmarks[LANDMARK_BLOBSTART]
+			if (length(landmarks[LANDMARK_KUDZUSTART]))
+				EV += landmarks[LANDMARK_KUDZUSTART]
 			EV += job_start_locations["Clown"]
 
 			if(!EV.len)
 				EV += landmarks[LANDMARK_LATEJOIN]
 				if (!EV.len)
-					message_admins("Pests event couldn't find a pest landmark!")
+					message_admins("Pests event couldn't find any valid landmarks!")
+					logTheThing( "debug", null, null, "Failed to find any valid landmarks for a Pests event!" )
 					cleanup_event()
 					return
 
 			var/atom/pestlandmark = pick(EV)
-
 			var/list/select = list()
 			if (src.pest_type) //customized
 				select += src.pest_type
@@ -91,7 +95,6 @@
 
 				var/datum/mind/M = pick(candidates)
 				if (M.current)
-					ticker.mode.Agimmicks |= M
 					M.current.make_ghost_critter(pestlandmark,select)
 					var/obj/item/implant/access/infinite/assistant/O = new /obj/item/implant/access/infinite/assistant(M.current)
 					O.owner = M.current


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes playable pest event players from agimmicks.
Fix logic that could pick nulls as a pest spawn location. This only worked when a null was selected due to fall backs in make critter proc.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Playable pests are explicitly not antags and do not need to be tracked.
Listing a dozen players at end of round as an animal doesn't help anyone, particularly as it's actually not set up correctly at the moment and is instead blank.
Atlas and potentially other maps have issues with pest spawn landmarks due to the lack of landmarks.