### PR TITLE
do not unbuckle people on shuttle start

### DIFF
--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -734,7 +734,8 @@
 		RegisterSignal(to_buckle, COMSIG_MOVABLE_SET_LOC, .proc/maybe_unbuckle)
 
 	proc/maybe_unbuckle(source, turf/oldloc)
-		if(!isturf(buckled_guy.loc) || !IN_RANGE(src, oldloc, 1))
+		// unbuckle if the guy is not on a turf, or if their chair is out of range and it's not a shuttle situation
+		if(!isturf(buckled_guy.loc) || (!IN_RANGE(src, oldloc, 1) && (!istype(get_area(src), /area/shuttle || !istype(get_area(oldloc), /area/shuttle)))))
 			UnregisterSignal(buckled_guy, COMSIG_MOVABLE_SET_LOC)
 			unbuckle()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Due to a recent change, the shuttle leaving automatically unbuckled people from the chairs (due to the chairs changing z-level and location). This caused people to be thrown around.

This PR adds an exception to the autounbuckling code for if the old and new location of the chairs are both shuttle type areas.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
safety concerns
