### PR TITLE
Rewrites The Spriting Guidelines

### DIFF
--- a/.github/SPRITE_GUIDELINES.md
+++ b/.github/SPRITE_GUIDELINES.md
@@ -2,35 +2,90 @@
 
 {%hackmd @ZeWaka/dark-theme %}
 
-## Basic Style :sunglasses: 
+## Spriting for Goonstation 🐝
 
-* New large object sprites should be in ¾ perspective. Example [here](https://i.imgur.com/tU8mmeR.png).
-    * Normally, items shouldn't be in ¾, but drawn in a flat projection.
-    * Large handheld item sprites should be shown side on, see tool and gun sprites for examples of this. 
-* Keep colour palettes simple, and where possible sample existing colour palettes to create consistency within departments.
-* Hue shift your shadows and highlights. Tutorial [here](https://i.imgur.com/fsTkpWQ.gif). Example:
+So, you want to contribute sprite art to Goonstation. Great! This set of guidelines details what's generally expected out of sprite contributions for Goonstation, and aims to provide helpful advice on the implementation and creation of sprites. As a disclaimer, this isn't a guide on 'How All Good Pixel Art Should Be Drawn', it's how sprites contributed specifically to Goonstation should be drawn.
+
+## What Program Should I use? 🖥️
+
+* Programs for making sprite are preference, and using better programs will for the most part make spriting *faster* rather than *better*. The most essential feature is a 1px size pencil tool, and beyond that layers and fill buckets are incredibly useful. 
+
+* The Byond sprite editor is usable but doesn't have layers and can be pretty clunky. Some free editors include piskel, paint.net, and GIMP. Aseprite is also good and free if compiled yourself, it otherwise costs money. Even photoshop can be used if you're already comfortable with it. 
+# Basic Style 😎
+
+## Perspective ⬜
+
+* Sprites should generally be in three-quarter perspective (3/4 perspective for short), with few exceptions. 3/4 perspecrtive essentially means that objects have one face and the top visible, facing head on. This includes item sprites for most cases.
+
+![](https://cdn.discordapp.com/attachments/799118122899996754/872975960058781726/perspective.png)
+
+* Avoid cabinet projection, where sprites are tilted, with their side visible.
+
+* Further examples [here](https://i.imgur.com/tU8mmeR.png).
+
+## Colors 🎨
+
+* Keep color palettes small and generally higher-contrast when possible. If an existing item is similar to your sprite, for example if it contains matching departmental colors, pull palettes from existing sprites to maintain consistency.
+
+![](https://cdn.discordapp.com/attachments/799118122899996754/872975810485710899/colors.png)
+
+* Avoid low contrast palettes or palettes with unnecessarily large amounts of colors, they make sprites look muddier and less clean. A lot can be done with a little if you use a good color palette.
+
+* Hue shift your shadows and highlights. Hue shifting is when you linearly change the hue of colors in a color scheme based on their value. A basic example of that would be darker colors getting bluer as they get darker, and lighter colors being slightly more yellow. You want this effect to be subtle, but still have an impact. Useful tutorial [here](https://i.imgur.com/fsTkpWQ.gif). Examples:
     ![](http://i.imgur.com/9iGrBo9.png) <-- Bad
     ![](http://i.imgur.com/gB8u1zp.png) <-- Good
-* Do not use straight black for outlining. Instead, use a darkened version of the colour at the edge of the sprite. Example:
 
-![](https://i.imgur.com/eUL0qTx.png)
-* If you just shrink a jpeg and submit that, you're fired. ![](https://wiki.ss13.co/images/a/af/FoodPancakes.png)
-* Unique in hand sprites are encouraged for every new item, this is especially true for items that need to be visually identified in combat. :lower_left_paintbrush: 
+* Consider using the palette provided here if you're having trouble creating a palette: 
+
+![](https://cdn.discordapp.com/attachments/585526776550391819/814227015875428372/unknown.png)
+
+## Outlines 🖋
+
+* All sprites should make use of selective outlines, "or sel-out". This means that sprites should have outlines consisting of darker shades of the colors it connects to, instead of having a single color outline. 
+
+![](https://cdn.discordapp.com/attachments/799118122899996754/872975861886877696/whiteboard.png)
+
+* Outlines should also be subject to the shading on the sprite, getting darker in darker parts of the sprites and lighter when outlining lighter parts.
+
+## In-hand Sprites ✋
+
+* In-hand sprites are sprites that appear over character sprites when they're holding an item. Unique in hand sprites are encouraged for every new item, this is especially true for items that need to be visually identified in combat.
+
+* For one-handed items, you'll need 8 total in-hand sprites, four for each cardinal direction for both hands. For two-handed items, you'll only need four. An example of in-hand sprites overlaid on the human sprite:
+
+![](https://cdn.discordapp.com/attachments/799118122899996754/873221988531974224/unknown.png)
+
+* The finished sprites should just be on their own though, so they're more like this:
+
+![](https://cdn.discordapp.com/attachments/799118122899996754/873222059453480970/unknown.png)
+
+## Other Details 👁️
+
 * Referencing popular culture is allowed, but try to be subtle about it. Commonly available content should be original. :cake: 
-* Icon states should generally be centered on the middle of the canvas. 
-* Keep the use of your sprite in-game in mind, it’s difficult and frustrating to click tiny sprites or sprites with 1px holes in them
-    * To fix this, add a transparency 1 pixel in the hole. 
+* Sprites should generally be centered on the middle of the canvas, especially if you can pick them up. 
+* Keep the use of your sprite in-game in mind, it’s difficult and frustrating to click tiny sprites or sprites with 1px holes in them.
+    * To fix this, add an almost fully transparent pixel in the gap. These are useful when you want something to be fully transparent, but still click-able.
 * Try to keep scale in mind in general. Things don’t need to be actually proportional, they just need to “feel” right in the game.  :arrow_up_down: 
-* It’s good (but not mandated) to distinguish different objects by more than just color if possible, to accommodate the colorblind. :traffic_light: 
+* It’s good (but not mandated) to distinguish different objects by more than just color if possible, to accommodate the colorblind. :traffic_light:
+* Avoid violently flashing lights in large spaces when making animations.
+* If you just shrink a jpeg and submit that, you're fired. ![](https://wiki.ss13.co/images/a/af/FoodPancakes.png)
+
+# Implementation 🔧
+
+* Sprites in Byond are kept in **.dmi files**, which are essentially modified .png files. You can find these files in the code in the 'icons' folder.
+
+* These files are made up of various named sprites called 'icon_states'. These names are used in code, and should be kept simple but descriptive.
+
+![](https://cdn.discordapp.com/attachments/799118122899996754/873218644199493642/unknown.png)
+
+* If an existing .dmi file is suitable for your sprite, use that instead of making a new one.
+
+* For sprites larger than 32x32, use the designated `widthXheight` files (ex: 120x120).
+
+![](https://cdn.discordapp.com/attachments/799118122899996754/873220172817760256/unknown.png)
 
 
-## Implementation :wrench:
-
-* Keep the names of your icon_states simple but descriptive.
-* Use already existing .dmi files that fit your purpose if possible.
-* Use the `widthXheight` files (ex: 120x120) for larger-than-normal sprites.
-
-
-## Meta :left_speech_bubble: 
+# Meta :left_speech_bubble: 
 * Do not be precious about your work. Be open to criticism and change both from other developers and players. 
 * Most untrained people can visually identify when something looks wrong or bad, it's your responsibility as the artist to parse that criticism and find a solution. 
+* If you'd like more feedback on your sprites or pointers on spriting, check out the #imspriter channel on the Goonstation discord. 

--- a/.github/SPRITE_GUIDELINES.md
+++ b/.github/SPRITE_GUIDELINES.md
@@ -11,11 +11,16 @@ So, you want to contribute sprite art to Goonstation. Great! This set of guideli
 * Programs for making sprite are preference, and using better programs will for the most part make spriting *faster* rather than *better*. The most essential feature is a 1px size pencil tool, and beyond that layers and fill buckets are incredibly useful. 
 
 * The Byond sprite editor is usable but doesn't have layers and can be pretty clunky. Some free editors include piskel, paint.net, and GIMP. Aseprite is also good and free if compiled yourself, it otherwise costs money. Even photoshop can be used if you're already comfortable with it. 
+
+## Human Base 🧍
+![](https://cdn.discordapp.com/attachments/659599207946256416/873919587761156106/unknown.png)
+
+* The above human base is useful for drawing clothing items or in-hands by layering them over the base to ensure sprites line-up.
 # Basic Style 😎
 
 ## Perspective ⬜
 
-* Sprites should generally be in three-quarter perspective (3/4 perspective for short), with few exceptions. 3/4 perspecrtive essentially means that objects have one face and the top visible, facing head on. This includes item sprites for most cases.
+* Sprites should generally be in three-quarter perspective (3/4 perspective for short), with few exceptions. 3/4 perspective essentially means that objects have one face and the top visible, facing head on. This includes item sprites for most cases.
 
 ![](https://cdn.discordapp.com/attachments/799118122899996754/872975960058781726/perspective.png)
 
@@ -88,4 +93,4 @@ So, you want to contribute sprite art to Goonstation. Great! This set of guideli
 # Meta :left_speech_bubble: 
 * Do not be precious about your work. Be open to criticism and change both from other developers and players. 
 * Most untrained people can visually identify when something looks wrong or bad, it's your responsibility as the artist to parse that criticism and find a solution. 
-* If you'd like more feedback on your sprites or pointers on spriting, check out the #imspriter channel on the Goonstation discord. 
+* If you'd like more feedback on your sprites or pointers on spriting, check out the #imspriter channel on the [Goonstation discord.](https://discord.gg/zd8t6pY) 


### PR DESCRIPTION
[help wanted]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR rewrites the spriting guidelines here on github, doesn't touch the game itself whatsoever. Aims to add more detailed and accurate information on spriting specifically for Goon. Includes some new picture examples for outlines, color palettes and perspective using sprites from the game itself, which I think are more relevant/useful, and still includes the links from the old guide for the most part. (I got rid of the old outline picture since I think it's not so useful, but I'm not married to the idea of not having it.) 

Opens with a section explaining the purpose of the guide, and that it's only really meant to apply to Goon. I included this specifically because I don't want people getting any ideas that techniques the guide says to avoid are supposed to be *always* bad in pixel art or something. Additionally I chose to immediately include some words on which program to use, since I see that getting asked a whole lot particularly and I think giving a concise response early is helpful.

Next is the 'basic style' section, which opens with an explanation of 3/4 perspective that's hopefully more detailed and clear, and includes some old cabinet sprites that got redone as 'what not to do' examples. Similarly there's images explaining color palettes  (including a link to the resprite palette) and then selective outlines, and a more detailed explanation of *what* exactly in-hand sprites are and how they're made. Then an 'other stuff' section that has stuff from the guide that I thought was worth keeping but didn't fit in the other sections, generic useful little tidbits. 

The implementation section now has a basic explanation of what .dmi files are and what icon_states are, mostly containing the same info but now providing some pictures. 

Finally the meta section at the end is mostly unchanged but now plugs the imspriter channel in the discord. Thinking now could probably also use a link tba

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I think the info in the guide is a bit lackluster, and I'd like it to be more detailed so it could instruct people more clearly on the expectations of Goon sprites, and give useful advice for making spriteart. 

I'm assuming there's some nice way to preview the guide from this PR with the formatting intact, I used the vscode preview to see what it looked like when writing it, if there's not I'll include screenshots of that here or something later. I'd like other people to read over what I've written, and would definitely appreciate grammar corrections or rewording of anything awkward or any critiques of the substance of the guide, I'm fine with adjusting or shuffling or cutting or adding info to the guide and I consider this a bit of a 'rough draft'. Also please keep in mind I'm trying to write descriptively based on our current standards (generally) for sprites, rather than trying to write *new* standards for spriting. The idea is to better clarify what we're already considering when judging whether sprites fit in the game or not.