### PR TITLE
Remove some spy bounty target subtypes

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -445,11 +445,9 @@
 
 	station_bounties[/obj/item/clothing/glasses/blindfold] = 1
 	station_bounties[/obj/item/clothing/glasses/meson] = 1
-	station_bounties[/obj/item/clothing/glasses/sunglasses/tanning] = 1
 	station_bounties[/obj/item/clothing/glasses/sunglasses/sechud] = 2
 	station_bounties[/obj/item/clothing/glasses/sunglasses] = 1
 	station_bounties[/obj/item/clothing/glasses/visor] = 1
-	station_bounties[/obj/item/clothing/glasses/healthgoggles/upgraded] = 1
 	station_bounties[/obj/item/clothing/glasses/healthgoggles] = 1
 
 	station_bounties[/obj/item/clothing/suit/space/santa] = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes upgraded prodoc and tanning sunglasses from the bounty list.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As subtypes, the parent type of these items are not accepted as bounty targets. However, the name of these items are identical which is very confusing to players who are told they need "ProDoc Healthgoggles" but nothing happens when they try to redeem "ProDoc Healthgoggles".
These subtypes will still be accepted for the parent rewards, which will make sense to the players and is not exploitable.