### PR TITLE
Fix medtrak scan when the cartidge is not loaded by default.

### DIFF
--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -346,7 +346,7 @@
 	var/datum/computer/file/pda_program/records/medical/record_prog = locate(/datum/computer/file/pda_program/records/medical) in programs
 	if (!record_prog)
 		return "<span class='alert'>ERROR: NO MEDICAL RECORD FILE</span>"
-	pda.active_program = record_prog
+	pda.run_program(record_prog)
 	record_prog.active1 = GR
 	record_prog.active2 = MR
 	record_prog.mode = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes an issue with using the medtrak PDA scanner when the PDA does not start with the cartridge by default.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5713.
