### PR TITLE
Makes the e-gun component functional

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -2782,7 +2782,7 @@
 	desc = ""
 	icon_state = "comp_gun2"
 	density = 0
-	compatible_guns = /obj/item/gun/energy
+	compatible_guns = list(/obj/item/gun/energy)
 	var/charging = 0
 
 	get_desc()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the e-gun component's compatible_guns var to be a list with a single type rather than just that type. Currently the component marks all guns as incompatible, meaning you can't use it in any meaningful way.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It doesn't work!! This makes it work