### PR TITLE
changes amount of donuts from sec boxes from 2 to 4

### DIFF
--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -33,14 +33,14 @@
 /obj/item/storage/box/robustdonuts
 	name = "robust donuts box"
 	icon_state = "box"
-	desc = "Contains two robust donuts, for security use"
-	spawn_contents = list(/obj/item/reagent_containers/food/snacks/donut/custom/robust = 2)
+	desc = "Contains four robust donuts, for security use"
+	spawn_contents = list(/obj/item/reagent_containers/food/snacks/donut/custom/robust = 4)
 
 /obj/item/storage/box/robusteddonuts
 	name = "robusted donuts box"
 	icon_state = "box"
-	desc = "Contains two robusted donuts, for security use"
-	spawn_contents = list(/obj/item/reagent_containers/food/snacks/donut/custom/robusted = 2)
+	desc = "Contains four robusted donuts, for security use"
+	spawn_contents = list(/obj/item/reagent_containers/food/snacks/donut/custom/robusted = 4)
 
 // For sec officers and the HoS. Really love spawning with a full backpack (Convair880).
 /obj/item/storage/box/security_starter_kit

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -262,12 +262,12 @@
 /datum/materiel/utility/donuts
 	name = "Robust Donuts"
 	path = /obj/item/storage/box/robustdonuts
-	description = "Two Robust Donuts, which are loaded with helpful chemicals which help you resist stuns!"
+	description = "Four Robust Donuts, which are loaded with helpful chemicals which help you resist stuns!"
 
 /datum/materiel/utility/donuts_robusted
 	name = "Robusted Donuts"
 	path = /obj/item/storage/box/robusteddonuts
-	description = "Two Robusted Donuts, which are loaded with helpful chemicals which heal you!"
+	description = "Four Robusted Donuts, which are loaded with helpful chemicals which heal you!"
 
 /datum/materiel/utility/crowdgrenades
 	name = "Crowd Dispersal Grenades"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the number of robust and robusted donuts from the sec purchases from 2 to 4.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Current boxes of donuts aren't good considering a box of donks provides similar use and more uses. Bringing the number up should hopefully help with making them better than something you can already get.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)Robust and Robusted donut sec purchases give 4 donuts instead of 2
```

