### PR TITLE
Removes Sea Turtle

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -4726,21 +4726,6 @@
 	},
 /turf/space/fluid/manta/nospawn,
 /area/station/shield_zone/manta)
-"aoQ" = (
-/obj/decal/poster/wallsign/stencil/right/n{
-	pixel_x = 1;
-	pixel_y = 38
-	},
-/obj/decal/poster/wallsign/stencil/right/g{
-	pixel_x = 14;
-	pixel_y = 38
-	},
-/obj/decal/poster/wallsign/stencil/right/e{
-	pixel_x = -12;
-	pixel_y = 38
-	},
-/turf/space/fluid/manta/nospawn,
-/area/station/shield_zone/manta)
 "aoR" = (
 /obj/stool/chair/comfy/green,
 /obj/landmark/start{
@@ -5224,10 +5209,6 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/starboard)
-"apU" = (
-/obj/machinery/drainage/big,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
 "apV" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Freezer";
@@ -5591,10 +5572,6 @@
 "aqO" = (
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/turret_protected/ai_upload)
-"aqP" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/seaturtlebridge)
 "aqQ" = (
 /obj/machinery/power/seaheater/big,
 /turf/space/fluid/manta,
@@ -5994,13 +5971,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/beepsky)
-"arP" = (
-/obj/miningteleporter,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"arQ" = (
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "arR" = (
 /obj/decal/tile_edge/check{
 	dir = 8;
@@ -6098,10 +6068,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
-"ase" = (
-/obj/item/constructioncone,
-/turf/simulated/floor,
-/area/station/construction/under_construction)
 "asg" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -6173,17 +6139,7 @@
 	},
 /turf/space/fluid/manta/nospawn,
 /area/station/shield_zone/manta)
-"ast" = (
-/obj/item/raw_material/rock,
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "asv" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
 "asx" = (
@@ -6788,15 +6744,6 @@
 /obj/item/clothing/suit/bathrobe,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/bathroom)
-"aur" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	name = "Crew Quarters"
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quarters)
 "aus" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 6;
@@ -9013,7 +8960,7 @@
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Gym"
 	},
-/turf/simulated/floor/carpet/arcade/half,
+/turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/quarters)
 "aAb" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/south,
@@ -9504,10 +9451,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
-"aBo" = (
-/obj/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperport)
 "aBp" = (
 /obj/machinery/disposal/mail/small{
 	dir = 1;
@@ -9960,24 +9903,6 @@
 "aCw" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
-"aCx" = (
-/obj/storage/closet/dresser{
-	anchored = 1;
-	name = "costume dresser"
-	},
-/obj/item/clothing/under/misc/flame,
-/obj/item/clothing/under/misc/mime,
-/obj/item/clothing/under/misc/mime/alt,
-/obj/item/clothing/under/suit/pinstripe,
-/obj/item/clothing/under/suit,
-/obj/item/clothing/under/gimmick/rainbow,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/item/clothing/under/pride/special,
-/turf/simulated/floor,
-/area/station/crew_quarters/quartersC)
 "aCC" = (
 /obj/table/reinforced/auto,
 /obj/machinery/microwave,
@@ -9996,10 +9921,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
-"aCF" = (
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
 "aCG" = (
 /obj/machinery/vending/security_ammo,
 /turf/simulated/floor/black,
@@ -10024,16 +9945,6 @@
 "aCM" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
-"aCO" = (
-/obj/decal/fakeobjects{
-	desc = "Under construction";
-	dir = 1;
-	icon = 'icons/obj/junk.dmi';
-	icon_state = "constructionsign";
-	name = "construction zone"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
 "aCP" = (
 /obj/stool/bed,
 /obj/item/storage/secure/ssafe{
@@ -10253,19 +10164,15 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/starboardupperhallway)
 "aDA" = (
-/obj/stool/bed,
-/obj/item/storage/secure/ssafe{
-	pixel_x = 26
+/obj/stool/chair{
+	anchored = 0;
+	dir = 4
 	},
-/obj/item/clothing/suit/bedsheet/green,
-/obj/cable{
-	icon_state = "1-2"
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersC)
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "aDB" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10298,20 +10205,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/visitation)
-"aDF" = (
-/obj/stool/bed,
-/obj/item/storage/secure/ssafe{
-	pixel_x = 26
-	},
-/obj/item/clothing/suit/bedsheet/green,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet{
-	dir = 4;
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersC)
 "aDG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10333,27 +10226,9 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
-"aDJ" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Crew Quarters C"
-	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quartersC)
-"aDK" = (
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
 "aDL" = (
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"aDM" = (
-/obj/machinery/vending/cards,
-/turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
 "aDO" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10378,6 +10253,9 @@
 /obj/item/bballbasket,
 /obj/item/basketball,
 /obj/item/basketball,
+/obj/machinery/light_switch/auto{
+	pixel_y = 24
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aDR" = (
@@ -10486,17 +10364,6 @@
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/starboard)
-"aEf" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperport)
 "aEg" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -10575,16 +10442,6 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
-"aEq" = (
-/obj/machinery/light/incandescent/netural,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersC)
 "aEr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
@@ -10787,12 +10644,6 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
-"aEV" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters)
 "aEW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10913,11 +10764,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
-"aFn" = (
-/obj/table/auto,
-/obj/machinery/microwave,
-/turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
 "aFo" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -11058,15 +10904,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/hor)
-"aFI" = (
-/obj/machinery/disposal/mail/small{
-	dir = 4;
-	mail_tag = "Crew Quarters";
-	name = "mail chute-'Crew Quarters'"
-	},
-/obj/disposalpipe/trunk/mail,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
 "aFJ" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/cable{
@@ -11280,9 +11117,6 @@
 	dir = 8
 	},
 /area/station/security/hos)
-"aGj" = (
-/turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
 "aGk" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -11458,8 +11292,9 @@
 	pixel_y = 26;
 	text = "NF"
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
+/obj/submachine/claw_machine,
+/turf/simulated/floor/specialroom/arcade,
+/area/station/crew_quarters/arcade)
 "aGG" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 9;
@@ -11517,6 +11352,14 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/disposal/mail/small{
+	dir = 4;
+	mail_tag = "Crew Quarters";
+	name = "mail chute-'Crew Quarters'"
+	},
+/obj/disposalpipe/trunk/mail{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "aGQ" = (
@@ -11528,32 +11371,6 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
-"aGR" = (
-/obj/stool/chair{
-	anchored = 0;
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
-"aGS" = (
-/obj/table/wood/auto,
-/obj/item/paper/book/from_file/monster_manual_revised{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/paper/book/from_file/DNDrulebook{
-	pixel_x = 3;
-	pixel_y = 1
-	},
-/obj/item/storage/box/nerd_kit{
-	pixel_y = -6
-	},
-/turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
 "aGU" = (
 /obj/decal/tile_edge/line/purple{
 	icon_state = "line3"
@@ -11704,13 +11521,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
 "aHo" = (
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
-/obj/cable{
-	icon_state = "2-8"
+/obj/noticeboard/persistent{
+	name = "Crew Quarters persistent notice board";
+	persistent_id = "crew quarters"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
@@ -11733,15 +11546,16 @@
 /turf/simulated/floor/caution/south,
 /area/station/engine/gas)
 "aHr" = (
-/obj/stool/chair{
-	anchored = 0;
-	dir = 8
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/decal/tile_edge/check{
+	color = "#AB8CB0";
+	dir = 8;
+	icon_state = "check1"
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/arcade)
 "aHs" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 4
@@ -11985,26 +11799,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
-"aHV" = (
-/obj/stool/bed,
-/obj/item/storage/secure/ssafe{
-	pixel_x = 26
-	},
-/obj/item/clothing/suit/bedsheet/green,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersC)
 "aHX" = (
 /turf/simulated/floor/engine/caution/corner{
 	dir = 8
@@ -12041,9 +11835,8 @@
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
-/obj/noticeboard/persistent{
-	name = "Crew Quarters persistent notice board";
-	persistent_id = "crew quarters"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
@@ -12104,8 +11897,11 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/arcade)
 "aIh" = (
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
@@ -12122,15 +11918,6 @@
 "aIi" = (
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
-"aIj" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters)
 "aIk" = (
 /obj/storage/closet/emergency,
 /obj/cable{
@@ -12159,14 +11946,6 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quartersB)
-"aIn" = (
-/obj/machinery/vending/snack,
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
 "aIp" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -12214,29 +11993,21 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"aIu" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersC)
 "aIv" = (
-/obj/stool/bed,
-/obj/item/storage/secure/ssafe{
-	pixel_x = 26
+/obj/storage/closet/dresser{
+	anchored = 1;
+	name = "costume dresser"
 	},
-/obj/item/clothing/suit/bedsheet/blue,
+/obj/item/clothing/under/misc/flame,
+/obj/item/clothing/under/misc/mime,
+/obj/item/clothing/under/misc/mime/alt,
+/obj/item/clothing/under/suit/pinstripe,
+/obj/item/clothing/under/suit,
+/obj/item/clothing/under/gimmick/rainbow,
+/obj/item/clothing/under/pride/special,
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/item/clothing/mask/horse_mask,
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "blue2"
@@ -12247,17 +12018,13 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/decal/tile_edge/check{
+	color = "#AB8CB0";
+	dir = 4;
+	icon_state = "check1"
+	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
-"aIy" = (
-/obj/stool/chair{
-	anchored = 0
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/arcade)
 "aIz" = (
 /obj/machinery/light/incandescent/netural,
 /obj/machinery/firealarm{
@@ -12269,53 +12036,6 @@
 	icon_state = "blue2"
 	},
 /area/station/crew_quarters/quartersB)
-"aIA" = (
-/obj/table/wood/auto,
-/obj/item/paper_bin{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/clipboard{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/clipboard{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/clipboard{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/clipboard{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
-"aIB" = (
-/obj/stool/chair{
-	anchored = 0;
-	dir = 8
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
 "aIC" = (
 /obj/machinery/rkit,
 /turf/simulated/floor/orangeblack,
@@ -12332,8 +12052,23 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13";
+	pixel_x = 10;
+	tag = ""
+	},
+/obj/machinery/sim/vr_bed{
+	dir = 8;
+	name = "VR simulation pod";
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
 /turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/arcade)
 "aIG" = (
 /obj/machinery/computer/telescope,
 /obj/machinery/power/data_terminal,
@@ -12345,28 +12080,12 @@
 	},
 /area/station/science/teleporter)
 "aIH" = (
-/obj/item/clothing/under/suit/dress{
-	desc = "A black dress. Very formal.";
-	name = "black dress"
-	},
-/obj/item/clothing/under/suit,
-/obj/item/clothing/under/shirt_pants,
-/obj/item/clothing/shoes/black,
-/obj/item/clothing/head/fedora,
-/obj/item/clothing/glasses/eyepatch{
-	name = "costume eyepatch"
-	},
-/obj/storage/closet/dresser{
-	anchored = 1;
-	name = "costume dresser"
-	},
-/obj/item/clothing/head/mime_beret,
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
+/turf/simulated/floor/carpet/arcade/half,
+/area/station/crew_quarters/arcade)
 "aII" = (
 /obj/table/round,
 /obj/decoration/decorativeplant/plant4{
@@ -12382,7 +12101,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/arcade)
 "aIK" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/power/apc/autoname_north,
@@ -12449,14 +12168,19 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/decal/tile_edge/check{
+	color = "#AB8CB0";
+	dir = 4;
+	icon_state = "check1"
+	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/arcade)
 "aIY" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
+/turf/simulated/floor/specialroom/arcade,
+/area/station/crew_quarters/arcade)
 "aIZ" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -12464,8 +12188,8 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
+/turf/simulated/floor/specialroom/arcade,
+/area/station/crew_quarters/arcade)
 "aJa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -12474,8 +12198,8 @@
 /obj/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
+/turf/simulated/floor/specialroom/arcade,
+/area/station/crew_quarters/arcade)
 "aJb" = (
 /turf/simulated/floor,
 /area/station/crew_quarters/fitness)
@@ -12520,8 +12244,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent/netural,
+/obj/decal/tile_edge/check{
+	color = "#AB8CB0";
+	dir = 8;
+	icon_state = "check1"
+	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/arcade)
 "aJm" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -12671,17 +12400,18 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/fitness)
 "aJK" = (
-/obj/stool/bed,
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
-/obj/item/clothing/suit/bedsheet/blue,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/blue,
+/obj/item/clothing/mask/horse_mask,
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "blue2"
@@ -12828,6 +12558,10 @@
 	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
@@ -13193,6 +12927,7 @@
 /area/station/security/hos)
 "aLh" = (
 /obj/machinery/light/incandescent/netural,
+/obj/storage/closet/wardrobe/pride,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
 "aLi" = (
@@ -13268,16 +13003,6 @@
 	},
 /turf/simulated/floor/sanitary/blue,
 /area/station/medical/medbay/restroom)
-"aLu" = (
-/obj/stool/chair{
-	anchored = 0;
-	dir = 4
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
 "aLv" = (
 /obj/item/reagent_containers/glass/bottle/bubblebath,
 /turf/simulated/floor/sanitary/blue,
@@ -13826,12 +13551,16 @@
 	},
 /area/station/medical/medbay/lobby)
 "aNh" = (
-/obj/item/device/radio/intercom{
+/obj/machinery/sim/vr_bed{
 	dir = 8;
-	name = "Station Intercom"
+	name = "VR simulation pod";
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
 	},
 /turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/arcade)
 "aNi" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -13858,8 +13587,11 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aNr" = (
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
+/obj/table/auto,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/device/t_scanner,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "aNs" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -14192,9 +13924,8 @@
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/communications/office)
 "aOr" = (
-/obj/machinery/computer/arcade,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "aOs" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -14239,16 +13970,12 @@
 /obj/machinery/light_switch/auto{
 	pixel_y = -24
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
 	},
-/obj/storage/closet/wardrobe/pride,
 /turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/arcade)
 "aOx" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -16250,14 +15977,6 @@
 /obj/machinery/light/incandescent/blueish,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"aUC" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	name = "Crew Quarters"
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/maint,
-/turf/simulated/floor,
-/area/station/crew_quarters/quarters)
 "aUD" = (
 /obj/loudspeaker{
 	layer = 4;
@@ -17677,23 +17396,28 @@
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
 "aYj" = (
-/obj/machinery/vending/capsule,
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/decoration/tabletopfull{
-	pixel_x = -5;
-	pixel_y = 25
+/obj/decal/tile_edge/check{
+	color = "#AB8CB0";
+	dir = 4;
+	icon_state = "check1"
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom"
 	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/arcade)
 "aYk" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/arcade/half,
-/area/station/crew_quarters/quarters)
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/specialroom/arcade,
+/area/station/crew_quarters/arcade)
 "aYm" = (
 /obj/stool/bed,
 /obj/item/storage/secure/ssafe{
@@ -17704,6 +17428,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/item/storage/box/crayon,
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "purple2"
@@ -17951,15 +17676,25 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/quartersA)
 "aYY" = (
-/obj/stool/bed,
-/obj/item/storage/secure/ssafe{
-	pixel_x = 26
+/obj/item/clothing/under/suit/dress{
+	desc = "A black dress. Very formal.";
+	name = "black dress"
 	},
-/obj/item/clothing/suit/bedsheet/pink,
+/obj/item/clothing/under/suit,
+/obj/item/clothing/under/shirt_pants,
+/obj/item/clothing/shoes/black,
+/obj/item/clothing/head/fedora,
+/obj/item/clothing/glasses/eyepatch{
+	name = "costume eyepatch"
+	},
+/obj/storage/closet/dresser{
+	anchored = 1;
+	name = "costume dresser"
+	},
+/obj/item/clothing/head/mime_beret,
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/item/storage/box/crayon,
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "purple2"
@@ -18818,8 +18553,11 @@
 /area/station/crew_quarters/fitness)
 "bbF" = (
 /obj/reagent_dispensers/watertank/fountain,
-/obj/machinery/light_switch/auto{
-	pixel_y = 24
+/obj/securearea{
+	desc = "An arcade and game room.";
+	icon_state = "arcade";
+	name = "ARCADE";
+	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
@@ -20427,18 +20165,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
-"bfr" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/securearea{
-	desc = "An arcade and game room.";
-	icon_state = "arcade";
-	name = "ARCADE";
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
 "bfu" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -22112,9 +21838,8 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/submachine/claw_machine,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "bjA" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -22474,40 +22199,23 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
 "bkt" = (
-/obj/machinery/sim/vr_bed{
-	dir = 4;
-	name = "VR simulation pod";
-	network = "arcadevr"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "bku" = (
-/obj/decal/tile_edge/check{
-	color = "#AB8CB0";
-	dir = 4;
-	icon_state = "check1"
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "bkv" = (
 /obj/decal/tile_edge/check{
 	color = "#AB8CB0";
 	dir = 8;
 	icon_state = "check1"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"bkw" = (
-/obj/machinery/sim/vr_bed{
-	dir = 8;
-	name = "VR simulation pod";
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -22862,40 +22570,42 @@
 /obj/machinery/light_switch/auto{
 	pixel_x = -24
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "blo" = (
-/obj/machinery/computer/arcade,
 /obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/specialroom/arcade,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "blp" = (
-/obj/machinery/computer/arcade,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/specialroom/arcade,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "blq" = (
-/obj/decal/tile_edge/check{
-	color = "#AB8CB0";
-	dir = 8;
-	icon_state = "check1"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "blr" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "blu" = (
 /obj/item/storage/toilet/random{
 	dir = 8;
@@ -22960,14 +22670,6 @@
 /obj/landmark/boxing_ring,
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"blz" = (
-/obj/machinery/r_door_control/podbay/mining/new_walls{
-	name = "Submarine Bay (Mining) door control"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "blA" = (
 /obj/loudspeaker,
 /obj/cable{
@@ -23438,12 +23140,14 @@
 	},
 /area/station/janitor/office)
 "bmC" = (
-/obj/stool/bar,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/specialroom/arcade,
-/area/station/crew_quarters/arcade)
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/orange,
+/area/station/mining/refinery)
 "bmE" = (
 /obj/table/reinforced/auto,
 /obj/item/clothing/head/helmet/men{
@@ -23881,22 +23585,27 @@
 	},
 /area/station/janitor/office)
 "bnE" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/item/device/matanalyzer{
+	pixel_x = 3;
+	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"bnF" = (
-/turf/simulated/floor/specialroom/arcade,
-/area/station/crew_quarters/arcade)
+/obj/item/device/matanalyzer{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/paper/book/from_file/minerals{
+	pixel_x = -4
+	},
+/obj/table/auto,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "bnG" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/landmark/gps_waypoint,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/orange,
+/area/station/mining/refinery)
 "bnH" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -24365,8 +24074,8 @@
 /area/station/janitor/office)
 "boR" = (
 /obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/orange,
+/area/station/mining/refinery)
 "boS" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Arcade"
@@ -24375,8 +24084,8 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/orange,
+/area/station/mining/refinery)
 "boT" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Bathroom"
@@ -26364,13 +26073,6 @@
 	},
 /turf/simulated/floor,
 /area/station/crewquarters/garbagegarbs)
-"buc" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bud" = (
 /obj/burning_barrel,
 /obj/decal/cleanable/gangtag{
@@ -26382,18 +26084,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerport)
-"bue" = (
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"buf" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light,
-/turf/space/fluid/manta,
-/area/mantaSpace)
 "bug" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
@@ -26733,31 +26423,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
-"bvr" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay2,
-/turf/space/fluid/manta,
-/area/mantaSpace)
-"bvs" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay3,
-/turf/space/fluid/manta,
-/area/mantaSpace)
-"bvt" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir"
-	},
-/obj/warp_beacon/sea_turtle,
-/obj/machinery/light/runway_light/delay4,
-/turf/space/fluid/manta,
-/area/mantaSpace)
 "bvv" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -27306,44 +26971,6 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/cargobay)
-"bwY" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/announcement/console_lower{
-	dir = 4;
-	req_access = null
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bwZ" = (
-/obj/machinery/neosmelter,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
-"bxa" = (
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
-"bxb" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/device/t_scanner,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bxc" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8
-	},
-/obj/machinery/portable_reclaimer,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "bxi" = (
 /obj/chicken_nesting_box,
 /obj/machinery/light/incandescent/netural{
@@ -27826,50 +27453,6 @@
 /obj/item/hand_labeler,
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
-"byE" = (
-/obj/shrub{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/drainage/big,
-/turf/simulated/floor/grass/random,
-/area/station/hallway/seaturtlehallway)
-"byF" = (
-/obj/machinery/vending/cola/red,
-/obj/decal/tile_edge/line/red{
-	color = "#e17627";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/machinery/drainage/big,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"byG" = (
-/obj/shrub{
-	dir = 1
-	},
-/obj/machinery/drainage/big,
-/turf/simulated/floor/grass/random,
-/area/station/hallway/seaturtlehallway)
-"byH" = (
-/obj/table/auto,
-/obj/item/paper/book/from_file/pocketguide/mining,
-/obj/item/storage/firstaid/toxin,
-/obj/machinery/drainage/big,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"byI" = (
-/obj/machinery/vending/cola/blue,
-/obj/machinery/drainage/big,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "byN" = (
 /obj/storage/crate/packing,
 /obj/blind_switch/area/north{
@@ -28348,41 +27931,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
-"bzY" = (
-/obj/rack,
-/obj/item/mop,
-/obj/item/storage/box/mousetraps,
-/obj/item/storage/box/biohazard_bags,
-/obj/item/storage/box/trash_bags,
-/obj/item/storage/box/trash_bags,
-/obj/item/spraybottle/cleaner,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/obj/item/sponge,
-/turf/simulated/floor/purple/checker{
-	dir = 8
-	},
-/area/station/janitor/supply)
-"bzZ" = (
-/obj/machinery/power/apc/autoname_south,
-/obj/cable,
-/obj/storage/secure/closet/civilian/janitor,
-/obj/item/chem_grenade/cleaner,
-/obj/item/chem_grenade/cleaner,
-/turf/simulated/floor/purple/checker{
-	dir = 8
-	},
-/area/station/janitor/supply)
 "bAa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -28425,10 +27973,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
-"bAe" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
 "bAf" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -28894,9 +28438,13 @@
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
 "bBs" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
+/turf/simulated/floor,
+/area/station/quartermaster/cargooffice)
+"bBt" = (
 /obj/machinery/computer/stockexchange,
 /obj/item/clothing/head/that,
 /obj/machinery/power/data_terminal,
@@ -28906,25 +28454,13 @@
 	icon_state = "red2"
 	},
 /area/station/quartermaster/cargooffice)
-"bBt" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4
-	},
+"bBu" = (
 /obj/table/wood/auto,
 /obj/decoration/decorativeplant/plant3{
 	pixel_y = 16
 	},
 /obj/item/pen/pencil,
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "red2"
-	},
-/area/station/quartermaster/cargooffice)
-"bBu" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/segment/mineral,
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "red2"
@@ -28962,6 +28498,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/item/clothing/head/that,
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "red2"
@@ -29023,19 +28560,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/starboard)
-"bBG" = (
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "stairs_middle"
-	},
-/area/station/mining/refinery)
-"bBH" = (
-/obj/machinery/r_door_control/podbay/mining/new_walls{
-	id = "door4";
-	name = "Submarine Bay (Mining) door control"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/mining)
 "bBJ" = (
 /obj/item/screwdriver,
 /turf/simulated/floor/shuttlebay,
@@ -29494,6 +29018,15 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/mining)
 "bCS" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/quartermaster/cargooffice)
+"bCT" = (
 /obj/stool/chair/office/yellow{
 	dir = 1
 	},
@@ -29501,29 +29034,30 @@
 /obj/landmark/start{
 	name = "Quartermaster"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "red2"
 	},
 /area/station/quartermaster/cargooffice)
-"bCT" = (
+"bCU" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
+/obj/disposalpipe/segment/mineral{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/area/station/quartermaster/cargooffice)
-"bCU" = (
-/obj/machinery/light_switch/auto{
-	pixel_y = -24
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "red2"
@@ -29532,6 +29066,9 @@
 "bCV" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/carpet{
 	icon_state = "red2"
 	},
@@ -29998,9 +29535,6 @@
 /obj/decal/fakeobjects/mantacontainer/blue,
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
-"bEo" = (
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "bEq" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -30205,13 +29739,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bFe" = (
-/obj/decal/tile_edge/carpet/fancy{
-	dir = 6;
-	icon_state = "frug1"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/port)
 "bFf" = (
 /obj/cable/reinforced{
 	icon_state = "4-8-thick"
@@ -31442,9 +30969,6 @@
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
-"bJA" = (
-/turf/simulated/wall/asteroid,
-/area/station/mining/staff_room)
 "bJC" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -33121,156 +32645,12 @@
 /obj/cable,
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
-"bNR" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/bank_data/console_upper{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bNT" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/computer/ordercomp/console_upper{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bNV" = (
-/obj/stool/chair/office/blue{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bNW" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bNX" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/seaturtle)
-"bNY" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/seaturtlebridge)
-"bOa" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bOb" = (
-/obj/item/device/matanalyzer{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/device/matanalyzer{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/obj/item/paper/book/from_file/minerals{
-	pixel_x = -4
-	},
-/obj/table/auto,
-/obj/decal/tile_edge/stripe/extra_big,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
-"bOd" = (
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bOe" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	req_access = null
-	},
-/obj/access_spawn/engineering,
-/obj/access_spawn/mining,
-/turf/simulated/floor/plating/random,
-/area/station/seaturtlebridge)
-"bOf" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bOg" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bOh" = (
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bOi" = (
-/turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/seaturtlebridge)
 "bOj" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bOk" = (
-/obj/machinery/power/apc/autoname_south,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bOm" = (
-/turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/mining/staff_room)
-"bOo" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Mining"
-	},
-/obj/access_spawn/mining,
-/obj/access_spawn/engineering,
-/obj/firedoor_spawn,
-/turf/simulated/floor/orange,
-/area/station/seaturtlebridge)
-"bOq" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
-"bOr" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
 "bOs" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -33281,29 +32661,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bOt" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bOu" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 6;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bOv" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/janitor/supply)
-"bOx" = (
-/obj/submachine/chef_sink/chem_sink,
-/turf/simulated/floor/purple/checker{
-	dir = 8
-	},
-/area/station/janitor/supply)
-"bOy" = (
-/turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/construction)
 "bOB" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -33311,25 +32668,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bOC" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bOD" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/disposal/small{
-	dir = 4
-	},
-/obj/disposalpipe/trunk,
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
 "bOE" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -33337,46 +32675,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bOF" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Mining"
-	},
-/obj/access_spawn/mining,
-/obj/access_spawn/engineering,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/orange,
-/area/station/seaturtlebridge)
-"bOG" = (
-/obj/machinery/light/small/netural{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/stool,
-/obj/landmark/start{
-	name = "Janitor"
-	},
-/turf/simulated/floor/purple/checker{
-	dir = 8
-	},
-/area/station/janitor/supply)
-"bOH" = (
-/obj/machinery/abcu,
-/turf/simulated/floor,
-/area/station/construction)
-"bOI" = (
-/obj/machinery/nanofab/refining,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
-"bOJ" = (
-/obj/machinery/nanofab/mining,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
 "bOM" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -33387,9 +32685,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bON" = (
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bOP" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -33400,83 +32695,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bOS" = (
-/turf/simulated/floor,
-/area/station/construction)
-"bOV" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bOW" = (
-/obj/decal/tile_edge/line/green{
-	color = "#ba9a65";
-	dir = 6;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bOY" = (
-/turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/crew_quarters/bathroom)
-"bOZ" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/bathroom)
-"bPc" = (
-/obj/item/storage/wall/fire{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs2_wide"
-	},
-/area/station/mining/refinery)
-"bPg" = (
-/obj/item/storage/toilet/random,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/bathroom)
-"bPq" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bPr" = (
-/obj/storage/closet,
-/obj/item/clothing/under/rank/orangeoveralls/yellow,
-/obj/item/clothing/under/rank/orangeoveralls/yellow,
-/obj/item/clothing/under/rank/orangeoveralls,
-/obj/item/clothing/under/rank/orangeoveralls,
-/obj/item/clothing/head/helmet/hardhat,
-/obj/item/clothing/head/helmet/hardhat,
-/obj/item/clothing/head/helmet/hardhat,
-/obj/item/clothing/head/helmet/hardhat,
-/turf/simulated/floor,
-/area/station/construction)
-"bPs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 10;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bPt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -33484,350 +32702,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bPu" = (
-/obj/table/reinforced/industrial/auto,
-/obj/item/room_planner,
-/obj/item/room_planner,
-/turf/simulated/floor,
-/area/station/construction)
-"bPv" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 4;
-	pixel_x = -4
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/bathroom)
-"bPw" = (
-/obj/decoration/toiletholder{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/bathroom)
-"bPx" = (
-/obj/machinery/manufacturer/mining,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bPz" = (
-/obj/machinery/recharger,
-/obj/item/cargotele{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/table/auto,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bPB" = (
-/obj/storage/cart{
-	name = "ore cart"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bPF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bPG" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/tile_edge/line/purple{
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bPH" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Custodial Closet";
-	req_access_txt = "26"
-	},
-/obj/access_spawn/janitor,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/janitor/supply)
-"bPJ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/purple/checker{
-	dir = 8
-	},
-/area/station/janitor/supply)
-"bPL" = (
-/obj/mopbucket,
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/purple/checker{
-	dir = 8
-	},
-/area/station/janitor/supply)
-"bPM" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bPN" = (
-/obj/table/reinforced/industrial/auto,
-/obj/item/sheet/glass/fullstack{
-	rand_pos = 0
-	},
-/obj/item/sheet/glass/fullstack{
-	rand_pos = 0
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bPO" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bPP" = (
-/obj/machinery/power/apc/autoname_south,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bPQ" = (
-/obj/item/clothing/head/plunger,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/bathroom)
-"bPR" = (
-/obj/machinery/light/small/netural{
-	dir = 4
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/bathroom)
-"bPS" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/seaturtlehallway)
-"bPT" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bPU" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bPV" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bPZ" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQa" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hallway/seaturtlehallway)
-"bQb" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/decal/tile_edge/line/green{
-	color = "#ba9a65";
-	dir = 5;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQc" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/construction)
-"bQd" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Bathroom"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/crew_quarters/bathroom)
-"bQf" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/potted_plant/potted_plant4{
-	dir = 1;
-	pixel_y = 28
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQg" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQj" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 9;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQk" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bQl" = (
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bQm" = (
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQn" = (
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/decoration/decorativeplant/plant7,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQp" = (
-/obj/machinery/vending/snack,
-/obj/decal/tile_edge/line/red{
-	color = "#e17627";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQq" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e17627";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/decoration/decorativeplant/plant7,
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQr" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e17627";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQt" = (
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 9;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQu" = (
-/obj/potted_plant/potted_plant4{
-	dir = 1;
-	pixel_y = 28
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQv" = (
-/obj/machinery/disposal_pipedispenser/mobile,
-/turf/simulated/floor,
-/area/station/construction)
-"bQw" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bQx" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -33861,169 +32735,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bQB" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQC" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQD" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQE" = (
-/obj/machinery/drainage/big,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQF" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 6;
-	icon_state = "line1"
-	},
-/obj/potted_plant/potted_plant4,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQG" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQH" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQI" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 10;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQJ" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQK" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQL" = (
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQM" = (
-/obj/potted_plant/potted_plant4,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQN" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 6;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/junction/right/south,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQO" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQP" = (
-/obj/table/glass/auto,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQQ" = (
-/obj/table/glass/auto,
-/obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQR" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/machinery/power/apc/autoname_east,
-/obj/cable,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQS" = (
-/obj/submachine/cargopad{
-	name = "Mining Teleport Pad"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bQT" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQV" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 10;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bQW" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -34035,69 +32746,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"bQX" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 10;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e17627";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#ba9a65";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bRa" = (
-/obj/item/device/gps,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bRf" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bRg" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bRh" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bRi" = (
 /obj/cable/reinforced{
 	icon_state = "4-8-thick"
@@ -34105,423 +32753,22 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bRj" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hangar/mining)
-"bRk" = (
-/obj/machinery/door_control/podbay/qm/new_walls/west{
-	id = "door4";
-	name = "Cargo Bay door control"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
 "bRl" = (
 /obj/machinery/vehicle/tank/minisub/mining,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/mining)
-"bRo" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Mining"
-	},
-/obj/access_spawn/mining,
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
-"bRp" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bRq" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bRt" = (
-/obj/machinery/manufacturer/general,
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bRu" = (
-/obj/item/cargotele{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/cargotele{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/machinery/recharger{
-	pixel_x = -7
-	},
-/obj/machinery/recharger{
-	pixel_x = 5
-	},
-/obj/table/reinforced/industrial/auto,
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bRv" = (
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 7
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = -2
-	},
-/obj/table/reinforced/industrial/auto,
-/turf/simulated/floor/caution/east,
-/area/station/hangar/mining)
-"bRw" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	dir = 4;
-	icon_state = "bdoormid1";
-	id = "door4"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bRx" = (
-/obj/forcefield/energyshield/perma/doorlink,
-/obj/machinery/door/poddoor/blast/pyro{
-	dir = 4;
-	icon_state = "bdoormid1";
-	id = "door4"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bRy" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
-/obj/storage/cart{
-	name = "ore cart"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bRz" = (
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRA" = (
-/obj/decal/poster/wallsign/poster_mining{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRB" = (
-/obj/item/storage/wall/medical{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRC" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRD" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/disposal/small{
-	dir = 1;
-	layer = 32;
-	name = "rockworm feeding unit";
-	pixel_y = 32
-	},
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRE" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRG" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Mining"
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/mining,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRH" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bRK" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e17627";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#ba9a65";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bRL" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bRM" = (
-/obj/decal/cleanable/dirt/dirt5,
-/turf/simulated/floor/caution/east,
-/area/station/hangar/mining)
-"bRN" = (
-/obj/table/auto,
-/obj/machinery/microwave,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRO" = (
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRP" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRQ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRR" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Mining";
-	req_access = null
-	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bRS" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Submarine Bay (Mining)";
-	req_access = null
-	},
-/obj/access_spawn/cargo,
-/obj/access_spawn/engineering,
-/obj/access_spawn/mining,
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/hangar/mining)
 "bRT" = (
 /turf/simulated/floor,
 /area/station/hangar/mining)
-"bRU" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bRV" = (
-/turf/simulated/floor/caution/east,
-/area/station/hangar/mining)
-"bRW" = (
-/obj/reagent_dispensers/watertank/fountain,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRZ" = (
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs_wide"
-	},
-/area/station/hangar/mining)
-"bSa" = (
-/obj/storage/crate,
-/obj/item/shipcomponent/sensor/mining,
-/obj/item/shipcomponent/sensor/mining,
-/obj/item/shipcomponent/sensor/mining,
-/obj/item/shipcomponent/sensor/mining,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/item/shipcomponent/secondary_system/orescoop,
-/obj/item/shipcomponent/secondary_system/orescoop,
-/obj/item/shipcomponent/secondary_system/orescoop,
-/obj/item/shipcomponent/secondary_system/orescoop,
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bSb" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	dir = 4;
-	icon_state = "bdoormid1";
-	id = "door4"
-	},
-/obj/forcefield/energyshield/perma/doorlink,
+"bSd" = (
+/obj/decal/cleanable/oil/streak,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/mining)
-"bSe" = (
-/obj/item/storage/wall/mining,
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
-"bSf" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bSg" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
 "bSj" = (
 /obj/stool/chair,
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bSk" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 10;
-	icon_state = "xtra_bigstripe-corner2"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bSl" = (
-/turf/simulated/floor/stairs{
-	dir = 4;
-	icon_state = "Stairs_wide"
-	},
-/area/station/hangar/mining)
-"bSm" = (
-/obj/decal/cleanable/dirt/dirt5,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bSo" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bSp" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bSq" = (
-/obj/table/auto,
-/obj/item/trench_map,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bSr" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bSs" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bSt" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 9;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bSu" = (
 /obj/table/auto,
 /obj/item/screwdriver,
@@ -34532,182 +32779,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bSv" = (
-/obj/submachine/cargopad{
-	name = "Mining Cargo Teleport Pad"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bSw" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8
-	},
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bSx" = (
-/turf/simulated/floor/stairs{
-	dir = 4;
-	icon_state = "Stairs2_wide"
-	},
-/area/station/hangar/mining)
-"bSz" = (
-/obj/storage/closet/welding_supply,
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bSA" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/seaturtle/boiler)
-"bSB" = (
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSC" = (
-/obj/machinery/power/furnace,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSD" = (
-/obj/storage/crate/furnacefuel,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSH" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/construction/under_construction)
-"bSI" = (
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bSJ" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/construction/under_construction)
-"bSK" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bSL" = (
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bSM" = (
-/obj/machinery/light/incandescent/blueish{
-	nostick = 1
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bSN" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle/boiler)
-"bSO" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSP" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSQ" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSR" = (
-/obj/machinery/power/terminal,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSS" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bST" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bSU" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/access_spawn/maint,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/construction/under_construction)
-"bSV" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bSW" = (
-/obj/machinery/light/incandescent/blueish{
-	nostick = 1
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bSX" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSY" = (
-/obj/machinery/power/smes,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSZ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bTa" = (
-/obj/machinery/power/furnace,
-/obj/cable,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bTb" = (
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
 "bTc" = (
 /obj/machinery/drainage/big,
 /obj/cable/reinforced{
@@ -34752,58 +32823,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bTf" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bTg" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bTh" = (
-/obj/cable,
-/obj/machinery/power/apc/autoname_east,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bTi" = (
-/obj/machinery/power/apc/autoname_south,
-/obj/cable,
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bTj" = (
-/obj/machinery/power/furnace,
-/obj/cable,
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bTk" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTl" = (
-/obj/machinery/mantapropulsion/big{
-	important = 0
-	},
-/turf/space/fluid/manta,
-/area/mantaSpace)
-"bTm" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
 "bTn" = (
 /obj/machinery/light/incandescent/blueish{
 	nostick = 1
@@ -34828,96 +32847,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bTp" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	icon_state = "line1"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTq" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTt" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bTv" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bTx" = (
-/obj/rack,
-/obj/item/clothing/suit/space/diving/engineering,
-/obj/item/clothing/head/helmet/space/engineer/diving/engineering,
-/obj/item/clothing/mask/breath{
-	pixel_x = -3
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -12
-	},
-/obj/item/tank/emergency_oxygen,
-/obj/item/tank/jetpack,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
-"bTB" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTC" = (
-/obj/machinery/drainage/big,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bTF" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -34940,17 +32869,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/security/secoffquarters)
-"bTI" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	frequency = 1455;
-	name = "Supply Intercom"
-	},
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs2_wide"
-	},
-/area/station/hangar/mining)
 "bTL" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -34962,365 +32880,28 @@
 	icon_state = "yellowblack"
 	},
 /area/station/engine/monitoring)
-"bTO" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTP" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/disposalpipe/junction/left/west,
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bTQ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bTR" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bTS" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bTT" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTV" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 6;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTX" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTY" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/junction/left/north,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTZ" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Submarine Bay (Mining)";
-	req_access = null
-	},
-/obj/access_spawn/cargo,
-/obj/access_spawn/engineering,
-/obj/access_spawn/mining,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bUa" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bUb" = (
-/obj/decal/cleanable/dirt/dirt2,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bUc" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bUd" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bUe" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bUf" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Mining"
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/mining,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bUg" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUh" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUi" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/junction/right/north,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUj" = (
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bUk" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bUl" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bUo" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bUp" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUq" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUu" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bUv" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bUw" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bUx" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/access_spawn/maint,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle/boiler)
-"bUy" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUA" = (
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/small,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bUC" = (
-/obj/table/reinforced/industrial/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/item/decoration/ashtray{
-	butts = 5;
-	name = "grubby old ashtray"
-	},
-/obj/item/cigbutt{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bUD" = (
-/obj/table/reinforced/industrial/auto,
-/obj/item/material_shaper,
-/obj/item/material_shaper,
-/turf/simulated/floor,
-/area/station/construction)
-"bUE" = (
-/obj/table/reinforced/industrial/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/item/cigbutt{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/clothing/glasses/construction,
-/obj/item/clothing/glasses/construction,
-/obj/item/clothing/glasses/construction,
-/turf/simulated/floor,
-/area/station/construction)
 "bWx" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
-"bZu" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
+"bXa" = (
+/obj/cable{
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor,
+/area/station/quartermaster/cargooffice)
+"bZu" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/hangar/mining)
+"caM" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 5
+	},
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "cea" = (
 /obj/decal/tile_edge/check{
 	dir = 4;
@@ -35422,14 +33003,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
-"coI" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "coR" = (
 /obj/storage/closet/dresser,
 /obj/item/clothing/shoes/mj_shoes,
@@ -35535,29 +33108,6 @@
 	},
 /turf/simulated/floor/stairs/dark/wide,
 /area/station/medical/robotics)
-"cxL" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 9;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/junction/left/south,
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "cxW" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -35566,6 +33116,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"cyK" = (
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/disposalpipe/segment/mineral{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/orange,
+/area/station/mining)
 "czR" = (
 /obj/potted_plant/potted_plant5{
 	dir = 1;
@@ -35603,14 +33165,6 @@
 	},
 /turf/simulated/floor/wood/six,
 /area/station/security/detectives_office_manta)
-"cDo" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "cGD" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -35692,6 +33246,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
+"cNc" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters)
 "cNm" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -35768,6 +33329,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"cZu" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/mineral{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor,
+/area/station/hangar/mining)
 "cZW" = (
 /obj/decal/tile_edge/line/blue{
 	icon_state = "line3"
@@ -35847,15 +33419,18 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
 "diy" = (
-/obj/table/auto,
-/obj/item/game_kit,
-/obj/item/storage/box/donkpocket_kit,
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
 	pixel_y = 20
 	},
+/obj/decal/tile_edge/check{
+	color = "#AB8CB0";
+	dir = 8;
+	icon_state = "check1"
+	},
+/obj/machinery/vending/capsule,
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/quarters)
+/area/station/crew_quarters/arcade)
 "dkb" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -35898,19 +33473,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/port)
-"dnh" = (
-/obj/decal/tile_edge/line/green{
-	color = "#ba9a65";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "dnT" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 8;
@@ -35938,14 +33500,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portupperhallway)
-"dqP" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
 "dxF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -35968,21 +33522,6 @@
 	dir = 1
 	},
 /area/station/engine/inner)
-"dyN" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	name = "Submarine Bay (Mining)";
-	req_access = null
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/engineering_mechanic,
-/obj/access_spawn/engineering_engine,
-/obj/access_spawn/mining,
-/obj/access_spawn/cargo,
-/turf/simulated/floor/plating/random,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "dAQ" = (
 /obj/shrub{
 	dir = 1;
@@ -36084,19 +33623,6 @@
 	},
 /turf/simulated/floor/wood/six,
 /area/station/security/detectives_office_manta)
-"dGn" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "dIP" = (
 /obj/cable,
 /obj/machinery/door/airlock/pyro/glass,
@@ -36219,14 +33745,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/ai_upload)
-"dXk" = (
-/obj/machinery/light/incandescent/blueish{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
 "dXJ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -36234,30 +33752,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
-"dXK" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
-"dYP" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "dZj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -36341,6 +33835,11 @@
 	icon_state = "fred2"
 	},
 /area/station/science/restroom)
+"egk" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment,
+/turf/simulated/floor/orange,
+/area/station/mining)
 "eid" = (
 /obj/stool/chair/red{
 	dir = 8
@@ -36370,6 +33869,10 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"elV" = (
+/obj/machinery/vending/cards,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "elX" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -36388,6 +33891,25 @@
 	icon_state = "green1"
 	},
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+"emx" = (
+/obj/decal/poster/wallsign/stencil/right/n{
+	pixel_x = 0;
+	pixel_y = 38
+	},
+/obj/decal/poster/wallsign/stencil/right/i{
+	pixel_x = 10;
+	pixel_y = 38
+	},
+/obj/decal/poster/wallsign/stencil/right/i{
+	pixel_x = -9;
+	pixel_y = 38
+	},
+/obj/decal/poster/wallsign/stencil/right/n{
+	pixel_x = 19;
+	pixel_y = 38
+	},
+/turf/space/fluid/manta/nospawn,
+/area/station/shield_zone/manta)
 "eoz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -36461,15 +33983,22 @@
 /turf/simulated/floor,
 /area/station/security/starboardtorpedoes)
 "eBV" = (
-/obj/machinery/portable_reclaimer,
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/machinery/firealarm{
+	pixel_y = 24;
+	text = "NF"
+	},
+/turf/simulated/floor/orange,
+/area/station/mining)
 "eCS" = (
 /obj/storage/secure/closet/personal,
 /turf/simulated/floor/green,
 /area/station/crew_quarters/market)
+"eDy" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "eEa" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -36523,20 +34052,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
-"eHC" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 8;
-	layer = -1
-	},
-/obj/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/construction)
 "eIb" = (
 /obj/stool/chair/couch{
 	dir = 4
@@ -36852,6 +34367,10 @@
 	icon_state = "fgreen2"
 	},
 /area/station/engine/engineering/ce)
+"fkT" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/orange,
+/area/station/mining)
 "flP" = (
 /obj/table/auto,
 /obj/decoration/decorativeplant/plant3{
@@ -36983,20 +34502,13 @@
 /turf/simulated/floor,
 /area/station/crewquarters/garbagegarbs)
 "ftI" = (
-/obj/machinery/sim/vr_bed{
-	dir = 8;
-	name = "VR simulation pod";
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
 	pixel_x = 10
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
+/obj/machinery/arc_electroplater,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "ftP" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -37122,6 +34634,14 @@
 /obj/machinery/chem_master,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
+"fEl" = (
+/obj/item/storage/wall/mining{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/orange,
+/area/station/mining)
 "fHz" = (
 /obj/stool/chair/comfy/blue{
 	dir = 1
@@ -37187,14 +34707,17 @@
 	},
 /area/station/crewquarters/garbagegarbs)
 "fLk" = (
-/obj/reagent_dispensers/fueltank,
-/obj/machinery/light/incandescent/netural{
-	dir = 8
+/obj/item/storage/wall/mining{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = 0
 	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/machinery/light/incandescent/netural{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/simulated/floor/orange,
+/area/station/mining)
 "fLG" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -37232,17 +34755,6 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
-"fTd" = (
-/obj/table/reinforced/auto,
-/obj/decoration/decorativeplant/plant4{
-	pixel_y = 12
-	},
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
 "fWd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37276,14 +34788,6 @@
 	},
 /turf/simulated/floor,
 /area/abandonedship)
-"fWO" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "fXz" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/security{
@@ -37294,6 +34798,9 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
+"fXJ" = (
+/turf/simulated/floor/orange,
+/area/station/mining)
 "fYb" = (
 /turf/simulated/floor/greenblack{
 	dir = 4
@@ -37309,15 +34816,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
-"fZX" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "gaD" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37388,11 +34886,6 @@
 "ghs" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crewquarters/cryotron)
-"gkj" = (
-/obj/cable,
-/obj/machinery/power/apc/autoname_south,
-/turf/simulated/floor,
-/area/station/hangar/mining)
 "glv" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
@@ -37452,12 +34945,21 @@
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
-"gpN" = (
-/obj/decal/cleanable/dirt/dirt3,
-/turf/simulated/floor/caution/south,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+"goI" = (
+/obj/item/paper/book/from_file/monster_manual_revised{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/paper/book/from_file/DNDrulebook{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/item/storage/box/nerd_kit{
+	pixel_y = -6
+	},
+/obj/table/reinforced/industrial/auto,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "grW" = (
 /obj/storage/secure/closet/engineering/atmos,
 /obj/item/clothing/mask/gas/emergency,
@@ -37513,13 +35015,6 @@
 	dir = 4
 	},
 /area/station/medical/head/private)
-"gwa" = (
-/obj/machinery/light/incandescent/blueish{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
 "gwf" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
@@ -37614,16 +35109,6 @@
 	},
 /turf/simulated/floor/bot/blue,
 /area/station/ai_monitored/storage/eva)
-"gEk" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 6;
-	icon_state = "xtra_bigstripe-corner2"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "gGq" = (
 /obj/machinery/disposal/mail/small{
 	dir = 4;
@@ -37638,6 +35123,15 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/sw,
 /area/station/security/hos)
+"gGQ" = (
+/obj/machinery/light/incandescent/blueish{
+	dir = 1;
+	nostick = 1;
+	pixel_y = 20
+	},
+/obj/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "gJi" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light/incandescent/netural{
@@ -37716,20 +35210,9 @@
 /turf/simulated/floor/caution/south,
 /area/diner/hangar)
 "gPa" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Submarine Bay (Mining)";
-	req_access = null
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/cargo,
-/turf/simulated/floor/orange,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/mining)
 "gQe" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 8;
@@ -37737,15 +35220,6 @@
 	},
 /turf/simulated/floor,
 /area/abandonedship)
-"gRw" = (
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 8;
-	name = "Mining"
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/mining,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "gRC" = (
 /obj/rack,
 /obj/item/clothing/shoes/magnetic{
@@ -37846,10 +35320,9 @@
 /area/station/crew_quarters/market)
 "gWm" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/mining)
 "gXc" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -37941,6 +35414,13 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
+"hoL" = (
+/obj/machinery/vehicle/tank/minisub/mining,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/hangar/mining)
 "hpA" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/ammo/bullets/antisingularity{
@@ -37958,21 +35438,6 @@
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering/ce/private)
-"hpN" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/obj/machinery/light/incandescent/blueish{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
 "hqw" = (
 /obj/decal/cleanable/blood{
 	icon_state = "floor6"
@@ -38056,15 +35521,11 @@
 	dir = 1
 	},
 /area/station/ranch)
-"hDt" = (
-/obj/machinery/manufacturer/hangar,
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
+"hEl" = (
+/obj/table/reinforced/industrial/auto,
+/obj/machinery/microwave,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "hGr" = (
 /obj/lattice{
 	dir = 10;
@@ -38098,6 +35559,15 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
+"hJJ" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4;
+	name = "Crew Quarters"
+	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/space,
+/area/station/crew_quarters/arcade)
 "hMf" = (
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor,
@@ -38207,13 +35677,6 @@
 	},
 /turf/simulated/floor/longtile,
 /area/station/bridge)
-"hSj" = (
-/obj/machinery/light/incandescent/netural,
-/obj/item/device/radio/intercom/cargo{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
 "hSo" = (
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -38301,6 +35764,10 @@
 	dir = 6
 	},
 /area/station/security/secoffquarters)
+"hZC" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "iaJ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
@@ -38316,12 +35783,36 @@
 	},
 /turf/space/fluid/manta,
 /area/mantaSpace)
+"ibu" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orange,
+/area/station/mining)
 "ibY" = (
 /obj/grille/catwalk{
 	dir = 6
 	},
 /turf/space/fluid/manta,
 /area/diner/hangar)
+"icf" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door_control/podbay/mining/new_walls/west{
+	name = "Submarine Bay (Mining) door control";
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/obj/item/device/matanalyzer,
+/turf/simulated/floor,
+/area/station/hangar/mining)
 "icF" = (
 /obj/shrub{
 	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
@@ -38382,6 +35873,10 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
+"igD" = (
+/obj/machinery/processor,
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "igT" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Interrogation"
@@ -38486,15 +35981,6 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/ce)
-"irk" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "iti" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -38509,14 +35995,6 @@
 /obj/machinery/light/runway_light/delay5,
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"iwW" = (
-/obj/storage/crate/abcumarker,
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/construction)
 "ixV" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/revimp_kit{
@@ -38692,23 +36170,15 @@
 	},
 /turf/simulated/floor/longtile,
 /area/station/bridge)
-"iQa" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
 "iSe" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/green,
 /area/station/crewquarters/garbagegarbs)
+"iTd" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/mining/refinery)
 "iUq" = (
 /obj/decal/tile_edge/line/black{
 	dir = 5;
@@ -38765,6 +36235,22 @@
 /obj/storage/secure/closet/civilian/kitchen,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen/therustykrab)
+"jge" = (
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/clipboard{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/table/reinforced/industrial/auto,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "jgp" = (
 /obj/table/auto,
 /obj/decoration/decorativeplant/plant3{
@@ -38787,14 +36273,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"jkh" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
 "jkr" = (
 /obj/stool/chair{
 	dir = 4
@@ -38814,27 +36292,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/porttorpedoes)
-"jlo" = (
-/obj/rack,
-/obj/item/clothing/suit/space/diving/engineering,
-/obj/item/clothing/head/helmet/space/engineer/diving/engineering,
-/obj/item/clothing/mask/breath{
-	pixel_x = -3
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -12
-	},
-/obj/item/tank/emergency_oxygen,
-/obj/item/tank/jetpack,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "jlt" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -38891,17 +36348,6 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/communications/bedroom)
-"jpd" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/obj/item/constructioncone,
-/turf/simulated/floor,
-/area/station/construction/under_construction)
 "jqA" = (
 /obj/rack,
 /obj/item/tank/air,
@@ -38925,14 +36371,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/access_spawn/cargo,
 /obj/access_spawn/mining,
-/obj/access_spawn/engineering_engine,
-/obj/access_spawn/engineering_mechanic,
 /turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/area/station/mining)
 "jtU" = (
 /turf/simulated/floor,
 /area/station/crewquarters/garbagegarbs)
@@ -38948,13 +36389,17 @@
 /turf/simulated/floor/special/submarinesdown,
 /area/station/hallway/starboardlowerhallway)
 "jvz" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/table/reinforced/industrial/auto,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/orange,
+/area/station/mining)
 "jwm" = (
 /obj/table/auto,
 /obj/item/device/detective_scanner,
@@ -38985,20 +36430,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/power)
-"jwL" = (
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"jBB" = (
-/obj/machinery/arc_electroplater,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
 "jDq" = (
 /obj/decal/tile_edge/line/orange{
 	dir = 1;
@@ -39034,11 +36465,9 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/starboard)
 "jKG" = (
-/obj/item/extinguisher,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor,
+/area/station/hangar/mining)
 "jLO" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
@@ -39099,16 +36528,6 @@
 	dir = 8
 	},
 /area/station/crewquarters/garbagegarbs)
-"jXP" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
 "jYl" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -39128,6 +36547,12 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/market)
+"jYM" = (
+/obj/decal/poster/wallsign/stencil/right/m{
+	pixel_y = 38
+	},
+/turf/space/fluid/manta/nospawn,
+/area/station/shield_zone/manta)
 "kai" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light/incandescent/warm{
@@ -39149,21 +36574,6 @@
 	dir = 4
 	},
 /area/station/security/interrogation)
-"keq" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/turf/simulated/floor,
-/area/station/construction)
 "keB" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -39241,6 +36651,13 @@
 	},
 /turf/simulated/floor,
 /area/station/security/visitation)
+"kjK" = (
+/obj/decal/poster/wallsign/stencil/right/g{
+	pixel_x = 0;
+	pixel_y = 38
+	},
+/turf/space/fluid/manta/nospawn,
+/area/station/shield_zone/manta)
 "kkK" = (
 /obj/machinery/light_switch/auto{
 	pixel_y = 24
@@ -39334,17 +36751,6 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
-"kxc" = (
-/obj/machinery/power/furnace,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
 "kxJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -39355,6 +36761,19 @@
 	dir = 8
 	},
 /area/station/security/brig)
+"kyC" = (
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Submarine Bay (Mining)";
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/mining)
 "kyJ" = (
 /obj/submachine/chef_sink/chem_sink{
 	desc = "A water-filled unit intended for hand-washing purposes.";
@@ -39380,14 +36799,6 @@
 	},
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
-"kDM" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/space)
 "kEJ" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -39466,6 +36877,20 @@
 	},
 /turf/simulated/floor/grime,
 /area/diner/backroom)
+"kRH" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor,
+/area/station/hangar/mining)
+"kUD" = (
+/obj/stool/chair{
+	anchored = 0;
+	dir = 8
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "kWs" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/wood/eight{
@@ -39520,6 +36945,10 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
+"lac" = (
+/obj/burning_barrel,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "len" = (
 /obj/decal/fakeobjects{
 	anchored = 1;
@@ -39547,16 +36976,6 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/research)
-"lfC" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
 "lfN" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -39566,6 +36985,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
+"ljJ" = (
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/stool/chair{
+	anchored = 0;
+	dir = 8
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "lmY" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -39653,12 +37082,6 @@
 	},
 /turf/simulated/floor/wood/five,
 /area/station/chapel/sanctuary)
-"lxB" = (
-/obj/item/device/matanalyzer,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "lAp" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -39711,24 +37134,6 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/research)
-"lHv" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/obj/machinery/light_switch/auto{
-	pixel_y = 24
-	},
-/obj/item/storage/wall/green{
-	dir = 4;
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersC)
 "lHH" = (
 /obj/decoration/clock{
 	pixel_x = 32
@@ -39766,6 +37171,15 @@
 	},
 /turf/simulated/floor/engine/glow/blue,
 /area/station/engine/singcore)
+"lLY" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	name = "Crew Quarters"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
+/obj/decal/cleanable/oil/streak,
+/turf/simulated/floor,
+/area/station/crew_quarters/quarters)
 "lNE" = (
 /obj/decal/tile_edge/check{
 	dir = 9;
@@ -39782,10 +37196,13 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen/therustykrab)
 "lNF" = (
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/reagent_dispensers/fueltank,
+/obj/machinery/light/incandescent/netural{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor,
+/area/station/hangar/mining)
 "lNJ" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -39860,15 +37277,6 @@
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
-"lTb" = (
-/obj/item/raw_material/rock,
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "lYo" = (
 /obj/item/device/radio/intercom/security{
 	dir = 4
@@ -39924,14 +37332,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
 "meh" = (
-/obj/table/auto,
-/obj/item/shipcomponent/secondary_system/repair,
-/obj/item/shipcomponent/secondary_system/repair,
-/obj/item/shipcomponent/secondary_system/repair,
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/machinery/ore_cloud_storage_container,
+/turf/simulated/floor/orange,
+/area/station/mining)
 "mfZ" = (
 /obj/stool/chair/green{
 	dir = 8
@@ -40029,16 +37432,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crewquarters/garbagegarbs)
-"mqg" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 10;
-	icon_state = "xtra_bigstripe-corner2"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "mrf" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -40204,6 +37597,15 @@
 	},
 /turf/space/fluid/manta,
 /area/mantaSpace)
+"mIu" = (
+/obj/machinery/disposal/cart_port{
+	name = "Ore cart port - to QM"
+	},
+/obj/disposalpipe/trunk/mineral{
+	dir = 4
+	},
+/turf/simulated/floor/orange,
+/area/station/mining)
 "mIx" = (
 /obj/reagent_dispensers/watertank/fountain,
 /obj/disposalpipe/segment/mail{
@@ -40340,13 +37742,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"ncp" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
 "ndD" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle,
@@ -40377,6 +37772,10 @@
 	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
+"ngd" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/orange,
+/area/station/mining)
 "nji" = (
 /obj/table/reinforced/auto,
 /obj/machinery/computer3/generic/personal/personel_alt{
@@ -40481,17 +37880,9 @@
 /turf/simulated/floor/wood/five,
 /area/station/chapel/sanctuary)
 "ntv" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/miningteleporter,
+/turf/simulated/floor/orange,
+/area/station/mining)
 "nuY" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -40581,12 +37972,7 @@
 /area/station/bridge)
 "nAY" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
-"nBB" = (
-/turf/simulated/floor/plating/random,
-/area/station/hangar/mining)
+/area/station/mining)
 "nBS" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -40601,7 +37987,6 @@
 	},
 /area/station/ranch)
 "nCe" = (
-/obj/machinery/manufacturer/hangar,
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -40611,10 +37996,16 @@
 	nostick = 1;
 	pixel_x = 10
 	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/machinery/manufacturer/mining,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
+	},
+/turf/simulated/floor/orange,
+/area/station/mining)
 "nFD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -40632,34 +38023,6 @@
 	dir = 6
 	},
 /area/station/crewquarters/cryotron)
-"nHc" = (
-/obj/table/reinforced/auto,
-/obj/item/device/light/zippo{
-	pixel_x = -4;
-	pixel_y = 15
-	},
-/obj/item/cigpacket/propuffs{
-	pixel_x = 8;
-	pixel_y = 14
-	},
-/obj/item/decoration/ashtray{
-	butts = 5;
-	name = "grubby old ashtray"
-	},
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"nJx" = (
-/obj/reagent_dispensers/fueltank,
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
 "nJP" = (
 /obj/table/auto,
 /obj/item/reagent_containers/glass/beaker/large/brute,
@@ -40797,6 +38160,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/listeningpost/syndicateassaultvessel)
+"nXG" = (
+/obj/machinery/neosmelter,
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "nYC" = (
 /obj/machinery/light/incandescent/blueish{
 	dir = 4;
@@ -40913,11 +38280,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
-"olF" = (
-/obj/item/raw_material/rock,
-/obj/disposalpipe/trunk,
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "omt" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cell_charger,
@@ -41005,18 +38367,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
-"oso" = (
-/obj/decal/tile_edge/check{
-	color = "#AB8CB0";
-	dir = 8;
-	icon_state = "check1"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "osu" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -41121,6 +38471,15 @@
 /obj/machinery/light/runway_light/delay3,
 /turf/space/fluid/manta,
 /area/mantaSpace)
+"oIj" = (
+/obj/stool/chair{
+	anchored = 0
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "oIR" = (
 /obj/machinery/weapon_stand/shotgun_rack,
 /obj/machinery/power/apc/autoname_west,
@@ -41258,20 +38617,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
-"oQD" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
-	},
-/obj/landmark/start{
-	name = "Miner"
-	},
-/obj/item/device/radio/intercom/cargo{
-	dir = 4
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "oRE" = (
 /obj/table/auto,
 /obj/machinery/cashreg{
@@ -41294,11 +38639,6 @@
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/starboard)
-"oVc" = (
-/turf/simulated/floor/caution/south,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "oVY" = (
 /obj/machinery/r_door_control{
 	id = "diner1"
@@ -41339,13 +38679,8 @@
 	},
 /area/station/security/interrogation)
 "oXC" = (
-/obj/machinery/door_control/podbay/mining/new_walls/west{
-	name = "Submarine Bay (Mining) door control"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/wall/asteroid,
+/area/station/mining)
 "oZK" = (
 /obj/item/device/audio_log,
 /obj/item/audio_tape{
@@ -41404,26 +38739,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
-"pfe" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/power/monitor/console_upper,
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1;
-	pixel_y = 20
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/drainage/big,
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
 "pfS" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
@@ -41553,14 +38868,19 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "psJ" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Mining";
+	req_access = null
 	},
-/obj/item/wrench,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/firedoor_spawn,
+/obj/access_spawn/mining,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mineral,
+/turf/simulated/floor,
+/area/station/hangar/mining)
 "ptd" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -41590,13 +38910,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"pvN" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/obj/decal/tile_edge/stripe/extra_big,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "pwc" = (
 /obj/rack,
 /obj/item/rubberduck,
@@ -41606,17 +38919,6 @@
 	},
 /turf/simulated/floor/green,
 /area/station/crew_quarters/market)
-"pws" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor,
-/area/station/construction)
 "pwt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41695,6 +38997,10 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crewquarters/cryotron)
+"pMM" = (
+/obj/decal/cleanable/dirt/mars,
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "pNh" = (
 /obj/machinery/power/data_terminal,
 /obj/item/device/net_sniffer,
@@ -41802,13 +39108,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portupperhallway)
-"qbl" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "qcy" = (
 /obj/machinery/light/incandescent/cool{
 	nostick = 1
@@ -41870,6 +39169,12 @@
 	dir = 4
 	},
 /area/station/security/secoffquarters)
+"qkH" = (
+/obj/table/reinforced/industrial/auto,
+/obj/item/game_kit,
+/obj/item/storage/box/donkpocket_kit,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "qkT" = (
 /obj/machinery/light_switch/auto{
 	pixel_x = 5;
@@ -41883,15 +39188,6 @@
 	dir = 4
 	},
 /area/station/crew_quarters/market)
-"qlY" = (
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/mining_horizontal{
-	name = "Submarine Bay (Mining)"
-	},
-/obj/forcefield/energyshield/perma/doorlink,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "qrl" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41905,6 +39201,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction)
+"qtR" = (
+/obj/machinery/r_door_control/podbay/mining/new_walls{
+	name = "Submarine Bay (Mining) door control"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/mining)
 "quC" = (
 /obj/storage/crate/wooden,
 /obj/machinery/light/incandescent/netural{
@@ -41931,15 +39233,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/starboardtorpedoes)
-"qyS" = (
-/obj/item/storage/wall/mining,
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "qAx" = (
 /turf/unsimulated/wall/setpieces/fakewindow{
 	dir = 6
@@ -42111,21 +39404,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
-"qPu" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/obj/table/reinforced/industrial/auto,
-/obj/item/sheet/steel/fullstack{
-	rand_pos = 0
-	},
-/obj/item/sheet/steel/fullstack{
-	rand_pos = 0
-	},
-/turf/simulated/floor,
-/area/station/construction)
 "qQk" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -42170,27 +39448,10 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"rdu" = (
-/obj/storage/cart{
-	name = "ore cart"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/caution/south,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "rdx" = (
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/orange,
+/area/station/mining)
 "rdE" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -42427,21 +39688,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/hos/quarter)
-"ruk" = (
-/obj/stool/bed,
-/obj/item/storage/wall/mining,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
-	},
-/obj/landmark/start{
-	name = "Miner"
-	},
-/obj/item/device/radio/intercom/cargo{
-	dir = 8
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "ruT" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -42492,17 +39738,13 @@
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "rCN" = (
-/obj/decal/tile_edge/check{
-	color = "#AB8CB0";
-	dir = 4;
-	icon_state = "check1"
-	},
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
 	pixel_y = 20
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
+/obj/machinery/nanofab/refining,
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "rGY" = (
 /obj/decoration/decorativeplant/plant5,
 /obj/machinery/light/incandescent/netural{
@@ -42555,6 +39797,19 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"rOC" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/upperport)
 "rRP" = (
 /obj/decal/fakeobjects{
 	density = 1;
@@ -42588,25 +39843,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"rUD" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 9;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "rVY" = (
 /obj/grille/catwalk{
 	dir = 5;
@@ -42638,10 +39874,13 @@
 /area/station/security/checkpoint/sec_foyer)
 "rXk" = (
 /obj/decal/cleanable/dirt/dirt3,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/machinery/manufacturer/hangar,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor,
+/area/station/hangar/mining)
 "rXH" = (
 /obj/machinery/light/incandescent/blueish{
 	dir = 1;
@@ -42736,17 +39975,14 @@
 /turf/simulated/floor/caution/south,
 /area/station/engine/inner)
 "skN" = (
-/obj/decal/cleanable/dirt/dirt4,
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/orange,
+/area/station/mining)
 "slh" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42762,14 +39998,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
-"smp" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "srA" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/glass/bottle/holywater,
@@ -42860,20 +40088,6 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/starboard)
-"sEK" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "sFy" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -42899,13 +40113,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/port)
-"sGr" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
 "sKg" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -43118,23 +40325,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/starboard)
-"tsQ" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e17627";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "ttM" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/north,
 /obj/machinery/guardbot_dock,
@@ -43160,25 +40350,6 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
-"txS" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/disposalpipe/junction/right/south,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "tAG" = (
 /obj/shrub{
 	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
@@ -43200,14 +40371,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
-"tCX" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor,
-/area/station/construction)
 "tHn" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -43252,16 +40415,6 @@
 "tJU" = (
 /turf/simulated/floor/caution/south,
 /area/station/engine/elect)
-"tKM" = (
-/obj/critter/rockworm{
-	name = "Gary the rockworm"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "tLe" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -43282,11 +40435,12 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/medical/head)
 "tLq" = (
-/obj/machinery/vehicle/tank/minisub,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/item/raw_material/rock,
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless/asteroid,
+/area/station/mining)
 "tNr" = (
 /obj/machinery/light/incandescent/blueish{
 	dir = 8;
@@ -43341,14 +40495,6 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"tXp" = (
-/obj/machinery/processor,
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
 "tYh" = (
 /obj/machinery/computer3/generic/communications,
 /obj/machinery/weapon_stand/rifle_rack/recharger,
@@ -43436,12 +40582,9 @@
 	},
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "uhg" = (
-/obj/table/auto,
-/obj/machinery/recharger,
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/item/storage/wall/mineralshelf,
+/turf/simulated/floor/orange,
+/area/station/mining)
 "uhU" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/clipboard,
@@ -43488,17 +40631,6 @@
 /obj/item/clothing/under/swimsuit/random,
 /turf/simulated/floor/sanitary/blue,
 /area/station/crew_quarters/bathroom)
-"ujg" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "ujF" = (
 /obj/machinery/power/data_terminal,
 /obj/cable,
@@ -43510,37 +40642,44 @@
 	},
 /turf/simulated/floor/engine/glow/blue,
 /area/station/engine/singcore)
-"ulJ" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "unq" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/green,
 /area/station/medical/research)
+"usf" = (
+/obj/critter/rockworm{
+	name = "Gary the rockworm"
+	},
+/obj/machinery/light/incandescent/netural{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/plating/airless/asteroid,
+/area/station/mining)
 "usW" = (
+/obj/item/cargotele{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/cargotele{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/machinery/recharger{
+	pixel_x = -7
+	},
+/obj/machinery/recharger{
+	pixel_x = 5
+	},
+/obj/table/reinforced/industrial/auto,
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
-"utz" = (
-/obj/item/storage/wall/mineralshelf,
-/obj/item/device/radio/intercom/cargo{
-	dir = 4
-	},
 /turf/simulated/floor/orange,
-/area/station/mining/refinery)
+/area/station/mining)
 "uvR" = (
 /obj/stool/bench/auto,
 /obj/decal/tile_edge/line/red{
@@ -43595,16 +40734,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
-"uEY" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/computer/card/console_lower{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
 "uFt" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -43665,6 +40794,21 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
+"uIV" = (
+/obj/storage/crate,
+/obj/item/shipcomponent/sensor/mining,
+/obj/item/shipcomponent/sensor/mining,
+/obj/item/shipcomponent/sensor/mining,
+/obj/item/shipcomponent/secondary_system/orescoop,
+/obj/item/shipcomponent/secondary_system/orescoop,
+/obj/item/shipcomponent/secondary_system/orescoop,
+/obj/machinery/light/incandescent/netural{
+	dir = 4;
+	nostick = 1;
+	pixel_x = 10
+	},
+/turf/simulated/floor,
+/area/station/hangar/mining)
 "uJF" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -43804,26 +40948,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
-"uTW" = (
-/obj/machinery/light/incandescent/blueish{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"uUd" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"uUj" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/mining/refinery)
 "uYi" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -43864,9 +40988,6 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/captain)
-"vea" = (
-/turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/mining/refinery)
 "veP" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -43877,11 +40998,12 @@
 	},
 /area/station/crewquarters/cryotron)
 "vft" = (
-/obj/decal/cleanable/oil/streak,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/machinery/drainage/big,
 /turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/area/station/hangar/mining)
 "vfw" = (
 /obj/decal/fakeobjects{
 	desc = "Under construction";
@@ -43892,6 +41014,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction)
+"vfQ" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/mining)
 "vhk" = (
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -43907,29 +41038,22 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
-"vkN" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs_wide"
-	},
-/area/station/mining/refinery)
 "vlK" = (
 /turf/simulated/floor/plating/random,
 /area/station/engine/elect)
 "vnk" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
+/obj/disposalpipe/segment/mineral{
+	dir = 4
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/mining)
 "vop" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/Port_A_Brig,
@@ -43950,14 +41074,14 @@
 	},
 /area/station/security/interrogation)
 "vqB" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4
+/obj/machinery/disposal/small{
+	dir = 8;
+	layer = 32;
+	name = "rockworm feeding unit"
 	},
-/obj/machinery/vehicle/tank/minisub,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/disposalpipe/trunk,
+/turf/simulated/floor/orange,
+/area/station/mining)
 "vrU" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/blue,
@@ -44034,13 +41158,6 @@
 	},
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/science/teleporter)
-"vyz" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "vzu" = (
 /obj/stool/bench/auto,
 /obj/decal/tile_edge/line/red{
@@ -44070,16 +41187,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
-"vzK" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "vBy" = (
 /obj/storage/secure/closet/personal,
 /obj/disposalpipe/segment/mail,
@@ -44177,13 +41284,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"vHg" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "vHN" = (
 /obj/machinery/manufacturer/uniform,
 /obj/machinery/light/incandescent/netural{
@@ -44225,9 +41325,7 @@
 	name = "Submarine Bay (Mining)"
 	},
 /turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/area/station/hangar/mining)
 "vNT" = (
 /obj/machinery/networked/test_apparatus/xraymachine,
 /obj/machinery/power/data_terminal,
@@ -44379,11 +41477,8 @@
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
 "wbL" = (
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/plating/airless/asteroid,
+/area/station/mining)
 "wdi" = (
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -44474,19 +41569,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
-"wnp" = (
-/obj/table/auto,
-/obj/machinery/coffeemaker,
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/obj/mug_rack{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
 "woI" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -44537,13 +41619,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
-"wwx" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "wxu" = (
 /obj/table/reinforced/bar/auto,
 /obj/decal/tile_edge/line/black{
@@ -44577,10 +41652,8 @@
 /obj/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/simulated/floor/caution/south,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/orange,
+/area/station/mining)
 "wzn" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/machinery/light/emergency{
@@ -44590,15 +41663,13 @@
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "wzI" = (
-/obj/storage/closet/welding_supply,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/orange,
+/area/station/mining)
 "wzU" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/wood/five,
@@ -44700,21 +41771,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
-"wOL" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 8;
-	name = "Mining";
-	req_access = null
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/mining/refinery)
 "wRO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -44838,12 +41894,6 @@
 /obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
-"xlP" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating/random,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "xod" = (
 /obj/machinery/manufacturer/robotics,
 /obj/machinery/light/incandescent/netural{
@@ -44857,29 +41907,22 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/machinery/portable_reclaimer,
+/turf/simulated/floor/orange,
+/area/station/mining)
 "xpG" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/market)
 "xpQ" = (
-/obj/disposalpipe/trunk/mineral{
-	dir = 4
-	},
-/obj/machinery/disposal/cart_port{
-	name = "Ore cart port - to QM"
+/obj/storage/cart{
+	name = "ore cart"
 	},
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
 	pixel_x = -10
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/orange,
+/area/station/mining)
 "xqw" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -44932,10 +41975,6 @@
 /obj/machinery/light/runway_light,
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"xwN" = (
-/obj/machinery/ore_cloud_storage_container,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "xwV" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg{
@@ -45263,14 +42302,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"ybh" = (
-/obj/machinery/sim/vr_bed{
+"yaM" = (
+/obj/decal/tile_edge/check{
+	color = "#AB8CB0";
 	dir = 4;
-	name = "VR simulation pod";
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
+	icon_state = "check1"
 	},
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -45278,12 +42314,28 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"ybh" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "yck" = (
-/obj/machinery/drainage/big,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hangar/mining)
+"ydZ" = (
+/obj/machinery/light/emergency{
+	dir = 4;
+	pixel_x = 10
+	},
+/obj/storage/closet/welding_supply,
+/turf/simulated/floor,
+/area/station/hangar/mining)
 "yea" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -45315,26 +42367,14 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/caution/south,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/orange,
+/area/station/mining)
 "yhC" = (
 /obj/cable{
 	icon_state = "6-8"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
-"yiv" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
 "ykr" = (
 /obj/table/round/auto,
 /obj/towelbin{
@@ -65766,7 +62806,7 @@ buU
 buU
 buU
 buU
-bFe
+buU
 buU
 aoq
 aie
@@ -66061,16 +63101,16 @@ bai
 bgN
 kly
 bqT
-xlP
+nAY
 fLk
-rdu
-lNF
+fEl
+fEl
 xpQ
 rdx
-lNF
+usf
 oXC
 nAY
-act
+aab
 aaa
 aaa
 aaa
@@ -66363,16 +63403,16 @@ bai
 bhC
 kly
 cxW
-xlP
+nAY
 ntv
-oVc
-lNF
+fXJ
+fXJ
 vqB
-lNF
+egk
 tLq
 wbL
-blz
-act
+nAY
+aab
 aaa
 aaa
 aaa
@@ -66665,16 +63705,16 @@ bqX
 biY
 gAR
 nuY
-xlP
+nAY
 eBV
-oVc
-lNF
-smp
-lNF
-lNF
+fXJ
+mIu
+bva
+bva
 jKG
-qlY
-act
+jKG
+bva
+jYM
 aaa
 aaa
 aaa
@@ -66971,12 +64011,12 @@ jsD
 skN
 yhc
 usW
-smp
-lNF
+jKG
+aYE
 rXk
 lNF
-vMo
-act
+bva
+emx
 aaa
 aaa
 aaa
@@ -67271,14 +64311,14 @@ kly
 uFt
 nAY
 wzI
-oVc
+fXJ
 jvz
-smp
-lxB
-lNF
+jKG
+bRT
 yck
-vMo
-act
+yck
+bva
+kjK
 aaa
 aaa
 aaa
@@ -67571,14 +64611,14 @@ aAW
 bjT
 dPl
 cty
-nAY
+gPa
 uhg
-oVc
-jvz
-smp
-lNF
-lNF
-lNF
+fXJ
+ibu
+jKG
+bRT
+hoL
+bSd
 vMo
 act
 aaa
@@ -67873,14 +64913,14 @@ bgy
 bkK
 boc
 boc
-nAY
-dYP
-oVc
-jvz
+gPa
+fXJ
+fXJ
+cyK
 psJ
-lNF
+cZu
 vft
-lNF
+bRl
 vMo
 act
 aaa
@@ -68175,15 +65215,15 @@ boc
 box
 boc
 boc
-nAY
+gPa
 meh
-oVc
-jvz
-smp
-lNF
-lNF
-wbL
-nAY
+fXJ
+fXJ
+jKG
+vfQ
+hoL
+bCP
+vMo
 act
 aaa
 aaa
@@ -68479,14 +65519,14 @@ bcj
 bIZ
 gWm
 xoE
-gpN
-jvz
-vqB
-lNF
-tLq
+fXJ
+fkT
+jKG
+icf
+kRH
 bZu
-nAY
-aoQ
+qtR
+act
 aaa
 aaa
 aaa
@@ -68782,12 +65822,12 @@ bsM
 nAY
 nCe
 wyh
-jvz
-dXK
+ngd
+jKG
 vnk
-lNF
-lNF
-nAY
+ydZ
+uIV
+bva
 act
 act
 aaa
@@ -69085,11 +66125,11 @@ nAY
 nAY
 nAY
 gPa
-coI
-nAY
-nAY
-dyN
-nAY
+bva
+kyC
+bva
+bva
+bva
 bEF
 act
 aaa
@@ -69688,7 +66728,7 @@ btJ
 bvd
 bvk
 ayM
-aze
+bXa
 bBt
 bCT
 byw
@@ -71184,13 +68224,13 @@ acO
 pXE
 aoJ
 apD
-aLJ
-aLJ
-aLJ
-aLJ
-aLJ
-aLJ
-aLJ
+iTd
+iTd
+iTd
+iTd
+iTd
+iTd
+iTd
 bgr
 box
 aKs
@@ -71486,13 +68526,13 @@ acO
 ait
 aGX
 aLq
-aLJ
-aNr
+iTd
+igD
 bkt
 bln
 ybh
 bnE
-aLJ
+iTd
 bgr
 box
 aKs
@@ -71788,14 +68828,14 @@ ait
 aoJ
 apD
 aLq
-aLJ
+iTd
 rCN
-bku
-bku
+aOr
+caM
 bku
 bku
 boR
-bfr
+bgr
 box
 aKs
 xod
@@ -72090,12 +69130,12 @@ ait
 aGX
 aLq
 aLq
-aLJ
-aLN
-aLX
+iTd
 aOr
-aLX
-bnF
+nXG
+aOr
+jbY
+ftS
 boR
 xfn
 box
@@ -72374,7 +69414,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+pMM
 aaa
 aaa
 aaa
@@ -72392,9 +69432,9 @@ aoJ
 apD
 aLq
 aLq
-aLJ
+iTd
 bjx
-aLX
+aOr
 blo
 bmC
 bnG
@@ -72694,12 +69734,12 @@ aGX
 aLq
 aLq
 aLq
-aLJ
-aLN
-aLX
+iTd
+aOr
+aOr
 blp
-aLX
-bnF
+jbY
+ftS
 boR
 bgr
 box
@@ -72996,12 +70036,12 @@ aQb
 aLq
 ykr
 aLz
-aLJ
-oso
-bkv
+iTd
+rCN
+aOr
 blq
-bkv
-bkv
+eDy
+eDy
 boR
 bgr
 box
@@ -73298,13 +70338,13 @@ aLq
 aLq
 aLv
 aLs
-aLJ
-aNr
-bkw
+iTd
+igD
+aOr
 blr
 ftI
 aNr
-aLJ
+iTd
 bgr
 bpY
 aKs
@@ -73600,13 +70640,13 @@ aLq
 aLq
 aLq
 ahI
-aLJ
-aLJ
-aLJ
-aLJ
-aLJ
-aLJ
-aLJ
+iTd
+iTd
+iTd
+iTd
+iTd
+iTd
+iTd
 hsB
 bqa
 aKs
@@ -75101,7 +72141,7 @@ acO
 pXE
 aoJ
 apD
-aLl
+ait
 baG
 aKW
 bcy
@@ -75399,11 +72439,11 @@ act
 act
 acO
 acO
-acO
+ait
 aoJ
 apD
-acD
-acD
+aLJ
+hJJ
 baG
 baG
 baG
@@ -75700,11 +72740,11 @@ act
 act
 acO
 acO
-acO
 aoJ
+bpc
 apD
-acD
-acD
+aLJ
+aLJ
 aIH
 aKK
 aLi
@@ -76001,12 +73041,12 @@ act
 act
 acO
 acO
-aim
-ait
-aGX
-acD
-acD
-aIn
+rOC
+apD
+aLJ
+aLJ
+aLJ
+aIH
 aIJ
 aKU
 aLj
@@ -76303,10 +73343,10 @@ act
 acO
 acO
 ait
-aoJ
-bpc
-apD
-acD
+aGX
+aLJ
+aLJ
+yaM
 aYj
 aIw
 aIV
@@ -76606,11 +73646,11 @@ acO
 ait
 aoJ
 aHG
-acD
-aur
-acD
+aLJ
+aLN
+aLX
 aYk
-aGj
+aLX
 aIY
 aCb
 aKl
@@ -76910,9 +73950,9 @@ apD
 acD
 acD
 aGF
-aFI
-aGR
-aLu
+aLX
+aYk
+aLX
 aIZ
 aAa
 bbE
@@ -77211,10 +74251,10 @@ apD
 acD
 acD
 acD
-aDM
-aIy
-aGS
-aIA
+aLN
+aLX
+aYk
+aLX
 aJa
 aCb
 bbF
@@ -77514,9 +74554,9 @@ acD
 igl
 acD
 diy
-aDK
+bkv
 aHr
-aIB
+bkv
 aJi
 aCb
 aDQ
@@ -77807,15 +74847,15 @@ act
 act
 acO
 acO
-ait
+qkH
 ait
 aGX
-acD
+ait
 acD
 ctG
 aCw
 acD
-aFn
+acD
 aNh
 aIg
 aIF
@@ -78108,15 +75148,15 @@ act
 act
 acO
 acO
-ait
+hEl
 aoJ
-aEf
-dJt
-aUC
-aDI
-aEV
-aGP
-acD
+bpc
+apD
+ait
+lLY
+aCw
+aCw
+cNc
 acD
 acD
 aIb
@@ -78409,16 +75449,16 @@ act
 act
 acO
 acO
-ait
+elV
 aoJ
 apD
-aCr
-aCr
-aCr
-aDJ
-aCr
+ait
+ait
+ait
+acD
+acD
 aHo
-aIj
+aDI
 wzZ
 aJR
 aKe
@@ -78710,14 +75750,14 @@ act
 act
 acO
 acO
-gNk
+gGQ
 aoJ
 apD
-aCr
-aCr
-lHv
-aIu
-aEq
+ait
+ait
+ait
+ait
+ait
 aCr
 aGp
 aIm
@@ -79011,15 +76051,15 @@ aaa
 act
 acO
 acO
-aBo
+ait
 ait
 aGX
-aCr
-aCr
-aCx
+ait
+ait
 aDA
-aDF
-aHV
+aDA
+ait
+aHO
 aCr
 lAp
 aJQ
@@ -79316,12 +76356,12 @@ tOg
 ait
 ait
 aGX
-aCr
-aCr
-aCr
-aCr
-aCr
-aCr
+ait
+oIj
+goI
+jge
+lac
+hZC
 aCr
 aIf
 aIv
@@ -79620,10 +76660,10 @@ ait
 aGX
 ait
 ait
+ljJ
+kUD
 ait
 ait
-ait
-nWC
 aGp
 aGp
 acf
@@ -119826,9 +116866,9 @@ aaa
 aaa
 aaa
 aab
-bQa
-bPF
-bQa
+aab
+aaa
+aab
 arb
 arb
 arb
@@ -120127,10 +117167,10 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 aab
-bQa
-bPF
-bQa
 aab
 aab
 aab
@@ -120429,11 +117469,11 @@ aaa
 aaa
 aaa
 aaa
-bPS
-bPS
-bTB
-bPS
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -120731,11 +117771,11 @@ aaa
 aaa
 aaa
 aaa
-bPS
-vyz
-bTC
-bON
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -121027,28 +118067,28 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bPS
-bTB
-bPS
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -121328,30 +118368,30 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-jXP
-uTW
-bOd
-bOd
-bPT
-bON
-bPF
-bON
-bPT
-bOd
-dXk
-bOd
-bOd
-jXP
-bOd
-uTW
-bOd
-bOd
-bOd
-bNX
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -121630,30 +118670,30 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-vea
-vea
-vea
-vea
-vea
-bQf
-bPF
-bQF
-bOm
-bOm
-bOm
-bOm
-bOm
-bOm
-bOm
-bOm
-bOm
-bOm
-bOd
-bSM
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -121932,30 +118972,30 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-vea
-utz
-vHg
-bPx
-uUj
-bQg
-bPF
-bQG
-bOm
-jlo
-cDo
-bOm
-wnp
-bRN
-bOm
-qyS
-oQD
-bOm
-bOd
-bOd
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -122233,32 +119273,32 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-vea
-vea
-ftS
-ftS
-xwN
-uUj
-ulJ
-bPF
-bQH
-bOm
-ruk
-bEo
-bRo
-bRz
-bRz
-bRo
-bEo
-bTx
-bOm
-bSA
-bSN
-bSA
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -122534,34 +119574,34 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-bOd
-vea
-arP
-qbl
-ftS
-bPz
-uUj
-bQg
-bPF
-bQH
-bOm
-bOm
-bOm
-bOm
-bRA
-bRO
-bOm
-bOm
-bOm
-bOm
-yiv
-bSB
-bSB
-bSA
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -122836,34 +119876,34 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-vea
-vea
-vea
-vea
-gRw
-vea
-vea
-bQg
-bPF
-bQH
-bOm
-jlo
-bEo
-bOm
-bRz
-bRz
-bOm
-bSe
-oQD
-bOm
-bSC
-bSO
-bSX
-bTa
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123138,34 +120178,34 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-vea
-bOI
-dqP
-bPc
-jbY
-bxb
-uUj
-bQg
-bPF
-bTp
-bOm
-ruk
-fWO
-bRo
-bRz
-bRz
-bRo
-fWO
-bTx
-bOm
-bSD
-bSP
-bSB
-bSD
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123438,37 +120478,37 @@ aaa
 aaa
 aaa
 aaa
-adx
-bNX
-bNX
-bOd
-vea
-vea
-bOJ
-bAe
-bBG
-jbY
-bPB
-uUj
-ulJ
-bPF
-bQG
-bOm
-bOm
-bOm
-bOm
-bRB
-bRP
-bOm
-bOm
-bOm
-bOm
-ncp
-bSP
-bSB
-bTb
-bSA
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123740,41 +120780,6 @@ aaa
 aaa
 aaa
 aaa
-adx
-bNX
-gwa
-bOd
-vea
-sGr
-bwZ
-bAe
-bBG
-gEk
-bRy
-uUj
-bQg
-bPF
-bQH
-bOm
-vzK
-lTb
-bPU
-bRz
-bRz
-bRW
-bSf
-hSj
-bOm
-bSC
-bSQ
-bSX
-bSX
-bTa
-bSA
-aaa
-aqQ
-aaa
-bTl
 aaa
 aaa
 aaa
@@ -123783,7 +120788,42 @@ aaa
 aaa
 aaa
 aaa
-arz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124042,37 +121082,37 @@ aaa
 aaa
 aaa
 aaa
-adx
-bNX
-bOd
-bOd
-vea
-bxa
-bxa
-bAe
-bBG
-pvN
-bQS
-uUj
-bQg
-bPF
-bQH
-bOm
-bJA
-ast
-bPV
-bRC
-bRQ
-bRQ
-bSg
-bSp
-bOm
-bSD
-bSP
-bSB
-bSB
-bSD
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124344,38 +121384,38 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-vea
-vea
-bxa
-bxa
-bAe
-bBG
-mqg
-bxc
-uUj
-bQg
-bPF
-bQH
-bOm
-tKM
-olF
-bRp
-bRD
-bRz
-bRz
-byH
-bSq
-bOm
-bSB
-bSP
-bSB
-bUu
-bUA
-bSA
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124646,38 +121686,38 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-vea
-tXp
-bxa
-bxa
-bAe
-bBG
-jbY
-jwL
-uUj
-ulJ
-bPF
-bQH
-bOm
-arQ
-arQ
-bPV
-bRE
-bUd
-bUk
-bUl
-bUo
-bOm
-kxc
-bSQ
-bSX
-bUv
-bSX
-bTj
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124948,38 +121988,38 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-vea
-bOq
-bxa
-jBB
-bOb
-vkN
-bPq
-irk
-uUj
-bQg
-bPF
-kDM
-bOm
-arQ
-bJA
-bRq
-bRF
-bUe
-lfC
-bTv
-bSr
-bOm
-bSD
-bSR
-bSY
-bUw
-bTh
-bSD
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125247,43 +122287,43 @@ aaa
 aaa
 aaa
 aaa
-aqP
-aqP
-aqP
-bNY
-bOe
-bOi
-bOi
-uUj
-uUj
-uUj
-uUj
-uUj
-vea
-wOL
-vea
-bQj
-bTO
-bQI
-bOm
-bOr
-bRf
-bOm
-bRG
-bUf
-bOm
-bOr
-bSs
-bOm
-bSA
-bSA
-bSA
-bUx
-bSA
-bSA
-bSA
-bPS
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125549,43 +122589,43 @@ aaa
 aaa
 aaa
 aaa
-aqP
-bNR
-bwY
-fTd
-bOf
-bOD
-bOF
-bPs
-txS
-bQw
-bQw
-bQw
-bQN
-cxL
-bSo
-bTm
-bTP
-bQk
-bPZ
-bQV
-bRg
-bOV
-bRH
-bUg
-bOV
-bOV
-bSt
-bPZ
-bQK
-dGn
-bUs
-bUy
-wwx
-bON
-bPS
-bON
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125851,43 +122891,43 @@ aaa
 aaa
 aaa
 aaa
-aqP
-pfe
-bNV
-bOa
-bOg
-bOk
-bNY
-bOt
-bPF
-bON
-bON
-bON
-bQT
-byE
-bQa
-bQl
-bTQ
-bQl
-bQa
-byG
-bRh
-bON
-bOC
-bUh
-bON
-bON
-bON
-bQa
-byI
-bON
-bUh
-bOC
-bON
-bON
-bTk
-bQE
-bTk
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -126153,43 +123193,43 @@ aaa
 aaa
 aaa
 aaa
-aqP
-bNT
-uEY
-nHc
-bOh
-jkh
-bOo
-bOu
-bPG
-bNW
-bOW
-dnh
-bQX
-bRK
-bQb
-bQl
-bTR
-bTS
-bTT
-bTV
-rUD
-bTX
-bTY
-bUi
-bTX
-sEK
-bUp
-bTT
-bUq
-fZX
-buc
-bOC
-bue
-bON
-bPS
-bON
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -126455,43 +123495,43 @@ aaa
 aaa
 aaa
 aaa
-aqP
-aqP
-aqP
-bNY
-bOe
-bNY
-bNY
-bOv
-bPH
-bOv
-bOy
-bOy
-bOy
-bRR
-bOy
-bQm
-bQB
-bQJ
-bPS
-bPS
-bva
-bva
-bTZ
-bRS
-bva
-bva
-bva
-bva
-bSH
-bSH
-bSH
-bTf
-bSH
-bSH
-bSJ
-bPS
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -126760,38 +123800,38 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-bNX
-bzY
-bPJ
-bPL
-bOy
-bOS
-tCX
-eHC
-bOy
-bQn
-bOC
-bON
-bQO
-bQO
-bRj
-hDt
-bUa
-bRT
-bTI
-iQa
-bSv
-bva
-jpd
-bSI
-aCO
-bST
-aCO
-ase
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127062,38 +124102,38 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-bNX
-bOx
-bOG
-bzZ
-bOy
-bOS
-bOS
-bPM
-bQc
-byF
-bOC
-bON
-bQP
-bQP
-bRj
-aYE
-bUb
-bRT
-bRZ
-bSk
-bSw
-bva
-bSI
-bSI
-bSI
-bST
-bSI
-bSI
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127364,38 +124404,38 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-bNX
-bOy
-bOy
-bOy
-bOy
-bPr
-bOS
-bUC
-bQc
-bQp
-bOC
-bON
-bQQ
-bQP
-bRj
-bRt
-bUc
-bUj
-bRj
-bSl
-bSx
-bva
-bSI
-bSI
-bSI
-bST
-bSI
-bSJ
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127667,40 +124707,6 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-bOy
-bOH
-keq
-bOS
-bOS
-bOS
-bUE
-bQc
-bQq
-bQC
-bQK
-bQR
-ujg
-bRj
-bRu
-bRL
-bRU
-bSa
-bSm
-gkj
-bva
-bSI
-bSI
-bSI
-bST
-bSI
-bSJ
-aaa
-aqQ
-aaa
-bTl
 aaa
 aaa
 aaa
@@ -127709,7 +124715,41 @@ aaa
 aaa
 aaa
 aaa
-arz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127969,36 +125009,36 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-bOy
-bOH
-bOS
-bOS
-bOS
-bOS
-bPO
-bQc
-bQr
-bON
-bON
-bva
-bva
-bva
-bRv
-bRM
-bRV
-bRV
-bRV
-bRV
-bva
-bSI
-bSS
-bSZ
-bTg
-bTi
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -128271,36 +125311,36 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-bOy
-bOy
-bQv
-bOS
-bOS
-bOS
-bPP
-bOy
-bQr
-bON
-bON
-bva
-uUd
-bRk
-bCP
-bCP
-bCP
-bCP
-bCP
-aCF
-bva
-bSI
-bST
-bSI
-bSI
-bSJ
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -128574,34 +125614,34 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-bOy
-pws
-bOS
-bPu
-qPu
-bPN
-bOy
-tsQ
-bON
-bTq
-bva
-bRa
-bRl
-bCP
-bCP
-bCP
-bCP
-bRl
-bRa
-bva
-bSI
-bST
-bSI
-bSI
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -128876,34 +125916,34 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-bOy
-bOy
-bOS
-bUD
-bOy
-bOy
-bOy
-bQt
-bON
-bON
-bva
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bva
-bSI
-bST
-bSI
-bSI
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129178,34 +126218,34 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-bOd
-bOy
-iwW
-bOy
-bOy
-bPQ
-bOZ
-bON
-bON
-bQL
-bva
-bTt
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bva
-ase
-bST
-ase
-bSJ
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129481,32 +126521,32 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-bOy
-bOY
-bOY
-bPv
-aLQ
-bQd
-bON
-bON
-bON
-bva
-bRa
-bRl
-bCP
-bCP
-bCP
-bCP
-bRl
-bRa
-bva
-bSJ
-bSU
-bSJ
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129784,30 +126824,30 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-bOZ
-bPg
-bPw
-bPR
-bOZ
-vyz
-bON
-bON
-bva
-nJx
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bSz
-bva
-bOd
-bSV
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130086,30 +127126,30 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-bOZ
-bOZ
-bOZ
-bOZ
-bOZ
-bQu
-bON
-bQM
-bva
-bva
-bBH
-bRw
-bRw
-bRw
-bRw
-bva
-bva
-bva
-bSK
-bSW
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130388,30 +127428,30 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-jXP
-dXk
-bOd
-bOd
-bPT
-bON
-bON
-bON
-bPT
-dXk
-nBB
-bCP
-apU
-apU
-bCP
-bOd
-hpN
-bOd
-bSL
-bNX
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130691,28 +127731,28 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bPS
-bQD
-bPS
-bNX
-bNX
-bBH
-bRx
-bRx
-bRx
-bSb
-bNX
-bNX
-bNX
-bNX
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130999,11 +128039,11 @@ aaa
 aaa
 aaa
 aaa
-bPS
-vyz
-bQE
-bON
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -131301,11 +128341,11 @@ aaa
 aaa
 aaa
 aaa
-bPS
-bPS
-bQD
-bPS
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -131605,7 +128645,7 @@ aaa
 aaa
 aaa
 aaa
-buf
+aaa
 aaa
 aaa
 aaa
@@ -131907,7 +128947,7 @@ aaa
 aaa
 aaa
 aaa
-bvr
+aaa
 aaa
 aaa
 aaa
@@ -132209,7 +129249,7 @@ aaa
 aaa
 aaa
 aaa
-bvs
+aaa
 aaa
 aaa
 aaa
@@ -132511,7 +129551,7 @@ aaa
 aaa
 aaa
 aaa
-bvt
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? --> This pr removes sea turtle, the engineering hangar has been retrofitted into mining, the reinfinery has replaced the arcade, the arcade has been moved to where nerd dungeon was, and nerd dungeon has been moved to maintence.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sea Turtle isolates miners which means they dont interact with the rest of the station much. It also gives them great distance between cargo and mining. This would promote crew and mining interaction


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Sea turtle has been completely removed from Manta, expect various changes on the west side of the map.
```
