### PR TITLE
Banana Peeling Text Fix

### DIFF
--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -895,8 +895,8 @@
 
 				return
 			boutput(user, "<span class='notice'>You peel [src].</span>")
-			src.name = copytext(src.name, 10)	// "unpeeled "
-			//src.name = "banana"
+			var/index = findtext(src.name, "unpeeled")
+			src.name = splicetext(src.name, index, index + 9)
 			src.icon_state = "banana-fruit"
 			new /obj/item/bananapeel(user.loc)
 		else


### PR DESCRIPTION
[BUG]

## About the PR
The previous text manipulation assumed that "unpeeled" would always be the first word in the name,
which isn't true when for example the banana has some quality prefix attached to it, or it was
spawned in as someone's trinket.

As for the fix, I basically made it first look for the starting position of the "unpeeled" text
and then use that with the `splicetext()` proc to remove "unpeeled " from the name while
preserving anything that occurred before it.

Fixes #5751.

## Why's this needed?
This will fix the issue with "eeled banana" named peeled bananas and the like while also
keeping any text that could appear before "unpeeled" so that you can for example
tell when this was someone's trinket that was just peeled or that this banana was
rotten.