### PR TITLE
Gunbot critter antag adjustments

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -209,6 +209,7 @@
 	var/reloaded_at = 0
 	var/next_shot_at = 0
 	var/image/default_obscurer
+	var/muzzle_flash = null
 
 	attack_range(atom/target, var/mob/user, params)
 		if (reloaded_at > ticker.round_elapsed_ticks && !current_shots)
@@ -223,6 +224,10 @@
 			var/pox = text2num(params["icon-x"]) - 16
 			var/poy = text2num(params["icon-y"]) - 16
 			shoot_projectile_ST_pixel(user, proj, target, pox, poy)
+			if (src.muzzle_flash)
+				if (isturf(user.loc))
+					var/turf/origin = user.loc
+					muzzle_flash_attack_particle(user, origin, target, src.muzzle_flash)
 			user.visible_message("<b class='alert'>[user] fires at [target] with the [holder.name]!</b>")
 			next_shot_at = ticker.round_elapsed_ticks + cooldown
 			if (!current_shots)
@@ -241,6 +246,7 @@
 		current_shots = 3
 		cooldown = 30
 		reload_time = 200
+		muzzle_flash = "muzzle_flash"
 
 	abg
 		proj = new/datum/projectile/bullet/abg
@@ -248,6 +254,7 @@
 		current_shots = 6
 		cooldown = 30
 		reload_time = 300
+		muzzle_flash = "muzzle_flash"
 
 	phaser
 		proj = new/datum/projectile/laser/light

--- a/code/mob/living/critter/gunbot.dm
+++ b/code/mob/living/critter/gunbot.dm
@@ -108,9 +108,6 @@
 					playsound(src.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 30, 1, -2)
 					user.visible_message("<span class='alert'>[user] shakes [src] [pick_string("descriptors.txt", "borg_shake")]!</span>")
 				if(INTENT_HARM) //Dumbo
-					var/h = ishunter(user)
-					var/ww = iswerewolf(user)
-					var/w = iswrestler(user)
 					if (ishuman(user) && !ishunter(user) && !iswerewolf(user) && !iswrestler(user))
 						if (user.is_hulk())
 							src.TakeDamage("All", 5, 0)

--- a/code/mob/living/critter/gunbot.dm
+++ b/code/mob/living/critter/gunbot.dm
@@ -105,9 +105,15 @@
 					SPAWN_DBG(0) playsound(src.loc, 'sound/impact_sounds/Generic_Swing_1.ogg', 40, 1)
 					user.visible_message("<span class='alert'><B>[user] shoves [src]! [prob(40) ? pick_string("descriptors.txt", "jerks") : null]</B></span>")
 				if(INTENT_GRAB) //Shake
+					if (istype(user, /mob/living/carbon/human/machoman))
+						. = ..()
+						return
 					playsound(src.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 30, 1, -2)
 					user.visible_message("<span class='alert'>[user] shakes [src] [pick_string("descriptors.txt", "borg_shake")]!</span>")
 				if(INTENT_HARM) //Dumbo
+					if (istype(user, /mob/living/carbon/human/machoman))
+						. = ..()
+						return
 					if (ishuman(user) && !ishunter(user) && !iswerewolf(user) && !iswrestler(user))
 						if (user.is_hulk())
 							src.TakeDamage("All", 5, 0)

--- a/code/mob/living/critter/gunbot.dm
+++ b/code/mob/living/critter/gunbot.dm
@@ -18,6 +18,10 @@
 	speechverb_ask = "queries"
 	metabolizes = 0
 
+	New()
+		. = ..()
+		APPLY_MOB_PROPERTY(src, PROP_THERMALVISION, src)
+
 	death(var/gibbed)
 		..(gibbed, 0)
 		if (!gibbed)
@@ -87,3 +91,43 @@
 
 	get_disorient_protection()
 		return max(..(), 80)
+
+	attack_hand(mob/user)
+		user.lastattacked = src
+		if(!user.stat)
+			if (user.a_intent != INTENT_HELP)
+				actions.interrupt(src, INTERRUPT_ATTACKED)
+			switch(user.a_intent)
+				if(INTENT_HELP) //Friend person
+					playsound(src.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 50, 1, -2)
+					user.visible_message("<span class='notice'>[user] gives [src] a [pick_string("descriptors.txt", "borg_pat")] pat on the [pick("back", "head", "shoulder")].</span>")
+				if(INTENT_DISARM) //Shove
+					SPAWN_DBG(0) playsound(src.loc, 'sound/impact_sounds/Generic_Swing_1.ogg', 40, 1)
+					user.visible_message("<span class='alert'><B>[user] shoves [src]! [prob(40) ? pick_string("descriptors.txt", "jerks") : null]</B></span>")
+				if(INTENT_GRAB) //Shake
+					playsound(src.loc, 'sound/impact_sounds/Generic_Shove_1.ogg', 30, 1, -2)
+					user.visible_message("<span class='alert'>[user] shakes [src] [pick_string("descriptors.txt", "borg_shake")]!</span>")
+				if(INTENT_HARM) //Dumbo
+					var/h = ishunter(user)
+					var/ww = iswerewolf(user)
+					var/w = iswrestler(user)
+					if (ishuman(user) && !ishunter(user) && !iswerewolf(user) && !iswrestler(user))
+						if (user.is_hulk())
+							src.TakeDamage("All", 5, 0)
+							if (prob(20))
+								var/turf/T = get_edge_target_turf(user, user.dir)
+								if (isturf(T))
+									src.visible_message("<span class='alert'><B>[user] savagely punches [src], sending them flying!</B></span>")
+									src.throw_at(T, 10, 2)
+								else
+									src.visible_message("<span class='alert'><B>[user] punches [src]!</B></span>")
+							playsound(src.loc, pick(sounds_punch), 50, 1, -1)
+						/*if (user.glove_weaponcheck())
+							user.energyclaws_attack(src)*/
+						else
+							user.visible_message("<span class='alert'><B>[user] punches [src]! What [pick_string("descriptors.txt", "borg_punch")]!</span>", "<span class='alert'><B>You punch [src]![prob(20) ? " Turns out they were made of metal!" : null] Ouch!</B></span>")
+							random_brute_damage(user, rand(2,5))
+							playsound(src.loc, 'sound/impact_sounds/Metal_Clang_3.ogg', 60, 1)
+							if(prob(10)) user.show_text("Your hand hurts...", "red")
+					else
+						. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
QOL improvements to player controlled antagonist critter gunbots.
Adds muzzleflash to their two weapon arms.
Gives them thermal vision (mk1) like a standard cyborg so they can get around in the dark.
Gives them cyborg style intent response. They cannot be punched except by critters, hunters, wrestlers and werewolves (transformed).
Makes them immune to grabs like a standard cyborg, except from macho man!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some quality of life adjustments to improve playing as an antag gunbot.
It was weird as a cyborg they were vulnerable to a lot of things that cyborgs were not, such as punches and suplexes.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Antagonist critter gunbots now have muzzleflash, thermalvision and cyborg style punch immunity.
```
