### PR TITLE
Echo Newline Flag

### DIFF
--- a/code/modules/networks/computer3/mainframe2/shell.dm
+++ b/code/modules/networks/computer3/mainframe2/shell.dm
@@ -221,7 +221,7 @@
 						if (pipetemp)
 							echo_text = pipetemp
 
-						var/add_newline = 1
+						var/add_newline = TRUE
 						if (command_list[1] == "-n")
 							add_newline = 0
 							command_list.Cut(1,2)

--- a/code/modules/networks/computer3/mainframe2/shell.dm
+++ b/code/modules/networks/computer3/mainframe2/shell.dm
@@ -223,7 +223,7 @@
 
 						var/add_newline = TRUE
 						if (command_list[1] == "-n")
-							add_newline = 0
+							add_newline = FALSE
 							command_list.Cut(1,2)
 
 						if(istype(command_list) && (command_list.len > 0))


### PR DESCRIPTION
[size/XS]

## About the PR

Adds the *-n* flag to echo, which stops it from appending a newline.

## Why’s this needed?

* Allows greater control
* It's not possible to prepend the output of a mainframe program without a newline.