### PR TITLE
Apprentice caps can be handmade, following their item description

### DIFF
--- a/code/obj/item/gift.dm
+++ b/code/obj/item/gift.dm
@@ -34,29 +34,29 @@
 		boutput(user, "<span class='notice'>You MUST put the paper on a table!</span>")
 		return
 	if (W.w_class < W_CLASS_BULKY)
-		if(istype(W, /obj/item/c_tube) && user.client)
-			var user_choice = input(user, "Do what to the cardboard tube?", "Cardboard tube") in list("Cancel", "Wrap", "Create Hat")
-			if(user_choice == "Cancel")
-				return
-			if(!(user_choice == "Wrap"))
-				var/a_used = 2 ** (src.w_class - 1)
-				if (src.amount < a_used)
-					boutput(user, "<span class='notice'>You need more paper!</span>")
-					return
-				src.amount -= a_used
-				tooltip_rebuild = 1
-				user.drop_item()
-				qdel(W)
-				var/obj/item/clothing/head/apprentice/A = new /obj/item/clothing/head/apprentice(src.loc)
-				A.add_fingerprint(user)
-				user.put_in_hand_or_drop(A)
-				if (src.amount <= 0)
-					user.u_equip(src)
-					var/obj/item/c_tube/C = new /obj/item/c_tube(src.loc)
-					user.put_in_hand_or_drop(C)
-					qdel(src)
-				return
 		if ((istool(user.l_hand, TOOL_CUTTING | TOOL_SNIPPING) && user.l_hand != W) || (istool(user.r_hand, TOOL_CUTTING | TOOL_SNIPPING) && user.r_hand != W))
+			if(istype(W, /obj/item/c_tube) && user.client)
+				var user_choice = input(user, "Do what to the cardboard tube?", "Cardboard tube") in list("Cancel", "Wrap", "Create Hat")
+				if(user_choice == "Cancel")
+					return
+				if(!(user_choice == "Wrap"))
+					var/a_used = 2 ** (src.w_class - 1)
+					if (src.amount < a_used)
+						boutput(user, "<span class='notice'>You need more paper!</span>")
+						return
+					src.amount -= a_used
+					tooltip_rebuild = 1
+					user.drop_item()
+					qdel(W)
+					var/obj/item/clothing/head/apprentice/A = new /obj/item/clothing/head/apprentice(src.loc)
+					A.add_fingerprint(user)
+					user.put_in_hand_or_drop(A)
+					if (src.amount <= 0)
+						user.u_equip(src)
+						var/obj/item/c_tube/C = new /obj/item/c_tube(src.loc)
+						user.put_in_hand_or_drop(C)
+						qdel(src)
+					return
 			if(istype(W, /obj/item/phone_handset/))
 				boutput(user, "<span class='notice'>You can't wrap that, it has a cord attached!</span>")
 				return

--- a/code/obj/item/gift.dm
+++ b/code/obj/item/gift.dm
@@ -34,6 +34,28 @@
 		boutput(user, "<span class='notice'>You MUST put the paper on a table!</span>")
 		return
 	if (W.w_class < W_CLASS_BULKY)
+		if(istype(W, /obj/item/c_tube) && user.client)
+			var user_choice = input(user, "Do what to the cardboard tube?", "Cardboard tube") in list("Cancel", "Wrap", "Create Hat")
+			if(user_choice == "Cancel")
+				return
+			if(!(user_choice == "Wrap"))
+				var/a_used = 2 ** (src.w_class - 1)
+				if (src.amount < a_used)
+					boutput(user, "<span class='notice'>You need more paper!</span>")
+					return
+				src.amount -= a_used
+				tooltip_rebuild = 1
+				user.drop_item()
+				qdel(W)
+				var/obj/item/clothing/head/apprentice/A = new /obj/item/clothing/head/apprentice(src.loc)
+				A.add_fingerprint(user)
+				user.put_in_hand_or_drop(A)
+				if (src.amount <= 0)
+					user.u_equip(src)
+					var/obj/item/c_tube/C = new /obj/item/c_tube(src.loc)
+					user.put_in_hand_or_drop(C)
+					qdel(src)
+				return
 		if ((istool(user.l_hand, TOOL_CUTTING | TOOL_SNIPPING) && user.l_hand != W) || (istool(user.r_hand, TOOL_CUTTING | TOOL_SNIPPING) && user.r_hand != W))
 			if(istype(W, /obj/item/phone_handset/))
 				boutput(user, "<span class='notice'>You can't wrap that, it has a cord attached!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the apprentice cap to be handmade using wrapping paper and a cardboard tube! Gives the user the option to wrap and turn into a gift, or create an apprentice cap. Some code I used accomplish this may be unnecessary as I used hand tele code as a reference for how to allow user input, and the gift wrapping code as a reference for deleting the old tube and spawning in a hat in its place. If anything is unnecessary, please let me know!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The apprentice cap already has an item description that claims its just a cardboard cone wrapped in wrapping paper, so why not add the ability to turn a cardboard tube (unroll & form into cone) into an apprentice cap?

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Obama Gaming
(+)Apprentice caps can now be handmade.
```
