### PR TITLE
Removes medical locker access from security officers on RP

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -261,7 +261,7 @@
 			return list(access_security, access_brig, access_forensics_lockers, access_armory,
 				access_medical, access_medlab, access_morgue, access_securitylockers,
 				access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
-				access_emergency_storage, access_chapel_office, access_kitchen, access_medical_lockers,
+				access_emergency_storage, access_chapel_office, access_kitchen,
 				access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_construction, access_hydro, access_mail,
 				access_engineering, access_maint_tunnels, access_external_airlocks,
 				access_tech_storage, access_engineering_storage, access_engineering_eva,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[INPUT WANTED][REMOVAL][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Security officers on the RP server currently have access to medical lockers (lockers in medbay, secure medical crates). This access is called "Medical Equipment" on identification computers.

This removes that access from them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The additional access security officers have on the RP server are a means to combat a low-population issue, where security officers would often be the only staff with medical access.

With medbay being manned for the most part, this is no longer needed, and removing it encourages interaction with medical staff.

I am aware that we have a second RP server that typically is much lower population, and this change would affect them as well.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Mordent
(+)Removed medical locker access from security officers on the RP servers (to be the same as the non-RP servers).
```