### PR TITLE
Rain Tile Improvements

### DIFF
--- a/code/obj/effects/precipitation.dm
+++ b/code/obj/effects/precipitation.dm
@@ -23,8 +23,10 @@ particles/rain
 		drift = generator("box", list(0.1, -1, 0), list(0.4, 0, 0))
 
 		tile
-			count = 8
-			spawning = 2.5
+			count = 5
+			spawning = 1.1
+			fade = 5
+			lifespan = generator("num", 4, 6, LINEAR_RAND)
 			position = generator("box", list(-96,32,0), list(300,64,50))
 			bound1 = list(-32, -48, -1000)
 			bound2 = list(32, 64, 1000)
@@ -34,10 +36,12 @@ particles/rain
 			width = 96
 			height = 96
 
+
 obj/effects/rain
 	particles = new/particles/rain
 	plane = PLANE_NOSHADOW_ABOVE
 	alpha = 200
+	var/static/list/particles/z_particles
 
 	client_attach
 		screen_loc = "CENTER"
@@ -49,7 +53,16 @@ obj/effects/rain
 		particles = new/particles/rain/sideways
 
 		tile
-			particles = new/particles/rain/sideways/tile
+			particles = null
 			// Offset pixel position to align bounding boxes and visual area
 			pixel_y = 16
 			pixel_x = -16
+
+			New()
+				..()
+				LAZYLISTINIT(z_particles)
+				var/z_level_str = "\"[src.loc.z]\""
+				if(!z_particles[z_level_str])
+					z_particles[z_level_str] = new/particles/rain/sideways/tile
+				particles = z_particles[z_level_str]
+


### PR DESCRIPTION
[performance]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Improves on #5735

Reduces client particle count for tile based rain effect
Also tweaks some params to improve visual experience

Share a single particle emitter throughout an entire z-level to allow for easy adjustment of the visual effect.

![RainParticles](https://user-images.githubusercontent.com/1017374/129435579-a23d242b-0ace-4802-a19f-f85434e799e7.gif) Prev
![LighterRain01](https://user-images.githubusercontent.com/1017374/129599152-08526c13-8894-4841-a288-61e07fb12d95.gif)New

---

![RainParticles2](https://user-images.githubusercontent.com/1017374/129435598-9bdde724-8f0f-4a16-b51d-cb3cffa0b693.gif)Prev
![LighterRain02](https://user-images.githubusercontent.com/1017374/129599175-de47ceea-9075-4b86-8321-09d1937d55ed.gif)New


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves reduced client responsiveness when majority of view contains particles.
Previously 5 quick directional inputs when surrounded by rain, typically 1 would be dropped.