### PR TITLE
Allow genetics computers to dispose of used DNA injectors

### DIFF
--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -53,13 +53,16 @@
 	..()
 
 /obj/machinery/computer/genetics/attackby(obj/item/W as obj, mob/user as mob)
-	if (istype(W,/obj/item/genetics_injector/dna_activator))
-		var/obj/item/genetics_injector/dna_activator/DNA = W
-		if (DNA.expended_properly)
-			user.drop_item()
-			qdel(DNA)
-			activated_bonus(user)
-		else if (DNA.uses < 1)
+	if (istype(W,/obj/item/genetics_injector))
+		var/obj/item/genetics_injector/DNA = W
+		if (istype(W,/obj/item/genetics_injector/dna_activator))
+			var/obj/item/genetics_injector/dna_activator/DNA_A = W
+			if (DNA_A.expended_properly)
+				user.drop_item()
+				qdel(DNA_A)
+				activated_bonus(user)
+				return
+		if (DNA.uses < 1)
 			// You get nothing from these but at least let people clean em up
 			boutput(user, "You dispose of the [DNA].")
 			user.drop_item()

--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -137,13 +137,16 @@
 				A.anchored = 1
 				qdel(src)
 
-		else if (istype(W,/obj/item/genetics_injector/dna_activator))
-			var/obj/item/genetics_injector/dna_activator/DNA = W
-			if (DNA.expended_properly)
-				user.drop_item()
-				qdel(DNA)
-				activated_bonus(user)
-			else if (DNA.uses < 1)
+		else if (istype(W,/obj/item/genetics_injector))
+			var/obj/item/genetics_injector/DNA = W
+			if (istype(W,/obj/item/genetics_injector/dna_activator))
+				var/obj/item/genetics_injector/dna_activator/DNA_A = W
+				if (DNA_A.expended_properly)
+					user.drop_item()
+					qdel(DNA_A)
+					activated_bonus(user)
+					return
+			if (DNA.uses < 1)
 				// You get nothing from these but at least let people clean em up
 				boutput(user, "You dispose of the [DNA].")
 				user.drop_item()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL][WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the genetics computer and Port-A-Gene to dispose of used DNA injectors. Disposing of used DNA injectors provides no additional benefit. This is a feature to help geneticists prevent a massive pile of used injectors under their feet.

This may have a small impact on balance as it would be slightly easier for antag geneticists to hide the gene they just used. However, I don't expect it to be significantly easier than stuffing a used injector in a box or any other disposal method.

Used DNA scramblers can also be disposed of in this way.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some geneticist play styles can use a lot of DNA injectors. For example, when experimenting with high complexity combos. This can lead to laggy right clicks on the piles of injectors, and it is generally a mess. Some genetics rooms have nearby disposal chutes, while others are more out of the way. This just makes cleanup easier.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Used DNA injectors can be disposed of in genetics computers.
```
