### PR TITLE
Fixes broken port-a-gene behavior

### DIFF
--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "PAG_0"
 	anchored = 0
-	circuit_type = /obj/item/circuitboard/portagene
 	var/mob/occupant = null
 	var/datum/character_preview/multiclient/occupant_preview = null
 	var/locked = 0
@@ -161,8 +160,14 @@
 			qdel(G)
 			return
 		else
-			..()
+			src.attack_hand(user)
 		return
+
+	set_broken()
+		var/datum/effects/system/harmless_smoke_spread/smoke = new /datum/effects/system/harmless_smoke_spread()
+		smoke.set_up(5, 0, src)
+		smoke.start()
+		qdel(src)
 
 	power_change()
 		return

--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -131,7 +131,7 @@
 
 	attack_hand(mob/user as mob)
 		if (src.status & BROKEN)
-			boutput(user, "<span class='notice'>The Port-A-Gene is busted! You'll need at least two sheets of glass to fix it.</span>")
+			boutput(user, "<span class='notice'>The [src] is busted! You'll need at least two sheets of glass to fix it.</span>")
 			return
 		. = ..()
 
@@ -145,9 +145,9 @@
 					src.status &= !BROKEN
 					src.icon_state = "PAG_0"
 					light.enable()
-					boutput(user, "<span class='notice'>You repair the Port-A-Gene!</span>")
+					boutput(user, "<span class='notice'>You repair the [src]!</span>")
 				else
-					boutput(user, "<span class='alert'>You need at least two sheets of glass to repair the Port-A-Gene.</span>")
+					boutput(user, "<span class='alert'>You need at least two sheets of glass to repair the [src].</span>")
 			else
 				boutput(user, "<span class='alert'>This is the wrong kind of material. You'll need a type of glass or crystal.</span>")
 

--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -131,7 +131,7 @@
 
 	attack_hand(mob/user as mob)
 		if (src.status & BROKEN)
-			boutput(user, "<span class='notice'>The [src] is busted! You'll need at least two sheets of glass to fix it.</span>")
+			boutput(user, "<span class='notice'>The [src.name] is busted! You'll need at least two sheets of glass to fix it.</span>")
 			return
 		. = ..()
 
@@ -145,9 +145,9 @@
 					src.status &= !BROKEN
 					src.icon_state = "PAG_0"
 					light.enable()
-					boutput(user, "<span class='notice'>You repair the [src]!</span>")
+					boutput(user, "<span class='notice'>You repair the [src.name]!</span>")
 				else
-					boutput(user, "<span class='alert'>You need at least two sheets of glass to repair the [src].</span>")
+					boutput(user, "<span class='alert'>You need at least two sheets of glass to repair the [src.name].</span>")
 			else
 				boutput(user, "<span class='alert'>This is the wrong kind of material. You'll need a type of glass or crystal.</span>")
 

--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "PAG_0"
 	anchored = 0
+	circuit_type = /obj/item/circuitboard/portagene
 	var/mob/occupant = null
 	var/datum/character_preview/multiclient/occupant_preview = null
 	var/locked = 0
@@ -119,25 +120,7 @@
 		.= 1
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (isscrewingtool(W) && (src.status & BROKEN))
-			src.icon_state = "PAG_broken"
-			playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
-			if(do_after(user, 2 SECONDS))
-				boutput(user, "<span class='notice'>The broken glass falls out.</span>")
-				var/obj/computerframe/A = new /obj/computerframe( src.loc )
-				if(src.material) A.setMaterial(src.material)
-				var/obj/item/raw_material/shard/glass/G = unpool(/obj/item/raw_material/shard/glass)
-				G.set_loc(src.loc)
-				var/obj/item/circuitboard/genetics/M = new /obj/item/circuitboard/genetics( A )
-				for (var/obj/C in src)
-					C.set_loc(src.loc)
-				A.circuit = M
-				A.state = 3
-				A.icon_state = "3"
-				A.anchored = 1
-				qdel(src)
-
-		else if (istype(W,/obj/item/genetics_injector/dna_activator))
+		if (istype(W,/obj/item/genetics_injector/dna_activator))
 			var/obj/item/genetics_injector/dna_activator/DNA = W
 			if (DNA.expended_properly)
 				user.drop_item()
@@ -178,7 +161,7 @@
 			qdel(G)
 			return
 		else
-			src.attack_hand(user)
+			..()
 		return
 
 	power_change()

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -94,6 +94,9 @@ ABSTRACT_TYPE(/obj/item/circuitboard)
 /obj/item/circuitboard/genetics
 	name = "Circuit board (Genetics)"
 	computertype = "/obj/machinery/computer/genetics"
+/obj/item/circuitboard/portagene
+	name = "Circuit board (Port-A-Gene)"
+	computertype = "/obj/machinery/computer/genetics/portable"
 /obj/item/circuitboard/tetris
 	name = "Circuit board (Robustris Pro)"
 	computertype = "/obj/machinery/computer/tetris"

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -94,9 +94,6 @@ ABSTRACT_TYPE(/obj/item/circuitboard)
 /obj/item/circuitboard/genetics
 	name = "Circuit board (Genetics)"
 	computertype = "/obj/machinery/computer/genetics"
-/obj/item/circuitboard/portagene
-	name = "Circuit board (Port-A-Gene)"
-	computertype = "/obj/machinery/computer/genetics/portable"
 /obj/item/circuitboard/tetris
 	name = "Circuit board (Robustris Pro)"
 	computertype = "/obj/machinery/computer/tetris"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the port-a-gene's behavior when broken.

1.  It previously turned into the genetics computer when repaired. Now repair is performed without it reverting to a standard computer frame. Just use two glass sheets on it to repair it.

2. It previously did not stop working when broken. Now it cannot be used until repaired.

3. It now ejects its occupant when broken so NPC's don't get trapped inside. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5729. A broken port-a-gene should not work normally.
