### PR TITLE
Prevent welders cauterising on harm

### DIFF
--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -48,7 +48,7 @@
 		if (!ismob(M))
 			return
 		src.add_fingerprint(user)
-		if (ishuman(M))
+		if (ishuman(M) && (user.a_intent != INTENT_HARM))
 			var/mob/living/carbon/human/H = M
 			if (H.bleeding || (H.butt_op_stage == 4 && user.zone_sel.selecting == "chest"))
 				if (!src.cautery_surgery(H, user, 15, src.welding))
@@ -107,6 +107,7 @@
 								return
 						else return ..()
 			else return ..()
+		else return ..()
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (isscrewingtool(W))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lit welders on harm intent always do damage.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Healing action on a Harm intent makes little sense to a user.
Simplifies using welders for damage rather than a unique interaction that can be difficult to understand in combat. Welders awkwardly alternate between damage and cauterizing if the target was bleeding.
Limb targeting with a lit welder would always try to cauterize if the target was missing a limb, using an unlit welder or anything else would do damage.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Welders will always do damage on harm intent rather than trying to cauterize bleeding.
```
