### PR TITLE
Further clamped Character Limits on AI Law Boards

### DIFF
--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -20,7 +20,7 @@ AI MODULES
 	throw_speed = 3
 	throw_range = 15
 	mats = 8
-	var/input_char_limit = 50
+	var/input_char_limit = 100
 	var/lawNumber = 0
 	var/lawTarget = null
 	// 1 = shows all laws, 0 = won't show law zero

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -242,7 +242,7 @@ AI MODULES
 /obj/item/aiModule/freeform
 	name = "'Freeform' AI Module"
 	lawNumber = 14
-	input_char_limit = 200
+	input_char_limit = 400
 
 	get_law_text(for_silicons)
 		return lawTarget ? lawTarget : "This law intentionally left blank."

--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -20,6 +20,7 @@ AI MODULES
 	throw_speed = 3
 	throw_range = 15
 	mats = 8
+	var/input_char_limit = 50
 	var/lawNumber = 0
 	var/lawTarget = null
 	// 1 = shows all laws, 0 = won't show law zero
@@ -38,7 +39,7 @@ AI MODULES
 		if (!user)
 			return
 		var/answer = input(user, text, title, default) as null|text
-		lawTarget = copytext(adminscrub(answer), 1, MAX_MESSAGE_LEN)
+		lawTarget = copytext(adminscrub(answer), 1, input_char_limit)
 		tooltip_rebuild = 1
 		boutput(user, "\The [src] now reads, \"[get_law_text(for_silicons=FALSE)]\".")
 
@@ -241,6 +242,7 @@ AI MODULES
 /obj/item/aiModule/freeform
 	name = "'Freeform' AI Module"
 	lawNumber = 14
+	input_char_limit = 200
 
 	get_law_text(for_silicons)
 		return lawTarget ? lawTarget : "This law intentionally left blank."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
default limit is set to ~~50~~ 100 chars
Freeform is set to ~~200~~ 400 chars
(Old limit was 1024 for all)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Abuse of non-freeform boards.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)MarkNstein
(*)AI Law Boards now have tighter character limits.
```
[BALANCE]