### PR TITLE
Weakens chameleon bomb and makes the traitor uplink give a box of 4 chameleon bombs instead of 1

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -509,10 +509,11 @@ This is basically useless for anyone but miners.
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/chambomb
-	name = "Chameleon Bomb"
-	item = /obj/item/device/chameleon/bomb
+	name = "Chameleon Bomb Case"
+	item = /obj/item/storage/box/chameleonbombcase
 	cost = 6
-	desc = "A questionable mixture of a chameleon projector and a bomb. Scan an object to take on its appearance, arm the bomb, and then explode the face(s) of whoever tries to touch it."
+	vr_allowed = 0
+	desc = "4 questionable mixtures of a chameleon projector and a bomb. Scan an object to take on its appearance, arm the bomb, and then explode the face(s) of whoever tries to touch it."
 	job = list("Clown")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -194,7 +194,7 @@
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "cham_bomb"
 	burn_possible = 0
-	var/strength = 32 // same as syndie pipebombs, calls the same proc
+	var/strength = 12
 
 	dropped()
 		return

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -361,6 +361,12 @@
 	spawn_contents = list(/obj/item/gun/kinetic/blowgun,\
 	/obj/item/storage/pouch/poison_dart = 2)
 
+/obj/item/storage/box/chameleonbomb
+	name = "chameleon bomb case"
+	desc = "A case that contains 4 syndicate chameleon bombs"
+	icon_state = "hard_case"
+	spawn_contents = list(/obj/item/device/chameleon/bomb = 4)
+
 // Starter kit used in the conspiracy/spy game mode.
 /obj/item/storage/box/spykit
 	name = "spy starter kit"


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Weakens the strength of chameleon bombs from 32 to 12, also makes the traitor purchase give a box of 4 chameleon bombs instead of a singular one.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The chameleon bomb purchase is not remotely worth the 6 tc as of now. This change aims to change chameleon bombs from a one time "oh that person is dead" to more of something that makes you afraid of picking things up for fear of it exploding.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)Chamelon bomb traitor purchase now gives a box of 4 bombs, power of chameleon bombs lowered to compensate.
```
