### PR TITLE
Removes the multitool mechcomp popup menu from airlocks if the panel is open

### DIFF
--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -297,8 +297,11 @@
 
 //If it's a multi-tool, let the user configure the device.
 /datum/component/mechanics_holder/proc/attackby(var/comsig_target, obj/item/W as obj, mob/user)
-	var/obj/machinery/door/hacked_door = comsig_target
-	if(!ispulsingtool(W) || !isliving(user) || user.stat || hacked_door.p_open)
+	if(istype(comsig_target, /obj/machinery/door))
+		var/obj/machinery/door/hacked_door = comsig_target
+		if(hacked_door.p_open)
+			return
+	if(!ispulsingtool(W) || !isliving(user) || user.stat)
 		return 0
 	if(length(src.configs))
 		var/selected_config = input("Select a config to modify!", "Config", null) as null|anything in src.configs

--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -297,8 +297,8 @@
 
 //If it's a multi-tool, let the user configure the device.
 /datum/component/mechanics_holder/proc/attackby(var/comsig_target, obj/item/W as obj, mob/user)
-	var/obj/machinery/door/airlock = comsig_target
-	if(!ispulsingtool(W) || !isliving(user) || user.stat || airlock.p_open)
+	var/obj/machinery/door/hacked_door = comsig_target
+	if(!ispulsingtool(W) || !isliving(user) || user.stat || hacked_door.p_open)
 		return 0
 	if(length(src.configs))
 		var/selected_config = input("Select a config to modify!", "Config", null) as null|anything in src.configs

--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -297,7 +297,8 @@
 
 //If it's a multi-tool, let the user configure the device.
 /datum/component/mechanics_holder/proc/attackby(var/comsig_target, obj/item/W as obj, mob/user)
-	if(!ispulsingtool(W) || !isliving(user) || user.stat)
+	var/obj/machinery/door/airlock = comsig_target
+	if(!ispulsingtool(W) || !isliving(user) || user.stat || airlock.p_open)
 		return 0
 	if(length(src.configs))
 		var/selected_config = input("Select a config to modify!", "Config", null) as null|anything in src.configs


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

From my understanding, it's a side effect of some recent mechcomp changes, which made hacking doors a bit annoying, since you need to close the popup window each time when clicking the door with a multitool.