### PR TITLE
Several changes to food boxes

### DIFF
--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -425,7 +425,9 @@ TRAYS
 	amount = 6
 	var/max_amount = 6
 	var/box_type = "donutbox"
+	var/has_closed_state = 1
 	var/contained_food = /obj/item/reagent_containers/food/snacks/donut/custom/random
+	var/allowed_food = /obj/item/reagent_containers/food/snacks/donut
 	var/contained_food_name = "donut"
 	tooltip_flags = REBUILD_DIST
 
@@ -441,6 +443,7 @@ TRAYS
 		max_amount = 12
 		box_type = "eggbox"
 		contained_food = /obj/item/reagent_containers/food/snacks/ingredient/egg
+		allowed_food = /obj/item/reagent_containers/food/snacks/ingredient/egg
 		contained_food_name = "egg"
 
 	lollipop
@@ -450,8 +453,11 @@ TRAYS
 		amount = 8
 		max_amount = 8
 		box_type = "lpop"
+		has_closed_state = 0
 		contained_food = /obj/item/reagent_containers/food/snacks/lollipop/random_medical
+		allowed_food = /obj/item/reagent_containers/food/snacks/lollipop
 		contained_food_name = "lollipop"
+		w_class = W_CLASS_SMALL
 
 	New()
 		..()
@@ -467,10 +473,10 @@ TRAYS
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if(src.amount >= src.max_amount)
-			boutput(user, "You can't fit anything else in this box!")
+			boutput(user, "You can't fit anything else in [src]!")
 			return
 		else
-			if(istype(W, src.contained_food))
+			if(istype(W, src.allowed_food))
 				user.drop_item()
 				W.set_loc(src)
 				src.amount ++
@@ -486,9 +492,13 @@ TRAYS
 				return ..()
 
 	attack_hand(mob/user as mob)
+		if((!istype(src.loc, /turf) && !user.is_in_hands(src)) || src.amount == 0)
+			..()
+			return
 		src.add_fingerprint(user)
-		var/obj/item/reagent_containers/food/snacks/myFood = locate(src.contained_food) in src
-		if(myFood)
+		var/list/obj/item/reagent_containers/food/snacks/myFoodList = src.contents
+		if(myFoodList.len >= 1)
+			var/obj/item/reagent_containers/food/snacks/myFood = myFoodList[myFoodList.len]
 			if(src.amount >= 1)
 				src.amount--
 				tooltip_rebuild = 1
@@ -502,6 +512,15 @@ TRAYS
 				user.put_in_hand_or_drop(newFood)
 				boutput(user, "You take [newFood] out of [src].")
 		src.update()
+
+	attack_self(mob/user as mob)
+		if(!src.has_closed_state) return
+		if(src.icon_state == "[src.box_type]")
+			src.icon_state = "[src.box_type][src.amount]"
+			boutput(user, "You open [src].")
+		else
+			src.icon_state = "[src.box_type]"
+			boutput(user, "You close [src].")
 
 	proc/update()
 		src.icon_state = "[src.box_type][src.amount]"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes several changes to food boxes (donut boxes, egg cartons and lollipop bowls)
- boxes can now be taken out of backpacks, pockets and other containers by clicking normally, instead of needing to click-drag the sprite to your character
- empty boxes can always be picked up by clicking on them
- clicking/activating certain boxes in hand allows you to open/close them
- all donuts/lollipops can be added to their respective boxes now instead of just the randomized/medicinal variants which they start off with
- taking items out of boxes now takes them out in order of most recently to least recently added
- lollipop bowls are now small items
- attempting to add an item to a full box now give the correct name of the box


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
make things work the way you'd expect them to


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DoctorStupid
(+)Donut boxes, egg cartons, and lollipop bowls are easier to move around in your inventory and can be re-closed by clicking/activating them in hand.
```
