### PR TITLE
Adds lamp manufacturer's to engineer lockers

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -559,7 +559,8 @@
 	/obj/item/clothing/glasses/meson,
 	/obj/item/pen/infrared,
 	/obj/item/clothing/head/helmet/welding,
-	/obj/item/clothing/suit/hi_vis)
+	/obj/item/clothing/suit/hi_vis,
+	/obj/item/lamp_manufacturer)
 
 /obj/storage/secure/closet/engineering/mining
 	name = "\improper Miner's locker"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, replacing a hallway full of lights as engineer can be one of those tasks that is simply not worth your time. This PR should encourage engineers to fix lights by making it more convinent to do so, and increase QoL for light repair.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Engineering lockers now come with lamp manufacturers.
```
