### PR TITLE
Add Donut 2 Syndicate shuttle to prefab_shuttles.dm

### DIFF
--- a/code/datums/prefab_shuttles.dm
+++ b/code/datums/prefab_shuttles.dm
@@ -88,6 +88,8 @@ var/list/prefab_shuttles = list()
 
 	disaster
 		prefab_path = "assets/maps/shuttles/donut2/donut2_disaster.dmm"
+	syndicate
+		prefab_path =  "assets/maps/shuttles/donut2/donut2_syndicate.dmm"
 
 /datum/prefab_shuttle/donut3
 	prefab_path = "assets/maps/shuttles/donut3/donut3_default.dmm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Apparently the tiny bit of code to allow the syndicate shuttle to be spawnable using the special-shuttles verb wasn't there. Now it is. ok