### PR TITLE
Makes incapacitators have a unswappable battery

### DIFF
--- a/code/obj/flock/goods.dm
+++ b/code/obj/flock/goods.dm
@@ -62,6 +62,7 @@
 	item_state = "incapacitor"
 	force = 1.0
 	rechargeable = 0 // yeah this is weird alien technology good fucking luck charging it
+	can_swap_cell = 0 // No
 	cell_type = /obj/item/ammo/power_cell/self_charging
 	projectiles = null
 	is_syndicate = 1 // it's less that this is a syndicate weapon and more that replicating it isn't trivial


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? --> title



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You could easily purchase gnesis from the same trader and get a 329 pu taser that deals twice the stam damage. This forces incapacitators to fill the niche of taser derringer. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+) Incapacitators now have an unswappable battery.
```
