### PR TITLE
Drinking flask spacebux reward

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1771,16 +1771,22 @@
 	initial_volume = 25
 	initial_reagents = list("energydrink"=20)
 
+/obj/item/reagent_containers/food/drinks/flask
+	name = "flask"
+	desc = "For the busy alcoholic."
+	icon = 'icons/obj/foodNdrink/bottle.dmi'
+	icon_state = "flask"
+	item_state = "flask"
+	g_amt = 5
+	initial_volume = 40
+	can_recycle = FALSE
 
-/obj/item/reagent_containers/food/drinks/detflask
+/obj/item/reagent_containers/food/drinks/flask/det
 	name = "detective's flask"
 	desc = "Must be migrational."
 	icon = 'icons/obj/foodNdrink/bottle.dmi'
 	icon_state = "detflask"
 	item_state = "detflask"
-	g_amt = 5
-	initial_volume = 40
-	can_recycle = FALSE
 	initial_reagents = list("bojack"=40)
 
 /obj/item/reagent_containers/food/drinks/cocktailshaker

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1771,22 +1771,16 @@
 	initial_volume = 25
 	initial_reagents = list("energydrink"=20)
 
-/obj/item/reagent_containers/food/drinks/flask
-	name = "flask"
-	desc = "For the busy alcoholic."
-	icon = 'icons/obj/foodNdrink/bottle.dmi'
-	icon_state = "flask"
-	item_state = "flask"
-	g_amt = 5
-	initial_volume = 40
-	can_recycle = FALSE
 
-/obj/item/reagent_containers/food/drinks/flask/det
+/obj/item/reagent_containers/food/drinks/detflask
 	name = "detective's flask"
 	desc = "Must be migrational."
 	icon = 'icons/obj/foodNdrink/bottle.dmi'
 	icon_state = "detflask"
 	item_state = "detflask"
+	g_amt = 5
+	initial_volume = 40
+	can_recycle = FALSE
 	initial_reagents = list("bojack"=40)
 
 /obj/item/reagent_containers/food/drinks/cocktailshaker

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1788,9 +1788,6 @@
 	icon = 'icons/obj/foodNdrink/bottle.dmi'
 	icon_state = "detflask"
 	item_state = "detflask"
-	g_amt = 5
-	initial_volume = 40
-	can_recycle = FALSE
 	initial_reagents = list("bojack"=40)
 
 /obj/item/reagent_containers/food/drinks/cocktailshaker

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1772,7 +1772,17 @@
 	initial_reagents = list("energydrink"=20)
 
 
-/obj/item/reagent_containers/food/drinks/detflask
+/obj/item/reagent_containers/food/drinks/flask
+	name = "flask"
+	desc = "For the busy alcoholic."
+	icon = 'icons/obj/foodNdrink/bottle.dmi'
+	icon_state = "flask"
+	item_state = "flask"
+	g_amt = 5
+	initial_volume = 40
+	can_recycle = FALSE
+
+/obj/item/reagent_containers/food/drinks/flask/det
 	name = "detective's flask"
 	desc = "Must be migrational."
 	icon = 'icons/obj/foodNdrink/bottle.dmi'

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -14,6 +14,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/human_item/trumpet,\
 	new /datum/bank_purchaseable/human_item/fiddle,\
 	new /datum/bank_purchaseable/human_item/gold_zippo,\
+	new /datum/bank_purchaseable/human_item/drinking_flask,\
 	new /datum/bank_purchaseable/human_item/toy_sword,\
 	new /datum/bank_purchaseable/human_item/sound_synth,\
 	new /datum/bank_purchaseable/human_item/record,\
@@ -226,6 +227,11 @@ var/global/list/persistent_bank_purchaseables =	list(\
 			name = "Gold Zippo"
 			cost = 500
 			path = /obj/item/device/light/zippo/gold
+
+		drinking_flask
+			name = "Drinking Flask"
+			cost = 400
+			path = /obj/item/reagent_containers/food/drinks/flask
 
 		toy_sword
 			name = "Toy Sword"

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -230,7 +230,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 
 		drinking_flask
 			name = "Drinking Flask"
-			cost = 0 //400
+			cost = 400
 			path = /obj/item/reagent_containers/food/drinks/flask
 
 		toy_sword

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -14,6 +14,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/human_item/trumpet,\
 	new /datum/bank_purchaseable/human_item/fiddle,\
 	new /datum/bank_purchaseable/human_item/gold_zippo,\
+	new /datum/bank_purchaseable/human_item/drinking_flask,\
 	new /datum/bank_purchaseable/human_item/toy_sword,\
 	new /datum/bank_purchaseable/human_item/sound_synth,\
 	new /datum/bank_purchaseable/human_item/record,\
@@ -225,7 +226,12 @@ var/global/list/persistent_bank_purchaseables =	list(\
 		gold_zippo
 			name = "Gold Zippo"
 			cost = 500
-			path = /obj/item/device/light/zippo/gold
+			path = /obj/item/device/light/zippo/
+
+		drinking_flask
+			name = "Drinking Flask"
+			cost = 0 //400
+			path = /obj/item/reagent_containers/food/drinks/flask
 
 		toy_sword
 			name = "Toy Sword"

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -14,7 +14,6 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/human_item/trumpet,\
 	new /datum/bank_purchaseable/human_item/fiddle,\
 	new /datum/bank_purchaseable/human_item/gold_zippo,\
-	new /datum/bank_purchaseable/human_item/drinking_flask,\
 	new /datum/bank_purchaseable/human_item/toy_sword,\
 	new /datum/bank_purchaseable/human_item/sound_synth,\
 	new /datum/bank_purchaseable/human_item/record,\
@@ -226,12 +225,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 		gold_zippo
 			name = "Gold Zippo"
 			cost = 500
-			path = /obj/item/device/light/zippo/
-
-		drinking_flask
-			name = "Drinking Flask"
-			cost = 0 //400
-			path = /obj/item/reagent_containers/food/drinks/flask
+			path = /obj/item/device/light/zippo/gold
 
 		toy_sword
 			name = "Toy Sword"

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -230,7 +230,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 
 		drinking_flask
 			name = "Drinking Flask"
-			cost = 400
+			cost = 0 //400
 			path = /obj/item/reagent_containers/food/drinks/flask
 
 		toy_sword

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -32300,7 +32300,7 @@
 /obj/landmark/start{
 	name = "Detective"
 	},
-/obj/item/reagent_containers/food/drinks/detflask,
+/obj/item/reagent_containers/food/drinks/flask/det,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bLN" = (

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -32300,7 +32300,7 @@
 /obj/landmark/start{
 	name = "Detective"
 	},
-/obj/item/reagent_containers/food/drinks/flask/det,
+/obj/item/reagent_containers/food/drinks/detflask,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bLN" = (

--- a/maps/manta_damaged.dmm
+++ b/maps/manta_damaged.dmm
@@ -623,7 +623,7 @@
 /area/station/bridge)
 "abf" = (
 /obj/item/device/radio/intercom/AI{
-	
+
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -668,7 +668,7 @@
 /area/station/hallway/starboardupperhallway)
 "abo" = (
 /obj/item/device/radio/intercom/brig{
-	
+
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -701,19 +701,19 @@
 /area/station/security/porttorpedoes)
 "abt" = (
 /obj/item/device/radio/intercom/medical{
-	
+
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "abu" = (
 /obj/item/device/radio/intercom/engineering{
-	
+
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "abv" = (
 /obj/item/device/radio/intercom/science{
-	
+
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -3156,7 +3156,7 @@
 	icon_state = "chair-b"
 	},
 /obj/item/device/radio/intercom/science{
-	
+
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -4353,7 +4353,7 @@
 /area/listeningpost/syndicateassaultvessel)
 "alv" = (
 /obj/item/device/radio/intercom/catering{
-	
+
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -6499,7 +6499,7 @@
 /area/station/medical/medbay/lobby)
 "apN" = (
 /obj/item/device/radio/intercom/security{
-	
+
 	},
 /turf/simulated/floor/damaged1,
 /area/station/bridge)
@@ -6951,7 +6951,7 @@
 /area/station/science/artifact)
 "aqB" = (
 /obj/item/device/radio/intercom/cargo{
-	
+
 	},
 /turf/simulated/floor/damaged4,
 /area/station/bridge)
@@ -8808,7 +8808,7 @@
 /obj/disposalpipe/segment,
 /obj/machinery/shieldgenerator/energy_shield,
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-	
+
 	},
 /turf/simulated/floor/bot,
 /area/station/engine/storage)
@@ -9287,7 +9287,7 @@
 "awi" = (
 /obj/machinery/fluid_canister,
 /obj/item/device/radio/intercom/loudspeaker/speaker/north{
-	
+
 	},
 /turf/simulated/floor/bot,
 /area/station/engine/storage)
@@ -10474,7 +10474,7 @@
 /area/station/engine/engineering/breakroom)
 "ayF" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/north{
-	
+
 	},
 /obj/machinery/portable_atmospherics/canister/air/large,
 /obj/machinery/camera{
@@ -11185,7 +11185,7 @@
 /area/station/crew_quarters/quarters)
 "aAb" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-	
+
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -11631,7 +11631,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom/loudspeaker/speaker/north{
-	
+
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
@@ -11984,7 +11984,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-	
+
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
@@ -12161,7 +12161,7 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aBY" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/north{
-	
+
 	},
 /obj/machinery/guardbot_dock,
 /obj/cable{
@@ -19961,7 +19961,7 @@
 	d2 = 4
 	},
 /obj/item/device/radio/intercom/security{
-	
+
 	},
 /obj/machinery/light/incandescent/warm{
 	dir = 1;
@@ -26457,7 +26457,7 @@
 /obj/table/wood/auto,
 /obj/item/storage/bible,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "purple1"
@@ -40926,7 +40926,7 @@
 	nostick = 1
 	},
 /obj/item/device/radio/intercom/science{
-	
+
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -41673,7 +41673,7 @@
 "bKV" = (
 /obj/landmark/artifact,
 /obj/item/device/radio/intercom/science{
-	
+
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
@@ -42013,7 +42013,7 @@
 /obj/landmark/start{
 	name = "Detective"
 	},
-/obj/item/reagent_containers/food/drinks/detflask,
+/obj/item/reagent_containers/food/drinks/flask/det,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bLN" = (
@@ -46113,7 +46113,7 @@
 /area/station/engine/engineering/breakroom)
 "bVm" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-	
+
 	},
 /turf/simulated/floor/damaged5,
 /area/station/engine/storage)
@@ -46151,7 +46151,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-	
+
 	},
 /turf/simulated/floor/damaged5,
 /area/station/engine/inner)
@@ -46238,7 +46238,7 @@
 /area/station/engine/inner)
 "bVB" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-	
+
 	},
 /turf/simulated/floor/damaged2,
 /area/station/engine/monitoring)
@@ -49277,7 +49277,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/item/device/radio/intercom/science{
-	
+
 	},
 /obj/item/paper/book/from_file/pharmacopia,
 /obj/access_spawn/research,

--- a/maps/manta_damaged.dmm
+++ b/maps/manta_damaged.dmm
@@ -623,7 +623,7 @@
 /area/station/bridge)
 "abf" = (
 /obj/item/device/radio/intercom/AI{
-
+	
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -668,7 +668,7 @@
 /area/station/hallway/starboardupperhallway)
 "abo" = (
 /obj/item/device/radio/intercom/brig{
-
+	
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -701,19 +701,19 @@
 /area/station/security/porttorpedoes)
 "abt" = (
 /obj/item/device/radio/intercom/medical{
-
+	
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "abu" = (
 /obj/item/device/radio/intercom/engineering{
-
+	
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "abv" = (
 /obj/item/device/radio/intercom/science{
-
+	
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -3156,7 +3156,7 @@
 	icon_state = "chair-b"
 	},
 /obj/item/device/radio/intercom/science{
-
+	
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -4353,7 +4353,7 @@
 /area/listeningpost/syndicateassaultvessel)
 "alv" = (
 /obj/item/device/radio/intercom/catering{
-
+	
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -6499,7 +6499,7 @@
 /area/station/medical/medbay/lobby)
 "apN" = (
 /obj/item/device/radio/intercom/security{
-
+	
 	},
 /turf/simulated/floor/damaged1,
 /area/station/bridge)
@@ -6951,7 +6951,7 @@
 /area/station/science/artifact)
 "aqB" = (
 /obj/item/device/radio/intercom/cargo{
-
+	
 	},
 /turf/simulated/floor/damaged4,
 /area/station/bridge)
@@ -8808,7 +8808,7 @@
 /obj/disposalpipe/segment,
 /obj/machinery/shieldgenerator/energy_shield,
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-
+	
 	},
 /turf/simulated/floor/bot,
 /area/station/engine/storage)
@@ -9287,7 +9287,7 @@
 "awi" = (
 /obj/machinery/fluid_canister,
 /obj/item/device/radio/intercom/loudspeaker/speaker/north{
-
+	
 	},
 /turf/simulated/floor/bot,
 /area/station/engine/storage)
@@ -10474,7 +10474,7 @@
 /area/station/engine/engineering/breakroom)
 "ayF" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/north{
-
+	
 	},
 /obj/machinery/portable_atmospherics/canister/air/large,
 /obj/machinery/camera{
@@ -11185,7 +11185,7 @@
 /area/station/crew_quarters/quarters)
 "aAb" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-
+	
 	},
 /obj/cable{
 	icon_state = "4-8";
@@ -11631,7 +11631,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom/loudspeaker/speaker/north{
-
+	
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
@@ -11984,7 +11984,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-
+	
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
@@ -12161,7 +12161,7 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aBY" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/north{
-
+	
 	},
 /obj/machinery/guardbot_dock,
 /obj/cable{
@@ -19961,7 +19961,7 @@
 	d2 = 4
 	},
 /obj/item/device/radio/intercom/security{
-
+	
 	},
 /obj/machinery/light/incandescent/warm{
 	dir = 1;
@@ -26457,7 +26457,7 @@
 /obj/table/wood/auto,
 /obj/item/storage/bible,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "purple1"
@@ -40926,7 +40926,7 @@
 	nostick = 1
 	},
 /obj/item/device/radio/intercom/science{
-
+	
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -41673,7 +41673,7 @@
 "bKV" = (
 /obj/landmark/artifact,
 /obj/item/device/radio/intercom/science{
-
+	
 	},
 /turf/simulated/floor,
 /area/station/science/artifact)
@@ -42013,7 +42013,7 @@
 /obj/landmark/start{
 	name = "Detective"
 	},
-/obj/item/reagent_containers/food/drinks/flask/det,
+/obj/item/reagent_containers/food/drinks/detflask,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office_manta/detectives_bedroom)
 "bLN" = (
@@ -46113,7 +46113,7 @@
 /area/station/engine/engineering/breakroom)
 "bVm" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-
+	
 	},
 /turf/simulated/floor/damaged5,
 /area/station/engine/storage)
@@ -46151,7 +46151,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-
+	
 	},
 /turf/simulated/floor/damaged5,
 /area/station/engine/inner)
@@ -46238,7 +46238,7 @@
 /area/station/engine/inner)
 "bVB" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/south{
-
+	
 	},
 /turf/simulated/floor/damaged2,
 /area/station/engine/monitoring)
@@ -49277,7 +49277,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/item/device/radio/intercom/science{
-
+	
 	},
 /obj/item/paper/book/from_file/pharmacopia,
 /obj/access_spawn/research,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a generic flask to the game, makes the detective's flask a child (adjusting existing paths accordingly) and adds the flask as a 400 spacebux reward. The generic flask sprite existed in the code previously, and was simply unused until now.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Outside of playing detective on Manta, it's not possible to have a flask. This brings us one step closer to drinking on the job in style.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Vaskritaya
(+)Flasks are now available from the Spacebux menu.
```
