### PR TITLE
Removes the crowbar from roboticist's backpacks on spawning

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -628,7 +628,6 @@ ABSTRACT_TYPE(/datum/job/research)
 	slot_eyes = list(/obj/item/clothing/glasses/healthgoggles)
 	slot_ears = list(/obj/item/device/radio/headset/medical)
 	slot_poc1 = list(/obj/item/reagent_containers/mender/brute)
-	items_in_backpack = list(/obj/item/crowbar)
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the crowbar from robo backpacks.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They spawn with a full mechanical toolbox, meaning the extra crowbar is essentially useless. 
Chucking it away every robo round is a minor annoyance.