### PR TITLE
- 90 minute auto call, 10 minute respawn timer for RP

### DIFF
--- a/_std/setup.dm
+++ b/_std/setup.dm
@@ -110,7 +110,7 @@ var/ZLOG_START_TIME
 #define NON_EUCLIDEAN 1
 
 // Used for /datum/respawn_controller - DOES NOT COVER ALL RESPAWNS YET
-#define DEFAULT_RESPAWN_TIME 15 MINUTES
+#define DEFAULT_RESPAWN_TIME 10 MINUTES
 #define RESPAWNS_ENABLED 0
 
 #if (defined(SERVER_SIDE_PROFILING_PREGAME) || defined(SERVER_SIDE_PROFILING_FULL_ROUND) || defined(SERVER_SIDE_PROFILING_INGAME_ONLY))
@@ -128,7 +128,7 @@ var/ZLOG_START_TIME
 
 //what counts as participation?
 #ifdef RP_MODE
-#define MAX_PARTICIPATE_TIME 80 MINUTES //the maximum shift time before it doesnt count as "participating" in the round
+#define MAX_PARTICIPATE_TIME 60 MINUTES //the maximum shift time before it doesnt count as "participating" in the round
 #else
 #define MAX_PARTICIPATE_TIME 40 MINUTES //ditto above
 #endif

--- a/code/WorkInProgress/cryospawn.dm
+++ b/code/WorkInProgress/cryospawn.dm
@@ -1,4 +1,4 @@
-#define CRYOSLEEP_DELAY 15 MINUTES
+#define CRYOSLEEP_DELAY 5 MINUTES
 #define CRYOTRON_MESSAGE_DELAY 3 SECONDS
 
 /obj/cryotron_spawner

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -7,7 +7,7 @@
 
 	var/shuttle_available = 1 // 0: Won't dock. | 1: Normal. | 2: Won't dock if called too early.
 	var/shuttle_available_threshold = 12000 // 20 min. Only works when shuttle_available == 2.
-	var/shuttle_auto_call_time = 72000 // 120 minutes.  Shuttle auto-called at this time and then again at this time + 1/2 this time, then every 1/2 this time after that. Set to 0 to disable.
+	var/shuttle_auto_call_time = 90 MINUTES // 120 minutes.  Shuttle auto-called at this time and then again at this time + 1/2 this time, then every 1/2 this time after that. Set to 0 to disable.
 	var/shuttle_last_auto_call = 0
 	var/shuttle_initial_auto_call_done = 0 // set to 1 after first call so we know to start checking shuttle_auto_call_time/2
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Rounds get pretty long and exhausting on RP. I feel like most people are sorta "done" around the 90 minute mark and only putter on under the RP-obligation not to "leave work early". I think that a 90 minute timer is about the right spot. Obviously, you can recall as normal.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Emily
(*)Auto Call Time shortened from 120 minutes to 90 minutes
(*)RP Respawn Time shortened from 15 minutes to 10 minutes
(*)You can now leave Industrial Cryo after only 5 minutes (prev. 15)
```
