### PR TITLE
Fixes bug with logging into ThinkDOS computers

### DIFF
--- a/code/modules/networks/computer3/base_os.dm
+++ b/code/modules/networks/computer3/base_os.dm
@@ -736,7 +736,7 @@
 			if(!acc_name || !acc_job)
 				return
 
-			if(!src.active_account && !src.initialize_accounts()) //Oh welp we can't write it to file
+			if(!src.initialize_accounts() && !src.active_account) //Oh welp we can't write it to file
 				src.print_text("<b>Error:</b> Unable to write account file.")
 				return -1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug wherein logging out of a thinkdos computer and then trying to log in again without removing an reinserting your ID would fail with "unable to write account file."


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs bad