### PR TITLE
sets over_hair to FALSE on a bunch of places it doesn't fit in and sets it  to TRUE on some places it should be in.

### DIFF
--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -693,6 +693,7 @@
 	icon_state = "adeptus"
 	item_state = "adeptus"
 	permeability_coefficient = 0.50
+	over_hair = TRUE
 	body_parts_covered = TORSO|LEGS|ARMS
 	wear_layer = MOB_OVERLAY_BASE
 
@@ -852,6 +853,7 @@
 	inhand_image_icon = 'icons/mob/inhand/overcoat/hand_suit_gimmick.dmi'
 	icon_state = "monkey"
 	item_state = "monkey"
+	over_hair = TRUE
 	body_parts_covered = TORSO|LEGS|ARMS
 	c_flags = COVERSMOUTH | COVERSEYES
 
@@ -888,6 +890,7 @@
 	item_state = "light_borg"
 	body_parts_covered = TORSO|LEGS|ARMS
 	c_flags = COVERSMOUTH | COVERSEYES
+	over_hair = TRUE
 	see_face = 0.0
 
 /obj/item/clothing/under/gimmick/utena //YJHTGHTFH's utena suit
@@ -1330,6 +1333,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves/ring)
 	icon_state = "joyful"
 	body_parts_covered = TORSO|LEGS|ARMS
 	wear_layer = MOB_OVERLAY_BASE
+	over_hair = TRUE
 
 /obj/item/clothing/head/rando
 	name = "red skull mask and cowl"
@@ -1478,6 +1482,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves/ring)
 	body_parts_covered = HEAD|TORSO|LEGS|ARMS
 	wear_layer = MOB_OVERLAY_BASE
 	icon_state = "hotdogsuit"
+	over_hair = TRUE
 
 /obj/item/clothing/under/gimmick/vampire
 	name = "absurdly stylish suit and vest"

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -233,7 +233,6 @@
 	var/armored = 0
 	body_parts_covered = TORSO|LEGS|ARMS
 	permeability_coefficient = 0.005
-	over_hair = 1
 
 	setupProperties()
 		..()
@@ -356,7 +355,6 @@
 	inhand_image_icon = 'icons/mob/inhand/overcoat/hand_suit_hazard.dmi'
 	body_parts_covered = TORSO|LEGS|ARMS
 	permeability_coefficient = 0.02
-	over_hair = 1
 
 	New()
 		. = ..()
@@ -1017,7 +1015,6 @@
 	body_parts_covered = TORSO|LEGS|ARMS
 	permeability_coefficient = 0.1
 	protective_temperature = 1000
-	over_hair = 1
 
 	New()
 		..()
@@ -1472,6 +1469,7 @@
 	wear_layer = MOB_OVERLAY_BASE
 	c_flags = COVERSEYES | COVERSMOUTH
 	body_parts_covered = TORSO|LEGS|ARMS
+	over_hair = TRUE
 	permeability_coefficient = 0.50
 
 /obj/item/clothing/suit/wizrobe
@@ -1634,7 +1632,6 @@
 	item_state = "chem_suit"
 	body_parts_covered = TORSO|LEGS|ARMS
 	permeability_coefficient = 0
-	over_hair = 1
 
 /obj/item/clothing/suit/security_badge
 	name = "Security Badge"

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -34,7 +34,7 @@
 	icon_state = "hoodie"
 	uses_multiple_icon_states = 1
 	item_state = "hoodie"
-	body_parts_covered = HEAD|TORSO|ARMS
+	body_parts_covered = TORSO|ARMS
 	var/hood = 0
 	var/hcolor = null
 
@@ -52,10 +52,12 @@
 		user.show_text("You flip [src]'s hood [src.hood ? "up" : "down"].")
 		if (src.hood)
 			src.over_hair = 1
+			src.body_parts_covered = HEAD|TORSO|ARMS
 			src.icon_state = "hoodie[src.hcolor ? "-[hcolor]" : null]-up"
 			src.item_state = "hoodie[src.hcolor ? "-[hcolor]" : null]-up"
 		else
 			src.over_hair = 0
+			src.body_parts_covered = TORSO|ARMS
 			src.icon_state = "hoodie[src.hcolor ? "-[hcolor]" : null]"
 			src.item_state = "hoodie[src.hcolor ? "-[hcolor]" : null]"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
sets over_hair to FALSE on biosuits, radsuits and spacesuits. none of these don't cover your head at all.

sets it to TRUE on hotdogsuits, light borg suit, monkey suit, flock robes, adeptus robes and the joyful suit. All of these are suits that cover your head.

Makes hoodies only cover your head when you have the hood on.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Suits that completely show your head shouldn't have that var because it looks silly when you put on a spacesuit and your hair disappears.

Your hair going through something that hides your head also looks silly.