### PR TITLE
Removes a few shipping containers from manta cargo.

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -6627,10 +6627,6 @@
 "atP" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/communications/office)
-"atQ" = (
-/obj/indestructible/invisible_block,
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
 "atR" = (
 /obj/table/auto,
 /obj/item/reagent_containers/mender_refill_cartridge/brute,
@@ -27223,19 +27219,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
-"bwL" = (
-/obj/storage/closet/mantacontainerred,
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
-"bwM" = (
-/obj/storage/closet/mantacontainerred/right,
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
-"bwN" = (
-/obj/storage/closet/mantacontainerred/right,
-/obj/item/instrument/harmonica,
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
 "bwP" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/cargobay)
@@ -29974,10 +29957,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/bot,
-/area/station/quartermaster/cargobay)
-"bEk" = (
-/obj/decal/fakeobjects/mantacontainer/upwards/yellow,
-/turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "bEl" = (
 /obj/machinery/conveyor/north{
@@ -72097,9 +72076,9 @@ boR
 xfn
 box
 aKs
-atQ
-atQ
-bwL
+bvk
+bvk
+bvk
 byy
 bvk
 bvk
@@ -72399,14 +72378,14 @@ boS
 brC
 bpW
 aKs
-atQ
-atQ
-bwM
+bvk
+bvk
+bvk
 byy
 bvk
-bNC
-bBz
-bEj
+bvk
+bvk
+bvk
 bwP
 bGE
 bHD
@@ -72701,14 +72680,14 @@ boR
 bgr
 box
 aKs
-atQ
-atQ
-bwL
+bvk
+bvk
+bvk
 byy
 bvk
 bvk
 bvk
-bEk
+bvk
 bwP
 fKa
 bHD
@@ -73003,14 +72982,14 @@ boR
 bgr
 box
 aKs
-atQ
-atQ
-bwN
+bvk
+bvk
+bvk
 byy
 bvk
-bvk
-bvk
-bvk
+bNC
+bBz
+bEj
 bwP
 bwP
 bwP

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -26247,23 +26247,14 @@
 /obj/item/storage/wall/fire{
 	pixel_y = 32
 	},
-/obj/storage/secure/closet/engineering/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "btM" = (
 /obj/machinery/manufacturer/hangar,
 /turf/simulated/floor/bot,
 /area/station/quartermaster/cargobay)
-"btN" = (
-/obj/machinery/manufacturer/mining,
-/turf/simulated/floor/bot,
-/area/station/quartermaster/cargobay)
-"btO" = (
-/obj/machinery/manufacturer/general,
-/turf/simulated/floor/bot,
-/area/station/quartermaster/cargobay)
 "btP" = (
-/obj/machinery/manufacturer/medical,
+/obj/machinery/manufacturer/mining,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 3;
@@ -35972,6 +35963,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"dBj" = (
+/obj/stool/chair/yellow{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/quartermaster/cargobay)
 "dCn" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -38240,7 +38237,6 @@
 	dir = 1;
 	pixel_y = 20
 	},
-/obj/storage/secure/closet/engineering/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "hVI" = (
@@ -38679,6 +38675,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/mining)
+"iQM" = (
+/obj/machinery/manufacturer/robotics,
+/turf/simulated/floor/bot,
+/area/station/quartermaster/cargobay)
 "iSe" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -39002,6 +39002,10 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
+"jFc" = (
+/obj/storage/secure/closet/engineering/cargo,
+/turf/simulated/floor,
+/area/station/quartermaster/cargobay)
 "jFQ" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -41566,6 +41570,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"pue" = (
+/obj/machinery/nanofab/refining,
+/turf/simulated/floor,
+/area/station/quartermaster/cargobay)
 "pvN" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -42906,6 +42914,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/secoffquarters)
+"sOt" = (
+/obj/decal/fakeobjects/mantacontainer/upwards,
+/turf/simulated/floor,
+/area/station/quartermaster/cargobay)
 "sTs" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -44676,6 +44688,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
+"wOa" = (
+/obj/machinery/manufacturer/medical,
+/turf/simulated/floor/bot,
+/area/station/quartermaster/cargobay)
 "wOL" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -44821,7 +44837,7 @@
 	name = "Submarine Bay (Engineering)"
 	})
 "xod" = (
-/obj/machinery/manufacturer/robotics,
+/obj/machinery/manufacturer/general,
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
 	pixel_y = 20
@@ -70566,7 +70582,7 @@ aLF
 bgr
 bpq
 aKs
-btM
+jFc
 bvg
 bwH
 ayM
@@ -70868,7 +70884,7 @@ aLF
 bfl
 bpU
 aKs
-btN
+jFc
 bvh
 bwI
 ayM
@@ -71170,7 +71186,7 @@ aLJ
 bgr
 box
 aKs
-btO
+btM
 bvi
 bwJ
 byw
@@ -72076,12 +72092,12 @@ boR
 xfn
 box
 aKs
-bvk
+wOa
 bvk
 bvk
 byy
 bvk
-bvk
+dBj
 bvk
 bvk
 bFv
@@ -72378,14 +72394,14 @@ boS
 brC
 bpW
 aKs
-bvk
+iQM
 bvk
 bvk
 byy
 bvk
-bvk
-bvk
-bvk
+bNC
+bBz
+bEj
 bwP
 bGE
 bHD
@@ -72680,14 +72696,14 @@ boR
 bgr
 box
 aKs
-bvk
+pue
 bvk
 bvk
 byy
 bvk
 bvk
 bvk
-bvk
+sOt
 bwP
 fKa
 bHD
@@ -72987,9 +73003,9 @@ bvk
 bvk
 byy
 bvk
-bNC
-bBz
-bEj
+bvk
+bvk
+bvk
 bwP
 bwP
 bwP


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? --> 
Removes 3 shipping containers from manta cargo to give qms more space

![image](https://user-images.githubusercontent.com/73148980/131915360-98878b19-3cd4-4e84-821d-ac4eec1176e1.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Manta cargo is quite large however  it can often feel quite small. This is largely due to some containers blocking 18 tiles of prime real estate for quartermasters to do. While the shipping containers do have quite cool asthetic value, the 4 ones in the corners already potray this quite well. This should increase QoL for qms on manta by a fair bit.
