### PR TITLE
Fixes Strange Green Goop not working

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2670,11 +2670,13 @@ datum
 
 			on_add()
 				if (holder && ismob(holder.my_atom))
-					APPLY_MOB_PROPERTY(holder, PROP_GHOSTVISION, src)
+					var/mob/M = holder.my_atom
+					APPLY_MOB_PROPERTY(M, PROP_GHOSTVISION, src)
 
 			on_remove()
 				if (ismob(holder.my_atom))
-					REMOVE_MOB_PROPERTY(holder, PROP_GHOSTVISION, src)
+					var/mob/M = holder.my_atom
+					REMOVE_MOB_PROPERTY(M, PROP_GHOSTVISION, src)
 
 		voltagen
 			name = "voltagen"

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2668,6 +2668,14 @@ datum
 			value = 3
 			viscosity = 0.4
 
+			on_add()
+				if (holder && ismob(holder.my_atom))
+					APPLY_MOB_PROPERTY(holder, PROP_GHOSTVISION, src)
+
+			on_remove()
+				if (ismob(holder.my_atom))
+					REMOVE_MOB_PROPERTY(holder, PROP_GHOSTVISION, src)
+
 		voltagen
 			name = "voltagen"
 			id = "voltagen"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds/removes the correct property to mobs on reagent add/remove.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently SGG is a completely nonfunctional chem. This fixes that.