### PR TITLE
New customs booth and clothing shop on Destiny

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -2134,9 +2134,6 @@
 "aic" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hangar/main)
-"aie" = (
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/toilets)
 "aii" = (
 /obj/cable{
 	icon_state = "1-10"
@@ -2666,6 +2663,10 @@
 	dir = 1
 	},
 /obj/machinery/drainage,
+/obj/machinery/light/incandescent{
+	dir = 4;
+	nostick = 1
+	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "akg" = (
@@ -2719,10 +2720,13 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "akq" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/crewquarters/garbagegarbs)
 "akr" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -3123,9 +3127,7 @@
 /area/station/crew_quarters/quartersB)
 "ame" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
+/area/station/crewquarters/garbagegarbs)
 "amf" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -3475,11 +3477,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
-"ank" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M01"
-	})
 "anm" = (
 /obj/disposalpipe/switch_junction{
 	dir = 2;
@@ -3612,14 +3609,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
-"anW" = (
-/obj/machinery/light/incandescent/cool{
-	dir = 4;
-	nostick = 1
-	},
-/obj/storage/secure/closet/personal,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/showers)
 "aob" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -3851,19 +3840,12 @@
 	dir = 4;
 	pixel_x = -8
 	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/clothing/head/plunger,
-/obj/landmark{
-	name = "shitty_bill_respawn"
-	},
-/obj/machinery/light/incandescent/cool{
+/obj/machinery/light/incandescent{
 	dir = 1;
 	nostick = 1
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/toilets)
+/area/station/crew_quarters/showers)
 "apl" = (
 /obj/stool/chair/wooden,
 /turf/simulated/floor/black,
@@ -4452,19 +4434,6 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
-"aro" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 8;
-	name = "Crew Quarters"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
 "arp" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -4508,10 +4477,12 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "arA" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 1;
+	name = "Changing Room"
+	},
+/turf/simulated/floor/green,
+/area/station/crewquarters/garbagegarbs)
 "arD" = (
 /obj/stool/chair/comfy/purple,
 /obj/landmark/start{
@@ -4681,18 +4652,19 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/solar/west)
 "asi" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 8;
 	name = "Crew Quarters"
 	},
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
+/area/station/crewquarters/garbagegarbs)
 "asj" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -4851,20 +4823,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
-"asN" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 8;
-	name = "Crew Quarters"
-	},
-/obj/firedoor_spawn,
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
 "asQ" = (
 /obj/decal/tile_edge/line/blue{
 	dir = 6;
@@ -5780,11 +5738,13 @@
 	},
 /area/station/atmos/highcap_storage)
 "awA" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = 6
-	},
-/obj/machinery/drainage,
+/obj/storage/closet/dresser/random,
+/obj/item/clothing/under/shorts/red,
+/obj/item/clothing/under/shorts/purple,
+/obj/item/clothing/under/shorts/green,
+/obj/item/clothing/under/shorts/blue,
+/obj/item/clothing/under/shorts/black,
+/obj/item/clothing/suit/bathrobe,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "awB" = (
@@ -5949,10 +5909,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
-"axo" = (
-/obj/machinery/light/small/floor/blueish,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/showers)
 "axs" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -6315,9 +6271,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "ayN" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/drainage,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "ayP" = (
@@ -6664,18 +6618,8 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "aAE" = (
-/obj/machinery/drainage,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = 6
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/showers)
-"aAF" = (
-/obj/machinery/light/small/floor/blueish,
-/obj/cable{
-	icon_state = "2-4"
-	},
+/obj/submachine/laundry_machine,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "aAK" = (
@@ -6793,12 +6737,6 @@
 	dir = 1
 	},
 /area/station/science/lobby)
-"aBd" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/showers)
 "aBh" = (
 /obj/machinery/drainage,
 /obj/machinery/shower{
@@ -7026,10 +6964,8 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "aBX" = (
-/obj/machinery/light_switch/east{
-	dir = 4
-	},
-/obj/storage/secure/closet/personal,
+/obj/machinery/manufacturer/uniform,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "aBY" = (
@@ -7207,8 +7143,12 @@
 	name = "Genetic Research"
 	})
 "aCz" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/toilets)
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 4
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/showers)
 "aCC" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -7425,13 +7365,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
-"aDD" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/toilets)
 "aDE" = (
 /obj/decal/tile_edge/line/blue{
 	color = "#485e81";
@@ -7531,22 +7464,12 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "aEg" = (
-/obj/item/storage/toilet/random{
-	dir = 8;
-	pixel_x = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/landmark{
-	name = "shitty_bill_respawn"
-	},
-/obj/machinery/light/incandescent/cool{
+/obj/disposalpipe/segment{
 	dir = 1;
-	nostick = 1
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/toilets)
+/area/station/crew_quarters/showers)
 "aEB" = (
 /obj/decal/tile_edge/line/black{
 	dir = 1;
@@ -9099,15 +9022,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "aKe" = (
+/obj/machinery/door/airlock/pyro{
+	dir = 2;
+	name = "Restroom"
+	},
+/obj/firedoor_spawn,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro{
-	name = "Toilets"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/showers)
 "aKg" = (
 /obj/machinery/computer3/generic/communications,
 /obj/item/device/radio/intercom/bridge{
@@ -9423,6 +9347,9 @@
 	dir = 8;
 	nostick = 1
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/west{
 	name = "West Central Maintenance"
@@ -9547,20 +9474,20 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/mining/refinery)
-"aLB" = (
-/obj/submachine/laundry_machine,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
 "aLC" = (
-/obj/submachine/chef_sink{
-	pixel_y = 8
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4;
+	req_access = null
 	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/west{
+	name = "West Central Maintenance"
+	})
 "aLF" = (
 /obj/storage/closet/dresser,
 /obj/item/clothing/mask/wrestling,
@@ -9596,18 +9523,15 @@
 	dir = 10
 	},
 /area/station/crew_quarters/observatory)
-"aLJ" = (
-/obj/submachine/chef_sink{
-	pixel_y = 8
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
 "aLL" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "aLN" = (
 /obj/machinery/drainage,
 /obj/machinery/door/window/southright{
@@ -9615,13 +9539,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
-"aLR" = (
-/obj/machinery/disposal/small{
-	dir = 8
-	},
-/obj/disposalpipe/trunk,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
 "aMa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10275,17 +10192,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
-"aOT" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/inner/west{
-	name = "West Central Maintenance"
-	})
 "aOX" = (
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -10474,13 +10380,6 @@
 	dir = 1
 	},
 /area/station/science/lobby)
-"aPR" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/floor/blueish,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
 "aPT" = (
 /obj/cable{
 	icon_state = "2-5"
@@ -11046,20 +10945,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/west)
 "aUh" = (
-/obj/storage/closet/dresser/random,
-/obj/item/clothing/under/gimmick/kilt,
-/obj/item/instrument/bagpipe,
-/obj/item/clothing/under/gimmick/princess,
-/obj/item/instrument/saxophone,
-/obj/item/clothing/head/flatcap,
-/obj/item/clothing/suit/jacket/yellow,
-/obj/item/clothing/suit/jacket/plastic/random_color,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "aUk" = (
-/obj/item/storage/wall/clothingrack/clothes1,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/obj/machinery/computer/card,
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "aUl" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -11634,12 +11525,15 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "aWJ" = (
-/obj/machinery/clothingbooth,
-/obj/machinery/light/incandescent/cool{
-	nostick = 1
+/obj/machinery/manufacturer/hop_and_uniform,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname  - SS13";
+	tag = ""
 	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "aWK" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -11780,9 +11674,13 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "aXi" = (
-/obj/machinery/light/small/floor/blueish,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/obj/cable,
+/obj/machinery/power/apc/autoname_south,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "aXn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -11994,12 +11892,12 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aYi" = (
-/obj/machinery/manufacturer/uniform,
-/obj/machinery/light/incandescent/cool{
-	nostick = 1
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "aYk" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -12896,16 +12794,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
-"bdu" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M01"
-	})
 "bdL" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 8;
@@ -13127,13 +13015,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/science/bot_storage)
-"bfw" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Dressing Room"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/plating/random,
-/area/station/crew_quarters/bar)
 "bfz" = (
 /obj/fitness/weightlifter,
 /obj/decal/tile_edge/stripe{
@@ -13488,6 +13369,19 @@
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/sauna)
+"bhP" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
+	dir = 1
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "bhQ" = (
 /obj/cryotron{
 	layer = 3.9
@@ -15139,6 +15033,13 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"bsq" = (
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 1;
+	name = "Shower"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/showers)
 "bsu" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -17529,6 +17430,12 @@
 /obj/disposalpipe/segment/food,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"bBS" = (
+/obj/item/storage/wall/clothingrack/clothes4,
+/turf/simulated/floor/greenblack{
+	dir = 4
+	},
+/area/station/crewquarters/garbagegarbs)
 "bBT" = (
 /obj/window_blinds/cog2/left{
 	dir = 4
@@ -19595,15 +19502,11 @@
 /area/station/hallway/primary/southeast)
 "czr" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M01"
-	})
+/obj/machinery/power/apc/autoname_east,
+/turf/simulated/floor/black,
+/area/station/crewquarters/garbagegarbs)
 "czI" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/northwest)
@@ -19887,13 +19790,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/ranch)
-"cJB" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 1
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/west)
 "cJG" = (
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
@@ -20018,20 +19914,10 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "cMt" = (
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/drinks/bottle/hobo_wine,
-/obj/machinery/light/lamp/bright,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M01"
-	})
+/obj/storage/closet/wardrobe/pride,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/black,
+/area/station/crewquarters/garbagegarbs)
 "cMB" = (
 /obj/decal/tile_edge/line/red{
 	dir = 8;
@@ -20040,16 +19926,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "cMF" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "green2"
+/turf/simulated/floor/greenblack{
+	dir = 8
 	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
+/area/station/crewquarters/garbagegarbs)
 "cML" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -20710,6 +20596,14 @@
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/medical/head)
+"daf" = (
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 8;
+	name = "Crew Quarters"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
+/area/station/crewquarters/garbagegarbs)
 "das" = (
 /obj/window_blinds/cog2/left{
 	dir = 8
@@ -20888,21 +20782,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/clown)
 "deQ" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/yellow,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
+/obj/stool/bench/auto,
+/turf/simulated/floor/green,
+/area/station/crewquarters/garbagegarbs)
 "deR" = (
 /obj/disposalpipe/segment/mineral{
 	dir = 4;
@@ -22165,14 +22047,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
-"dIA" = (
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/light/small/floor/blueish,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
 "dIB" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -22324,6 +22198,9 @@
 	icon_state = "engine_caution_misc"
 	},
 /area/station/science/lab)
+"dMT" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/security/checkpoint/customs)
 "dMU" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -22383,17 +22260,6 @@
 	dir = 5
 	},
 /area/station/security/hos)
-"dOK" = (
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/autoname_north,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/showers)
 "dOL" = (
 /obj/decal/tile_edge/line/white{
 	icon_state = "line3"
@@ -23545,6 +23411,18 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
+"erP" = (
+/obj/disposalpipe/segment,
+/obj/machinery/light/emergency{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "erY" = (
 /obj/decal/tile_edge/line/green{
 	dir = 4;
@@ -26772,18 +26650,16 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "fLO" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
+/obj/machinery/disposal/small{
+	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "green2"
+/obj/disposalpipe/trunk{
+	dir = 4
 	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
+/turf/simulated/floor/greenblack{
+	dir = 4
+	},
+/area/station/crewquarters/garbagegarbs)
 "fLR" = (
 /obj/item/storage/wall/emergency{
 	pixel_y = 32
@@ -26972,19 +26848,6 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
-"fPF" = (
-/obj/potted_plant/potted_plant4{
-	dir = 1;
-	pixel_y = 32
-	},
-/obj/stool/chair/office/red,
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
 "fPK" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -27844,9 +27707,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/medical/dome)
 "gkn" = (
-/obj/machinery/light/small/floor/blueish,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/toilets)
+/area/station/crew_quarters/showers)
 "gkx" = (
 /obj/decal/poster/wallsign/framed_award/mdlicense{
 	pixel_y = 28
@@ -28098,6 +27961,12 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
+"goR" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "goT" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -28574,18 +28443,9 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/main)
 "gDl" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
-	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/green,
+/area/station/crewquarters/garbagegarbs)
 "gDo" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -28789,17 +28649,6 @@
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/courtroom)
-"gHR" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/pyro{
-	dir = 8;
-	name = "Restroom"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/locker)
 "gIg" = (
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -28870,19 +28719,9 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "gKs" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/bright,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
+/obj/item/storage/wall/clothingrack/hatrack/hatrack_2,
+/turf/simulated/floor/greenblack,
+/area/station/crewquarters/garbagegarbs)
 "gKy" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/clown)
@@ -30364,15 +30203,11 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "hwT" = (
-/obj/cable{
-	icon_state = "1-4"
+/obj/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
+/turf/simulated/floor/green,
+/area/station/crewquarters/garbagegarbs)
 "hxf" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -30523,6 +30358,12 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/heads)
+"hCu" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "hCD" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -30809,25 +30650,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/hallway/primary/north)
 "hLx" = (
-/obj/storage/closet/dresser/random,
-/obj/item/clothing/under/suit/dress{
-	desc = "A black dress. Very formal.";
-	name = "black dress"
+/obj/stool/chair/comfy/green{
+	dir = 4
 	},
-/obj/item/clothing/under/suit,
-/obj/item/clothing/under/shirt_pants,
-/obj/item/clothing/shoes/black,
-/obj/item/clothing/glasses/eyepatch{
-	name = "costume eyepatch"
-	},
-/obj/item/clothing/head/mime_beret,
-/obj/item/clothing/head/mime_bowler,
-/obj/item/clothing/under/misc/mime,
-/obj/item/clothing/under/misc/mime/alt,
-/obj/item/clothing/suit/suspenders,
-/obj/item/clothing/suit/scarf,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "hLU" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 1
@@ -31026,6 +30853,16 @@
 	},
 /turf/simulated/floor/red/checker,
 /area/station/security/main)
+"hTf" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/window/eastright,
+/obj/firedoor_spawn,
+/obj/access_spawn/head_of_personnel,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/security/checkpoint/customs)
 "hTw" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -31194,12 +31031,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
-"hZL" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
 "hZM" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -31474,11 +31305,6 @@
 /area/station/medical/head)
 "igr" = (
 /obj/disposalpipe/segment,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=central_hall3";
 	location = "bathroom";
@@ -31633,21 +31459,12 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/psychiatrist)
 "inP" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/red,
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/item/storage/wall/clothingrack/hatrack/hatrack_1,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/greenblack{
+	dir = 8
 	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
-	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
+/area/station/crewquarters/garbagegarbs)
 "ioe" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
@@ -32043,16 +31860,6 @@
 	icon_state = "fblue1"
 	},
 /area/station/engine/engineering/ce)
-"iyz" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
 "iyB" = (
 /obj/item/storage/wall/fire{
 	pixel_y = 32
@@ -32294,16 +32101,12 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/medbay/restroom)
-"iGY" = (
+"iGm" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/item/device/radio/beacon,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "iHc" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -32728,16 +32531,6 @@
 /obj/access_spawn/research,
 /turf/simulated/floor/plating/random,
 /area/station/science/lobby)
-"iWD" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
 "iWQ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -32830,22 +32623,6 @@
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "jaZ" = (
-/obj/table/round/auto,
-/obj/item/shaker/mustard{
-	pixel_x = -1;
-	pixel_y = 8
-	},
-/obj/item/shaker/ketchup{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/item/shaker/pepper{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/shaker/salt{
-	pixel_x = 3
-	},
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -32922,9 +32699,13 @@
 /turf/simulated/floor/white,
 /area/station/maintenance/inner/south)
 "jdu" = (
-/obj/machinery/bathtub{
-	anchored = 1;
-	dir = 8
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/machinery/drainage,
+/obj/machinery/light/incandescent{
+	dir = 8;
+	nostick = 1
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
@@ -33860,16 +33641,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/medical/robotics)
-"jDh" = (
-/obj/machinery/drainage,
-/obj/table,
-/obj/towelbin,
-/obj/item/reagent_containers/bath_bomb,
-/obj/item/reagent_containers/bath_bomb,
-/obj/item/reagent_containers/bath_bomb,
-/obj/item/reagent_containers/bath_bomb,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/showers)
 "jDp" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -34033,21 +33804,13 @@
 	},
 /area/station/crew_quarters/bar)
 "jGW" = (
-/obj/stool/bed,
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/machinery/manufacturer/uniform,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	name = "autoname - SS13"
 	},
-/obj/item/clothing/suit/bedsheet/pink,
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M01"
-	})
+/turf/simulated/floor/black,
+/area/station/crewquarters/garbagegarbs)
 "jHi" = (
 /obj/landmark/gps_waypoint,
 /obj/disposalpipe/segment,
@@ -34560,21 +34323,25 @@
 /turf/simulated/floor,
 /area/station/hangar/qm)
 "jWD" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/pink,
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/storage/closet/dresser/random,
+/obj/item/clothing/under/suit/dress{
+	desc = "A black dress. Very formal.";
+	name = "black dress"
 	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/obj/item/clothing/under/suit,
+/obj/item/clothing/under/shirt_pants,
+/obj/item/clothing/shoes/black,
+/obj/item/clothing/glasses/eyepatch{
+	name = "costume eyepatch"
 	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M01"
-	})
+/obj/item/clothing/head/mime_beret,
+/obj/item/clothing/head/mime_bowler,
+/obj/item/clothing/under/misc/mime,
+/obj/item/clothing/under/misc/mime/alt,
+/obj/item/clothing/suit/suspenders,
+/obj/item/clothing/suit/scarf,
+/turf/simulated/floor/black,
+/area/station/crewquarters/garbagegarbs)
 "jWF" = (
 /obj/disposalpipe/segment,
 /obj/machinery/firealarm{
@@ -34735,6 +34502,17 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
+"keg" = (
+/obj/table/reinforced/auto,
+/obj/machinery/door/window/eastleft,
+/obj/firedoor_spawn,
+/obj/access_spawn/head_of_personnel,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/cashreg,
+/turf/simulated/floor/plating/random,
+/area/station/security/checkpoint/customs)
 "kek" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37095,21 +36873,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
 "ltJ" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/red,
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/item/storage/wall/clothingrack/clothes3,
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/greenblack{
+	dir = 4
 	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
+/area/station/crewquarters/garbagegarbs)
 "luc" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -37652,16 +37421,11 @@
 	},
 /area/space)
 "lMu" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/stool/chair/green,
+/turf/simulated/floor/greenblack{
+	dir = 8
 	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
+/area/station/crewquarters/garbagegarbs)
 "lME" = (
 /obj/storage/crate{
 	desc = "A private crate that isn't yours.";
@@ -37916,11 +37680,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
-"lSE" = (
-/obj/disposalpipe/segment,
-/obj/stool/chair/moveable,
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "lSP" = (
 /obj/machinery/chem_master{
 	dir = 8
@@ -38394,11 +38153,16 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "mfj" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4;
+	req_access = null
 	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/inner/west{
+	name = "West Central Maintenance"
+	})
 "mgA" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -39201,6 +38965,10 @@
 /obj/access_spawn/tech_storage,
 /turf/simulated/floor/plating/random,
 /area/station/storage/tech)
+"mDE" = (
+/obj/submachine/laundry_machine,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/showers)
 "mDH" = (
 /obj/item/constructioncone,
 /obj/cable{
@@ -39615,6 +39383,13 @@
 	dir = 4
 	},
 /area/station/security/main)
+"mNm" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/showers)
 "mNz" = (
 /obj/machinery/disposal/mail/small{
 	dir = 1;
@@ -39640,14 +39415,12 @@
 /area/station/hallway/primary/central)
 "mOK" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "blue2"
+/turf/simulated/floor/greenblack{
+	dir = 4
 	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
+/area/station/crewquarters/garbagegarbs)
 "mOP" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -39970,6 +39743,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/hallway/secondary/entry)
+"nba" = (
+/turf/simulated/floor/greenblack{
+	dir = 8
+	},
+/area/station/crewquarters/garbagegarbs)
 "nbl" = (
 /obj/decal/tile_edge/line/blue{
 	color = "#485e81";
@@ -40203,21 +39981,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
-"nhb" = (
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/drinks/bottle/hobo_wine,
-/obj/machinery/light/lamp/bright,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
 "nhd" = (
 /obj/machinery/door/airlock/pyro/external,
 /obj/firedoor_spawn,
@@ -41303,15 +41066,14 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "nKA" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
+/turf/simulated/floor/green,
+/area/station/crewquarters/garbagegarbs)
 "nLc" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -42249,19 +42011,6 @@
 /obj/machinery/nanofab/refining,
 /turf/simulated/floor,
 /area/station/mining/staff_room)
-"omk" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 8
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/inner/west{
-	name = "West Central Maintenance"
-	})
 "omH" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
@@ -42632,14 +42381,10 @@
 /area/station/engine/gas)
 "owD" = (
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M01"
-	})
+/turf/simulated/floor/black,
+/area/station/crewquarters/garbagegarbs)
 "owE" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -42788,15 +42533,10 @@
 	},
 /area/station/crew_quarters/quartersA)
 "ozR" = (
-/obj/cable{
-	icon_state = "1-4"
+/turf/simulated/floor/greenblack{
+	dir = 1
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
+/area/station/crewquarters/garbagegarbs)
 "oAr" = (
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
@@ -45487,21 +45227,16 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "qaD" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/yellow,
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/machinery/light/incandescent/netural,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	name = "autoname - SS13"
 	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/turf/simulated/floor/greenblack/corner{
+	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
+/area/station/crewquarters/garbagegarbs)
 "qaT" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -46100,6 +45835,16 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
+"qrh" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/mail,
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "qrn" = (
 /obj/reagent_dispensers/watertank/fountain,
 /turf/simulated/floor/purple,
@@ -46287,15 +46032,6 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/engineering/ce)
-"qzf" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/toilets)
 "qzq" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -46569,6 +46305,17 @@
 /area/station/crew_quarters/hor{
 	name = "Research Director's Quarters"
 	})
+"qFk" = (
+/obj/machinery/door/airlock/pyro{
+	dir = 8;
+	name = "Restroom"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/showers)
 "qFK" = (
 /obj/potted_plant/potted_plant3,
 /turf/simulated/floor/wood/eight{
@@ -46651,8 +46398,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "qHP" = (
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/obj/machinery/disposal/small,
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "qHX" = (
 /obj/table/reinforced/auto,
 /obj/item/kitchen/utensil/knife,
@@ -47404,19 +47155,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/hallway/secondary/construction)
 "rcJ" = (
-/obj/table/wood/auto,
-/obj/machinery/light/lamp/bright,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
+/turf/simulated/floor/green,
+/area/station/crewquarters/garbagegarbs)
 "rcZ" = (
 /obj/decal/tile_edge/stripe{
 	dir = 6;
@@ -47522,16 +47262,17 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "rfz" = (
-/obj/machinery/recharge_station,
-/obj/landmark/start{
-	name = "Cyborg"
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 4
 	},
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/toilets)
+/area/station/crew_quarters/showers)
 "rgt" = (
 /obj/cable,
 /obj/cable{
@@ -47934,18 +47675,8 @@
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "rtC" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
-	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M01"
-	})
+/turf/simulated/floor/black,
+/area/station/crewquarters/garbagegarbs)
 "rtF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -48523,6 +48254,18 @@
 	dir = 1
 	},
 /area/station/science/lobby)
+"rIj" = (
+/obj/machinery/door/airlock/pyro/glass/command,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/head_of_personnel,
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "rIl" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -49415,18 +49158,13 @@
 	},
 /area/station/bridge)
 "sjk" = (
-/obj/potted_plant/potted_plant5{
-	dir = 1;
-	pixel_y = 32
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/stool/chair/office/green,
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "green2"
+/turf/simulated/floor/greenblack{
+	dir = 6
 	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
+/area/station/crewquarters/garbagegarbs)
 "sjv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -50340,6 +50078,13 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
+"sOn" = (
+/obj/machinery/disposal/small{
+	dir = 8
+	},
+/obj/disposalpipe/trunk,
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/showers)
 "sOM" = (
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -50889,18 +50634,11 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/pharmacy)
 "tbI" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
+/obj/item/storage/wall/clothingrack/clothes2,
+/turf/simulated/floor/greenblack/corner{
+	dir = 8
 	},
-/turf/simulated/floor/carpet{
-	dir = 10;
-	icon_state = "red2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
+/area/station/crewquarters/garbagegarbs)
 "tbU" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -51137,10 +50875,10 @@
 /area/station/hallway/primary/southeast)
 "tgT" = (
 /obj/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/toilets)
+/area/station/crew_quarters/showers)
 "thi" = (
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-L"
@@ -51468,9 +51206,12 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/psychiatrist)
 "trO" = (
-/obj/storage/closet/wardrobe/pride,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/obj/machinery/computer/bank_data{
+	dir = 4
+	},
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "trW" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -52879,14 +52620,9 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "uev" = (
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/table/auto,
-/obj/towelbin,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/locker)
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "ueV" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 4
@@ -54143,6 +53879,13 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
+"uKi" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/junction,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "uKk" = (
 /obj/disposalpipe/trunk/mail{
 	dir = 8
@@ -54429,16 +54172,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
-"uRj" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/pyro{
-	name = "showers"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/toilets)
 "uRB" = (
 /obj/landmark/gps_waypoint,
 /obj/cable{
@@ -54666,18 +54399,11 @@
 	},
 /area/station/crew_quarters/quartersC)
 "uXo" = (
-/obj/potted_plant/potted_plant3{
-	dir = 1;
-	pixel_y = 32
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/stool/chair/office/yellow,
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M02"
-	})
+/turf/simulated/floor/greenblack/corner,
+/area/station/crewquarters/garbagegarbs)
 "uXs" = (
 /obj/machinery/light{
 	dir = 4
@@ -55051,6 +54777,15 @@
 /obj/disposalpipe/trunk,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
+"veJ" = (
+/obj/table/auto,
+/obj/machinery/cashreg{
+	name = "Clothing Store credit transfer device"
+	},
+/turf/simulated/floor/greenblack{
+	dir = 8
+	},
+/area/station/crewquarters/garbagegarbs)
 "veL" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/brute,
@@ -55389,9 +55124,6 @@
 	},
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/supply)
-"vpb" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/solar/east)
 "vpo" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56224,18 +55956,16 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "vNt" = (
-/obj/potted_plant/potted_plant2{
-	dir = 1;
-	pixel_y = 32
-	},
-/obj/stool/chair/office/purple,
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "purple2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M01"
-	})
+/obj/storage/closet/dresser/random,
+/obj/item/clothing/under/gimmick/kilt,
+/obj/item/instrument/bagpipe,
+/obj/item/clothing/under/gimmick/princess,
+/obj/item/instrument/saxophone,
+/obj/item/clothing/head/flatcap,
+/obj/item/clothing/suit/jacket/yellow,
+/obj/item/clothing/suit/jacket/plastic/random_color,
+/turf/simulated/floor/black,
+/area/station/crewquarters/garbagegarbs)
 "vNP" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -57270,6 +57000,21 @@
 	dir = 4
 	},
 /area/station/science/artifact)
+"wrM" = (
+/obj/storage/closet/dresser/random,
+/obj/item/clothing/under/shorts/red,
+/obj/item/clothing/under/shorts/purple,
+/obj/item/clothing/under/shorts/green,
+/obj/item/clothing/under/shorts/blue,
+/obj/item/clothing/under/shorts/black,
+/obj/item/clothing/suit/bathrobe,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/crew_quarters/showers)
 "wsb" = (
 /obj/decal/tile_edge/line/blue{
 	color = "#485e81";
@@ -57288,8 +57033,13 @@
 	},
 /area/station/crew_quarters/pool)
 "wsc" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/locker)
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/turf/simulated/floor/black,
+/area/station/security/checkpoint/customs)
 "wsz" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 4
@@ -57739,11 +57489,12 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "wDY" = (
-/obj/machinery/door/unpowered/wood/stall{
-	lock_dir = 8
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 8;
+	name = "Toilet"
 	},
 /turf/simulated/floor/sanitary,
-/area/station/crew_quarters/toilets)
+/area/station/crew_quarters/showers)
 "wEa" = (
 /obj/disposalpipe/segment{
 	dir = 8
@@ -58041,6 +57792,16 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"wLA" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/security/checkpoint/customs)
 "wLJ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/detectives_office)
@@ -58917,21 +58678,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/science/testchamber)
 "xlF" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/green,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
-	},
-/turf/simulated/floor/carpet{
-	dir = 9;
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
+/turf/simulated/floor/greenblack/corner,
+/area/station/crewquarters/garbagegarbs)
 "xmb" = (
 /obj/landmark/start{
 	name = "Geneticist"
@@ -59121,19 +58869,6 @@
 /area/station/medical/research{
 	name = "Genetic Research"
 	})
-"xqc" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 8;
-	name = "Crew Quarters"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M01"
-	})
 "xqi" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 1;
@@ -59174,6 +58909,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
+"xqT" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/security/checkpoint/customs)
 "xrf" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/south)
@@ -59205,21 +58950,14 @@
 /turf/simulated/floor/yellow,
 /area/station/mining/refinery)
 "xrW" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet/green,
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/item/storage/secure/ssafe{
-	pixel_y = 28
+/turf/simulated/floor/greenblack{
+	dir = 8
 	},
-/turf/simulated/floor/carpet{
-	dir = 5;
-	icon_state = "green2"
-	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M03"
-	})
+/area/station/crewquarters/garbagegarbs)
 "xsa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -59724,16 +59462,16 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
 "xEg" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/machinery/clothingbooth,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 10;
+	name = "autoname - SS13"
 	},
-/turf/simulated/floor/carpet{
-	dir = 6;
-	icon_state = "red2"
+/turf/simulated/floor/greenblack/corner{
+	dir = 1
 	},
-/area/station/crew_quarters/quartersA{
-	name = "Crew Quarters M04"
-	})
+/area/station/crewquarters/garbagegarbs)
 "xFd" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -59871,6 +59609,16 @@
 	dir = 8
 	},
 /area/station/hydroponics/bay)
+"xID" = (
+/obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/greenblack{
+	dir = 4
+	},
+/area/station/crewquarters/garbagegarbs)
 "xIO" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -60450,15 +60198,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/sec)
-"xZR" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/stool/chair/moveable{
-	dir = 8
-	},
-/turf/simulated/floor/black,
-/area/station/hallway/primary/central)
 "xZV" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 8;
@@ -60664,9 +60403,6 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
 /area/station/engine/gas)
-"yfE" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/solar/west)
 "yfL" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -100995,7 +100731,7 @@ bkt
 bkt
 aJL
 aLg
-aOT
+azi
 aFK
 qOx
 aFK
@@ -101296,8 +101032,8 @@ bkt
 aGs
 xqm
 azi
-aMm
 fEO
+aMm
 aFK
 aFK
 aFK
@@ -101598,10 +101334,10 @@ ayV
 azi
 aMm
 aMm
-aMm
 fEO
 aMm
-cJB
+aMm
+vii
 vBV
 vBV
 vBV
@@ -101900,8 +101636,8 @@ azi
 aMm
 aMm
 aMm
-aMm
 fEO
+aMm
 aMm
 aFK
 vBV
@@ -102202,9 +101938,9 @@ aMm
 aMm
 aMm
 xTa
-xTa
-omk
-xTa
+fEO
+aMm
+aMm
 aFK
 vBV
 vBV
@@ -102499,15 +102235,15 @@ aMm
 auZ
 azi
 aMm
-aCz
-aCz
-aCz
-aCz
-wsc
-qHP
-aPR
-qHP
-vii
+brp
+brp
+brp
+brp
+brp
+fEO
+aMm
+aMm
+aFK
 vBV
 vBV
 lbp
@@ -102801,14 +102537,14 @@ qOS
 aMm
 vaP
 aMm
-aCz
+brp
 apk
-aCz
+brp
 apk
-wsc
-aLB
-mfj
-qHP
+brp
+fEO
+aMm
+aMm
 aFK
 aUI
 aWs
@@ -103089,7 +102825,7 @@ aaa
 uNs
 aWn
 aXq
-yfE
+arP
 arP
 bkt
 bkt
@@ -103103,17 +102839,17 @@ xTa
 brp
 brp
 brp
-aCz
+brp
 wDY
-aCz
+brp
 wDY
-wsc
+brp
 aLC
 mfj
-qHP
-aFK
-aFK
-aFK
+dMT
+dMT
+dMT
+dMT
 lbp
 bkh
 uCX
@@ -103391,7 +103127,7 @@ arP
 arP
 asz
 arP
-yfE
+arP
 awP
 cEG
 glY
@@ -103403,16 +103139,16 @@ brp
 brp
 brp
 awA
-brp
+wrM
 aAE
-aCz
-aDD
+mDE
+vfC
 gkn
-aie
-wsc
-aLJ
-aPR
-qHP
+vfC
+brp
+xWf
+uSJ
+dMT
 aUh
 trO
 aWJ
@@ -103703,20 +103439,20 @@ rVY
 xeC
 brp
 jdu
+bsq
 vfC
-axo
 vfC
-aAF
-uRj
-qzf
-tgT
+vfC
+vfC
+vfC
+vfC
 tgT
 aKe
 aLL
-iGY
-qHP
-qHP
-qHP
+eEC
+rIj
+hCu
+iGm
 qHP
 lbp
 bkh
@@ -104005,22 +103741,22 @@ aBs
 pXL
 brp
 brp
-dOK
+brp
+vfC
 ayN
-ayN
-aBd
-aCz
-wDY
-aCz
-wDY
-wsc
+vfC
+vfC
+vfC
+vfC
+mNm
+brp
 uev
-hZL
-qHP
-qHP
-qHP
+uSJ
+wLA
+aUh
+goR
 aXi
-bfw
+lbp
 bjv
 uCX
 mOZ
@@ -104307,18 +104043,18 @@ gEh
 amJ
 brp
 akf
+bsq
+gkn
 vfC
-jDh
-anW
 aBX
-aCz
+sOn
 aEg
 aCz
 rfz
-wsc
-aLR
-dIA
-qHP
+brp
+uSJ
+uSJ
+wLA
 aUk
 hLx
 aYi
@@ -104586,15 +104322,15 @@ aNg
 aIZ
 apT
 qcS
-ank
-ank
-ank
-akq
-akq
-akq
-arA
-arA
-arA
+ame
+ame
+ame
+ame
+ame
+ame
+ame
+ame
+ame
 ame
 ame
 ame
@@ -104613,16 +104349,16 @@ brp
 brp
 brp
 brp
-aCz
-aCz
-aCz
-aCz
-wsc
-wsc
-gHR
-wsc
-wsc
-wsc
+brp
+qFk
+brp
+brp
+brp
+uSJ
+uSJ
+xqT
+keg
+hTf
 wsc
 lbp
 lbp
@@ -104888,16 +104624,16 @@ eQZ
 jsQ
 apT
 aAl
-ank
+ame
 jGW
 rtC
-akq
+ame
 deQ
 gDl
 arA
 xlF
 fLO
-ame
+bBS
 ltJ
 tbI
 bhX
@@ -104916,16 +104652,16 @@ kCe
 arY
 arY
 arY
-arY
+awp
 fEh
 kCe
 arY
 arY
-awp
-jHN
+arY
+erP
 igr
-uxF
-lSE
+arY
+awp
 jaZ
 rLJ
 nje
@@ -105190,16 +104926,16 @@ uZV
 tkJ
 apT
 xas
-ank
+ame
 cMt
-bdu
-akq
-nhb
-iWD
-arA
+rtC
+ame
+ame
+ame
+ame
 gKs
 hwT
-ame
+rcJ
 rcJ
 ozR
 bhX
@@ -105228,7 +104964,7 @@ uSJ
 uSJ
 fUR
 pDe
-xZR
+vry
 gvA
 fXk
 iem
@@ -105492,18 +105228,18 @@ kJe
 aVl
 apT
 iyB
-ank
+ame
 vNt
 owD
 akq
 uXo
 mOK
-arA
+xID
 sjk
 nKA
-ame
-fPF
-iyz
+rcJ
+rcJ
+ozR
 bhX
 nvB
 uSP
@@ -105794,16 +105530,16 @@ kJe
 cqv
 apT
 kTa
-ank
+ame
 jWD
 czr
-akq
+ame
 qaD
 lMu
-arA
+veJ
 xrW
 cMF
-ame
+nba
 inP
 xEg
 bhX
@@ -106096,18 +105832,18 @@ ajc
 aiI
 apT
 sRe
-ank
-ank
-xqc
-akq
-akq
-aro
-arA
-arA
+ame
+ame
+ame
+ame
+ame
+ame
+ame
+ame
 asi
+daf
 ame
 ame
-asN
 bhX
 eQM
 eQM
@@ -106400,16 +106136,16 @@ aKq
 aql
 ajY
 arY
-aql
+arY
 jHN
 arY
 aql
 waX
 aSB
-aql
+uKi
+arY
 jHN
 jWF
-aql
 ajY
 arY
 arY
@@ -106702,7 +106438,7 @@ aKw
 ajS
 kek
 kek
-vxk
+bhP
 opK
 kek
 vxk
@@ -106711,7 +106447,7 @@ hoL
 jtP
 aks
 cGP
-jtP
+qrh
 dUv
 aks
 aks
@@ -109727,7 +109463,7 @@ vvE
 rWB
 apR
 apR
-vpb
+nrA
 vne
 uGe
 vVd
@@ -110029,12 +109765,12 @@ aaa
 aaa
 aaa
 aaa
-vpb
-vpb
-vpb
-vpb
+nrA
+nrA
+nrA
+nrA
 iqW
-vpb
+nrA
 nnS
 tFq
 aSo
@@ -110338,7 +110074,7 @@ uNs
 kga
 aXT
 nrA
-vpb
+nrA
 aAM
 aAM
 ast


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a customs booth near the bridge, reduces the size of the locker room/showers/restroom
Replaces a few of the crew quarters with a clothing shop


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Destiny was lacking a second customs area for the HoP to use. If the HoP wanted to sit in their office and change IDs they're aaaaallll the way at the tip of the ship where no one will see or find them. The clothing shop was just a small thing I added to free up space in the locker room.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sord
(+)Destiny now has a customs booth near the bridge, as well as a new clothing shop replacing some of the old crew quarters!
```
