### PR TITLE
Changes ling island iced tea recipes heat when being created

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1315,14 +1315,9 @@ datum
 			id = "lingtea"
 			result = "lingtea"
 			required_reagents = list("longisland" = 1, "neurotoxin" = 1)
+			required_temperature = T0C + 100
 			result_amount = 2
 			mix_phrase = "The toxin upsets the delicate balance of alcohol and sours in this mix. Ew."
-
-			does_react(var/datum/reagents/holder)
-				if(holder?.my_atom?.is_open_container())
-					return 1
-				else
-					return
 
 		cocktail_longbeach
 			name = "Long Beach Iced Tea"

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1314,7 +1314,7 @@ datum
 			name = "Ling Island Iced Tea"
 			id = "lingtea"
 			result = "lingtea"
-			required_reagents = list("longisland" = 1, "neurotoxin" = 1)
+			required_reagents = list("longisland" = 1, "capulettium" = 1)
 			result_amount = 2
 			mix_phrase = "The toxin upsets the delicate balance of alcohol and sours in this mix. Ew."
 

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1314,9 +1314,15 @@ datum
 			name = "Ling Island Iced Tea"
 			id = "lingtea"
 			result = "lingtea"
-			required_reagents = list("longisland" = 1, "capulettium" = 1)
+			required_reagents = list("longisland" = 1, "neurotoxin" = 1)
 			result_amount = 2
 			mix_phrase = "The toxin upsets the delicate balance of alcohol and sours in this mix. Ew."
+
+			does_react(var/datum/reagents/holder)
+				if(holder?.my_atom?.is_open_container())
+					return 1
+				else
+					return
 
 		cocktail_longbeach
 			name = "Long Beach Iced Tea"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes ling island iced tea to need to be heated when being created.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Using the long island iced tea recipe you can instantly purge all neurotoxin which isnt fun for lings who have one of their abilities rendered pretty much useless. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)Ling Island Iced Tea recipe now requires heating to 100C when being created.
```
