### PR TITLE
Fix sleeper agent callout

### DIFF
--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -92,7 +92,7 @@
 			play_all_numbers()
 			broadcast_sound(signal_intro)
 
-			sleep(30 SECONDS) //30s to let the signal play
+			sleep(2 SECONDS)
 			var/mob/living/carbon/human/H = null
 			num_agents = min(num_agents,candidates.len)
 			for(var/i = 0, i<num_agents,i++)

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -197,7 +197,7 @@
 					if (M.client.ignore_sound_flags & SOUND_ALL)
 						continue
 				M.playsound_local(M, soundfile, 30, 0, flags = SOUND_IGNORE_SPACE)
-				sleep(1.2 SECONDS)
+				sleep(1 SECOND)
 
 	proc/play_all_numbers()
 		var/batch = 0

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -92,8 +92,8 @@
 			sleep(2 SECONDS)
 			if (length(candidates))
 				var/mob/living/carbon/human/H = null
-				num_agents = min(num_agents,length(candidates))
-				for(var/i = 0, i<num_agents,i++)
+				num_agents = min(num_agents, length(candidates))
+				for(var/i in 0 to num_agents)
 					H = pick(candidates)
 					candidates -= H
 					if(istype(H))

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -88,6 +88,7 @@
 
 		SPAWN_DBG(1 SECOND)
 			broadcast_sound(signal_intro)
+			sleep(8 SECONDS)
 			play_all_numbers()
 			broadcast_sound(signal_intro)
 
@@ -195,8 +196,8 @@
 				if (M.client.ignore_sound_flags)
 					if (M.client.ignore_sound_flags & SOUND_ALL)
 						continue
-				M << sound(soundfile, volume = 30, channel = sound_channel, wait = 1)
-
+				M.playsound_local(M, soundfile, 30, 0, flags = SOUND_IGNORE_SPACE)
+				sleep(1.2 SECONDS)
 
 	proc/play_all_numbers()
 		var/batch = 0

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -82,9 +82,6 @@
 					num_agents = 1
 				else
 					num_agents = 0
-		if(!num_agents)
-			cleanup_event()
-			return
 
 		SPAWN_DBG(1 SECOND)
 			broadcast_sound(signal_intro)
@@ -93,13 +90,16 @@
 			broadcast_sound(signal_intro)
 
 			sleep(2 SECONDS)
-			var/mob/living/carbon/human/H = null
-			num_agents = min(num_agents,candidates.len)
-			for(var/i = 0, i<num_agents,i++)
-				H = pick(candidates)
-				candidates -= H
-				if(istype(H))
-					awaken_sleeper_agent(H)
+			if (length(candidates))
+				var/mob/living/carbon/human/H = null
+				num_agents = min(num_agents,length(candidates))
+				for(var/i = 0, i<num_agents,i++)
+					H = pick(candidates)
+					candidates -= H
+					if(istype(H))
+						awaken_sleeper_agent(H)
+			else
+				message_admins("No valid candidates to wake for sleeper event.")
 
 			if (src.centcom_headline && src.centcom_message && random_events.announce_events)
 				sleep(src.message_delay)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reworks sleeper agent callout to use playsound_local.
Fix 25% chance of no agents resulting in everyone getting a peculiar noise message but the sleeper event promptly being cancelled without playing the radio messages or announcement.
Fixes https://github.com/goonstation/goonstation/issues/4981 - This will now respect volume controls.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sleeper agent callout could get it's order jumbled up due to queuing sounds. However it's hard to tell if this is fixed here due to local server.
Sounds used the cursed << method to play.
Sounds ignored volume controls.
num_agents could be 0, presumably as a fake out but this would also cancel out of the rest of the event without playing the audio.

https://user-images.githubusercontent.com/70909958/128004496-f98e709c-d2f3-4d5d-a537-7c5a311ac760.mp4