### PR TITLE
Make syndicate command helmet only scan with the syndi device scanner

### DIFF
--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -732,6 +732,7 @@
 		icon_state = "indusred"
 		item_state = "indusred"
 		is_syndicate = 1
+
 		setupProperties()
 			..()
 			setProperty("meleeprot_head", 7)

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -731,6 +731,7 @@
 		desc = "Ooh, fancy."
 		icon_state = "indusred"
 		item_state = "indusred"
+		is_syndicate = 1
 		setupProperties()
 			..()
 			setProperty("meleeprot_head", 7)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the syndicate command helmet require a syndicate device analyser to scan for blueprints.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is a possible petasusaphilic hat that can appear at round start and is then extremely cheap to manufacture. It's syndicate equipment that is better than the industrial mining helmet so it should probably be blocked.
Another case of needing a better manufacturing recipe but that is a big rework and as syndicate gear + petasusaphilic it probably shouldn't be scannable either way.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Scanning Syndicate command helmet now requires a syndicate device analyser.
```