### PR TITLE
Fixes hotspot logging runtimes

### DIFF
--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -159,6 +159,13 @@ var/datum/explosion_controller/explosions
 	proc/logMe(var/power)
 		//I do not give a flying FUCK about what goes on in the colosseum. =I
 		if(!istype(get_area(epicenter), /area/colosseum))
+
+			if(istype(source,  /datum/sea_hotspot))
+				var/logmsg = "Hotspot explosion with power [power] at [log_loc(epicenter)]."
+				logTheThing("bombing", null, null, logmsg)
+				logTheThing("diary", null, null, logmsg, "combat")
+				return
+
 			// Cannot read null.name
 			var/logmsg = "Explosion with power [power] (Source: [source ? "[source.name]" : "*unknown*"])  at [log_loc(epicenter)]. Source last touched by: [key_name(source?.fingerprintslast)] (usr: [ismob(user) ? key_name(user) : user])"
 			if(power > 10)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor] [runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Explosions are expected to be caused by an atom, with a `name` and such. When a datum causes them, it creates a lot of runtimes. 

Current approach is just 'copy regular explosion logging but make it work with hotspots'. If that feels too spammy, I could just fix the runtime without adding actual logging. Lemme know.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes bad