### PR TITLE
Refurbishes Destiny by updating walls, doors, windows, and other minor things

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -9,28 +9,27 @@
 /turf/space,
 /area/space)
 "aaf" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/landmark/spawner{
+	name = "monkeyspawn_horse"
 	},
-/turf/space,
-/area/station/shield_zone)
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
 "aag" = (
 /turf/space,
 /area/station/shield_zone)
 "aah" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/middle{
+/obj/window_blinds/cog2/right{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/bridge/captain)
+/area/station/crew_quarters/captain)
 "aai" = (
 /obj/lattice{
 	dir = 6;
@@ -47,26 +46,18 @@
 /area/space)
 "aal" = (
 /obj/lattice{
-	dir = 10;
+	dir = 9;
 	icon_state = "lattice-dir"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
 	},
 /turf/space,
 /area/space)
 "aam" = (
-/obj/wingrille_spawn/reinforced_crystal,
-/obj/cable{
-	icon_state = "0-4"
+/obj/lattice,
+/obj/warp_beacon{
+	name = "Destiny forward beacon"
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/garden/aviary)
+/turf/space,
+/area/space)
 "aan" = (
 /obj/lattice{
 	dir = 5;
@@ -75,90 +66,6 @@
 /turf/space,
 /area/space)
 "aao" = (
-/obj/landmark/spawner{
-	name = "monkeyspawn_horse"
-	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aap" = (
-/obj/wingrille_spawn/reinforced_crystal,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/garden/aviary)
-"aaq" = (
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aar" = (
-/obj/stool/chair/wooden{
-	dir = 4
-	},
-/obj/critter/crow,
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aat" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/right{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/captain)
-"aau" = (
-/obj/table/wood/round/auto,
-/obj/item/paper_bin{
-	pixel_y = 3
-	},
-/obj/item/pen,
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aav" = (
-/obj/machinery/portableowl/attached{
-	name = "an Owl of Even More Prettiness"
-	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aaw" = (
-/obj/lattice,
-/obj/warp_beacon{
-	name = "Destiny forward beacon"
-	},
-/turf/space,
-/area/space)
-"aax" = (
-/obj/shrub{
-	dir = 8
-	},
-/obj/item/storage/pill_bottle/cyberpunk,
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aay" = (
-/obj/wingrille_spawn/reinforced_crystal,
-/obj/landmark/artifact,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/garden/aviary)
-"aaz" = (
-/obj/tree1{
-	layer = 30
-	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aaA" = (
-/obj/machinery/light/small/floor/greenish,
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aaB" = (
 /obj/table/wood/round/auto,
 /obj/item/device/light/candle/small{
 	pixel_y = 4
@@ -169,84 +76,108 @@
 	},
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
-"aaC" = (
+"aap" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
+/turf/space,
+/area/space)
+"aaq" = (
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"aar" = (
 /obj/table/wood/round/auto,
 /obj/item/clothing/under/gimmick/owl,
 /obj/item/clothing/mask/owl_mask,
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
-"aaD" = (
-/obj/critter/parrot/random,
+"aat" = (
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
+"aau" = (
+/obj/stool/chair/wooden{
+	dir = 1
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"aav" = (
 /obj/stool/chair/wooden{
 	dir = 8
 	},
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
-"aaG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
+"aaw" = (
+/obj/item/space_thing,
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
-"aaH" = (
-/obj/machinery/portableowl/attached{
-	name = "The Sexiest Owl"
-	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aaI" = (
+"aax" = (
 /obj/stool/chair/wooden{
-	dir = 1
-	},
-/obj/landmark/gps_waypoint,
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon11,
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aaL" = (
-/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/science/chemistry)
-"aaM" = (
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"aay" = (
+/obj/table/wood/round/auto,
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"aaz" = (
 /obj/shrub{
+	dir = 8
+	},
+/obj/item/storage/pill_bottle/cyberpunk,
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"aaA" = (
+/obj/decal/tile_edge/line/green{
+	dir = 6;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"aaB" = (
+/obj/decal/tile_edge/line/green{
+	icon_state = "line1"
+	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"aaC" = (
+/obj/critter/owl{
+	aggressive = 0;
+	angertext = "hoots uncontrollably at";
+	atkcarbon = 1;
+	health = 10000;
+	name = "Hooty McOwlface"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegreen/side{
 	dir = 1
 	},
-/obj/item/reagent_containers/food/drinks/bottle/fancy_beer,
-/turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
-"aaN" = (
-/obj/critter/parrot/random,
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aaO" = (
-/obj/decal/tile_edge/line/green{
-	icon_state = "line1"
-	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aaQ" = (
-/obj/decal/tile_edge/line/green{
-	icon_state = "line1"
-	},
-/obj/critter/parrot/random,
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"aaU" = (
-/obj/wingrille_spawn/reinforced_crystal,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/garden/aviary)
-"aaZ" = (
-/turf/simulated/floor/bluegreen/side{
-	dir = 9
-	},
-/area/station/garden/aviary)
-"abb" = (
+"aaD" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -254,35 +185,25 @@
 	dir = 5
 	},
 /area/station/garden/aviary)
-"abd" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+"aaG" = (
+/obj/decal/tile_edge/line/green{
+	dir = 4;
+	icon_state = "line1"
 	},
-/turf/space,
-/area/space)
-"abe" = (
 /obj/machinery/light/small/floor/greenish,
 /obj/tree1{
 	layer = 30
 	},
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
-"abf" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/left{
-	dir = 4
-	},
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
-"abg" = (
+"aaH" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
 /turf/simulated/floor/bluegreen/side{
 	dir = 8
 	},
 /area/station/garden/aviary)
-"abh" = (
+"aaI" = (
 /obj/item/device/radio/beacon,
 /obj/cable{
 	icon_state = "1-2"
@@ -291,72 +212,189 @@
 	icon_state = "nt_logo"
 	},
 /area/station/garden/aviary)
-"abi" = (
-/obj/decal/tile_edge/line/green{
-	dir = 4;
-	icon_state = "line1"
+"aaJ" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/hos)
+"aaL" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/chemistry)
+"aaM" = (
+/obj/disposalpipe/segment,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/garden/aviary)
+"aaN" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/glass/botany{
+	name = "Aviary"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/stairs{
+	dir = 1
+	},
+/area/station/garden/aviary)
+"aaO" = (
+/obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/garden/aviary)
+"aaQ" = (
+/obj/machinery/portableowl/attached{
+	name = "an Owl of Even More Prettiness"
 	},
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
-"abl" = (
-/obj/wingrille_spawn/reinforced_crystal,
-/obj/cable{
-	icon_state = "0-8"
+"aaT" = (
+/obj/window_blinds/cog2/right{
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
+/area/station/crew_quarters/heads)
+"aaU" = (
+/obj/landmark/artifact,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/garden/aviary)
+"aaV" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads)
+"aaZ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"abb" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"abd" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/space)
+"abe" = (
+/obj/table/wood/round/auto,
+/obj/item/paper_bin{
+	pixel_y = 3
+	},
+/obj/item/pen,
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"abf" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/quartersA)
+"abg" = (
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"abh" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/navbeacon/tour/destiny/tour17,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"abi" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/hos)
+"abl" = (
+/obj/stool/chair/wooden{
+	dir = 4
+	},
+/obj/critter/crow,
+/turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "abm" = (
-/obj/decal/tile_edge/line/green{
-	dir = 4;
-	icon_state = "line1"
+/obj/window_blinds/cog2/left{
+	dir = 8
 	},
-/obj/machinery/light/small/floor/greenish,
-/obj/tree1{
-	layer = 30
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"abn" = (
-/obj/shrub{
-	dir = 6
-	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"abo" = (
-/obj/wingrille_spawn,
-/obj/disposalpipe/segment,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
+/area/station/crew_quarters/hos)
+"abn" = (
+/obj/table/wood/auto,
+/obj/item/clothing/suit/cultist/nerd,
+/obj/item/clothing/mask/skull{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/apprentice{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"abo" = (
+/obj/table/wood/auto,
+/obj/item/clipboard,
+/obj/item/clipboard,
+/obj/item/clipboard,
+/obj/item/pen,
+/obj/item/pen,
+/obj/item/pen,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "abr" = (
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
+"abu" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "abw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Aviary'"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/stairs{
-	dir = 1
-	},
-/area/station/hallway/primary/north)
-"abx" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/hallway/primary/north)
+/area/station/garden/aviary)
+"abx" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/bridge/captain)
 "abA" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
@@ -366,98 +404,51 @@
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
-/obj/item/clothing/suit/bedsheet/blue,
+/obj/item/clothing/suit/bedsheet/pink,
 /obj/machinery/light_switch/east{
 	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;
-	icon_state = "blue2"
+	icon_state = "purple2"
 	},
-/area/station/crew_quarters/quartersA)
-"abK" = (
-/obj/wingrille_spawn,
+/area/station/crew_quarters/quartersB)
+"abF" = (
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"abG" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/quartersB)
+"abH" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor/plating/random,
+/obj/machinery/light/small/floor/blueish,
+/turf/simulated/floor/black,
 /area/station/hallway/primary/north)
+"abK" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/bridge/captain)
 "abL" = (
-/obj/stool/chair/wooden,
-/obj/potted_plant/potted_plant5{
-	dir = 1;
-	pixel_y = 32
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"abN" = (
-/obj/stool/bench/green/auto,
-/obj/machinery/light/incandescent{
-	nostick = 1
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"abP" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/quartersA)
-"abT" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/hos)
-"abV" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Captain's Office'";
-	req_access_txt = "20"
-	},
-/turf/simulated/floor/black,
-/area/station/bridge/captain)
-"abW" = (
-/obj/machinery/power/apc{
-	areastring = "Aviary";
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"acb" = (
-/obj/machinery/vending/book,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"acd" = (
-/obj/table/wood/round/auto,
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"ace" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/left{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/hos)
-"acf" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/right{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/bridge/captain)
-"acg" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -468,28 +459,35 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/captain)
-"ach" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/captain)
-"ack" = (
-/obj/cable{
-	icon_state = "1-2"
+"abN" = (
+/obj/machinery/disposal/small{
+	dir = 8
 	},
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
 /area/station/bridge/captain)
-"acl" = (
-/obj/stool/chair/wooden{
-	dir = 1
+"abP" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/quartersB)
+"abQ" = (
+/obj/stool/chair/moveable{
+	dir = 8
 	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"acm" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/bridge/captain)
+"abR" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -505,6 +503,114 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/captain)
+"abS" = (
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/bridge/captain)
+"abT" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/ce)
+"abV" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/bridge/captain)
+"abW" = (
+/obj/machinery/portableowl/attached{
+	name = "The Sexiest Owl"
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"abY" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/captain)
+"acb" = (
+/obj/critter/parrot/random,
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"acc" = (
+/obj/shrub{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/drinks/bottle/fancy_beer,
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"acd" = (
+/obj/machinery/light/small/floor/greenish,
+/obj/tree1{
+	layer = 30
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"ace" = (
+/obj/window_blinds/cog2/left{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/ce)
+"acf" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/captain)
+"acg" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "captain";
+	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
+	icon_state = "bedsheet-captain";
+	name = "special bedsheet"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
+"ach" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
+"ack" = (
+/obj/table/wood/auto,
+/obj/displaycase{
+	displayed = new /obj/item/captaingun;
+	pixel_y = 8
+	},
+/obj/machinery/light/incandescent{
+	nostick = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
+"acl" = (
+/obj/machinery/portableowl/attached{
+	name = "A Prettier Owl"
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"acm" = (
+/obj/item/rubberduck,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = 6
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/sanitary/blue,
+/area/station/crew_quarters/captain)
 "aco" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -512,11 +618,13 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "acp" = (
@@ -544,6 +652,12 @@
 	dir = 4
 	},
 /area/station/solar/east)
+"acs" = (
+/obj/machinery/portableowl/attached{
+	name = "an Owl with a chip out of his beak"
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
 "acu" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -558,168 +672,40 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
+"acD" = (
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads)
 "acF" = (
-/obj/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "fgreen2"
 	},
-/obj/machinery/light_switch/north{
-	pixel_x = -5;
-	pixel_y = 28
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "acJ" = (
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "fgreen2"
-	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
-"acK" = (
-/obj/machinery/light/emergency,
-/turf/simulated/floor/carpet{
-	icon_state = "fgreen2"
-	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
-"acL" = (
-/obj/critter/dog/george/blair,
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.5;
-	pixel_x = 24
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "fgreen2"
-	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
-"acM" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/heads)
-"acS" = (
-/obj/blind_switch/area/north{
-	pixel_x = 5;
-	pixel_y = 28
-	},
-/obj/machinery/light_switch/north{
-	pixel_x = -5;
-	pixel_y = 28
-	},
-/obj/table/wood/auto/desk,
-/obj/machinery/phone,
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/heads)
-"acT" = (
-/obj/machinery/disposal/mail/small{
-	dir = 1;
-	mail_tag = "hop";
-	mailgroup = "command";
-	message = "1";
-	name = "mail chute-'Head of Personnel'";
-	pixel_y = 32
-	},
-/obj/disposalpipe/trunk/mail,
-/obj/filing_cabinet,
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/heads)
-"acU" = (
-/obj/table/reinforced/auto,
-/obj/bedsheetbin{
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/judgerobe,
-/obj/item/clothing/head/powdered_wig,
-/obj/item/device/radio/headset/civilian,
-/obj/item/device/radio/headset/civilian,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.5;
-	pixel_x = 24
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/heads)
-"acX" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/middle{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quartersA)
-"acY" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "fgreen2"
-	},
-/area/station/crew_quarters/heads)
-"acZ" = (
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/small{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/heads)
-"adb" = (
-/obj/machinery/vending/cards,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"adc" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Crew Quarters'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quartersA)
-"add" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/quartersB)
-"ade" = (
+/turf/simulated/floor/carpet{
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads)
+"acK" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads)
+"acL" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -742,10 +728,24 @@
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/heads)
-"adg" = (
-/turf/simulated/wall/auto/gannets,
-/area/station/crew_quarters/quartersB)
-"adi" = (
+"acM" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/heads)
+"acO" = (
+/obj/stool/chair/office,
+/obj/landmark/start{
+	name = "Head of Personnel"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads)
+"acP" = (
 /obj/machinery/computer/card{
 	dir = 8
 	},
@@ -763,30 +763,167 @@
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/heads)
-"adj" = (
-/obj/potted_plant/potted_plant5{
-	dir = 1;
-	pixel_y = 32
+"acQ" = (
+/obj/decal/tile_edge/line/green{
+	icon_state = "line1"
 	},
-/obj/storage/closet/office,
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"acS" = (
+/obj/table/reinforced/auto,
+/obj/window/reinforced/west,
+/obj/machinery/door/window/southleft{
+	req_access_txt = "15"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/item/reagent_containers/food/drinks/mug/random_color{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/stamp/hop{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/machinery/cashreg,
+/obj/firedoor_spawn,
+/obj/access_spawn/head_of_personnel,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"adl" = (
-/obj/table/wood/auto,
-/obj/item/clothing/suit/cultist/nerd,
-/obj/item/clothing/mask/skull{
-	pixel_x = 10;
+/area/station/crew_quarters/heads)
+"acT" = (
+/obj/table/reinforced/auto,
+/obj/window/reinforced/east,
+/obj/machinery/door/window/southright{
+	req_access_txt = "15"
+	},
+/obj/item/clipboard{
 	pixel_y = 5
 	},
-/obj/item/clothing/head/apprentice{
-	pixel_x = -10;
-	pixel_y = 10
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen,
+/obj/item/pen/fancy,
+/obj/firedoor_spawn,
+/obj/access_spawn/head_of_personnel,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/heads)
+"acU" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/window_blinds/cog2,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/heads)
+"acX" = (
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/quartersB)
+"acY" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=aviary";
+	location = "customs";
+	name = "bot navigation beacon"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
+"acZ" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"adb" = (
+/obj/table/wood/auto,
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"adc" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quartersB)
+"add" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/quartersC)
+"ade" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"adg" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/quartersC)
+"adh" = (
+/obj/shrub{
+	dir = 10
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"adi" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/switch_junction{
+	dir = 1;
+	icon_state = "pipe-sj2";
+	mail_tag = "hop";
+	name = "Head of Personnel mail router"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"adj" = (
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon13,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"adl" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/hos)
 "adn" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
@@ -801,115 +938,25 @@
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon18,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
+"adu" = (
+/obj/shrub{
+	dir = 6
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
 "adv" = (
-/obj/machinery/portableowl/attached{
-	name = "A Prettier Owl"
+/obj/decal/tile_edge/line/green{
+	dir = 4;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "adw" = (
-/obj/stool/chair/wooden{
-	dir = 4
+/turf/simulated/floor/bluegreen/side{
+	dir = 9
 	},
-/turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "adz" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"adB" = (
-/obj/stool/bench/green/auto,
-/obj/landmark{
-	name = "kudzustart"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"adG" = (
-/obj/disposalpipe/switch_junction{
-	dir = 4;
-	icon_state = "pipe-sj2";
-	mail_tag = "aviary";
-	name = "aviary mail router"
-	},
-/obj/machinery/light/small/floor/blueish,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"adI" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"adL" = (
-/obj/table/wood/auto,
-/obj/item/clipboard,
-/obj/item/clipboard,
-/obj/item/clipboard,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"adM" = (
-/obj/stool/chair/wooden{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"adN" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/ce)
-"adT" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/switch_junction{
-	dir = 4;
-	icon_state = "pipe-sj2";
-	mail_tag = "hydroponics";
-	name = "hydroponics mail router"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=research";
-	location = "hydro";
-	name = "bot navigation beacon"
-	},
-/obj/machinery/light/small/floor/blueish,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/southeast)
-"adX" = (
-/obj/table/reinforced/bar/auto{
-	name = "table"
-	},
-/obj/decal/fakeobjects/plantpot{
-	pixel_y = 10
-	},
-/obj/shrub/captainshrub{
-	pixel_y = 22
-	},
-/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff{
-	pixel_y = 12
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "fblue2"
-	},
-/area/station/bridge/captain)
-"adY" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -924,7 +971,15 @@
 	icon_state = "fred2"
 	},
 /area/station/crew_quarters/hos)
-"aed" = (
+"adB" = (
+/obj/stool/chair/comfy/blue{
+	dir = 8
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA)
+"adG" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -943,71 +998,64 @@
 	icon_state = "fred2"
 	},
 /area/station/crew_quarters/hos)
-"aef" = (
-/obj/critter/turtle/sylvester/HoS,
+"adI" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
 /turf/simulated/floor/carpet{
 	icon_state = "fred2"
 	},
 /area/station/crew_quarters/hos)
-"aeh" = (
-/obj/window/bulletproof/south,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/purplewhite,
-/area/station/science/chemistry)
-"aei" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/left{
-	dir = 8
+"adL" = (
+/obj/decal/tile_edge/line/green{
+	dir = 8;
+	icon_state = "line1"
 	},
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/ce)
-"aem" = (
-/obj/stool/chair/comfy/blue{
-	dir = 8
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA)
-"aeo" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/disposalpipe/segment,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"adM" = (
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
-"aeq" = (
-/obj/disposalpipe/segment/mail{
+"adN" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
+"adT" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/switch_junction{
 	dir = 4;
-	icon_state = "pipe-c"
+	icon_state = "pipe-sj2";
+	mail_tag = "hydroponics";
+	name = "hydroponics mail router"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/hos)
-"aet" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=research";
+	location = "hydro";
+	name = "bot navigation beacon"
 	},
-/obj/disposalpipe/segment,
+/obj/machinery/light/small/floor/blueish,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"aeu" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"aev" = (
+/area/station/hallway/primary/southeast)
+"adW" = (
+/obj/machinery/light,
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"adX" = (
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
+"adY" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -1022,25 +1070,7 @@
 	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/ce)
-"aew" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/southeast)
-"aey" = (
-/obj/wingrille_spawn,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/bar)
-"aeB" = (
+"aed" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -1059,35 +1089,84 @@
 	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/ce)
-"aeD" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
+"aef" = (
 /turf/simulated/floor/carpet{
 	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/ce)
-"aeG" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/middle{
+"aeh" = (
+/obj/window/bulletproof/south,
+/obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "0-4"
+/turf/simulated/floor/purplewhite,
+/area/station/science/chemistry)
+"aei" = (
+/obj/window_blinds/cog2/left{
+	dir = 8
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
+"aem" = (
+/obj/stool/chair/comfy/purple{
+	dir = 8
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "purple2"
+	},
 /area/station/crew_quarters/quartersB)
-"aeM" = (
+"aeo" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/junction,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"aep" = (
+/obj/table/wood/auto,
+/obj/item/storage/box/nerd_kit{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/dice/magic8ball{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"aeq" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/ce)
-"aeP" = (
+"aet" = (
+/obj/table/wood/auto,
+/obj/item/paper/book/from_file/monster_manual_revised{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/paper/book/from_file/DNDrulebook{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"aeu" = (
+/obj/machinery/disposal/mail{
+	mail_tag = "aviary";
+	name = "mail chute-'Aviary'"
+	},
+/obj/disposalpipe/trunk/mail,
+/turf/simulated/floor/bluegreen/side{
+	dir = 4
+	},
+/area/station/garden/aviary)
+"aev" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -1104,17 +1183,25 @@
 /area/station/crew_quarters/hor{
 	name = "Research Director's Quarters"
 	})
-"aeQ" = (
+"aew" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"aeV" = (
+/area/station/hallway/primary/southeast)
+"aey" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/bar)
+"aeB" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -1135,7 +1222,7 @@
 /area/station/crew_quarters/hor{
 	name = "Research Director's Quarters"
 	})
-"aeX" = (
+"aeD" = (
 /obj/item/reagent_containers/food/snacks/beefood{
 	desc = "A little birthday cupcake for Heisenbee.  May not taste good to non-bees.";
 	icon = 'icons/obj/foodNdrink/food_dessert.dmi';
@@ -1159,26 +1246,111 @@
 /area/station/crew_quarters/hor{
 	name = "Research Director's Quarters"
 	})
-"afa" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Crew Quarters'"
+"aeG" = (
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/quartersC)
+"aeM" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
+"aeP" = (
+/obj/cable{
+	icon_state = "1-8"
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fblue2"
+	},
+/area/station/crew_quarters/md)
+"aeQ" = (
+/obj/decal/tile_edge/line/green{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/machinery/light/small/floor/greenish,
+/obj/tree1{
+	layer = 30
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"aeV" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/table/wood/auto,
+/obj/machinery/networked/printer{
+	name = "Medical Director's Quarters";
+	pixel_y = 7
+	},
+/obj/machinery/light_switch/west{
+	dir = 4
+	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "fblue2"
+	},
+/area/station/crew_quarters/md)
+"aeX" = (
+/obj/critter/bat/doctor,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "fblue2"
+	},
+/area/station/crew_quarters/md)
+"afa" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "aff" = (
-/obj/machinery/light/small/floor/blueish,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/clothing/suit/bedsheet/blue,
+/obj/machinery/light_switch/east{
+	dir = 4
+	},
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA)
 "afg" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/md)
 "afh" = (
 /obj/pool/perspective{
 	dir = 1;
@@ -1189,54 +1361,52 @@
 	},
 /area/station/crew_quarters/pool)
 "afi" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/quartersC)
-"afj" = (
-/obj/stool/chair/comfy/red,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "red2"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/quarters_east{
 	name = "Crew Quarters D"
 	})
-"afk" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/left{
-	dir = 4
-	},
-/obj/cable,
+"afj" = (
+/obj/reagent_dispensers/fueltank,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/captain)
+/area/station/maintenance/northwest)
+"afk" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/heads)
 "afl" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "fblue1"
+/obj/cable{
+	icon_state = "1-8"
 	},
-/area/station/crew_quarters/md)
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northeast)
 "afn" = (
-/obj/stool/chair/office/blue{
-	dir = 1
-	},
+/obj/machinery/light/small,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 4;
-	icon_state = "fblue2"
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northeast)
+"afu" = (
+/obj/decal/poster/wallsign/poster_y4nt{
+	pixel_x = -32
 	},
-/area/station/crew_quarters/md)
+/obj/decal/tile_edge/line/red{
+	dir = 10;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "afC" = (
-/turf/simulated/wall/auto/gannets,
-/area/station/crew_quarters/quartersC)
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "afD" = (
-/obj/machinery/bot/secbot/formal,
+/obj/disposalpipe/segment,
+/obj/machinery/vending/cola/red,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "afE" = (
@@ -1255,29 +1425,18 @@
 	},
 /area/station/science/lobby)
 "afF" = (
-/obj/decal/mule/beacon,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
-	location = "North Primary Hall"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
+/obj/disposalpipe/segment,
+/obj/machinery/vending/cola/blue,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "afG" = (
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/light{
+/obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
+/obj/decal/tile_edge/line/blue{
+	dir = 4;
+	icon_state = "line1"
 	},
-/obj/machinery/vending/medical_public,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "afH" = (
@@ -1288,30 +1447,38 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "afI" = (
-/obj/reagent_dispensers/foamtank,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northwest)
-"afL" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
+"afL" = (
+/obj/decal/tile_edge/line/red{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/stool/bench/auto,
+/obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "afM" = (
+/obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/cable{
-	icon_state = "2-8"
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -1319,27 +1486,53 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "afN" = (
+/obj/disposalpipe/switch_junction{
+	dir = 1;
+	icon_state = "pipe-sj2";
+	mail_tag = "seccheck";
+	name = "security checkpoint mail router"
+	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/stool/bench/auto,
+/obj/machinery/light/emergency,
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"afO" = (
+/obj/disposalpipe/switch_junction{
+	desc = "An underfloor mail pipe.";
+	dir = 2;
+	icon_state = "pipe-sj2";
+	mail_tag = "medbooth";
+	name = "medical booth mail router"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "afS" = (
+/obj/decal/tile_edge/line/white{
+	icon_state = "line1"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
 "afU" = (
 /obj/decal/tile_edge/line/black{
 	dir = 9;
@@ -1368,25 +1561,31 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "afY" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/segment,
+/obj/decal/tile_edge/line/red{
+	dir = 9;
+	icon_state = "line1"
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=command_quarters";
-	location = "aviary";
-	name = "bot navigation beacon"
-	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
+"afZ" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/hallway/primary/north)
 "aga" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment/mail,
+/obj/decal/tile_edge/line/blue{
+	dir = 5;
+	icon_state = "line1"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/decal/mule/dropoff,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "agf" = (
@@ -1400,26 +1599,53 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "agi" = (
-/obj/reagent_dispensers/fueltank,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northwest)
-"agj" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Tool Storage'";
-	req_access_txt = "12"
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
+/obj/machinery/disposal/mail/small{
+	mail_tag = "seccheck";
+	mailgroup = "security";
+	name = "mail chute-'Security Checkpoint'"
+	},
+/obj/disposalpipe/trunk/mail{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
+"agj" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4;
+	name = "Tool Storage";
+	req_access_txt = null
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/storage/tools)
 "agl" = (
-/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail,
+/obj/machinery/light/emergency{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname - SS13"
+	},
+/obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "agm" = (
@@ -1438,42 +1664,59 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "agn" = (
+/obj/stool/bench/auto,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
+	},
+/obj/decal/tile_edge/line/blue{
+	dir = 4;
+	icon_state = "line1"
+	},
+/obj/machinery/light,
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "ago" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/obj/decal/tile_edge/line/white{
+	icon_state = "line1"
+	},
+/obj/machinery/computer3/generic/med_data{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
+"agp" = (
+/obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
-"agp" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
-	},
-/obj/stool/chair/office/blue{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Medical Doctor"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "agq" = (
 /obj/stool/chair/pew/fancy/center,
 /turf/simulated/floor/specialroom/chapel{
@@ -1481,26 +1724,27 @@
 	},
 /area/station/chapel/sanctuary)
 "agr" = (
-/obj/disposalpipe/segment,
-/obj/machinery/vending/cola/blue,
+/obj/machinery/vending/cards,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "agt" = (
-/obj/machinery/portableowl/attached{
-	name = "A Pretty Owl"
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/light,
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/decal/mule/dropoff,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "agu" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/area/station/hangar/main)
 "agy" = (
 /obj/shrub{
 	dir = 1;
@@ -1515,44 +1759,45 @@
 /turf/simulated/floor/bluewhite,
 /area/station/crew_quarters/pool)
 "agz" = (
-/obj/machinery/light,
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
-"agE" = (
-/obj/decal/tile_edge/line/white{
-	dir = 5;
-	icon_state = "line2"
+/obj/table/wood/auto,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/vending/medical,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"agE" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/hallway/secondary/exit)
+"agF" = (
+/obj/shrub{
+	dir = 4;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
-"agF" = (
-/obj/table/reinforced/auto,
-/obj/item/sheet/steel/fullstack,
-/obj/item/sheet/glass/fullstack,
-/obj/item/storage/box/cablesbox,
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
 /turf/simulated/floor,
-/area/station/hangar/main)
+/area/station/crew_quarters/lounge/port)
 "agG" = (
-/obj/decal/tile_edge/line/green{
-	dir = 8;
-	icon_state = "line1"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/light/small/floor/greenish,
-/obj/tree1{
-	layer = 30
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=command_quarters";
+	location = "aviary";
+	name = "bot navigation beacon"
 	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "agH" = (
 /obj/stool/bench/red/auto,
 /obj/machinery/atmospherics/pipe/simple/junction{
@@ -1570,20 +1815,18 @@
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
-/obj/item/clothing/suit/bedsheet/pink,
+/obj/item/clothing/suit/bedsheet/green,
 /obj/machinery/light_switch/east{
 	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;
-	icon_state = "purple2"
+	icon_state = "green2"
 	},
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "agL" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/md)
 "agO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -1594,17 +1837,15 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "agP" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "agQ" = (
 /turf/simulated/floor/engine,
 /area/station/hangar/main)
@@ -1619,28 +1860,19 @@
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/crew_quarters/pool)
+"agT" = (
+/obj/disposalpipe/segment,
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "agU" = (
-/obj/machinery/computer/card,
-/obj/item/device/radio/intercom/security{
-	pixel_x = 8;
-	pixel_y = 28
+/obj/disposalpipe/segment/mail,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/blind_switch/area/north{
-	pixel_x = -10;
-	pixel_y = 28
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "fblue2"
-	},
-/area/station/bridge/captain)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "agV" = (
-/obj/storage/crate,
-/obj/item/clothing/mask/horse_mask,
-/obj/item/clothing/under/misc/barber,
-/obj/item/clothing/shoes/brown,
-/obj/item/clothing/head/bald_cap,
-/obj/item/clothing/head/wig,
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -1648,11 +1880,12 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
 "agY" = (
-/obj/wingrille_spawn,
-/turf/simulated/floor/plating/random,
+/obj/stool/chair/wooden{
+	dir = 8
+	},
+/turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "agZ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -1666,10 +1899,10 @@
 	name = "Atmospherics Security Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/atmos/highcap_storage)
 "aha" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/middle{
 	dir = 4
 	},
@@ -1680,113 +1913,94 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
+"ahb" = (
+/obj/window_blinds/cog2/right{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/bridge/captain)
 "ahc" = (
 /obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/royal,
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
-/obj/item/clothing/suit/bedsheet/green,
 /obj/machinery/light_switch/east{
 	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;
-	icon_state = "green2"
+	icon_state = "red2"
 	},
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "ahe" = (
-/obj/stool/chair/wooden{
-	dir = 8
+/obj/decal/tile_edge/line/green{
+	icon_state = "line1"
 	},
+/obj/critter/parrot/random,
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "ahp" = (
-/obj/machinery/computer3/generic/communications,
-/obj/item/device/radio/intercom/bridge{
-	broadcasting = 0;
-	pixel_x = -7;
-	pixel_y = 28
+/obj/machinery/door/airlock/pyro/command{
+	name = "Captain's Office"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
+/obj/firedoor_spawn,
+/obj/access_spawn/captain,
+/turf/simulated/floor/black,
+/area/station/bridge/captain)
+"ahq" = (
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/light/incandescent{
-	dir = 1;
-	nostick = 1
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/light_switch/north{
-	pixel_x = 9;
-	pixel_y = 28
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fblue2"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge/captain)
 "ahr" = (
-/obj/wingrille_spawn/reinforced,
-/obj/decal/poster/wallsign/security{
-	icon_state = "sec"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
-"aht" = (
-/obj/machinery/disposal/mail{
-	mail_tag = "aviary";
-	name = "mail chute-'Aviary'"
-	},
-/obj/disposalpipe/trunk/mail,
-/turf/simulated/floor/bluegreen/side{
-	dir = 4
-	},
-/area/station/garden/aviary)
-"ahw" = (
-/obj/table/reinforced/bar/auto{
-	name = "table"
-	},
-/obj/disposalpipe/trunk/mail,
-/obj/machinery/disposal/mail/small{
+/obj/disposalpipe/segment{
 	dir = 1;
-	mail_tag = "captain";
-	mailgroup = "command";
-	message = "1";
-	name = "mail chute-'Captain'";
-	pixel_y = 32
+	icon_state = "pipe-c"
 	},
-/obj/machinery/light/lamp/green{
-	pixel_x = -6;
-	pixel_y = 12;
-	switchon = 1
+/obj/decal/tile_edge/stripe{
+	dir = 8;
+	icon_state = "xtra_bigstripe-edge"
 	},
-/obj/item/paper/book/from_file/space_law,
-/obj/item/reagent_containers/food/drinks/mug/random_color{
-	pixel_x = 4;
-	pixel_y = 8
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "fblue2"
+/turf/simulated/floor,
+/area/station/hangar/main)
+"aht" = (
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/bridge/captain)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"ahu" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"ahw" = (
+/obj/machinery/light/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/stairs,
+/area/station/hangar/main)
 "ahx" = (
 /obj/stool/bench/yellow/auto,
 /obj/machinery/light/emergency{
@@ -1797,81 +2011,63 @@
 	},
 /area/station/hallway/secondary/exit)
 "ahC" = (
-/obj/potted_plant/potted_plant2{
-	dir = 1;
-	pixel_y = 32
+/obj/decal/tile_edge/line/green{
+	dir = 10;
+	icon_state = "line1"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"ahD" = (
+/obj/stool/chair/comfy/blue{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Captain"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fblue2"
 	},
 /area/station/bridge/captain)
-"ahD" = (
-/obj/table/wood/auto,
-/obj/item/storage/box/nerd_kit{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/dice/magic8ball{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
 "ahE" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/light{
+/obj/machinery/light/emergency{
 	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "ahF" = (
-/obj/stool/chair/moveable{
-	dir = 8
-	},
+/obj/critter/cat/jones,
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "1-8"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/bridge/captain)
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
 "ahG" = (
-/obj/wingrille_spawn/reinforced,
-/obj/decal/poster/wallsign/medbay{
-	icon_state = "med"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/medical/medbooth)
-"ahJ" = (
-/obj/disposalpipe/trunk,
-/obj/machinery/disposal/small{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/hangar/main)
-"ahK" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/orangeblack/side{
-	dir = 9
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
+"ahJ" = (
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/black,
+/area/station/hangar/main)
+"ahK" = (
+/obj/stool/bench/yellow/auto,
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
 	},
 /area/station/hallway/secondary/exit)
 "ahN" = (
@@ -1888,18 +2084,26 @@
 	},
 /area/station/atmos/highcap_storage)
 "ahP" = (
-/obj/disposalpipe/segment,
-/obj/decal/tile_edge/stripe{
-	dir = 10;
-	icon_state = "xtra_bigstripe-corner2"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
 	},
-/turf/simulated/floor,
+/obj/submachine/cargopad{
+	name = "North Pod Bay Pad"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/black,
 /area/station/hangar/main)
 "ahS" = (
-/obj/machinery/light{
+/obj/disposalpipe/segment,
+/obj/machinery/light/emergency{
 	dir = 8
 	},
-/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "ahU" = (
@@ -1913,11 +2117,9 @@
 	},
 /area/station/atmos/highcap_storage)
 "ahY" = (
+/obj/reagent_dispensers/watertank/fountain,
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
@@ -1930,18 +2132,7 @@
 	name = "West Central Maintenance"
 	})
 "aic" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'North Pod Bay'"
-	},
-/obj/machinery/secscanner{
-	dir = 4;
-	pixel_x = -20
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
+/turf/simulated/wall/auto/supernorn,
 /area/station/hangar/main)
 "aie" = (
 /turf/simulated/floor/sanitary,
@@ -1958,30 +2149,36 @@
 	name = "West Central Maintenance"
 	})
 "aik" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Crew Quarters'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "ail" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
+/obj/decal/tile_edge/stripe{
+	dir = 9;
+	icon_state = "xtra_bigstripe-corner2"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
+"aim" = (
+/obj/machinery/disposal/mail/small{
 	dir = 8;
-	name = "autoname  - SS13"
+	mail_tag = "pod_fore";
+	name = "mail chute-'North Pod Bay'"
 	},
-/obj/submachine/cargopad{
-	name = "North Pod Bay Pad"
+/obj/disposalpipe/trunk/mail{
+	dir = 4
 	},
-/obj/decal/tile_edge/line/black{
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/item/device/radio/beacon,
-/turf/simulated/floor/black,
+/obj/machinery/light,
+/turf/simulated/floor,
 /area/station/hangar/main)
 "ain" = (
 /obj/cable{
@@ -1995,18 +2192,16 @@
 	},
 /area/station/crew_quarters/sauna)
 "aip" = (
-/obj/table/wood/auto,
-/obj/item/clothing/gloves/latex,
-/obj/item/scissors,
-/obj/item/razor_blade,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
+/obj/machinery/disposal/small{
+	dir = 4
 	},
-/obj/item_dispenser/latex_gloves,
+/obj/disposalpipe/trunk,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
+"aiq" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/northeast)
 "aiu" = (
 /obj/stool/bench/red/auto,
 /obj/machinery/atmospherics/pipe/simple/junction{
@@ -2017,53 +2212,49 @@
 	},
 /area/station/crew_quarters/sauna)
 "aix" = (
-/obj/cable{
-	icon_state = "0-2"
+/obj/airbridge_controller{
+	id = "escape";
+	tunnel_width = 3
 	},
-/obj/machinery/power/apc/autoname_north,
-/obj/table/wood/auto,
-/obj/machinery/shipalert{
-	pixel_x = 30;
-	pixel_y = -2
-	},
-/obj/item/paper_bin{
-	pixel_y = 5
-	},
-/obj/item/pen,
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/bridge/captain)
+/turf/space,
+/area/space)
 "aiy" = (
+/obj/item/storage/toilet/random{
+	dir = 4;
+	pixel_x = -8
+	},
+/turf/simulated/floor/sanitary/blue,
+/area/station/crew_quarters/captain)
+"aiz" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/sanitary/blue,
+/area/station/crew_quarters/captain)
+"aiB" = (
 /obj/machinery/disposal/small{
 	dir = 8
 	},
 /obj/disposalpipe/trunk{
-	dir = 4
+	dir = 1
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
+/turf/simulated/floor,
+/area/station/hangar/main)
+"aiC" = (
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/green{
+	pixel_x = -6;
+	pixel_y = 4;
+	switchon = 1
 	},
-/area/station/bridge/captain)
-"aiz" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/item/card/id/captains_spare,
+/obj/item/pen/fancy,
+/obj/machinery/light/emergency,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/bridge/captain)
-"aiB" = (
-/obj/table/reinforced/bar/auto{
-	name = "table"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/recharger{
-	pixel_y = 5
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "fblue2"
-	},
-/area/station/bridge/captain)
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
 "aiD" = (
 /obj/decal/tile_edge/line/blue{
 	color = "#485e81";
@@ -2078,112 +2269,139 @@
 /area/station/crew_quarters/pool)
 "aiF" = (
 /obj/machinery/light,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/bridge/captain)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "aiI" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/belt/utility,
-/obj/item/storage/toolbox/electrical,
-/obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/device/light/flashlight,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/lounge/port)
 "aiJ" = (
 /obj/disposalpipe/segment,
 /obj/critter/boogiebot,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "aiK" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/north)
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/lounge/starboard)
 "aiL" = (
-/obj/table/auto,
-/obj/machinery/networked/printer{
-	pixel_y = 5;
-	print_id = "Lounge"
-	},
-/obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/decal/poster/wallsign/statistics1{
-	desc = "A poster with a bar chart depicting the rapid growth of chemistry lab related explosions. Although who even uses a bar chart when you could be using a line chart...";
-	pixel_y = 32
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13"
 	},
-/turf/simulated/floor,
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge";
+	pixel_y = 10
+	},
+/obj/railing/yellow{
+	pixel_y = 10
+	},
+/turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/starboard)
 "aiM" = (
 /turf/space,
 /area/shuttle/merchant_shuttle/left_station/destiny)
+"aiN" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/lounge/port)
 "aiS" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "captain";
-	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
-	icon_state = "bedsheet-captain";
-	name = "special bedsheet"
+/obj/machinery/light/incandescent{
+	nostick = 1
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/turf/simulated/floor/carpet{
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
+"aiT" = (
+/obj/machinery/light/emergency,
+/turf/simulated/floor/carpet{
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "aiU" = (
-/obj/item/storage/toilet/random{
+/obj/critter/dog/george/blair,
+/obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -8
+	layer = 3.5;
+	pixel_x = 24
 	},
-/turf/simulated/floor/sanitary/blue,
-/area/station/crew_quarters/captain)
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "aiW" = (
-/obj/machinery/light,
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/floor/sanitary,
-/area/station/hallway/primary/east/restroom)
+/obj/decal/tile_edge/stripe{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/obj/railing/yellow{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/lounge/starboard)
 "aiX" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/disposal/mail/small{
+	dir = 8;
+	mail_tag = "crew";
+	name = "mail chute-'Crew Lounge'"
+	},
+/obj/disposalpipe/trunk/mail{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/obj/railing/yellow{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/lounge/starboard)
+"aiZ" = (
+/turf/space,
+/area/shuttle/merchant_shuttle/right_station/destiny)
+"ajc" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/lounge/port)
+"aje" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch/north{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/north)
+"ajh" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /obj/landmark{
 	icon_state = "x3";
 	name = "peststart"
 	},
-/obj/submachine/chef_sink/chem_sink{
-	dir = 1
-	},
-/turf/simulated/floor/sanitary,
-/area/station/hallway/primary/east/restroom)
-"aiZ" = (
-/turf/space,
-/area/shuttle/merchant_shuttle/right_station/destiny)
-"ajc" = (
-/obj/wingrille_spawn,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/lounge/port)
-"aje" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/lounge/starboard)
 "ajk" = (
 /obj/storage/closet/dresser,
 /obj/item/clothing/suit/bathrobe,
@@ -2217,23 +2435,21 @@
 	})
 "ajo" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/decal/tile_edge/line/white{
-	icon_state = "line1"
-	},
-/obj/machinery/computer3/generic/med_data{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-4"
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"ajq" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/lounge/port)
 "ajs" = (
 /obj/landmark/start{
 	name = "Cyborg"
@@ -2243,22 +2459,19 @@
 	},
 /area/station/medical/robotics)
 "aju" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/green{
-	pixel_x = -6;
-	pixel_y = 4;
-	switchon = 1
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/item/card/id/captains_spare,
-/obj/item/pen/fancy,
-/obj/machinery/light/emergency,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
+/obj/machinery/door/airlock/pyro/command{
+	name = "Head of Personnel's Office";
+	req_access = null
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/obj/firedoor_spawn,
+/obj/access_spawn/head_of_personnel,
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads)
 "ajv" = (
 /obj/table/auto,
 /obj/towelbin{
@@ -2273,26 +2486,24 @@
 	name = "Pool Shower Room"
 	})
 "ajw" = (
-/obj/wingrille_spawn,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/lounge/starboard)
 "ajz" = (
 /obj/disposalpipe/segment,
-/obj/stool/bench/red,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "ajB" = (
-/obj/table/wood/auto,
-/obj/item/storage/photo_album{
-	pixel_y = -10
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/item/camera{
-	pixel_y = 6
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
 	},
-/obj/item/pinpointer,
-/obj/item/hand_tele,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "ajE" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -2317,128 +2528,135 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/starboard)
 "ajN" = (
-/obj/machinery/power/apc{
+/turf/simulated/floor/carpet{
 	dir = 1;
-	name = "N APC";
-	pixel_y = 24
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads)
+"ajO" = (
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads)
+"ajQ" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13"
+	},
+/obj/decal/tile_edge/stripe{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	location = "Net Cafe"
 	},
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/green{
-	pixel_x = -6;
-	pixel_y = 4;
-	switchon = 1
+/obj/railing/yellow{
+	dir = 1
 	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fgreen2"
-	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
-"ajO" = (
-/obj/table/wood/auto,
-/obj/item/device/gps{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/rum_spaced{
-	pixel_y = 8
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fgreen2"
-	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
-"ajQ" = (
-/obj/machinery/light,
-/obj/rack,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/tank/air,
-/obj/item/clothing/head/emerg,
-/obj/item/clothing/mask/breath,
-/obj/item/crowbar,
-/turf/simulated/floor,
-/area/station/hangar/main)
+/turf/simulated/floor/bot,
+/area/station/crew_quarters/lounge/port)
 "ajS" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/light/small/floor/blueish,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon8,
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
+	dir = 1
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "ajU" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "hop";
-	icon_state = "bedsheet-hop"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
-	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "fgreen2"
-	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
-"ajV" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/sanitary,
-/area/station/hallway/primary/east/restroom)
-"ajX" = (
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/disposal/small{
+	dir = 8
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/bridge/captain)
-"ajY" = (
-/obj/machinery/light,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"aka" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/gannets/command{
-	name = "airlock-'Captain's Quarters'";
-	req_access_txt = "20"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/captain)
-"akb" = (
-/obj/disposalpipe/segment/mail,
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 4
+/area/station/crew_quarters/heads)
+"ajV" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/turf/simulated/floor/sanitary/blue,
-/area/station/crew_quarters/captain)
-"ake" = (
-/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/stairs{
+	dir = 1;
+	icon_state = "Stairs_wide"
+	},
+/area/station/crew_quarters/lounge/starboard)
+"ajX" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/machinery/door/airlock/gannets/command{
-	name = "airlock-'Head of Personnel's Quarters'";
-	req_access_txt = "55"
+/obj/cable{
+	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
+"ajY" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
+"aka" = (
+/obj/disposalpipe/segment/mail,
+/obj/machinery/light/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
+"akb" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northeast)
+"akc" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
+"akd" = (
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/medical/medbooth)
+"ake" = (
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light/emergency,
+/obj/storage/closet/office,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -2450,65 +2668,64 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
+"akg" = (
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/window_blinds/cog2,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/heads)
 "akh" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
+/obj/machinery/light{
+	dir = 8
 	},
-/area/station/crew_quarters/heads)
-"akj" = (
+/obj/stool/bench/green/auto,
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/light_switch/west{
-	dir = 4
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
+"akj" = (
+/turf/space,
+/area/shuttle_sound_spawn)
 "akk" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/light/emergency{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=bridge2";
+	location = "quarters_eastboard";
+	name = "bot navigation beacon"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "akl" = (
-/obj/cable{
-	icon_state = "1-4"
+/obj/stool/bench/green/auto,
+/obj/landmark{
+	name = "kudzustart"
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/manufacturer/hop_and_uniform,
-/obj/machinery/light/incandescent{
-	dir = 8;
-	nostick = 1
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/heads)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "akp" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/sanitary/blue,
-/area/station/crew_quarters/captain)
+/obj/disposalpipe/switch_junction{
+	dir = 4;
+	icon_state = "pipe-sj2";
+	mail_tag = "captain";
+	name = "Captain mail router"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "akq" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters M02"
 	})
 "akr" = (
-/obj/machinery/light{
-	dir = 8
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
@@ -2520,26 +2737,18 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "aku" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters P02"
 	})
 "akv" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/switch_junction{
+	dir = 4;
+	icon_state = "pipe-sj2";
+	mail_tag = "aviary";
+	name = "aviary mail router"
 	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/potted_plant/potted_plant2{
-	dir = 8
-	},
+/obj/machinery/light/small/floor/blueish,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "akz" = (
@@ -2565,20 +2774,15 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "akC" = (
-/obj/disposalpipe/segment,
-/obj/table/auto/desk,
-/obj/item/paper_bin{
-	pixel_y = 5
+/obj/shrub,
+/obj/disposalpipe/segment/mail{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/item/pen,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
@@ -2597,40 +2801,48 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "akG" = (
-/obj/disposalpipe/segment,
-/obj/table/auto/desk,
-/obj/machinery/networked/printer{
-	name = "Customs";
-	pixel_y = 7
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"akL" = (
-/obj/machinery/power/data_terminal,
-/obj/cable,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/hos)
+"akK" = (
+/obj/storage/closet/wardrobe/blue,
+/obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/light/emergency,
-/obj/storage/closet/office,
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "blue2"
 	},
-/area/station/crew_quarters/heads)
-"akO" = (
-/obj/table/wood/auto,
-/obj/item/paper/book/from_file/monster_manual_revised{
-	pixel_x = 5;
-	pixel_y = 5
+/area/station/crew_quarters/quartersA)
+"akL" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/quartersA)
+"akN" = (
+/obj/decal/tile_edge/line/blue{
+	dir = 6;
+	icon_state = "line1"
 	},
-/obj/item/paper/book/from_file/DNDrulebook{
-	pixel_x = -5;
-	pixel_y = 8
+/obj/potted_plant/potted_plant2{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
+"akO" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fblue1"
+	},
+/area/station/bridge/captain)
 "akP" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 1;
@@ -2654,33 +2866,38 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "akS" = (
-/obj/disposalpipe/segment,
-/obj/stool/chair/office/red,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fred2"
+	},
+/area/station/crew_quarters/hos)
 "akT" = (
-/obj/disposalpipe/segment,
-/obj/stool/bench/red,
-/obj/machinery/light{
+/obj/window_blinds/cog2/right{
 	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/drainage,
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon12,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"akU" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/hallway/primary/north)
+/area/station/crew_quarters/quartersA)
+"akU" = (
+/obj/stool/chair/comfy/blue,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA)
 "akV" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/clipboard,
@@ -2702,61 +2919,38 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "akW" = (
-/obj/rack,
-/obj/item/tank/jetpack,
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/suit/space/captain,
-/obj/item/clothing/head/helmet/space/captain,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA)
 "akX" = (
 /obj/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4
+/obj/stool/bench/red,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"akY" = (
+/obj/storage/secure/closet/command/captain,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
+"ala" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/medical/medbooth)
+"alb" = (
+/obj/stool/chair/office/red{
+	dir = 1
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"akY" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/bridge/captain)
-"ala" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/table/wood/auto,
-/obj/machinery/networked/printer{
-	name = "Medical Director's Quarters";
-	pixel_y = 7
-	},
-/obj/machinery/light_switch/west{
-	dir = 4
-	},
-/obj/cable,
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "fblue2"
+	dir = 4;
+	icon_state = "fred2"
 	},
-/area/station/crew_quarters/md)
-"alb" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/hallway/primary/north)
+/area/station/crew_quarters/hos)
 "alc" = (
 /obj/disposalpipe/segment,
 /obj/stool/chair/comfy/purple,
@@ -2785,10 +2979,10 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "alq" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "alw" = (
@@ -2803,14 +2997,6 @@
 	},
 /area/station/solar/west)
 "alx" = (
-/obj/stool/chair/comfy/purple{
-	dir = 8
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersB)
-"alz" = (
 /obj/stool/chair/comfy/green{
 	dir = 8
 	},
@@ -2818,19 +3004,58 @@
 	icon_state = "green2"
 	},
 /area/station/crew_quarters/quartersC)
-"alA" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light{
+"alz" = (
+/obj/stool/chair/comfy/red{
 	dir = 8
 	},
-/obj/stool/bench/green/auto,
+/turf/simulated/floor/carpet{
+	icon_state = "red2"
+	},
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
+"alA" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/carpet{
+	icon_state = "fblue1"
+	},
+/area/station/crew_quarters/quartersA)
+"alB" = (
+/obj/table/reinforced/bar/auto{
+	name = "table"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/item/clipboard{
+	pixel_y = 5
+	},
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/stamp/cap{
+	pixel_y = 5
+	},
+/obj/item/pen/fancy,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "fblue2"
+	},
+/area/station/bridge/captain)
+"alJ" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "green2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P01"
+	})
 "alL" = (
 /obj/cable,
 /obj/cable{
@@ -2843,9 +3068,17 @@
 	},
 /area/station/solar/east)
 "alN" = (
-/obj/storage/secure/closet/command/captain,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "red";
+	icon_state = "bedsheet-red"
+	},
+/obj/item/stamp/hos,
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "fred2"
+	},
+/area/station/crew_quarters/hos)
 "alT" = (
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -2853,20 +3086,8 @@
 	},
 /area/station/bridge)
 "alU" = (
-/obj/table/wood/auto,
-/obj/displaycase{
-	displayed = new /obj/item/captaingun;
-	pixel_y = 8
-	},
-/obj/machinery/light/incandescent{
-	nostick = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/north)
 "alV" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -2874,54 +3095,63 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/west)
 "alX" = (
-/obj/item/rubberduck,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = 6
+/obj/rack,
+/obj/item/clothing/suit/fire,
+/obj/item/clothing/mask/gas/emergency,
+/obj/item/clothing/head/helmet/firefighter,
+/obj/item/tank/air,
+/obj/item/extinguisher,
+/obj/item/crowbar,
+/obj/item/storage/wall/fire{
+	pixel_y = 32
 	},
-/obj/machinery/drainage,
-/turf/simulated/floor/sanitary/blue,
-/area/station/crew_quarters/captain)
+/obj/item/device/light/flashlight,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/north)
 "amc" = (
-/obj/stool/chair/comfy/blue,
+/obj/stool/chair/comfy/purple,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
-	icon_state = "blue2"
+	icon_state = "purple2"
 	},
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
 "ame" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters M04"
 	})
 "amf" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'The Snip'"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 8;
+	name = "The Snip"
+	},
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
 "amg" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Arcade'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Arcade"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/arcade)
 "amh" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters P04"
 	})
@@ -2931,9 +3161,9 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
-	icon_state = "blue2"
+	icon_state = "purple2"
 	},
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
 "amo" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -2958,11 +3188,11 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
-	icon_state = "fred1"
+	icon_state = "fgreen1"
 	},
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "amt" = (
-/obj/stool/chair/office/red{
+/obj/stool/chair/office/yellow{
 	dir = 1
 	},
 /obj/cable{
@@ -2970,9 +3200,9 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
-	icon_state = "fred2"
+	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "amv" = (
 /obj/disposalpipe/switch_junction{
 	dir = 2;
@@ -3005,28 +3235,38 @@
 	},
 /area/station/bridge)
 "amy" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/lounge/starboard)
+/area/station/maintenance/central)
 "amA" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
-	bcolor = "red";
-	icon_state = "bedsheet-red"
+	bcolor = "yellow";
+	icon_state = "bedsheet-yellow"
 	},
-/obj/item/stamp/hos,
 /turf/simulated/floor/carpet{
 	dir = 6;
-	icon_state = "fred2"
+	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "amB" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment,
-/obj/machinery/door/airlock/gannets/glass,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
+"amD" = (
+/obj/machinery/portableowl/attached{
+	name = "A Pretty Owl"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
 "amE" = (
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -3039,27 +3279,26 @@
 	},
 /turf/simulated/floor/yellow/side,
 /area/station/atmos/highcap_storage)
+"amI" = (
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "fblue2"
+	},
+/area/station/bridge/captain)
 "amJ" = (
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "amL" = (
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
-/obj/stool/chair/comfy/blue,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/blind_switch/area/north{
-	pixel_y = 28
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/garden/aviary)
 "amM" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -3088,15 +3327,11 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/arcade)
 "amP" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Bridge'"
 	},
 /obj/cable{
 	icon_state = "2-8"
@@ -3117,25 +3352,27 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/door/airlock/pyro/command{
+	name = "Bridge"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/heads,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "amQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/vending/snack,
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon10,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "amS" = (
-/obj/stool/chair/comfy/purple,
+/obj/stool/chair/comfy/green,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
-	icon_state = "purple2"
+	icon_state = "green2"
 	},
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "amT" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 1;
@@ -3146,13 +3383,7 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
-"amU" = (
-/obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "amV" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -3167,10 +3398,10 @@
 	name = "Bridge Lockdown Door";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "amY" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -3185,6 +3416,7 @@
 	name = "Bridge Lockdown Door";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "ana" = (
@@ -3193,24 +3425,22 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
-	icon_state = "purple2"
+	icon_state = "green2"
 	},
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "anf" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment,
-/obj/machinery/door/airlock/gannets/glass/morgue/alt{
-	name = "glass airlock-'Chapel'";
-	req_access_txt = ""
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Chapel"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
 "ang" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/morgue/alt{
-	name = "glass airlock-'Chapel'";
-	req_access_txt = ""
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Chapel"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
 "anh" = (
@@ -3219,11 +3449,13 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
-	icon_state = "fgreen1"
+	icon_state = "fpurple1"
 	},
-/area/station/crew_quarters/ce)
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "ani" = (
-/obj/stool/chair/office/yellow{
+/obj/stool/chair/office/purple{
 	dir = 1
 	},
 /obj/cable{
@@ -3231,9 +3463,11 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
-	icon_state = "fgreen2"
+	icon_state = "fpurple2"
 	},
-/area/station/crew_quarters/ce)
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "anj" = (
 /obj/disposalpipe/segment,
 /obj/machinery/ai_status_display{
@@ -3242,18 +3476,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "ank" = (
-/obj/landmark/spawner{
-	name = "monkeyspawn_mrsmuggles"
-	},
-/obj/machinery/light/incandescent{
-	dir = 1;
-	nostick = 1
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M01"
+	})
 "anm" = (
 /obj/disposalpipe/switch_junction{
 	dir = 2;
@@ -3267,20 +3493,22 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "ano" = (
-/obj/machinery/door/firedoor/border_only,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "anr" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
+	bcolor = "pink";
+	icon_state = "bedsheet-pink"
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;
-	icon_state = "fgreen2"
+	icon_state = "fpurple2"
 	},
-/area/station/crew_quarters/ce)
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "ans" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -3293,21 +3521,20 @@
 /area/station/hallway/primary/central)
 "anu" = (
 /obj/disposalpipe/segment,
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "anv" = (
-/obj/decal/stage_edge/alt{
-	pixel_y = 10
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P01"
+	})
 "anw" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -3316,15 +3543,17 @@
 /turf/simulated/floor/plating/airless,
 /area/station/solar/east)
 "anz" = (
-/obj/stool/chair/comfy/green,
+/obj/stool/chair/comfy/red,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
-	icon_state = "green2"
+	icon_state = "red2"
 	},
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "anA" = (
 /obj/disposalpipe/segment,
 /obj/decal/pole{
@@ -3333,15 +3562,12 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "anB" = (
-/obj/machinery/light/incandescent{
-	nostick = 1
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "fgreen2"
-	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/north)
 "anC" = (
 /obj/machinery/shuttle/engine/propulsion{
 	icon_state = "alt_propulsion"
@@ -3354,15 +3580,17 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
-	icon_state = "green2"
+	icon_state = "red2"
 	},
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "anI" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "anJ" = (
@@ -3398,11 +3626,9 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
-	icon_state = "fpurple1"
+	icon_state = "fblue1"
 	},
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "aoh" = (
 /obj/disposalpipe/segment,
 /obj/stool/chair/pew/fancy/right,
@@ -3411,7 +3637,7 @@
 	},
 /area/station/chapel/sanctuary)
 "aoj" = (
-/obj/stool/chair/office/purple{
+/obj/stool/chair/office/blue{
 	dir = 1
 	},
 /obj/cable{
@@ -3419,11 +3645,9 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
-	icon_state = "fpurple2"
+	icon_state = "fblue2"
 	},
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "aoo" = (
 /obj/machinery/computer/ordercomp{
 	dir = 8
@@ -3445,11 +3669,22 @@
 	},
 /area/station/chapel/sanctuary)
 "aov" = (
-/obj/stool/chair/wooden{
-	dir = 1
+/obj/table/reinforced/bar/auto{
+	name = "table"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/decal/fakeobjects/plantpot{
+	pixel_y = 10
+	},
+/obj/shrub/captainshrub{
+	pixel_y = 22
+	},
+/obj/item/reagent_containers/food/drinks/bottle/thegoodstuff{
+	pixel_y = 12
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "fblue2"
+	},
+/area/station/bridge/captain)
 "aow" = (
 /obj/decal/tile_edge/line/green{
 	dir = 4;
@@ -3511,17 +3746,23 @@
 	},
 /area/station/chapel/sanctuary)
 "aoK" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
+/obj/table/reinforced/bar/auto{
+	name = "table"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/disposalpipe/segment/mail,
+/obj/machinery/recharger{
+	pixel_y = 5
+	},
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "fblue2"
+	},
+/area/station/bridge/captain)
 "aoL" = (
-/obj/stool/bench/green/auto,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/bridge/captain)
 "aoP" = (
 /obj/table/wood/round/auto,
 /obj/machinery/phone,
@@ -3562,22 +3803,16 @@
 "aoZ" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
-	bcolor = "pink";
-	icon_state = "bedsheet-pink"
+	bcolor = "black";
+	icon_state = "bedsheet-black"
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;
-	icon_state = "fpurple2"
+	icon_state = "fblue2"
 	},
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "apa" = (
-/obj/wingrille_spawn/reinforced_crystal,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-8"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/garden/aviary)
 "apb" = (
@@ -3630,50 +3865,28 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "apl" = (
-/obj/machinery/portableowl/attached{
-	name = "an Owl with a chip out of his beak"
-	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
+/obj/stool/chair/wooden,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "apm" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/middle{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
+/obj/storage/closet/welding_supply,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/area/station/maintenance/northwest)
 "apn" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/reagent_dispensers/foamtank,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "fred1"
-	},
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
 "apo" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "fred1"
-	},
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
 "apq" = (
 /obj/stool/chair/comfy/green{
 	dir = 4
@@ -3731,30 +3944,33 @@
 	},
 /area/station/chapel/sanctuary)
 "apy" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/right{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/area/station/crew_quarters/lounge/port)
 "apz" = (
-/obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 1
+/obj/potted_plant/potted_plant5{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/storage/closet/office,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"apB" = (
+/obj/disposalpipe/segment/mail{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads)
+/area/station/bridge/captain)
 "apE" = (
-/obj/shrub{
-	dir = 10
-	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
+/obj/machinery/bot/secbot/formal,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "apF" = (
 /obj/stool/chair/comfy/yellow{
 	dir = 4
@@ -3786,45 +4002,30 @@
 	},
 /area/station/bridge)
 "apJ" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/hallway/primary/east/restroom)
-"apN" = (
-/obj/wingrille_spawn/reinforced_crystal,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
+/area/station/crew_quarters/lounge/starboard)
+"apN" = (
+/obj/shrub{
+	dir = 4
+	},
+/turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "apR" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/central)
 "apT" = (
-/obj/machinery/computer/airbr/emergency_shuttle{
-	density = 0;
-	emergency = 0;
-	id = "merchant_L";
-	pixel_y = 32;
-	req_access_txt = ""
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port)
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/central)
 "apU" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "fblue1"
-	},
-/area/station/crew_quarters/md)
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northeast)
 "apZ" = (
 /obj/crematorium{
 	id = "crematorium"
@@ -3833,30 +4034,24 @@
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aqb" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/middle{
-	dir = 8
-	},
+/obj/machinery/portable_atmospherics/canister/air/large,
 /obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/md)
+/area/station/maintenance/northeast)
 "aqc" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Chapel'"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 1
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
 "aqd" = (
-/obj/item/space_thing,
+/obj/stool/chair/wooden,
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "aqf" = (
@@ -3921,28 +4116,50 @@
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "aqp" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
 	},
-/obj/item/storage/wall/emergency{
-	pixel_y = 32
+/obj/machinery/disposal/brig{
+	destination_tag = "prisoner"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northwest)
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/obj/disposalpipe/trunk/brig{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "aqq" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/west{
 	name = "West Central Maintenance"
 	})
 "aqu" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 1;
+	name = "Captain's Nest"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/captain,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/bridge/captain)
+/area/station/crew_quarters/captain)
 "aqw" = (
 /obj/machinery/computer/announcement{
 	announces_arrivals = 1
@@ -4005,10 +4222,7 @@
 	dir = 4;
 	name = "crematorium pipe"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "aqG" = (
 /obj/disposaloutlet{
@@ -4056,14 +4270,36 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
+"aqN" = (
+/obj/table/reinforced/auto,
+/obj/window/reinforced/north,
+/obj/window/reinforced/south,
+/obj/machinery/door/window/eastright{
+	req_access_txt = "1"
+	},
+/obj/machinery/cashreg,
+/obj/disposalpipe/segment/brig{
+	dir = 4
+	},
+/obj/access_spawn/security,
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "aqO" = (
-/obj/shrub,
-/obj/machinery/light{
-	dir = 8
+/obj/decal/tile_edge/line/red{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/disposalpipe/segment/brig{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "aqP" = (
+/obj/machinery/sleep_console{
+	dir = 4
+	},
 /obj/decal/tile_edge/line/white{
 	icon_state = "line3"
 	},
@@ -4076,10 +4312,25 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
 "aqQ" = (
-/turf/simulated/wall/auto/gannets,
-/area/station/maintenance/northeast)
+/obj/table/reinforced/auto,
+/obj/window/reinforced/north,
+/obj/window/reinforced/south,
+/obj/machinery/door/window/westleft{
+	req_access_txt = "5"
+	},
+/obj/machinery/cashreg,
+/obj/random_item_spawner/medicine{
+	max_amt2spawn = 3;
+	min_amt2spawn = 2
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/access_spawn/medical,
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
 "aqT" = (
-/obj/wingrille_spawn,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/arcade)
 "aqU" = (
@@ -4095,7 +4346,6 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 10;
@@ -4105,6 +4355,7 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "aqW" = (
@@ -4144,48 +4395,99 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "arh" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/obj/decal/tile_edge/line/white{
+	dir = 4;
+	icon_state = "line1"
+	},
+/obj/machinery/disposal/morgue{
+	destination_tag = "deceased"
+	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/obj/disposalpipe/trunk/morgue{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
 "arj" = (
-/obj/storage/closet/welding_supply,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northwest)
-"ark" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line2"
+	},
+/obj/storage/secure/closet/security/equipment,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
-"arm" = (
-/obj/machinery/atmospherics/valve{
-	name = "Purge Valve"
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
+"ark" = (
+/obj/decal/tile_edge/line/white{
+	dir = 6;
+	icon_state = "line2"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/obj/stool/bed/moveable/hospital,
+/obj/item/clothing/suit/bedsheet,
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
+"arm" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
 "aro" = (
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon10,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M02"
+	})
 "arp" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/window{
 	req_access_txt = "83"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/rancher,
 /turf/simulated/floor/black,
 /area/station/ranch)
 "ars" = (
-/obj/stool/chair/office{
-	dir = 1
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fgreen2"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
 	},
-/area/station/crew_quarters/heads)
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P02"
+	})
 "aru" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -4197,17 +4499,16 @@
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/office)
 "arv" = (
-/obj/decal/tile_edge/line/green{
-	dir = 8;
-	icon_state = "line1"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "arA" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters M03"
 	})
@@ -4256,7 +4557,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "arJ" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/window/reinforced/north,
 /obj/machinery/door/window/westright{
@@ -4276,10 +4576,12 @@
 	persistent_id = "kitchen";
 	pixel_x = 15
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/kitchen,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "arK" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters P03"
 	})
@@ -4295,7 +4597,7 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "arP" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/solar/west)
 "arR" = (
 /obj/cable{
@@ -4304,7 +4606,6 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 1;
@@ -4315,34 +4616,31 @@
 	opacity = 0
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"arS" = (
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads)
 "arU" = (
-/obj/disposalpipe/segment/brig{
-	dir = 4
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/turf/simulated/floor,
+/area/station/hangar/main)
 "arV" = (
-/obj/table/reinforced/auto,
-/obj/window/reinforced/north,
-/obj/window/reinforced/south,
-/obj/machinery/door/window/eastright{
-	req_access_txt = "1"
+/obj/disposalpipe/segment,
+/obj/decal/tile_edge/stripe{
+	dir = 10;
+	icon_state = "xtra_bigstripe-corner2"
 	},
-/obj/machinery/cashreg,
-/obj/disposalpipe/segment/brig{
-	dir = 4
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/turf/simulated/floor,
+/area/station/hangar/main)
 "arW" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -4356,7 +4654,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/janitor/office)
 "arY" = (
 /obj/disposalpipe/segment,
@@ -4371,39 +4669,38 @@
 /area/station/hallway/primary/central)
 "asc" = (
 /turf/simulated/floor/carpet/blue/standard/edge/west,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "asg" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "ash" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/solar/west)
 "asi" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/middle{
-	dir = 4
-	},
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
 	},
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M03"
+	})
 "asj" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/chapel/sanctuary)
 "asl" = (
@@ -4414,22 +4711,28 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "asm" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Freezer'";
-	req_access_txt = "28"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Meat Locker";
+	req_access_txt = null
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/kitchen,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "aso" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "fgreen2"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
 	},
-/area/station/crew_quarters/heads)
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P03"
+	})
 "asq" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -4470,39 +4773,27 @@
 	name = "East Central Maintenance"
 	})
 "asw" = (
-/obj/decal/tile_edge/line/white{
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/machinery/disposal/morgue{
-	destination_tag = "deceased"
-	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/obj/disposalpipe/trunk/morgue{
-	dir = 8
-	},
-/obj/machinery/light{
+/obj/machinery/vehicle/escape_pod{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/door/window/westright,
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge"
 	},
-/obj/cable{
-	icon_state = "2-4"
+/obj/decal/tile_edge/stripe{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/turf/simulated/floor/engine,
+/area/station/hallway/secondary/exit)
 "asz" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "44|50"
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/west)
 "asB" = (
@@ -4513,7 +4804,6 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 6;
@@ -4523,6 +4813,7 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "asD" = (
@@ -4531,12 +4822,12 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/carpet/blue/standard/narrow/east,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "asF" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/east{
 	name = "East Central Maintenance"
@@ -4564,12 +4855,16 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "fgreen2"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
 	},
-/area/station/crew_quarters/heads)
+/obj/firedoor_spawn,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M04"
+	})
 "asQ" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 6;
@@ -4619,11 +4914,6 @@
 	name = "East Central Maintenance"
 	})
 "ata" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical{
-	name = "glass airlock-'Medbay'";
-	req_access_txt = ""
-	},
 /obj/machinery/secscanner{
 	dir = 4;
 	icon_state = "scanner_off";
@@ -4641,6 +4931,12 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "atc" = (
@@ -4682,15 +4978,14 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "atu" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Kitchen'";
-	req_access_txt = "28"
-	},
 /obj/disposalpipe/segment/food{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Kitchen"
+	},
+/obj/access_spawn/kitchen,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "atv" = (
@@ -4765,14 +5060,18 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "atP" = (
-/obj/stool/chair/office/yellow{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P04"
+	})
 "atR" = (
 /obj/storage/secure/closet/medical/medicine,
 /obj/decal/tile_edge/line/red{
@@ -4790,7 +5089,6 @@
 	icon_state = "pipe-j2";
 	name = "brig pipe"
 	},
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2{
 	layer = 2.9;
 	pixel_y = 13
@@ -4798,6 +5096,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/interrogation)
 "atU" = (
@@ -4805,15 +5104,24 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/Zeta)
 "atV" = (
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fgreen2"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/crew_quarters/heads)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"atW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/vending/snack,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "atX" = (
+/obj/machinery/atmospherics/pipe/simple/junction,
 /obj/table/reinforced/auto,
 /obj/item/kitchen/utensil/knife,
 /obj/item/kitchen/utensil/knife,
@@ -4918,7 +5226,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "aus" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -4926,6 +5233,7 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/chapel/sanctuary)
 "aut" = (
@@ -4951,13 +5259,13 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "auv" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/chapel/sanctuary)
 "aux" = (
@@ -5056,10 +5364,9 @@
 	},
 /area/station/medical/medbay/treatment)
 "auO" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/chapel/sanctuary)
 "auP" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -5070,10 +5377,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "auS" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -5083,10 +5390,10 @@
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "auT" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -5096,6 +5403,7 @@
 /obj/disposalpipe/segment/food{
 	icon_state = "pipe-c"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "auV" = (
@@ -5123,7 +5431,7 @@
 	},
 /area/station/hydroponics/bay)
 "auX" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/storage/tools)
 "auY" = (
 /obj/disposalpipe/segment/mail{
@@ -5143,12 +5451,12 @@
 	name = "West Central Maintenance"
 	})
 "ava" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "avf" = (
@@ -5425,8 +5733,14 @@
 /obj/disposalpipe/junction,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
+"awq" = (
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "awt" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/food,
 /obj/cable{
 	icon_state = "0-4"
@@ -5434,17 +5748,19 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "awu" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering/alt{
-	name = "airlock-'West SMES'";
-	req_access_txt = "44|50"
+/obj/machinery/door/airlock/pyro/engineering/alt{
+	dir = 4;
+	name = "West SMES"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor,
 /area/station/maintenance/south)
 "awz" = (
@@ -5484,7 +5800,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 6
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/west)
 "awG" = (
 /obj/decal/tile_edge/line/green{
@@ -5528,10 +5844,12 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "awO" = (
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 10;
+	level = 2
 	},
-/area/station/crew_quarters/heads)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/central)
 "awP" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -5552,8 +5870,13 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "awX" = (
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "awZ" = (
 /obj/machinery/light{
 	dir = 4
@@ -5566,7 +5889,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "axa" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/window/reinforced/west,
 /obj/machinery/cashreg,
@@ -5576,6 +5898,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "axc" = (
@@ -5631,24 +5954,15 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "axs" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/table/reinforced/auto,
-/obj/window/reinforced/west,
-/obj/machinery/door/window/southleft{
-	req_access_txt = "15"
+/obj/cable{
+	icon_state = "0-2"
 	},
-/obj/disposalpipe/segment/mail,
-/obj/item/reagent_containers/food/drinks/mug/random_color{
-	pixel_x = 4;
-	pixel_y = 8
+/obj/cable{
+	icon_state = "0-8"
 	},
-/obj/item/stamp/hop{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/obj/machinery/cashreg,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/garden/aviary)
 "axv" = (
 /obj/disposalpipe/trunk{
 	dir = 8
@@ -5659,11 +5973,11 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "axz" = (
-/obj/decal/tile_edge/line/black{
+/obj/decal/tile_edge/stripe{
 	dir = 8;
-	icon_state = "line1"
+	icon_state = "xtra_bigstripe-edge"
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor,
 /area/station/hangar/main)
 "axA" = (
 /obj/lattice,
@@ -5717,6 +6031,8 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/bar,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "axJ" = (
@@ -5762,7 +6078,6 @@
 /turf/simulated/floor/yellow/side,
 /area/station/atmos/highcap_storage)
 "axO" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/machinery/door/window/westleft{
 	req_access_txt = "35"
@@ -5773,6 +6088,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/hydro,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "axQ" = (
@@ -5821,7 +6138,14 @@
 /turf/simulated/floor,
 /area/station/atmos/highcap_storage)
 "axZ" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/obj/machinery/light/incandescent/cool{
+	dir = 8;
+	nostick = 1
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
 "aye" = (
 /obj/machinery/light/incandescent/cool{
@@ -5852,12 +6176,13 @@
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
 "ayh" = (
-/obj/lattice{
-	dir = 9;
-	icon_state = "lattice-dir"
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/space,
-/area/space)
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/garden/aviary)
 "aym" = (
 /obj/decal/tile_edge/line/red{
 	icon_state = "line3"
@@ -5868,17 +6193,27 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "ayn" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4;
 	level = 2
 	},
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Freezer Temperature Control Room'";
-	req_access_txt = ""
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "Cold Storage Control"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/kitchen,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/catering)
+"ayo" = (
+/obj/disposalpipe/segment/mail,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "ayp" = (
 /obj/stool/chair/office/blue{
 	dir = 1
@@ -5893,6 +6228,8 @@
 	req_access_txt = "25"
 	},
 /obj/machinery/cashreg,
+/obj/firedoor_spawn,
+/obj/access_spawn/bar,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "ayv" = (
@@ -5914,7 +6251,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "ayx" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/item/paper/book/from_file/pharmacopia,
 /obj/machinery/phone,
@@ -5931,6 +6267,8 @@
 	dir = 8;
 	req_access_txt = "5|33"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "ayy" = (
@@ -5942,10 +6280,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "ayz" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/turret_protected/Zeta)
 "ayE" = (
@@ -5983,10 +6321,6 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "ayP" = (
-/obj/reagent_dispensers/watertank/fountain,
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
@@ -6050,13 +6384,13 @@
 	name = "West Central Maintenance"
 	})
 "azl" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "azm" = (
@@ -6078,21 +6412,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "azn" = (
-/obj/item/device/radio/beacon,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "tour;next_tour=tour17;desc=In the event of catastrophic station damage or approved shift change, a shuttle will be dispatched from the regional Central Command dock to this location. Should this occur, remember to line up quietly and enter single-file. No shoving please!";
-	freq = 1443;
-	location = "tour16";
-	name = "tour beacon - escape"
-	},
-/obj/landmark/gps_waypoint,
-/obj/cable{
-	icon_state = "4-8"
-	},
+/obj/stool/bench/yellow,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "azo" = (
@@ -6115,22 +6435,23 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "azz" = (
-/obj/wingrille_spawn/reinforced,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable,
-/obj/window_blinds/cog2,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
-"azA" = (
-/obj/machinery/door/airlock/gannets/glass/toxins{
-	name = "glass airlock-'Quarantine'";
-	req_access_txt = "84"
-	},
+/obj/table/auto,
+/obj/item/decoration/ashtray,
+/obj/machinery/light,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/orangeblack/side,
+/area/station/hallway/secondary/exit)
+"azA" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass/toxins{
+	dir = 4;
+	name = "Quarantine"
+	},
+/obj/access_spawn/pathology,
 /turf/simulated/floor/green,
 /area/station/medical/cdc)
 "azB" = (
@@ -6149,10 +6470,10 @@
 /area/station/medical/medbay/restroom)
 "azG" = (
 /obj/window_blinds/cog2,
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/baroffice)
 "azL" = (
@@ -6169,15 +6490,15 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/bar)
 "azR" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/obj/wingrille_spawn,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "azS" = (
@@ -6187,20 +6508,21 @@
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/central)
 "azT" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/obj/wingrille_spawn,
 /obj/disposalpipe/segment/mail,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "azV" = (
-/obj/shrub{
-	dir = 4
+/obj/critter/parrot/random,
+/obj/stool/chair/wooden{
+	dir = 8
 	},
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
@@ -6214,10 +6536,10 @@
 	},
 /area/station/hallway/secondary/construction)
 "azX" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/chapel/sanctuary)
 "azZ" = (
@@ -6252,62 +6574,35 @@
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "aAh" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/stool/bench/green/auto,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"aAl" = (
+/obj/machinery/light/incandescent/cool{
+	dir = 1;
+	nostick = 1
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=aviary";
-	location = "customs";
-	name = "bot navigation beacon"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"aAl" = (
-/obj/machinery/disposal/small{
-	dir = 4
-	},
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/decal/tile_edge/stripe{
-	icon_state = "xtra_bigstripe-edge";
-	pixel_y = 10
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/railing/yellow{
-	pixel_y = 10
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port)
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/central)
 "aAo" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/main)
 "aAp" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/east{
 	name = "East Central Maintenance"
 	})
 "aAq" = (
+/obj/cable,
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/garden/aviary)
 "aAs" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -6316,15 +6611,12 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "aAu" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/hos)
 "aAw" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -6364,27 +6656,13 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "aAC" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
-"aAD" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "44|50"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/inner/east{
-	name = "East Central Maintenance"
-	})
 "aAE" = (
 /obj/machinery/drainage,
 /obj/machinery/shower{
@@ -6408,7 +6686,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "aAM" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner/east{
 	name = "East Central Maintenance"
 	})
@@ -6432,11 +6710,9 @@
 /turf/simulated/floor/sanitary,
 /area/station/science/restroom)
 "aAT" = (
-/obj/disposalpipe/switch_junction{
+/obj/disposalpipe/segment/mail{
 	dir = 4;
-	icon_state = "pipe-sj2";
-	mail_tag = "captain";
-	name = "Captain mail router"
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
@@ -6463,13 +6739,13 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "aAW" = (
-/obj/wingrille_spawn/reinforced,
 /obj/decal/poster/wallsign/medbay{
 	icon_state = "med"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/lobby)
 "aAZ" = (
@@ -6485,21 +6761,24 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "aBa" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/cdc)
 "aBb" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/security/alt,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/security{
+	dir = 4;
+	req_access = null
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/courtroom)
 "aBc" = (
@@ -6578,12 +6857,17 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "aBt" = (
-/obj/decal/tile_edge/line/green{
-	dir = 10;
-	icon_state = "line1"
+/obj/machinery/vending/book,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname  - SS13"
 	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "aBv" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 6;
@@ -6673,11 +6957,20 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/cdc)
 "aBL" = (
-/turf/simulated/wall/auto/gannets,
-/area/station/crew_quarters/quartersA)
+/obj/table/reinforced/auto,
+/obj/item/sheet/steel/fullstack,
+/obj/item/sheet/glass/fullstack,
+/obj/item/storage/box/cablesbox,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
 "aBN" = (
 /obj/disposalpipe/junction{
 	dir = 4;
@@ -6715,6 +7008,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "aBU" = (
+/obj/disposalpipe/segment,
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
@@ -6758,12 +7052,13 @@
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aCc" = (
-/obj/disposalpipe/segment/mail{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/wall/auto/gannets,
-/area/station/crew_quarters/quartersA)
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/garden/aviary)
 "aCe" = (
 /obj/machinery/light/emergency,
 /turf/simulated/floor/black,
@@ -6813,11 +7108,11 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "aCo" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 8
 	},
@@ -6912,13 +7207,13 @@
 	name = "Genetic Research"
 	})
 "aCz" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/toilets)
 "aCC" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/cdc)
 "aCE" = (
@@ -6934,6 +7229,19 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
+"aCH" = (
+/obj/machinery/computer/ordercomp{
+	dir = 4
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
 "aCK" = (
 /obj/storage/closet/welding_supply,
 /obj/decal/tile_edge/line/yellow{
@@ -6951,7 +7259,6 @@
 	},
 /area/station/chapel/sanctuary)
 "aCT" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
@@ -6959,6 +7266,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "aCU" = (
@@ -6990,22 +7298,21 @@
 /turf/simulated/floor/purple,
 /area/station/medical/cdc)
 "aCW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "aCZ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "aDb" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -7016,52 +7323,23 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "aDe" = (
-/obj/machinery/disposal/mail/small{
-	dir = 8;
-	mail_tag = "pod_fore";
-	name = "mail chute-'North Pod Bay'"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/disposalpipe/trunk/mail{
-	dir = 4
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/light,
 /turf/simulated/floor,
 /area/station/hangar/main)
 "aDg" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/switch_junction{
-	dir = 1;
-	icon_state = "pipe-sj2";
-	mail_tag = "hop";
-	name = "Head of Personnel mail router"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"aDi" = (
-/obj/wingrille_spawn/reinforced,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/blast{
-	density = 0;
-	dir = 4;
-	icon_state = "bdoormid0";
-	id = "atmos_shield";
-	layer = 4;
-	name = "Atmospherics Security Shield";
-	opacity = 0
-	},
-/turf/simulated/floor/plating/random,
-/area/station/atmos/highcap_storage)
+/obj/storage/closet/welding_supply,
+/turf/simulated/floor,
+/area/station/hangar/main)
 "aDj" = (
 /obj/machinery/mass_driver{
 	dir = 4;
@@ -7182,10 +7460,8 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "aDF" = (
-/obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
+/obj/disposalpipe/junction{
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
@@ -7290,10 +7566,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "aEF" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	name = "glass airlock-'Research'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -7304,8 +7576,21 @@
 	dir = 5;
 	icon_state = "line1"
 	},
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4;
+	name = "Research"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
+"aEH" = (
+/obj/machinery/light,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "aEK" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -7347,13 +7632,15 @@
 	icon_state = "pipe-c";
 	name = "crematorium pipe"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical{
-	name = "glass airlock-'Cloning'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 8;
+	name = "Cloning"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -7512,7 +7799,7 @@
 /area/station/medical/medbay/treatment)
 "aFs" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/treatment)
 "aFt" = (
 /obj/stool/chair/office/purple{
@@ -7543,18 +7830,14 @@
 	},
 /area/station/science/lobby)
 "aFC" = (
-/obj/machinery/computer/ordercomp{
-	dir = 4
-	},
-/obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hangar/main)
+/area/station/crew_quarters/lounge/port)
 "aFE" = (
 /obj/decal/boxingrope{
 	dir = 4
@@ -7562,10 +7845,10 @@
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "aFF" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/north)
 "aFG" = (
@@ -7603,17 +7886,23 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "aFK" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/west)
 "aFL" = (
 /obj/cable{
+	icon_state = "1-4"
+	},
+/obj/stool/chair/office{
+	dir = 1
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light_switch/north{
-	pixel_y = 28
-	},
-/turf/simulated/floor/sanitary,
-/area/station/hallway/primary/east/restroom)
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "aFM" = (
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 6
@@ -7662,7 +7951,7 @@
 	},
 /obj/table/round/auto,
 /turf/simulated/floor/darkblue/checker,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "aFX" = (
 /obj/decal/tile_edge/line/blue{
 	icon_state = "line1"
@@ -7681,36 +7970,24 @@
 /turf/simulated/floor/yellow/side,
 /area/station/atmos/highcap_storage)
 "aFY" = (
-/obj/item/storage/toilet/random{
-	pixel_y = 8
+/obj/cable{
+	icon_state = "2-4"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/blind_switch/area/south{
-	pixel_y = 28
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/sanitary,
-/area/station/hallway/primary/east/restroom)
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "aGb" = (
-/obj/window/cubicle{
-	dir = 4
-	},
-/obj/table/auto,
-/obj/item/reagent_containers/glass/bottle/bubblebath,
-/obj/machinery/disposal/small{
-	dir = 1;
-	pixel_y = 32
-	},
-/obj/disposalpipe/trunk,
-/obj/item/sponge{
-	name = "loofah"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/sanitary,
-/area/station/hallway/primary/east/restroom)
+/obj/machinery/light,
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "aGc" = (
 /obj/machinery/atmospherics/valve,
 /obj/decal/tile_edge/line/blue{
@@ -7725,14 +8002,14 @@
 	},
 /area/station/atmos/highcap_storage)
 "aGd" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical{
-	id = "medbay_door";
-	name = "glass airlock-'Medbay'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -7767,10 +8044,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "aGi" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	name = "glass airlock-'Research'"
-	},
 /obj/decal/tile_edge/line/purple{
 	dir = 6;
 	icon_state = "line1"
@@ -7784,18 +8057,26 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4;
+	name = "Research"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "aGl" = (
-/obj/machinery/bathtub{
-	pixel_y = 4
+/obj/cable{
+	icon_state = "1-8"
 	},
-/obj/item/reagent_containers/bath_bomb,
+/obj/stool/chair/office{
+	dir = 1
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/sanitary,
-/area/station/hallway/primary/east/restroom)
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "aGn" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -7842,7 +8123,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/refinery)
 "aGD" = (
 /obj/decal/tile_edge/line/blue{
@@ -7868,6 +8149,16 @@
 	dir = 1
 	},
 /area/station/medical/medbay/treatment)
+"aGF" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/lounge/port)
 "aGG" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -7897,7 +8188,6 @@
 	},
 /area/station/medical/medbay/cloner)
 "aGK" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2{
 	dir = 4
 	},
@@ -7905,6 +8195,7 @@
 	dir = 4
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/cloner)
 "aGM" = (
@@ -7920,12 +8211,30 @@
 	name = "Genetic Research"
 	})
 "aGN" = (
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/hos)
+/obj/disposalpipe/segment/mail,
+/obj/machinery/navbeacon/tour/destiny/tour15,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"aGO" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Crew Lounge"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/lounge/starboard)
 "aGR" = (
 /obj/item/slag_shovel,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -7942,7 +8251,7 @@
 	name = "Genetic Research"
 	})
 "aGV" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/north)
 "aGW" = (
 /obj/decal/tile_edge/line/black{
@@ -8063,8 +8372,23 @@
 	},
 /area/station/science/lobby)
 "aHq" = (
-/obj/machinery/vending/floppy,
-/turf/simulated/floor,
+/obj/machinery/disposal/small{
+	dir = 4
+	},
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge";
+	pixel_y = 10
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/railing/yellow{
+	pixel_y = 10
+	},
+/turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/port)
 "aHw" = (
 /obj/disposalpipe/segment/mail{
@@ -8074,19 +8398,9 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "aHx" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 20
+/turf/simulated/floor/stairs{
+	icon_state = "Stairs2_wide"
 	},
-/obj/shrub{
-	dir = 4;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
-	},
-/obj/machinery/light_switch/east{
-	dir = 4
-	},
-/turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "aHy" = (
 /obj/cable{
@@ -8192,11 +8506,11 @@
 	name = "Pool Shower Room"
 	})
 "aHV" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "aHW" = (
@@ -8256,7 +8570,7 @@
 /area/station/hallway/primary/southeast)
 "aIi" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/Zeta)
 "aIk" = (
 /obj/machinery/computer/ordercomp{
@@ -8324,12 +8638,8 @@
 	},
 /area/station/medical/medbay/treatment)
 "aIu" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/north)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/lounge/starboard)
 "aIB" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 4;
@@ -8363,39 +8673,47 @@
 	},
 /area/station/crew_quarters/fitness)
 "aIP" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/captain)
+/obj/machinery/vending/pizza{
+	anchored = 1
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "aIR" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/security/alt{
-	name = "glass airlock-'Cell #1'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/security{
+	dir = 4;
+	name = "glass airlock-'Cell #1"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/brig,
 /turf/simulated/floor,
 /area/station/security/brig)
 "aIX" = (
-/obj/disposalpipe/segment,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
+/obj/machinery/manufacturer/general,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/floor,
+/area/station/hangar/main)
+"aIZ" = (
+/obj/machinery/vending/pizza{
+	anchored = 1
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "aJc" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/restroom)
 "aJd" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
@@ -8405,6 +8723,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/head)
 "aJe" = (
@@ -8423,7 +8742,6 @@
 	},
 /area/station/turret_protected/Zeta)
 "aJf" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -8431,8 +8749,15 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/turret_protected/Zeta)
+"aJl" = (
+/obj/table/auto,
+/obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
+/obj/item/storage/box/diskbox,
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "aJn" = (
 /turf/space,
 /area/shuttle/mining/station)
@@ -8494,8 +8819,16 @@
 	dir = 6
 	},
 /area/station/medical/medbay/treatment)
+"aJq" = (
+/obj/table/auto,
+/obj/machinery/computer3/generic/personal{
+	pixel_y = 9
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "aJw" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
 /obj/machinery/door/poddoor/pyro{
@@ -8513,6 +8846,8 @@
 /obj/machinery/door/window/eastleft{
 	req_access_txt = "5|33"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/pharmacy)
 "aJx" = (
@@ -8619,7 +8954,6 @@
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
 "aJI" = (
-/obj/wingrille_spawn/reinforced,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 4;
@@ -8633,10 +8967,10 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/storage/eva)
 "aJJ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 4;
@@ -8650,6 +8984,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/storage/eva)
 "aJL" = (
@@ -8665,13 +9000,13 @@
 	name = "West Central Maintenance"
 	})
 "aJM" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/fitness)
 "aJN" = (
@@ -8686,10 +9021,10 @@
 	},
 /obj/cable,
 /obj/decal/poster/wallsign/gym,
-/turf/simulated/wall/auto/reinforced/gannets,
+/obj/wingrille_spawn/auto,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/fitness)
 "aJO" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -8699,6 +9034,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/fitness)
 "aJT" = (
@@ -8742,12 +9078,20 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
 "aKc" = (
-/obj/table/wood/auto,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/computer/card,
+/obj/item/device/radio/intercom/security{
+	pixel_x = 8;
+	pixel_y = 28
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/blind_switch/area/north{
+	pixel_x = -10;
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "fblue2"
+	},
+/area/station/bridge/captain)
 "aKd" = (
 /obj/machinery/light/emergency{
 	dir = 4
@@ -8758,18 +9102,41 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Restroom'"
+/obj/machinery/door/airlock/pyro{
+	name = "Toilets"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
 "aKg" = (
-/obj/table/wood/auto,
-/obj/item/paper_bin{
-	pixel_y = 5
+/obj/machinery/computer3/generic/communications,
+/obj/item/device/radio/intercom/bridge{
+	broadcasting = 0;
+	pixel_x = -7;
+	pixel_y = 28
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname  - SS13"
+	},
+/obj/machinery/light/incandescent{
+	dir = 1;
+	nostick = 1
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/light_switch/north{
+	pixel_x = 9;
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fblue2"
+	},
+/area/station/bridge/captain)
 "aKh" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_normal"
@@ -8793,11 +9160,33 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery/storage)
 "aKl" = (
-/obj/stool/chair/wooden{
-	dir = 8
+/obj/table/reinforced/bar/auto{
+	name = "table"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/disposalpipe/trunk/mail,
+/obj/machinery/disposal/mail/small{
+	dir = 1;
+	mail_tag = "captain";
+	mailgroup = "command";
+	message = "1";
+	name = "mail chute-'Captain'";
+	pixel_y = 32
+	},
+/obj/machinery/light/lamp/green{
+	pixel_x = -6;
+	pixel_y = 12;
+	switchon = 1
+	},
+/obj/item/paper/book/from_file/space_law,
+/obj/item/reagent_containers/food/drinks/mug/random_color{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "fblue2"
+	},
+/area/station/bridge/captain)
 "aKn" = (
 /obj/item/device/radio/intercom/bridge{
 	broadcasting = 0;
@@ -8814,9 +9203,10 @@
 	},
 /area/station/security/hos)
 "aKq" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/hos)
+/obj/disposalpipe/segment,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "aKv" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -8834,13 +9224,11 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/navbeacon/tour/destiny/tour15,
-/obj/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/unary/outlet_injector{
+	icon_state = "on";
+	on = 1
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "aKx" = (
@@ -8921,7 +9309,7 @@
 	name = "E.V.A. Security Shield";
 	opacity = 0
 	},
-/obj/wingrille_spawn/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/storage/eva)
 "aKX" = (
@@ -8972,7 +9360,6 @@
 	name = "Genetic Research"
 	})
 "aKZ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -8981,6 +9368,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "aLa" = (
@@ -9013,6 +9401,20 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
+"aLf" = (
+/obj/item_dispenser/idcarddispenser,
+/obj/table/wood/auto/desk,
+/obj/item/folder{
+	pixel_y = 5
+	},
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen,
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads)
 "aLg" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -9026,48 +9428,53 @@
 	name = "West Central Maintenance"
 	})
 "aLh" = (
-/obj/disposalpipe/segment{
+/obj/potted_plant/potted_plant2{
 	dir = 1;
-	icon_state = "pipe-c"
+	pixel_y = 32
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/bridge/captain)
 "aLi" = (
-/obj/decal/tile_edge/stripe{
-	dir = 8;
-	icon_state = "xtra_bigstripe-edge"
+/obj/reagent_dispensers/fueltank,
+/obj/machinery/light_switch/north{
+	pixel_y = 28
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
 "aLj" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/storage/secure/closet/command/hop,
-/obj/decal/poster/wallsign/framed_award/firstbill{
-	pixel_y = 28
+/obj/stool/chair/office{
+	dir = 1
 	},
 /turf/simulated/floor/carpet{
-	dir = 9;
+	dir = 1;
 	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "aLm" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "aLn" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/cable{
+	icon_state = "0-2"
 	},
-/obj/machinery/navbeacon/tour/destiny/tour17,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/machinery/power/apc/autoname_north,
+/obj/table/wood/auto,
+/obj/machinery/shipalert{
+	pixel_x = 30;
+	pixel_y = -2
+	},
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen,
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/bridge/captain)
 "aLq" = (
 /obj/random_item_spawner/medicine,
 /obj/random_item_spawner/med_kit,
@@ -9216,18 +9623,19 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
 "aMa" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13"
 	},
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/lounge/port)
+/area/station/maintenance/central)
 "aMb" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "aMd" = (
@@ -9262,13 +9670,21 @@
 /area/station/maintenance/inner/west{
 	name = "West Central Maintenance"
 	})
-"aMr" = (
-/obj/disposalpipe/segment,
-/obj/machinery/light/emergency{
-	dir = 8
+"aMo" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
+"aMr" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/bridge/captain)
 "aMs" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9296,16 +9712,17 @@
 /area/station/science/lab)
 "aMt" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=escape";
-	location = "command_quarters";
-	name = "bot navigation beacon"
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Captain's Office";
+	req_access = null
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/captain,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/area/station/bridge/captain)
 "aMu" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -9404,13 +9821,13 @@
 /turf/simulated/floor/red,
 /area/station/science/lab)
 "aMx" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/pool)
 "aMy" = (
@@ -9443,8 +9860,16 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/light/small/floor/blueish,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "aME" = (
@@ -9472,15 +9897,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "aML" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
 	},
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/lounge/starboard)
+/area/station/maintenance/central)
 "aMN" = (
 /obj/cabinet/psychiatry,
 /obj/machinery/firealarm{
@@ -9533,7 +9959,13 @@
 /turf/simulated/floor/grey,
 /area/station/mining/refinery)
 "aNg" = (
-/obj/machinery/light,
+/obj/landmark/spawner{
+	name = "monkeyspawn_mrsmuggles"
+	},
+/obj/machinery/light/incandescent{
+	dir = 1;
+	nostick = 1
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -9551,7 +9983,6 @@
 /turf/simulated/floor/purple,
 /area/station/medical/medbay/pharmacy)
 "aNi" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/machinery/door/window/westright{
 	req_access_txt = "31"
@@ -9563,6 +9994,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/black,
 /area/station/quartermaster/office)
 "aNk" = (
@@ -9631,18 +10064,20 @@
 	},
 /area/station/medical/medbay)
 "aNN" = (
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "fblue2"
+/obj/table/wood/auto,
+/obj/item/storage/photo_album{
+	pixel_y = -10
 	},
-/area/station/bridge/captain)
+/obj/item/camera{
+	pixel_y = 6
+	},
+/obj/item/pinpointer,
+/obj/item/hand_tele,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
 "aNQ" = (
 /obj/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
@@ -9712,10 +10147,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "aOu" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "aOw" = (
@@ -9789,7 +10224,6 @@
 	},
 /area/station/medical/medbay/treatment)
 "aOH" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -9803,6 +10237,7 @@
 	name = "Teleporter Blast Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "aOJ" = (
@@ -9852,8 +10287,8 @@
 	name = "West Central Maintenance"
 	})
 "aOX" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/storage/tools)
 "aPb" = (
@@ -9867,8 +10302,8 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "aPc" = (
-/obj/disposalpipe/segment,
-/obj/machinery/vending/cola/red,
+/obj/disposalpipe/junction,
+/obj/shrub,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "aPd" = (
@@ -9886,7 +10321,11 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "aPf" = (
-/obj/stool/chair/wooden,
+/obj/stool/chair/wooden{
+	dir = 1
+	},
+/obj/landmark/gps_waypoint,
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon11,
 /turf/simulated/floor/grass/random/alt,
 /area/station/garden/aviary)
 "aPk" = (
@@ -9929,7 +10368,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aPq" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
 "aPs" = (
 /obj/decal/tile_edge/line/purple{
@@ -10078,11 +10517,13 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "aQa" = (
-/obj/machinery/light/emergency{
-	dir = 4
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/garden/aviary)
 "aQf" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 10;
@@ -10095,14 +10536,14 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "aQG" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Computer Core'";
-	req_access_txt = "19"
+/obj/machinery/door/airlock/pyro/command{
+	name = "Computer Core"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research_director,
 /turf/simulated/floor/purple,
 /area/station/science/research_director)
 "aQL" = (
@@ -10112,7 +10553,7 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aQM" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/ranch)
 "aQP" = (
 /obj/railing/yellow,
@@ -10197,30 +10638,39 @@
 	},
 /area/station/science/research_director)
 "aRK" = (
-/obj/decal/tile_edge/line/red{
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment/mail{
+/obj/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/secscanner{
+	dir = 4;
+	pixel_x = -20
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/stool/bench/auto,
-/obj/machinery/light,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pod Bay Storage"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/area/station/hangar/main)
 "aRO" = (
 /obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/west)
 "aRW" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "aRY" = (
@@ -10278,7 +10728,7 @@
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 8
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
 "aSj" = (
 /obj/disposalpipe/segment/morgue{
@@ -10312,8 +10762,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/east{
 	name = "East Central Maintenance"
@@ -10355,20 +10805,17 @@
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "aSB" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13"
-	},
 /obj/disposalpipe/segment,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=podbay";
+	location = "quarters_west";
+	name = "bot navigation beacon"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "aSG" = (
 /obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner/east{
 	name = "East Central Maintenance"
 	})
@@ -10387,10 +10834,12 @@
 /area/station/hallway/primary/west)
 "aSR" = (
 /turf/simulated/floor/carpet/blue/standard,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "aSU" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "aSV" = (
@@ -10458,8 +10907,15 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay)
+"aTi" = (
+/obj/machinery/vending/book,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "aTn" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -10490,13 +10946,13 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "aTt" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/main)
 "aTG" = (
@@ -10521,10 +10977,10 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "aTO" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/psychiatrist)
 "aTP" = (
@@ -10539,9 +10995,9 @@
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
 /obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "aTS" = (
@@ -10564,19 +11020,18 @@
 	dir = 4
 	},
 /area/station/science/research_director)
-"aTY" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/west)
 "aTZ" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 10
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"aUb" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
 "aUc" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -10644,10 +11099,13 @@
 /area/station/turret_protected/ai)
 "aUB" = (
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/security/alt{
-	name = "glass airlock-'Security'"
+/obj/machinery/door/airlock/pyro/glass/security{
+	dir = 8;
+	name = "Security";
+	req_access = null
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "aUC" = (
@@ -10689,16 +11147,22 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aUF" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13"
+/obj/disposalpipe/junction,
+/obj/table/auto/desk,
+/obj/machinery/computer3/generic/personal{
+	pixel_y = 9
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "aUH" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "aUI" = (
@@ -10711,8 +11175,14 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "aUS" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/md)
+/obj/stool/chair/office/yellow{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "aUT" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -10724,15 +11194,25 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
-"aUW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering/alt{
-	name = "airlock-'Engineering'";
-	req_access_txt = "44"
+"aUV" = (
+/obj/machinery/light,
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/bridge/captain)
+"aUW" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 8;
+	name = "Engineering"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering,
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "aUY" = (
@@ -10747,11 +11227,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/west)
 "aVa" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/engineering{
-	name = "glass airlock-'Quartermaster's Office'";
-	req_access_txt = "31"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -10766,6 +11241,11 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Cargo"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/orangeblack/side{
 	dir = 1
 	},
@@ -10796,10 +11276,9 @@
 	},
 /area/station/medical/cdc)
 "aVl" = (
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs2_wide"
-	},
+/obj/machinery/vending/standard,
+/obj/machinery/light,
+/turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "aVn" = (
 /obj/decal/cleanable/dirt,
@@ -10887,11 +11366,6 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "aVz" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/engineering{
-	name = "glass airlock-'Quartermaster's Office'";
-	req_access_txt = "31"
-	},
 /obj/decal/tile_edge/line/yellow{
 	dir = 10;
 	icon_state = "line1"
@@ -10901,6 +11375,11 @@
 	icon_state = "line1"
 	},
 /obj/disposalpipe/segment/mineral,
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Cargo"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "aVA" = (
@@ -10913,8 +11392,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple{
+	level = 2
+	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "aVF" = (
@@ -10964,22 +11446,23 @@
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "aVN" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/engine/gas)
 "aVT" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Computer Core'"
+/obj/machinery/door/airlock/pyro/command{
+	name = "Computer Core"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research_director,
 /turf/simulated/floor/plating/random,
 /area/station/turret_protected/Zeta)
 "aVX" = (
@@ -11024,10 +11507,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "aWh" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "aWj" = (
@@ -11070,11 +11553,11 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "aWm" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/research_director)
 "aWn" = (
@@ -11092,13 +11575,13 @@
 	},
 /area/station/solar/west)
 "aWq" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/engine/gas)
 "aWs" = (
@@ -11118,21 +11601,22 @@
 /turf/simulated/floor/blue,
 /area/station/science/lab)
 "aWE" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/engine/gas)
 "aWH" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical{
-	name = "glass airlock-'Monkeydome'";
-	req_access_txt = "9"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	name = "Monkeydome"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medlab,
 /turf/simulated/floor/grass/random,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -11222,7 +11706,6 @@
 	},
 /area/station/science/research_director)
 "aWU" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/window/reinforced/south,
 /obj/machinery/door/window/westleft{
@@ -11233,10 +11716,11 @@
 	desc = "Holy shit! This cake probably costs more than the gross domestic product of Bulgaria!";
 	name = "Extravagant Chocolate Gateau"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/kitchen,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "aWV" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -11244,6 +11728,7 @@
 	layer = 2.9;
 	pixel_y = 13
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/research_director)
 "aXb" = (
@@ -11339,15 +11824,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
+/obj/machinery/light_switch/west{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
@@ -11393,7 +11872,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/sw,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "aXB" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
@@ -11448,7 +11927,6 @@
 	},
 /area/station/turret_protected/Zeta)
 "aXO" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -11459,6 +11937,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/courtroom)
 "aXP" = (
@@ -11474,16 +11953,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"aXQ" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
 "aXT" = (
 /obj/lattice{
 	dir = 1;
@@ -11547,7 +12016,6 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aYn" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -11557,6 +12025,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/cdc)
 "aYp" = (
@@ -11574,10 +12043,12 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/obj/machinery/door/airlock/gannets/morgue/alt{
-	name = "airlock-'Morgue'";
-	req_access_txt = "29"
+/obj/machinery/door/airlock/pyro/medical/morgue{
+	dir = 4;
+	name = "Morgue"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/morgue,
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "aYr" = (
@@ -11598,14 +12069,17 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "aYy" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
 /obj/disposalpipe/switch_junction{
 	dir = 1;
 	icon_state = "pipe-sj2";
 	mail_tag = "pharmacy";
 	name = "pharmacy mail router"
 	},
+/obj/disposalpipe/segment/food{
+	dir = 4
+	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "aYz" = (
@@ -11625,7 +12099,7 @@
 /area/station/hallway/primary/west)
 "aYC" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/restroom)
 "aYD" = (
 /obj/cable{
@@ -11732,31 +12206,23 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aZs" = (
-/obj/stool/bed,
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/cable{
+	icon_state = "0-8"
 	},
-/obj/item/clothing/suit/bedsheet/red,
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/cable{
+	icon_state = "0-2"
 	},
-/obj/blind_switch/area/east{
-	dir = 4
-	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/garden/aviary)
 "aZw" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/black,
 /area/station/ranch)
 "aZC" = (
@@ -11768,13 +12234,9 @@
 	can_rupture = 0;
 	dir = 10
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "aZE" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -11787,6 +12249,7 @@
 	name = "Chemistry Shutter";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/chemistry)
 "aZL" = (
@@ -11839,29 +12302,35 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bab" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Crew Quarters'"
+/obj/disposalpipe/segment,
+/obj/table/auto/desk,
+/obj/item/paper_bin{
+	pixel_y = 5
 	},
+/obj/item/pen,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/area/station/hallway/primary/north)
 "bac" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/pool)
 "baf" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/pool)
 "bah" = (
@@ -11920,26 +12389,25 @@
 	dir = 5
 	},
 /obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
 "baB" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	name = "glass airlock-'Research'"
-	},
 /obj/decal/tile_edge/line/purple{
 	dir = 5;
 	icon_state = "line1"
 	},
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4;
+	name = "Research"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "baE" = (
@@ -11974,25 +12442,16 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "baO" = (
-/obj/table/wood/auto,
-/obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
-"bbc" = (
-/obj/decal/tile_edge/line/green{
-	icon_state = "line1"
-	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/turf/simulated/floor/grass/random/alt,
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
 /area/station/garden/aviary)
+"bbc" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "bbg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -12003,13 +12462,16 @@
 	},
 /area/station/quartermaster/cargobay)
 "bbo" = (
-/obj/wingrille_spawn/reinforced_crystal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/garden/aviary)
+/area/station/hallway/primary/north)
 "bbr" = (
 /obj/item/storage/toolbox/emergency,
 /obj/item/storage/firstaid/oxygen,
@@ -12185,7 +12647,7 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/treatment)
 "bbZ" = (
 /obj/disposalpipe/segment,
@@ -12196,7 +12658,6 @@
 /turf/simulated/floor/purple,
 /area/station/science/research_director)
 "bce" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -12209,10 +12670,10 @@
 	name = "Chemistry Shutter";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/chemistry)
 "bcf" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -12229,10 +12690,10 @@
 	name = "Chemistry Shutter";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/chemistry)
 "bcg" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -12248,10 +12709,11 @@
 	name = "Chemistry Shutter";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/chemistry)
 "bch" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/restroom)
 "bcl" = (
 /obj/machinery/portable_reclaimer,
@@ -12277,7 +12739,6 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "bcD" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -12291,6 +12752,7 @@
 	name = "E.V.A. Security Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/storage/eva)
 "bcF" = (
@@ -12330,11 +12792,11 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "bcN" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/courtroom)
 "bcU" = (
@@ -12357,7 +12819,6 @@
 	name = "Genetic Research"
 	})
 "bdc" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -12374,6 +12835,7 @@
 	opacity = 0
 	},
 /obj/disposalpipe/segment,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/storage/eva)
 "bdd" = (
@@ -12395,14 +12857,15 @@
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/south)
 "bdj" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'Mining'";
-	req_access_txt = "50"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/mining{
+	dir = 1;
+	name = "Refinery"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/mining,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "bdl" = (
@@ -12433,6 +12896,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
+"bdu" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "purple2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M01"
+	})
 "bdL" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 8;
@@ -12449,20 +12922,20 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "bdQ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "bdV" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/artifact)
 "bdY" = (
@@ -12480,7 +12953,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/restroom)
 "beb" = (
 /obj/disposalpipe/switch_junction{
@@ -12506,19 +12979,23 @@
 /area/station/maintenance/west)
 "bej" = (
 /obj/disposalpipe/segment,
-/obj/machinery/recharge_station,
+/obj/table/auto/desk,
+/obj/machinery/networked/printer{
+	name = "Customs";
+	pixel_y = 7
+	},
+/obj/cable,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "beo" = (
-/obj/stool/chair/comfy/red{
-	dir = 8
+/obj/disposalpipe/segment/mail,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon9,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "bep" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
@@ -12536,7 +13013,7 @@
 /area/station/crew_quarters/barber_shop)
 "bey" = (
 /obj/disposalpipe/segment,
-/obj/machinery/photocopier,
+/obj/stool/chair/office/red,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "beM" = (
@@ -12549,12 +13026,12 @@
 "beT" = (
 /obj/forcefield/energyshield/perma,
 /turf/simulated/floor/stairs/medical/wide/other,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "beU" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/disposal)
 "bfd" = (
 /obj/disposalpipe/switch_junction{
@@ -12571,7 +13048,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "bfe" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/window/reinforced/west,
 /obj/item/clipboard,
@@ -12583,6 +13059,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/engine/elect)
 "bff" = (
@@ -12612,10 +13089,11 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "bfp" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 1
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/carpet/red/fancy/narrow/south,
 /area/station/crew_quarters/bar)
 "bfq" = (
@@ -12639,7 +13117,6 @@
 /turf/simulated/floor/purplewhite,
 /area/station/science/artifact)
 "bfu" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -12647,13 +13124,14 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/bot_storage)
 "bfw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Dressing Room'"
+/obj/machinery/door/airlock/pyro{
+	name = "Dressing Room"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/bar)
 "bfz" = (
@@ -12716,10 +13194,6 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "bfX" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/security/alt{
-	name = "airlock-'Security'"
-	},
 /obj/machinery/secscanner{
 	dir = 4;
 	pixel_x = -20
@@ -12727,6 +13201,11 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "bgb" = (
@@ -12808,29 +13287,36 @@
 /obj/stool/chair/comfy/blue{
 	dir = 8
 	},
-/obj/landmark/start{
-	name = "Captain"
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "N APC";
+	pixel_y = 24
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "fblue2"
+/obj/blind_switch/area/north{
+	pixel_x = -10;
+	pixel_y = 28
 	},
-/area/station/bridge/captain)
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
 "bgB" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "fblue1"
+/obj/machinery/light_switch/north{
+	pixel_x = -5;
+	pixel_y = 28
 	},
-/area/station/bridge/captain)
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
 "bgF" = (
 /obj/machinery/light{
 	dir = 4
@@ -12838,36 +13324,23 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bgJ" = (
-/obj/table/reinforced/bar/auto{
-	name = "table"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/item/clipboard{
-	pixel_y = 5
-	},
-/obj/item/paper_bin{
-	pixel_y = 5
-	},
-/obj/item/stamp/cap{
-	pixel_y = 5
-	},
-/obj/item/pen/fancy,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 4;
-	icon_state = "fblue2"
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
 	},
-/area/station/bridge/captain)
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
 "bgM" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 8;
+	name = "Captain's Nest"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/bridge/captain)
+/obj/firedoor_spawn,
+/obj/access_spawn/captain,
+/turf/simulated/floor/sanitary/blue,
+/area/station/crew_quarters/captain)
 "bgR" = (
 /obj/machinery/chem_master,
 /obj/decal/poster/wallsign/poster_ptoe{
@@ -12878,16 +13351,11 @@
 	},
 /area/station/science/chemistry)
 "bgS" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/bridge/captain)
+/turf/simulated/floor/sanitary/blue,
+/area/station/crew_quarters/captain)
 "bgT" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/clipboard,
@@ -12939,10 +13407,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "bhw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Courtroom'"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Courtroom"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
 "bhA" = (
@@ -12955,15 +13424,15 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "bhD" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/toxins{
-	name = "glass airlock-'Toxins'";
-	req_access_txt = "7"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/toxins_alt{
+	name = "Toxins"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/tox,
 /turf/simulated/floor,
 /area/station/science/lab)
 "bhE" = (
@@ -13024,7 +13493,7 @@
 	layer = 3.9
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/nw,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "bhT" = (
 /obj/decal/tile_edge/line/black{
 	dir = 10;
@@ -13033,7 +13502,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "bhX" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/barber_shop)
 "bhY" = (
 /obj/decal/tile_edge/line/grey{
@@ -13111,7 +13580,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/wingrille_spawn,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "bip" = (
@@ -13142,15 +13611,17 @@
 	},
 /area/station/crew_quarters/observatory)
 "biH" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/arcade)
 "biT" = (
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
+/obj/stool/chair/wooden{
+	dir = 8
 	},
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "biV" = (
 /obj/decal/tile_edge/line/white{
 	dir = 4;
@@ -13175,11 +13646,11 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "bjb" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/secondary/construction)
 "bjf" = (
@@ -13237,11 +13708,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "bjr" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Janitor Supply Closet";
-	req_access_txt = "26"
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 1;
+	name = "Janitor's Closet"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/janitor,
 /turf/simulated/floor,
 /area/station/janitor/supply)
 "bjs" = (
@@ -13375,7 +13847,7 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "bkt" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner/west{
 	name = "West Central Maintenance"
 	})
@@ -13427,7 +13899,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering/ce)
 "bkD" = (
 /obj/decal/tile_edge/stripe{
@@ -13528,10 +14000,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "bkT" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	name = "glass airlock-'Research'"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -13539,24 +14007,19 @@
 	dir = 6;
 	icon_state = "line1"
 	},
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4;
+	name = "Research"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "bkW" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/royal,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/machinery/light_switch/east{
-	dir = 4
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/obj/disposalpipe/segment,
+/obj/machinery/photocopier,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "bkY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -13576,7 +14039,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "bll" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
@@ -13584,6 +14046,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/kitchen)
 "bls" = (
@@ -13606,10 +14069,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "blJ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/secondary/construction)
 "blM" = (
@@ -13648,7 +14111,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/cdc)
 "bmz" = (
 /obj/machinery/disposal/mail/small{
@@ -13662,10 +14125,10 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bmF" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "bmL" = (
@@ -13713,24 +14176,24 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "bmX" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Disposals'"
-	},
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/door/airlock/pyro/classic{
+	name = "Disposals"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "bmY" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/toxins{
-	name = "airlock-'Pathology Research'";
-	req_access_txt = "84"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/toxins_alt{
+	name = "Pathology"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/pathology,
 /turf/simulated/floor,
 /area/station/medical/cdc)
 "bng" = (
@@ -13754,7 +14217,6 @@
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
 "bnq" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -13766,6 +14228,7 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "bnt" = (
@@ -13783,7 +14246,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/clown)
 "bnx" = (
 /obj/machinery/shower{
@@ -13792,21 +14255,11 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
-"bnC" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
 "bnG" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/security/hos)
 "bnO" = (
@@ -13825,10 +14278,11 @@
 /area/station/medical/medbay)
 "bnX" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/window/eastleft{
 	req_access_txt = "1"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "bnY" = (
@@ -13862,25 +14316,19 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "bon" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/showers{
 	name = "Pool Shower Room"
 	})
 "boq" = (
-/obj/critter/owl{
-	aggressive = 0;
-	angertext = "hoots uncontrollably at";
-	atkcarbon = 1;
-	health = 10000;
-	name = "Hooty McOwlface"
+/obj/cable{
+	icon_state = "4-8"
 	},
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/bluegreen/side{
-	dir = 1
-	},
-/area/station/garden/aviary)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "bot" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -13898,7 +14346,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "bou" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/window/reinforced/west,
 /obj/item/clipboard,
@@ -13913,6 +14360,7 @@
 /obj/disposalpipe/segment/mineral{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/quartermaster/office)
 "bov" = (
@@ -13965,11 +14413,16 @@
 	},
 /area/station/science/chemistry)
 "boZ" = (
+/obj/decal/mule/beacon,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	location = "North Primary Hall"
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "bpd" = (
 /obj/decal/stage_edge,
 /obj/table/reinforced/bar/auto,
@@ -14007,7 +14460,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/clown)
 "bpi" = (
 /obj/machinery/shower{
@@ -14034,18 +14487,19 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1"
+	icon_state = "purple1"
 	},
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
 "bpo" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/command/alt{
-	name = "airlock-'Chief Engineer's Office'";
-	req_access_txt = "49"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Chief Engineer's Office"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_chief,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -14061,7 +14515,6 @@
 /turf/space,
 /area/station/engine/core)
 "bpq" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -14069,6 +14522,7 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "bps" = (
@@ -14090,7 +14544,6 @@
 	dir = 8
 	},
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -14103,11 +14556,11 @@
 	dir = 9;
 	icon_state = "line1"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "bpw" = (
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -14123,6 +14576,7 @@
 /obj/machinery/light/emergency{
 	dir = 4
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "bpx" = (
@@ -14155,7 +14609,6 @@
 	},
 /area/station/science/teleporter)
 "bpJ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
@@ -14163,6 +14616,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/north)
 "bpO" = (
@@ -14218,7 +14672,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
 "bpZ" = (
 /obj/machinery/light{
@@ -14276,11 +14730,12 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/engineering{
-	name = "glass airlock-'Engineering'";
-	req_access_txt = "44"
+/obj/machinery/door/airlock/pyro/engineering/alt{
+	dir = 4;
+	name = "Engine Room"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor,
 /area/station/engine/gas)
 "bqp" = (
@@ -14445,7 +14900,7 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "brp" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/showers)
 "brt" = (
 /obj/disposalpipe/segment/mail{
@@ -14455,10 +14910,7 @@
 	icon_state = "2-8"
 	},
 /obj/decal/poster/wallsign/engineering,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "brw" = (
 /obj/disposalpipe/segment/mail{
@@ -14467,16 +14919,16 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "bry" = (
-/obj/wingrille_spawn/reinforced_crystal,
 /obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/garden/aviary)
+/area/station/hallway/primary/north)
 "brA" = (
 /obj/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -14528,7 +14980,6 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -14545,6 +14996,7 @@
 	dir = 4;
 	name = "autoname - SS13"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "brH" = (
@@ -14554,7 +15006,6 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -14567,6 +15018,7 @@
 	dir = 6;
 	icon_state = "line1"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "brI" = (
@@ -14592,10 +15044,10 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "brO" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/observatory)
 "brQ" = (
@@ -14603,9 +15055,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "purple1"
+	icon_state = "fgreen1"
 	},
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "brW" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -14627,18 +15079,17 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "bsd" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fred1"
+	},
+/area/station/crew_quarters/hos)
 "bsl" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -14745,8 +15196,8 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "bsH" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/north)
 "bsK" = (
@@ -14783,6 +15234,13 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge)
+"bsV" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/ranch)
 "bsZ" = (
 /obj/landmark/start{
 	name = "AI"
@@ -14880,13 +15338,9 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "btU" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "fgreen2"
-	},
-/area/station/crew_quarters/heads)
+/obj/machinery/light/small/floor/blueish,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "buf" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -15056,14 +15510,16 @@
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "buN" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Medical Director's Office'";
-	req_access_txt = "53"
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 1;
+	id = "medirecdoor";
+	name = "Medical Director's Office"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical_director,
 /turf/simulated/floor/white,
 /area/station/medical/head)
 "buS" = (
@@ -15238,9 +15694,11 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen1"
+	icon_state = "fred1"
 	},
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "bvu" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
@@ -15339,14 +15797,15 @@
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/catering)
 "bvI" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical{
-	name = "airlock-'Operating Theater'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	name = "Operating Theater"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "bvJ" = (
@@ -15421,7 +15880,7 @@
 	dir = 10;
 	level = 2
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/catering)
 "bvR" = (
 /obj/machinery/light/incandescent/harsh{
@@ -15441,7 +15900,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "bvV" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5
@@ -15455,16 +15914,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "bwd" = (
-/obj/critter/bat/doctor,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
 	name = "autoname - SS13"
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "fblue2"
-	},
-/area/station/crew_quarters/md)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "bwj" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -15593,8 +16049,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "bwE" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/stool/bench/green/auto,
+/obj/machinery/light/incandescent{
+	nostick = 1
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
@@ -15719,13 +16176,13 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bxh" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/brig)
 "bxx" = (
@@ -15835,11 +16292,11 @@
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "bxW" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -15862,7 +16319,6 @@
 /area/station/engine/engineering)
 "byb" = (
 /obj/cable,
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 1;
@@ -15874,6 +16330,7 @@
 	opacity = 0
 	},
 /obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "byh" = (
@@ -15957,11 +16414,12 @@
 	},
 /area/station/engine/engineering)
 "byu" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "byw" = (
@@ -15975,11 +16433,11 @@
 	name = "Combustion Chamber Heat Shield";
 	opacity = 0
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/core)
 "byx" = (
@@ -15992,7 +16450,6 @@
 	name = "Combustion Chamber Heat Shield";
 	opacity = 0
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
@@ -16000,6 +16457,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/core)
 "byy" = (
@@ -16013,11 +16471,11 @@
 	name = "Combustion Chamber Heat Shield";
 	opacity = 0
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/core)
 "byB" = (
@@ -16137,8 +16595,9 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
 "byQ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon13,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "byR" = (
@@ -16242,13 +16701,19 @@
 /turf/space,
 /area/space)
 "bzo" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
+/obj/window_blinds/cog2/middle{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/hallway/primary/north)
+/area/station/bridge/captain)
 "bzq" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -16670,7 +17135,7 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost)
@@ -16974,14 +17439,25 @@
 /area/space)
 "bBw" = (
 /obj/disposalpipe/segment,
-/obj/machinery/vending/coffee,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "bBx" = (
-/turf/simulated/floor/carpet{
-	icon_state = "fblue2"
+/obj/window_blinds/cog2/middle{
+	dir = 4
 	},
-/area/station/crew_quarters/md)
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/bridge/captain)
 "bBy" = (
 /obj/landmark/map{
 	name = "DESTINY"
@@ -16990,10 +17466,7 @@
 /area/space)
 "bBz" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "bBA" = (
 /obj/cable{
@@ -17017,17 +17490,14 @@
 /area/station/engine/core)
 "bBG" = (
 /obj/disposalpipe/segment/food,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen)
 "bBH" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "bBI" = (
 /obj/cable{
@@ -17044,7 +17514,7 @@
 	dir = 4;
 	name = "combustion chamber inlet valve"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "bBQ" = (
 /obj/cable{
@@ -17059,6 +17529,14 @@
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"bBT" = (
+/obj/window_blinds/cog2/left{
+	dir = 4
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/bridge/captain)
 "bCj" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -17104,17 +17582,18 @@
 /turf/space,
 /area/space)
 "bDd" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Teleporter'";
-	req_access_txt = "17"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Teleporter"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/teleporter,
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "bDg" = (
@@ -17157,19 +17636,15 @@
 /area/station/crew_quarters/kitchen)
 "bEj" = (
 /obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "2-8"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 8
 	},
-/turf/simulated/floor/carpet{
-	dir = 8;
-	icon_state = "fblue2"
-	},
-/area/station/crew_quarters/md)
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northeast)
 "bEs" = (
 /turf/simulated/floor/red,
 /area/station/security/main)
@@ -17184,7 +17659,6 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "bFc" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
@@ -17195,6 +17669,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "bFk" = (
@@ -17208,7 +17683,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "bFn" = (
 /obj/decal/tile_edge/line/red{
 	dir = 4;
@@ -17292,7 +17767,7 @@
 /turf/simulated/floor/carpet/blue/standard/edge/ne,
 /area/station/maintenance/inner/south)
 "bHI" = (
-/obj/machinery/light{
+/obj/machinery/light/emergency{
 	dir = 4
 	},
 /turf/simulated/floor/black,
@@ -17313,7 +17788,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/cargobay)
 "bIa" = (
 /obj/cable{
@@ -17368,13 +17843,13 @@
 /turf/simulated/floor/black,
 /area/station/ai_monitored/storage/eva)
 "bKE" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/security/beepsky)
 "bKN" = (
@@ -17404,16 +17879,14 @@
 	},
 /area/station/crew_quarters/fitness)
 "bLc" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "black";
-	icon_state = "bedsheet-black"
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "fblue2"
-	},
-/area/station/crew_quarters/md)
+/obj/rack,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/clothing/head/emerg,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/air,
+/obj/item/crowbar,
+/turf/simulated/floor,
+/area/station/hangar/main)
 "bLl" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -17428,19 +17901,15 @@
 /turf/simulated/floor/black,
 /area/station/ai_monitored/storage/eva)
 "bLM" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/right{
-	dir = 8
-	},
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/md)
+/obj/rack,
+/obj/item/clothing/head/emerg,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/clothing/mask/breath,
+/obj/item/crowbar,
+/obj/item/tank/air,
+/turf/simulated/floor,
+/area/station/hangar/main)
 "bLW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/chemistry{
-	name = "airlock-'Test Chamber'";
-	req_access_txt = "33"
-	},
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 1;
@@ -17451,6 +17920,11 @@
 	name = "Teleporter Blast Shield";
 	opacity = 0
 	},
+/obj/machinery/door/airlock/pyro/toxins_alt{
+	dir = 8;
+	name = "Test Chamber"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "bMy" = (
@@ -17517,7 +17991,7 @@
 /area/station/hallway/primary/southeast)
 "bND" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/security/main)
 "bNL" = (
 /obj/decal/tile_edge/line/yellow{
@@ -17565,7 +18039,7 @@
 /obj/machinery/r_door_control{
 	id = "pod_star"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/qm)
 "bPV" = (
 /obj/cable{
@@ -17578,7 +18052,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/west)
 "bQt" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/obj/machinery/light,
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
 /area/station/bridge/captain)
 "bQv" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -17591,6 +18068,14 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/catering)
+"bQK" = (
+/obj/shrub{
+	dir = 4;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "bQX" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 6;
@@ -17638,21 +18123,21 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "bTw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/toxins{
-	name = "airlock-'Toxins'";
-	req_access_txt = "7"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/toxins_alt{
+	name = "Toxins"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/tox,
 /turf/simulated/floor/plating/random,
 /area/station/science/lab)
 "bTG" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hangar/qm)
 "bTH" = (
@@ -17790,13 +18275,15 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "bWA" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical{
-	name = "airlock-'Operating Theater'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 4;
+	name = "Operating Theater"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "bXe" = (
@@ -17869,11 +18356,23 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
+"bYy" = (
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/computer/stockexchange,
+/obj/noticeboard/persistent{
+	name = "Crew Quarters persistent notice board";
+	persistent_id = "crew quarters"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "bYC" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "bZb" = (
 /obj/disposalpipe/segment,
@@ -17896,7 +18395,6 @@
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "bZX" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/window/reinforced/west,
 /obj/machinery/door/window/northleft{
@@ -17910,6 +18408,7 @@
 /obj/item/pen,
 /obj/item/stamp,
 /obj/disposalpipe/segment/food,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "caf" = (
@@ -17927,7 +18426,6 @@
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "car" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/window/reinforced/east,
 /obj/machinery/door/window/northright{
@@ -17939,6 +18437,7 @@
 /obj/item/reagent_containers/food/snacks/sandwich/meat_m{
 	name = "100% synthetic freerange monkey sandwich"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/crew_quarters/kitchen)
 "caD" = (
@@ -17993,7 +18492,10 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/main)
 "cbq" = (
-/obj/machinery/door/airlock/gannets/alt,
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "shower"
+	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "cbS" = (
@@ -18005,11 +18507,6 @@
 	},
 /area/station/medical/medbay/treatment)
 "ccz" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Computer Core'";
-	req_access_txt = "19"
-	},
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -18019,6 +18516,12 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Computer Core"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research_director,
 /turf/simulated/floor,
 /area/station/turret_protected/Zeta)
 "ccK" = (
@@ -18034,6 +18537,7 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "ccN" = (
+/obj/disposalpipe/trunk,
 /obj/stool/chair/couch{
 	dir = 8;
 	icon_state = "chair_couch-blue";
@@ -18082,7 +18586,6 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "cdK" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2{
 	dir = 4
 	},
@@ -18095,14 +18598,16 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/cloner)
 "cec" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/morgue{
-	name = "airlock-'Chapel Office'";
-	req_access_txt = "22"
+/obj/machinery/door/airlock/pyro/medical/morgue{
+	dir = 4;
+	name = "Chaplain's Office"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/chapel_office,
 /turf/simulated/floor/stairs{
 	dir = 8;
 	icon_state = "wood2_stairs"
@@ -18178,17 +18683,8 @@
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
-"cfQ" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
-/area/station/engine/core)
 "cfS" = (
 /obj/decoration/decorativeplant/plant7,
 /obj/machinery/light/incandescent/netural{
@@ -18248,31 +18744,21 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lab)
-"cgR" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13"
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P03"
-	})
 "cgY" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	can_rupture = 0;
 	dir = 10
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "chm" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon14,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "chx" = (
 /obj/stool/chair/couch{
 	dir = 4;
@@ -18294,6 +18780,12 @@
 	dir = 5
 	},
 /area/station/hydroponics/bay)
+"chI" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/lounge/starboard)
 "chN" = (
 /obj/item/clothing/shoes/pink{
 	pixel_y = -6
@@ -18321,14 +18813,15 @@
 /turf/simulated/floor/specialroom/clown,
 /area/station/crew_quarters/clown)
 "civ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Hydroponics'";
-	req_access_txt = "35"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 8;
+	name = "Hydroponics"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/hydro,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "ciz" = (
@@ -18381,15 +18874,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "cjy" = (
-/obj/decal/poster/wallsign/poster_y4nt{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
+	dir = 6
 	},
-/obj/decal/tile_edge/line/red{
-	dir = 10;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P02"
+	})
 "cjC" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -18465,7 +18956,7 @@
 	dir = 4;
 	name = "crematorium pipe"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
@@ -18479,7 +18970,6 @@
 /turf/simulated/floor/yellow,
 /area/station/hallway/secondary/construction)
 "clo" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -18489,10 +18979,13 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/door/airlock/gannets/chemistry{
-	name = "airlock-'Science Teleporter'"
-	},
 /obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/medical{
+	name = "Teleporter Control Room";
+	req_access = null;
+	req_access_txt = null
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/orangeblack,
 /area/station/science/teleporter)
 "clt" = (
@@ -18548,7 +19041,6 @@
 /turf/simulated/floor/grey,
 /area/station/mining/refinery)
 "cmz" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/middle{
 	dir = 8
 	},
@@ -18556,6 +19048,7 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -18634,7 +19127,7 @@
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "cor" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
 "coJ" = (
 /obj/machinery/light/incandescent{
@@ -18647,7 +19140,6 @@
 	},
 /area/station/science/lobby)
 "coZ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -18655,6 +19147,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/head)
 "cpn" = (
@@ -18756,10 +19249,17 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "cqv" = (
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs_wide"
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.5;
+	pixel_x = 24
 	},
+/obj/shrub{
+	dir = 4;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
+/turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "cqy" = (
 /obj/decal/tile_edge/line/green{
@@ -18799,13 +19299,13 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "crr" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "cru" = (
@@ -18817,15 +19317,13 @@
 	},
 /area/station/security/hos)
 "crG" = (
-/obj/decal/tile_edge/line/blue{
-	dir = 6;
-	icon_state = "line1"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
 	},
-/obj/potted_plant/potted_plant2{
-	dir = 4
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/space,
+/area/space)
 "crL" = (
 /obj/table/reinforced/auto,
 /obj/item/aiModule/reset,
@@ -18869,7 +19367,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "csz" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen)
 "csC" = (
 /obj/submachine/poster_creator{
@@ -19030,7 +19528,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southeast)
 "cxn" = (
 /obj/decal/tile_edge/line/white{
@@ -19047,14 +19545,12 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "cxX" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical{
-	id = "cloning";
-	name = "glass airlock-'Cloning'";
-	req_access_txt = "9"
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 8;
+	name = "Cloning"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 1
@@ -19097,25 +19593,26 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
-"czI" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
+"czr" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "purple2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M01"
 	})
+"czI" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/northwest)
 "czX" = (
 /obj/landmark{
 	name = "kudzustart"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
-"cAf" = (
-/obj/disposalpipe/trunk,
-/obj/machinery/disposal/small{
-	dir = 1;
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "cAo" = (
 /obj/decal/tile_edge/line/green{
 	dir = 10;
@@ -19149,7 +19646,6 @@
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "cAB" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
@@ -19159,13 +19655,13 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "cAY" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
+/obj/airbridge_controller{
+	id = "merchant_R";
+	primary_controller = 1
 	},
 /turf/space,
 /area/space)
@@ -19176,13 +19672,13 @@
 /turf/simulated/floor/delivery,
 /area/station/storage/tools)
 "cBI" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "cBV" = (
@@ -19195,8 +19691,18 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "cBW" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/medical/medbooth)
+/obj/potted_plant/potted_plant4{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/stool/chair/office/red,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "red2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P02"
+	})
 "cBY" = (
 /obj/decal/tile_edge/line/green{
 	dir = 6;
@@ -19224,12 +19730,13 @@
 	},
 /area/station/hydroponics/bay)
 "cCx" = (
-/obj/decal/tile_edge/line/red{
-	dir = 8;
-	icon_state = "line1"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname  - SS13"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/space,
+/area/space)
 "cCQ" = (
 /obj/decal/tile_edge/line/white{
 	icon_state = "line3"
@@ -19262,10 +19769,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "44|50"
-	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/west{
 	name = "West Central Maintenance"
@@ -19278,15 +19783,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
-"cFb" = (
+"cEW" = (
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "green2"
 	},
 /area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
+	name = "Crew Quarters P01"
 	})
 "cFs" = (
 /obj/decal/tile_edge/line/white{
@@ -19327,12 +19832,13 @@
 /turf/simulated/floor/specialroom/clown,
 /area/station/crew_quarters/clown)
 "cGP" = (
-/obj/disposalpipe/segment,
-/obj/disposalpipe/segment/brig{
-	dir = 4
+/obj/cable{
+	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mail,
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon15,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/area/station/hallway/primary/central)
 "cHJ" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -19341,17 +19847,6 @@
 	dir = 4
 	},
 /area/station/hangar/sec)
-"cHM" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
 "cIg" = (
 /obj/decal/tile_edge/line/red{
 	icon_state = "line3"
@@ -19363,11 +19858,11 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cIj" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "cID" = (
@@ -19385,18 +19880,18 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "cIT" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/ranch)
 "cJB" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Restroom'"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 1
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "cJG" = (
@@ -19447,7 +19942,6 @@
 	name = "West Central Maintenance"
 	})
 "cKN" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -19455,6 +19949,7 @@
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "cKW" = (
@@ -19523,31 +20018,33 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "cMt" = (
-/obj/machinery/vending/air_vendor,
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
-"cMB" = (
+/obj/table/wood/auto,
+/obj/item/reagent_containers/food/drinks/bottle/hobo_wine,
+/obj/machinery/light/lamp/bright,
+/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/disposalpipe/junction{
+/turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "pipe-j2";
-	name = "prisoner router"
+	icon_state = "purple2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M01"
+	})
+"cMB" = (
+/obj/decal/tile_edge/line/red{
+	dir = 8;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "cMF" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/green,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	dir = 5;
+	dir = 6;
 	icon_state = "green2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -19563,15 +20060,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
-"cMO" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor/vertical{
-	dir = 8
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "cNk" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -19582,28 +20070,33 @@
 /turf/simulated/floor/specialroom/clown,
 /area/station/crew_quarters/clown)
 "cNy" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
+/obj/decal/tile_edge/line/blue{
+	dir = 4;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "cNA" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/clown)
 "cNQ" = (
-/obj/landmark{
-	name = "blobstart"
+/obj/disposalpipe/segment/brig{
+	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northwest)
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "cNW" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -19617,11 +20110,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "cOo" = (
-/obj/landmark{
-	name = "blobstart"
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
 "cOv" = (
 /obj/decal/tile_edge/line/green{
 	dir = 6;
@@ -19630,10 +20123,10 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "cOB" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "cOJ" = (
@@ -19643,23 +20136,17 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "cON" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/segment/mail,
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 4
 	},
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Captain's Office'";
-	req_access_txt = "20"
-	},
-/turf/simulated/floor/black,
-/area/station/bridge/captain)
+/turf/simulated/floor/sanitary/blue,
+/area/station/crew_quarters/captain)
 "cOP" = (
-/obj/decal/tile_edge/stripe{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
@@ -19668,7 +20155,7 @@
 	dir = 5;
 	level = 2
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southwest)
 "cQd" = (
 /obj/decal/tile_edge/line/white{
@@ -19691,12 +20178,12 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "cQT" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "cQY" = (
@@ -19729,26 +20216,22 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "cRl" = (
-/obj/stool/chair/comfy/blue{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "N APC";
-	pixel_y = 24
-	},
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "2-4"
+	},
+/obj/stool/chair/comfy/blue,
+/obj/cable{
+	icon_state = "4-8"
 	},
 /obj/blind_switch/area/north{
-	pixel_x = -10;
 	pixel_y = 28
 	},
-/obj/cable{
-	icon_state = "0-8"
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "cRs" = (
 /obj/machinery/guardbot_dock,
 /obj/machinery/power/data_terminal,
@@ -19803,13 +20286,13 @@
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/research_director)
 "cRY" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/armory)
 "cSp" = (
@@ -19830,18 +20313,19 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/light_switch/north{
 	pixel_x = -5;
 	pixel_y = 28
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "cTp" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/fitness)
 "cTA" = (
 /obj/decal/tile_edge/line/red{
@@ -19865,31 +20349,17 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
-"cUk" = (
-/obj/machinery/vending/pizza{
-	anchored = 1
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
 "cUl" = (
-/obj/stool/chair/couch/green{
-	dir = 4
+/turf/simulated/floor/stairs{
+	icon_state = "Stairs2_wide"
 	},
-/obj/machinery/power/apc/autoname_north,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor,
 /area/station/crew_quarters/lounge/starboard)
 "cUo" = (
+/obj/table/wood/auto/desk,
 /obj/machinery/firealarm{
 	layer = 3.5;
 	pixel_y = 28
 	},
-/obj/table/wood/auto/desk,
 /obj/item/folder,
 /obj/item/paper_bin{
 	pixel_y = 3
@@ -19897,19 +20367,18 @@
 /obj/item/pen,
 /turf/simulated/floor/carpet{
 	dir = 5;
-	icon_state = "fgreen2"
+	icon_state = "fpurple2"
 	},
-/area/station/crew_quarters/ce)
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "cUq" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/equipment)
 "cUy" = (
 /turf/simulated/floor/carpet/blue/standard/innercorner/east,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "cUC" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 4;
@@ -19939,19 +20408,42 @@
 	name = "West Central Maintenance"
 	})
 "cUO" = (
-/obj/critter/cat/jones,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "N APC";
+	pixel_y = 24
+	},
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/green{
+	pixel_x = -6;
+	pixel_y = 4;
+	switchon = 1
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "cUP" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Captain's Restroom'"
+/obj/table/wood/auto,
+/obj/item/device/gps{
+	pixel_y = 5
 	},
-/turf/simulated/floor/sanitary/blue,
-/area/station/crew_quarters/captain)
+/obj/item/reagent_containers/food/drinks/rum_spaced{
+	pixel_y = 8
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "cUU" = (
 /obj/rack,
 /obj/item/chem_grenade/firefighting,
@@ -19987,25 +20479,24 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
-"cVE" = (
-/obj/decal/tile_edge/stripe{
-	icon_state = "xtra_bigstripe-edge";
-	pixel_y = 10
-	},
-/obj/railing/yellow{
-	pixel_y = 10
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/starboard)
 "cVU" = (
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'"
+/obj/decal/poster/wallsign/security{
+	icon_state = "sec"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/black,
-/area/station/maintenance/northwest)
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "cWh" = (
 /obj/table/round/auto,
 /obj/machinery/cashreg,
@@ -20097,11 +20588,26 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "cXp" = (
-/obj/machinery/light{
-	dir = 1
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "hop";
+	icon_state = "bedsheet-hop"
 	},
-/turf/simulated/floor/sanitary/blue,
-/area/station/crew_quarters/captain)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname  - SS13"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "cXv" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/engine,
@@ -20117,7 +20623,6 @@
 /turf/simulated/floor/red/checker,
 /area/station/security/main)
 "cYl" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
@@ -20130,6 +20635,7 @@
 	name = "Chamber Two Heat Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "cYt" = (
@@ -20137,7 +20643,6 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "cYR" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/middle{
 	dir = 4
 	},
@@ -20145,14 +20650,15 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/bridge/captain)
+/area/station/crew_quarters/captain)
 "cZl" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/secondary/construction)
 "cZn" = (
@@ -20183,11 +20689,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/east)
 "cZE" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/toxins{
-	name = "glass airlock-'Chamber Access'";
-	req_access_txt = "7"
+/obj/machinery/door/airlock/pyro/glass/toxins{
+	name = "Toxins"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/tox,
 /turf/simulated/floor/plating/random,
 /area/station/science/lab)
 "cZP" = (
@@ -20205,12 +20711,18 @@
 /turf/simulated/floor/blue/checker,
 /area/station/medical/head)
 "das" = (
-/obj/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	name = "deceased router"
+/obj/window_blinds/cog2/left{
+	dir = 8
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/hallway/primary/east/restroom)
 "daA" = (
 /obj/disposalpipe/junction{
 	dir = 4;
@@ -20288,16 +20800,19 @@
 /area/station/maintenance/east)
 "dcK" = (
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/security/alt{
-	name = "glass airlock-'Security'"
-	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/security{
+	dir = 8;
+	name = "Security";
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "dcP" = (
@@ -20350,7 +20865,7 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "ddu" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/research_director)
 "ddB" = (
 /obj/disposalpipe/segment/mail{
@@ -20368,19 +20883,25 @@
 /turf/space,
 /area/space)
 "dex" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/clown)
 "deQ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-4"
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/yellow,
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M02"
 	})
 "deR" = (
 /obj/disposalpipe/segment/mineral{
@@ -20397,12 +20918,6 @@
 	dir = 10
 	},
 /area/station/science/lobby)
-"dfb" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
-/area/station/engine/power)
 "dfn" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -20415,16 +20930,15 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "dfp" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "44|50"
-	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/engine,
 /area/station/maintenance/south)
 "dft" = (
@@ -20432,7 +20946,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/mineral,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/disposal)
 "dfz" = (
 /obj/machinery/light/small/blueish{
@@ -20504,13 +21018,15 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 2
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/security/alt{
-	name = "glass airlock-'Brig'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/security{
+	name = "Brig";
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/brig,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "dgv" = (
@@ -20539,7 +21055,7 @@
 "dgX" = (
 /obj/disposalpipe/segment/mail,
 /obj/decal/poster/wallsign/fire,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "dhb" = (
 /obj/machinery/atmospherics/pipe/vent{
@@ -20552,13 +21068,13 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "dhr" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "dhs" = (
@@ -20590,19 +21106,19 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "die" = (
-/obj/wingrille_spawn,
 /obj/disposalpipe/segment,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/arcade)
 "dip" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/toxins{
-	name = "glass airlock-'Gas Storage'";
-	req_access_txt = "8"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/toxins{
+	name = "Toxins"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/tox_storage,
 /turf/simulated/floor,
 /area/station/science/lab)
 "djl" = (
@@ -20619,7 +21135,7 @@
 	dir = 8;
 	layer = 2.15
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/clown)
 "dkp" = (
 /obj/decal/tile_edge/line/white{
@@ -20647,13 +21163,16 @@
 	},
 /area/station/science/teleporter)
 "dkK" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable,
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/southwest)
+/obj/machinery/door/airlock/pyro{
+	dir = 8;
+	name = "laundry"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/white,
+/area/station/maintenance/inner/south)
 "dkN" = (
 /obj/rack,
 /obj/item/clothing/shoes/magnetic,
@@ -20718,12 +21237,6 @@
 	icon_state = "fpurple1"
 	},
 /area/station/science/research_director)
-"dlK" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
-/area/station/maintenance/south)
 "dlR" = (
 /obj/shrub{
 	dir = 8
@@ -20739,7 +21252,6 @@
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -20747,6 +21259,7 @@
 	name = "QM - Mining Transfer Shutters";
 	opacity = 0
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "dmd" = (
@@ -20822,15 +21335,6 @@
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/sauna)
-"dnv" = (
-/obj/item/storage/wall/fire{
-	pixel_y = 32
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "dnC" = (
 /obj/stool/bed/moveable,
 /obj/item/clothing/suit/bedsheet,
@@ -20867,11 +21371,11 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "dnW" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "doz" = (
@@ -20896,6 +21400,7 @@
 	name = "QM Announcement Computer";
 	req_access_txt = "31"
 	},
+/obj/access_spawn/cargo,
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "dpw" = (
@@ -20924,8 +21429,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Community Center"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -20945,9 +21453,6 @@
 "dqx" = (
 /turf/simulated/floor/carpet/purple/standard/edge/north,
 /area/station/maintenance/west)
-"dqz" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/security/hos)
 "dqU" = (
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
@@ -20979,14 +21484,14 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/elect)
 "dsE" = (
-/obj/wingrille_spawn,
 /obj/window_blinds/cog2/left,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/detectives_office)
 "dta" = (
@@ -21033,26 +21538,26 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "dtC" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/cargobay)
 "dug" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/chemistry)
 "duw" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "duC" = (
@@ -21075,15 +21580,21 @@
 /turf/simulated/floor/delivery,
 /area/station/quartermaster/cargobay)
 "duK" = (
-/obj/machinery/door/firedoor/border_only,
+/obj/decal/poster/wallsign/medbay{
+	icon_state = "med"
+	},
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'"
+/obj/cable{
+	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/area/station/medical/medbooth)
 "dva" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/wood{
@@ -21120,14 +21631,25 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "dvA" = (
-/obj/machinery/light/small,
+/obj/decal/tile_edge/line/white{
+	icon_state = "line1"
+	},
+/obj/disposalpipe/trunk/mail{
+	dir = 8
+	},
+/obj/stool/chair/comfy/wheelchair,
+/obj/machinery/disposal/mail/small{
+	mail_tag = "medbooth";
+	mailgroup = "medbay";
+	mailgroup2 = "medresearch";
+	name = "mail chute-'Medical Booth'"
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
 "dwa" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -21136,6 +21658,7 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
 "dwj" = (
@@ -21173,14 +21696,16 @@
 	},
 /area/station/science/research_director)
 "dxa" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 1
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "dxj" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -21196,14 +21721,16 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Computer Core'";
-	req_access_txt = "11"
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Research Director's Office"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research_director,
 /turf/simulated/floor/purple,
 /area/station/science/research_director)
 "dxQ" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/robotics)
 "dyR" = (
 /obj/stool/chair/comfy/blue{
@@ -21292,14 +21819,14 @@
 /turf/simulated/floor/black,
 /area/station/ai_monitored/storage/eva)
 "dBD" = (
-/obj/table/auto,
-/obj/item/decoration/ashtray,
-/obj/machinery/light,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/orangeblack/side,
-/area/station/hallway/secondary/exit)
+/obj/machinery/light_switch/north{
+	pixel_y = 28
+	},
+/turf/simulated/floor/sanitary,
+/area/station/hallway/primary/east/restroom)
 "dBQ" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 8;
@@ -21353,11 +21880,14 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/alt,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Community Center"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -21374,7 +21904,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/testchamber)
 "dDE" = (
 /obj/decal/tile_edge/stripe{
@@ -21384,7 +21914,6 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "dDQ" = (
-/obj/wingrille_spawn,
 /obj/window_blinds/cog2/right,
 /obj/cable{
 	icon_state = "0-2"
@@ -21392,6 +21921,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/detectives_office)
 "dDS" = (
@@ -21418,8 +21948,14 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "dEo" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor/vertical{
+	dir = 8
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
@@ -21561,8 +22097,8 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "dGS" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/south)
 "dGZ" = (
@@ -21638,13 +22174,13 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
 "dIB" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hangar/qm)
 "dJd" = (
@@ -21672,11 +22208,11 @@
 	},
 /area/station/science/teleporter)
 "dJz" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "dJZ" = (
@@ -21692,13 +22228,27 @@
 	},
 /area/station/medical/robotics)
 "dKo" = (
-/obj/wingrille_spawn,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
+"dKr" = (
+/obj/item/device/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 20
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
+/obj/stool/chair/couch/green{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "dKD" = (
 /obj/decal/tile_edge/line/white{
 	dir = 4;
@@ -21727,10 +22277,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
 "dLf" = (
 /obj/decal/tile_edge/line/black{
@@ -21743,13 +22290,6 @@
 /obj/stool/bench/auto,
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/research_director)
-"dLP" = (
-/obj/wingrille_spawn/reinforced,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/disposal)
 "dLS" = (
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -21802,21 +22342,15 @@
 	},
 /area/station/science/lab)
 "dNe" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
 "dNi" = (
-/obj/decal/poster/wallsign/framed_award/mdlicense{
-	pixel_y = 28
+/obj/cable{
+	icon_state = "0-2"
 	},
-/obj/stool/chair/comfy/blue,
-/obj/landmark/start{
-	name = "Medical Director"
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fblue2"
-	},
-/area/station/crew_quarters/md)
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northeast)
 "dNw" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light{
@@ -21905,14 +22439,14 @@
 /area/station/hydroponics/bay)
 "dPX" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering/ce)
 "dQf" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "dQx" = (
 /obj/machinery/camera{
@@ -21941,6 +22475,15 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/tools)
+"dRj" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/tank/air_repressurization/west{
+	dir = 4
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/central)
 "dRw" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -21960,11 +22503,11 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "dRR" = (
-/obj/wingrille_spawn,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "dRX" = (
@@ -21978,7 +22521,6 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "dRY" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -21986,6 +22528,7 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "dSf" = (
@@ -22028,16 +22571,13 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "dTa" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "dTm" = (
@@ -22083,18 +22623,14 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;
-	icon_state = "purple2"
+	icon_state = "green2"
 	},
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "dUj" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/bright,
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet{
-	dir = 1;
 	icon_state = "red2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -22128,12 +22664,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
+/obj/machinery/light/small/floor/blueish,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "dUM" = (
@@ -22157,7 +22688,6 @@
 	},
 /area/station/science/teleporter)
 "dUS" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -22167,14 +22697,15 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/door/airlock/gannets/glass/command/alt{
-	name = "glass airlock-'Head of Security's Office'";
-	req_access = list(37);
-	req_access_txt = "37"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/command{
+	dir = 4;
+	name = "Head of Security's Office";
+	req_access = null
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/hos)
 "dVf" = (
@@ -22197,16 +22728,18 @@
 	name = "Teleporter Blast Shield";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	name = "glass airlock-'Teleporter Pad'"
-	},
 /obj/cable{
 	icon_state = "1-8"
 	},
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Teleporter Pad";
+	req_access_txt = null
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/stairs{
 	dir = 4;
 	icon_state = "medstairs_alone"
@@ -22278,17 +22811,17 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "dXH" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	icon_state = "pipe-c";
 	name = "crematorium pipe"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/cloner)
 "dYq" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/beepsky)
 "dYs" = (
 /obj/decal/tile_edge/line/black{
@@ -22311,6 +22844,24 @@
 	dir = 8
 	},
 /area/station/science/research_director)
+"dYH" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname  - SS13"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/potted_plant/potted_plant2{
+	dir = 8
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "dYS" = (
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-L"
@@ -22349,24 +22900,10 @@
 	},
 /turf/simulated/floor,
 /area/station/science/bot_storage)
-"dZt" = (
-/obj/machinery/atmospherics/pipe/tank/air_repressurization/west{
-	dir = 1
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "dZW" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
-"eav" = (
-/obj/shrub{
-	dir = 4;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
 "eaD" = (
 /obj/decal/tile_edge/stripe{
 	dir = 4;
@@ -22408,7 +22945,6 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "eaZ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
@@ -22419,6 +22955,7 @@
 	name = "Teleporter Blast Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "ebe" = (
@@ -22501,11 +23038,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "edY" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Freezer'";
-	req_access_txt = "28"
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "Cold Storage"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/kitchen,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/catering)
 "eer" = (
@@ -22544,12 +23082,6 @@
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"efC" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/engine/engineering)
 "efX" = (
 /obj/surgery_tray,
 /obj/item/scalpel,
@@ -22564,9 +23096,9 @@
 /turf/simulated/floor/blackwhite,
 /area/station/medical/robotics)
 "egb" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	name = "deceased router"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
@@ -22577,16 +23109,15 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "egf" = (
-/obj/decal/tile_edge/line/white{
-	dir = 5;
-	icon_state = "line1"
+/obj/machinery/vending/cigarette,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical/alt{
-	name = "glass airlock-'Medical Booth'"
+/turf/simulated/floor/orangeblack/side{
+	dir = 9
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/area/station/hallway/secondary/exit)
 "egw" = (
 /obj/machinery/conveyor{
 	id = "disposals";
@@ -22615,21 +23146,16 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
-"ehn" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/caution/northsouth,
-/area/station/hallway/secondary/exit)
 "ehp" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/door/poddoor/blast{
+	dir = 1;
+	layer = 4
 	},
-/turf/simulated/floor/plating/random,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/turf/simulated/floor/engine{
+	dir = 8;
+	icon_state = "engine_caution_misc"
+	},
+/area/station/hangar/main)
 "ehr" = (
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/supply)
@@ -22637,27 +23163,12 @@
 /turf/simulated/floor/carpet/purple/standard/edge/south,
 /area/station/maintenance/west)
 "ehV" = (
-/obj/decal/tile_edge/line/black{
-	icon_state = "line1"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
 	},
-/obj/machinery/disposal/mail/small{
-	mail_tag = "seccheck";
-	mailgroup = "security";
-	name = "mail chute-'Security Checkpoint'"
-	},
-/obj/disposalpipe/trunk/mail{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "eiB" = (
 /obj/rack,
 /obj/item/storage/toolbox/artistic,
@@ -22716,18 +23227,23 @@
 	},
 /area/station/science/lobby)
 "ejK" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/fitness)
-"ekr" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
+"ekq" = (
+/obj/machinery/door/window/eastleft,
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
+/turf/simulated/floor/sanitary,
+/area/station/hallway/primary/east/restroom)
+"ekr" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "eku" = (
 /obj/cable{
@@ -22775,18 +23291,15 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "emM" = (
-/obj/decal/tile_edge/line/black{
-	dir = 10;
-	icon_state = "line2"
+/obj/disposalpipe/segment/mail,
+/obj/machinery/light/emergency{
+	dir = 4
 	},
-/obj/storage/secure/closet/security/equipment,
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
+	dir = 4
 	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "enr" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/purple/checker,
@@ -22836,7 +23349,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "eov" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/west)
 "eoz" = (
 /obj/lattice{
@@ -22868,61 +23381,34 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "epn" = (
-/obj/storage/closet/wardrobe/orange,
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "red2"
+/obj/machinery/light_switch/north{
+	pixel_y = 28
 	},
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
 "eqd" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/disposal/mail/small{
-	dir = 8;
-	mail_tag = "crew";
-	name = "mail chute-'Crew Lounge'"
-	},
-/obj/disposalpipe/trunk/mail{
-	dir = 8
-	},
-/obj/decal/tile_edge/stripe{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/obj/railing/yellow{
-	dir = 1
-	},
-/turf/simulated/floor/black,
+/obj/storage/closet/office,
+/turf/simulated/floor,
 /area/station/crew_quarters/lounge/starboard)
 "eql" = (
 /turf/simulated/floor/carpet/blue/standard/edge/se,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "equ" = (
-/obj/decal/tile_edge/line/black{
-	icon_state = "line1"
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
+	dir = 1
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P02"
 	})
 "eqv" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/pharmacy)
 "eqy" = (
 /obj/machinery/vending/coffee,
@@ -22931,8 +23417,16 @@
 	},
 /area/station/crew_quarters/fitness)
 "eqH" = (
-/obj/disposalpipe/junction,
-/obj/shrub,
+/obj/disposalpipe/segment,
+/obj/stool/bench/red,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/drainage,
+/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon12,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "eqI" = (
@@ -22974,19 +23468,20 @@
 	},
 /area/station/hydroponics/bay)
 "erm" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"erp" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical{
-	name = "airlock-'Operating Theater'"
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fred1"
 	},
+/area/station/crew_quarters/hos)
+"erp" = (
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	name = "Operating Theater"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "erq" = (
@@ -23015,8 +23510,8 @@
 	},
 /area/station/bridge)
 "erC" = (
-/obj/wingrille_spawn,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/bar)
 "erE" = (
@@ -23061,8 +23556,8 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "esp" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "esr" = (
@@ -23081,11 +23576,12 @@
 	},
 /area/station/hydroponics/bay)
 "esZ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Ranch'";
-	req_access_txt = "83"
+/obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 8;
+	name = "Ranch"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/rancher,
 /turf/simulated/floor,
 /area/station/ranch)
 "eta" = (
@@ -23106,9 +23602,15 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
@@ -23120,11 +23622,14 @@
 /turf/simulated/floor/yellow,
 /area/station/mining/refinery)
 "etA" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/glass/mining{
+	dir = 4;
+	name = "Refinery"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/mining/refinery)
 "etC" = (
@@ -23156,17 +23661,12 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "euu" = (
-/obj/decal/tile_edge/line/white{
-	icon_state = "line1"
+/obj/warp_beacon{
+	name = "Destiny west beacon"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/obj/lattice,
+/turf/space,
+/area/space)
 "euN" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -23225,33 +23725,13 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "evi" = (
-/obj/decal/tile_edge/line/white{
-	icon_state = "line1"
+/obj/table/wood/auto,
+/obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "blue2"
 	},
-/obj/disposalpipe/trunk/mail{
-	dir = 8
-	},
-/obj/stool/chair/comfy/wheelchair,
-/obj/machinery/disposal/mail/small{
-	mail_tag = "medbooth";
-	mailgroup = "medbay";
-	mailgroup2 = "medresearch";
-	name = "mail chute-'Medical Booth'"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
-"evH" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/item/storage/wall/fire{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
+/area/station/crew_quarters/quartersA)
 "evM" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -23299,7 +23779,7 @@
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southwest)
 "ewR" = (
 /obj/machinery/light{
@@ -23413,7 +23893,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "eyB" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/middle{
 	dir = 8
 	},
@@ -23421,6 +23900,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/head)
 "eyE" = (
@@ -23451,17 +23931,11 @@
 	},
 /area/station/medical/medbay)
 "ezt" = (
-/obj/decal/tile_edge/line/white{
-	dir = 6;
-	icon_state = "line2"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/obj/stool/bed/moveable/hospital,
-/obj/item/clothing/suit/bedsheet,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/main)
 "ezX" = (
 /obj/machinery/light{
 	dir = 8
@@ -23547,15 +24021,76 @@
 /turf/simulated/floor/plating/airless,
 /area/station/hallway/secondary/construction)
 "eAu" = (
-/turf/simulated/wall/auto/gannets,
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/obj/shrub,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "eAx" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/medical/medbooth)
+/obj/storage/crate,
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13"
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "eAY" = (
 /obj/stool/chair/couch/green{
 	dir = 8
@@ -23572,10 +24107,12 @@
 /area/station/crew_quarters/baroffice)
 "eBj" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/security/alt{
-	name = "airlock-'Detective's Office'"
+/obj/machinery/door/airlock/pyro/security{
+	name = "Detective's Room";
+	req_access = null
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/forensics,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "eBK" = (
@@ -23622,6 +24159,18 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
+"eCs" = (
+/obj/decal/tile_edge/line/white{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/machinery/vending/medical,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
 "eCT" = (
 /obj/machinery/atmospherics/valve{
 	name = "chamber loop valve"
@@ -23629,11 +24178,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "eDc" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Hydroponics'";
-	req_access_txt = "35"
+/obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 8;
+	name = "Hydroponics"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/hydro,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "eDk" = (
@@ -23658,7 +24208,7 @@
 /area/station/hydroponics/bay)
 "eDn" = (
 /obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southwest)
 "eDs" = (
 /obj/cable{
@@ -23677,10 +24227,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/testchamber)
 "eDL" = (
 /obj/storage/closet/wardrobe/pride,
@@ -23692,13 +24239,10 @@
 /turf/simulated/floor/darkblue,
 /area/station/crew_quarters/pool)
 "eDQ" = (
-/obj/potted_plant/potted_plant2{
-	dir = 1;
-	pixel_y = 32
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/stool/chair/office/purple,
 /turf/simulated/floor/carpet{
-	dir = 1;
 	icon_state = "purple2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -23744,10 +24288,10 @@
 	dir = 4;
 	icon_state = "xtra_bigstripe-edge"
 	},
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "eFj" = (
@@ -23766,19 +24310,31 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "eFx" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/cloner)
 "eFD" = (
-/obj/storage/closet/office,
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/green,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "green2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P01"
+	})
 "eFI" = (
 /obj/window/reinforced/north,
 /obj/window/reinforced/east,
@@ -23825,8 +24381,14 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
+"eHe" = (
+/obj/tree1{
+	layer = 30
+	},
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
 "eHw" = (
 /obj/stool/chair/office/purple{
 	dir = 8
@@ -23842,7 +24404,6 @@
 /turf/simulated/floor/purple,
 /area/station/medical/cdc)
 "eHB" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/plasticflaps,
 /obj/decal/tile_edge/stripe{
 	dir = 6;
@@ -23852,17 +24413,19 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "eHD" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'Cargo'";
-	req_access_txt = "31|40|50"
-	},
 /obj/disposalpipe/segment/mineral{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 4;
+	name = "Cargo"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/cargobay)
 "eHO" = (
@@ -23876,6 +24439,7 @@
 "eIa" = (
 /obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "eId" = (
@@ -23971,19 +24535,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
-"eJZ" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13"
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P04"
-	})
 "eKe" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -24002,15 +24553,15 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "eKA" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	id = "cloning";
-	name = "glass airlock-'Genetics'";
-	req_access_txt = "9"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 4;
+	name = "Genetics"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medlab,
 /turf/simulated/floor/black,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -24020,7 +24571,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "eLi" = (
 /obj/machinery/conveyor{
@@ -24051,18 +24602,18 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "eLS" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Utility Room'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe,
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Community Center"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "eMg" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/warehouse)
 "eMD" = (
 /obj/machinery/computer/announcement{
@@ -24096,11 +24647,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "eNc" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "eNv" = (
@@ -24117,12 +24668,8 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "eNw" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor/vertical{
+	dir = 8
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
@@ -24158,7 +24705,6 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 1;
@@ -24168,6 +24714,7 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "eOF" = (
@@ -24285,7 +24832,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "eQz" = (
 /obj/storage/secure/closet/engineering/mechanic,
 /obj/decal/tile_edge/line/black{
@@ -24302,7 +24849,7 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "eQM" = (
-/obj/wingrille_spawn,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/barber_shop)
 "eQU" = (
@@ -24318,7 +24865,10 @@
 /area/station/engine/elect)
 "eQZ" = (
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "1-8"
+	},
+/obj/decal/stage_edge/alt{
+	pixel_y = 10
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
@@ -24337,6 +24887,11 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
+"eRv" = (
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/lounge/port)
 "eRz" = (
 /obj/machinery/flasher/portable,
 /obj/decal/mule/dropoff,
@@ -24349,14 +24904,11 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
-"eRJ" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/science/testchamber)
 "eSA" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/robotics)
 "eSF" = (
 /obj/decal/tile_edge/stripe{
@@ -24489,10 +25041,7 @@
 /area/station/security/detectives_office)
 "eVf" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
 "eVh" = (
 /obj/decal/cleanable/dirt/jen,
@@ -24535,13 +25084,13 @@
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "eWt" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hangar/qm)
 "eWC" = (
@@ -24619,13 +25168,8 @@
 /turf/space,
 /area/space)
 "eYj" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/gannets/toxins{
-	name = "airlock-'Test Chamber'";
-	req_access_txt = "8"
 	},
 /obj/machinery/door/poddoor/blast{
 	density = 0;
@@ -24637,6 +25181,10 @@
 	name = "Test Chamber Blast Shield";
 	opacity = 0
 	},
+/obj/machinery/door/airlock/pyro/toxins_alt{
+	name = "Test Chamber"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "eYq" = (
@@ -24656,7 +25204,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "eYI" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -24670,17 +25217,9 @@
 	name = "Test Chamber Blast Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/science/testchamber)
-"eZd" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "eZl" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24694,11 +25233,20 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "eZo" = (
-/obj/machinery/vending/computer3,
-/turf/simulated/floor,
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge";
+	pixel_y = 10
+	},
+/obj/railing/yellow{
+	pixel_y = 10
+	},
+/turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/port)
 "eZu" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -24706,15 +25254,15 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/south)
 "eZD" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
 "eZL" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -24724,22 +25272,20 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "fap" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 1
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/testchamber)
 "far" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/courtroom)
 "faA" = (
@@ -24760,15 +25306,16 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "faU" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/maintenance{
-	name = "airlock-'Maintenance'"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Crew Lounge"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/south)
 "fbh" = (
 /obj/disposalpipe/segment/mineral,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/staff_room)
 "fbl" = (
 /obj/machinery/meter,
@@ -24824,14 +25371,15 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "fci" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Janitor's Supply Closet'";
-	req_access_txt = "26"
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4;
+	name = "Janitor's Closet"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/janitor,
 /turf/simulated/floor/plating/random,
 /area/station/janitor/supply)
 "fcj" = (
@@ -24844,27 +25392,18 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "fcx" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/bridge/captain)
-"fcM" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/decal/stage_edge/alt{
-	pixel_y = 10
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
+/area/station/crew_quarters/captain)
 "fcP" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/cargobay)
 "fcQ" = (
 /obj/decal/tile_edge/line/blue{
@@ -24936,7 +25475,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "fdZ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -24946,6 +25484,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "fed" = (
@@ -24962,9 +25501,12 @@
 	dir = 4;
 	icon_state = "line1"
 	},
-/obj/machinery/door/airlock/gannets/morgue/alt{
-	name = "airlock-'Morgue'"
+/obj/machinery/door/airlock/pyro/medical/morgue{
+	dir = 4;
+	name = "Morgue"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/morgue,
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "ffB" = (
@@ -24975,7 +25517,7 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/testchamber)
 "ffJ" = (
 /obj/machinery/power/apc/autoname_north,
@@ -24987,7 +25529,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "ffK" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -24995,6 +25536,7 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/power)
 "ffW" = (
@@ -25031,19 +25573,21 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "fgz" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
 "fgA" = (
-/obj/storage/closet/wardrobe/green,
+/obj/storage/closet/wardrobe/orange,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "green2"
+	icon_state = "red2"
 	},
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "fgQ" = (
 /obj/machinery/power/data_terminal,
 /obj/cable,
@@ -25065,7 +25609,7 @@
 	},
 /area/station/solar/west)
 "fhG" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/storage/eva)
 "fhM" = (
 /obj/cable{
@@ -25093,7 +25637,6 @@
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "fiu" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -25102,28 +25645,28 @@
 	dir = 8;
 	icon_state = "line1"
 	},
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Hydroponics'";
-	req_access_txt = "35"
+/obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 1;
+	name = "Hydroponics"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/hydro,
 /turf/simulated/floor/black,
 /area/station/hydroponics/bay)
 "fiK" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "fiN" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "44|50"
-	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/west)
 "fjq" = (
@@ -25157,11 +25700,13 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "fjJ" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/bridge/captain)
+/obj/rack,
+/obj/item/tank/jetpack,
+/obj/item/clothing/mask/gas/emergency,
+/obj/item/clothing/suit/space/captain,
+/obj/item/clothing/head/helmet/space/captain,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/captain)
 "fjW" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light/incandescent/harsh{
@@ -25171,19 +25716,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "fjX" = (
-/obj/stool{
-	desc = "A soft little bed the general size and shape of a space bee.";
-	icon = 'icons/misc/critter.dmi';
-	icon_state = "beebed";
-	name = "heisenbed"
-	},
-/obj/critter/domestic_bee/heisenbee,
 /turf/simulated/floor/carpet{
-	icon_state = "fpurple2"
+	icon_state = "fblue2"
 	},
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "fkB" = (
 /obj/machinery/power/data_terminal,
 /obj/cable,
@@ -25219,7 +25755,6 @@
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "flb" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/middle{
 	dir = 4
 	},
@@ -25227,6 +25762,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
 "flr" = (
@@ -25270,27 +25806,20 @@
 	},
 /area/station/science/chemistry)
 "fmv" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/left{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
+/obj/machinery/portable_atmospherics/canister/air/large,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/md)
+/area/station/maintenance/northeast)
 "fmI" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "fmJ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/middle{
 	dir = 8
 	},
@@ -25301,6 +25830,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -25314,16 +25844,32 @@
 	},
 /area/station/ranch)
 "fnt" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/chemistry)
 "fnv" = (
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer3/generic/secure_data{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 9;
+	dir = 0;
 	name = "autoname - SS13"
 	},
-/turf/space,
-/area/space)
+/obj/blind_switch/area/west{
+	dir = 4
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "fred2"
+	},
+/area/station/crew_quarters/hos)
 "fny" = (
 /obj/machinery/networked/test_apparatus/heater,
 /obj/machinery/power/data_terminal,
@@ -25339,7 +25885,7 @@
 	},
 /area/station/science/artifact)
 "fnS" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/lounge)
 "fnT" = (
 /obj/disposalpipe/segment/mail{
@@ -25392,15 +25938,15 @@
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/supply)
 "fpd" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/disposalpipe/segment,
-/obj/machinery/door/airlock/gannets/glass,
-/obj/decal/tile_edge/line/red{
-	dir = 9;
-	icon_state = "line1"
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/hangar/main)
 "fpf" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -25426,10 +25972,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "fqe" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "fqk" = (
@@ -25451,14 +25997,15 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/maintenance{
-	name = "airlock-'Disposals'"
-	},
 /obj/disposalpipe/segment/mineral{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/door/airlock/pyro/classic{
+	dir = 4;
+	name = "Disposals"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "fqr" = (
@@ -25478,7 +26025,6 @@
 	},
 /area/station/science/lobby)
 "fqw" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -25489,6 +26035,7 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/courtroom)
 "fqN" = (
@@ -25571,10 +26118,10 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "fsk" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "fsN" = (
@@ -25582,38 +26129,68 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/refinery)
 "ftz" = (
 /obj/machinery/atmospherics/valve{
 	name = "Air Reserve (West)"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/lobby)
 "ftD" = (
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
-"fuc" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'West Maintenance'"
+"ftW" = (
+/obj/blind_switch/area/north{
+	pixel_x = 5;
+	pixel_y = 28
 	},
+/obj/machinery/light_switch/north{
+	pixel_x = -5;
+	pixel_y = 28
+	},
+/obj/table/wood/auto/desk,
+/obj/machinery/phone,
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads)
+"fuc" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 1
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
+"fuu" = (
+/obj/machinery/disposal/mail/small{
+	dir = 1;
+	mail_tag = "hop";
+	mailgroup = "command";
+	message = "1";
+	name = "mail chute-'Head of Personnel'";
+	pixel_y = 32
+	},
+/obj/disposalpipe/trunk/mail,
+/obj/filing_cabinet,
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads)
 "fuT" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/maintenance{
-	name = "airlock-'Maintenance'"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 1
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "fuY" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/detectives_office)
 "fvq" = (
@@ -25657,19 +26234,40 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "fvW" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
-"fwk" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/left{
-	dir = 4
+/obj/table/reinforced/auto,
+/obj/bedsheetbin{
+	pixel_y = 2
 	},
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
+/obj/item/clothing/suit/judgerobe,
+/obj/item/clothing/head/powdered_wig,
+/obj/item/device/radio/headset/civilian,
+/obj/item/device/radio/headset/civilian,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname  - SS13"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.5;
+	pixel_x = 24
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "N APC";
+	pixel_y = 24
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads)
+"fwk" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
 	})
 "fwG" = (
 /obj/decal/tile_edge/line/red{
@@ -25701,12 +26299,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "fwV" = (
-/obj/rack,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/head/emerg,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/air,
-/obj/item/crowbar,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/station/hangar/main)
 "fxq" = (
@@ -25751,10 +26349,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
 "fzp" = (
 /turf/simulated/floor/specialroom/arcade,
@@ -25780,7 +26375,6 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "fzM" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -25788,6 +26382,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/black,
 /area/station/ranch)
 "fAh" = (
@@ -25823,18 +26418,16 @@
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "fBs" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/middle{
+/obj/window_blinds/cog2/left{
 	dir = 4
 	},
 /obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/captain)
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "fBW" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -25842,6 +26435,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/main)
 "fCq" = (
@@ -25924,14 +26518,10 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "fEn" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Crew Quarters'"
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters P03"
 	})
@@ -25988,17 +26578,6 @@
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
-"fFU" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P04"
-	})
 "fGi" = (
 /obj/machinery/disposal/mail/small{
 	dir = 8;
@@ -26033,15 +26612,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/hangar/qm)
-"fGT" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "fHf" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -26082,7 +26652,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "fIF" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/interrogation)
 "fIK" = (
 /obj/machinery/vending/paint/broken,
@@ -26134,11 +26704,11 @@
 	},
 /area/mining/magnet)
 "fJS" = (
-/obj/machinery/light/incandescent{
-	nostick = 1
+/turf/simulated/floor/stairs{
+	dir = 1;
+	icon_state = "Stairs2_wide"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/area/station/crew_quarters/lounge/port)
 "fJY" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -26202,26 +26772,27 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "fLO" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/green,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname  - SS13"
 	},
 /turf/simulated/floor/carpet{
-	dir = 9;
+	dir = 10;
 	icon_state = "green2"
 	},
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters M03"
 	})
 "fLR" = (
-/turf/simulated/floor/stairs{
-	icon_state = "Stairs2_wide"
+/obj/item/storage/wall/emergency{
+	pixel_y = 32
 	},
-/area/station/crew_quarters/lounge/starboard)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/central)
 "fLS" = (
 /obj/machinery/manufacturer/mechanic,
 /obj/decal/tile_edge/line/black{
@@ -26253,10 +26824,11 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "50"
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/mining,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "fMJ" = (
@@ -26299,7 +26871,6 @@
 	},
 /area/mining/magnet)
 "fMT" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
@@ -26314,18 +26885,9 @@
 	name = "Bridge Lockdown Door";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
-"fNh" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P03"
-	})
 "fNr" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
@@ -26410,20 +26972,19 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
-"fOw" = (
-/obj/disposalpipe/segment/brig{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/security/interrogation)
 "fPF" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/potted_plant/potted_plant4{
+	dir = 1;
+	pixel_y = 32
 	},
-/obj/disposalpipe/segment/mail,
-/obj/wingrille_spawn,
-/turf/simulated/floor/plating/random,
-/area/station/hallway/primary/north)
+/obj/stool/chair/office/red,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "red2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M04"
+	})
 "fPK" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -26458,9 +27019,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "fRu" = (
@@ -26482,10 +27040,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/dome)
 "fRM" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg{
 	name = "bail payment device"
@@ -26493,20 +27050,31 @@
 /obj/machinery/door/window/eastright{
 	req_access_txt = "1"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "fRQ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Utility Room'"
+/obj/machinery/door/airlock/pyro{
+	dir = 1;
+	name = "laundry"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/maintenance/inner/south)
 "fSF" = (
-/obj/decal/poster/wallsign/fire,
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/science/lab)
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/obj/disposalpipe/segment/food{
+	dir = 4
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/medical/research{
+	name = "Genetic Research"
+	})
 "fST" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -26542,18 +27110,28 @@
 	},
 /area/station/security/hos)
 "fTz" = (
-/obj/machinery/vehicle/escape_pod{
+/obj/table/auto,
+/obj/random_item_spawner/desk_stuff,
+/obj/machinery/computer/airbr/emergency_shuttle{
+	density = 0;
+	dir = 8;
+	id = "escape";
+	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/device/light/flashlight,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/door/window/westright,
-/obj/decal/tile_edge/stripe{
-	icon_state = "xtra_bigstripe-edge"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/decal/tile_edge/stripe{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/orangeblack,
 /area/station/hallway/secondary/exit)
 "fTL" = (
 /obj/machinery/power/apc/autoname_north,
@@ -26571,8 +27149,8 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "fTO" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/purple,
 /area/station/science/artifact)
 "fUk" = (
@@ -26625,18 +27203,11 @@
 /obj/machinery/light/small/floor/blueish,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
-"fUV" = (
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/science/testchamber)
 "fVD" = (
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 1;
@@ -26650,6 +27221,7 @@
 	icon_state = "0-8"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "fVH" = (
@@ -26678,13 +27250,13 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/red,
 /area/station/security/hos)
 "fWj" = (
@@ -26704,20 +27276,16 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "fWL" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/right{
+/obj/window_blinds/cog2/middle{
 	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "fXk" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -26782,10 +27350,7 @@
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
 "fYN" = (
 /obj/decal/tile_edge/line/red{
@@ -26809,12 +27374,12 @@
 /turf/simulated/floor/blue/checker,
 /area/station/medical/head)
 "fZn" = (
-/obj/machinery/door/airlock/gannets/glass/toxins{
-	name = "glass airlock-'Gas Storage'";
-	req_access_txt = "8"
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/glass/toxins{
+	dir = 4;
+	name = "Toxins"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
@@ -26844,17 +27409,6 @@
 	dir = 8
 	},
 /area/station/engine/engineering)
-"fZF" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/barber_shop)
 "fZV" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe,
 /obj/disposalpipe/segment,
@@ -26922,15 +27476,19 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "gaP" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/disposalpipe/segment/mail,
-/obj/machinery/door/airlock/gannets/glass,
-/obj/decal/tile_edge/line/blue{
-	dir = 5;
-	icon_state = "line1"
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/bright,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "purple2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P04"
+	})
 "gbD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -27017,23 +27575,40 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "gcA" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/left{
+/obj/window_blinds/cog2/middle{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "gdj" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
 /turf/simulated/floor/carpet{
 	dir = 10;
-	icon_state = "blue2"
+	icon_state = "purple2"
 	},
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
+"gdy" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
+	},
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "green2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P01"
+	})
 "gdR" = (
 /obj/machinery/manufacturer/mining,
 /obj/machinery/camera{
@@ -27065,19 +27640,23 @@
 /area/station/quartermaster/cargobay)
 "geT" = (
 /obj/machinery/atmospherics/pipe/simple,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/unpowered/wood,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 4;
+	name = "Sauna"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
 /area/station/crew_quarters/sauna)
 "gfI" = (
 /obj/stool/bed,
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
-/obj/item/clothing/suit/bedsheet/green,
+/obj/item/clothing/suit/bedsheet/red,
 /obj/item/storage/secure/ssafe{
 	pixel_y = 28
 	},
@@ -27086,18 +27665,20 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
-	icon_state = "green2"
+	icon_state = "red2"
 	},
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "gfZ" = (
 /turf/simulated/floor/carpet/blue/standard/edge/south,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "ggS" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/lobby)
 "ghv" = (
 /obj/machinery/light/incandescent{
@@ -27125,19 +27706,18 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "ghJ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command{
-	name = "airlock-'Research Director's Quarters'";
-	req_access_txt = "11"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Head of Security's Quarters"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical_director,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "ghM" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -27224,15 +27804,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
-"gjq" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch/north{
-	pixel_y = 28
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "gjt" = (
 /obj/submachine/ATM/atm_alt{
 	pixel_y = 32
@@ -27240,14 +27811,15 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "gjD" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Bar Office'";
-	req_access_txt = "25"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "Bartender's Room"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/bar,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/baroffice)
 "gjG" = (
@@ -27265,10 +27837,10 @@
 	},
 /area/station/medical/medbay)
 "gjP" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/dome)
 "gkn" = (
@@ -27276,20 +27848,18 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "gkx" = (
-/obj/decal/poster/wallsign/framed_award/rddiploma{
+/obj/decal/poster/wallsign/framed_award/mdlicense{
 	pixel_y = 28
 	},
-/obj/stool/chair/comfy/purple,
+/obj/stool/chair/comfy/blue,
 /obj/landmark/start{
-	name = "Research Director"
+	name = "Medical Director"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "fpurple2"
+	icon_state = "fblue2"
 	},
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "gky" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -27345,7 +27915,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "glG" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/qm)
 "glY" = (
 /obj/cable{
@@ -27401,13 +27971,13 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "gmR" = (
-/obj/cable{
-	icon_state = "2-8"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
 "gmS" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -27415,9 +27985,11 @@
 	icon_state = "line1"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/airlock/gannets/morgue/alt{
-	name = "airlock-'Morgue'"
+/obj/machinery/door/airlock/pyro/medical/morgue{
+	name = "Morgue"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/morgue,
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "gmT" = (
@@ -27496,12 +28068,27 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "gnZ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
+"gox" = (
+/obj/item/device/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 20
+	},
+/obj/shrub{
+	dir = 4;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
+/obj/machinery/light_switch/east{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "goC" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 9;
@@ -27512,13 +28099,14 @@
 	name = "Genetic Research"
 	})
 "goT" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Bar'"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Bar"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "goX" = (
@@ -27526,6 +28114,14 @@
 	dir = 1
 	},
 /area/station/engine/power)
+"gpl" = (
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_engine,
+/turf/simulated/floor/engine/vacuum,
+/area/station/engine/core)
 "gpG" = (
 /obj/item/device/radio/beacon,
 /obj/cable{
@@ -27603,25 +28199,27 @@
 /turf/simulated/floor/white,
 /area/station/science/artifact)
 "gsa" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Janitor's Office'";
-	req_access_txt = "26"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "Janitor's Office"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/janitor,
 /turf/simulated/floor,
 /area/station/janitor/office)
 "gso" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/chemistry{
-	name = "airlock-'Chemistry'";
-	req_access_txt = "33|12"
+/obj/machinery/door/airlock/pyro/sci_alt{
+	dir = 1;
+	name = "Chemistry"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/chemistry,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "gsy" = (
@@ -27703,13 +28301,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "gvA" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/bar)
 "gwa" = (
@@ -27744,20 +28342,22 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "gwC" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "gwS" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/gannets/security{
-	name = "airlock-'West Pod Bay'"
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "West Podbay"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "gxe" = (
@@ -27794,7 +28394,6 @@
 "gxr" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/window/westleft{
 	dir = 4;
 	req_access_txt = "50"
@@ -27802,6 +28401,8 @@
 /obj/disposalpipe/segment{
 	dir = 8
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/mining,
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "gxT" = (
@@ -27850,9 +28451,6 @@
 /obj/machinery/navbeacon/tour/destiny/tour3,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
-"gzL" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/security/detectives_office)
 "gzN" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -27869,8 +28467,8 @@
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/south)
 "gAK" = (
-/obj/machinery/vending/pizza{
-	anchored = 1
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
@@ -27937,23 +28535,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
-"gBG" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Crew Quarters'"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P04"
-	})
 "gBH" = (
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/east)
 "gBJ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2{
 	layer = 2.9;
 	pixel_y = 13
@@ -27964,6 +28549,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/baroffice)
 "gBW" = (
@@ -27978,26 +28564,23 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "gCx" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southwest)
 "gDe" = (
 /obj/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/security/main)
 "gDl" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/yellow,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname  - SS13"
 	},
 /turf/simulated/floor/carpet{
-	dir = 9;
+	dir = 10;
 	icon_state = "blue2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -28007,16 +28590,16 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "12"
-	},
 /obj/cable{
 	icon_state = "1-8"
 	},
 /obj/disposalpipe/segment/mineral{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "gDu" = (
@@ -28034,7 +28617,6 @@
 	},
 /area/station/security/hos)
 "gDG" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2{
 	layer = 2.9;
 	pixel_y = 13
@@ -28042,13 +28624,14 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/baroffice)
 "gDV" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/hangar/qm)
 "gDY" = (
@@ -28062,8 +28645,8 @@
 	},
 /area/station/crew_quarters/bar)
 "gEg" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/black,
 /area/station/ranch)
 "gEh" = (
@@ -28077,15 +28660,9 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "gEl" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/hangar/main)
+/obj/machinery/atmospherics/pipe/vent,
+/turf/simulated/floor/plating/airless,
+/area/space)
 "gEo" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -28117,14 +28694,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/bojackson,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
-"gEX" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "gFq" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/cable{
@@ -28190,12 +28759,6 @@
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/courtroom)
-"gHk" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/starboard)
 "gHp" = (
 /obj/decal/tile_edge/line/white{
 	dir = 5;
@@ -28227,13 +28790,14 @@
 	},
 /area/station/crew_quarters/courtroom)
 "gHR" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Restroom'"
+/obj/machinery/door/airlock/pyro{
+	dir = 8;
+	name = "Restroom"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/locker)
 "gIg" = (
@@ -28267,6 +28831,9 @@
 "gJb" = (
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
@@ -28303,17 +28870,21 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "gKs" = (
-/obj/machinery/manufacturer/general,
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/bright,
+/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "0-2"
 	},
-/obj/decal/poster/wallsign/pod_build{
-	pixel_y = 32
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "green2"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M03"
+	})
 "gKy" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/clown)
 "gLf" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -28343,7 +28914,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "gMN" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/observatory)
 "gMR" = (
 /obj/machinery/conveyor{
@@ -28380,10 +28951,11 @@
 /turf/space,
 /area/mining/magnet)
 "gNv" = (
-/turf/simulated/wall/auto/gannets,
-/area/station/crew_quarters/ce)
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "gND" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -28397,6 +28969,7 @@
 	name = "Bridge Lockdown Door";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "gNL" = (
@@ -28430,7 +29003,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
 "gOC" = (
 /obj/lattice{
@@ -28444,11 +29017,11 @@
 /turf/space,
 /area/space)
 "gOO" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/bar)
 "gOZ" = (
@@ -28477,15 +29050,6 @@
 	},
 /turf/space,
 /area/station/engine/core)
-"gPk" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
-/area/station/mining/refinery)
 "gPm" = (
 /obj/decal/tile_edge/line/white{
 	dir = 1;
@@ -28501,6 +29065,10 @@
 	dir = 4
 	},
 /area/station/medical/medbay)
+"gPE" = (
+/obj/machinery/light,
+/turf/simulated/floor/sanitary,
+/area/station/hallway/primary/east/restroom)
 "gPZ" = (
 /obj/machinery/floorflusher{
 	id = "solitary_n"
@@ -28534,15 +29102,16 @@
 	},
 /area/station/security/beepsky)
 "gQS" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Ranch'";
-	req_access_txt = "83"
+/obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 1;
+	name = "Ranch"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/rancher,
 /turf/simulated/floor,
 /area/station/ranch)
 "gRh" = (
@@ -28575,7 +29144,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "gSn" = (
@@ -28593,6 +29162,10 @@
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/office)
 "gTE" = (
+/obj/disposalpipe/junction{
+	dir = 8;
+	name = "brig pipe"
+	},
 /obj/stool/chair/red,
 /obj/landmark/start{
 	name = "Security Officer"
@@ -28601,12 +29174,12 @@
 /area/station/security/main)
 "gTN" = (
 /obj/disposalpipe/segment,
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/detectives_office)
 "gTV" = (
@@ -28631,7 +29204,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "gUF" = (
 /obj/decal/tile_edge/line/purple{
@@ -28664,15 +29237,23 @@
 /turf/space,
 /area/space)
 "gVu" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
+"gVv" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
+	},
+/area/station/hallway/secondary/exit)
 "gVw" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -28692,10 +29273,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "gVz" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hangar/qm)
 "gVE" = (
@@ -28726,14 +29307,15 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Hydroponics'";
-	req_access_txt = "35"
-	},
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
 	},
+/obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 8;
+	name = "Hydroponics"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/hydro,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "gVT" = (
@@ -28762,14 +29344,19 @@
 	},
 /area/space)
 "gWx" = (
-/obj/cable{
-	icon_state = "2-8"
+/obj/disposalpipe/segment/brig{
+	dir = 4
 	},
-/obj/machinery/light_switch/north{
-	pixel_y = 28
+/obj/landmark/start{
+	name = "Security Officer"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northwest)
+/obj/stool/chair/office/red{
+	dir = 4
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "gWO" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -28798,15 +29385,11 @@
 	name = "East Central Maintenance"
 	})
 "gXC" = (
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "1-4"
 	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/hallway/primary/east/restroom)
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "gXL" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -28862,22 +29445,21 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "gYu" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "gYP" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light_switch/north{
-	pixel_x = 10;
-	pixel_y = 28
+/obj/disposalpipe/switch_junction{
+	dir = 2;
+	mail_tag = "pod_fore";
+	name = "north pod bay mail router"
 	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom";
-	pixel_x = -5
+/obj/machinery/light/emergency{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "gZc" = (
 /obj/player_piano,
 /turf/simulated/floor/specialroom/chapel{
@@ -28888,10 +29470,9 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 9
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/treatment)
 "gZr" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -28906,6 +29487,7 @@
 	opacity = 0
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "gZs" = (
@@ -28934,16 +29516,13 @@
 /turf/simulated/floor/plating/airless,
 /area/station/hallway/secondary/construction)
 "gZM" = (
-/obj/machinery/disposal/small{
-	dir = 8
+/turf/simulated/floor/stairs{
+	dir = 1;
+	icon_state = "Stairs_wide"
 	},
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/area/station/crew_quarters/lounge/port)
 "hag" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/east)
 "hap" = (
 /obj/lattice{
@@ -28953,14 +29532,15 @@
 /turf/space,
 /area/station/shield_zone)
 "har" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/engineering{
-	name = "glass airlock-'East Pod Bay'";
-	req_access_txt = "31|40|50"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/mining{
+	dir = 4;
+	name = "Cargo"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/cargobay)
 "hax" = (
@@ -28980,7 +29560,6 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "hbc" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -28990,14 +29569,15 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "hbs" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "hby" = (
@@ -29012,10 +29592,10 @@
 /turf/space,
 /area/space)
 "hbG" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/brig)
 "hbT" = (
@@ -29047,21 +29627,11 @@
 /turf/simulated/floor,
 /area/station/storage/warehouse)
 "hce" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/r_door_control{
+	id = "pod_fore"
 	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/light/emergency{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13"
-	},
-/obj/machinery/drainage,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hangar/main)
 "hct" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 8;
@@ -29099,13 +29669,15 @@
 /turf/simulated/floor/yellow,
 /area/station/hallway/secondary/construction)
 "hdF" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical{
-	name = "airlock-'Cryogenics'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 1;
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
 "hdY" = (
@@ -29122,17 +29694,18 @@
 /turf/simulated/floor/neutral,
 /area/station/engine/core)
 "heG" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/teleporter)
 "heS" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'AI Core'";
-	req_access_txt = "19"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/command{
+	dir = 1;
+	name = "AI Core"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/ai_upload,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "hfq" = (
@@ -29184,13 +29757,15 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "hgP" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/security/alt{
-	name = "glass airlock-'Security'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/security{
+	name = "Security";
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor,
 /area/station/security/equipment)
 "hhQ" = (
@@ -29238,14 +29813,8 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
-	dir = 1
+	dir = 5
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
@@ -29296,26 +29865,7 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"hkJ" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
-	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
 "hkY" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/command/alt{
-	name = "glass airlock-'Head of Security's Office'";
-	req_access = list(37);
-	req_access_txt = "37"
-	},
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -29326,47 +29876,57 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/door/airlock/pyro/command{
+	name = "Head of Security's Office";
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/hos,
 /turf/simulated/floor/black,
 /area/station/security/hos)
 "hkZ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-8"
+/obj/machinery/bathtub{
+	pixel_y = 4
 	},
-/turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/exit)
+/obj/item/reagent_containers/bath_bomb,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/hallway/primary/east/restroom)
 "hle" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/central)
 "hlp" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "hlu" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/bar)
 "hlR" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom"
+/obj/cable{
+	icon_state = "0-8"
 	},
-/obj/disposalpipe/trunk/mail,
-/obj/machinery/disposal/mail,
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
+/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/area/station/hallway/secondary/exit)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/hangar/main)
 "hlW" = (
 /obj/machinery/launcher_loader/south,
 /obj/lattice{
@@ -29409,18 +29969,14 @@
 /turf/simulated/floor/black,
 /area/station/ai_monitored/storage/eva)
 "hnP" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/command/alt{
-	aiControlDisabled = 1;
-	name = "glass airlock-'Armory'";
-	req_access_txt = "37"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/weapons,
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "hoL" = (
@@ -29428,9 +29984,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
-	dir = 5
-	},
+/obj/machinery/navbeacon/tour/destiny/tour14,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "hpa" = (
@@ -29465,7 +30019,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/south)
 "hqk" = (
 /obj/machinery/chem_dispenser,
@@ -29515,15 +30069,23 @@
 /area/station/hallway/primary/west)
 "hqQ" = (
 /obj/decal/poster/wallsign/bar,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/bar)
 "hqZ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/equipment)
+"hrc" = (
+/obj/window_blinds/cog2/left{
+	dir = 4
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/heads)
 "hre" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -29546,18 +30108,10 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "hrh" = (
-/obj/machinery/vehicle/escape_pod{
-	dir = 8
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/window/eastright,
-/obj/decal/tile_edge/stripe{
-	icon_state = "xtra_bigstripe-edge"
-	},
-/obj/decal/tile_edge/stripe{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor,
 /area/station/hangar/main)
 "hro" = (
 /obj/stool/chair/comfy{
@@ -29633,7 +30187,7 @@
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/bar)
 "hsC" = (
 /obj/cable{
@@ -29676,20 +30230,15 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
 "huh" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/plasticflaps{
 	layer = 3
 	},
-/obj/machinery/door/airlock/gannets/security,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/beepsky)
 "hul" = (
@@ -29740,10 +30289,10 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "hvz" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/artifact)
 "hvZ" = (
@@ -29815,24 +30364,15 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "hwT" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/bright,
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet{
-	dir = 1;
 	icon_state = "green2"
 	},
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters M03"
 	})
-"hwV" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/disposalpipe/segment,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "hxf" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -29948,97 +30488,41 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"hzH" = (
-/obj/storage/crate,
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/item/clothing/glasses/vr{
-	network = "arcadevr"
-	},
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "hzJ" = (
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"hAc" = (
+/obj/decal/tile_edge/stripe{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
 "hBb" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/right{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "hBp" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/left{
-	dir = 8
-	},
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/hallway/primary/east/restroom)
+/area/station/crew_quarters/lounge/starboard)
 "hBy" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/heads)
 "hCD" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -30066,7 +30550,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering)
 "hDy" = (
 /obj/stool/chair/red{
@@ -30124,14 +30608,14 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "hEf" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/restroom)
 "hEr" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
-/area/station/hangar/main)
+/area/station/crew_quarters/lounge/port)
 "hEA" = (
 /obj/decal/tile_edge/line/white{
 	dir = 5;
@@ -30151,27 +30635,20 @@
 	},
 /area/station/medical/medbay)
 "hEG" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/engineering{
-	name = "glass airlock-'Cargo Bay'";
-	req_access_txt = "31"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 4;
+	name = "Cargo"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/black,
 /area/station/quartermaster/cargobay)
-"hES" = (
-/obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/overfloor/northeast,
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "hFf" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 9;
@@ -30184,11 +30661,11 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "hGG" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "hGO" = (
@@ -30203,7 +30680,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
 "hHl" = (
 /obj/lattice{
@@ -30213,7 +30690,7 @@
 /turf/space,
 /area/station/turret_protected/armory_outside)
 "hHS" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/head)
 "hII" = (
 /obj/decal/tile_edge/line/black{
@@ -30245,6 +30722,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
+"hKi" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "hKo" = (
 /obj/fitness/stacklifter,
 /obj/decal/tile_edge/stripe{
@@ -30316,16 +30799,15 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "hLs" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/middle{
-	dir = 4
+/obj/cable{
+	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/area/station/hallway/primary/north)
 "hLx" = (
 /obj/storage/closet/dresser/random,
 /obj/item/clothing/under/suit/dress{
@@ -30350,7 +30832,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 1
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
 "hMC" = (
 /obj/cable{
@@ -30387,17 +30869,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "hNu" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/lab)
 "hOV" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/decal/tile_edge/line/red{
 	dir = 9;
 	icon_state = "line1"
@@ -30422,6 +30903,7 @@
 	name = "Interrogation Room";
 	opacity = 0
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "hQq" = (
@@ -30446,9 +30928,12 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay)
 "hQz" = (
+/obj/machinery/sleep_console{
+	dir = 8
+	},
 /obj/decal/tile_edge/line/white{
 	icon_state = "line3"
 	},
@@ -30533,7 +31018,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "hTd" = (
 /obj/cable{
@@ -30640,26 +31125,9 @@
 /obj/machinery/computer/ordercomp,
 /turf/simulated/floor,
 /area/station/mining/staff_room)
-"hWT" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/security/brig)
-"hWV" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/table/wood/auto,
-/obj/item/dye_bottle,
-/obj/item/dye_bottle,
-/obj/item/storage/pill_bottle/hairgrownium,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/barber_shop)
 "hXg" = (
 /obj/decal/poster/wallsign/engineering,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/construction)
 "hXh" = (
 /obj/decal/tile_edge/line/green{
@@ -30683,10 +31151,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 9
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "hYx" = (
 /obj/machinery/camera{
@@ -30752,7 +31217,6 @@
 /turf/simulated/floor/red/checker,
 /area/station/security/main)
 "iai" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -30760,6 +31224,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/fitness)
 "iak" = (
@@ -30779,10 +31244,6 @@
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "iaY" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/security/alt{
-	name = "airlock-'Security'"
-	},
 /obj/machinery/secscanner{
 	dir = 4;
 	pixel_x = -20
@@ -30790,13 +31251,17 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "ibd" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/office)
 "ibg" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-8"
@@ -30804,6 +31269,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "ibp" = (
@@ -30830,21 +31296,23 @@
 /turf/simulated/floor,
 /area/station/security/equipment)
 "ibO" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/right{
 	dir = 8
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "icv" = (
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 1;
@@ -30856,19 +31324,22 @@
 	opacity = 0
 	},
 /obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "icC" = (
-/obj/item/storage/wall/clothingrack/clothes2,
-/obj/potted_plant/potted_plant1{
+/obj/item/storage/wall/clothingrack/clothes1,
+/obj/potted_plant/potted_plant2{
 	dir = 1;
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "green2"
+	icon_state = "red2"
 	},
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "icF" = (
 /obj/storage/secure/closet/animal,
 /obj/decal/tile_edge/line/white{
@@ -30963,17 +31434,20 @@
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "ifC" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical{
-	name = "glass airlock-'Medbay'";
-	req_access_txt = null
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/door/airlock/pyro/glass/med{
+	name = "Medbay"
+	},
+/obj/machinery/door/airlock/pyro/glass/med{
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -30996,7 +31470,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/head)
 "igr" = (
 /obj/disposalpipe/segment,
@@ -31062,17 +31536,15 @@
 	},
 /area/station/science/artifact)
 "ihG" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/window_blinds/cog2,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay)
 "ijn" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance,
 /obj/cable{
 	icon_state = "1-4"
 	},
@@ -31082,6 +31554,11 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Crew Lounge"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/south)
 "ijD" = (
@@ -31097,13 +31574,13 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/refinery)
 "ikf" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/staff_room)
 "ilK" = (
 /obj/stool/bed,
@@ -31111,26 +31588,28 @@
 /turf/simulated/floor/white/checker2,
 /area/station/maintenance/outer/sw)
 "ilX" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/ranch)
 "imh" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical/alt{
-	name = "airlock-'Psychiatrist's Office'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 1;
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
 "imi" = (
@@ -31151,21 +31630,24 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/psychiatrist)
 "inP" = (
-/obj/machinery/light{
-	dir = 1
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/red,
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/obj/submachine/claw_machine,
-/obj/machinery/light_switch/east{
-	pixel_x = 0;
+/obj/item/storage/secure/ssafe{
 	pixel_y = 28
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 1
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "red2"
 	},
-/area/station/hallway/secondary/exit)
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M04"
+	})
 "ioe" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -31282,10 +31764,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "44|50"
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/east)
 "irD" = (
@@ -31303,16 +31785,15 @@
 /turf/simulated/floor,
 /area/station/security/equipment)
 "irW" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
 /area/station/crew_quarters/lounge/starboard)
 "isa" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering)
 "isd" = (
 /obj/potted_plant/potted_plant3,
@@ -31436,6 +31917,7 @@
 	},
 /obj/machinery/cashreg,
 /obj/item/kitchen/food_box/lollipop,
+/obj/access_spawn/medical,
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "iuY" = (
@@ -31536,13 +32018,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
-"ixL" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "iyg" = (
 /obj/decal/tile_edge/line/green{
 	dir = 1;
@@ -31569,23 +32044,24 @@
 	},
 /area/station/engine/engineering/ce)
 "iyz" = (
-/obj/potted_plant/potted_plant4{
-	dir = 1;
-	pixel_y = 32
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/stool/chair/office/red,
 /turf/simulated/floor/carpet{
-	dir = 1;
 	icon_state = "red2"
 	},
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters M04"
 	})
 "iyB" = (
-/turf/simulated/floor/stairs{
-	icon_state = "Stairs_wide"
+/obj/item/storage/wall/fire{
+	pixel_y = 32
 	},
-/area/station/crew_quarters/lounge/port)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/central)
 "iyE" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/disposalpipe/segment/morgue{
@@ -31636,13 +32112,21 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "iAD" = (
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "fgreen2"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname  - SS13"
 	},
-/area/station/crew_quarters/heads)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/noticeboard/persistent{
+	name = "Customs persistent notice board";
+	persistent_id = "customs"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "iAI" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -31651,6 +32135,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "iAM" = (
@@ -31695,18 +32180,24 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
-"iCU" = (
-/obj/machinery/macrofab/emergency_pod,
-/obj/machinery/light{
-	dir = 1
+"iCH" = (
+/obj/disposalpipe/segment{
+	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
+"iCU" = (
+/obj/machinery/vehicle/miniputt,
 /turf/simulated/floor/engine,
 /area/station/hangar/main)
 "iDa" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "iDG" = (
 /obj/decal/tile_edge/line/black{
@@ -31773,24 +32264,34 @@
 /area/station/security/equipment)
 "iEm" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/manufacturer/hop_and_uniform,
+/obj/machinery/light/incandescent{
+	dir = 8;
+	nostick = 1
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/area/station/crew_quarters/heads)
 "iEn" = (
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Medbay Restroom'"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro{
+	name = "Toilets"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/restroom)
 "iGY" = (
@@ -31825,18 +32326,14 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "iHi" = (
-/obj/table/auto,
-/obj/machinery/computer3/generic/personal{
-	pixel_y = 9
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge";
+	pixel_y = 10
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-2"
+/obj/railing/yellow{
+	pixel_y = 10
 	},
-/obj/machinery/light_switch/north{
-	pixel_y = 28
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/starboard)
 "iHl" = (
 /obj/lattice{
@@ -31845,7 +32342,6 @@
 /turf/space,
 /area/station/turret_protected/armory_outside)
 "iHK" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -31860,6 +32356,7 @@
 	name = "Atmospherics Security Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/atmos/highcap_storage)
 "iHR" = (
@@ -31896,11 +32393,12 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "iJy" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/command/alt{
-	name = "airlock-'AI Core'";
-	req_access_txt = "19"
+/obj/machinery/door/airlock/pyro/command{
+	name = "AI Upload";
+	req_access = null
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/ai_upload,
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -31958,10 +32456,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "iLQ" = (
 /obj/disposalpipe/segment/mail{
@@ -31992,36 +32487,17 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "iMF" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/power)
 "iNp" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 20
+/turf/simulated/floor/stairs{
+	icon_state = "Stairs_wide"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
-/obj/stool/chair/couch/green{
-	dir = 8
-	},
-/turf/simulated/floor,
 /area/station/crew_quarters/lounge/starboard)
-"iOd" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
 "iOr" = (
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
@@ -32107,20 +32583,19 @@
 	},
 /area/station/medical/head)
 "iRM" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/janitor/office)
 "iRY" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "iRZ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
@@ -32130,6 +32605,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -32154,16 +32630,11 @@
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
 "iUs" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/yellow,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	dir = 9;
+	dir = 10;
 	icon_state = "blue2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -32178,13 +32649,14 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "iUF" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/table/auto,
-/obj/towelbin,
-/turf/simulated/floor/sanitary,
-/area/station/hallway/primary/east/restroom)
+/turf/simulated/floor/stairs{
+	dir = 1;
+	icon_state = "Stairs2_wide"
+	},
+/area/station/crew_quarters/lounge/starboard)
 "iUK" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -32214,13 +32686,13 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "iVG" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "iWe" = (
@@ -32241,31 +32713,26 @@
 /turf/simulated/floor/specialroom/clown,
 /area/station/crew_quarters/clown)
 "iWm" = (
+/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/chemistry{
-	name = "airlock-'Science Lobby'";
-	req_access_txt = null
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 1;
+	name = "Research"
 	},
+/obj/firedoor_spawn,
 /obj/access_spawn/research,
-/obj/access_spawn/maint,
 /turf/simulated/floor/plating/random,
 /area/station/science/lobby)
 "iWD" = (
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/drinks/bottle/hobo_wine,
-/obj/machinery/light/lamp/bright,
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet{
-	dir = 1;
 	icon_state = "blue2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -32302,7 +32769,6 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "iXY" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -32310,6 +32776,7 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/turret_protected/Zeta)
 "iYk" = (
@@ -32390,20 +32857,18 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "jbg" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/science/lobby)
 "jbp" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/ai_status_display{
-	pixel_y = 32
+/obj/cable{
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 5
-	},
-/area/station/hallway/secondary/exit)
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/hallway/primary/north)
 "jbI" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -32416,7 +32881,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/head)
 "jcl" = (
 /obj/decal/tile_edge/stripe{
@@ -32433,7 +32898,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "jcL" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/south)
 "jcO" = (
 /turf/simulated/floor/carpet{
@@ -32451,14 +32916,8 @@
 /turf/simulated/floor,
 /area/station/hangar/qm)
 "jdi" = (
-/obj/decal/tile_edge/stripe{
-	icon_state = "xtra_bigstripe-edge"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/primary/east/restroom)
 "jdl" = (
 /turf/simulated/floor/white,
 /area/station/maintenance/inner/south)
@@ -32479,7 +32938,7 @@
 	},
 /area/station/medical/robotics)
 "jeg" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/courtroom)
 "jer" = (
 /obj/disposalpipe/junction,
@@ -32508,13 +32967,13 @@
 /turf/simulated/floor/purple,
 /area/station/science/artifact)
 "jfp" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/bar)
 "jfx" = (
@@ -32624,19 +33083,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
-"jgQ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical/alt{
-	name = "airlock-'Medbay'"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/bluewhite,
-/area/station/medical/medbay)
 "jhn" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
@@ -32645,7 +33091,6 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "jhS" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -32655,6 +33100,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/hos)
 "jhV" = (
@@ -32680,22 +33126,14 @@
 	},
 /area/station/medical/cdc)
 "jiV" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/table/reinforced/auto,
-/obj/window/reinforced/east,
-/obj/machinery/door/window/southright{
-	req_access_txt = "15"
+/obj/disposalpipe/segment,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname  - SS13"
 	},
-/obj/item/clipboard{
-	pixel_y = 5
-	},
-/obj/item/paper_bin{
-	pixel_y = 5
-	},
-/obj/item/pen,
-/obj/item/pen/fancy,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/heads)
+/area/station/hallway/primary/north)
 "jjD" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -32718,15 +33156,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "jka" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-2"
-	},
+/obj/cable,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/hangar/main)
+/area/station/crew_quarters/lounge/port)
 "jkK" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/brute,
@@ -32739,10 +33175,19 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "jkW" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/turret_protected/Zeta)
+"jlx" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/heads)
 "jlF" = (
 /obj/machinery/vending/medical,
 /obj/item_dispenser/prescription_glasses,
@@ -32760,11 +33205,6 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "jmC" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'Mining'";
-	req_access_txt = "50"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -32772,6 +33212,12 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/mining{
+	dir = 4;
+	name = "Mining"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/mining,
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "jmF" = (
@@ -32816,16 +33262,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "jmT" = (
-/obj/storage/closet/wardrobe/pink,
+/obj/storage/closet/wardrobe/green,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "purple2"
+	icon_state = "green2"
 	},
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "jmW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -32837,10 +33283,7 @@
 /area/station/science/lobby)
 "jnZ" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "jol" = (
 /obj/machinery/power/apc/autoname_north,
@@ -32857,16 +33300,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
-"joE" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/incandescent{
-	dir = 1;
-	nostick = 1
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
 "joO" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 9
@@ -32874,7 +33307,7 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "jpP" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/pharmacy)
 "jqb" = (
 /obj/storage/secure/closet/security/equipment,
@@ -32899,17 +33332,19 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "jqm" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'Mechanics'";
-	req_access_txt = "45"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Mechanic's Lab";
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_mechanic,
 /turf/simulated/floor/black,
 /area/station/engine/elect)
 "jqv" = (
@@ -32997,26 +33432,8 @@
 /turf/simulated/floor/black,
 /area/station/hangar/qm)
 "jsQ" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13"
-	},
-/obj/decal/tile_edge/stripe{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	location = "Net Cafe"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/railing/yellow{
-	dir = 1
-	},
-/turf/simulated/floor/bot,
+/obj/machinery/vending/medical_public,
+/turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "jsZ" = (
 /obj/table/wood/auto,
@@ -33031,9 +33448,11 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;
-	icon_state = "green2"
+	icon_state = "red2"
 	},
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "jtd" = (
 /obj/stool/chair/red{
 	anchored = 0;
@@ -33062,6 +33481,9 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "jtm" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
 /obj/decal/tile_edge/line/white{
 	icon_state = "line3"
 	},
@@ -33072,31 +33494,22 @@
 /obj/machinery/light_switch/north{
 	pixel_y = 28
 	},
-/obj/machinery/sleeper/compact{
-	dir = 8
-	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
-"jtC" = (
-/obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/light/emergency{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "jtH" = (
-/obj/decal/tile_edge/stripe{
-	icon_state = "xtra_bigstripe-edge"
+/obj/window_blinds/cog2/middle{
+	dir = 4
 	},
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/quartersA)
 "jtJ" = (
 /obj/decal/tile_edge/line/black{
 	dir = 1;
@@ -33128,11 +33541,16 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/navbeacon/tour/destiny/tour14,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "jug" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/cloner)
 "juI" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -33143,19 +33561,16 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "juJ" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/equipment)
 "juT" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "jva" = (
@@ -33165,15 +33580,6 @@
 	icon_state = "fblue6"
 	},
 /area/station/engine/engineering/ce)
-"jvG" = (
-/obj/disposalpipe/segment,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=podbay";
-	location = "quarters_west";
-	name = "bot navigation beacon"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "jvN" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -33191,13 +33597,15 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "jwe" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical/alt{
-	name = "airlock-'Medbay'"
-	},
 /obj/disposalpipe/junction{
 	dir = 2
 	},
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 1;
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "jwj" = (
@@ -33264,7 +33672,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "jxv" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/tools)
 "jxZ" = (
 /obj/decal/tile_edge/line/blue{
@@ -33343,7 +33751,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/wingrille_spawn/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/fitness)
 "jzx" = (
@@ -33370,13 +33778,13 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "jAa" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/security/beepsky)
 "jAb" = (
@@ -33395,7 +33803,7 @@
 	},
 /area/station/chapel/sanctuary)
 "jAQ" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/elect)
 "jBx" = (
 /obj/decal/tile_edge/line/green{
@@ -33439,7 +33847,6 @@
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "jCM" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
@@ -33450,6 +33857,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
 "jDh" = (
@@ -33528,10 +33936,7 @@
 	dir = 1;
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
 "jEp" = (
 /obj/item/device/light/glowstick/red,
@@ -33546,7 +33951,7 @@
 	dir = 5;
 	level = 2
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
 "jFj" = (
 /obj/machinery/power/monitor,
@@ -33587,34 +33992,27 @@
 	},
 /area/station/crew_quarters/sauna)
 "jGv" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "jGA" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/noticeboard/persistent{
-	name = "Customs persistent notice board";
-	persistent_id = "customs"
+/obj/cable{
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/carpet{
+	icon_state = "fblue1"
+	},
+/area/station/crew_quarters/quartersA)
 "jGC" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/bot_storage)
 "jGF" = (
@@ -33635,9 +34033,21 @@
 	},
 /area/station/crew_quarters/bar)
 "jGW" = (
-/obj/machinery/vending/medical_public,
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/clothing/suit/bedsheet/pink,
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "purple2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M01"
+	})
 "jHi" = (
 /obj/landmark/gps_waypoint,
 /obj/disposalpipe/segment,
@@ -33694,13 +34104,13 @@
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
 "jJC" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Pool Room'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Pool"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/pool)
 "jJR" = (
@@ -33794,6 +34204,17 @@
 /area/station/crew_quarters/showers{
 	name = "Pool Shower Room"
 	})
+"jLO" = (
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "line2"
+	},
+/obj/machinery/vending/security,
+/obj/machinery/light_switch/north,
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "jMc" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -33847,7 +34268,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/power)
 "jOv" = (
 /obj/decal/tile_edge/line/blue{
@@ -33872,8 +34293,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 4
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "jPb" = (
@@ -33887,20 +34310,17 @@
 	},
 /area/station/security/beepsky)
 "jPk" = (
-/obj/decal/tile_edge/line/black{
-	dir = 1;
-	icon_state = "line1"
+/obj/machinery/recharge_station,
+/obj/machinery/light_switch/north{
+	pixel_x = 10;
+	pixel_y = 28
 	},
-/obj/item/device/radio/intercom/security,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
+/obj/item/device/radio/intercom{
+	name = "Station Intercom";
+	pixel_x = -5
 	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/turf/simulated/floor,
+/area/station/hangar/main)
 "jQr" = (
 /obj/storage/secure/closet/medical{
 	name = "locker"
@@ -33914,7 +34334,6 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "jQM" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -33924,6 +34343,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/observatory)
 "jQR" = (
@@ -33942,6 +34362,12 @@
 	dir = 4
 	},
 /area/station/security/main)
+"jRm" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/central)
 "jRo" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/machinery/chem_heater{
@@ -33950,11 +34376,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
-"jRB" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "jSy" = (
 /obj/stool/chair/couch/yellow{
 	dir = 8
@@ -33965,10 +34386,10 @@
 /turf/simulated/floor/carpet/blue/standard/edge/nw,
 /area/station/maintenance/inner/south)
 "jSJ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "jSM" = (
@@ -33988,11 +34409,11 @@
 /turf/simulated/floor/black,
 /area/station/hangar/qm)
 "jSQ" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/orangeblack/side{
-	dir = 10
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/sanitary,
+/area/station/hallway/primary/east/restroom)
 "jSS" = (
 /obj/railing/yellow,
 /obj/table/wood/round,
@@ -34023,10 +34444,10 @@
 	},
 /area/station/science/chemistry)
 "jTB" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/observatory)
 "jTU" = (
@@ -34086,14 +34507,18 @@
 /turf/simulated/floor/industrial,
 /area/station/mining/refinery)
 "jVS" = (
-/obj/decal/tile_edge/stripe{
-	icon_state = "xtra_bigstripe-edge"
+/obj/stool/chair/comfy/red,
+/obj/landmark/start{
+	name = "Head of Security"
 	},
-/obj/cable{
-	icon_state = "2-8"
+/obj/decal/poster/wallsign/framed_award/hos_medal{
+	pixel_y = 28
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fred2"
+	},
+/area/station/crew_quarters/hos)
 "jWb" = (
 /obj/storage/closet/office,
 /turf/simulated/floor/purpleblack{
@@ -34135,25 +34560,29 @@
 /turf/simulated/floor,
 /area/station/hangar/qm)
 "jWD" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.5;
-	pixel_x = 24
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/pink,
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/obj/shrub{
-	dir = 4;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "purple2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M01"
+	})
 "jWF" = (
-/obj/wingrille_spawn/reinforced,
-/obj/cable{
-	icon_state = "0-2"
+/obj/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
 	},
-/turf/simulated/floor/plating/random,
-/area/station/hangar/main)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "jXy" = (
 /obj/landmark{
 	icon_state = "x3";
@@ -34185,7 +34614,7 @@
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
 "jZT" = (
 /obj/table/reinforced/auto,
@@ -34217,36 +34646,18 @@
 	dir = 4
 	},
 /area/station/chapel/sanctuary)
-"kaG" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port)
 "kbb" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/power)
 "kbc" = (
-/obj/decal/tile_edge/line/black{
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/machinery/recharger/wall/sticky{
-	pixel_y = 32
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/obj/machinery/manufacturer/hangar,
+/turf/simulated/floor,
+/area/station/hangar/main)
 "kbg" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -34269,6 +34680,16 @@
 /obj/decal/mule/beacon,
 /turf/simulated/floor,
 /area/station/mining/staff_room)
+"kbO" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/central)
 "kcH" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
@@ -34284,6 +34705,14 @@
 	},
 /turf/simulated/floor/red,
 /area/station/science/lab)
+"kcK" = (
+/obj/window_blinds/cog2/right{
+	dir = 8
+	},
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/hallway/primary/east/restroom)
 "kdF" = (
 /obj/disposalpipe/trunk/morgue{
 	dir = 4
@@ -34310,8 +34739,10 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment/mail,
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
+	dir = 1
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "ken" = (
@@ -34331,19 +34762,6 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"keB" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
-	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
 "keH" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 8;
@@ -34460,7 +34878,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery/storage)
 "khR" = (
 /obj/cable{
@@ -34472,17 +34890,17 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/west)
 "kiG" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'";
-	req_access_txt = "12|33"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 8
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "kiI" = (
@@ -34530,17 +34948,17 @@
 	},
 /area/station/crew_quarters/pool)
 "kkd" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/gannets/glass{
-	name = "airlock-'Central Warehouse'";
-	req_access_txt = "12"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Central Warehouse"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/storage/warehouse)
 "kkf" = (
@@ -34567,11 +34985,6 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/surgery/storage)
 "kkC" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	name = "glass airlock-'Pharmacy'";
-	req_access_txt = "5"
-	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	icon_state = "pdoor0";
@@ -34583,6 +34996,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/sci{
+	name = "Pharmacy"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor,
 /area/station/medical/medbay/pharmacy)
 "kkM" = (
@@ -34650,33 +35068,30 @@
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
 "kly" = (
-/obj/machinery/door/poddoor/blast,
-/turf/simulated/floor/engine{
-	dir = 4;
-	icon_state = "engine_caution_misc"
-	},
-/area/station/hallway/secondary/exit)
-"klI" = (
-/obj/cable{
-	icon_state = "1-4"
+/obj/decal/tile_edge/stripe{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
-"klO" = (
-/obj/airbridge_controller{
-	id = "merchant_R"
+/area/station/hangar/main)
+"klI" = (
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/space,
-/area/space)
+/obj/submachine/ATM/atm_alt{
+	pixel_y = 32
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "kng" = (
-/obj/wingrille_spawn,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/east)
 "knC" = (
@@ -34692,6 +35107,18 @@
 	},
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
+"knY" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/machinery/recharger/wall/sticky{
+	pixel_y = 32
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "koh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -34713,11 +35140,11 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "koq" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/disposalpipe/segment/mineral{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/mining/refinery)
 "kox" = (
@@ -34857,18 +35284,15 @@
 /turf/simulated/floor/red/checker,
 /area/station/security/main)
 "ktf" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/janitor/supply)
 "kty" = (
-/obj/item_dispenser/idcarddispenser,
-/obj/table/wood/auto/desk,
-/obj/item/folder{
-	pixel_y = 5
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 1;
+	name = "Customs"
 	},
-/obj/item/paper_bin{
-	pixel_y = 5
-	},
-/obj/item/pen,
+/obj/firedoor_spawn,
+/obj/access_spawn/head_of_personnel,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -34887,26 +35311,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
-"kvC" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
 "kvI" = (
 /obj/machinery/atmospherics/valve{
 	dir = 1;
 	name = "cold loop bypass outlet valve"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "kvW" = (
 /obj/disposalpipe/segment{
@@ -35025,13 +35435,13 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "kyA" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/power)
 "kyU" = (
@@ -35042,6 +35452,19 @@
 	},
 /turf/simulated/floor/bluewhite/corner,
 /area/station/medical/medbay)
+"kyV" = (
+/obj/stool/chair/couch/green{
+	dir = 4
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "kyW" = (
 /turf/simulated/floor,
 /area/station/turret_protected/Zeta)
@@ -35050,22 +35473,30 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "kzI" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/security/hos)
 "kzY" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs2_wide"
-	},
+/obj/machinery/vending/cola/red,
+/turf/simulated/floor,
 /area/station/crew_quarters/lounge/starboard)
+"kAs" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P01"
+	})
 "kAM" = (
 /turf/simulated/floor/stairs{
 	icon_state = "wood_stairs"
@@ -35116,17 +35547,22 @@
 	},
 /area/station/security/beepsky)
 "kBS" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
+/obj/table/wood/auto,
+/obj/item/clothing/gloves/latex,
+/obj/item/scissors,
+/obj/item/razor_blade,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname  - SS13"
 	},
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
+/obj/item_dispenser/latex_gloves,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "kCc" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/engine,
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
 /area/station/hangar/main)
 "kCd" = (
 /obj/storage/closet/biohazard,
@@ -35146,16 +35582,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "kCh" = (
-/obj/item/storage/wall/clothingrack/clothes3,
-/obj/potted_plant/potted_plant3{
+/obj/item/storage/wall/clothingrack/clothes2,
+/obj/potted_plant/potted_plant1{
 	dir = 1;
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "purple2"
+	icon_state = "green2"
 	},
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "kCw" = (
 /obj/table/wood/round/auto,
 /obj/item/card_group/plain,
@@ -35165,16 +35601,13 @@
 	},
 /area/station/crew_quarters/bar)
 "kCM" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/pink,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
 	},
 /turf/simulated/floor/carpet{
-	dir = 5;
+	dir = 6;
 	icon_state = "purple2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -35184,14 +35617,14 @@
 /turf/simulated/floor/bluegreen,
 /area/station/medical/medbay/treatment2)
 "kDq" = (
-/obj/wingrille_spawn/reinforced,
 /obj/forcefield/energyshield/perma,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "kDO" = (
 /obj/disposalpipe/trunk{
 	dir = 1
@@ -35205,41 +35638,52 @@
 	},
 /area/station/crew_quarters/bar)
 "kDU" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/decal/tile_edge/stripe{
-	dir = 8;
-	icon_state = "xtra_bigstripe-edge"
+/obj/window_blinds/cog2/middle{
+	dir = 8
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/hos)
 "kEq" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/armory)
 "kEs" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/door/poddoor/blast{
+	autoclose = 1;
+	dir = 1;
+	doordir = "left";
+	icon_state = "bdoorleft1";
+	id = "pod_fore";
+	layer = 4;
+	name = "North Pod Hangar"
 	},
-/turf/simulated/floor/plating/random,
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/engine{
+	icon_state = "engine_caution_west"
+	},
 /area/station/hangar/main)
 "kEz" = (
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
-	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/north)
 "kEM" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -35252,28 +35696,13 @@
 	},
 /area/station/science/lobby)
 "kFa" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'North Pod Bay'"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/secscanner{
-	dir = 4;
-	pixel_x = -20
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "2-4"
+/obj/stool/chair/wooden,
+/obj/potted_plant/potted_plant5{
+	dir = 1;
+	pixel_y = 32
 	},
 /turf/simulated/floor/black,
-/area/station/hangar/main)
+/area/station/hallway/primary/north)
 "kFj" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -35489,17 +35918,16 @@
 /area/station/medical/dome)
 "kMO" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Escape'"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/exit)
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/north)
 "kMP" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -35507,7 +35935,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "kMS" = (
-/obj/wingrille_spawn/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/lobby)
 "kNO" = (
@@ -35578,7 +36006,6 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "kPu" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 4;
@@ -35589,6 +36016,7 @@
 	name = "Test Chamber Blast Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/science/testchamber)
 "kPG" = (
@@ -35599,7 +36027,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "kPJ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -35609,6 +36036,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/black,
 /area/station/ranch)
 "kPK" = (
@@ -35631,18 +36059,15 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "kQp" = (
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
+/obj/machinery/vending/floppy,
 /turf/simulated/floor,
-/area/station/hangar/main)
+/area/station/crew_quarters/lounge/port)
 "kQB" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering)
 "kQH" = (
 /obj/machinery/deep_fryer,
@@ -35652,21 +36077,18 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "kQY" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs_wide"
-	},
+/obj/machinery/vending/coffee,
+/obj/machinery/light,
+/turf/simulated/floor,
 /area/station/crew_quarters/lounge/starboard)
 "kRc" = (
-/obj/disposalpipe/junction,
-/obj/cable{
-	icon_state = "4-8"
+/obj/window_blinds/cog2/left{
+	dir = 4
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/quartersA)
 "kRw" = (
 /obj/machinery/light/small/floor/blueish{
 	pixel_y = 15
@@ -35678,19 +36100,20 @@
 	dir = 4
 	},
 /obj/decal/poster/wallsign/danger_highvolt,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "kSJ" = (
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/south)
 "kTa" = (
-/turf/simulated/floor/stairs{
-	icon_state = "Stairs2_wide"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/crew_quarters/lounge/port)
+/obj/machinery/light_switch/north{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/central)
 "kTK" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 4;
@@ -35703,8 +36126,8 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "kUp" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "kUx" = (
@@ -35728,7 +36151,7 @@
 /turf/simulated/floor/neutral/side,
 /area/station/engine/power)
 "kUH" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/dome)
 "kVa" = (
 /obj/table/auto,
@@ -35737,10 +36160,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "kVB" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "kVD" = (
@@ -35764,19 +36187,6 @@
 /obj/machinery/fluid_canister,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
-"kWy" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
-	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
 "kWI" = (
 /obj/railing/orange/reinforced{
 	dir = 1
@@ -35785,15 +36195,6 @@
 	dir = 1
 	},
 /area/station/ranch)
-"kWU" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port)
 "kXk" = (
 /obj/stool/chair/couch/green,
 /obj/item/toy/plush/small,
@@ -35805,6 +36206,7 @@
 	},
 /area/station/crew_quarters/observatory)
 "kXs" = (
+/obj/disposalpipe/segment/brig,
 /obj/submachine/poster_creator,
 /obj/decal/tile_edge/line/white{
 	icon_state = "line1"
@@ -35846,7 +36248,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/kitchen)
 "kXT" = (
@@ -35863,7 +36265,6 @@
 /turf/simulated/floor/blackwhite,
 /area/station/medical/robotics)
 "kYa" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
@@ -35871,6 +36272,7 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/head)
 "kYh" = (
@@ -35924,22 +36326,25 @@
 /turf/space,
 /area/station/com_dish/comdish)
 "kZb" = (
-/obj/wingrille_spawn,
 /obj/decal/tile_edge/stripe{
 	icon_state = "xtra_bigstripe-edge"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "kZe" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/heads)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "kZp" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -35951,14 +36356,17 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "kZz" = (
-/obj/wingrille_spawn,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "laa" = (
-/obj/machinery/disposal/small{
-	dir = 4
-	},
-/obj/disposalpipe/trunk,
+/obj/disposalpipe/segment,
+/obj/storage/crate,
+/obj/item/clothing/mask/horse_mask,
+/obj/item/clothing/under/misc/barber,
+/obj/item/clothing/shoes/brown,
+/obj/item/clothing/head/bald_cap,
+/obj/item/clothing/head/wig,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
 "lac" = (
@@ -35975,7 +36383,6 @@
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
 "lam" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/machinery/door/window/westleft{
 	req_access_txt = "45"
@@ -35984,6 +36391,8 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_mechanic,
 /turf/simulated/floor/black,
 /area/station/engine/elect)
 "lao" = (
@@ -36031,29 +36440,35 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "lbp" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/bar)
 "lbA" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/treatment)
 "lbL" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13"
 	},
-/obj/disposalpipe/switch_junction{
-	dir = 1;
-	mail_tag = "escape";
-	name = "escape mail router"
+/turf/space,
+/area/space)
+"lbV" = (
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "line1"
 	},
-/obj/machinery/light/small/floor/blueish,
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Security Checkpoint";
+	req_access_txt = null
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "lck" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -36111,10 +36526,10 @@
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/kitchen)
 "ldS" = (
@@ -36134,10 +36549,10 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/food,
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/west)
 "leR" = (
@@ -36148,13 +36563,15 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "leZ" = (
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'West SMES'";
-	req_access_txt = "44"
-	},
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/door/airlock/pyro/engineering/alt{
+	dir = 4;
+	name = "West SMES"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor,
 /area/station/engine/power)
 "lfd" = (
@@ -36198,35 +36615,32 @@
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/supply)
 "lhr" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/lounge/starboard)
-"lhu" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
-/area/station/mining/staff_room)
 "lhD" = (
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/window_blinds/cog2/right{
+	dir = 8
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
-"liw" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/hos)
+"liw" = (
+/obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "liA" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -36285,9 +36699,22 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
+"lkz" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "lkF" = (
 /obj/disposalpipe/segment/food,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/teleporter)
 "lkL" = (
 /obj/disposalpipe/segment,
@@ -36319,18 +36746,19 @@
 /area/station/turret_protected/ai)
 "llG" = (
 /obj/decal/poster/wallsign/pool,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
 "llI" = (
-/obj/disposalpipe/junction,
-/obj/table/auto/desk,
-/obj/machinery/computer3/generic/personal{
-	pixel_y = 9
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "llO" = (
@@ -36400,7 +36828,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "lnf" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2{
 	dir = 4
 	},
@@ -36413,6 +36840,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -36420,9 +36848,9 @@
 	name = "Genetic Research"
 	})
 "lnt" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/hangar/qm)
 "lnz" = (
@@ -36476,7 +36904,7 @@
 	can_rupture = 0;
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "loO" = (
 /obj/decal/tile_edge/line/white{
@@ -36528,17 +36956,13 @@
 /turf/space,
 /area/station/hangar/sec)
 "lrb" = (
-/obj/disposalpipe/segment,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
+/obj/disposalpipe/junction,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "lrf" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -36548,32 +36972,29 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "lrv" = (
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
+/obj/decal/stage_edge/alt{
+	pixel_y = 10
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/starboard)
 "lrx" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "lsa" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/left,
 /obj/cable{
 	icon_state = "0-4"
@@ -36581,6 +37002,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 1
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment1)
 "lss" = (
@@ -36655,10 +37077,10 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "lto" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/armory)
 "lty" = (
@@ -36670,40 +37092,36 @@
 /area/station/security/detectives_office)
 "ltz" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
 "ltJ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/red,
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Escape'"
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
 	},
-/obj/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "red2"
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/secondary/exit)
-"ltO" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/security/main)
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M04"
+	})
 "luc" = (
-/obj/cable{
-	icon_state = "0-2"
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/obj/stool/chair/office/blue{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Medical Doctor"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
 "lut" = (
 /obj/stool/bar,
 /obj/landmark/start{
@@ -36711,11 +37129,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
-"luv" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/south)
 "luA" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -36731,6 +37144,15 @@
 	},
 /turf/simulated/floor,
 /area/station/security/equipment)
+"lvl" = (
+/obj/disposalpipe/segment/brig{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/interrogation)
 "lvC" = (
 /obj/disposalpipe/trunk/mail{
 	dir = 8
@@ -36753,8 +37175,39 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/interrogation)
+"lvO" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/blast{
+	density = 0;
+	dir = 4;
+	icon_state = "bdoormid0";
+	id = "atmos_shield";
+	layer = 4;
+	name = "Atmospherics Security Shield";
+	opacity = 0
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/atmos/highcap_storage)
+"lvY" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Construction Room"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/mining,
+/turf/simulated/floor/plating/random,
+/area/station/hallway/secondary/construction)
 "lwm" = (
 /obj/table/wood/auto/desk{
 	pixel_y = -2
@@ -36789,16 +37242,24 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "lwH" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/outer/sw)
 "lxd" = (
-/obj/disposalpipe/segment/mail{
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pod Bay Storage"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor,
 /area/station/hangar/main)
 "lxl" = (
 /obj/cable{
@@ -36867,14 +37328,14 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "lAi" = (
+/obj/machinery/vending/pda,
 /turf/simulated/floor,
-/area/station/hangar/main)
+/area/station/crew_quarters/lounge/port)
 "lAF" = (
 /obj/machinery/bot/cleanbot,
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/office)
 "lBQ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/forcefield/energyshield/perma{
 	dir = 8
 	},
@@ -36882,8 +37343,9 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "lCc" = (
 /obj/table/auto,
 /obj/item/pen/crayon/rainbow,
@@ -36924,21 +37386,21 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fblue1"
+	icon_state = "purple1"
 	},
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
 "lEH" = (
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 1
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "lFN" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/artifact)
 "lFY" = (
@@ -36980,7 +37442,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/interrogation)
 "lHj" = (
 /obj/cable{
@@ -37023,9 +37485,9 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
-	icon_state = "fred1"
+	icon_state = "fgreen1"
 	},
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "lJc" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37048,10 +37510,12 @@
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical{
-	name = "glass airlock-'Cloning'"
+/obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 8;
+	name = "Cloning"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -37091,13 +37555,13 @@
 	},
 /area/station/medical/cdc)
 "lKI" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/observatory)
 "lKU" = (
@@ -37115,7 +37579,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "lLn" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/middle{
 	dir = 8
 	},
@@ -37126,8 +37589,9 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "lLC" = (
 /obj/machinery/door_control{
 	id = "combustion";
@@ -37171,18 +37635,8 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
-"lMh" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "lMr" = (
 /obj/machinery/magnet_chassis{
 	pixel_x = 16
@@ -37198,16 +37652,11 @@
 	},
 /area/space)
 "lMu" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/yellow,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	dir = 5;
+	dir = 6;
 	icon_state = "blue2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -37247,11 +37696,9 @@
 /turf/simulated/floor/green,
 /area/station/medical/medbay/treatment1)
 "lML" = (
-/obj/machinery/vending/book,
-/obj/machinery/light{
-	dir = 1
+/turf/simulated/floor/stairs{
+	icon_state = "Stairs_wide"
 	},
-/turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "lMY" = (
 /obj/machinery/door/poddoor/blast{
@@ -37272,7 +37719,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "lNB" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
@@ -37280,8 +37726,13 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/lab)
+"lNC" = (
+/obj/bookshelf/persistent,
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "lNG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37296,12 +37747,9 @@
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/lobby)
 "lNV" = (
-/obj/decal/tile_edge/line/blue{
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/decal/poster/wallsign/escape_right,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/exit)
 "lOs" = (
 /obj/cable,
 /obj/cable{
@@ -37310,7 +37758,6 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 1;
@@ -37321,13 +37768,18 @@
 	opacity = 0
 	},
 /obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "lOt" = (
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor/vertical{
-	dir = 6
+/obj/machinery/light/incandescent/cool{
+	dir = 4;
+	nostick = 1
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
 "lOK" = (
 /obj/machinery/vending/cola/blue,
@@ -37402,8 +37854,6 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/food,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -37413,6 +37863,10 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "lRE" = (
@@ -37429,10 +37883,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "lRH" = (
-/obj/machinery/drainage,
-/obj/submachine/chef_sink{
-	dir = 8;
-	name = "utility sink"
+/obj/stool/chair/comfy/barber_chair{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
@@ -37512,7 +37964,6 @@
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "lTX" = (
-/obj/wingrille_spawn/reinforced,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 4;
@@ -37526,6 +37977,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/south)
 "lVh" = (
@@ -37554,10 +38006,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "lWa" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "lWc" = (
@@ -37646,16 +38098,25 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "lXQ" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/machinery/door/poddoor/blast{
+	autoclose = 1;
+	dir = 1;
+	doordir = "right";
+	icon_state = "bdoorright1";
+	id = "pod_fore";
+	layer = 4;
+	name = "North Pod Hangar"
 	},
-/obj/cable{
-	icon_state = "1-8"
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
+/turf/simulated/floor/engine{
+	icon_state = "engine_caution_west"
 	},
-/area/station/hallway/secondary/exit)
+/area/station/hangar/main)
 "lXX" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=quarters_west";
@@ -37678,13 +38139,13 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "lYC" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
 "lYE" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -37716,10 +38177,11 @@
 	},
 /area/station/science/lobby)
 "lZA" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/security{
-	name = "airlock-'West Pod Bay'"
+/obj/machinery/door/airlock/pyro/security{
+	name = "West Podbay"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/black,
 /area/station/hangar/sec)
 "mas" = (
@@ -37743,7 +38205,7 @@
 /turf/space,
 /area/space)
 "maX" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/lobby)
 "mby" = (
 /obj/table/reinforced/auto,
@@ -37804,7 +38266,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/cargobay)
 "mde" = (
 /obj/stool/chair/boxingrope_corner{
@@ -37813,8 +38275,9 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "mdn" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/external,
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/core)
 "mdr" = (
@@ -37833,16 +38296,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "mdE" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/red,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	dir = 9;
+	dir = 10;
 	icon_state = "red2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -37862,11 +38320,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/west)
 "men" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/mining/refinery)
 "mev" = (
@@ -37885,13 +38343,13 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "meH" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "meK" = (
@@ -37941,20 +38399,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
-"mgc" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/obj/item/device/radio/beacon,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/starboard)
 "mgA" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -37979,15 +38423,12 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "mgL" = (
-/obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/disposalpipe/segment/mail,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "mhy" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/navbeacon{
@@ -38011,7 +38452,7 @@
 /obj/decal/poster/wallsign/security{
 	icon_state = "sec"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "mhF" = (
 /obj/machinery/light_switch/north{
@@ -38058,18 +38499,10 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
 "mjk" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/courtroom)
-"mjT" = (
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
-	dir = 9
-	},
-/turf/simulated/wall/auto/gannets,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P03"
-	})
 "mkf" = (
 /obj/machinery/light,
 /turf/simulated/floor/specialroom/freezer,
@@ -38145,10 +38578,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "mlE" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "mlN" = (
@@ -38180,10 +38613,8 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "mma" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Research Director's Office'";
-	req_access_txt = "11"
+/obj/machinery/door/airlock/pyro/command/alt{
+	name = "Research Director's Office"
 	},
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -38192,6 +38623,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research_director,
 /turf/simulated/floor/black,
 /area/station/science/research_director)
 "mmi" = (
@@ -38201,14 +38634,14 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
 "mms" = (
-/obj/table/wood/auto/desk,
 /obj/machinery/firealarm{
 	layer = 3.5;
 	pixel_y = 28
 	},
+/obj/table/wood/auto/desk,
 /obj/item/folder,
 /obj/item/paper_bin{
 	pixel_y = 3
@@ -38216,11 +38649,9 @@
 /obj/item/pen,
 /turf/simulated/floor/carpet{
 	dir = 5;
-	icon_state = "fpurple2"
+	icon_state = "fblue2"
 	},
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "mmK" = (
 /obj/machinery/light{
 	dir = 8
@@ -38232,6 +38663,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/access_spawn/bar,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
 "mne" = (
@@ -38239,19 +38671,19 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "mnh" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
 "mni" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/pool)
 "mom" = (
@@ -38332,7 +38764,6 @@
 	},
 /area/station/science/lobby)
 "mqo" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -38343,6 +38774,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/storage/tools)
 "mqy" = (
@@ -38365,37 +38797,25 @@
 /area/station/medical/medbay)
 "mqM" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai)
 "mre" = (
 /obj/storage/closet/port_a_sci,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "msf" = (
-/obj/table/wood/auto/desk,
-/obj/machinery/light/lamp{
-	pixel_x = -5;
-	pixel_y = 10;
-	switchon = 1
+/obj/table/auto,
+/obj/random_item_spawner/tools,
+/obj/item/device/light/flashlight,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13"
 	},
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "fblue2"
-	},
-/area/station/crew_quarters/md)
+/obj/item/clothing/suit/hi_vis,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northeast)
 "msO" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'East Pod Bay'";
-	req_access_txt = "31"
-	},
 /obj/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -38406,6 +38826,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/mining{
+	name = "Cargo"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor,
 /area/station/hangar/qm)
 "mtm" = (
@@ -38416,11 +38841,6 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "mtu" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/chemistry{
-	name = "airlock-'Chemistry'";
-	req_access_txt = "33"
-	},
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -38431,10 +38851,16 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/sci_alt{
+	dir = 1;
+	name = "Chemistry"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/chemistry,
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
 "mtF" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering)
 "mtJ" = (
 /obj/decal/tile_edge/stripe{
@@ -38516,13 +38942,11 @@
 /area/station/medical/medbay/treatment)
 "mvA" = (
 /obj/disposalpipe/segment/mail{
-	dir = 4;
+	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/heads)
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/quartersA)
 "mvD" = (
 /obj/landmark{
 	icon_state = "x3";
@@ -38539,18 +38963,14 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "mvR" = (
-/obj/stool/chair/office,
-/obj/landmark/start{
-	name = "Head of Personnel"
-	},
+/obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
-	dir = 8;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/heads)
+/obj/machinery/navbeacon/tour/destiny/tour16,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "mwc" = (
 /obj/submachine/ice_cream_dispenser,
 /obj/item/storage/box/ic_cones,
@@ -38558,17 +38978,24 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "mwl" = (
-/obj/machinery/r_door_control{
-	id = "pod_fore"
+/obj/machinery/sim/vr_bed{
+	dir = 8;
+	name = "VR simulation pod";
+	network = "arcadevr"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/hangar/main)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname  - SS13"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "mwq" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "mww" = (
@@ -38585,17 +39012,7 @@
 /turf/simulated/floor/red,
 /area/station/science/lab)
 "mwU" = (
-/obj/machinery/vehicle/escape_pod{
-	dir = 8
-	},
-/obj/machinery/door/window/eastleft,
-/obj/decal/tile_edge/stripe{
-	icon_state = "xtra_bigstripe-edge"
-	},
-/obj/decal/tile_edge/stripe{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
+/obj/machinery/light/small/floor/blueish,
 /turf/simulated/floor/engine,
 /area/station/hangar/main)
 "mxy" = (
@@ -38682,7 +39099,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "mAN" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/secscanner{
 	dir = 4;
 	icon_state = "scanner_off";
@@ -38691,13 +39107,15 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/airlock/gannets/glass/medical{
-	name = "glass airlock-'Medbay'";
-	req_access_txt = ""
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "mAO" = (
@@ -38718,7 +39136,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/artifact)
 "mBc" = (
 /obj/cable{
@@ -38755,39 +39173,32 @@
 /turf/simulated/floor/white,
 /area/station/maintenance/inner/south)
 "mDc" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "mDp" = (
-/obj/machinery/door/poddoor/blast{
-	autoclose = 1;
+/obj/machinery/camera{
+	c_tag = "autotag";
 	dir = 1;
-	doordir = "left";
-	icon_state = "bdoorleft1";
-	id = "pod_fore";
-	layer = 4;
-	name = "North Pod Hangar"
+	name = "autoname - SS13"
 	},
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 4;
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_west"
-	},
+/turf/simulated/floor,
 /area/station/hangar/main)
 "mDD" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/maintenance{
+	name = "Tech Storage";
+	req_access = null;
+	req_access_txt = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/tech_storage,
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "mDH" = (
@@ -38798,13 +39209,13 @@
 /turf/simulated/floor/yellow,
 /area/station/hallway/secondary/construction)
 "mDJ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "mED" = (
@@ -38824,12 +39235,15 @@
 /obj/machinery/plantpot,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
-"mEW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/engineering/alt{
-	name = "glass airlock-'Engine Room'";
-	req_access_txt = "44"
+"mEV" = (
+/obj/decal/tile_edge/line/white{
+	dir = 1;
+	icon_state = "line1"
 	},
+/obj/item/storage/wall/office,
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
+"mEW" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -38837,18 +39251,21 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Engine Room"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "mEY" = (
-/obj/wingrille_spawn,
-/obj/cable{
-	icon_state = "0-4"
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 4;
+	name = "Guardbot Depot"
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/hallway/primary/central)
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/science/bot_storage)
 "mFb" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -38890,10 +39307,14 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "mFp" = (
-/obj/wingrille_spawn/reinforced,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/secondary/exit)
 "mFK" = (
@@ -38952,8 +39373,8 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/wingrille_spawn,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/west)
 "mGL" = (
@@ -38973,8 +39394,8 @@
 	},
 /area/station/bridge)
 "mGQ" = (
-/obj/wingrille_spawn,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/southeast)
 "mGU" = (
@@ -38989,7 +39410,6 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "mGZ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -38997,6 +39417,7 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/brig)
 "mHC" = (
@@ -39047,10 +39468,10 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "mIK" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/south)
 "mIP" = (
@@ -39064,14 +39485,7 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
-"mJl" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "mJA" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -39088,6 +39502,7 @@
 /obj/window_blinds/cog2/right{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "mJN" = (
@@ -39123,11 +39538,26 @@
 	},
 /area/station/crew_quarters/bar)
 "mKS" = (
-/obj/cable{
-	icon_state = "1-4"
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northwest)
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "mLz" = (
 /obj/decal/stage_edge/alt,
 /turf/simulated/floor/wood/three,
@@ -39163,7 +39593,7 @@
 /obj/machinery/atmospherics/valve{
 	name = "Air Reserve (West)"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southwest)
 "mNk" = (
 /obj/decal/tile_edge/line/white{
@@ -39199,23 +39629,20 @@
 /turf/simulated/floor/greenwhite/other,
 /area/station/medical/cdc)
 "mOA" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "mOK" = (
-/obj/potted_plant/potted_plant3{
-	dir = 1;
-	pixel_y = 32
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/stool/chair/office/yellow,
 /turf/simulated/floor/carpet{
-	dir = 1;
 	icon_state = "blue2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -39262,13 +39689,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/west)
 "mPx" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "mPX" = (
@@ -39278,10 +39705,10 @@
 	},
 /area/station/crew_quarters/bar)
 "mQo" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/engine/gas)
 "mQr" = (
@@ -39312,22 +39739,6 @@
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
-"mRE" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/stool/chair/office,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/decal/poster/wallsign/poster_rand{
-	pixel_y = 32
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
 "mRM" = (
 /obj/storage/closet/office,
 /obj/machinery/power/apc{
@@ -39346,10 +39757,7 @@
 	},
 /area/station/crew_quarters/courtroom)
 "mRX" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai)
 "mSf" = (
 /obj/machinery/door/poddoor/blast{
@@ -39375,16 +39783,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/qm)
-"mSS" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "mTb" = (
 /obj/disposalpipe/segment,
 /obj/decal/tile_edge/line/yellow{
@@ -39395,7 +39793,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "mTi" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -39405,6 +39802,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/bar)
 "mTv" = (
@@ -39418,7 +39816,7 @@
 /turf/simulated/floor/red/checker,
 /area/station/security/main)
 "mTM" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering/ce)
 "mUg" = (
 /obj/machinery/camera{
@@ -39427,12 +39825,14 @@
 	name = "autoname - SS13"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fred2"
+	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "mUm" = (
-/obj/stool/chair/comfy/barber_chair{
-	dir = 8
+/obj/machinery/drainage,
+/obj/submachine/chef_sink{
+	dir = 8;
+	name = "utility sink"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
@@ -39469,10 +39869,14 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "mXn" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/lounge/port)
+/area/station/maintenance/central)
 "mXO" = (
 /obj/table/auto,
 /obj/random_item_spawner/tools,
@@ -39482,11 +39886,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "mYh" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/south)
 "mYi" = (
@@ -39550,6 +39954,7 @@
 	pixel_x = 13;
 	pixel_y = -3
 	},
+/obj/disposalpipe/segment/morgue,
 /obj/cable{
 	icon_state = "2-8"
 	},
@@ -39559,10 +39964,12 @@
 /obj/forcefield/energyshield/perma{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Crew Lounge"
+	},
 /turf/simulated/floor/wood,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "nbl" = (
 /obj/decal/tile_edge/line/blue{
 	color = "#485e81";
@@ -39586,18 +39993,30 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "nbr" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/cloner)
 "nbB" = (
-/obj/machinery/vehicle/miniputt,
-/obj/cable{
-	icon_state = "1-2"
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/pink,
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "purple2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P04"
+	})
 "ncb" = (
 /obj/cable{
 	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	layer = 3.5;
@@ -39626,16 +40045,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/pharmacy)
-"ndy" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P04"
-	})
 "ndC" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -39715,7 +40124,6 @@
 	},
 /area/station/science/lobby)
 "nfj" = (
-/obj/wingrille_spawn,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -39723,6 +40131,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/west)
 "nfp" = (
@@ -39795,28 +40204,23 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "nhb" = (
-/obj/machinery/door/poddoor/blast{
-	autoclose = 1;
+/obj/table/wood/auto,
+/obj/item/reagent_containers/food/drinks/bottle/hobo_wine,
+/obj/machinery/light/lamp/bright,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet{
 	dir = 1;
-	id = "pod_fore";
-	layer = 4;
-	name = "North Pod Hangar"
+	icon_state = "blue2"
 	},
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 4;
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_west"
-	},
-/area/station/hangar/main)
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M02"
+	})
 "nhd" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "50"
-	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "nhj" = (
@@ -39856,7 +40260,6 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 9;
@@ -39869,6 +40272,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "nje" = (
@@ -39925,24 +40329,21 @@
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "nkj" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/window_blinds/cog2{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/hos)
 "nlk" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Athletic Center'"
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Community Center"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/fitness)
 "nlx" = (
@@ -39988,15 +40389,15 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "nmN" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "nmP" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/power)
 "nnm" = (
 /obj/disposalpipe/segment/mineral{
@@ -40015,8 +40416,8 @@
 	},
 /area/station/medical/cdc)
 "nnS" = (
-/turf/space,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/solar/east)
 "nor" = (
 /obj/disposalpipe/segment/mail{
@@ -40035,13 +40436,13 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "npm" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "npz" = (
@@ -40116,7 +40517,6 @@
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
 "nqH" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -40132,8 +40532,16 @@
 	name = "E.V.A. Security Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/storage/eva)
+"nqL" = (
+/obj/machinery/light,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/sanitary,
+/area/station/hallway/primary/east/restroom)
 "nqM" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -40184,18 +40592,16 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
+"nrA" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/solar/east)
 "nrF" = (
-/obj/disposalpipe/segment,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=customs";
-	location = "podbay";
-	name = "bot navigation beacon"
+/obj/machinery/atmospherics/pipe/manifold{
+	dir = 4;
+	level = 2
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/central)
 "nsf" = (
 /obj/decal/poster/wallsign/poster_borg{
 	pixel_y = 32
@@ -40249,13 +40655,13 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 4;
-	icon_state = "red2"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 8
 	},
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
+/turf/simulated/floor/black,
+/area/station/maintenance/northwest)
 "nuF" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
@@ -40274,37 +40680,37 @@
 /area/station/security/main)
 "nve" = (
 /turf/simulated/floor/carpet{
-	icon_state = "purple2"
+	icon_state = "green2"
 	},
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "nvn" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/engineering{
-	name = "glass airlock-'Gas Storage'";
-	req_access_txt = "44"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 8;
+	name = "Gas Storage";
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_storage,
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "nvB" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname  - SS13"
 	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/navbeacon/tour/destiny/tour18,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "nvG" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command{
-	name = "airlock-'E.V.A.'";
-	req_access_txt = "18"
-	},
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 4;
@@ -40323,29 +40729,40 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/command{
+	dir = 1;
+	name = "EVA Storage"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/eva,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/storage/eva)
 "nvQ" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
-/area/station/hallway/primary/east/restroom)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/lounge/starboard)
 "nvT" = (
-/obj/disposalpipe/segment/mail,
-/obj/machinery/light{
-	dir = 4
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/red,
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon9,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "red2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P02"
+	})
 "nwA" = (
-/obj/decal/tile_edge/stripe{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
@@ -40358,19 +40775,15 @@
 	},
 /area/station/security/beepsky)
 "nwT" = (
-/obj/stool/bench/yellow,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=quarters_eastboard";
-	location = "escape";
-	name = "bot navigation beacon"
-	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/orangeblack/side{
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "nxg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -40414,27 +40827,22 @@
 	},
 /area/station/crew_quarters/courtroom)
 "nxR" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "nyt" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "nyu" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'Cargo'";
-	req_access_txt = "31|40|50"
 	},
 /obj/cable{
 	icon_state = "2-8"
@@ -40442,6 +40850,12 @@
 /obj/disposalpipe/segment/mineral{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/mining{
+	dir = 4;
+	name = "Cargo"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "nyz" = (
@@ -40483,10 +40897,6 @@
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "nzu" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'Atmospherics'"
-	},
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -40505,6 +40915,11 @@
 	name = "Atmospherics Security Shield";
 	opacity = 0
 	},
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Atmospherics"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering,
 /turf/simulated/floor/black,
 /area/station/atmos/highcap_storage)
 "nzx" = (
@@ -40573,13 +40988,11 @@
 /turf/simulated/floor/purple,
 /area/station/medical/cdc)
 "nBO" = (
-/obj/airbridge_controller{
-	id = "escape";
-	primary_controller = 1;
-	tunnel_width = 3
+/obj/machinery/atmospherics/valve{
+	name = "Purge Valve"
 	},
-/turf/space,
-/area/space)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/central)
 "nCG" = (
 /obj/machinery/computer/pathology{
 	dir = 4
@@ -40619,12 +41032,10 @@
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "nDa" = (
-/obj/airbridge_controller{
-	id = "escape";
-	tunnel_width = 3
-	},
-/turf/space,
-/area/space)
+/obj/cable,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/hangar/main)
 "nDb" = (
 /obj/table,
 /obj/cable{
@@ -40644,12 +41055,12 @@
 /turf/simulated/floor/blue/side,
 /area/station/medical/medbay)
 "nDJ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/right,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment2)
 "nDO" = (
@@ -40689,19 +41100,7 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
-"nFa" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
 "nFk" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
@@ -40716,30 +41115,28 @@
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "nFH" = (
-/obj/stool/bench/yellow/auto,
+/obj/machinery/vending/snack,
 /turf/simulated/floor/orangeblack/side{
-	dir = 8
+	dir = 10
 	},
 /area/station/hallway/secondary/exit)
 "nGm" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/switch_junction{
-	dir = 1;
-	mail_tag = "crew";
-	name = "crew lounge mail router"
-	},
+/obj/disposalpipe/segment/mail,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "nGz" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "nHb" = (
 /obj/decal/tile_edge/line/blue{
@@ -40802,7 +41199,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "nIm" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -40810,25 +41206,36 @@
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment/morgue,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "nIn" = (
 /obj/machinery/door/poddoor/blast{
+	autoclose = 1;
 	dir = 1;
-	layer = 4
+	id = "pod_fore";
+	layer = 4;
+	name = "North Pod Hangar"
+	},
+/obj/forcefield/energyshield/perma/doorlink{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 4;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
 	},
 /turf/simulated/floor/engine{
-	dir = 8;
-	icon_state = "engine_caution_misc"
+	icon_state = "engine_caution_west"
 	},
 /area/station/hangar/main)
 "nIE" = (
-/obj/disposalpipe/segment/mail,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "2-8"
+	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -40859,24 +41266,15 @@
 /turf/simulated/floor/yellow,
 /area/station/mining/refinery)
 "nJF" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
-"nJI" = (
-/obj/disposalpipe/segment/mail,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=bridge2";
-	location = "quarters_eastboard";
-	name = "bot navigation beacon"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "nKb" = (
 /obj/item/device/radio/intercom/cargo{
 	dir = 8
@@ -40905,13 +41303,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "nKA" = (
-/obj/potted_plant/potted_plant5{
-	dir = 1;
-	pixel_y = 32
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/stool/chair/office/green,
 /turf/simulated/floor/carpet{
-	dir = 1;
 	icon_state = "green2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -40977,25 +41372,19 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "nNy" = (
-/obj/machinery/door/poddoor/blast{
-	autoclose = 1;
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/bright,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet{
 	dir = 1;
-	doordir = "right";
-	icon_state = "bdoorright1";
-	id = "pod_fore";
-	layer = 4;
-	name = "North Pod Hangar"
+	icon_state = "red2"
 	},
-/obj/forcefield/energyshield/perma/doorlink{
-	desc = "A door-linked force field that prevents gasses from passing through it.";
-	dir = 4;
-	name = "Door-linked Atmospheric Forcefield";
-	powerlevel = 1
-	},
-/turf/simulated/floor/engine{
-	icon_state = "engine_caution_west"
-	},
-/area/station/hangar/main)
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P02"
+	})
 "nNJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41012,7 +41401,7 @@
 	pixel_y = 1;
 	target_pressure = 1e+031
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/lounge)
 "nOh" = (
 /obj/decal/tile_edge/line/red{
@@ -41054,11 +41443,11 @@
 /turf/simulated/floor/white,
 /area/station/maintenance/inner/south)
 "nOL" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/brig)
 "nPK" = (
@@ -41088,16 +41477,11 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "nQY" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/pink,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	dir = 9;
+	dir = 10;
 	icon_state = "purple2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -41127,14 +41511,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "nRA" = (
-/obj/wingrille_spawn/reinforced_crystal,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating/random,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/garden/aviary)
 "nRI" = (
 /obj/cable{
@@ -41173,10 +41550,10 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Athletic Center'"
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Community Center"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/fitness)
 "nTB" = (
@@ -41202,7 +41579,6 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "nUU" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/right,
 /obj/cable{
 	icon_state = "0-2"
@@ -41210,6 +41586,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/engine/engineering/ce)
 "nVa" = (
@@ -41244,11 +41621,11 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "nVL" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/research_director)
 "nVM" = (
@@ -41298,37 +41675,26 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/equipment)
 "nXF" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9;
 	level = 2
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/lobby)
 "nXS" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13"
-	},
-/obj/machinery/light_switch/east{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
+/obj/machinery/vending/cola/blue,
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
-	dir = 4
+	dir = 6
 	},
 /area/station/hallway/secondary/exit)
 "nYu" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/engine/elect)
 "nYA" = (
 /obj/disposaloutlet{
@@ -41387,7 +41753,7 @@
 /area/station/quartermaster/cargobay)
 "nZe" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "nZh" = (
 /obj/cable{
@@ -41404,7 +41770,7 @@
 	on = 1;
 	transfer_rate = 1000
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
 "nZr" = (
 /obj/decal/tile_edge/line/yellow{
@@ -41423,18 +41789,6 @@
 /obj/item/storage/firstaid/fire,
 /turf/simulated/floor,
 /area/station/mining/staff_room)
-"nZG" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Crew Quarters'"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
 "nZL" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 1;
@@ -41452,31 +41806,21 @@
 	})
 "oas" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "oat" = (
-/obj/table/auto,
-/obj/random_item_spawner/desk_stuff,
-/obj/machinery/computer/airbr/emergency_shuttle{
-	density = 0;
-	dir = 8;
-	id = "escape";
-	pixel_y = 32
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13"
-	},
-/obj/item/storage/toolbox/emergency,
-/obj/item/device/light/flashlight,
-/obj/machinery/light{
+/obj/machinery/vehicle/escape_pod{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/door/window/westleft,
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge"
 	},
-/turf/simulated/floor/orangeblack,
+/obj/decal/tile_edge/stripe{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/engine,
 /area/station/hallway/secondary/exit)
 "oaB" = (
 /obj/decal/tile_edge/stripe/extra_big,
@@ -41522,9 +41866,13 @@
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "obv" = (
-/obj/machinery/vehicle/miniputt,
-/turf/simulated/floor/engine,
-/area/station/hangar/main)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "obL" = (
 /obj/table/reinforced/auto,
 /obj/decal/tile_edge/line/blue{
@@ -41553,8 +41901,8 @@
 	},
 /area/station/hallway/secondary/construction)
 "oco" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/lab)
 "oct" = (
@@ -41570,7 +41918,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "ocW" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
@@ -41578,10 +41925,11 @@
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "odn" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery/storage)
 "ods" = (
 /obj/machinery/light/incandescent{
@@ -41603,9 +41951,9 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "purple1"
+	icon_state = "fgreen1"
 	},
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "odI" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 1;
@@ -41634,7 +41982,6 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
 "oer" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -41642,6 +41989,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "ofh" = (
@@ -41670,13 +42018,13 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "ofT" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/brig)
 "ogi" = (
@@ -41712,13 +42060,16 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "ogq" = (
-/obj/machinery/light/emergency{
-	dir = 4
+/obj/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/stairs{
-	dir = 1
+/obj/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2";
+	name = "prisoner router"
 	},
-/area/station/hangar/main)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "ogs" = (
 /obj/machinery/door/unpowered/wood/stall{
 	lock_dir = 1
@@ -41753,6 +42104,14 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
+"ohf" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/table/auto,
+/obj/towelbin,
+/turf/simulated/floor/sanitary,
+/area/station/hallway/primary/east/restroom)
 "ohy" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -41768,21 +42127,22 @@
 /turf/simulated/floor/engine,
 /area/station/hangar/qm)
 "ohD" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "oik" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Chapel'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -41796,18 +42156,20 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "oiF" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/cargobay)
 "oiW" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/right{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "ojd" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/snacks/pie/cream,
@@ -41825,7 +42187,6 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "ojU" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/decal/tile_edge/line/blue{
 	color = "#485e81";
 	icon_state = "line1"
@@ -41833,16 +42194,17 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/gannets/medical/alt{
-	id = "hallway_door";
-	name = "airlock-'Psychiatrist's Office'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Psychiatrist's Office"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
 "okm" = (
@@ -41863,13 +42225,13 @@
 /turf/simulated/floor,
 /area/station/medical/robotics)
 "okK" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/psychiatrist)
 "olu" = (
@@ -41877,7 +42239,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "olI" = (
 /obj/decal/tile_edge/line/yellow{
@@ -41888,13 +42250,14 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "omk" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Restroom'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/west{
 	name = "West Central Maintenance"
@@ -41907,20 +42270,23 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "omL" = (
-/obj/machinery/door/airlock/gannets/medical{
-	name = "airlock-'Blood Storage'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 4;
+	name = "Blood Storage"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery/storage)
 "omO" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/atmospherics/pipe/simple/insulated/cold,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "ong" = (
@@ -41930,7 +42296,6 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 5;
@@ -41940,17 +42305,18 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "ons" = (
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "onG" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/south)
 "ooc" = (
@@ -41994,50 +42360,37 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "oon" = (
-/obj/wingrille_spawn/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/fitness)
 "opk" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/decal/tile_edge/stripe{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/obj/railing/yellow{
-	dir = 1
-	},
-/turf/simulated/floor/black,
+/obj/machinery/photocopier,
+/turf/simulated/floor,
 /area/station/crew_quarters/lounge/starboard)
+"opx" = (
+/obj/decal/tile_edge/line/white{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/item/device/radio/intercom/medical,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname  - SS13"
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
 "opK" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon8,
+/obj/machinery/light/small/floor/blueish,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 1
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
-"opV" = (
-/obj/machinery/sim/vr_bed{
-	dir = 4;
-	name = "VR simulation pod";
-	network = "arcadevr"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "opX" = (
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
@@ -42056,12 +42409,12 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "oqq" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/showers{
 	name = "Pool Shower Room"
 	})
 "oqy" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
 "orm" = (
 /obj/landmark/start{
@@ -42123,10 +42476,8 @@
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/supply)
 "otX" = (
-/turf/simulated/wall/auto/gannets,
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/md)
 "ouE" = (
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
@@ -42134,11 +42485,6 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
 	name = "crematorium pipe"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	name = "glass airlock-'Pharmacy'";
-	req_access_txt = "9"
 	},
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
@@ -42151,6 +42497,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/botany{
+	name = "Genetics"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medlab,
 /turf/simulated/floor/white,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -42219,6 +42570,16 @@
 	dir = 1
 	},
 /area/station/medical/cdc)
+"owc" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "green2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P01"
+	})
 "owi" = (
 /obj/lattice{
 	dir = 4;
@@ -42253,17 +42614,8 @@
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "ows" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/stool/chair/office{
-	dir = 1
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/decal/stage_edge/alt{
+	pixel_y = 10
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/starboard)
@@ -42278,6 +42630,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
+"owD" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "purple2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M01"
+	})
 "owE" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -42306,26 +42668,53 @@
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "oxe" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/heads)
+/obj/table/wood/auto,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 0;
+	name = "autoname - SS13"
+	},
+/obj/machinery/light/lamp/bright,
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA)
 "oxo" = (
-/obj/machinery/vehicle/pod_smooth/light,
-/turf/simulated/floor/engine,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 1;
+	name = "Pod Bay Storage"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor,
 /area/station/hangar/main)
 "oxp" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light,
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
-"oxu" = (
-/obj/wingrille_spawn/reinforced,
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
+/obj/potted_plant/potted_plant3{
+	dir = 1;
+	pixel_y = 32
 	},
-/obj/window_blinds/cog2,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/heads)
+/obj/stool/chair/office/green,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "green2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P01"
+	})
+"oxu" = (
+/obj/item/storage/wall/clothingrack/clothes4,
+/obj/potted_plant/potted_plant4{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA)
 "oyj" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -42376,27 +42765,33 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
-	icon_state = "fgreen1"
+	icon_state = "fpurple1"
 	},
-/area/station/crew_quarters/ce)
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "ozD" = (
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Head of Personnel's Office'";
-	req_access_txt = "55"
+/obj/stool/bed,
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
+/obj/item/clothing/suit/bedsheet/blue,
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
 	},
-/area/station/crew_quarters/heads)
-"ozR" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/bright,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
+/obj/blind_switch/area/east{
+	dir = 4
 	},
 /turf/simulated/floor/carpet{
-	dir = 1;
+	dir = 5;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA)
+"ozR" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet{
 	icon_state = "red2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -42430,7 +42825,6 @@
 	},
 /area/station/engine/engineering/ce)
 "oAI" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/middle{
 	dir = 8
 	},
@@ -42441,25 +42835,39 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/ce)
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "oAQ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Disposals'"
-	},
 /obj/decal/tile_edge/stripe{
 	dir = 8;
 	icon_state = "xtra_bigstripe-edge"
 	},
+/obj/machinery/door/airlock/pyro/classic{
+	dir = 4;
+	name = "Disposals"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "oAX" = (
-/obj/disposalpipe/junction{
-	icon_state = "pipe-j2"
+/obj/machinery/firealarm{
+	layer = 3.5;
+	pixel_y = 28
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/table/wood/auto/desk,
+/obj/machinery/light/lamp{
+	pixel_x = -5;
+	pixel_y = 10;
+	switchon = 1
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "fred2"
+	},
+/area/station/crew_quarters/hos)
 "oBe" = (
 /obj/landmark{
 	icon_state = "x3";
@@ -42468,11 +42876,11 @@
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/south)
 "oCD" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/beepsky)
 "oCH" = (
@@ -42528,13 +42936,13 @@
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "oDt" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "oDv" = (
 /obj/machinery/drainage,
 /obj/machinery/shower{
@@ -42551,7 +42959,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/warehouse)
 "oEk" = (
 /obj/submachine/chef_sink/chem_sink{
@@ -42572,14 +42980,15 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "oEE" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Janitor Supply Closet";
-	req_access_txt = "26"
+/obj/machinery/door/airlock/pyro/alt{
+	dir = 4;
+	name = "Janitor's Closet"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/janitor,
 /turf/simulated/floor,
 /area/station/crew_quarters/bar)
 "oGa" = (
@@ -42604,13 +43013,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "oHb" = (
-/obj/potted_plant/potted_plant3{
-	dir = 1;
-	pixel_y = 32
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/stool/chair/office/yellow,
 /turf/simulated/floor/carpet{
-	dir = 1;
 	icon_state = "blue2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -42624,23 +43030,25 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "oHo" = (
-/obj/stool/bench/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/tile_edge/line/blue{
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/machinery/light,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Escape"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/area/station/hallway/secondary/exit)
 "oHB" = (
 /obj/storage/crate,
 /obj/item/fuel_pellet/cerenkite,
@@ -42709,19 +43117,6 @@
 	},
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/lobby)
-"oKp" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13"
-	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P04"
-	})
 "oKR" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -42750,8 +43145,8 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "oLP" = (
@@ -42780,16 +43175,13 @@
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/dome)
 "oMj" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "oMw" = (
 /obj/lattice{
@@ -42860,7 +43252,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/west)
 "oOQ" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -42914,10 +43306,12 @@
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/ce)
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "oQF" = (
 /obj/disposalpipe/type_sensing_outlet/drone_factory,
 /turf/simulated/floor/plating/random,
@@ -42932,18 +43326,22 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "oQW" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/tech)
 "oRc" = (
 /obj/disposalpipe/segment/food,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/tools)
 "oRh" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering/alt{
-	name = "airlock-'Construction Room'";
-	req_access_txt = "44|50"
+/obj/cable{
+	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Construction Room"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "oRz" = (
@@ -42952,10 +43350,10 @@
 	name = "Genetic Research"
 	})
 "oRH" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 8
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "oRI" = (
@@ -43001,10 +43399,7 @@
 /obj/cable{
 	icon_state = "4-10"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "oTi" = (
 /obj/decal/tile_edge/line/yellow{
@@ -43027,10 +43422,9 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "oTy" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13"
+/obj/airbridge_controller{
+	id = "merchant_L";
+	primary_controller = 1
 	},
 /turf/space,
 /area/space)
@@ -43039,12 +43433,15 @@
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/south)
 "oTZ" = (
-/obj/decal/tile_edge/stripe{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "oUn" = (
 /obj/decal/tile_edge/line/black{
 	dir = 9;
@@ -43060,7 +43457,6 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/reinforced,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 4;
@@ -43070,13 +43466,14 @@
 	name = "Atmospherics Security Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/south)
 "oUL" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "oUR" = (
@@ -43134,7 +43531,7 @@
 /turf/simulated/floor/white,
 /area/station/maintenance/inner/south)
 "oVF" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/storage/tech)
 "oVI" = (
 /obj/cable{
@@ -43237,23 +43634,14 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/medical/cdc)
-"oYY" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/engine/power)
 "oZd" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/yellow,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
 	},
 /turf/simulated/floor/carpet{
-	dir = 5;
+	dir = 6;
 	icon_state = "blue2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -43267,10 +43655,6 @@
 	dir = 5
 	},
 /area/station/security/hos)
-"oZP" = (
-/obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/overfloor/vertical,
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/maintenance/central)
 "oZR" = (
 /obj/machinery/disposal/small{
 	dir = 8
@@ -43383,15 +43767,6 @@
 	},
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
-"pcf" = (
-/obj/item/storage/wall/emergency{
-	pixel_y = 32
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "pci" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -43435,13 +43810,13 @@
 	},
 /area/station/engine/engineering/ce)
 "ped" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/courtroom)
 "pee" = (
@@ -43501,7 +43876,7 @@
 	dir = 4;
 	name = "Air Reserve (West)"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southwest)
 "pgg" = (
 /obj/reagent_dispensers/watertank/big,
@@ -43583,7 +43958,7 @@
 /area/station/science/artifact)
 "pib" = (
 /obj/cable,
-/obj/wingrille_spawn/reinforced_crystal/full,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/hangar/sec)
 "pif" = (
@@ -43595,7 +43970,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "pih" = (
-/obj/wingrille_spawn/reinforced,
 /obj/forcefield/energyshield/perma{
 	dir = 10
 	},
@@ -43603,8 +43977,9 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "pim" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -43657,9 +44032,11 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet{
-	icon_state = "fgreen1"
+	icon_state = "fred1"
 	},
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "pkR" = (
 /obj/machinery/light,
 /obj/decal/tile_edge/stripe{
@@ -43734,12 +44111,17 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "pmJ" = (
-/obj/decal/tile_edge/stripe{
-	dir = 9;
-	icon_state = "xtra_bigstripe-corner2"
+/obj/disposalpipe/segment,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=customs";
+	location = "podbay";
+	name = "bot navigation beacon"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "pmK" = (
 /obj/decal/tile_edge/line/green{
 	dir = 1;
@@ -43758,11 +44140,12 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical/alt{
-	id = "hallway_door";
-	name = "airlock-'Medbay'"
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 4;
+	name = "Medbay"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "pmW" = (
@@ -43776,26 +44159,19 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "pnc" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command{
-	name = "airlock-'Chief Engineer's Quarters'";
-	req_access_txt = "49"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Research Director's Quarters"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research_director,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/ce)
-"pnG" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P04"
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
 	})
 "pnR" = (
 /obj/cable{
@@ -43813,16 +44189,9 @@
 	},
 /turf/simulated/floor/black,
 /area/station/teleporter)
-"poA" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9;
-	level = 2
-	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/maintenance/central)
 "poI" = (
 /obj/decal/poster/wallsign/fire,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "ppd" = (
 /obj/decal/cleanable/dirt,
@@ -43850,9 +44219,6 @@
 /obj/item/circuitboard/powermonitor_smes,
 /obj/item/circuitboard/operating,
 /obj/item/circuitboard/genetics,
-/obj/item/circuitboard/qmorder,
-/obj/item/circuitboard/qmsupply,
-/obj/item/circuitboard/telescope,
 /obj/cable,
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
@@ -43860,9 +44226,13 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/area/station/crew_quarters/quartersA)
 "ppM" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -43943,7 +44313,6 @@
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
 "psH" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -43953,6 +44322,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "psI" = (
@@ -43984,7 +44354,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/com_dish/auxdish)
 "pud" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/catering)
 "pun" = (
 /obj/item/storage/wall/fire{
@@ -44004,10 +44374,7 @@
 /area/station/security/brig)
 "pvn" = (
 /obj/decal/poster/wallsign/fire,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "pvx" = (
 /obj/machinery/recharger/wall/sticky{
@@ -44083,8 +44450,8 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "pwD" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/security/hos)
 "pwO" = (
@@ -44132,13 +44499,6 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/hallway/secondary/construction)
-"pyF" = (
-/obj/wingrille_spawn,
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/lounge/starboard)
 "pyI" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -44174,13 +44534,13 @@
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "pzM" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "pzY" = (
@@ -44216,29 +44576,39 @@
 /turf/simulated/floor/yellow,
 /area/station/hallway/secondary/construction)
 "pBO" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/east)
 "pCh" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom"
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/ne,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "pCF" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/head)
+"pCL" = (
+/obj/machinery/computer/airbr/emergency_shuttle{
+	density = 0;
+	emergency = 0;
+	id = "merchant_R";
+	pixel_y = 32;
+	req_access_txt = ""
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/lounge/starboard)
 "pCM" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/security/hos)
 "pCU" = (
@@ -44275,7 +44645,6 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
 "pDz" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/middle,
 /obj/cable{
 	icon_state = "0-8"
@@ -44283,6 +44652,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment2)
 "pDF" = (
@@ -44311,10 +44681,7 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "pEk" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/kitchen)
 "pEw" = (
 /obj/item/device/radio/beacon,
@@ -44327,10 +44694,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "pEC" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/bar)
 "pFu" = (
 /obj/machinery/light{
@@ -44354,12 +44718,9 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "pGe" = (
-/obj/wingrille_spawn/reinforced,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/ranch)
+/obj/machinery/light/small/floor/greenish,
+/turf/simulated/floor/grass/random/alt,
+/area/station/garden/aviary)
 "pGh" = (
 /obj/decal/tile_edge/line/white{
 	dir = 4;
@@ -44398,18 +44759,15 @@
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
 "pGY" = (
-/obj/item/storage/wall/clothingrack/clothes1,
-/obj/potted_plant/potted_plant2{
-	dir = 1;
-	pixel_y = 32
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "red2"
+/obj/cable{
+	icon_state = "0-4"
 	},
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
 "pHa" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -44417,16 +44775,27 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
+/obj/disposalpipe/junction{
 	dir = 4
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "pHz" = (
-/obj/wingrille_spawn/reinforced,
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/hangar/main)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "pHC" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
@@ -44435,10 +44804,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "pHK" = (
 /obj/machinery/conveyor{
@@ -44468,42 +44834,36 @@
 /area/station/hallway/primary/east)
 "pHY" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/storage)
-"pIc" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Crew Lounge'"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port)
 "pIj" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/primary/west)
 "pJz" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
 	name = "Courtroom"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/courtroom)
 "pJD" = (
 /obj/cable{
+	icon_state = "2-8"
+	},
+/obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "pJE" = (
@@ -44592,30 +44952,33 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "pLt" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/security/alt{
-	name = "glass airlock-'Cell #2'"
-	},
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/pyro/glass/security{
+	dir = 4;
+	name = "glass airlock-'Cell #1"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/brig,
 /turf/simulated/floor,
 /area/station/security/brig)
 "pLA" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/observatory)
 "pMa" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Head of Security's Quarters"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/hos,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/area/station/crew_quarters/hos)
 "pMA" = (
 /obj/decal/tile_edge/stripe{
 	dir = 10;
@@ -44627,18 +44990,6 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
-"pMB" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Crew Quarters'"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
 "pMO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -44756,18 +45107,26 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "pOw" = (
-/obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/md)
+/obj/disposalpipe/segment/mail{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/vending/medical_public,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "pOU" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "pPB" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/vertical,
@@ -44776,10 +45135,10 @@
 	},
 /area/station/medical/medbay/treatment)
 "pPI" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/beepsky)
 "pPJ" = (
@@ -44795,12 +45154,12 @@
 	},
 /area/station/science/lobby)
 "pQt" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/airlock/gannets/glass,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "pQx" = (
@@ -44856,10 +45215,15 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "pSd" = (
-/turf/simulated/floor/orangeblack/side{
-	dir = 8
+/obj/decal/tile_edge/stripe{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
 	},
-/area/station/hallway/secondary/exit)
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
 "pSO" = (
 /obj/landmark/magnet_shield,
 /obj/grille/catwalk/cross{
@@ -44874,15 +45238,6 @@
 	dir = 5
 	},
 /area/mining/magnet)
-"pSS" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/decal/stage_edge/alt{
-	pixel_y = 10
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
 "pST" = (
 /obj/lattice{
 	dir = 10;
@@ -44954,12 +45309,15 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "pUo" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/door_control{
+	id = "pod_fore";
+	name = "Hangar Door Control";
+	pixel_x = -24;
+	pixel_y = -8
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/machinery/light,
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "pUR" = (
 /obj/decal/tile_edge/stripe{
 	dir = 8;
@@ -44970,9 +45328,6 @@
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
@@ -44991,7 +45346,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "pVV" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -45000,6 +45354,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/head)
 "pWD" = (
@@ -45036,11 +45391,9 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 8;
-	icon_state = "fpurple1"
+	icon_state = "fblue1"
 	},
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "pYk" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 1;
@@ -45134,29 +45487,35 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "qaD" = (
-/obj/stool/bench/yellow,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/yellow,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M02"
+	})
 "qaT" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
 "qaW" = (
-/obj/machinery/vehicle/escape_pod{
-	dir = 4
+/obj/disposalpipe/segment,
+/obj/machinery/light/emergency{
+	dir = 8
 	},
-/obj/machinery/door/window/westleft,
-/obj/decal/tile_edge/stripe{
-	icon_state = "xtra_bigstripe-edge"
-	},
-/obj/decal/tile_edge/stripe{
-	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
-	},
-/turf/simulated/floor/engine,
-/area/station/hallway/secondary/exit)
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "qbK" = (
 /obj/railing/orange/reinforced,
 /turf/simulated/floor/grasstodirt,
@@ -45186,16 +45545,6 @@
 "qcx" = (
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
-"qcK" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
 "qcR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -45203,8 +45552,15 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "qcS" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/lounge/port)
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/central)
 "qcW" = (
 /obj/machinery/bot/guardbot/old/tourguide/destiny,
 /obj/machinery/navbeacon/tour/destiny/tour20,
@@ -45220,34 +45576,38 @@
 /turf/simulated/floor/circuit,
 /area/station/crew_quarters/fitness)
 "qcX" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical{
-	name = "airlock-'Operating Theater'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	name = "Operating Theater"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "qcZ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "qda" = (
 /obj/decal/poster/wallsign/hazard_bio,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/cdc)
 "qel" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/gannets/maintenance,
+/obj/machinery/door/airlock/pyro/classic{
+	dir = 4;
+	name = "Disposals"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "qet" = (
@@ -45306,9 +45666,9 @@
 /area/station/maintenance/south)
 "qfg" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
-	dir = 6
+	dir = 9
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters P03"
 	})
@@ -45321,7 +45681,6 @@
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
 "qgo" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/middle{
 	dir = 8
 	},
@@ -45332,10 +45691,9 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "qgF" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -45350,10 +45708,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "qgQ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "qhx" = (
@@ -45389,20 +45747,26 @@
 	},
 /area/station/science/artifact)
 "qit" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/bot_storage)
 "qjp" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/machinery/vehicle/escape_pod{
+	dir = 8
 	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon14,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/machinery/door/window/eastright,
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge"
+	},
+/obj/decal/tile_edge/stripe{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "qjq" = (
 /obj/decal/tile_edge/line/black{
 	dir = 10;
@@ -45455,17 +45819,6 @@
 	dir = 9
 	},
 /area/station/medical/medbay)
-"qlc" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering/alt{
-	name = "airlock-'Construction Room'";
-	req_access_txt = "44|50"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/construction)
 "qlE" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -45486,10 +45839,7 @@
 /area/station/quartermaster/cargobay)
 "qmh" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/testchamber)
 "qmm" = (
 /obj/machinery/light/incandescent/cool{
@@ -45544,13 +45894,10 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "qmN" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/chapel/sanctuary)
 "qnD" = (
 /obj/table/reinforced/bar/auto{
@@ -45575,11 +45922,12 @@
 	},
 /area/station/engine/engineering)
 "qol" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/decal/tile_edge/line/black,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Mime Hovel'"
+/obj/machinery/door/airlock/pyro/classic{
+	dir = 4;
+	name = "Mime Hovel"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/white,
 /area/station/maintenance/outer/sw)
 "qom" = (
@@ -45601,16 +45949,18 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/head)
 "qoC" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
 /turf/simulated/floor/carpet{
 	dir = 10;
-	icon_state = "green2"
+	icon_state = "red2"
 	},
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "qoH" = (
 /obj/decal/tile_edge/line/red{
 	dir = 1;
@@ -45656,13 +46006,13 @@
 	},
 /area/station/bridge)
 "qpm" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/artifact)
 "qps" = (
@@ -45718,7 +46068,7 @@
 	},
 /area/station/hallway/secondary/exit)
 "qqo" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
 "qqv" = (
 /obj/machinery/light,
@@ -45766,13 +46116,15 @@
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
 "qsu" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "qsN" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -45834,34 +46186,16 @@
 	},
 /area/station/science/lobby)
 "qug" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/toxins{
-	name = "airlock-'Toxins'";
-	req_access_txt = "7"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/toxins{
+	name = "Toxins"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/tox_storage,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
-"quy" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13"
-	},
-/obj/decal/tile_edge/stripe{
-	icon_state = "xtra_bigstripe-edge";
-	pixel_y = 10
-	},
-/obj/railing/yellow{
-	pixel_y = 10
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/starboard)
 "qvK" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -45894,8 +46228,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/alt,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Community Center"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -45910,17 +46247,12 @@
 	},
 /area/station/engine/engineering)
 "qxC" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/solar/east)
 "qxE" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 8;
 	icon_state = "line1"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical/alt{
-	id = "hallway_door";
-	name = "airlock-'Medbay'"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -45928,41 +46260,33 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 4;
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
 /area/station/medical/medbay)
 "qyS" = (
-/obj/wingrille_spawn/reinforced,
 /obj/forcefield/energyshield/perma{
 	dir = 8
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "qzc" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/engineering/ce)
-"qzd" = (
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/obj/item/device/radio/beacon,
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port)
 "qzf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -45980,23 +46304,18 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "qAo" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/decal/tile_edge/line/white{
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/machinery/door/airlock/gannets/medical{
-	name = "airlock-'Robotics'";
-	req_access_txt = "29"
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 1;
+	name = "Robotics"
 	},
+/obj/access_spawn/robotics,
 /turf/simulated/floor/white,
 /area/station/medical/robotics)
 "qAy" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/toxins{
-	name = "glass airlock-'Pathology Research'";
-	req_access_txt = "84"
-	},
 /obj/decal/tile_edge/line/green{
 	dir = 8;
 	icon_state = "line1"
@@ -46004,6 +46323,12 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/toxins_alt{
+	dir = 4;
+	name = "Pathology"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/pathology,
 /turf/simulated/floor,
 /area/station/medical/cdc)
 "qBe" = (
@@ -46038,13 +46363,13 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "qBT" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/main)
 "qCr" = (
@@ -46138,7 +46463,6 @@
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "qEd" = (
-/obj/wingrille_spawn/reinforced,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 8;
@@ -46151,6 +46475,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/pharmacy)
 "qEe" = (
@@ -46218,26 +46543,32 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "qET" = (
-/obj/machinery/power/monitor{
-	dir = 4
-	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/computer3/terminal/zeta{
+	dir = 4;
+	setup_os_string = "ZETA_MAINFRAME"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 0;
 	name = "autoname - SS13"
 	},
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
 /obj/blind_switch/area/west{
 	dir = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;
-	icon_state = "fgreen2"
+	icon_state = "fpurple2"
 	},
-/area/station/crew_quarters/ce)
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "qFK" = (
 /obj/potted_plant/potted_plant3,
 /turf/simulated/floor/wood/eight{
@@ -46262,15 +46593,13 @@
 	},
 /area/station/engine/engineering)
 "qGv" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "qGx" = (
 /obj/machinery/conveyor{
 	id = "disposals";
@@ -46288,36 +46617,37 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "qGY" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "qHK" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/alt{
-	name = "airlock-'Observatory'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Observatory"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/observatory)
 "qHL" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment/mineral{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "12"
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "qHP" = (
@@ -46382,31 +46712,30 @@
 	},
 /area/station/crew_quarters/sauna)
 "qJg" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/gannets/morgue{
-	name = "airlock-'Chapel Office'";
-	req_access_txt = "22"
+/obj/machinery/door/airlock/pyro/medical/morgue{
+	name = "Chaplain's Office"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/chapel_office,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
 	},
 /area/station/chapel/office)
 "qJu" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "qJB" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -46420,6 +46749,7 @@
 	name = "Teleporter Blast Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "qJC" = (
@@ -46433,7 +46763,6 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "qJT" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
@@ -46444,6 +46773,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/red,
 /area/station/security/hos)
 "qKp" = (
@@ -46464,10 +46794,10 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "qKu" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/bot_storage)
 "qKY" = (
@@ -46480,11 +46810,11 @@
 /turf/simulated/floor/carpet/purple/fancy/innercorner/ne_sw,
 /area/station/crew_quarters/bar)
 "qLd" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/main)
 "qLt" = (
@@ -46497,26 +46827,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"qLR" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Crew Quarters'"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
 "qLS" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/secondary/construction)
 "qMF" = (
@@ -46529,10 +46847,10 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "qMZ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/cloner)
 "qNH" = (
@@ -46541,24 +46859,19 @@
 	},
 /area/station/quartermaster/cargobay)
 "qNN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/reagent_dispensers/foamtank,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
 "qNS" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Chief Engineer's Office'";
-	req_access_txt = "49"
+/obj/machinery/door/airlock/pyro/command/alt{
+	name = "Chief Engineer's Office"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_chief,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -46572,6 +46885,20 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
+"qOi" = (
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/obj/item/device/radio/beacon,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/lounge/port)
 "qOm" = (
 /obj/decal/tile_edge/stripe{
 	dir = 1;
@@ -46639,10 +46966,7 @@
 /turf/simulated/floor/caution/misc,
 /area/station/quartermaster/cargobay)
 "qPl" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/construction)
 "qPF" = (
 /obj/disposaloutlet{
@@ -46653,23 +46977,22 @@
 /area/station/crew_quarters/kitchen)
 "qPI" = (
 /turf/simulated/floor/carpet{
-	icon_state = "green2"
+	icon_state = "red2"
 	},
-/area/station/crew_quarters/quartersC)
+/area/station/crew_quarters/quarters_east{
+	name = "Crew Quarters D"
+	})
 "qPW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command{
-	name = "airlock-'Medical Director's Quarters'";
-	req_access_txt = "53"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/md)
+/area/station/hallway/primary/north)
 "qQc" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/chapel/office)
 "qQE" = (
 /obj/cable{
@@ -46681,30 +47004,31 @@
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
 "qQG" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "qQY" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
 "qRr" = (
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
-/obj/stool/chair/office{
-	dir = 1
+/obj/stool/chair/office,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/decal/poster/wallsign/poster_rand{
+	pixel_y = 32
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -46718,7 +47042,7 @@
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "qRO" = (
 /obj/cable{
@@ -46749,25 +47073,26 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "qTs" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical{
-	name = "airlock-'Robotics'";
-	req_access_txt = "29"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 1;
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/robotics,
 /turf/simulated/floor/white,
 /area/station/medical/robotics)
 "qTv" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/psychiatrist)
 "qTD" = (
@@ -46815,23 +47140,18 @@
 	},
 /area/station/bridge)
 "qVt" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /obj/disposalpipe/switch_junction{
 	dir = 1;
-	icon_state = "pipe-sj2";
-	mail_tag = "seccheck";
-	name = "security checkpoint mail router"
+	mail_tag = "escape";
+	name = "escape mail router"
 	},
+/obj/machinery/light/small/floor/blueish,
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/stool/bench/auto,
-/obj/machinery/light/emergency,
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -46875,7 +47195,6 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "qWR" = (
-/obj/wingrille_spawn/reinforced,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 4;
@@ -46889,6 +47208,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/south)
 "qWY" = (
@@ -46916,23 +47236,18 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "qXs" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "qXK" = (
-/obj/wingrille_spawn,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
+/obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/hallway/primary/central)
+/area/station/maintenance/southeast)
 "qYj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -46972,13 +47287,13 @@
 /turf/simulated/floor/purple,
 /area/station/science/research_director)
 "qYv" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/science/bot_storage)
 "qYH" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "qYJ" = (
@@ -46987,16 +47302,16 @@
 	},
 /area/station/engine/elect)
 "qYM" = (
-/obj/machinery/manufacturer/hangar,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/cable{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northeast)
 "qYN" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -47053,13 +47368,10 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "qZS" = (
-/obj/potted_plant/potted_plant4{
-	dir = 1;
-	pixel_y = 32
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/stool/chair/office/red,
 /turf/simulated/floor/carpet{
-	dir = 1;
 	icon_state = "red2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -47072,31 +47384,39 @@
 /turf/simulated/floor/purple,
 /area/station/science/artifact)
 "raU" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/toxins{
-	name = "airlock-'Chamber Access'";
-	req_access_txt = "7"
+/obj/machinery/door/airlock/pyro/glass/toxins{
+	dir = 4;
+	name = "Toxins"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/tox,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "rco" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/gannets/engineering/alt{
-	name = "airlock-'Construction Room'";
-	req_access_txt = "44|50"
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Construction Room"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/secondary/construction)
 "rcJ" = (
-/obj/machinery/manufacturer/general,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom"
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/bright,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "red2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M04"
+	})
 "rcZ" = (
 /obj/decal/tile_edge/stripe{
 	dir = 6;
@@ -47165,7 +47485,6 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "reT" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -47173,16 +47492,14 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/security/beepsky)
 "rfh" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
 "rfj" = (
 /obj/machinery/atmospherics/valve{
@@ -47216,11 +47533,11 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "rgt" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/cdc)
 "rgz" = (
@@ -47231,17 +47548,17 @@
 /turf/space,
 /area/station/engine/core)
 "rhL" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "rhY" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/disposal)
 "riD" = (
 /obj/cable{
@@ -47352,8 +47669,11 @@
 	},
 /area/station/crew_quarters/courtroom)
 "rlC" = (
-/obj/machinery/manufacturer/hangar,
-/turf/simulated/floor,
+/obj/machinery/vehicle/miniputt,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/engine,
 /area/station/hangar/main)
 "rnN" = (
 /obj/table/wood/auto,
@@ -47464,19 +47784,20 @@
 	},
 /area/station/medical/medbay/treatment)
 "rpj" = (
-/obj/reagent_dispensers/fueltank,
-/obj/machinery/light_switch/north{
-	pixel_y = 28
+/obj/lattice{
+	icon_state = "lattice-dir"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/turf/space,
+/area/station/shield_zone)
 "rpt" = (
-/obj/decal/tile_edge/line/green{
-	dir = 6;
-	icon_state = "line1"
+/obj/machinery/power/apc{
+	areastring = "Aviary";
+	dir = 1;
+	name = "N APC";
+	pixel_y = 24
 	},
-/turf/simulated/floor/grass/random/alt,
-/area/station/garden/aviary)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "rpz" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -47515,8 +47836,17 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/cargobay)
 "rqQ" = (
-/turf/simulated/wall/auto/gannets,
-/area/station/hangar/main)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 9;
+	name = "autoname - SS13"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/machinery/light/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "rrF" = (
 /obj/disposalpipe/segment/mineral,
 /obj/disposalpipe/segment{
@@ -47529,10 +47859,11 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/door/airlock/gannets/glass/medical{
-	name = "glass airlock-'Medbay'";
-	req_access_txt = null
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	name = "Medbay"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -47602,6 +47933,19 @@
 	},
 /turf/simulated/floor/black,
 /area/station/teleporter)
+"rtC" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname  - SS13"
+	},
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "purple2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M01"
+	})
 "rtF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -47658,11 +48002,7 @@
 /turf/simulated/floor,
 /area/station/security/equipment)
 "rvg" = (
-/obj/wingrille_spawn/reinforced,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor,
 /area/station/hangar/main)
 "rvt" = (
 /obj/cable{
@@ -47758,24 +48098,21 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "rxC" = (
-/obj/decal/tile_edge/line/white{
-	dir = 1;
-	icon_state = "line1"
+/obj/machinery/vending/coffee,
+/obj/machinery/ai_status_display{
+	pixel_y = 32
 	},
-/obj/submachine/chef_sink/chem_sink{
-	layer = 3;
-	pixel_y = 8
+/obj/cable{
+	icon_state = "2-4"
 	},
-/obj/machinery/light_switch/north{
-	pixel_x = 8;
-	pixel_y = 28
+/turf/simulated/floor/orangeblack/side{
+	dir = 5
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/area/station/hallway/secondary/exit)
 "ryx" = (
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	name = "glass airlock-'Emergency Artifact Flusher";
-	req_access_txt = "8"
+/obj/machinery/door/airlock/pyro/glass/sci{
+	dir = 1;
+	name = "Artifact Flusher"
 	},
 /turf/simulated/floor/white,
 /area/station/science/artifact)
@@ -47783,10 +48120,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "rzj" = (
 /obj/decal/tile_edge/line/black{
@@ -47928,7 +48262,6 @@
 /turf/simulated/floor/black,
 /area/station/hangar/sec)
 "rCp" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
@@ -47936,6 +48269,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/armory)
 "rCH" = (
@@ -48000,42 +48334,44 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/east)
 "rEM" = (
+/obj/disposalpipe/segment,
 /obj/cable{
 	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "rER" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/security/alt{
-	name = "airlock-'Interrogation Room'"
+/obj/disposalpipe/segment/brig{
+	dir = 4
 	},
+/obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/security{
+	dir = 4;
+	name = "Interrogation Room";
+	req_access_txt = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "rEX" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "rFf" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
 "rFo" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe{
 	dir = 10
 	},
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
 "rFq" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -48119,7 +48455,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "rGW" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/middle{
 	dir = 4
 	},
@@ -48136,6 +48471,7 @@
 	name = "Bridge Lockdown Door";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "rHk" = (
@@ -48169,16 +48505,9 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "rHx" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/light/small/floor/blueish,
-/obj/cable{
-	icon_state = "2-4"
+/obj/disposalpipe/segment,
+/obj/disposalpipe/segment/brig{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
@@ -48195,7 +48524,6 @@
 	},
 /area/station/science/lobby)
 "rIl" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
@@ -48206,19 +48534,9 @@
 	layer = 2.9;
 	pixel_y = 13
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/interrogation)
-"rIw" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P03"
-	})
 "rIH" = (
 /obj/decal/tile_edge/stripe{
 	dir = 8;
@@ -48306,14 +48624,10 @@
 	},
 /area/station/crew_quarters/fitness)
 "rKX" = (
-/obj/airbridge_controller{
-	id = "merchant_L";
-	primary_controller = 1
-	},
-/turf/space,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/overfloor/vertical,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/central)
 "rKY" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -48321,6 +48635,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
 "rLn" = (
@@ -48343,31 +48658,25 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "rLJ" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/bar)
 "rLS" = (
-/obj/cable{
-	icon_state = "4-8"
+/turf/simulated/floor/carpet{
+	icon_state = "blue2"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/north)
+/area/station/crew_quarters/quartersA)
 "rMc" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/plasticflaps{
 	layer = 3
-	},
-/obj/machinery/door/airlock/gannets/security,
-/obj/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/security/beepsky)
 "rMl" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "rMN" = (
 /obj/lattice{
@@ -48401,28 +48710,25 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/gannets/maintenance,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/east)
 "rNq" = (
-/obj/shrub,
-/obj/disposalpipe/segment/mail{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/critter/turtle/sylvester/HoS,
+/turf/simulated/floor/carpet{
+	icon_state = "fred2"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/area/station/crew_quarters/hos)
 "rNC" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/lobby)
 "rNF" = (
@@ -48431,32 +48737,33 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
-"rOm" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
-/area/station/maintenance/inner/south)
 "rOK" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/pink,
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/obj/machinery/light_switch/north{
+/obj/item/storage/secure/ssafe{
 	pixel_y = 28
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/north)
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "purple2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P04"
+	})
 "rQk" = (
 /obj/decal/stage_edge,
 /obj/machinery/computer/stockexchange,
 /turf/simulated/floor/carpet/red/fancy/edge/north,
 /area/station/crew_quarters/fitness)
 "rRj" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	name = "glass airlock-'Lab Access'";
-	req_access_txt = "33"
+/obj/machinery/door/airlock/pyro/sci_alt{
+	dir = 4;
+	name = "Chemistry"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/purple,
 /area/station/science/chemistry)
 "rRk" = (
@@ -48475,21 +48782,21 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "rRL" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command/alt{
-	name = "airlock-'Computer Core'";
-	req_access_txt = "19"
+/obj/machinery/door/airlock/pyro/command{
+	name = "Computer Core"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor/purple,
 /area/station/science/research_director)
 "rRM" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/lobby)
 "rRR" = (
@@ -48510,14 +48817,10 @@
 /turf/simulated/floor/blue/checker,
 /area/station/medical/head)
 "rRU" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/bright,
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet{
-	dir = 1;
 	icon_state = "purple2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -48527,21 +48830,18 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
 "rSD" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
+/obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/cable{
-	icon_state = "0-4"
-	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/northwest)
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "rSL" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -48578,6 +48878,9 @@
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
 "rTo" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /obj/decal/tile_edge/line/white{
 	icon_state = "line3"
 	},
@@ -48587,9 +48890,6 @@
 	},
 /obj/cable{
 	icon_state = "0-2"
-	},
-/obj/machinery/sleeper/compact{
-	dir = 4
 	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
@@ -48607,14 +48907,12 @@
 /area/station/crew_quarters/pool)
 "rUn" = (
 /obj/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/north)
+/obj/disposalpipe/segment/mail,
+/obj/machinery/navbeacon/tour/destiny/tour18,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "rUZ" = (
 /obj/lattice{
 	dir = 4;
@@ -48673,21 +48971,36 @@
 	},
 /area/station/engine/engineering/ce)
 "rVY" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 8
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
+"rWb" = (
+/obj/machinery/light/small,
+/obj/item/storage/wall/emergency{
+	pixel_y = 32
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/north)
 "rWB" = (
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 4;
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	dir = 9;
 	level = 2
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
 "rWK" = (
 /obj/decal/tile_edge/line/white{
@@ -48703,7 +49016,6 @@
 	},
 /area/station/security/main)
 "rWN" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -48711,6 +49023,7 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/security/hos)
 "rWO" = (
@@ -48758,13 +49071,13 @@
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/office)
 "rYL" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/right{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
 "rZl" = (
@@ -48772,17 +49085,22 @@
 /turf/simulated/floor/industrial,
 /area/station/mining/refinery)
 "rZZ" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/bar)
 "saj" = (
-/obj/disposalpipe/segment/mail,
-/obj/disposalpipe/segment/mail{
+/obj/machinery/light{
 	dir = 4
 	},
+/obj/disposalpipe/segment/mail,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "saq" = (
@@ -48798,16 +49116,12 @@
 /turf/simulated/floor/yellow,
 /area/station/hallway/secondary/construction)
 "saC" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-8"
+/obj/machinery/door/poddoor/blast,
+/turf/simulated/floor/engine{
+	dir = 4;
+	icon_state = "engine_caution_misc"
 	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/medical/medbooth)
+/area/station/hallway/secondary/exit)
 "saI" = (
 /obj/stool/bench/blue/auto,
 /obj/decal/tile_edge/line/blue{
@@ -48816,16 +49130,6 @@
 	},
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
-"saJ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
-	dir = 1
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "sbo" = (
 /obj/stool/chair{
 	desc = "";
@@ -48841,11 +49145,21 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/crew_quarters/pool)
+"sbJ" = (
+/obj/machinery/computer/airbr/emergency_shuttle{
+	density = 0;
+	emergency = 0;
+	id = "merchant_L";
+	pixel_y = 32;
+	req_access_txt = ""
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/lounge/port)
 "scn" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/lounge)
 "scC" = (
@@ -48867,6 +49181,15 @@
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
+"sde" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/lounge/port)
 "sdr" = (
 /obj/decal/tile_edge/line/green{
 	icon_state = "line3"
@@ -48879,7 +49202,6 @@
 	},
 /area/station/medical/cdc)
 "sdF" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/decal/tile_edge/line/white{
 	dir = 1;
 	icon_state = "line1"
@@ -48887,12 +49209,14 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/airlock/gannets/morgue/alt{
-	name = "airlock-'Morgue'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/medical/morgue{
+	name = "Morgue"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/morgue,
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "sdV" = (
@@ -48951,10 +49275,14 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "sfV" = (
-/turf/simulated/floor/stairs{
-	icon_state = "Stairs_wide"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/crew_quarters/lounge/starboard)
+/obj/item/storage/wall/fire{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/central)
 "sfW" = (
 /obj/decal/tile_edge/line/black{
 	dir = 6;
@@ -48990,25 +49318,26 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "shi" = (
-/obj/stool/bench/yellow,
+/obj/item/device/radio/beacon,
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "tour;next_tour=tour17;desc=In the event of catastrophic station damage or approved shift change, a shuttle will be dispatched from the regional Central Command dock to this location. Should this occur, remember to line up quietly and enter single-file. No shoving please!";
+	freq = 1443;
+	location = "tour16";
+	name = "tour beacon - escape"
+	},
+/obj/landmark/gps_waypoint,
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "shk" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/refinery)
-"shC" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P04"
-	})
 "shS" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -49023,10 +49352,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "sio" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/maintenance{
-	name = "airlock-'Disposals'"
+/obj/machinery/door/airlock/pyro/classic{
+	dir = 4;
+	name = "Disposals"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "siz" = (
@@ -49060,7 +49390,6 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "sjd" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 1;
@@ -49071,6 +49400,7 @@
 	name = "Test Chamber Blast Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/science/testchamber)
 "sjg" = (
@@ -49085,16 +49415,18 @@
 	},
 /area/station/bridge)
 "sjk" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
+/obj/potted_plant/potted_plant5{
 	dir = 1;
-	name = "autoname - SS13"
+	pixel_y = 32
 	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/stool/chair/office/green,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "green2"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/north)
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M03"
+	})
 "sjv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -49115,45 +49447,21 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "skl" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Ranch'";
-	req_access_txt = "83"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/glass/botany{
+	dir = 8;
+	name = "Ranch"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/rancher,
 /turf/simulated/floor,
 /area/station/ranch)
 "skn" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer3/generic/med_data{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
-	},
-/obj/blind_switch/area/west{
-	dir = 4
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "fblue2"
-	},
-/area/station/crew_quarters/md)
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/northeast)
 "skP" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/security{
-	name = "airlock-'Security'"
-	},
 /obj/machinery/secscanner,
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -49161,6 +49469,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/security,
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/plating/random,
 /area/station/security/main)
 "skY" = (
@@ -49174,27 +49485,24 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "slo" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/cloner)
 "sly" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/psychiatrist)
 "slC" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
-/area/station/crewquarters/cryotron)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/entry)
 "smP" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -49268,7 +49576,6 @@
 	},
 /area/station/crew_quarters/pool)
 "spi" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/disposalpipe/segment/mail{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -49279,6 +49586,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "spk" = (
@@ -49295,7 +49603,6 @@
 /turf/simulated/floor/plating/airless,
 /area/station/engine/power)
 "spE" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -49305,20 +49612,19 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/artifact)
 "spW" = (
-/obj/cable{
-	icon_state = "0-8"
+/obj/disposalpipe/segment/brig{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northwest)
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "sqE" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -49334,10 +49640,11 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "sqV" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/clown)
 "sqW" = (
 /obj/cable{
@@ -49410,21 +49717,21 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "sud" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/brig,
 /obj/window_blinds/cog2,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/hos)
 "svL" = (
 /obj/disposalpipe/segment/mineral,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/disposal)
 "swl" = (
-/turf/simulated/wall/auto/gannets,
-/area/station/crew_quarters/md)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/northeast)
 "swn" = (
 /obj/potted_plant/potted_plant3,
 /obj/cable{
@@ -49438,10 +49745,9 @@
 /area/station/science/lobby)
 "swo" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/overfloor/vertical,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/outer/sw)
 "swv" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/machinery/door/window/westright{
 	req_access_txt = "35"
@@ -49459,21 +49765,25 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/hydro,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "swO" = (
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/area/station/crew_quarters/heads{
-	name = "Head of Personnel's Quarters"
-	})
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads)
 "swP" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/mining/refinery)
 "swT" = (
@@ -49483,6 +49793,22 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"sxz" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/yellow,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P03"
+	})
 "sxU" = (
 /obj/grille/catwalk/cross{
 	dir = 1
@@ -49542,41 +49868,14 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "sAU" = (
-/obj/table/wood/auto,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
+/obj/landmark{
+	name = "blobstart"
 	},
-/obj/machinery/light/lamp/bright,
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
-"sBo" = (
-/obj/machinery/computer/airbr/emergency_shuttle{
-	density = 0;
-	emergency = 0;
-	id = "merchant_R";
-	pixel_y = 32;
-	req_access_txt = ""
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/starboard)
-"sBA" = (
-/obj/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northwest)
 "sBV" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
@@ -49596,15 +49895,12 @@
 /turf/simulated/floor/greenwhite/other,
 /area/station/medical/cdc)
 "sCg" = (
-/obj/machinery/light/small,
-/obj/item/storage/wall/emergency{
-	pixel_y = 32
+/obj/machinery/macrofab/emergency_pod,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/north)
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "sCE" = (
 /obj/decal/tile_edge/stripe{
 	icon_state = "xtra_bigstripe-edge"
@@ -49636,10 +49932,6 @@
 /turf/simulated/floor/grey,
 /area/station/mining/refinery)
 "sDu" = (
-/obj/machinery/door/airlock/gannets/glass/medical{
-	name = "glass airlock-'Observation Room'";
-	req_access_txt = ""
-	},
 /obj/decal/tile_edge/line/green{
 	dir = 8;
 	icon_state = "line1"
@@ -49650,6 +49942,11 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Observation Room"
+	},
+/obj/access_spawn/medical,
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
 "sDE" = (
@@ -49660,17 +49957,17 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "sDJ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/power)
 "sDU" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/security/hos)
 "sEl" = (
@@ -49720,7 +50017,7 @@
 /area/station/hallway/primary/central)
 "sFF" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/pharmacy)
 "sFY" = (
 /obj/table/reinforced/chemistry/auto,
@@ -49755,11 +50052,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
-"sGz" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/starboard)
 "sGK" = (
 /obj/submachine/cargopad{
 	name = "Botany Pad"
@@ -49768,7 +50060,6 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "sHt" = (
-/obj/wingrille_spawn,
 /obj/decal/tile_edge/stripe{
 	dir = 10;
 	icon_state = "xtra_bigstripe-edge"
@@ -49777,6 +50068,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "sHw" = (
@@ -49816,17 +50108,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
 "sIw" = (
-/obj/table/auto,
-/obj/random_item_spawner/tools,
-/obj/item/device/light/flashlight,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
+/obj/disposalpipe/segment/morgue{
+	dir = 4
 	},
-/obj/item/clothing/suit/hi_vis,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
 "sIE" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating/random,
@@ -49857,11 +50144,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "sJq" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	name = "glass airlock-'Guardbot Depot'";
-	req_access_txt = "33"
+/obj/machinery/door/airlock/pyro/glass/sci{
+	name = "Guardbot Depot"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "sJu" = (
@@ -49879,13 +50165,13 @@
 /area/station/quartermaster/cargobay)
 "sJM" = (
 /obj/decal/poster/wallsign/medbay_left,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/baroffice)
 "sJS" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
 "sKh" = (
 /obj/decal/tile_edge/line/black{
@@ -49936,7 +50222,6 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "sLy" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -49953,6 +50238,7 @@
 	opacity = 0
 	},
 /obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "sLL" = (
@@ -49968,9 +50254,11 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "fgreen2"
+	icon_state = "fpurple2"
 	},
-/area/station/crew_quarters/ce)
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "sLT" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50023,12 +50311,16 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "sMV" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/area/station/medical/medbooth)
 "sNq" = (
 /obj/stool/chair/office/purple{
 	dir = 8
@@ -50048,18 +50340,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
-"sOu" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 9;
-	name = "autoname - SS13"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/light/emergency{
-	dir = 4
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "sOM" = (
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -50068,7 +50348,7 @@
 /area/station/crew_quarters/bar)
 "sPd" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/head)
 "sPs" = (
 /obj/cable{
@@ -50134,22 +50414,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "sRe" = (
-/obj/rack,
-/obj/item/clothing/suit/fire,
-/obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/head/helmet/firefighter,
-/obj/item/tank/air,
-/obj/item/extinguisher,
-/obj/item/crowbar,
-/obj/item/storage/wall/fire{
-	pixel_y = 32
-	},
-/obj/item/device/light/flashlight,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/north)
+/area/station/maintenance/central)
 "sRN" = (
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
@@ -50199,12 +50473,21 @@
 /turf/simulated/floor/plating/airless,
 /area/station/security/hos)
 "sUb" = (
-/obj/warp_beacon{
-	name = "Destiny west beacon"
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/red,
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/obj/lattice,
-/turf/space,
-/area/space)
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "red2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P02"
+	})
 "sUg" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -50219,7 +50502,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/staff_room)
 "sVp" = (
 /obj/decal/stage_edge,
@@ -50229,16 +50512,18 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
 "sVr" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/northwest)
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "sVu" = (
 /obj/decal/poster/wallsign/hazard_coldloop,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "sVY" = (
 /obj/machinery/computer/teleporter,
@@ -50253,8 +50538,16 @@
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "sWu" = (
-/turf/space,
-/area/shuttle_sound_spawn)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/north)
 "sWw" = (
 /obj/rack,
 /obj/item/clothing/suit/bio_suit/paramedic,
@@ -50285,14 +50578,14 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "sXh" = (
-/obj/machinery/door_control{
-	id = "pod_fore";
-	name = "Hangar Door Control";
-	pixel_x = -24;
-	pixel_y = -8
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/light,
-/turf/simulated/floor/engine,
+/obj/reagent_dispensers/foamtank,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
 /area/station/hangar/main)
 "sXj" = (
 /obj/decal/tile_edge/line/green{
@@ -50329,7 +50622,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "sXG" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "sXJ" = (
 /obj/storage/secure/closet/animal,
@@ -50445,13 +50738,22 @@
 /area/station/engine/power)
 "sZK" = (
 /obj/disposalpipe/segment/morgue,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
 "sZO" = (
-/turf/simulated/floor/carpet{
-	icon_state = "fgreen2"
+/obj/stool{
+	desc = "A soft little bed the general size and shape of a space bee.";
+	icon = 'icons/misc/critter.dmi';
+	icon_state = "beebed";
+	name = "heisenbed"
 	},
-/area/station/crew_quarters/ce)
+/obj/critter/domestic_bee/heisenbee,
+/turf/simulated/floor/carpet{
+	icon_state = "fpurple2"
+	},
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "sZP" = (
 /obj/table/reinforced/industrial,
 /obj/item/kitchen/utensil/fork{
@@ -50464,6 +50766,9 @@
 /obj/item/reagent_containers/food/drinks/mug/random_color{
 	pixel_x = -5;
 	pixel_y = 14
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -50478,16 +50783,10 @@
 	},
 /area/station/security/beepsky)
 "sZQ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/cable,
-/obj/cable{
-	icon_state = "0-8"
-	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/northeast)
+/area/station/medical/medbooth)
 "sZX" = (
 /turf/simulated/floor/yellow,
 /area/station/mining/refinery)
@@ -50539,15 +50838,8 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/elect)
-"tat" = (
-/obj/airbridge_controller{
-	id = "merchant_R";
-	primary_controller = 1
-	},
-/turf/space,
-/area/space)
 "taI" = (
 /obj/decal/tile_edge/line/blue{
 	icon_state = "line1"
@@ -50597,16 +50889,13 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/pharmacy)
 "tbI" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/red,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname  - SS13"
 	},
 /turf/simulated/floor/carpet{
-	dir = 9;
+	dir = 10;
 	icon_state = "red2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -50651,7 +50940,7 @@
 /turf/simulated/floor/purple,
 /area/station/medical/medbay/pharmacy)
 "tci" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
 "tcR" = (
 /obj/disposalpipe/segment/mail{
@@ -50709,16 +50998,15 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "tdq" = (
-/obj/decal/tile_edge/line/black{
-	dir = 9;
-	icon_state = "line2"
+/obj/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/vending/security,
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/wingrille_spawn/auto/crystal,
+/turf/simulated/floor/plating/random,
+/area/station/hangar/main)
 "tdX" = (
 /obj/submachine/cargopad{
 	name = "Artifact Lab Pad"
@@ -50759,11 +51047,11 @@
 	icon_state = "line1"
 	},
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "tfj" = (
@@ -50803,14 +51091,11 @@
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/psychiatrist)
 "tgk" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/airbridge_controller{
+	id = "merchant_L"
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/turf/space,
+/area/space)
 "tgu" = (
 /obj/table/wood/auto,
 /obj/item/storage/toolbox/artistic,
@@ -50879,16 +51164,14 @@
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
 "tib" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical{
-	name = "glass airlock-'Monkeydome'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "1-8"
+/obj/machinery/door/airlock/pyro/glass/med{
+	name = "Monkeydome"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -50939,17 +51222,14 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "tjt" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/right{
-	dir = 4
-	},
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
+	},
+/obj/item/storage/wall/emergency{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quarters_east{
-	name = "Crew Quarters D"
-	})
+/area/station/maintenance/northwest)
 "tjA" = (
 /obj/decal/tile_edge/line/green{
 	dir = 4;
@@ -50987,24 +51267,21 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "tkw" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hangar/main)
-"tkJ" = (
-/obj/decal/tile_edge/stripe{
+/obj/potted_plant/potted_plant2{
 	dir = 1;
-	icon_state = "xtra_bigstripe-edge"
+	pixel_y = 32
 	},
-/obj/railing/yellow{
-	dir = 1
+/obj/stool/chair/office/purple,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "purple2"
 	},
-/turf/simulated/floor/delivery,
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P04"
+	})
+"tkJ" = (
+/obj/machinery/vending/air_vendor,
+/turf/simulated/floor,
 /area/station/crew_quarters/lounge/port)
 "tkQ" = (
 /obj/disposalpipe/segment,
@@ -51128,11 +51405,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
-/area/station/crewquarters/cryotron)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/entry)
 "tnE" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -51191,17 +51465,17 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "trD" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/psychiatrist)
 "trO" = (
 /obj/storage/closet/wardrobe/pride,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
 "trW" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "tsA" = (
@@ -51215,9 +51489,9 @@
 /obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
 /turf/simulated/floor/carpet{
 	dir = 10;
-	icon_state = "purple2"
+	icon_state = "green2"
 	},
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "tsT" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/food{
@@ -51281,6 +51555,19 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
+"tup" = (
+/obj/potted_plant/potted_plant3{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/stool/chair/office/yellow,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P03"
+	})
 "tuI" = (
 /obj/storage/closet/coffin,
 /obj/machinery/power/apc/autoname_north,
@@ -51300,10 +51587,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/power)
 "tvL" = (
 /obj/potted_plant/potted_plant4{
@@ -51324,10 +51608,10 @@
 /turf/simulated/floor/carpet/red/fancy/innercorner/omni,
 /area/station/crew_quarters/fitness)
 "twI" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/secondary/construction)
 "txb" = (
@@ -51375,11 +51659,17 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/item/storage/secure/ssafe{
+/obj/storage/secure/closet/command/hop,
+/obj/decal/poster/wallsign/framed_award/firstbill{
 	pixel_y = 28
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/captain)
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "fgreen2"
+	},
+/area/station/crew_quarters/heads{
+	name = "Head of Personnel's Quarters"
+	})
 "tzg" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 4
@@ -51416,7 +51706,7 @@
 /area/station/turret_protected/armory_outside)
 "tBE" = (
 /obj/disposalpipe/segment/food,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/central)
 "tBK" = (
 /obj/decal/tile_edge/stripe,
@@ -51442,7 +51732,6 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -51450,6 +51739,7 @@
 	name = "QM - Mining Transfer Shutters";
 	opacity = 0
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "tCM" = (
@@ -51465,35 +51755,34 @@
 /turf/simulated/floor/purple,
 /area/station/science/research_director)
 "tCW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/toxins{
-	name = "airlock-'Toxins'";
-	req_access_txt = "7"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/toxins_alt{
+	name = "Toxins"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/tox,
 /turf/simulated/floor/black,
 /area/station/science/lab)
 "tDb" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering/alt{
-	name = "airlock-'Engineering'";
-	req_access_txt = "44"
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 8;
+	name = "Engineering"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering,
 /turf/simulated/floor/black,
 /area/station/engine/gas)
 "tDr" = (
-/obj/disposalpipe/segment,
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/navbeacon/tour/destiny/tour16,
-/obj/machinery/door/firedoor/border_only,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "tDE" = (
@@ -51540,13 +51829,13 @@
 /area/station/medical/cdc)
 "tEs" = (
 /obj/disposalpipe/segment,
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "tEz" = (
@@ -51606,7 +51895,10 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
+/obj/machinery/light/incandescent{
+	dir = 1;
+	nostick = 1
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/starboard)
 "tFm" = (
@@ -51639,12 +51931,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "tFN" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/medical/medbooth)
+/area/station/hallway/secondary/exit)
 "tFQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51670,7 +51962,6 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "tGj" = (
-/obj/wingrille_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 8;
 	level = 2
@@ -51678,6 +51969,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/lab)
 "tGB" = (
@@ -51712,44 +52004,37 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "tHd" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "tHl" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/chemistry{
-	name = "airlock-'Artifact Lab'";
-	req_access_txt = "8"
+/obj/machinery/door/airlock/pyro/sci_alt{
+	name = "Artifact Lab"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor/black,
 /area/station/science/artifact)
 "tHw" = (
 /obj/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
 /obj/decal/tile_edge/line/yellow{
 	dir = 10;
 	icon_state = "line1"
 	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "tHB" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Pod Bay Storage'"
+/obj/airbridge_controller{
+	id = "merchant_R"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/turf/space,
+/area/space)
 "tHD" = (
 /obj/disposalpipe/segment,
 /obj/shrub,
@@ -51764,9 +52049,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "tII" = (
-/obj/decal/poster/wallsign/escape_right,
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/hallway/secondary/exit)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "Toilets"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east/restroom)
 "tIJ" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 10;
@@ -51790,7 +52082,18 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "tJo" = (
-/turf/simulated/wall/auto/gannets,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Crew Lounge"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/port)
 "tKk" = (
 /obj/decal/tile_edge/line/white{
@@ -51850,7 +52153,7 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "tLM" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/quartermaster/cargobay)
 "tLN" = (
 /obj/stool/chair/yellow{
@@ -51864,7 +52167,9 @@
 /obj/machinery/light/emergency{
 	dir = 4
 	},
-/turf/simulated/floor/stairs,
+/turf/simulated/floor/stairs{
+	dir = 1
+	},
 /area/station/hangar/main)
 "tMv" = (
 /obj/disposalpipe/segment{
@@ -51892,10 +52197,13 @@
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "tMJ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Pod Bay Storage'"
-	},
+/obj/machinery/light,
+/obj/rack,
+/obj/item/clothing/suit/space/emerg,
+/obj/item/tank/air,
+/obj/item/clothing/head/emerg,
+/obj/item/clothing/mask/breath,
+/obj/item/crowbar,
 /turf/simulated/floor,
 /area/station/hangar/main)
 "tMO" = (
@@ -51931,10 +52239,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "tNB" = (
-/obj/wingrille_spawn/reinforced,
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/exit)
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/primary/east/restroom)
 "tNG" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -52009,7 +52315,7 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "tPI" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/treatment1)
 "tQx" = (
 /obj/disposalpipe/switch_junction{
@@ -52053,27 +52359,16 @@
 	},
 /area/station/science/lobby)
 "tRk" = (
-/obj/machinery/firealarm{
-	layer = 3.5;
-	pixel_y = 28
+/obj/landmark{
+	name = "blobstart"
 	},
-/obj/table/wood/auto/desk,
-/obj/item/folder,
-/obj/item/paper_bin{
-	pixel_y = 3
-	},
-/obj/item/pen,
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "fblue2"
-	},
-/area/station/crew_quarters/md)
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/northeast)
 "tRs" = (
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 1;
@@ -52084,6 +52379,7 @@
 	opacity = 0
 	},
 /obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "tRv" = (
@@ -52094,10 +52390,10 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/engineering/ce)
 "tRI" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/cdc)
 "tSN" = (
 /obj/cable{
@@ -52151,12 +52447,13 @@
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "tUp" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/disposalpipe/trunk,
+/obj/machinery/disposal/small{
+	dir = 1;
+	pixel_y = 32
 	},
-/obj/disposalpipe/junction,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "tUy" = (
 /obj/reagent_dispensers/fueltank,
 /obj/machinery/light_switch/north{
@@ -52172,21 +52469,15 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
 "tUU" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "tVg" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -52222,11 +52513,6 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical{
-	id = "medbay_door";
-	name = "glass airlock-'Medbay'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -52236,6 +52522,11 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -52276,10 +52567,7 @@
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "tWB" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/sec)
 "tXg" = (
 /turf/simulated/floor,
@@ -52292,15 +52580,15 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "tXw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'Cargo'";
-	req_access_txt = "31"
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 4;
+	name = "Cargo"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/black,
 /area/station/quartermaster/office)
 "tXG" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -52310,6 +52598,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "tXW" = (
@@ -52355,14 +52644,15 @@
 	},
 /area/station/security/main)
 "tYJ" = (
-/obj/rack,
-/obj/item/clothing/head/emerg,
-/obj/item/clothing/suit/space/emerg,
-/obj/item/clothing/mask/breath,
-/obj/item/crowbar,
-/obj/item/tank/air,
-/turf/simulated/floor,
-/area/station/hangar/main)
+/obj/decal/tile_edge/stripe{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/obj/railing/yellow{
+	dir = 1
+	},
+/turf/simulated/floor/delivery,
+/area/station/crew_quarters/lounge/port)
 "tZI" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -52410,10 +52700,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "uax" = (
-/obj/disposalpipe/segment{
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "uaF" = (
@@ -52556,10 +52846,10 @@
 	},
 /area/station/medical/robotics)
 "ued" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer3/generic/secure_data{
+/obj/machinery/power/monitor{
 	dir = 4
 	},
+/obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -52571,14 +52861,11 @@
 /obj/blind_switch/area/west{
 	dir = 4
 	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
-	},
 /turf/simulated/floor/carpet{
 	dir = 9;
-	icon_state = "fred2"
+	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "uer" = (
 /obj/machinery/power/smes,
 /obj/cable{
@@ -52604,7 +52891,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/treatment)
 "ueW" = (
 /obj/cable{
@@ -52673,16 +52960,17 @@
 	},
 /area/station/crew_quarters/observatory)
 "uhu" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/chemistry{
-	name = "airlock-'Science Restroom'"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/sci_alt{
+	dir = 4;
+	name = "Research"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/science/restroom)
 "uhv" = (
@@ -52760,29 +53048,29 @@
 /turf/simulated/floor/purple,
 /area/station/medical/cdc)
 "uiN" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2{
 	layer = 2.9;
 	pixel_y = 13
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/surgery)
 "uiW" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical{
-	name = "glass airlock-'Medbay'";
-	req_access_txt = null
+/obj/machinery/door/airlock/pyro/glass/med{
+	name = "Medbay"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
 /area/station/medical/medbay/treatment)
 "ujn" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "ujx" = (
@@ -52833,22 +53121,11 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/restroom)
-"ukJ" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
-/area/station/ai_monitored/armory)
 "ukK" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/engineering/alt{
-	name = "glass airlock-'Engine Room'";
-	req_access_txt = "44"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -52857,6 +53134,11 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Engine Room"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "ukO" = (
@@ -52871,25 +53153,36 @@
 	},
 /area/station/bridge)
 "ulf" = (
-/obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/secscanner{
+	dir = 4;
+	pixel_x = -20
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pod Bay Storage"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/area/station/hangar/main)
 "ulF" = (
 /obj/machinery/light,
 /turf/simulated/floor/engine,
 /area/station/hangar/sec)
 "ulP" = (
-/obj/disposalpipe/segment/brig{
-	dir = 4
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge"
 	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
 "umi" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
@@ -52941,21 +53234,15 @@
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "uny" = (
-/obj/disposalpipe/segment/brig{
-	dir = 4
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge"
 	},
-/obj/landmark/start{
-	name = "Security Officer"
+/obj/cable{
+	icon_state = "2-8"
 	},
-/obj/stool/chair/office/red{
-	dir = 4
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/turf/simulated/floor,
+/area/station/hangar/main)
 "unT" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
@@ -52968,14 +53255,18 @@
 	name = "Chamber One Heat Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "unV" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_engine,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "uof" = (
@@ -52994,7 +53285,6 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "uor" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail,
 /obj/cable{
 	icon_state = "0-8"
@@ -53002,6 +53292,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "uou" = (
@@ -53095,6 +53386,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
+"urP" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/primary/east/restroom)
 "urX" = (
 /obj/machinery/clonegrinder,
 /obj/machinery/camera{
@@ -53112,7 +53409,6 @@
 /area/station/medical/medbay/cloner)
 "usd" = (
 /obj/disposalpipe/segment/mail,
-/obj/wingrille_spawn,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
@@ -53123,6 +53419,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/central)
 "usk" = (
@@ -53304,20 +53601,23 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "uym" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/plasticflaps{
 	layer = 3
 	},
-/obj/machinery/door/airlock/gannets/security,
 /obj/cable{
 	icon_state = "2-4"
 	},
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/door/airlock/pyro/security{
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/beepsky)
 "uyu" = (
@@ -53346,7 +53646,7 @@
 "uyz" = (
 /obj/forcefield/energyshield/perma,
 /turf/simulated/floor/stairs/medical/wide,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "uyP" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -53362,14 +53662,14 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "uzd" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0;
 	dir = 9
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/lab)
 "uzO" = (
 /obj/machinery/guardbot_dock,
@@ -53382,7 +53682,7 @@
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
 "uAP" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/staff_room)
 "uBe" = (
 /obj/grille/catwalk/cross{
@@ -53434,11 +53734,11 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "uBs" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2{
 	dir = 4
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -53497,7 +53797,7 @@
 	dir = 4;
 	name = "Air Reserve (Security)"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "uCi" = (
 /obj/decal/tile_edge/line/yellow{
@@ -53516,35 +53816,38 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "uCC" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Restroom'"
+/obj/machinery/manufacturer/hangar,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/east/restroom)
+/turf/simulated/floor,
+/area/station/hangar/main)
 "uCM" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 1
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/south)
 "uCV" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/toxins{
-	name = "airlock-'Toxins'";
-	req_access_txt = "7"
+/obj/machinery/door/airlock/pyro/toxins_alt{
+	dir = 8;
+	name = "Toxins"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/tox_storage,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "uCX" = (
@@ -53581,12 +53884,14 @@
 /turf/simulated/floor/purple,
 /area/station/science/research_director)
 "uDz" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/decal/cleanable/dirt,
+/obj/creepy_sound_trigger,
 /obj/item/bananapeel,
-/obj/machinery/door/airlock/gannets/maintenance,
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/classic{
+	dir = 4
 	},
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/clown)
@@ -53607,7 +53912,7 @@
 /obj/machinery/atmospherics/valve{
 	name = "Air Reserve (Medbay)"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/treatment)
 "uEa" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -53633,16 +53938,13 @@
 /turf/simulated/floor/white,
 /area/station/maintenance/inner/south)
 "uEr" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/red,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
 	},
 /turf/simulated/floor/carpet{
-	dir = 5;
+	dir = 6;
 	icon_state = "red2"
 	},
 /area/station/crew_quarters/quartersA{
@@ -53666,11 +53968,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "uEY" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/security,
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/security{
+	dir = 1;
+	name = "Detective's Office";
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/forensics,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "uFs" = (
@@ -53678,14 +53985,11 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/disposalpipe/segment/mail{
-	dir = 4
+/obj/machinery/door/airlock/pyro/glass/mining{
+	name = "Mining"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/engineering/alt{
-	name = "airlock-'Mining Office'";
-	req_access_txt = "50"
-	},
+/obj/firedoor_spawn,
+/obj/access_spawn/mining,
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "uFM" = (
@@ -53708,19 +54012,35 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "uHa" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'Cargo'";
-	req_access_txt = "31"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 4;
+	name = "Cargo"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/black,
 /area/station/quartermaster/office)
+"uHm" = (
+/obj/decal/tile_edge/line/white{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/submachine/chef_sink/chem_sink{
+	layer = 3;
+	pixel_y = 8
+	},
+/obj/machinery/light_switch/north{
+	pixel_x = 8;
+	pixel_y = 28
+	},
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
 "uHA" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -53741,13 +54061,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "uHN" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "uHR" = (
@@ -53765,7 +54085,6 @@
 /turf/simulated/floor/blue,
 /area/station/science/lab)
 "uIa" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -53773,12 +54092,13 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "uIi" = (
 /obj/landmark/start/latejoin,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "uIs" = (
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
@@ -53798,21 +54118,18 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/wingrille_spawn,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/southeast)
 "uJT" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/armory)
 "uJW" = (
 /obj/stool/chair/office/yellow{
@@ -53853,8 +54170,14 @@
 /turf/simulated/floor/purple,
 /area/station/science/artifact)
 "uKt" = (
+/obj/stool/bench/yellow,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=quarters_eastboard";
+	location = "escape";
+	name = "bot navigation beacon"
+	},
 /obj/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
@@ -54041,7 +54364,7 @@
 	name = "Genetic Research"
 	})
 "uOM" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/outer/sw)
 "uOS" = (
 /obj/cable{
@@ -54091,27 +54414,29 @@
 /area/station/hallway/primary/west)
 "uQP" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "uRc" = (
-/obj/decal/tile_edge/line/white{
-	dir = 1;
-	icon_state = "line1"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/item/storage/wall/office,
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/obj/submachine/claw_machine,
+/obj/machinery/light_switch/east{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit)
 "uRj" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "airlock-'Restroom'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro{
+	name = "showers"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/toilets)
 "uRB" = (
@@ -54159,10 +54484,7 @@
 /area/station/security/main)
 "uSu" = (
 /obj/decal/poster/wallsign/space,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
 "uSD" = (
 /obj/decal/tile_edge/line/black{
@@ -54188,7 +54510,6 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/barber_shop)
 "uTd" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -54196,6 +54517,7 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "uTm" = (
@@ -54218,7 +54540,6 @@
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "uTQ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
@@ -54228,6 +54549,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/courtroom)
 "uUV" = (
@@ -54237,20 +54559,22 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "uVl" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/window_blinds/cog2/right{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
 "uVw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/medical{
-	name = "glass airlock-'Monkeydome'"
+/obj/machinery/door/airlock/pyro/glass/med{
+	dir = 4;
+	name = "Monkeydome"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
 "uVH" = (
@@ -54266,9 +54590,9 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;
-	icon_state = "blue2"
+	icon_state = "purple2"
 	},
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
 "uVL" = (
 /obj/landmark/start{
 	name = "Geneticist"
@@ -54285,7 +54609,6 @@
 	},
 /area/station/medical/medbay/cloner)
 "uWp" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/junction{
 	dir = 2
 	},
@@ -54295,6 +54618,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/psychiatrist)
 "uWr" = (
@@ -54329,7 +54653,7 @@
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
-/obj/item/clothing/suit/bedsheet/pink,
+/obj/item/clothing/suit/bedsheet/green,
 /obj/item/storage/secure/ssafe{
 	pixel_y = 28
 	},
@@ -54338,15 +54662,22 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
-	icon_state = "purple2"
+	icon_state = "green2"
 	},
-/area/station/crew_quarters/quartersB)
+/area/station/crew_quarters/quartersC)
 "uXo" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/potted_plant/potted_plant3{
+	dir = 1;
+	pixel_y = 32
 	},
-/turf/simulated/floor/sanitary,
-/area/station/hallway/primary/east/restroom)
+/obj/stool/chair/office/yellow,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M02"
+	})
 "uXs" = (
 /obj/machinery/light{
 	dir = 4
@@ -54368,32 +54699,24 @@
 /turf/simulated/floor/black,
 /area/station/science/lobby)
 "uXK" = (
-/obj/decal/tile_edge/line/black{
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/machinery/disposal/brig{
-	destination_tag = "prisoner"
-	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/obj/disposalpipe/trunk/brig{
-	dir = 4
-	},
-/obj/machinery/light{
+/obj/machinery/vehicle/escape_pod{
 	dir = 8
 	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/obj/machinery/door/window/eastleft,
+/obj/decal/tile_edge/stripe{
+	icon_state = "xtra_bigstripe-edge"
+	},
+/obj/decal/tile_edge/stripe{
+	dir = 1;
+	icon_state = "xtra_bigstripe-edge"
+	},
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "uYb" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
 "uYf" = (
 /obj/machinery/light{
@@ -54421,16 +54744,16 @@
 /turf/simulated/floor/orangeblack,
 /area/station/quartermaster/office)
 "uYp" = (
-/obj/item/storage/wall/clothingrack/clothes4,
-/obj/potted_plant/potted_plant4{
+/obj/item/storage/wall/clothingrack/clothes3,
+/obj/potted_plant/potted_plant3{
 	dir = 1;
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "blue2"
+	icon_state = "purple2"
 	},
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
 "uYL" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -54455,12 +54778,12 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/engineering{
-	name = "glass airlock-'Engine Control Room'";
-	req_access_txt = "44"
-	},
 /obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Control Center"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_control,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "uZa" = (
@@ -54494,21 +54817,12 @@
 	dir = 8
 	},
 /area/station/medical/medbay)
-"uZU" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Crew Lounge'"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/starboard)
 "uZV" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/hangar/main)
+/obj/decal/stage_edge/alt{
+	pixel_y = 10
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "uZZ" = (
 /obj/machinery/light/emergency{
 	dir = 8
@@ -54524,16 +54838,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "vae" = (
-/obj/storage/closet/wardrobe/blue,
+/obj/storage/closet/wardrobe/pink,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "blue2"
+	icon_state = "purple2"
 	},
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
 "vao" = (
 /obj/decal/tile_edge/line/white{
 	dir = 4;
@@ -54566,16 +54880,16 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "vaX" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/window_blinds/cog2{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/research_director)
 "vbd" = (
@@ -54583,7 +54897,7 @@
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
-/obj/item/clothing/suit/bedsheet/blue,
+/obj/item/clothing/suit/bedsheet/pink,
 /obj/item/storage/secure/ssafe{
 	pixel_y = 28
 	},
@@ -54592,9 +54906,9 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
-	icon_state = "blue2"
+	icon_state = "purple2"
 	},
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
 "vby" = (
 /obj/machinery/door/poddoor/blast{
 	density = 0;
@@ -54612,23 +54926,34 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/wingrille_spawn/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/teleporter)
 "vbF" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/bright,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "green2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P01"
+	})
 "vbJ" = (
-/obj/machinery/light/small/floor/blueish,
-/turf/simulated/floor/engine,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
 /area/station/hangar/main)
 "vbN" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/vending/computer3,
 /turf/simulated/floor,
-/area/station/hangar/main)
+/area/station/crew_quarters/lounge/port)
 "vbS" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -54655,14 +54980,20 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "vcl" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "vcB" = (
-/obj/storage/closet/welding_supply,
-/turf/simulated/floor,
-/area/station/hangar/main)
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/orangeblack/side,
+/area/station/hallway/secondary/exit)
 "vcC" = (
 /obj/lattice{
 	dir = 9;
@@ -54684,6 +55015,12 @@
 /obj/machinery/vehicle/pod_smooth/industrial,
 /turf/simulated/floor/engine,
 /area/station/hangar/qm)
+"vew" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/sanitary,
+/area/station/hallway/primary/east/restroom)
 "veC" = (
 /obj/decal/tile_edge/line/black{
 	dir = 1;
@@ -54724,15 +55061,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/main)
-"vfk" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/submachine/ATM/atm_alt{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
 "vfx" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
@@ -54766,10 +55094,6 @@
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "vga" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/chemistry{
-	name = "airlock-'Science Teleporter'"
-	},
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -54777,6 +55101,12 @@
 	icon_state = "2-8"
 	},
 /obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/medical{
+	name = "Teleporter Control Room";
+	req_access = null;
+	req_access_txt = null
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/science/teleporter)
 "vgb" = (
@@ -54814,7 +55144,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
 "vgU" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southeast)
 "vgX" = (
 /obj/machinery/light/incandescent{
@@ -54838,6 +55168,14 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/hallway/secondary/construction)
+"vii" = (
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 1
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/west)
 "viC" = (
 /obj/cabinet/medical,
 /obj/disposalpipe/segment/mail{
@@ -54849,21 +55187,21 @@
 /obj/machinery/launcher_loader/south{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/disposal)
 "viM" = (
-/obj/stool/chair/comfy/red,
+/obj/stool/chair/comfy/yellow,
 /obj/landmark/start{
-	name = "Head of Security"
+	name = "Chief Engineer"
 	},
-/obj/decal/poster/wallsign/framed_award/hos_medal{
+/obj/item/storage/secure/ssafe{
 	pixel_y = 28
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "fred2"
+	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "vjU" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
@@ -54882,7 +55220,7 @@
 	dir = 4;
 	name = "crematorium pipe"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/cloner)
 "vkF" = (
 /obj/decal/tile_edge/line/white{
@@ -54900,18 +55238,20 @@
 	},
 /area/station/security/main)
 "vkH" = (
-/obj/stool/chair/comfy/yellow,
-/obj/landmark/start{
-	name = "Chief Engineer"
-	},
-/obj/item/storage/secure/ssafe{
+/obj/decal/poster/wallsign/framed_award/rddiploma{
 	pixel_y = 28
+	},
+/obj/stool/chair/comfy/purple,
+/obj/landmark/start{
+	name = "Research Director"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "fgreen2"
+	icon_state = "fpurple2"
 	},
-/area/station/crew_quarters/ce)
+/area/station/crew_quarters/hor{
+	name = "Research Director's Quarters"
+	})
 "vll" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -54934,13 +55274,13 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/science/lobby)
 "vmd" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
 "vmj" = (
 /obj/lattice{
@@ -54950,7 +55290,9 @@
 /turf/space,
 /area/station/com_dish/auxdish)
 "vmx" = (
-/obj/stool/chair/wooden,
+/obj/stool/chair/wooden{
+	dir = 1
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "vmC" = (
@@ -54960,15 +55302,12 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "vmL" = (
-/obj/decal/tile_edge/line/red{
-	dir = 8;
-	icon_state = "line1"
+/obj/cable{
+	icon_state = "0-2"
 	},
-/obj/disposalpipe/segment/brig{
-	dir = 4
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/hangar/main)
 "vne" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -55009,11 +55348,10 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "vnG" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/morgue/alt{
-	name = "glass airlock-'Mass Driver'";
-	req_access_txt = ""
+/obj/machinery/door/airlock/pyro/medical/morgue{
+	name = "Chapel"
 	},
+/obj/access_spawn/chapel_office,
 /turf/simulated/floor/specialroom/chapel{
 	dir = 4
 	},
@@ -55035,13 +55373,16 @@
 /turf/simulated/floor/bot,
 /area/station/hallway/primary/southeast)
 "voE" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13"
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
 	},
-/turf/simulated/floor,
-/area/station/hangar/main)
+/obj/table/wood/auto,
+/obj/item/dye_bottle,
+/obj/item/dye_bottle,
+/obj/item/storage/pill_bottle/hairgrownium,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "voF" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -55049,7 +55390,7 @@
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/supply)
 "vpb" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/solar/east)
 "vpo" = (
 /obj/cable{
@@ -55068,10 +55409,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "vpW" = (
 /obj/item/storage/wall/emergency{
@@ -55079,6 +55417,21 @@
 	},
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/south)
+"vqg" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/item/device/radio/intercom/security,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 6;
+	name = "autoname  - SS13"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "vqo" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 4;
@@ -55150,20 +55503,17 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "vsk" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/window_blinds/cog2,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
 "vso" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/crew_quarters/hos)
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/ce)
 "vsu" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -55198,18 +55548,29 @@
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "vsH" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+/obj/cable{
+	icon_state = "0-2"
 	},
-/obj/decal/tile_edge/line/blue{
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/station/hallway/secondary/exit)
 "vsI" = (
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
+"vtr" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/machinery/light/small/floor/blueish,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "vts" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -55218,7 +55579,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
 "vtx" = (
 /obj/disposalpipe/segment/food{
@@ -55227,7 +55588,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
 "vty" = (
 /obj/disposalpipe/segment{
@@ -55240,14 +55601,14 @@
 /area/station/maintenance/southwest)
 "vtM" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
 "vtX" = (
-/obj/machinery/computer/security{
-	dir = 8
+/obj/table/wood/auto/desk,
+/obj/machinery/light/lamp{
+	pixel_x = -5;
+	pixel_y = 10;
+	switchon = 1
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -55255,9 +55616,9 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "fred2"
+	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "vur" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -55305,13 +55666,12 @@
 /turf/simulated/floor/black,
 /area/station/hangar/qm)
 "vvr" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/baroffice)
 "vvz" = (
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
 	dir = 8;
@@ -55322,6 +55682,7 @@
 	opacity = 0
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "vvB" = (
@@ -55330,21 +55691,21 @@
 	pixel_y = 28
 	},
 /obj/table/wood/auto/desk,
-/obj/machinery/light/lamp{
-	pixel_x = -5;
-	pixel_y = 10;
-	switchon = 1
+/obj/item/folder,
+/obj/item/paper_bin{
+	pixel_y = 3
 	},
+/obj/item/pen,
 /turf/simulated/floor/carpet{
 	dir = 5;
-	icon_state = "fred2"
+	icon_state = "fgreen2"
 	},
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "vvC" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "vvE" = (
@@ -55352,7 +55713,7 @@
 	dir = 1;
 	name = "Air Reserve (Crew Quarters)"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "vwi" = (
 /obj/disposalpipe/segment,
@@ -55400,10 +55761,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
 "vwV" = (
 /obj/storage/crate,
@@ -55425,10 +55783,14 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/unary/outlet_injector{
-	icon_state = "on";
-	on = 1
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
+	dir = 1
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
@@ -55437,9 +55799,9 @@
 	dir = 10;
 	icon_state = "line1"
 	},
-/obj/machinery/door/airlock/gannets/glass/engineering/alt{
-	name = "airlock-'Refinery Chute'";
-	req_access_txt = "50"
+/obj/machinery/door/airlock/pyro/glass/mining{
+	dir = 1;
+	name = "Refinery"
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
@@ -55469,30 +55831,24 @@
 /area/station/hangar/sec)
 "vyf" = (
 /obj/decal/poster/wallsign/engineering,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/gas)
 "vyZ" = (
-/obj/table/reinforced/auto,
-/obj/window/reinforced/north,
-/obj/window/reinforced/south,
-/obj/machinery/door/window/westleft{
-	req_access_txt = "5"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/cashreg,
-/obj/random_item_spawner/medicine{
-	max_amt2spawn = 3;
-	min_amt2spawn = 2
+/obj/cable{
+	icon_state = "2-4"
 	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+/turf/simulated/floor/orangeblack/side{
+	dir = 8
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/area/station/hallway/secondary/exit)
 "vAb" = (
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
 "vAm" = (
 /obj/cable{
@@ -55504,19 +55860,19 @@
 /turf/simulated/floor/purpleblack,
 /area/station/science/lobby)
 "vAq" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "vAL" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment1)
 "vAW" = (
@@ -55531,10 +55887,10 @@
 /area/station/mining/staff_room)
 "vBt" = (
 /obj/disposalpipe/segment/mail,
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "vBQ" = (
@@ -55564,19 +55920,21 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "vDh" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/engineering{
-	name = "glass airlock-'Cargo Bay'";
-	req_access_txt = "31"
+/obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	dir = 4;
+	name = "Cargo"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/cargo,
 /turf/simulated/floor/black,
 /area/station/quartermaster/cargobay)
 "vDH" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/window_blinds/cog2{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/research_director)
 "vDL" = (
@@ -55604,9 +55962,21 @@
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "vED" = (
-/obj/machinery/vending/cola/red,
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/green,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "green2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P01"
+	})
 "vEX" = (
 /obj/landmark{
 	name = "blobstart"
@@ -55616,10 +55986,7 @@
 	name = "West Central Maintenance"
 	})
 "vFm" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
 "vFp" = (
 /obj/cable{
@@ -55676,8 +56043,8 @@
 	},
 /area/station/science/lobby)
 "vGD" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "vHc" = (
@@ -55693,33 +56060,42 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "vHu" = (
-/obj/machinery/door/window/eastleft,
 /obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 8;
-	icon_state = "pipe-c"
+	name = "Escape"
 	},
-/turf/simulated/floor/sanitary,
-/area/station/hallway/primary/east/restroom)
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/hallway/secondary/exit)
 "vHG" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/security/alt{
-	name = "glass airlock-'Security'"
-	},
+/obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/security{
+	name = "Security";
+	req_access = null
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor,
 /area/station/security/main)
 "vIa" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4
+/obj/stool/bench/yellow,
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "vIc" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -55739,23 +56115,24 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/staff_room)
 "vIK" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/gannets/glass{
-	name = "glass airlock-'Pool Room'"
-	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5;
 	level = 2
 	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pool"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "vJp" = (
@@ -55769,15 +56146,24 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "vJJ" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-8"
+/obj/window/cubicle{
+	dir = 4
+	},
+/obj/table/auto,
+/obj/item/reagent_containers/glass/bottle/bubblebath,
+/obj/machinery/disposal/small{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/disposalpipe/trunk,
+/obj/item/sponge{
+	name = "loofah"
 	},
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/random,
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/sanitary,
+/area/station/hallway/primary/east/restroom)
 "vJZ" = (
 /turf/simulated/floor/blackwhite{
 	dir = 4
@@ -55810,11 +56196,8 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "vMh" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
-/area/station/crewquarters/cryotron)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/entry)
 "vNb" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 5
@@ -55841,10 +56224,18 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "vNt" = (
-/obj/machinery/vending/standard,
-/obj/machinery/light,
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
+/obj/potted_plant/potted_plant2{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/stool/chair/office/purple,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "purple2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M01"
+	})
 "vNP" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -55859,7 +56250,7 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "vOb" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/catering)
 "vOh" = (
 /obj/table,
@@ -55894,16 +56285,18 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "vPE" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/main)
 "vQd" = (
-/obj/disposalpipe/segment/morgue{
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/area/station/hallway/secondary/exit)
 "vQg" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/courtroom)
 "vQz" = (
 /obj/disposalpipe/segment{
@@ -55918,23 +56311,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
-"vRv" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P04"
-	})
 "vRU" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/food,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "vSh" = (
@@ -55980,18 +56363,15 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "vUr" = (
-/obj/decal/tile_edge/line/white{
-	dir = 1;
-	icon_state = "line1"
+/obj/item/device/radio/intercom{
+	name = "Station Intercom"
 	},
-/obj/item/device/radio/intercom/medical,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
+/obj/disposalpipe/trunk/mail,
+/obj/machinery/disposal/mail,
+/turf/simulated/floor/orangeblack/side{
+	dir = 1
 	},
-/turf/simulated/floor/blue,
-/area/station/medical/medbooth)
+/area/station/hallway/secondary/exit)
 "vUQ" = (
 /obj/decal/tile_edge/stripe,
 /obj/machinery/light_switch/west{
@@ -56023,7 +56403,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 1
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/treatment1)
 "vVU" = (
 /obj/cable{
@@ -56062,19 +56442,23 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "vWD" = (
-/obj/machinery/light,
+/obj/airbridge_controller{
+	id = "escape";
+	primary_controller = 1;
+	tunnel_width = 3
+	},
+/turf/space,
+/area/space)
+"vWQ" = (
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/hallway/primary/east/restroom)
-"vWQ" = (
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/orangeblack/side,
-/area/station/hallway/secondary/exit)
 "vWS" = (
 /obj/machinery/light/incandescent/netural{
 	nostick = 1
@@ -56214,15 +56598,18 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "waX" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/window_blinds/cog2/right{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/cable,
-/turf/simulated/floor/plating/random,
-/area/station/hallway/primary/east/restroom)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13"
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "wbN" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -56236,6 +56623,7 @@
 	name = "E.V.A. Security Shield";
 	opacity = 0
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/storage/eva)
 "wbU" = (
@@ -56347,14 +56735,6 @@
 	},
 /turf/space,
 /area/station/hangar/qm)
-"weM" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon15,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "weR" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 4
@@ -56362,7 +56742,6 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "weZ" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/window/reinforced/east,
 /obj/table/reinforced/auto,
 /obj/item/paper_bin{
@@ -56373,27 +56752,29 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "wfj" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/disposalpipe/segment/mail{
 	dir = 4
-	},
-/obj/machinery/door/airlock/gannets/morgue/alt{
-	name = "airlock-'Crematorium'";
-	req_access_txt = "27"
 	},
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 4;
+	name = "Morgue"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/crematorium,
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "wfk" = (
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/security/beepsky)
 "wft" = (
@@ -56523,20 +56904,25 @@
 /turf/simulated/floor/black,
 /area/station/medical/morgue)
 "wig" = (
-/turf/simulated/wall/auto/gannets,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
 /area/station/crew_quarters/lounge/starboard)
 "wii" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/command{
-	name = "airlock-'Head of Security's Quarters'";
-	req_access_txt = "37"
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/machinery/door/airlock/pyro/command/alt{
+	dir = 4;
+	name = "Chief Engineer's Quarters"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_chief,
 /turf/simulated/floor/black,
-/area/station/crew_quarters/hos)
+/area/station/crew_quarters/ce)
 "wiB" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -56547,15 +56933,10 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/command/alt{
-	aiControlDisabled = 1;
-	name = "glass airlock-'Armory'";
-	req_access_txt = "37"
+/obj/machinery/door/airlock/pyro/weapons{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/red,
 /area/station/security/hos)
 "wiU" = (
@@ -56571,8 +56952,8 @@
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass,
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "wjw" = (
@@ -56605,14 +56986,15 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Maintenance'"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 1
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/maint,
 /turf/simulated/floor/black,
 /area/station/maintenance/south)
 "wkD" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/storage)
 "wkV" = (
 /turf/simulated/floor/purpleblack,
@@ -56627,10 +57009,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/testchamber)
 "wmd" = (
 /obj/disposalpipe/segment/mail{
@@ -56652,13 +57031,9 @@
 /turf/simulated/floor/plating/airless,
 /area/station/security/beepsky)
 "wnu" = (
-/obj/disposalpipe/switch_junction{
-	dir = 2;
-	mail_tag = "pod_fore";
-	name = "north pod bay mail router"
-	},
-/obj/machinery/light/emergency{
-	dir = 4
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
@@ -56761,34 +57136,16 @@
 /turf/simulated/floor/purple,
 /area/station/medical/medbay/pharmacy)
 "wpf" = (
-/obj/disposalpipe/segment/mail{
-	dir = 4
-	},
-/obj/decal/tile_edge/line/black{
-	icon_state = "line1"
-	},
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
-/obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "wpg" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "wpH" = (
 /obj/table/reinforced/auto,
@@ -56875,17 +57232,20 @@
 /turf/simulated/floor/grey,
 /area/station/maintenance/inner/south)
 "wqY" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/right{
 	dir = 8
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
 "wra" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/pyro/external{
+	dir = 8
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/caution/northsouth,
 /area/station/hallway/secondary/exit)
 "wrw" = (
@@ -56928,7 +57288,7 @@
 	},
 /area/station/crew_quarters/pool)
 "wsc" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/locker)
 "wsz" = (
 /obj/machinery/light/incandescent/warm{
@@ -56988,7 +57348,7 @@
 	dir = 9;
 	level = 2
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "wuy" = (
 /obj/machinery/light/incandescent/cool{
@@ -56998,11 +57358,13 @@
 /turf/simulated/floor/white,
 /area/station/maintenance/inner/south)
 "wuB" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/lounge/port)
 "wuX" = (
@@ -57022,19 +57384,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
-"wvq" = (
-/obj/machinery/sim/vr_bed{
-	dir = 8;
-	name = "VR simulation pod";
-	network = "arcadevr"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "wvw" = (
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/tools,
@@ -57046,12 +57395,9 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "wvQ" = (
-/obj/disposalpipe/switch_junction{
-	desc = "An underfloor mail pipe.";
-	dir = 2;
-	icon_state = "pipe-sj2";
-	mail_tag = "medbooth";
-	name = "medical booth mail router"
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/mail{
+	dir = 4
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -57099,11 +57445,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "wwR" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/chapel/sanctuary)
 "wxa" = (
@@ -57111,24 +57457,18 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/cargobay)
 "wxh" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
-"wxt" = (
-/obj/airbridge_controller{
-	id = "merchant_L"
-	},
-/turf/space,
-/area/space)
 "wxN" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 8;
@@ -57196,7 +57536,7 @@
 /area/station/maintenance/southwest)
 "wAa" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "wAi" = (
 /obj/lattice,
 /obj/warp_beacon{
@@ -57229,10 +57569,11 @@
 	},
 /area/station/solar/east)
 "wAW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets{
-	name = "Courtroom"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Pool"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -57289,7 +57630,6 @@
 	},
 /area/station/medical/robotics)
 "wCa" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -57299,10 +57639,11 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/research_director)
 "wCG" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner/south)
 "wCL" = (
 /obj/disposalpipe/segment/mail{
@@ -57344,6 +57685,20 @@
 	},
 /turf/simulated/floor/industrial,
 /area/station/mining/refinery)
+"wDt" = (
+/obj/table/wood/auto,
+/obj/machinery/light/lamp/bright,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "blue2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters P03"
+	})
 "wDD" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -57468,7 +57823,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/elect)
 "wFA" = (
 /turf/simulated/floor/carpet/grime,
@@ -57527,16 +57882,23 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "wId" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/maintenance/north)
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1
+	},
+/turf/simulated/floor/sanitary,
+/area/station/hallway/primary/east/restroom)
 "wIG" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
 "wIJ" = (
 /obj/disposalpipe/segment,
@@ -57573,18 +57935,18 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "wJh" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/mining/refinery)
 "wJw" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/left,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/engine/engineering/ce)
 "wJC" = (
@@ -57601,10 +57963,10 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "wJG" = (
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "wJI" = (
@@ -57637,19 +57999,18 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/Zeta)
 "wKX" = (
 /turf/simulated/floor/carpet{
-	icon_state = "blue2"
+	icon_state = "purple2"
 	},
-/area/station/crew_quarters/quartersA)
+/area/station/crew_quarters/quartersB)
 "wKZ" = (
 /obj/pool/perspective,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "wLk" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -57659,6 +58020,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "wLr" = (
@@ -57680,10 +58042,7 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "wLJ" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
 "wML" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor/vertical{
@@ -57692,11 +58051,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "wMN" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hangar/main)
 "wNd" = (
@@ -57707,7 +58066,7 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "wNe" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/armory)
 "wNj" = (
 /turf/simulated/floor/black,
@@ -57731,10 +58090,10 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "wOu" = (
@@ -57742,7 +58101,6 @@
 /turf/simulated/floor/engine,
 /area/station/hangar/sec)
 "wOw" = (
-/obj/wingrille_spawn/reinforced,
 /obj/decal/poster/wallsign/medbay{
 	icon_state = "med"
 	},
@@ -57750,6 +58108,7 @@
 	dir = 4
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/lobby)
 "wOz" = (
@@ -57789,12 +58148,6 @@
 	icon_state = "engine_caution_south"
 	},
 /area/station/hangar/qm)
-"wPO" = (
-/obj/decal/stage_edge/alt{
-	pixel_y = 10
-	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
 "wPR" = (
 /obj/machinery/vending/mechanics,
 /obj/item/device/radio/intercom/engineering,
@@ -57837,7 +58190,7 @@
 /turf/simulated/floor/delivery,
 /area/station/quartermaster/office)
 "wQT" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/teleporter)
 "wRa" = (
 /obj/item/reagent_containers/food/drinks/tea,
@@ -57875,7 +58228,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/cargobay)
 "wRz" = (
 /turf/simulated/floor/purpleblack/corner{
@@ -57896,22 +58249,17 @@
 	},
 /area/station/medical/head)
 "wRV" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'Mining'";
-	req_access_txt = "50"
+/obj/machinery/door/airlock/pyro/glass/mining{
+	dir = 4;
+	name = "Mining"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/mining,
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
 "wSp" = (
-/obj/wingrille_spawn/reinforced,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/secondary/exit)
 "wSq" = (
@@ -57939,8 +58287,8 @@
 	},
 /area/station/crew_quarters/fitness)
 "wTv" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/observatory)
 "wTy" = (
@@ -57956,11 +58304,9 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
-	icon_state = "fpurple2"
+	icon_state = "fblue2"
 	},
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "wTX" = (
 /obj/decal/tile_edge/line/white{
 	dir = 1;
@@ -57994,25 +58340,21 @@
 /turf/simulated/floor/blue/checker,
 /area/station/medical/head)
 "wUD" = (
-/obj/decal/tile_edge/line/black{
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/submachine/weapon_vendor/security,
-/obj/machinery/power/apc/autoname_north,
+/obj/machinery/manufacturer/general,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/obj/decal/poster/wallsign/pod_build{
+	pixel_y = 32
+	},
+/turf/simulated/floor,
+/area/station/hangar/main)
 "wUH" = (
 /obj/disposalpipe/segment,
-/obj/wingrille_spawn,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "wVm" = (
@@ -58049,16 +58391,16 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/staff_room)
 "wVF" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "wVL" = (
@@ -58114,7 +58456,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "wXo" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/artifact)
 "wXJ" = (
 /obj/cable{
@@ -58125,7 +58467,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "wXU" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/crematorium)
 "wYq" = (
 /obj/machinery/shuttle/engine/heater{
@@ -58210,19 +58552,14 @@
 	},
 /area/station/crew_quarters/courtroom)
 "xas" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/decal/tile_edge/stripe{
-	icon_state = "xtra_bigstripe-edge";
-	pixel_y = 10
+/obj/item/storage/wall/emergency{
+	pixel_y = 32
 	},
-/obj/railing/yellow{
-	pixel_y = 10
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/lounge/port)
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/central)
 "xaC" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -58240,14 +58577,15 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "xaM" = (
-/obj/disposalpipe/segment/mail,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname  - SS13"
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_north,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/north)
 "xaP" = (
 /obj/cable,
 /obj/machinery/power/data_terminal,
@@ -58264,13 +58602,13 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/chemistry)
 "xcJ" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/south)
 "xcM" = (
 /obj/cable{
@@ -58289,25 +58627,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "xcQ" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/bright,
-/obj/machinery/power/apc/autoname_north,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet{
-	dir = 1;
 	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P03"
-	})
-"xdJ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
 	},
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters P03"
@@ -58332,7 +58656,7 @@
 /turf/simulated/floor/purple,
 /area/station/medical/medbay/pharmacy)
 "xeC" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/hallway/primary/central)
 "xeV" = (
 /obj/potted_plant/potted_plant3,
@@ -58389,13 +58713,14 @@
 	dir = 8;
 	icon_state = "xtra_bigstripe-edge"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/maintenance{
-	name = "airlock-'Disposals'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/classic{
+	dir = 4;
+	name = "Disposals"
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "xgE" = (
@@ -58424,7 +58749,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
 "xhd" = (
 /obj/machinery/power/reactor_stats{
@@ -58441,18 +58766,7 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
-"xhh" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
 "xhi" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -58460,6 +58774,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/research_director)
 "xhn" = (
@@ -58476,8 +58791,19 @@
 /turf/simulated/floor/yellow,
 /area/station/hallway/secondary/construction)
 "xhr" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/maintenance/northwest)
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/submachine/weapon_vendor/security,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/red,
+/area/station/security/checkpoint{
+	name = "Security Checkpoint"
+	})
 "xht" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/wood{
@@ -58491,15 +58817,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
-"xhF" = (
-/obj/table/auto,
-/obj/machinery/computer3/generic/personal{
-	pixel_y = 9
-	},
-/obj/machinery/power/data_terminal,
-/obj/cable,
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
 "xio" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -58507,14 +58824,14 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "xiq" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "xiJ" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/psychiatrist)
 "xiV" = (
 /obj/disposalpipe/segment/ejection{
@@ -58528,19 +58845,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
-"xjc" = (
-/obj/machinery/portable_atmospherics/canister/air/large,
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor/vertical{
-	dir = 8
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "xjd" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/secondary/exit)
 "xjp" = (
@@ -58575,60 +58885,53 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "xjL" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "xjY" = (
-/obj/machinery/atmospherics/pipe/vent,
-/turf/simulated/floor/plating/airless,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe/overfloor/northeast,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/central)
 "xjZ" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/southwest)
 "xko" = (
-/obj/wingrille_spawn/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
 "xle" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
+/obj/table/reinforced/auto,
+/obj/item/storage/belt/utility,
+/obj/item/storage/toolbox/electrical,
+/obj/item/reagent_containers/food/drinks/fueltank,
+/obj/item/device/light/flashlight,
 /obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/lounge/port)
-"xlm" = (
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
-/area/station/science/testchamber)
-"xlF" = (
-/obj/shrub{
-	dir = 4;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
-	},
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
-"xlK" = (
-/obj/machinery/light{
-	dir = 4
+/area/station/hangar/main)
+"xlm" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/testchamber)
+"xlF" = (
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/green,
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/disposalpipe/segment/mail,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "green2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M03"
+	})
 "xmb" = (
 /obj/landmark/start{
 	name = "Geneticist"
@@ -58672,7 +58975,7 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay)
 "xml" = (
 /obj/machinery/disposal_pipedispenser,
@@ -58694,15 +58997,18 @@
 	},
 /area/station/medical/cdc)
 "xmE" = (
-/obj/machinery/door/airlock/gannets/medical{
-	name = "airlock-'Medbay'"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 1;
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -58711,7 +59017,7 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/psychiatrist)
 "xnn" = (
 /obj/machinery/power/terminal{
@@ -58730,16 +59036,6 @@
 /obj/storage/crate/furnacefuel,
 /turf/simulated/floor,
 /area/station/engine/gas)
-"xnA" = (
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "xnF" = (
 /obj/decal/tile_edge/line/red{
 	icon_state = "line1"
@@ -58762,12 +59058,11 @@
 /area/station/crew_quarters/fitness)
 "xpp" = (
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer3/generic/med_data{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "0-2"
-	},
-/obj/machinery/computer3/terminal/zeta{
-	dir = 4;
-	setup_os_string = "ZETA_MAINFRAME"
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -58782,11 +59077,9 @@
 	},
 /turf/simulated/floor/carpet{
 	dir = 9;
-	icon_state = "fpurple2"
+	icon_state = "fblue2"
 	},
-/area/station/crew_quarters/hor{
-	name = "Research Director's Quarters"
-	})
+/area/station/crew_quarters/md)
 "xpq" = (
 /obj/decal/tile_edge/line/white{
 	dir = 5;
@@ -58810,29 +59103,37 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external{
-	req_access_txt = "44|50"
-	},
+/obj/machinery/door/airlock/pyro/external,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/east)
 "xqa" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/chemistry{
-	name = "airlock-'Genetics'";
-	req_access_txt = "9"
-	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
 /obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/medical/alt{
+	name = "Genetics"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medlab,
 /turf/simulated/floor/plating/random,
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
 "xqc" = (
-/turf/simulated/wall/auto/gannets,
-/area/station/maintenance/central)
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M01"
+	})
 "xqi" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 1;
@@ -58874,7 +59175,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "xrf" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
 "xrA" = (
 /obj/decal/tile_edge/line/yellow{
@@ -58887,10 +59188,10 @@
 /turf/simulated/floor,
 /area/station/mining/staff_room)
 "xrE" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "xrK" = (
@@ -58904,9 +59205,21 @@
 /turf/simulated/floor/yellow,
 /area/station/mining/refinery)
 "xrW" = (
-/obj/machinery/vending/pda,
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/port)
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/green,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "green2"
+	},
+/area/station/crew_quarters/quartersA{
+	name = "Crew Quarters M03"
+	})
 "xsa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -58932,12 +59245,12 @@
 	},
 /area/station/medical/medbay)
 "xsD" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "xti" = (
@@ -58975,12 +59288,22 @@
 /turf/simulated/floor/black,
 /area/station/security/main)
 "xuF" = (
-/obj/disposalpipe/segment/mail,
-/obj/machinery/light/emergency{
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname  - SS13"
+	},
+/obj/machinery/light_switch/east{
 	dir = 4
 	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/north)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
+	},
+/turf/simulated/floor/orangeblack/side{
+	dir = 4
+	},
+/area/station/hallway/secondary/exit)
 "xuL" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -59014,8 +59337,8 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "xvC" = (
-/obj/wingrille_spawn,
 /obj/decal/poster/wallsign/barber,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/barber_shop)
 "xvG" = (
@@ -59068,10 +59391,18 @@
 /turf/simulated/floor/circuit,
 /area/station/medical/robotics)
 "xxD" = (
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
-	dir = 4
+/obj/stool/bed,
+/obj/item/clothing/suit/bedsheet/yellow,
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
-/turf/simulated/wall/auto/gannets,
+/obj/item/storage/secure/ssafe{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "blue2"
+	},
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters P03"
 	})
@@ -59101,7 +59432,6 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "xxS" = (
-/obj/wingrille_spawn/reinforced,
 /obj/window_blinds/cog2/left{
 	dir = 8
 	},
@@ -59114,6 +59444,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/research{
 	name = "Genetic Research"
@@ -59128,6 +59459,22 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
+"xyB" = (
+/obj/table/auto,
+/obj/machinery/networked/printer{
+	pixel_y = 5;
+	print_id = "Lounge"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/decal/poster/wallsign/statistics1{
+	desc = "A poster with a bar chart depicting the rapid growth of chemistry lab related explosions. Although who even uses a bar chart when you could be using a line chart...";
+	pixel_y = 32
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "xyY" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -59141,7 +59488,6 @@
 	},
 /area/station/medical/medbay)
 "xzn" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -59151,6 +59497,7 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "xzx" = (
@@ -59234,7 +59581,6 @@
 /turf/simulated/floor/purple,
 /area/station/medical/cdc)
 "xAC" = (
-/obj/wingrille_spawn/reinforced,
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
@@ -59244,6 +59590,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hydroponics/bay)
 "xAG" = (
@@ -59262,19 +59609,19 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "xAR" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/chemistry{
-	name = "airlock-'Artifact Lab'";
-	req_access_txt = "8"
-	},
 /obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/sci_alt{
+	name = "Artifact Lab"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor/black,
 /area/station/science/artifact)
 "xBL" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/lab)
 "xBQ" = (
@@ -59320,34 +59667,34 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "xCS" = (
-/obj/bookshelf/persistent,
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
+/obj/machinery/vehicle/pod_smooth/light,
+/turf/simulated/floor/engine,
+/area/station/hangar/main)
 "xCV" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
 /obj/cable{
 	icon_state = "0-8"
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/ai_monitored/armory)
 "xCW" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'West SMES'";
-	req_access_txt = "44"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Control Center"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_power,
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "xCX" = (
@@ -59377,27 +59724,16 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "xEg" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/red,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet{
-	dir = 5;
+	dir = 6;
 	icon_state = "red2"
 	},
 /area/station/crew_quarters/quartersA{
 	name = "Crew Quarters M04"
 	})
-"xEG" = (
-/obj/table/auto,
-/obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
-/obj/item/storage/box/diskbox,
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
 "xFd" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -59410,18 +59746,19 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
-"xFi" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/item/storage/wall/emergency{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/central)
 "xFk" = (
-/turf/simulated/wall/auto/reinforced/gannets,
-/area/station/maintenance/northeast)
+/obj/decal/tile_edge/line/white{
+	dir = 5;
+	icon_state = "line1"
+	},
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 4;
+	name = "Medbay Checkpoint"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
+/turf/simulated/floor/blue,
+/area/station/medical/medbooth)
 "xFM" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -59437,7 +59774,6 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -59447,20 +59783,21 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/mining/refinery)
 "xGw" = (
-/obj/machinery/power/data_terminal,
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/machinery/computer/stockexchange,
-/obj/noticeboard/persistent{
-	name = "Crew Quarters persistent notice board";
-	persistent_id = "crew quarters"
+/obj/disposalpipe/segment/mail,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=escape";
+	location = "command_quarters";
+	name = "bot navigation beacon"
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/north)
 "xGH" = (
 /obj/machinery/disposal/small{
 	dir = 4
@@ -59507,7 +59844,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/south)
 "xHN" = (
 /turf/simulated/floor/yellow/corner,
@@ -59617,10 +59954,7 @@
 /area/station/crew_quarters/fitness)
 "xLM" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/bridge)
 "xLS" = (
 /obj/decal/tile_edge/line/blue{
@@ -59660,17 +59994,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/equipment)
-"xMX" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/mail,
-/obj/machinery/light/small/floor/blueish,
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
-	dir = 1
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "xNk" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -59682,11 +60005,12 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/engineering{
-	name = "airlock-'Mining'";
-	req_access_txt = "50"
+/obj/machinery/door/airlock/pyro/glass/mining{
+	dir = 4;
+	name = "Mining"
 	},
+/obj/firedoor_spawn,
+/obj/access_spawn/mining,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "xNz" = (
@@ -59706,7 +60030,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/bar)
 "xNZ" = (
 /obj/cable{
@@ -59719,8 +60043,19 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/security/main)
 "xOF" = (
-/turf/simulated/wall/auto/gannets,
-/area/station/hallway/primary/east/restroom)
+/obj/table/auto,
+/obj/machinery/computer3/generic/personal{
+	pixel_y = 9
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light_switch/north{
+	pixel_y = 28
+	},
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/starboard)
 "xPd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -59761,20 +60096,22 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "xPU" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/medical/alt{
-	name = "airlock-'Medbay'"
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/pyro/medical/alt2{
+	dir = 1;
+	name = "Medbay"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "xQd" = (
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "xQy" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay)
 "xQP" = (
 /obj/storage/secure/closet/medical/chemical,
@@ -59838,14 +60175,15 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
+/obj/disposalpipe/switch_junction{
+	dir = 1;
+	mail_tag = "crew";
+	name = "crew lounge mail router"
 	},
-/obj/disposalpipe/segment/mail,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "xTa" = (
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/west{
 	name = "West Central Maintenance"
 	})
@@ -59858,7 +60196,6 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "xTJ" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-4"
@@ -59878,6 +60215,7 @@
 /obj/window_blinds/cog2/middle{
 	dir = 4
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/bridge)
 "xTV" = (
@@ -59903,7 +60241,7 @@
 /turf/space,
 /area/station/engine/core)
 "xUA" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/disposal)
 "xUB" = (
 /obj/shrub{
@@ -59962,8 +60300,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
 "xVU" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "xVV" = (
@@ -60030,23 +60368,12 @@
 /area/station/maintenance/inner/east{
 	name = "East Central Maintenance"
 	})
-"xYq" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters P04"
-	})
 "xYC" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/bot_storage)
 "xYE" = (
 /obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/artifact)
 "xYQ" = (
 /obj/item_dispenser/medical_mask,
@@ -60060,7 +60387,7 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "xZd" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/lounge)
 "xZg" = (
 /obj/cable{
@@ -60088,11 +60415,11 @@
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "xZr" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/quartermaster/office)
 "xZy" = (
@@ -60106,7 +60433,7 @@
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
 "xZF" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/atmos/highcap_storage)
 "xZP" = (
 /obj/decal/tile_edge/stripe{
@@ -60143,12 +60470,11 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "yal" = (
-/obj/wingrille_spawn/reinforced_crystal/full,
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/light/incandescent{
+	nostick = 1
 	},
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/lounge/starboard)
+/turf/simulated/floor,
+/area/station/hangar/main)
 "yar" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -60163,42 +60489,42 @@
 /turf/space,
 /area/station/engine/core)
 "ybk" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/main)
 "ybt" = (
-/obj/wingrille_spawn/reinforced,
 /obj/forcefield/energyshield/perma{
 	dir = 10
 	},
 /obj/cable{
 	icon_state = "0-4"
 	},
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/entry)
 "ybu" = (
-/obj/decal/tile_edge/line/black{
-	dir = 9;
-	icon_state = "line1"
+/obj/disposalpipe/trunk,
+/obj/machinery/disposal/small{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/gannets/glass/security/alt{
-	name = "glass airlock-'Security Checkpoint'"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/red,
-/area/station/security/checkpoint{
-	name = "Security Checkpoint"
-	})
+/turf/simulated/floor,
+/area/station/hangar/main)
 "ybU" = (
-/obj/machinery/vending/cola/blue,
+/obj/item/storage/toilet/random{
+	pixel_y = 8
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/orangeblack/side{
-	dir = 6
+/obj/blind_switch/area/south{
+	pixel_y = 28
 	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/sanitary,
+/area/station/hallway/primary/east/restroom)
 "ycg" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -60213,11 +60539,9 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/plasticflaps{
 	layer = 3
 	},
-/obj/machinery/door/airlock/gannets/security,
 /turf/simulated/floor/wood{
 	icon_state = "wooden"
 	},
@@ -60341,15 +60665,14 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "yfE" = (
-/turf/space,
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/solar/west)
 "yfL" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/outer/sw)
 "ygs" = (
@@ -60374,16 +60697,10 @@
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/danger_highvolt,
-/turf/simulated/wall/auto/reinforced/gannets{
-	explosion_resistance = 20;
-	name = "very reinforced wall"
-	},
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "ygC" = (
 /obj/machinery/portable_atmospherics/canister/air/large,
-/obj/cable{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
 "yhf" = (
@@ -60508,11 +60825,16 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "ykg" = (
-/obj/cable{
-	icon_state = "1-4"
+/obj/machinery/sim/vr_bed{
+	dir = 4;
+	name = "VR simulation pod";
+	network = "arcadevr"
 	},
-/turf/simulated/floor,
-/area/station/crew_quarters/lounge/starboard)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "ykm" = (
 /obj/machinery/light/incandescent/warm/very{
 	dir = 4;
@@ -60545,13 +60867,13 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
 "ykE" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/turf/simulated/wall/auto/gannets,
+/turf/simulated/wall/auto/supernorn,
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
@@ -60577,7 +60899,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "yln" = (
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/Zeta)
 "ylo" = (
 /obj/table/reinforced/chemistry/auto,
@@ -60588,17 +60910,17 @@
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "ylq" = (
-/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/overfloor/vertical{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple{
+	level = 2
 	},
-/turf/simulated/wall/auto/reinforced/gannets,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/central)
 "ylA" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "ylC" = (
@@ -60635,8 +60957,8 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "ymf" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/cdc)
 
@@ -89236,7 +89558,7 @@ wTX
 bvL
 wfZ
 iIV
-jgQ
+xPU
 vNk
 vNk
 vNk
@@ -91964,10 +92286,10 @@ dcW
 bVD
 uio
 wur
-hWT
-hWT
-hWT
-hWT
+jGv
+jGv
+jGv
+jGv
 ruC
 jMc
 erE
@@ -92264,13 +92586,13 @@ pNK
 pNK
 pNK
 iDa
-hWT
-hWT
+jGv
+jGv
 vLx
-hWT
+jGv
 oql
-hWT
-hWT
+jGv
+jGv
 vXY
 vpJ
 kUp
@@ -92560,19 +92882,19 @@ dcE
 gmS
 gvv
 eKY
-hWT
-hWT
-hWT
-hWT
-hWT
+jGv
+jGv
+jGv
+jGv
+jGv
 iDa
 hwp
 xRT
 hTw
-hWT
+jGv
 rvt
 vLx
-hWT
+jGv
 fJl
 fXQ
 gCx
@@ -92864,17 +93186,17 @@ aOO
 gUa
 uBl
 dGE
-hWT
+jGv
 hrf
 hEe
 iDa
 uMD
 bJh
 gPZ
-hWT
+jGv
 sHw
 bJh
-hWT
+jGv
 rwx
 pNK
 pNK
@@ -93166,21 +93488,21 @@ xAQ
 gUa
 xNk
 mYi
-hWT
+jGv
 cbq
-hWT
+jGv
 uBV
-hWT
-hWT
+jGv
+jGv
 aIR
-hWT
+jGv
 pLt
 jGv
-hWT
+jGv
 vXY
 vNk
 ros
-dkK
+kUp
 aaa
 aaa
 aag
@@ -93772,7 +94094,7 @@ phF
 tnU
 wnZ
 pmW
-hWT
+jGv
 edh
 uZw
 wNj
@@ -95580,7 +95902,7 @@ nDc
 xmg
 yea
 gUa
-hWT
+jGv
 lLR
 dQf
 ofT
@@ -95903,7 +96225,7 @@ vFm
 vFm
 vFm
 vFm
-dqz
+vFm
 hHl
 iHl
 bME
@@ -96790,8 +97112,8 @@ vty
 lvN
 xCl
 owq
-fOw
-ltO
+lvl
+oMj
 mNk
 pSX
 wVw
@@ -97112,7 +97434,7 @@ pCM
 pwD
 vFm
 vFm
-dqz
+vFm
 iHl
 nzx
 iHl
@@ -97394,8 +97716,8 @@ vty
 lvN
 fIF
 rER
-fOw
-ltO
+fIF
+oMj
 gca
 bEs
 nRn
@@ -97693,7 +98015,7 @@ enR
 wqa
 fRJ
 vty
-ltO
+oMj
 eRz
 uZw
 nlZ
@@ -97995,7 +98317,7 @@ aWH
 uBs
 ykE
 vty
-ltO
+oMj
 nNv
 wNj
 xio
@@ -98297,7 +98619,7 @@ uWS
 jgy
 ykE
 vty
-ltO
+oMj
 uvA
 wNj
 xio
@@ -98319,9 +98641,9 @@ ubE
 rdF
 bFn
 jNQ
-ukJ
 wNe
-ukJ
+wNe
+wNe
 cgc
 iHl
 tAI
@@ -98615,13 +98937,13 @@ juJ
 juJ
 nXe
 uJT
-ukJ
-ukJ
+wNe
+wNe
 kOL
 nCZ
-ukJ
-ukJ
-ukJ
+wNe
+wNe
+wNe
 kEq
 pyB
 ubx
@@ -98901,7 +99223,7 @@ flr
 oRz
 ykE
 ykJ
-ltO
+oMj
 cQi
 lfd
 eaL
@@ -98917,13 +99239,13 @@ pvx
 lyo
 oMj
 uJT
-ukJ
-ukJ
-ukJ
-ukJ
 wNe
-ukJ
-ukJ
+wNe
+wNe
+wNe
+wNe
+wNe
+wNe
 xCV
 rod
 ubx
@@ -99203,7 +99525,7 @@ aMz
 oRz
 ykE
 ykJ
-ltO
+oMj
 vFs
 obh
 fJY
@@ -99217,13 +99539,13 @@ ktd
 kFP
 hTd
 gKe
-ltO
+oMj
 bvg
 ejf
 wNe
-ukJ
-ukJ
-ukJ
+wNe
+wNe
+wNe
 jPb
 gat
 bKE
@@ -99505,11 +99827,11 @@ aME
 nxs
 ykE
 rjR
-ltO
+oMj
 bfW
 tEf
 waB
-ltO
+oMj
 nGz
 vPE
 rFO
@@ -99800,7 +100122,7 @@ qEd
 ckK
 xxS
 cmz
-wqY
+fSF
 eKA
 iRZ
 fmJ
@@ -99811,17 +100133,17 @@ mhz
 bfX
 iaY
 qRy
-ltO
+oMj
 pMP
 vPE
 bnX
 fRM
-ltO
+oMj
 qBT
 fBW
 ybk
 vPE
-ltO
+oMj
 caW
 xNZ
 uym
@@ -100123,7 +100445,7 @@ bra
 kzp
 btb
 btT
-ltO
+oMj
 aTt
 qLd
 oCD
@@ -100390,7 +100712,7 @@ awJ
 aBD
 wLJ
 wLJ
-gzL
+wLJ
 pXa
 aHw
 atc
@@ -100933,17 +101255,17 @@ aaa
 aaa
 aaa
 aaa
+aiM
+aiM
+aiM
+aiM
+aiM
+aiM
+aiM
 aaa
 aaa
 aaa
 aaa
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
 aaa
 aaa
 aaa
@@ -101235,17 +101557,17 @@ aaa
 aaa
 aaa
 aaa
+aiM
+aiM
+aiM
+aiM
+aiM
+aiM
+aiM
 aaa
 aaa
 aaa
 aaa
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
-aiM
 aaa
 aaa
 aaa
@@ -101279,7 +101601,7 @@ aMm
 aMm
 fEO
 aMm
-aTY
+cJB
 vBV
 vBV
 vBV
@@ -101533,11 +101855,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-ayh
+aal
 aaa
 aaa
 aaa
@@ -101548,6 +101866,10 @@ aiM
 aiM
 aiM
 aiM
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101631,7 +101953,7 @@ ale
 xuv
 mtF
 mtF
-efC
+isa
 mtF
 mtF
 mtF
@@ -101834,12 +102156,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aab
-sUb
+euu
 awa
 aaa
 aaa
@@ -101850,6 +102168,10 @@ aiM
 aiM
 aiM
 aiM
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101941,7 +102263,7 @@ uur
 dcV
 nOm
 byt
-efC
+isa
 faA
 bZv
 bZv
@@ -102137,10 +102459,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 npA
 aaa
 aaa
@@ -102152,6 +102470,10 @@ aiM
 aiM
 aiM
 aiM
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -102185,7 +102507,7 @@ wsc
 qHP
 aPR
 qHP
-cJB
+vii
 vBV
 vBV
 lbp
@@ -102243,7 +102565,7 @@ nfp
 kxW
 mMP
 gIg
-efC
+isa
 awu
 xrf
 xrf
@@ -102439,10 +102761,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 izQ
 aaa
 aaa
@@ -102450,7 +102768,11 @@ aaa
 aaa
 aaa
 aaa
-wxt
+tgk
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -102545,7 +102867,7 @@ dHP
 yag
 dHP
 qnP
-efC
+isa
 ncb
 lck
 pTf
@@ -102741,10 +103063,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 npA
 aaa
 aaa
@@ -102754,6 +103072,10 @@ aaa
 aaa
 aaa
 aaa
+aag
+aag
+aag
+aag
 aag
 aag
 aag
@@ -102847,7 +103169,7 @@ dTP
 isN
 dHP
 bzq
-efC
+isa
 tdb
 bUr
 yhB
@@ -103039,10 +103361,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aag
@@ -103057,6 +103375,10 @@ aag
 aag
 aag
 aag
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -103149,7 +103471,7 @@ dHP
 yag
 dHP
 njh
-efC
+isa
 kUB
 oVe
 mzT
@@ -103322,10 +103644,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aag
@@ -103352,19 +103670,23 @@ aaa
 npA
 aaa
 aaa
+crG
+aaa
+aaa
+aaa
 oTy
 aaa
 aaa
-aaa
+gEl
 rKX
-aaa
-aaa
+rKX
+nBO
 xjY
-oZP
-oZP
+apR
+apR
 arm
-hES
-gEX
+apR
+apR
 arP
 hqx
 aUc
@@ -103608,10 +103930,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aag
@@ -103637,10 +103955,10 @@ aaa
 aaa
 aaa
 aaa
-fnv
 aaa
 aaa
 aaa
+lbL
 aaa
 aaa
 aaa
@@ -103650,23 +103968,27 @@ aaa
 aaa
 aaa
 aAo
-kEs
+agu
 aAo
+fpd
+kCc
+aiN
+apy
 jka
-uZV
-qcS
-xle
+aiN
+ajq
+aiN
 wuB
-qcS
+eRv
 apR
-qcS
+kbO
 aMa
 mXn
 axZ
 aNQ
 gJb
-eZd
-fGT
+aNQ
+aNQ
 fiN
 khR
 wcB
@@ -103879,11 +104201,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aag
 aag
 aag
 aag
@@ -103916,7 +104234,7 @@ aag
 aag
 aag
 aaa
-oTy
+crG
 aaa
 aaa
 aaa
@@ -103932,40 +104250,44 @@ aaa
 aaa
 aaa
 aaa
-xhr
+czI
+ajX
+qNN
+fwk
+akc
 rSD
 sVr
-chm
+aAo
 agu
 ehp
-deQ
 aAo
+hce
 kEs
 nIn
-aAo
-mwl
-mDp
-nhb
-nNy
+lXQ
 aAo
 aAo
 aAo
-nIn
+ehp
 aAo
+xle
+aBL
+aCH
+aDg
 aiI
 agF
 aFC
-vcB
-tJo
-xlF
+aiN
+sbJ
+aiN
 klI
-qcS
+bQK
 apT
-qcS
-vfk
-eav
-xqc
-mJl
+jRm
+anJ
+anJ
+anJ
+anJ
 anJ
 anJ
 anJ
@@ -104178,11 +104500,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aag
@@ -104203,7 +104520,8 @@ aaa
 aaa
 aaa
 aaa
-oTy
+aaa
+crG
 aaa
 aaa
 aaa
@@ -104218,7 +104536,11 @@ aaa
 aaa
 aaa
 aaa
-abP
+abf
+akT
+jtH
+kRc
+abG
 uVl
 acX
 lYC
@@ -104234,40 +104556,39 @@ czI
 tjt
 apm
 fwk
-xhr
+jLO
 aqp
 arj
-chm
+aAo
 tdq
 uXK
-emM
 aAo
-gEl
+sCg
+agQ
 mwU
-aAo
+agQ
 iCU
-agQ
+pUo
 vbJ
-agQ
-obv
+qjp
+aAo
 sXh
 rvg
 hrh
-aAo
-qNN
+mDp
+aiI
 lAi
-hEr
-voE
-tJo
-xrW
+aEH
+aiN
+ajq
+aiN
 aNg
-qcS
-apR
+aIZ
+apT
 qcS
 ank
-cUk
-xqc
-lMh
+ank
+ank
 akq
 akq
 akq
@@ -104277,6 +104598,7 @@ arA
 ame
 ame
 ame
+bhX
 bhX
 bhX
 bhX
@@ -104477,11 +104799,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aag
@@ -104490,36 +104807,41 @@ aaa
 aaa
 aaa
 aaa
+abw
+aCc
+aCc
+aCc
+baO
 nRA
-bbo
+aFF
 bbo
 bry
-aGV
-aFF
-abx
-bzo
-bzo
+bry
 bsH
-bQt
+abx
+ahb
+bzo
+bBx
+bBT
 acf
 aah
 cYR
 fcx
-aIP
+abu
 aat
 fBs
 afk
-fvW
+aaT
 fWL
 gcA
-oxe
-apy
+hrc
+afk
 hLs
-asi
+bsH
 abf
 oxe
 akU
-bsH
+evi
 abP
 uVH
 amc
@@ -104532,54 +104854,54 @@ afC
 jsZ
 anz
 qoC
-eAu
+czI
 sAU
 afj
-baO
+fwk
 xhr
 cNQ
 agi
-chm
+aAo
 wUD
 arU
 ehV
-aAo
-gKs
-jdi
-kBS
 agQ
 agQ
 agQ
 agQ
+xCS
+agQ
+kly
+rvg
 oxo
-agQ
+hrh
 cOP
-lAi
+hrh
 tMJ
-hEr
+aiI
 kQp
 hEr
 ajQ
-tJo
+qOi
 aHq
 eQZ
 jsQ
-qzd
+apT
 aAl
-pSS
+ank
 jGW
-xqc
-xnA
+rtC
 akq
+deQ
 gDl
-hkJ
 arA
+xlF
 fLO
-kWy
 ame
+ltJ
 tbI
-keB
 bhX
+kBS
 aip
 laa
 jHi
@@ -104587,7 +104909,7 @@ agV
 eQM
 vwA
 mcA
-amU
+aKq
 arY
 uxF
 kCe
@@ -104662,10 +104984,10 @@ bBB
 dvy
 dSD
 tvK
-dfb
+nmP
 leZ
 jOo
-oYY
+tvK
 aaa
 aaa
 aag
@@ -104777,11 +105099,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aag
@@ -104789,40 +105106,45 @@ aaa
 aaa
 aaa
 aaa
-nRA
-bbo
-bbo
+abw
+aCc
+aCc
+ayh
+pGe
+acs
+adu
+adW
 apa
 apl
 abn
 agz
-agY
+aep
 vmx
-adl
+abx
 aKc
 ahD
-aov
-bQt
-agU
+amI
+aoL
+acf
 bgz
 aNN
-aqu
-aIP
+aiC
+abu
 cRl
 ajB
 aju
-fvW
-amL
+aaV
+aaV
 iEm
 ake
-akh
+akg
 akh
 akl
 akL
 oxu
 alA
 adB
-aBL
+abP
 uYp
 bpm
 aem
@@ -104834,55 +105156,55 @@ afC
 icC
 bvt
 alz
-eAu
+czI
 pGY
 apn
-beo
-xhr
+fwk
+knY
 spW
 afI
-chm
+aAo
 kbc
 ulP
-equ
-aAo
+wiB
+wiB
 rlC
-jtH
-wiB
-wiB
-nbB
 wiB
 wiB
 wiB
 wiB
+pSd
+bLc
+aAo
+uCC
 nwA
 fwV
-aAo
-qYM
+bLM
+aiI
 vbN
-tgk
-tYJ
-tJo
-eZo
 kJe
+tYJ
+aGF
+eZo
+uZV
 tkJ
-kaG
+apT
 xas
-wPO
+ank
 cMt
-xqc
-xFi
+bdu
 akq
+nhb
 iWD
-bnC
 arA
+gKs
 hwT
-cFb
 ame
+rcJ
 ozR
-aXQ
 bhX
-hWV
+voE
+aKb
 aKb
 aKb
 yhz
@@ -105078,53 +105400,53 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aaa
 aaa
 aaa
+abw
+aCc
+aCc
+aaU
+aaq
+aaq
+aMo
+eHe
+aaq
+aaq
+aaq
 nRA
-bbo
-bbo
-aay
-aaq
-aaG
-aaz
-aaq
-aaq
-aaq
-aGV
-abL
-adL
+kFa
+abo
+adb
+aet
+vmx
+abx
 aKg
 akO
 aov
 bQt
-ahp
+acf
 bgB
 adX
 fjJ
-aIP
+abu
 cSY
-awX
-akW
-fvW
+awq
+afk
+acD
 acF
 swO
-oxe
-apz
+arS
+afk
 iAD
-aso
-awO
-oxe
-jGA
 abr
-aBL
+akL
+akK
+jGA
+rLS
+abP
 vae
 lEn
 wKX
@@ -105136,55 +105458,55 @@ afC
 fgA
 pkf
 qPI
-eAu
+czI
 epn
 apo
-biT
-xhr
+fwk
+vqg
 gWx
 mKS
-chm
+aAo
 jPk
 uny
 wpf
+agQ
+agQ
+mwU
+agQ
+agQ
+agQ
+hAc
+bLc
 aAo
-gYP
-jVS
-kCc
-agQ
-agQ
-vbJ
-agQ
-agQ
-agQ
-oTZ
-fwV
-aAo
-rcJ
-lAi
-hEr
+aIX
+rvg
+hrh
+yal
+aiI
+aTi
+kJe
 fJS
-tJo
+sde
 lML
 kJe
 aVl
-kWU
+apT
 iyB
-kJe
+ank
 vNt
-xqc
-dnv
+owD
 akq
+uXo
 mOK
-qcK
 arA
+sjk
 nKA
-iOd
 ame
+fPF
 iyz
-xhh
 bhX
-fZF
+nvB
+uSP
 uSP
 uSP
 rvx
@@ -105269,7 +105591,7 @@ dfp
 hUh
 hUh
 byT
-luv
+nhd
 ujx
 mAV
 bCZ
@@ -105379,54 +105701,54 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aaa
 aaa
-nRA
-bbo
+abw
+aCc
+ayh
+aaq
+aaq
+aaq
+aaq
+aaq
+aaq
+aaq
+aaq
+aaq
+aaq
 apa
-aaq
-aaq
-aaz
-aaq
-aaq
-aaq
-aaq
-aaq
-aaq
-agY
 abr
-adM
+biT
+agY
+agY
+bwd
+abx
 aKl
-aKl
+alB
 aoK
-bQt
-ahw
+apB
+acf
 bgJ
-aiB
+adX
 akY
-aIP
+abu
 tyV
 awX
-alN
-fvW
+afk
+aLf
 aLj
 acJ
-oxe
+arS
 kty
-ars
-btU
-awO
-ozD
 aMy
+btU
+akL
+ozD
+akW
 aff
-aBL
+abP
 vbd
 ami
 abB
@@ -105438,57 +105760,57 @@ afC
 gfI
 anD
 ahc
-eAu
-aZs
+czI
+czI
 nuy
-bkW
-xhr
-xhr
+fwk
+lbV
+aqN
 cVU
-chm
+aAo
 ybu
 arV
 ahr
-aAo
+ahw
 ahJ
 ahP
-kDU
+ahJ
 tMo
 axz
 ail
-axz
-ogq
-aLi
-pmJ
-aDe
+aim
 aAo
-rpj
-lAi
-tkw
+aLi
+rvg
+aDe
+aiB
+aiI
+gox
+kJe
 gZM
-tJo
+sde
 aHx
 kJe
 cqv
-kWU
+apT
 kTa
-kJe
+ank
 jWD
-xqc
-gjq
+czr
 akq
+qaD
 lMu
-nFa
 arA
+xrW
 cMF
-cHM
 ame
+inP
 xEg
-kvC
 bhX
-mUm
 lRH
 mUm
+lRH
+hKi
 prP
 eQM
 xWf
@@ -105511,7 +105833,7 @@ ekr
 ekr
 cEI
 vry
-qXK
+aCZ
 aDq
 aAx
 vry
@@ -105681,57 +106003,57 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aaa
 aaa
-nRA
-apa
+abw
+ayh
+aay
+aau
+aaq
+aaq
+aaq
 acd
 acl
 aaq
-aaq
+acb
 aaA
 adv
-aaq
-aaN
+aaG
+nRA
 rpt
-abi
-abm
-aGV
-abW
-aeu
+aMy
 abr
-aff
+btU
 abr
+ahp
+aoL
+abQ
+abL
 abV
 aqu
 ahF
 acg
 ack
-aka
+abu
 cUO
 aiS
-alU
-fvW
+afk
+ftW
 ajN
-anB
-oxe
+acJ
+jlx
 acS
 atV
-btU
-mvA
-axs
-ppF
 adn
-aCc
-aBL
+mvA
+akL
+ppF
+akL
+abP
+abP
 adc
-aBL
+abP
 adg
 adg
 afa
@@ -105740,53 +106062,53 @@ afC
 afC
 aik
 afC
+czI
 eAu
-eAu
-bab
-eAu
-aGV
-aqO
 aMy
-cjy
-cCx
+afu
+cMB
+aqO
+afL
+aAo
+aAo
 vmL
 aRK
+wMN
+hlR
+wMN
+wMN
+wMN
+ulf
+nDa
+ezt
 aAo
-aAo
-jWF
-kFa
-wMN
-wMN
-wMN
-wMN
-wMN
 aic
-pHz
+aic
 lxd
-aAo
-rqQ
-rqQ
-tHB
-rqQ
-tJo
-tJo
-ajc
-ajc
-pIc
+aic
+aiI
+aiI
 ajc
 ajc
 tJo
+ajc
+ajc
+aiI
+apT
+sRe
+ank
+ank
 xqc
-mSS
 akq
 akq
-pMB
+aro
 arA
 arA
-qLR
+asi
 ame
 ame
-nZG
+asN
+bhX
 eQM
 eQM
 eQM
@@ -105868,12 +106190,12 @@ iQC
 vFp
 lLC
 pvn
-mdn
+gpl
 cfC
-dlK
-dlK
+xrf
+xrf
 fYn
-dlK
+xrf
 bza
 bza
 pST
@@ -105981,115 +106303,115 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-ayh
+aal
 aaa
 aag
 aai
-nRA
-apa
+abw
+ayh
+aaz
+aav
+aaq
+aaq
+aaq
 aax
-ahe
+aax
+aax
 aaq
-aaq
+acc
+acQ
 adw
-adw
-adw
-aaq
+aaH
 aaM
-aaO
+abA
 aaZ
 abg
-abo
-abA
-aet
-aLh
 abr
+aAh
+abx
+aLh
+aMr
 aoL
-bQt
-ahC
+aUV
+acf
 bgM
-aqu
-aiF
-aIP
+acf
+acf
+abu
 cUP
-aIP
-aIP
-fvW
+aiT
+afk
+fuu
 ajO
 acK
-oxe
+acO
 acT
 acY
-asN
+abA
 mvR
 jiV
-aAh
+knC
 abA
 tDr
-aIX
-knC
 abA
+knC
+aAC
 ahS
 abA
 knC
-aDF
-aMr
+abA
+tDr
 abA
 knC
-abA
+jiV
 ahS
 abA
 knC
-aIX
-aMr
-abA
-knC
 abA
 abA
-cGP
+rHx
+afM
+afY
+abA
+avx
 lrb
-fpd
-abA
-avx
-kRc
 avx
 abA
-nrF
+pmJ
 abA
 avx
-oAX
+aDF
 avx
+oTZ
+aAC
+abA
+ahS
 aeo
 aDF
 abA
-aMr
-tUp
-oAX
+tDr
 abA
-ahS
 abA
+lrb
+abA
+abA
+qaW
+aKq
+aql
+ajY
 arY
-jer
-arY
-arY
-jtC
-hwV
 aql
 jHN
 arY
 aql
+waX
 aSB
-jvG
 aql
 jHN
-sBA
+jWF
 aql
-ixL
+ajY
+arY
 arY
 jHN
 anA
@@ -106282,57 +106604,53 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aab
-aaw
-abd
-aaf
-aal
 aam
+abd
+rpj
+aap
+amL
+aaw
+acd
+aaf
+aaq
+aaq
 aqd
 abe
 aao
-aaq
+aar
 aPf
-aau
+aaq
 aaB
 aaC
 aaI
-aaq
+aaN
 bbc
 boq
 abh
-abw
-bwE
-aeu
-aLn
 abr
+bwE
+abx
+aLn
+abK
 abN
-bQt
-aix
+abR
+acf
 bgS
 aiy
 acm
-aIP
+abu
 cXp
 aiU
-alX
+afk
 fvW
 ajU
 acL
-oxe
+acP
 acU
 acZ
 ade
 adi
-azz
-aAq
-aAC
-aDg
 byZ
 prL
 byZ
@@ -106340,7 +106658,7 @@ byZ
 byZ
 prL
 byZ
-aMt
+xGw
 byZ
 prL
 byZ
@@ -106350,48 +106668,52 @@ prL
 byZ
 byZ
 byZ
+pHz
+adM
+adM
+ogq
 afN
+afZ
 agl
-agl
-cMB
+byZ
 qVt
-fPF
-hce
-byZ
-lbL
 byZ
 byZ
-nvB
+rUn
 byZ
 byZ
-xSt
+ahu
+byZ
+nwT
+chm
+vtr
 byZ
 etk
-qjp
-rHx
+ahu
 byZ
-tUU
+byZ
+byZ
 xSt
-byZ
-byZ
+aGN
+abH
 byZ
 nGm
 aKw
 ajS
-aks
+kek
 kek
 vxk
 opK
-xMX
-saJ
+kek
+vxk
 hjC
 hoL
 jtP
+aks
+cGP
+jtP
 dUv
 aks
-weM
-dUv
-ajS
 aks
 aks
 aks
@@ -106417,7 +106739,7 @@ ekr
 gND
 uYf
 uSJ
-mEY
+mOA
 anN
 uSJ
 cZP
@@ -106585,115 +106907,115 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aan
 aaa
 aag
 aak
+axs
+aAq
+aaQ
+abl
+aaq
 apN
-aap
+aaq
 aav
-aar
+aav
 azV
 aaq
-ahe
+aaq
 ahe
 aaD
-aaq
-aaq
-aaQ
+aeu
+aaO
+adn
 abb
 aht
-abK
-adn
-aeQ
-liA
 abr
-aoL
-bQt
-bQt
+aAh
+abx
+abx
+aMt
+ahq
+abS
+abY
 cON
 aiz
-ajX
+aiz
 ach
-akb
-akp
-akp
+ach
+ach
+acM
+acM
 hBy
-hBy
-hBy
+acM
 acM
 acM
 kZe
-acM
-acM
-acM
-aAu
-aAT
+akp
+adj
+abr
+aMy
+abr
 byQ
 abr
 aMy
 abr
 bHI
-abr
+obv
 aMy
 abr
-aQa
-aUF
+byQ
+abr
 aMy
 abr
 bHI
-abr
-aMy
-abr
-aQa
+aAT
+atV
+adn
+adn
 egb
-ppF
+afO
+aga
 adn
-adn
-das
+avy
 wvQ
-gaP
-adn
-avy
-lhD
 avy
 adn
-nvT
+beo
 adn
 avy
-uax
+mgL
 avy
+gYP
+adn
+atV
+agU
 wnu
-adn
-ppF
+mgL
+ayo
 ahE
-ulf
+adn
 uax
-xaM
-xuF
+atV
+adn
 adn
 saj
 aLm
+dEp
+aka
 akB
-akB
-xlK
-jRB
 dEp
 oGd
 akB
 dEp
+emM
 akk
-nJI
 dEp
 oGd
 akB
 dEp
-sOu
+rqQ
+akB
 akB
 oGd
 akB
@@ -106889,57 +107211,57 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aaa
 aaa
-apN
-aap
-acd
-acl
+axs
+aAq
+aay
+aau
 aaq
 aaq
 aaq
 aaq
 aaq
 aaq
+aaq
+ahC
+adL
+aeQ
+nRA
 aBt
 arv
 agG
-aGV
-acb
-afL
-afY
 abr
 abr
 abr
 abr
 aMy
-liA
-ajY
+aht
+aiF
+acf
+acf
+acf
+acf
+abu
+atW
 aIP
-aIP
-aIP
-aIP
-aIP
-amQ
+abr
+abr
+aht
 gAK
 abr
 abr
 liA
 akr
-abr
-abr
+aAu
+aaJ
 pMa
-adI
+aaJ
 aeq
-aKq
+aeq
 wii
-aKq
+aeq
 aeM
 aeM
 pnc
@@ -106948,53 +107270,53 @@ afg
 afg
 ghJ
 afg
-pOw
+aiq
 pOw
 qPW
-pOw
+akN
 cNy
 afG
 agn
-crG
+dNe
 lNV
 vsH
 oHo
-dNe
-tII
+xjd
+xjd
 mFp
-ltJ
 xjd
 xjd
+vHu
 wSp
-xjd
-xjd
+lNV
+alU
 kMO
 tNB
 tII
-wId
+urP
 aiK
-xOF
-uCC
+aiK
+ajw
 nvQ
-wig
-wig
-ajw
-pyF
-uZU
+aGO
 ajw
 ajw
-wig
-xqc
-mSS
+aiK
+apT
+sRe
+anv
+anv
+kAs
 aku
 aku
+ars
 fEn
-xxD
 arK
-gBG
+aso
 amh
 amh
-gBG
+atP
+biH
 biH
 biH
 biH
@@ -107076,12 +107398,12 @@ aYp
 vFp
 aZd
 pvn
-cfQ
+rMl
 wIG
-dlK
-dlK
-dlK
-dlK
+xrf
+xrf
+xrf
+xrf
 bza
 bza
 ngq
@@ -107191,51 +107513,51 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aaa
 aaa
-apN
-bbo
-aap
+axs
+aCc
+aAq
 aaq
 aaq
-abe
 aaq
-aaH
+acd
+aaq
+abW
 aaq
 aaq
-boZ
+aUb
 aaq
-agY
-adb
-afM
-xSt
+apa
+agr
+abF
+ahu
+abH
+byZ
+byZ
+byZ
 aMC
-byZ
-byZ
+ahu
+abH
 byZ
 aXv
-xSt
-aMC
+dYH
 byZ
-akj
+byZ
+abH
+fDo
+byZ
+byZ
+ahu
+fDo
+byZ
+byZ
+lkz
 akv
-byZ
-byZ
-aMC
-fDo
-byZ
-byZ
-xSt
-fDo
-byZ
-byZ
+adl
+fnv
 adz
 adG
 vso
@@ -107257,48 +107579,48 @@ ala
 xFk
 aqQ
 duK
-cBW
+dNe
 egf
 vyZ
 ahG
-dNe
+ahx
 ahK
 ahY
-lXQ
+ahK
 ahx
-nFH
+gVv
 ayP
 nFH
-ahx
+alU
 kEz
-pSd
+tNB
 jSQ
-wId
-rLS
-xOF
-uXo
+ohf
+aiK
+dKr
+ajJ
 iUF
-wig
+chI
 iNp
 ajJ
 kzY
-gHk
+apT
 sfV
-ajJ
+anv
 vED
-xqc
-evH
+alJ
 aku
+nvT
 mdE
-rIw
+fEn
 xxD
 iUs
-fFU
 amh
+rOK
 nQY
-xYq
 biH
-opV
+ykg
+ken
 ken
 iWe
 lxl
@@ -107494,50 +107816,50 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aaa
 aaa
 aaa
-apN
-bbo
-bbo
-aap
+axs
+aCc
+aCc
+aAq
 aaq
 aaq
-aaz
 aaq
-boZ
+eHe
 aaq
-aGV
-adj
+aUb
+aaq
+nRA
+apz
 aMy
-liA
+aht
 abr
-abr
-abr
-abr
-aMy
-liA
 abr
 abr
 abr
 aMy
+aht
 abr
 abr
 abr
 aMy
 abr
-aro
-liA
-atP
 abr
 abr
+aMy
+abr
+amQ
+aht
+aUS
+abr
+abr
+iCH
+akr
+adl
+jVS
 erm
 adI
 vso
@@ -107555,52 +107877,52 @@ aeX
 swl
 dNi
 afl
-bwd
-xFk
+ala
+opx
 luc
 ago
-cBW
+dNe
 vUr
 agp
 ajo
-dNe
-hlR
+xtB
+xtB
 nIE
-mgL
 xtB
 xtB
+tUU
 rEM
-xtB
-xtB
+vcB
+alU
 aje
-pUo
+tNB
 vWQ
-wId
-rOK
-xOF
+vew
+aiK
+kyV
 gXC
 ajV
-wig
+chI
 cUl
-ykg
-kQY
-gHk
-fLR
 ajJ
+kQY
+apT
+fLR
+anv
 oxp
-xqc
-pcf
+cEW
 aku
+cBW
 qZS
-xdJ
-xxD
+fEn
+tup
 oHb
-ndy
 amh
+tkw
 eDQ
-pnG
 biH
-cAf
+tUp
+tku
 tku
 tku
 stZ
@@ -107681,7 +108003,7 @@ dSf
 weR
 xRI
 uyi
-dlK
+xrf
 dfz
 bZv
 bZv
@@ -107797,11 +108119,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aag
@@ -107809,31 +108126,36 @@ aaa
 aaa
 aaa
 aaa
-apN
-bbo
-bbo
-aap
+axs
+aCc
+aCc
+aAq
+pGe
+adh
+aUb
+amD
+apa
 apE
 boZ
 agt
-agY
+agT
 afD
 afF
-aga
+abA
 bBw
 aPc
-agr
+abA
 abA
 akX
 eqH
-abA
-abA
-ajz
-akT
-ajz
+akX
 abA
 abA
 knC
+ajz
+bkW
+aUF
+bab
 bej
 bey
 llI
@@ -107842,7 +108164,7 @@ akG
 akS
 bsd
 rNq
-aGN
+vso
 vtX
 lJb
 aef
@@ -107857,52 +108179,52 @@ fjX
 swl
 msf
 apU
-bBx
-xFk
+ala
+mEV
 sIw
 afS
-cBW
+dNe
 uRc
 vIa
-euu
-dNe
-inP
+hzJ
+hzJ
+hzJ
 shi
 hzJ
 hzJ
 hzJ
 azn
-hzJ
-hzJ
-hzJ
-qaD
+azz
+alU
+xaM
+tNB
 dBD
-wId
-rUn
+nqL
+aiK
 xOF
 aFL
 aiW
-wig
+chI
 iHi
 ows
 opk
-gHk
-cVE
+apT
+kTa
 anv
 vbF
-xqc
-gjq
+owc
 aku
+nNy
 dUj
-fNh
-xxD
+fEn
+wDt
 xcQ
-shC
 amh
+gaP
 rRU
-vRv
 biH
-hzH
+eAx
+dHb
 dHb
 pFP
 euN
@@ -107983,7 +108305,7 @@ bxO
 rTc
 xRI
 uyi
-dlK
+xrf
 qff
 bZv
 umL
@@ -108101,11 +108423,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aag
@@ -108114,20 +108431,21 @@ aaa
 aaa
 aaa
 aaa
-apN
-aaU
-abl
+axs
+aQa
+aQa
+aZs
+baO
+nRA
+aFF
+bpJ
+bsH
+aGV
+aFF
 bry
-aGV
-aFF
+bry
 bpJ
-bsH
-aGV
-aFF
-bzo
-bzo
-bpJ
-bzo
+bry
 bsH
 aGV
 aFF
@@ -108142,9 +108460,13 @@ aFF
 bpJ
 bsH
 aGV
+jbp
+bsH
+abi
+oAX
 alb
-bsH
-abT
+alN
+vso
 vvB
 amt
 amA
@@ -108159,52 +108481,52 @@ aoZ
 swl
 tRk
 afn
-bLc
-xFk
+ala
+uHm
 cOo
 dvA
-cBW
+dNe
 rxC
 vQd
-evi
-dNe
-jbp
+qqm
+qqm
+qqm
 uKt
+xuF
 qqm
 qqm
 qqm
-nwT
 nXS
-qqm
-qqm
-qqm
+alU
+sWu
+tNB
 ybU
 wId
-sjk
-xOF
+aiK
+xyB
 aFY
 aiX
-wig
+ajh
 aiL
 lrv
 eqd
-mgc
-quy
-fcM
+apT
+aAl
+anv
 eFD
-xqc
-xnA
+gdy
 aku
+sUb
 uEr
-cgR
-xxD
+fEn
+sxz
 oZd
-oKp
 amh
+nbB
 kCM
-eJZ
 biH
-wvq
+mwl
+upR
 upR
 oEz
 amE
@@ -108285,8 +108607,8 @@ rDf
 teA
 xRI
 jhn
-dlK
-dlK
+xrf
+xrf
 fMH
 vmd
 uYb
@@ -108406,11 +108728,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aag
@@ -108431,7 +108748,8 @@ aaa
 aaa
 aaa
 aaa
-cAY
+aaa
+cCx
 aaa
 aaa
 aaa
@@ -108446,6 +108764,10 @@ aaa
 aaa
 aaa
 aaa
+abi
+abm
+kDU
+lhD
 abT
 ace
 lLn
@@ -108458,53 +108780,53 @@ agL
 agP
 qgo
 qGv
-aUS
+swl
 fmv
 aqb
-bLM
-xFk
+ala
+eCs
 arh
 ark
-cBW
+dNe
 agE
 asw
-ezt
+lNV
+wra
 dNe
-vJJ
 fTz
-tII
-ehn
 dNe
+wra
+lNV
 oat
-dNe
-ehn
-tII
-qaW
+agE
+alU
+rWb
+tNB
 vJJ
-wId
-sCg
-xOF
+ekq
+aiK
+lNC
 aGb
-vHu
+aIu
 wig
-xCS
+aIu
 tFf
-irW
-sGz
-irW
-joE
-xEG
-xqc
-mJl
+aJl
+apT
+jRm
+anv
+anv
+anv
 aku
-aku
+cjy
+equ
 qfg
-mjT
+arK
 arK
 amh
 amh
 amh
-amh
+biH
 biH
 biH
 biH
@@ -108587,7 +108909,7 @@ bxP
 xVG
 aXg
 dtd
-lhu
+uAP
 moD
 uOS
 dnW
@@ -108711,11 +109033,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aag
 aag
 aag
 aag
@@ -108748,7 +109066,7 @@ aag
 aag
 aag
 aaa
-cAY
+cCx
 aaa
 aaa
 aaa
@@ -108764,43 +109082,47 @@ aaa
 aaa
 aaa
 aaa
-xFk
+swl
+akb
+qYM
+ala
+akd
 sMV
 sZQ
-cBW
+dNe
 tFN
 saC
-eAx
-dNe
-hkZ
-kly
 dNe
 wra
 dNe
-hkZ
+tFN
 dNe
 wra
 dNe
-kly
+saC
+tFN
+alU
+alX
+tNB
 hkZ
-wId
-sRe
-xOF
+gPE
+aiK
+bYy
 aGl
-vWD
-wig
-xGw
+aIu
+pCL
+aIu
 qRr
-irW
-sBo
-irW
-mRE
-xhF
-xqc
+aJq
+apT
+jRm
+anJ
+anJ
+anJ
 gmR
 eNw
 ygC
-xjc
+ygC
 qxC
 vXo
 whl
@@ -108874,7 +109196,7 @@ mTM
 aLv
 mUL
 nHL
-cfQ
+rMl
 bpo
 xiq
 iKS
@@ -108885,11 +109207,11 @@ eZL
 vcl
 sVu
 tSN
-lhu
-lhu
-lhu
-lhu
-lhu
+uAP
+uAP
+uAP
+uAP
+uAP
 kbn
 npj
 qGY
@@ -109044,10 +109366,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aag
@@ -109076,33 +109394,37 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+vWD
 eSP
 aaa
 aaa
-nBO
 aaa
 aaa
-aaa
-aaa
-aaa
-wId
+alU
+anB
+jdi
+das
+kcK
 aIu
 apJ
 hBp
-waX
-irW
-yal
+aIu
+wig
+aIu
 lhr
 irW
-sGz
-irW
+apR
+dRj
 aML
 amy
 lOt
-dZt
+aNQ
 dEo
-gmR
-cMO
+aNQ
+aNQ
 xpW
 hhQ
 gBH
@@ -109152,7 +109474,7 @@ gVu
 tgI
 dTm
 bMM
-aDi
+lvO
 awB
 axM
 lTX
@@ -109187,7 +109509,7 @@ tfd
 jlI
 rMl
 pJD
-lhu
+uAP
 xrA
 tjW
 gxe
@@ -109362,10 +109684,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 aag
 aag
 aag
@@ -109389,6 +109707,10 @@ aag
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+cCx
 aaa
 aaa
 aaa
@@ -109396,15 +109718,15 @@ cAY
 aaa
 aaa
 aaa
-tat
-aaa
-aaa
-aaa
+apR
+awO
+vvE
+nrF
 ylq
 vvE
 rWB
-vvE
-poA
+apR
+apR
 vpb
 vne
 uGe
@@ -109454,7 +109776,7 @@ gVu
 acu
 dTm
 bMM
-aDi
+lvO
 ahN
 pmu
 wCG
@@ -109489,7 +109811,7 @@ eaF
 lcl
 fsk
 pkR
-lhu
+uAP
 xjD
 vOp
 brZ
@@ -109683,24 +110005,24 @@ aaa
 aaa
 aaa
 aaa
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
+aag
 aaa
 aaa
 aaa
 aaa
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
 aaa
 aaa
 aaa
@@ -109715,7 +110037,7 @@ iqW
 vpb
 nnS
 tFq
-aAD
+aSo
 aDB
 xXH
 asY
@@ -109756,14 +110078,14 @@ gVu
 tgI
 dTm
 bMM
-aDi
+lvO
 ahU
 axV
 qpz
 wCG
 dMU
 kfI
-rOm
+wCG
 vMh
 asD
 aFW
@@ -109791,7 +110113,7 @@ yaR
 rUZ
 mdn
 osY
-lhu
+uAP
 bsu
 vOp
 oaB
@@ -109998,10 +110320,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aag
+aag
+aag
+aag
 aag
 aag
 aag
@@ -110015,7 +110337,7 @@ aaa
 uNs
 kga
 aXT
-nnS
+nrA
 vpb
 aAM
 aAM
@@ -110058,7 +110380,7 @@ gVu
 tgI
 dTm
 bMM
-aDi
+lvO
 jzx
 kpR
 aId
@@ -110076,7 +110398,7 @@ xcJ
 dCR
 qxo
 ijU
-gPk
+ijU
 dpT
 aGB
 fsN
@@ -110093,7 +110415,7 @@ gGR
 rgz
 rMl
 unV
-lhu
+uAP
 umD
 mtm
 tIJ
@@ -110298,11 +110620,11 @@ aaa
 aaa
 aaa
 aaa
+tHB
 aaa
 aaa
 aaa
 aaa
-klO
 aaa
 aaa
 aaa
@@ -110360,11 +110682,11 @@ gVu
 tgI
 dTm
 bMM
-aDi
+lvO
 jzx
 kpR
 aId
-rOm
+wCG
 vpW
 clF
 dqf
@@ -110585,11 +110907,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-nDa
+aix
 aaa
 aaa
 aaa
@@ -110608,6 +110926,10 @@ aiZ
 aiZ
 aiZ
 aiZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -110662,11 +110984,11 @@ qXs
 tgI
 dTm
 dzY
-aDi
+lvO
 ahU
 axX
 amG
-rOm
+wCG
 kSJ
 kSJ
 kSJ
@@ -110883,10 +111205,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 agf
 agf
 agf
@@ -110910,6 +111228,10 @@ aiZ
 aiZ
 aiZ
 aiZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -110964,11 +111286,11 @@ aAb
 lyW
 ado
 atm
-aDi
+lvO
 ahU
 axX
 qqv
-rOm
+wCG
 bde
 kSJ
 kSJ
@@ -111183,10 +111505,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 agf
 agf
 agf
@@ -111212,6 +111530,10 @@ aiZ
 aiZ
 aiZ
 aiZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -111270,7 +111592,7 @@ iHK
 jBD
 axX
 llk
-rOm
+wCG
 jSy
 egP
 dzX
@@ -111484,10 +111806,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 agf
 agf
 agf
@@ -111514,6 +111832,10 @@ aiZ
 aiZ
 aiZ
 aiZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -111572,7 +111894,7 @@ xZF
 ezZ
 aGc
 aIf
-rOm
+wCG
 bHq
 vqo
 bXt
@@ -111785,10 +112107,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 agf
 agf
 agf
@@ -111816,6 +112134,10 @@ aiZ
 aiZ
 aiZ
 aiZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -111877,7 +112199,7 @@ xZF
 wCG
 mIK
 onG
-rOm
+wCG
 mIK
 mYh
 eZu
@@ -111885,7 +112207,7 @@ ijn
 dGS
 jcL
 jcL
-fRQ
+dkK
 wCG
 shk
 wJh
@@ -112087,28 +112409,28 @@ aaa
 aaa
 aaa
 aaa
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+akj
 aaa
 aaa
 aaa
 aaa
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-sWu
 aaa
 aaa
 aaa
@@ -112164,7 +112486,7 @@ gFr
 aQM
 aQM
 esZ
-pGe
+bsV
 aQM
 fzM
 aZw
@@ -112389,28 +112711,28 @@ aaa
 aaa
 aaa
 aaa
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
 aaa
 aaa
 aaa
 aaa
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
 aaa
 aaa
 aaa
@@ -112692,27 +113014,27 @@ aaa
 aaa
 aaa
 aaa
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
 aaa
 aaa
 aaa
 aaa
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
 aaa
 aaa
 aaa
@@ -112995,26 +113317,26 @@ aaa
 aaa
 aaa
 aaa
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
 aaa
 aaa
 aaa
 aaa
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
 aaa
 aaa
 aaa
@@ -113113,10 +113435,10 @@ eMg
 kkd
 eMg
 qPl
-qlc
-dlK
-dlK
-dlK
+rco
+xrf
+xrf
+xrf
 evT
 wxh
 dYS
@@ -113299,23 +113621,23 @@ aaa
 aaa
 aaa
 aaa
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
+agf
 aaa
 aaa
 aaa
 aaa
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
-agf
 aaa
 aaa
 aaa
@@ -113418,7 +113740,7 @@ qPl
 wqL
 wac
 vhD
-dlK
+xrf
 vbS
 qcZ
 vrK
@@ -113720,7 +114042,7 @@ qPl
 qhx
 mBt
 eVh
-dlK
+xrf
 oRh
 wxh
 dYS
@@ -113972,7 +114294,7 @@ bvP
 bTc
 hag
 gPd
-pGe
+bsV
 dlR
 kMA
 kWI
@@ -115199,7 +115521,7 @@ qKu
 veC
 qWY
 xYC
-sJq
+mEY
 xYC
 qYv
 rVl
@@ -116737,7 +117059,7 @@ bHM
 wxa
 oiF
 qPl
-rco
+lvY
 qPl
 qPl
 blJ
@@ -117011,7 +117333,7 @@ xYC
 qit
 xYC
 qit
-sJq
+mEY
 qit
 xYC
 oUL
@@ -117906,10 +118228,10 @@ aaa
 nyt
 fIK
 pHa
-esr
-esr
-esr
-esr
+pUT
+pUT
+pUT
+pUT
 iWm
 aHo
 aSz
@@ -121264,7 +121586,7 @@ cxh
 wSq
 jGF
 ppd
-eIa
+qXK
 aaa
 aaa
 aag
@@ -121545,7 +121867,7 @@ dgX
 dnU
 dCq
 kgh
-fSF
+poI
 eNz
 wdv
 eri
@@ -122169,7 +122491,7 @@ eWc
 rrF
 bhn
 lmK
-eIa
+qXK
 aaa
 aag
 aag
@@ -123362,14 +123684,14 @@ eGp
 dGZ
 ukc
 exl
-eRJ
+xlm
 eDC
 xlm
 eYI
 bLW
 sjd
 xlm
-fUV
+wlz
 qqo
 qqo
 qqo
@@ -126077,7 +126399,7 @@ riZ
 mPx
 dZW
 dZW
-dLP
+dTa
 xUA
 xUA
 xUA


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Things this PR does:

-Gives Destiny supernorn walls
-Replaces all old 2d windows with auto window grille spawners for both normal and plasma windows
-Updates all the doors to pyro doors 
     *closest or most appropriate match was chosen for those with no direct sprite)
-Adds access spawners to destiny as opposed to using door codes
-Adds firedoor spawns as opposed to the old 2d sprites
-Moves two trees by one tile in the aviary to prevent a lighting glitch

What this PR does not do:

-Change any of Destiny's lighting
       *this is important as supernorn bounces light differently, and now some of the lighting is spotty
                 **I will be fixing this next if this is merged
-Change any door placements
-Change any firedoor placements
-Change any of Destiny's map lay out
-Update the Syndie listening post
-Change any normal windows into plasma windows and vice versa

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This is needed as Destiny is our only map currently where the primary ship is not in the modern goon style.
Destiny has the potential to be a great map, but I feel as if people aren't touching it due it being kinda ugly in its old style, this change I feel will encourage more people to update Destiny to be a healthier map that can be voted as often as our more popular maps.

tl;dr: 2d style (🤮) is ugly and is now gone

[wow this took longer than I expected, a lot more manual work too, big thanks to Sov and Zjdtmkhzt for helping me fix a bug!!]

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Yellow/Myco
(*)Refurbishes Destiny by updating walls, doors, and windows to the modern style!

```
