### PR TITLE
Prevents furnace stuffing from a distance

### DIFF
--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -83,7 +83,7 @@
 				message_admins("[key_name(user)] is trying to force [key_name(target)] into a furnace at [log_loc(src)].")
 				src.add_fingerprint(user)
 				sleep(5 SECONDS)
-				if(grab?.affecting && src.active) //ZeWaka: Fix for null.affecting
+				if(grab?.affecting && src.active && IN_RANGE(src, user, 1)) //ZeWaka: Fix for null.affecting
 					var/mob/M = grab.affecting
 					user.visible_message("<span class='alert'>[user] stuffs [M] into the furnace!</span>")
 					logTheThing("combat", user, M, "forced [constructTarget(M,"combat")] into a furnace at [log_loc(src)].")

--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -83,7 +83,7 @@
 				message_admins("[key_name(user)] is trying to force [key_name(target)] into a furnace at [log_loc(src)].")
 				src.add_fingerprint(user)
 				sleep(5 SECONDS)
-				if(grab?.affecting && src.active && IN_RANGE(src, user, 1)) //ZeWaka: Fix for null.affecting
+				if(grab?.affecting && src.active && in_interact_range(src, user)) //ZeWaka: Fix for null.affecting
 					var/mob/M = grab.affecting
 					user.visible_message("<span class='alert'>[user] stuffs [M] into the furnace!</span>")
 					logTheThing("combat", user, M, "forced [constructTarget(M,"combat")] into a furnace at [log_loc(src)].")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There was no range check on furnace stuffing, meaning as long as the stuffee is grabbed after 5 seconds they die instantly regardless of location.
Shoutouts to taocat/ook for the bug report:
https://clips.twitch.tv/TemperedBlitheYakinikuHeyGirl--X3K9EVv-7FBW-8j


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Telekinetic furnace stuffing is really fucking funny, but not very good