### PR TITLE
Selective Outline -> Colored Outline in Spriting Guidelines

### DIFF
--- a/.github/SPRITE_GUIDELINES.md
+++ b/.github/SPRITE_GUIDELINES.md
@@ -46,9 +46,9 @@ So, you want to contribute sprite art to Goonstation. Great! This set of guideli
 
 ## Outlines 🖋
 
-* All sprites should make use of selective outlines, "or sel-out". This means that sprites should have outlines consisting of darker shades of the colors it connects to, instead of having a single color outline. 
+* All sprites should make use of colored outlines. This means that sprites should have outlines consisting of darker shades of the colors it connects to, instead of having a single color outline. 
 
-![](https://cdn.discordapp.com/attachments/799118122899996754/872975861886877696/whiteboard.png)
+![](https://cdn.discordapp.com/attachments/659599207946256416/882768492942737438/whiteboard.png)
 
 * Outlines should also be subject to the shading on the sprite, getting darker in darker parts of the sprites and lighter when outlining lighter parts.
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes the spriting guidelines, modifying 'selective outline' to 'colored outline' in two places.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

User 'Par' from Gannet's multi-server spriting discord server informed me that selective outline *can* refer to outlines that are partial, instead of simply outlines that aren't consistently the same color. As far as I can tell, the term is kinda muddy online and is used for both, while the phrase 'colored outline' is *always* right here. I also think the term is more intuitive to understand if you're new to pixel art, so it's potentially more accurate and definitely more readable, and accuracy and readability are a big deal with guides like this.

Overall I think it improves the guidelines, if only a little.