### PR TITLE
Resist out of grabs, pulls while stunned (Not Cuffed)

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1328,17 +1328,22 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 				for (var/obj/item/grab/G in src.grabbed_by)
 					G.do_resist()
 					struggled_grab = 1
-			else
-				if(src.pulled_by)
-					for (var/mob/O in AIviewers(src, null))
-						O.show_message(text("<span class='alert'>[] resists []'s pulling!</span>", src, src.pulled_by), 1, group = "resist")
-					src.pulled_by.remove_pulling()
-					struggled_grab = 1
+			else if(src.pulled_by)
+				for (var/mob/O in AIviewers(src, null))
+					O.show_message(text("<span class='alert'>[] breaks free from []'s pulling!</span>", src, src.pulled_by), 1, group = "resist")
+				src.pulled_by.remove_pulling()
+				struggled_grab = 1
 		else
-			for (var/obj/item/grab/G in src.grabbed_by)
-				if (G.stunned_targets_can_break())
-					G.do_resist()
-					struggled_grab = 1
+			if(src.grabbed_by.len > 0)
+				for (var/obj/item/grab/G in src.grabbed_by)
+					if (G.stunned_targets_can_break())
+						G.do_resist()
+						struggled_grab = 1
+			else if(src.pulled_by)
+				for (var/mob/O in AIviewers(src, null))
+					O.show_message(text("<span class='alert'>[] breaks free from []'s pulling!</span>", src, src.pulled_by), 1, group = "resist")
+				src.pulled_by.remove_pulling()
+				struggled_grab = 1
 
 		if (!src.grabbed_by || !src.grabbed_by.len && !struggled_grab)
 			if (src.buckled)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1334,7 +1334,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 				src.pulled_by.remove_pulling()
 				struggled_grab = 1
 		else
-			if(src.grabbed_by.len > 0)
+			if(length(src.grabbed_by) > 0)
 				for (var/obj/item/grab/G in src.grabbed_by)
 					if (G.stunned_targets_can_break())
 						G.do_resist()

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -313,7 +313,8 @@
 			src.affecting:was_harmed(src.assailant)
 
 	proc/stunned_targets_can_break()
-		.= (src.state == GRAB_PIN)
+		.= TRUE // Allow stunned players to break all grabs - Emily 2021
+		//.= (src.state == GRAB_PIN)
 
 	proc/check()
 		if(!assailant || !affecting)

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -313,8 +313,7 @@
 			src.affecting:was_harmed(src.assailant)
 
 	proc/stunned_targets_can_break()
-		.= TRUE // Allow stunned players to break all grabs - Emily 2021
-		//.= (src.state == GRAB_PIN)
+		. = TRUE // Allow stunned players to break all grabs
 
 	proc/check()
 		if(!assailant || !affecting)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

- Allows you to resist out of grabs and pulls while stunned (but not cuffed)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes it harder to transport stunned people around unless you cuff them first

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Emily
(*)Resist Buff: you can now struggle out of grabs and pulls while stunned using the resist button/key (Default Z), unless cuffed
```
