### PR TITLE
Makes Medical Director spawn with doctor's medkit

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -402,6 +402,7 @@ ABSTRACT_TYPE(/datum/job/command)
 
 	slot_back = list(/obj/item/storage/backpack/withO2)
 	slot_belt = list(/obj/item/device/pda2/medical_director)
+	slot_lhan = list(/obj/item/storage/firstaid/regular/doctor_spawn)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
 	slot_jump = list(/obj/item/clothing/under/rank/medical_director)
 	slot_suit = list(/obj/item/clothing/suit/labcoat)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance] I guess?

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As the title says

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Menders spawn only in the medkits doctor starts with, meaning, medical director is limited to having only one synthflesh mender. This PR allows MDir to have 3 automenders in total.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)The MD now spawns with a medkit containing a brute and a burn automender, meaning that they have three menders total. 
```
