### PR TITLE
Prevent unconcious emotes

### DIFF
--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -482,7 +482,7 @@
 		if (dead_check && isdead(src))
 			src.emote_allowed = 0
 			return 0
-		if (src.getStatusDuration("paralysis") > 0)
+		if (voluntary && src.getStatusDuration("paralysis") > 0)
 			return 0
 		if (world.time >= (src.last_emote_time + src.last_emote_wait))
 			if (!(src.client && (src.client.holder && admin_bypass) && !src.client.player_mode) && voluntary)

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -482,6 +482,8 @@
 		if (dead_check && isdead(src))
 			src.emote_allowed = 0
 			return 0
+		if (src.getStatusDuration("paralysis") > 0)
+			return 0
 		if (world.time >= (src.last_emote_time + src.last_emote_wait))
 			if (!(src.client && (src.client.holder && admin_bypass) && !src.client.player_mode) && voluntary)
 				src.emote_allowed = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Disallow voluntary emotes when unconscious (paralysis).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Scream, burp and fart function during unconscious but other emotes do not.
Currently the game allows changeling stung or other unconscious players to make a screaming racket, unconscious people aren't known for screaming.
Fixes #5868 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)You can no longer emote while unconscious.
```
