### PR TITLE
Removes pickpocket gun from VR uplink list

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -690,6 +690,7 @@ This is basically useless for anyone but miners.
 	name = "Pickpocket Gun"
 	item = /obj/item/gun/energy/pickpocket
 	cost = 3
+	vr_allowed = 0
 	desc = "A stealthy claw gun capable of stealing and planting items, and severely messing with people."
 	job = list("Engineer", "Chief Engineer", "Mechanic", "Clown", "Staff Assistant")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[removal]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Pickpocket guns are coded to be useless in restricted Z levels, so they don't work in VR gun sim at all. They also send admin notices whenever someone tries to use a pickpocket gun in restricted Z, so they create unnecessary bloat in admin alerts.

