### PR TITLE
Ensure path to shipping is clear for -ify admin verbs

### DIFF
--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2745,6 +2745,8 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 				for (var/turf/S in space)
 					I.color = ambient_light
 					S.UpdateOverlays(I, "ambient")
+				shippingmarket.clear_path_to_market()
+
 				logTheThing("admin", src, null, "turned space into a swamp.")
 				logTheThing("diary", src, null, "turned space into a swamp.", "admin")
 				message_admins("[key_name(src)] turned space into a swamp.")
@@ -2819,6 +2821,7 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 						created_loot.initialize()
 
 					LAGCHECK(LAG_MED)
+				shippingmarket.clear_path_to_market()
 				logTheThing("admin", src, null, "generated a trench on station Z[hostile_mob_toggle ? " with hostile mobs" : ""].")
 				logTheThing("diary", src, null, "generated a trench on station Z[hostile_mob_toggle ? " with hostile mobs" : ""].", "admin")
 				message_admins("[key_name(src)] generated a trench on station Z[hostile_mob_toggle ? " with hostile mobs" : ""].")

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -282,7 +282,7 @@
 
 		shipped_thing.throw_at(target, 100, 1)
 
-	proc/clear_path_to_market(list/obj/objs, list/turf/turfs)
+	proc/clear_path_to_market()
 		var/turf/T
 		var/list/bounds = get_area_turfs(/area/supply/delivery_point)
 		bounds += get_area_turfs(/area/supply/sell_point)
@@ -301,6 +301,7 @@
 			//Wacks asteroids and skip normal turfs that belong
 			if(istype(T, /turf/simulated/wall/asteroid))
 				T.ReplaceWith(/turf/simulated/floor/plating/airless/asteroid, force=TRUE)
+				continue
 			else if(!istype(T, /turf/unsimulated))
 				continue
 

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -282,6 +282,35 @@
 
 		shipped_thing.throw_at(target, 100, 1)
 
+	proc/clear_path_to_market(list/obj/objs, list/turf/turfs)
+		var/turf/T
+		sleep(5 SECONDS)
+		var/list/bounds = get_area_turfs(/area/supply/delivery_point)
+		bounds += get_area_turfs(/area/supply/sell_point)
+		bounds += get_area_turfs(/area/supply/spawn_point)
+		var/min_x = INFINITY
+		var/max_x = 0
+		var/min_y = INFINITY
+		var/max_y = 0
+		for(T in bounds)
+			min_x = min(min_x, T.x)
+			min_y = min(min_y, T.y)
+			max_x = max(max_x, T.x)
+			max_y = max(max_y, T.y)
+		var/list/turf/to_clear = block(locate(min_x, min_y, Z_LEVEL_STATION), locate(max_x, max_y, Z_LEVEL_STATION))
+		for(T in to_clear)
+			//Wacks asteroids and skip normal turfs that belong
+			if(istype(T, /turf/simulated/wall/asteroid))
+				T.ReplaceWith(/turf/simulated/floor/plating/airless/asteroid, force=TRUE)
+			else if(!istype(T, /turf/unsimulated))
+				continue
+
+			//Uh, make sure we don't block the shipping lanes!
+			for(var/atom/A in T)
+				if(A.density)
+					qdel(A)
+
+
 // Debugging and admin verbs (mostly coder)
 
 /client/proc/cmd_modify_market_variables()

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -283,7 +283,6 @@
 		shipped_thing.throw_at(target, 100, 1)
 
 	proc/clear_path_to_market()
-		var/turf/T
 		var/list/bounds = get_area_turfs(/area/supply/delivery_point)
 		bounds += get_area_turfs(/area/supply/sell_point)
 		bounds += get_area_turfs(/area/supply/spawn_point)
@@ -291,13 +290,14 @@
 		var/max_x = 0
 		var/min_y = INFINITY
 		var/max_y = 0
-		for(T in bounds)
-			min_x = min(min_x, T.x)
-			min_y = min(min_y, T.y)
-			max_x = max(max_x, T.x)
-			max_y = max(max_y, T.y)
+		for(var/turf/boundry as anything in bounds)
+			min_x = min(min_x, boundry.x)
+			min_y = min(min_y, boundry.y)
+			max_x = max(max_x, boundry.x)
+			max_y = max(max_y, boundry.y)
+
 		var/list/turf/to_clear = block(locate(min_x, min_y, Z_LEVEL_STATION), locate(max_x, max_y, Z_LEVEL_STATION))
-		for(T in to_clear)
+		for(var/turf/T as anything in to_clear)
 			//Wacks asteroids and skip normal turfs that belong
 			if(istype(T, /turf/simulated/wall/asteroid))
 				T.ReplaceWith(/turf/simulated/floor/plating/airless/asteroid, force=TRUE)

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -284,7 +284,6 @@
 
 	proc/clear_path_to_market(list/obj/objs, list/turf/turfs)
 		var/turf/T
-		sleep(5 SECONDS)
 		var/list/bounds = get_area_turfs(/area/supply/delivery_point)
 		bounds += get_area_turfs(/area/supply/sell_point)
 		bounds += get_area_turfs(/area/supply/spawn_point)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Clears out region between shipping and receiving when -ify verbs are used of:
- Dense atoms
- Asteroids


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves issues where annoying objects will obstruct shipping and receiving. 