### PR TITLE
Add new cloud save fetch and put procs for targeting other keys

### DIFF
--- a/code/player.dm
+++ b/code/player.dm
@@ -169,7 +169,7 @@
 
 	/// Returns cloud data and saves from goonhub for the target ckey in list form
 	proc/cloud_fetch_target_ckey(target)
-		if(!cdn ) return
+		if(!cdn) return
 		target = ckey(target)
 		if (!target) return
 

--- a/code/player.dm
+++ b/code/player.dm
@@ -121,7 +121,7 @@
 		request.begin_async()
 		return TRUE // I guess
 
-	/// Sets a cloud key value pair and send it to goonhub for a target ckey
+	/// Sets a cloud key value pair and sends it to goonhub for a target ckey
 	proc/cloud_put_target(target, key, value)
 		var/list/data = cloud_fetch_target_data_only(target)
 		if(!data)

--- a/code/player.dm
+++ b/code/player.dm
@@ -149,23 +149,23 @@
 
 	/// Downloads cloud data from goonhub
 	proc/cloud_fetch()
-		var/list/ret = cloud_fetch_target_ckey(src.ckey)
-		if (ret)
-			cloudsaves = ret["saves"]
-			clouddata = ret["cdata"]
+		var/list/data = cloud_fetch_target_ckey(src.ckey)
+		if (data)
+			cloudsaves = data["saves"]
+			clouddata = data["cdata"]
 			return TRUE
 
 	/// returns the clouddata of a target ckey in list form
 	proc/cloud_fetch_target_data_only(target)
-		var/list/ret = cloud_fetch_target_ckey(target)
-		if (ret)
-			return ret["cdata"]
+		var/list/data = cloud_fetch_target_ckey(target)
+		if (data)
+			return data["cdata"]
 
 	/// returns the cloudsaves of a target ckey in list form
 	proc/cloud_fetch_target_saves_only(target)
-		var/list/ret = cloud_fetch_target_ckey(target)
-		if (ret)
-			return ret["saves"]
+		var/list/data = cloud_fetch_target_ckey(target)
+		if (data)
+			return data["saves"]
 
 	/// Returns cloud data and saves from goonhub for the target ckey in list form
 	proc/cloud_fetch_target_ckey(target)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds new procs for fetching cloudsaves and clouddata from goonhub cloud store for a provided ckey
* data is returned in list for for easy manipulation and processing


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* The current fetch and put procs self target the user's client and don't support targets
* unlimited power