### PR TITLE
small improvements to artifact forms

### DIFF
--- a/code/obj/artifacts/artifact_machines/heal_field.dm
+++ b/code/obj/artifacts/artifact_machines/heal_field.dm
@@ -23,7 +23,7 @@
 	var/field_strength = 2
 
 	get_artifact_type()
-		return field_type == HEALING ? ART_HEALING_NAME : ART_HARMING_NAME
+		return field_type == ART_HEALING ? ART_HEALING_NAME : ART_HARMING_NAME
 
 	New()
 		..()

--- a/code/obj/artifacts/artifact_machines/heal_field.dm
+++ b/code/obj/artifacts/artifact_machines/heal_field.dm
@@ -6,7 +6,7 @@
 #define ART_HARMING 1
 /datum/artifact/bio_damage_field_generator
 	associated_object = /obj/machinery/artifact/bio_damage_field_generator
-	type_name = list(ART_HEALING_NAME, ART_HARMING_NAME)
+	type_name = "Healing/Damaging Aura"
 	rarity_weight = 200
 	validtypes = list("martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,

--- a/code/obj/artifacts/artifact_machines/heal_field.dm
+++ b/code/obj/artifacts/artifact_machines/heal_field.dm
@@ -2,9 +2,13 @@
 	name = "artifact bio damage field generator"
 	associated_datum = /datum/artifact/bio_damage_field_generator
 
+#define ART_HEALING 0
+#define ART_HARMING 1
+#define ART_HEALING_NAME "Healing Energy Field"
+#define ART_HARMING_NAME "Harming Energy Field"
 /datum/artifact/bio_damage_field_generator
 	associated_object = /obj/machinery/artifact/bio_damage_field_generator
-	type_name = "Organic Aura Projector"
+	type_name = list(ART_HEALING_NAME, ART_HARMING_NAME)
 	rarity_weight = 200
 	validtypes = list("martian","wizard","eldritch","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,
@@ -15,8 +19,11 @@
 	deact_text = "shuts down, causing the energy field to vanish!"
 	react_xray = list(12,70,90,11,"COMPLEX")
 	var/field_radius = 7
-	var/field_type = 0 // 0 healing, 1 harming
+	var/field_type = ART_HEALING
 	var/field_strength = 2
+
+	get_artifact_type()
+		return field_type == HEALING ? ART_HEALING_NAME : ART_HARMING_NAME
 
 	New()
 		..()
@@ -30,7 +37,7 @@
 		if (src.artitype.name == "eldritch")
 			harmprob += 42 // total of 75% chance of it being nasty
 		if (prob(harmprob))
-			src.field_type = 1
+			src.field_type = ART_HARMING
 		if (src.field_type && src.artitype.name == "eldritch")
 			src.field_strength *= 2
 
@@ -38,10 +45,15 @@
 		if (..())
 			return
 		for (var/mob/living/carbon/M in range(O,src.field_radius))
-			if (src.field_type)
+			if (src.field_type == ART_HARMING)
 				random_brute_damage(M, src.field_strength)
 				boutput(M, "<span class='alert'>Waves of painful energy wrack your body!</span>")
 			else
 				M.HealDamage("All", src.field_strength, src.field_strength)
 				boutput(M, "<span class='notice'>Waves of soothing energy wash over you!</span>")
 			O.ArtifactFaultUsed(M)
+
+#undef ART_HEALING
+#undef ART_HARMING
+#undef ART_HEALING_NAME
+#undef ART_HARMING_NAME

--- a/code/obj/artifacts/artifact_machines/heal_field.dm
+++ b/code/obj/artifacts/artifact_machines/heal_field.dm
@@ -4,8 +4,6 @@
 
 #define ART_HEALING 0
 #define ART_HARMING 1
-#define ART_HEALING_NAME "Healing Energy Field"
-#define ART_HARMING_NAME "Harming Energy Field"
 /datum/artifact/bio_damage_field_generator
 	associated_object = /obj/machinery/artifact/bio_damage_field_generator
 	type_name = list(ART_HEALING_NAME, ART_HARMING_NAME)
@@ -21,9 +19,6 @@
 	var/field_radius = 7
 	var/field_type = ART_HEALING
 	var/field_strength = 2
-
-	get_artifact_type()
-		return field_type == ART_HEALING ? ART_HEALING_NAME : ART_HARMING_NAME
 
 	New()
 		..()
@@ -55,5 +50,3 @@
 
 #undef ART_HEALING
 #undef ART_HARMING
-#undef ART_HEALING_NAME
-#undef ART_HARMING_NAME

--- a/code/obj/artifacts/artifact_objects/container.dm
+++ b/code/obj/artifacts/artifact_objects/container.dm
@@ -71,6 +71,7 @@
 		O.visible_message("<span class='alert'><b>With a blinding light [O] vanishes, leaving its contents behind.</b></span>")
 		O.ArtifactFaultUsed(user)
 		playsound(O.loc, "sound/effects/warp2.ogg", 50, 1)
+		O.remove_artifact_forms()
 		artifact_controls.artifacts -= src
 		qdel(O)
 		return

--- a/code/obj/artifacts/artifact_objects/healer.dm
+++ b/code/obj/artifacts/artifact_objects/healer.dm
@@ -4,7 +4,7 @@
 
 /datum/artifact/healer_bio
 	associated_object = /obj/artifact/healer_bio
-	type_name = "Healer"
+	type_name = "Single Target Healer"
 	rarity_weight = 350
 	validtypes = list("martian","precursor")
 	validtriggers = list(/datum/artifact_trigger/force,/datum/artifact_trigger/electric,/datum/artifact_trigger/heat,

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -70,6 +70,7 @@
 		. = ..()
 		if(isobj(A))
 			checkArtifactVars(A)
+			src.updateTypeLabel()
 
 	attackby(obj/item/W, mob/living/user)
 		if(istype(W, /obj/item/pen)) // write on it
@@ -125,10 +126,7 @@
 			if("origin")
 				artifactOrigin = params["newOrigin"]
 			if("type")
-				// update the displayed label in the name of the object
-				if(O)
-					O.remove_suffixes("([artifactType])")
-					O.name_suffix("([params["newType"]])")
+				src.updateTypeLabel(params["newType"])
 				artifactType = params["newType"]
 			if("trigger")
 				artifactTriggers = params["newTriggers"]
@@ -151,6 +149,19 @@
 			"artifactDetails" = artifactDetails,
 			"hasPen" = P
 		)
+
+	/// updates the label that shows what type the artifact supposedly is
+	proc/updateTypeLabel(var/newtype = null)
+		if(isobj(src.attached))
+			var/obj/O = src.attached
+			O.remove_suffixes("([src.artifactType])")
+			O.name_suffix("([newtype])")
+
+	/// removes the label that shows what type the arifact supposedly is
+	proc/removeTypeLabel()
+		if(isobj(src.attached))
+			var/obj/O = src.attached
+			O.remove_suffixes("([src.artifactType])")
 
 /obj/artifact_paper_dispenser
 	name = "artifact analysis form tray"

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -117,10 +117,18 @@
 		if (!params["hasPen"])
 			boutput(usr, "You can't write without a pen!")
 			return FALSE
+
+		var/obj/O = null
+		if(isobj(src.loc))
+			O = src.loc
 		switch(action)
 			if("origin")
 				artifactOrigin = params["newOrigin"]
 			if("type")
+				// update the displayed label in the name of the object
+				if(O)
+					O.remove_suffixes("([artifactType])")
+					O.name_suffix("([params["newType"]])")
 				artifactType = params["newType"]
 			if("trigger")
 				artifactTriggers = params["newTriggers"]
@@ -129,8 +137,8 @@
 			if("detail")
 				artifactDetails = params["newDetail"]
 		. = TRUE
-		if(isobj(src.loc))
-			src.checkArtifactVars(src.loc)
+		if(O)
+			src.checkArtifactVars(O)
 
 	ui_data(mob/user)
 		var/obj/item/pen/P = user.find_type_in_hand(/obj/item/pen)

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -24,7 +24,7 @@
 			lastAnalysis++
 
 		// check type
-		if(A.get_artifact_type() == src.artifactType)
+		if(A.type_name == src.artifactType)
 			lastAnalysis++
 
 		// if a trigger would be redundant, let's just say it's cool!

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -70,7 +70,7 @@
 		. = ..()
 		if(isobj(A))
 			checkArtifactVars(A)
-			src.updateTypeLabel()
+			src.updateTypeLabel(src.artifactType)
 
 	attackby(obj/item/W, mob/living/user)
 		if(istype(W, /obj/item/pen)) // write on it
@@ -150,18 +150,27 @@
 			"hasPen" = P
 		)
 
+	remove_from_attached()
+		src.removeTypeLabel()
+		. = ..()
+
 	/// updates the label that shows what type the artifact supposedly is
-	proc/updateTypeLabel(var/newtype = null)
+	proc/updateTypeLabel(var/newtype)
+		// nothing to set, so no need!
+		if(newtype == "")
+			return
 		if(isobj(src.attached))
 			var/obj/O = src.attached
-			O.remove_suffixes("([src.artifactType])")
-			O.name_suffix("([newtype])")
+			O.remove_suffixes("\[[src.artifactType]\]")
+			O.name_suffix("\[[newtype]\]")
+			O.UpdateName()
 
-	/// removes the label that shows what type the arifact supposedly is
+	/// removes the label that shows what type the artifact supposedly is
 	proc/removeTypeLabel()
 		if(isobj(src.attached))
 			var/obj/O = src.attached
-			O.remove_suffixes("([src.artifactType])")
+			O.remove_suffixes("\[[src.artifactType]\]")
+			O.UpdateName()
 
 /obj/artifact_paper_dispenser
 	name = "artifact analysis form tray"

--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -24,7 +24,7 @@
 			lastAnalysis++
 
 		// check type
-		if(A.type_name == src.artifactType)
+		if(A.get_artifact_type() == src.artifactType)
 			lastAnalysis++
 
 		// if a trigger would be redundant, let's just say it's cool!

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -189,7 +189,7 @@ ABSTRACT_TYPE(/datum/artifact/)
 	/// get the artifact type name
 	/// an artifact may have different ones depending on the values
 	/// for instance, healing aura artifacts are referred to differently from damage aura ones
-	/proc/get_artifact_type()
+	proc/get_artifact_type()
 		return src.type_name
 
 // SPECIFIC DATUMS

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -185,6 +185,13 @@ ABSTRACT_TYPE(/datum/artifact/)
 	proc/get_rarity_modifier()
 		return src.rarity_weight ? 0.995**src.rarity_weight : 0.2
 
+
+	/// get the artifact type name
+	/// an artifact may have different ones depending on the values
+	/// for instance, healing aura artifacts are referred to differently from damage aura ones
+	/proc/get_artifact_type()
+		return src.type_name
+
 // SPECIFIC DATUMS
 
 ABSTRACT_TYPE(/datum/artifact/art)

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -185,13 +185,6 @@ ABSTRACT_TYPE(/datum/artifact/)
 	proc/get_rarity_modifier()
 		return src.rarity_weight ? 0.995**src.rarity_weight : 0.2
 
-
-	/// get the artifact type name
-	/// an artifact may have different ones depending on the values
-	/// for instance, healing aura artifacts are referred to differently from damage aura ones
-	proc/get_artifact_type()
-		return src.type_name
-
 // SPECIFIC DATUMS
 
 ABSTRACT_TYPE(/datum/artifact/art)

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -501,9 +501,9 @@
 		AP.remove_from_attached()
 		removed++
 	if(removed == 1)
-		T.visible_message("The artifact form that was attached falls to the ground.")
+		src.visible_message("The artifact form that was attached falls to the ground.")
 	else if(removed > 1)
-		T.visible_message("All the artifact forms that were attached fall to the ground.")
+		src.visible_message("All the artifact forms that were attached fall to the ground.")
 
 /obj/proc/ArtifactDestroyed()
 	// Call this rather than straight disposing() on an artifact if you want to destroy it. This way, artifacts can have their own

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -493,6 +493,12 @@
 		src.ArtifactDestroyed()
 	return
 
+/// Removes all artifact forms attached to this and makes them fall to the floor
+/// Because artifacts often like to disappear in mysterious ways
+/obj/proc/remove_artifact_forms()
+	for(var/obj/item/sticker/postit/artifact_paper/AP in src.vis_contents)
+		AP.fall_off()
+
 /obj/proc/ArtifactDestroyed()
 	// Call this rather than straight disposing() on an artifact if you want to destroy it. This way, artifacts can have their own
 	// version of this for ones that will deliver a payload if broken.
@@ -514,6 +520,8 @@
 				T.visible_message("<span class='alert'><B>[src] warps in on itself and vanishes!</B></span>")
 			if("precursor")
 				T.visible_message("<span class='alert'><B>[src] implodes, crushing itself into dust!</B></span>")
+
+	src.remove_artifact_forms()
 
 	src.ArtifactDeactivated()
 

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -496,8 +496,14 @@
 /// Removes all artifact forms attached to this and makes them fall to the floor
 /// Because artifacts often like to disappear in mysterious ways
 /obj/proc/remove_artifact_forms()
+	var/removed = 0
 	for(var/obj/item/sticker/postit/artifact_paper/AP in src.vis_contents)
-		AP.fall_off()
+		AP.remove_from_attached()
+		removed++
+	if(removed == 1)
+		T.visible_message("The artifact form that was attached falls to the ground.")
+	else if(removed > 1)
+		T.visible_message("All the artifact forms that were attached fall to the ground.")
 
 /obj/proc/ArtifactDestroyed()
 	// Call this rather than straight disposing() on an artifact if you want to destroy it. This way, artifacts can have their own


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- When an artifact is deleted, all forms attached to it should now detach and fall to the floor. (Previously it could happen that they stayed and you could still use the artifact via clicking them.)
- When an artifact form is attached to an artifact, the set artifact type on the form will be displayed in the artifact's name. (Similar to labels, but with brackets instead of parentheses, so it looks more official.)
- Renamed the two types of healing artifacts to be more clear, because there was some confusion there about which label should be used for which artifact. (I am open for suggestions on cooler names for these as long as they are still clear.^^)
- (I also changed the biofield artifact code to use a define, because I had originally planned to do more changes there.)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- fixes #5316 and other similar bugs
- Makes it easier for people to tell what a labelled artifact is. (Some people did not realize they could read the forms.)
- Reduces confusion for less experienced artifact scientists.