### PR TITLE
Removes thindoors in AI upload for manta

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -9814,7 +9814,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/glass/windoor{
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
 /turf/simulated/floor/longtile/black,
@@ -10769,11 +10769,11 @@
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
 "aET" = (
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/starboard)
@@ -10849,7 +10849,7 @@
 	layer = 3.5;
 	pixel_y = -24
 	},
-/obj/machinery/door/airlock/pyro/glass/windoor{
+/obj/machinery/door/airlock/pyro/glass{
 	dir = 4
 	},
 /turf/simulated/floor/longtile/black,
@@ -11023,13 +11023,13 @@
 	},
 /area/station/turret_protected/ai_upload)
 "aFD" = (
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	layer = 3.5;
 	pixel_y = -24
+	},
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/starboard)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title, swaps out thindoors for standard glass doors.
![image](https://user-images.githubusercontent.com/73148980/132590168-af7be45d-e9e7-4c7e-a186-d9544a175ad1.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The AI can bolt these doors, and these thindoors cant be hacked. Having unhackable doors in AI upload is bad.
