### PR TITLE
Adds a component that makes objs destroyable with projectiles

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -37,6 +37,7 @@
 	// find the attached trunk (if present) and init gas resvr.
 	New()
 		..()
+		src.AddComponent(/datum/component/obj_projectile_damage)
 		SPAWN_DBG(0.5 SECONDS)
 			if (src)
 				trunk = locate() in src.loc
@@ -62,6 +63,11 @@
 			pool(air_contents)
 			air_contents = null
 		..()
+
+	onDestroy()
+		playsound(src.loc, "sound/impact_sounds/Machinery_Break_1.ogg", 50, 1)
+		elecflash(src.loc, power = 2)
+		. = ..()
 
 	proc/initair()
 		air_contents = unpool(/datum/gas_mixture)

--- a/code/datums/components/obj_projectile_damage.dm
+++ b/code/datums/components/obj_projectile_damage.dm
@@ -1,0 +1,32 @@
+/datum/component/obj_projectile_damage
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+
+/datum/component/obj_projectile_damage/Initialize()
+	if(!istype(parent, /obj))
+		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_ATOM_HITBY_PROJ, .proc/projectile_collide)
+	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, .proc/examine)
+
+/datum/component/obj_projectile_damage/proc/projectile_collide(owner, var/obj/projectile/P)
+	var/obj/O = parent
+	if(P.proj_data.damage_type & (D_KINETIC | D_ENERGY | D_SLASHING))
+		if (O && (O._health/O._max_health) <= 0.5 && prob(abs((O._health/O._max_health) - 1) * 60))
+			var/obj/decal/cleanable/machine_debris/gib = null
+			gib = make_cleanable(/obj/decal/cleanable/machine_debris, O.loc)
+			gib.streak_cleanable()
+			elecflash(O, power = 2)
+		O.changeHealth(-round(((P.power/2)*P.proj_data.ks_ratio), 1.0))
+
+/datum/component/obj_projectile_damage/proc/examine(mob/owner, mob/examiner, list/lines)
+	var/obj/O = parent
+	switch(O._health/O._max_health)
+		if (0.60 to 0.90)
+			lines += "<span class='alert'>It is a little bit damaged.</span>"
+		if (0.30 to 0.60)
+			lines += "<span class='alert'>It looks pretty beaten up.</span>"
+		if (0 to 0.30)
+			lines += "<span class='alert'><b>It seems to be on the verge of falling apart!</b></span>"
+
+/datum/component/obj_projectile_damage/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_ATOM_HITBY_PROJ, COMSIG_ATOM_EXAMINE))
+	. = ..()

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1708,6 +1708,7 @@
 
 	New()
 		..()
+		src.AddComponent(/datum/component/obj_projectile_damage)
 		if(!print_id)
 			src.print_id = "GENERIC"
 
@@ -1778,6 +1779,10 @@
 
 		else
 			return attack_hand(user)
+
+	onDestroy()
+		robogibs(src.loc,null)
+		. = ..()
 
 	attack_hand(mob/user as mob)
 		if(..() || (status & (NOPOWER|BROKEN)))

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -269,6 +269,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\components\mechComp_signals.dm"
 #include "code\datums\components\mob_pierce.dm"
 #include "code\datums\components\no_gravity.dm"
+#include "code\datums\components\obj_projectile_damage.dm"
 #include "code\datums\components\power_cell.dm"
 #include "code\datums\components\simplelight.dm"
 #include "code\datums\components\smartgun.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BALANCE] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a component, only compatible with objects, when you shoot something with that component it will take damage and eventually break when taking enough damage, a few effects will also happen like sparks and scraps flying around. sadly I couldn't record a good video of it, but it looks like shooting a door except it has way less health.

Adds that component to printers and disposal chutes, as those are things I hear people complain because they block bullets the most. Could easily be added to more stuff on request. Also makes printers explode into robot gibs when they are destroyed, disposal chutes will just do a weak electric shock and play a sound.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes firefight better, quick way to make shooting machinery have some effect on it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Arthur Holiday
(+)You can now destroy printers and disposal chutes by shooting them.
```
