### PR TITLE
Make buddies less spammy when handed weapons

### DIFF
--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -140,7 +140,8 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 			if(3) return ..("<font face='System'size=3>[uppertext(message)]!!</font>")
 			else
 				var/honk = pick("WACKA", "QUACK","QUACKY","GAGGLE")
-				playsound(src.loc, "sound/misc/amusingduck.ogg", 50, 0)
+				if(!ON_COOLDOWN(src, "bootleg_sound", 15 SECONDS))
+					playsound(src.loc, "sound/misc/amusingduck.ogg", 50, 0)
 				return ..("<font face='Comic Sans MS' size=3>[honk]!!</font>")
 	Move()
 		if(..())

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -957,7 +957,7 @@
 				if (src.locked) // Are we locked?
 					if(src.on && !src.idle)
 						if(!DeceptionCheck(null, user, "togglelock")) // Let's try to unlock em
-							speak("Well shoot, I'd love to hold that gun! But... I have a tool module installed, and the combined mass and power draw of both a tool module <I>and</I> a gun would definitely fry my drive train and void my warranty. ")
+							//speak("Well shoot, I'd love to hold that gun! But... I have a tool module installed, and the combined mass and power draw of both a tool module <I>and</I> a gun would definitely fry my drive train and void my warranty. ")
 							return	// welp
 					else	// Can't charm our way in if they're asleep
 						boutput(user, "You try to give [src] your [Q], but its tool module is in the way.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Puts a cooldown on duck sounds from the Super Protector Friend III.
Comments out an unnecessary line when you try to give a buddy a weapon.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You can sound spam with the Super Protector Friend III by offering them a weapon.
Buddies gave two messages when you attempt to hand them a weapon. The first message seems both misleading and redundant.