### PR TITLE
Custom cigarettes last half as long as commercial, filtered cigarettes

### DIFF
--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -508,6 +508,7 @@
 		..()
 		src.reagents.maximum_volume = 600
 		src.reagents.clear_reagents()
+		numpuffs = 20
 
 	is_open_container()
 		return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR halves the numpuffs variable for custom cigarettes (such as  those made with paper and cannabis) from 40 to 20. While this reduces the number of puffs which happen every 5 cycles, it also increases the volume of chems absorbed each puff. This means that, while lasting less than before, these new joints make you twice as high!
The total duration of a cigarette is thus reduced from about +10 minutes to 5-7 minutes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently it is almost impossible to have a consistent flow of chemicals in custom joints. They give chems only every 5 cycles and each puff gives you chems for up to one or two cycles. This change should make your joints much more exciting.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Vocalpocal
(+)Custom cigarettes now last half as long but make you twice as high #nofilter
```
