### PR TITLE
Prevent tugs loading AI eyes

### DIFF
--- a/code/WorkInProgress/tug.dm
+++ b/code/WorkInProgress/tug.dm
@@ -16,6 +16,9 @@
 		if (!istype(C)|| C.anchored || get_dist(user, src) > 1 || get_dist(src,C) > 1 )
 			return
 
+		if (istype(C, /mob/dead/))
+			return
+
 		if (istype(C, /obj/vehicle/tug))
 			user.show_text("\The [C] is too heavy for \the [src]!", "red")
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a mob/dead check to cargo tug carts.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The AI could load it's eye, making it visible and duplicating it when the AI exits.