### PR TITLE
Improves-Alcohol-Bottles-Capacity

### DIFF
--- a/code/modules/food_and_drink/alcohol.dm
+++ b/code/modules/food_and_drink/alcohol.dm
@@ -52,8 +52,8 @@
 	g_amt = 40
 	bottle_style = "wine"
 	label = "wine"
-	initial_volume = 50
-	initial_reagents = list("wine"=30)
+	initial_volume = 100
+	initial_reagents = list("wine"=60)
 
 /obj/item/reagent_containers/food/drinks/bottle/hobo_wine
 	name = "fortified wine"
@@ -66,8 +66,8 @@
 	label = "vermouth"
 	alt_filled_state = 1
 	var/safe = 0
-	initial_volume = 50
-	initial_reagents = list("wine"=20,"ethanol"=5)
+	initial_volume = 100
+	initial_reagents = list("wine"=80,"ethanol"=20)
 
 	New()
 		..()
@@ -107,8 +107,8 @@
 	alt_filled_state = 1
 	heal_amt = 1
 	g_amt = 60
-	initial_volume = 50
-	initial_reagents = list("champagne"=30)
+	initial_volume = 100
+	initial_reagents = list("champagne"=60)
 	var/makes_shards_on_break = 1
 
 	afterattack(obj/O as obj, mob/user as mob)
@@ -147,8 +147,8 @@
 		alt_filled_state = 1
 		heal_amt = 1
 		g_amt = 60
-		initial_volume = 50
-		initial_reagents = list("champagne"=30)
+		initial_volume = 100
+		initial_reagents = list("champagne"=60)
 
 	breakaway_glass
 		makes_shards_on_break = 0
@@ -172,23 +172,23 @@
 	label = "spicedrum"
 	alt_filled_state = 1
 	heal_amt = 1
-	initial_volume = 50
-	initial_reagents = list("rum"=30)
+	initial_volume = 100
+	initial_reagents = list("rum"=60)
 
 /obj/item/reagent_containers/food/drinks/rum_spaced
 	name = "spaced rum"
 	desc = "Rum which has been exposed to cosmic radiation. Don't worry, radiation does everything!"
 	icon_state = "rum"
 	heal_amt = 1
-	initial_volume = 60
-	initial_reagents = list("rum"=30,"yobihodazine"=30)
+	initial_volume = 120
+	initial_reagents = list("rum"=60,"yobihodazine"=60)
 
 /obj/item/reagent_containers/food/drinks/grog
 	name = "Ye Olde Grogge"
 	desc = "The dusty glass bottle has caustic fumes wafting out of it. You're not sure drinking it is a good idea."
 	icon_state = "moonshine"
 	heal_amt = 0
-	initial_volume = 60
+	initial_volume = 120
 	initial_reagents = "grog"
 
 /obj/item/reagent_containers/food/drinks/bottle/mead
@@ -222,8 +222,8 @@
 	label = "none"
 	heal_amt = 1
 	g_amt = 60
-	initial_volume = 50
-	initial_reagents = list("vodka"=30)
+	initial_volume = 100
+	initial_reagents = list("vodka"=60)
 
 /obj/item/reagent_containers/food/drinks/bottle/vodka/vr
 	icon_state = "vr_vodka"
@@ -239,8 +239,8 @@
 	alt_filled_state = 1
 	heal_amt = 1
 	g_amt = 60
-	initial_volume = 50
-	initial_reagents = list("tequila"=30)
+	initial_volume = 100
+	initial_reagents = list("tequila"=60)
 
 /obj/item/reagent_containers/food/drinks/bottle/gin
 	name = "gin"
@@ -252,8 +252,8 @@
 	alt_filled_state = 1
 	heal_amt = 1
 	g_amt = 60
-	initial_volume = 50
-	initial_reagents = list("gin"=30)
+	initial_volume = 100
+	initial_reagents = list("gin"=60)
 
 /obj/item/reagent_containers/food/drinks/bottle/ntbrew
 	name = "NanoTrasen Brew"
@@ -265,8 +265,8 @@
 	alt_filled_state = 1
 	heal_amt = 1
 	g_amt = 60
-	initial_volume = 60
-	initial_reagents = list("wine"=40,"charcoal"=20)
+	initial_volume = 120
+	initial_reagents = list("wine"=80,"charcoal"=40)
 
 /obj/item/reagent_containers/food/drinks/bottle/thegoodstuff
 	name = "Stinkeye's Special Reserve"
@@ -291,7 +291,7 @@
 	alt_filled_state = 1
 	heal_amt = 1
 	g_amt = 40
-	initial_volume = 60
+	initial_volume = 120
 	initial_reagents = "bojack"
 
 /obj/item/reagent_containers/food/drinks/moonshine
@@ -309,7 +309,7 @@
 	icon_state = "curacao"
 	heal_amt = 1
 	rc_flags = RC_FULLNESS
-	initial_volume = 50
+	initial_volume = 100
 	initial_reagents = "curacao"
 
 /obj/item/reagent_containers/food/drinks/dehab
@@ -379,7 +379,7 @@
 	g_amt = 40
 	bottle_style = "vermouthC"
 	label = "label-none"
-	initial_volume = 50
+	initial_volume = 100
 
 /obj/item/reagent_containers/food/drinks/bottle/empty/tall
 	name = "tall bottle"
@@ -391,7 +391,7 @@
 	alt_filled_state = 1
 	heal_amt = 1
 	g_amt = 60
-	initial_volume = 50
+	initial_volume = 100
 
 /obj/item/reagent_containers/food/drinks/bottle/empty/rectangular
 	name = "rectangular bottle"
@@ -403,7 +403,7 @@
 	alt_filled_state = 1
 	heal_amt = 1
 	g_amt = 60
-	initial_volume = 50
+	initial_volume = 100
 
 /obj/item/reagent_containers/food/drinks/bottle/empty/square
 	name = "square bottle"
@@ -415,7 +415,7 @@
 	alt_filled_state = 1
 	heal_amt = 1
 	g_amt = 60
-	initial_volume = 50
+	initial_volume = 100
 
 /obj/item/reagent_containers/food/drinks/bottle/empty/masculine
 	name = "wide bottle"
@@ -427,6 +427,6 @@
 	alt_filled_state = 1
 	heal_amt = 1
 	g_amt = 60
-	initial_volume = 50
+	initial_volume = 100
 
 

--- a/code/obj/machinery/glass_recycler.dm
+++ b/code/obj/machinery/glass_recycler.dm
@@ -46,7 +46,7 @@
 				else
 					if (istype(W,/obj/item/reagent_containers/food/drinks/bottle))
 						var/obj/item/reagent_containers/food/drinks/bottle/B = W
-						if (!B.broken) glass_amt += 1
+						if (!B.broken) glass_amt += 2
 					else
 						glass_amt += W.amount
 		else if (istype(W, /obj/item/material_piece) && W.material?.material_flags & MATERIAL_CRYSTAL && W.material?.alpha <= 180)
@@ -132,7 +132,7 @@
 			return 1
 */
 	proc/create(var/object)
-		if(src.glass_amt < 1 || ((object == "pitcher" || object == "largebeaker" || object == "round" || object == "plate") && src.glass_amt < 2))
+		if(src.glass_amt < 1 || ((object == "pitcher" || object == "largebeaker" || object == "round" || object == "plate" || object == "drinkbottles" || object == "longbottle" || object == "tallbottle" || object == "rectangularbottle" || object == "squarebottle" || object == "masculinebottle") && src.glass_amt < 2))
 			src.visible_message("<span class='alert'>[src] doesn't have enough glass to make that!</span>")
 			return
 
@@ -153,22 +153,22 @@
 				src.glass_amt -= 1
 			if("drinkbottle")
 				G = new /obj/item/reagent_containers/food/drinks/bottle/soda(get_turf(src))
-				src.glass_amt -= 1
+				src.glass_amt -= 2
 			if("longbottle")
 				G = new /obj/item/reagent_containers/food/drinks/bottle/empty/long(get_turf(src))
-				src.glass_amt -= 1
+				src.glass_amt -= 2
 			if("tallbottle")
 				G = new /obj/item/reagent_containers/food/drinks/bottle/empty/tall(get_turf(src))
-				src.glass_amt -= 1
+				src.glass_amt -= 2
 			if("rectangularbottle")
 				G = new /obj/item/reagent_containers/food/drinks/bottle/empty/rectangular(get_turf(src))
-				src.glass_amt -= 1
+				src.glass_amt -= 2
 			if("squarebottle")
 				G = new /obj/item/reagent_containers/food/drinks/bottle/empty/square(get_turf(src))
-				src.glass_amt -= 1
+				src.glass_amt -= 2
 			if("masculinebottle")
 				G = new /obj/item/reagent_containers/food/drinks/bottle/empty/masculine(get_turf(src))
-				src.glass_amt -= 1
+				src.glass_amt -= 2
 			if("plate")
 				G = new /obj/item/plate(get_turf(src))
 				src.glass_amt -= PLATE_COST


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[LABEL][balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Doubles the amount of liquids that can fit in many bottles from 50 to 100, bottles such as the champagne bottles and wine bottles that fit 50 but only have 30 will fit 100 and have 60. Price of bottles on glass recycler will go  to 2 accordingly.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some bottles have a way too small capacity, wine bottles, for instance only come with enough wine to fill a  single wine glass, besides that, it would be good to be able to store more of your personal mix drinks in less bottles as bartender. As for balance concerns, the bar already has large beakers, pitchers and round glasses.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hans
(+)Enhances the capacity of some of the bottles so they can serve more glasses.
```
