### PR TITLE
Change get_dist() to GET_DIST() to handle z-levels

### DIFF
--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -30,7 +30,7 @@
 			. = max(., UI_INTERACTIVE)
 
 		// Regular ghosts can always at least view if in range.
-		if(get_dist(src, src_object) <= ((WIDE_TILE_WIDTH - 1)/ 2))
+		if(GET_DIST(src, src_object) <= ((WIDE_TILE_WIDTH - 1)/ 2))
 			. = max(., UI_UPDATE)
 
 	// Check if the state allows interaction
@@ -115,7 +115,7 @@
 	if (istype(src_object.loc, /obj/item/storage)) // If the object is in a storage item, like a backpack.
 		return UI_CLOSE
 
-	var/dist = get_dist(src_object, src)
+	var/dist = GET_DIST(src_object, src)
 
 	if(viewcheck && !(dist <= 1 || (src_object in view(src)))) // If the object is obscured, close it.
 		return UI_CLOSE

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -29,7 +29,7 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 		return
 
 	// Robots can interact with anything they can see.
-	if(get_dist(src, src_object) <= ((WIDE_TILE_WIDTH - 1)/ 2))
+	if(GET_DIST(src, src_object) <= ((WIDE_TILE_WIDTH - 1)/ 2))
 		return UI_INTERACTIVE
 
 	// AI Borgs can recieve updates from anything that the AI can see.
@@ -44,7 +44,7 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 		return
 
 	// Robots can interact with anything they can see.
-	if(get_dist(src, src_object) <= ((WIDE_TILE_WIDTH - 1)/ 2))
+	if(GET_DIST(src, src_object) <= ((WIDE_TILE_WIDTH - 1)/ 2))
 		return UI_INTERACTIVE
 
 	return UI_UPDATE // AI eyebots can recieve updates from anything that the AI can see.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjusted TGUI distance calculations to use the GET_DIST() macro which will short-circuit and and provide infinite distance when comparing items on different z-levels.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5683
