### PR TITLE
Changes ww serum to require 3 units to infect instead of 0 units

### DIFF
--- a/code/modules/chemistry/Reagents-Diseases.dm
+++ b/code/modules/chemistry/Reagents-Diseases.dm
@@ -71,7 +71,7 @@ datum
 			id = "werewolf_serum"
 			description = "A mutagenic substance associated with a mythical beast."
 			reagent_state = LIQUID
-			minimum_to_infect = 0
+			minimum_to_infect = 3
 			fluid_r = 173
 			fluid_g = 65
 			fluid_b = 133


### PR DESCRIPTION
[BALANCE]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes ww serum to need 3 units to infect somebody with lycanthropy instead of the previous 0


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Using 1 unit of ww serum you can dilute it into incredibly small amounts then turn the entire server into werewolfs which isnt fun for antags/sec who have to deal with tons of people that can instantly stun them.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)Werewolf serum requires 3 u to infect lycanthropy instead of 0 u
```
