### PR TITLE
Fix Wraith triggering crusher

### DIFF
--- a/code/WorkInProgress/recycling/crusher.dm
+++ b/code/WorkInProgress/recycling/crusher.dm
@@ -28,6 +28,11 @@
 	if(istype(AM,/obj/item/scrap) || istype(AM, /obj/fluid) || istype(AM, /obj/decal) || isobserver(AM) || isintangible(AM) || istype(AM, /obj/machinery/conveyor))
 		return
 
+	if(istype(AM,/mob/wraith))
+		var/mob/wraith/W = AM
+		if(!W.haunting)
+			return
+
 	if(!(AM.temp_flags & BEING_CRUSHERED))
 		actions.start(new /datum/action/bar/crusher(AM), src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents ghost form wraith being crushered.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ghost form wraith triggers crusher and would be killed eventually.
Currently there seems to be no risk to a player unless they sit there for the whole action bar but it shouldn't really happen.
Haunting wraiths still get crushered as they are a physical form.