### PR TITLE
Cleaning QOL

### DIFF
--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -177,10 +177,8 @@
 /atom/proc/clean_forensic()
 	if (!src)
 		return
-
 	if (!(src.flags & FPRINT))
 		return
-
 	// The first version accidently looped through everything for every atom. Consequently, cleaner grenades caused horrendous lag on my local server. Woops.
 	if (!ismob(src)) // Mobs are a special case.
 		if (isobj(src))
@@ -201,6 +199,9 @@
 				#else
 				CI.UpdateOverlays(null, "blood_splatter")
 				#endif
+				if (istype(src, /obj/item/clothing))
+					var/obj/item/clothing/C = src
+					C.clean_stains()
 
 		else if (istype(src, /obj/decal/cleanable) || istype(src, /obj/reagent_dispensers/cleanable))
 			pool(src)
@@ -238,6 +239,9 @@
 						#else
 						check.UpdateOverlays(null, "blood_splatter")
 						#endif
+						if (istype(check, /obj/item/clothing))
+							var/obj/item/clothing/C = check
+							C.clean_stains()
 
 			if (isnull(M.gloves)) // Can't clean your hands when wearing gloves.
 				M.add_forensic_trace("bDNA", M.blood_DNA)

--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -199,9 +199,9 @@
 				#else
 				CI.UpdateOverlays(null, "blood_splatter")
 				#endif
-				if (istype(src, /obj/item/clothing))
-					var/obj/item/clothing/C = src
-					C.clean_stains()
+		if (istype(src, /obj/item/clothing))
+			var/obj/item/clothing/C = src
+			C.clean_stains()
 
 		else if (istype(src, /obj/decal/cleanable) || istype(src, /obj/reagent_dispensers/cleanable))
 			pool(src)
@@ -239,9 +239,9 @@
 						#else
 						check.UpdateOverlays(null, "blood_splatter")
 						#endif
-						if (istype(check, /obj/item/clothing))
-							var/obj/item/clothing/C = check
-							C.clean_stains()
+				if (istype(check, /obj/item/clothing))
+					var/obj/item/clothing/C = check
+					C.clean_stains()
 
 			if (isnull(M.gloves)) // Can't clean your hands when wearing gloves.
 				M.add_forensic_trace("bDNA", M.blood_DNA)

--- a/code/obj/item/clothing.dm
+++ b/code/obj/item/clothing.dm
@@ -77,6 +77,11 @@
 			for (var/i in src.stains)
 				. += i + " "
 
+	proc/clean_stains()
+		if (islist(src.stains) && length(src.stains))
+			src.stains = list()
+			src.UpdateName()
+
 /obj/item/clothing/under
 	equipped(var/mob/user, var/slot)
 		..()

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -208,17 +208,19 @@ WET FLOOR SIGN
 
 	if(src.reagents.has_reagent("water") || src.reagents.has_reagent("cleaner"))
 		JOB_XP(user, "Janitor", 2)
+	playsound(src.loc, "sound/effects/zzzt.ogg", 50, 1, -6)
+	// Make sure we clean an item that was sprayed directly in case it is in contents
+	if (!isturf(A.loc))
+		if (istype(A, /obj/item))
+			src.reagents.reaction(A, TOUCH, 5)
+			src.reagents.remove_any(5)
+			return
 	var/obj/decal/D = new/obj/decal(get_turf(src))
 	D.name = "chemicals"
 	D.icon = 'icons/obj/chemical.dmi'
 	D.icon_state = "chempuff"
 	D.create_reagents(5) // cogwerks: lowered from 10 to 5
 	src.reagents.trans_to(D, 5)
-	playsound(src.loc, "sound/effects/zzzt.ogg", 50, 1, -6)
-	// Direct cleaning for objects or items directly sprayed in containers are not cleaned
-	if (istype(A, /obj/item))
-		D.reagents.reaction(A)
-		D.reagents.remove_any(1)
 	var/log_reagents = log_reagents(src)
 	var/travel_distance = max(min(get_dist(get_turf(src), A), 3), 1)
 	SPAWN_DBG(0)

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -295,6 +295,8 @@ WET FLOOR SIGN
 		. += "<span class='notice'>[src] is wet!</span>"
 
 /obj/item/mop/afterattack(atom/A, mob/user as mob)
+	if (ismob(A))
+		return
 	if ((src.reagents.total_volume < 1 || mopcount >= 9) && !istype(A, /obj/fluid))
 		boutput(user, "<span class='notice'>Your mop is dry!</span>", group = "mop")
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1. Adds a clean_stains() proc to clothing that removes all stains.
2. Makes clean_forensic() call clean_stains() on clothing.
3. Directly cleans items that aren't on a turf (i.e. in contents) when sprayed by a spray bottle.
4. Fixes mop attack intent check using the wrong intent var.
5. Prevent pointless "Mop is dry" messages when a  dry mop is used on a person.
6. Adds the attack intent check to sponges so you can wipe someone down without "attacking" them.
7. Reduce sponge stamina damage from default (20) to 5. It's a sponge!
8. Fix sponge menu options building a list using += which would add hidden duplicate menu options and prevent the intended automatic selection when there is only a single action available.
9. Moves an inline return for code readability.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cleaning did not change the name of items, so they remained "blood soaked".
Using the spray bottle on items in your pocket/belt/bag or in a container inventory would not clean them.
Mops and sponges often get clicked on people moving around. Changing these to no longer whack people with red text reduces confusion.