### PR TITLE
remove overrides on shuttlefloor attack procs

### DIFF
--- a/code/modules/transport/shuttle/shuttle_turfobjs.dm
+++ b/code/modules/transport/shuttle/shuttle_turfobjs.dm
@@ -41,8 +41,6 @@
 	heat_capacity = 0
 	turf_flags = MOB_STEP
 
-	attackby()
-	attack_hand()
 	hitby()
 		. = ..()
 	reagent_act()
@@ -62,8 +60,6 @@
 	icon = 'icons/turf/shuttle.dmi'
 	turf_flags = MOB_STEP
 
-	attackby()
-	attack_hand()
 	hitby()
 		. = ..()
 	reagent_act()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Shuttlefloor turfs seem to override pretty much all the procs, I assume so that they can't be destroyed and stuff.
But this leads to it being impossible to pin people on them, or move pulled objects by clicking the floor.

I can't really think of anything that could destroy unsimulated shuttle floors by clicking them with stuff, so I propose removing them. If that is an issue, maybe we can find another solution to make them indestructible while still being able to do stuff like pins and pulls.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being unable to pin/move via pull on shuttles is really unintuitive and not nice.

