### PR TITLE
Nerf thermal resist against energy weapons

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1057,6 +1057,8 @@
 	src.health -= max(0, brute)
 	if (!is_heat_resistant())
 		src.health -= max(0, burn)
+	else
+		src.health -= max(0, burn * 0.5)
 
 /mob/proc/TakeDamageAccountArmor(zone, brute, burn, tox, damage_type)
 	TakeDamage(zone, brute - get_melee_protection(zone,damage_type), burn - get_melee_protection(zone,damage_type))

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -342,8 +342,8 @@
 		burn *= src.mutantrace.firevuln
 		tox *= src.mutantrace.toxvuln
 
-	if (is_heat_resistant())
-		burn = 0
+	if (src.is_heat_resistant())
+		burn *= 0.5
 
 	//if (src.bioHolder && src.bioHolder.HasEffect("resist_toxic"))
 		//tox = 0
@@ -353,9 +353,6 @@
 	//tox = max(0, burn)
 
 	if (brute + burn + tox <= 0) return
-
-	if (src.is_heat_resistant())
-		burn = 0 //mostly covered by individual procs that cause burn damage, but just in case
 
 	//Bandaid fix for tox damage being mysteriously unhooked in here.
 	if (tox)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Change thermal resist to reduce energy damage by 50%.
Remove a redundant thermal resistance check.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previously thermalres reduced energy damage to a flat 0 which was excessive considering how good thermal resistance is.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)CodeDude
(*)Thermal resist now reduces damage from energy weapons to 50% instead of blocking it completely.
```
