### PR TITLE
AddsVapourEffectToSomeChems

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -294,6 +294,18 @@ datum
 			result_amount = 1
 			mix_phrase = "Stinging vapors rise from the solution."
 
+			on_reaction(var/datum/reagents/holder, var/created_volume)
+				var/location = get_turf(holder.my_atom)
+
+				var/list/mob/living/carbon/mobs_affected = list()
+				for(var/mob/living/carbon/C in range(location, 1))
+					if(!issmokeimmune(C))
+						mobs_affected += C
+				for(var/mob/living/carbon/C as anything in mobs_affected)
+					C.reagents.add_reagent("chlorine", (0.5 * created_volume) / length(mobs_affected))
+				return
+
+
 		/*tricalomel
 			name = "Pentetic Acid"
 			id = "tricalomel"
@@ -1965,6 +1977,20 @@ datum
 			required_temperature = T0C + 275
 			mix_phrase = "It smells like a bad hangover in here."
 
+			on_reaction(var/datum/reagents/holder, var/created_volume)
+				var/location = get_turf(holder.my_atom)
+
+				for(var/mob/M in all_viewers(null, location))
+					boutput(M, "<span class='alert'>The solution generates a strong vapor!</span>")
+
+				var/list/mob/living/carbon/mobs_affected = list()
+				for(var/mob/living/carbon/C in range(location, 1))
+					if(!issmokeimmune(C))
+						mobs_affected += C
+				for(var/mob/living/carbon/C as anything in mobs_affected)
+					C.reagents.add_reagent("acetaldehyde", (0.4 * created_volume) / length(mobs_affected))
+				return
+
 		acetic_acid
 			name = "Acetic Acid"
 			id = "acetic_acid"
@@ -2009,6 +2035,21 @@ datum
 			required_temperature = T0C + 150 // really more like 620 but fuck it
 			result_amount = 2
 			mix_phrase = "Ugh, it smells like the morgue in here."
+
+			on_reaction(var/datum/reagents/holder, var/created_volume)
+				var/location = get_turf(holder.my_atom)
+
+				for(var/mob/M in all_viewers(null, location))
+					boutput(M, "<span class='alert'>The solution generates a strong vapor!</span>")
+
+				var/list/mob/living/carbon/mobs_affected = list()
+				for(var/mob/living/carbon/C in range(location, 1))
+					if(!issmokeimmune(C))
+						mobs_affected += C
+				for(var/mob/living/carbon/C as anything in mobs_affected)
+					C.reagents.add_reagent("formaldehyde", (0.25 * created_volume) / length(mobs_affected))
+				return
+
 
 		haloperidol // COGWERKS CHEM REVISION PROJECT: marked for revision - antipsychotic
 			name = "Haloperidol"
@@ -3112,6 +3153,22 @@ datum
 			required_reagents = list("morphine" = 1, "antihistamine" = 1, "cleaner" = 1, "phosphorus" = 1, "potassium" = 1, "fuel" = 1)
 			mix_phrase = "The mixture dries into a pale blue powder."
 			mix_sound = 'sound/misc/fuse.ogg'
+
+			on_reaction(var/datum/reagents/holder, var/created_volume)
+				var/location = get_turf(holder.my_atom)
+
+				for(var/mob/M in all_viewers(null, location))
+					boutput(M, "<span class='alert'>The solution generates a strong vapor!</span>")
+
+				var/list/mob/living/carbon/mobs_affected = list()
+				for(var/mob/living/carbon/C in range(location, 1))
+					if(!issmokeimmune(C))
+						mobs_affected += C
+				for(var/mob/living/carbon/C as anything in mobs_affected)
+					C.reagents.add_reagent("krokodil", (0.2 * created_volume) / length(mobs_affected))
+				return
+
+
 
 	/*	helldrug // the worst thing. if splashed on floor, create void turf. if ingested, replace mob with crunch critter and teleport user to hell
 			name = "Cthonium"

--- a/code/modules/chemistry/Reagents-Drugs.dm
+++ b/code/modules/chemistry/Reagents-Drugs.dm
@@ -403,7 +403,21 @@ datum
 			minimum_reaction_temperature = T0C+400
 
 			reaction_temperature(exposed_temperature, exposed_volume)
+				var/location = get_turf(holder.my_atom)
 				var/myvol = volume
+
+				for(var/mob/M in all_viewers(null, location))
+					boutput(M, "<span class='alert'>The solution generates a strong vapor!</span>")
+
+				var/list/mob/living/carbon/mobs_affected = list()
+				for(var/mob/living/carbon/C in range(location, 1))
+					if(!issmokeimmune(C))
+						mobs_affected += C
+				for(var/mob/living/carbon/C as anything in mobs_affected)
+					C.reagents.add_reagent("neurotoxin", (0.1 * myvol) / length(mobs_affected))
+					C.reagents.add_reagent("space_drugs", (0.1 * myvol) / length(mobs_affected))
+
+
 				holder.del_reagent(id)
 				holder.add_reagent("neurotoxin", myvol, null)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[LABEL][FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->This makes more reagents create vapours on the people around them if they don't have masks, like cyanide and meth do. 

Neurotoxin(space drugs and neuro) 1 per 10 neuro created of each
Calomel(chlorine)     1 per 2 created
Krokodil(krokodil)     1 per 5 created
Acetaldehyde(acet) 2 per 5 created
Formaldehyde(formal) 1 per 4 created


## Why's this needed? <!-- Describe why you think this should be added to the game. --> Vapour effect feels a bit underused.
The vapour effect is interesting and somewhat underused, this is gonna make barkeep chemistry(or even regular chemistry if you forget your mask) somewhat more interesting when you have to keep your distance when heating chemicals. None of these provide much danger if you make them in reasonable quantities, 100 units of neurotoxin being made for instance will put 10 units in you, if there is someone near its gonna go 5 to each.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hans
(*)Adds the same vapour effect as meth and cyanide to a quantity of chemicals.
```
