### PR TITLE
Refactor antag candidate picking procs into a single all-purpose one.

### DIFF
--- a/_std/defines/roles.dm
+++ b/_std/defines/roles.dm
@@ -11,6 +11,7 @@
 #define ROLE_HEAD_REV "head_rev"
 #define ROLE_CONSPIRATOR "conspirator"
 #define ROLE_ARCFIEND "arcfiend"
+#define ROLE_MISC "misc"
 
 // special antagonist roles
 #define ROLE_GANG_MEMBER "gang_member"

--- a/code/datums/gamemodes/assday_classic.dm
+++ b/code/datums/gamemodes/assday_classic.dm
@@ -40,7 +40,7 @@
 		num_wraiths += 1
 
 
-	var/list/possible_traitors = get_possible_traitors(num_traitors)
+	var/list/possible_traitors = get_possible_enemies(ROLE_TRAITOR, num_traitors)
 
 	if (!possible_traitors.len)
 		return 0
@@ -70,7 +70,7 @@
 		possible_traitors.Remove(traitor)
 
 	if(num_wraiths)
-		var/list/possible_wraiths = get_possible_wraiths(num_wraiths)
+		var/list/possible_wraiths = get_possible_enemies(ROLE_WRAITH, num_wraiths)
 		var/list/chosen_wraiths = antagWeighter.choose(pool = possible_wraiths, role = ROLE_WRAITH, amount = num_wraiths, recordChosen = 1)
 		for (var/datum/mind/wraith in chosen_wraiths)
 			traitors += wraith
@@ -104,66 +104,6 @@
 
 	SPAWN_DBG (rand(waittime_l, waittime_h))
 		send_intercept()
-
-/datum/game_mode/assday/proc/get_possible_traitors(minimum_traitors=1)
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_traitor)
-				candidates += player.mind
-
-	if(candidates.len < minimum_traitors)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_traitor set to yes were ready. We need [minimum_traitors] traitors so including players who don't want to be traitors in the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-				if ((minimum_traitors > 1) && (candidates.len >= minimum_traitors))
-					break
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
-
-/datum/game_mode/assday/proc/get_possible_wraiths(minimum_traitors=1)
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_wraith)
-				candidates += player.mind
-
-	if(candidates.len < minimum_traitors)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_wraith set to yes were ready. We need [minimum_traitors] wraiths so including players who don't want to be wraiths in the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-				if ((minimum_traitors > 1) && (candidates.len >= minimum_traitors))
-					break
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
 
 /datum/game_mode/assday/send_intercept()
 	var/intercepttext = "Cent. Com. Update Requested staus information:<BR>"

--- a/code/datums/gamemodes/blob.dm
+++ b/code/datums/gamemodes/blob.dm
@@ -28,7 +28,7 @@
 	var/i = rand(-5, 0)
 	var/num_blobs = max(2, min(round((num_players + i) / 20), blobs_possible))
 
-	var/list/possible_blobs = get_possible_blobs(num_blobs)
+	var/list/possible_blobs = get_possible_enemies(ROLE_BLOB, num_blobs)
 
 	if (!possible_blobs || !islist(possible_blobs) || !possible_blobs.len || possible_blobs.len < blobs_minimum)
 		return 0
@@ -142,30 +142,3 @@
 		boutput(world, "<span style='font-size:20px; color:red'><b>Blob victory!</b> - The crew has failed to stop the overmind! The station is lost to the blob!")
 
 	..()
-
-/datum/game_mode/blob/proc/get_possible_blobs(num_blobs=1)
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_blob)
-				candidates += player.mind
-
-	if(candidates.len < num_blobs)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_blob set to yes were ready. We need [num_blobs], so including players who don't want to be blobstart in the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates

--- a/code/datums/gamemodes/changeling.dm
+++ b/code/datums/gamemodes/changeling.dm
@@ -25,7 +25,7 @@
 	var/i = rand(5)
 	var/num_changelings = max(1, min(round((num_players + i) / 15), changelings_possible))
 
-	var/list/possible_changelings = get_possible_changelings(num_changelings)
+	var/list/possible_changelings = get_possible_enemies(ROLE_CHANGELING, num_changelings)
 
 	if (!possible_changelings.len)
 		return 0
@@ -67,30 +67,6 @@
 
 	SPAWN_DBG (rand(waittime_l, waittime_h))
 		send_intercept()
-
-/datum/game_mode/changeling/proc/get_possible_changelings(num_changelings=1)
-	var/list/candidates = list()
-
-	for(var/mob/new_player/player in mobs)
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.client) && (player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_changeling)
-				candidates += player.mind
-
-	if(candidates.len < num_changelings)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_changeling set to yes were ready. We need [num_changelings], so including players who don't want to be changelings in the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
 
 /datum/game_mode/changeling/send_intercept()
 	var/intercepttext = "Cent. Com. Update Requested staus information:<BR>"

--- a/code/datums/gamemodes/conspiracy.dm
+++ b/code/datums/gamemodes/conspiracy.dm
@@ -25,7 +25,7 @@
 
 	var/numConspirators = max(2, min(round(numPlayers / 5), maxConspirators)) // Selects number of conspirators
 
-	var/list/potentialAntags = getPotentialAntags(numConspirators)
+	var/list/potentialAntags = get_possible_enemies(ROLE_CONSPIRATOR, numConspirators)
 	if (!potentialAntags.len)
 		return 0
 
@@ -72,36 +72,6 @@
 
 	SPAWN_DBG (rand(waittime_l, waittime_h))
 		send_intercept()
-
-/datum/game_mode/conspiracy/proc/getPotentialAntags(minimum_conspirators=2)
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_conspirator)
-				candidates += player.mind
-
-	if(candidates.len < minimum_conspirators)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_conspirator set to yes were ready. We need [minimum_conspirators] conspirators so including players who don't want to be traitors in the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-				if ((minimum_conspirators > 1) && (candidates.len >= minimum_conspirators))
-					break
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
 
 /datum/game_mode/conspiracy/proc/random_radio_frequency()
 	var/list/blacklisted = list(0, 1451, 1457)

--- a/code/datums/gamemodes/disaster.dm
+++ b/code/datums/gamemodes/disaster.dm
@@ -11,15 +11,7 @@
 	var/const/shuttle_waittime = 4000
 
 /datum/game_mode/disaster/pre_setup()
-	var/list/candidates = list()
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player))
-			continue
-		if (player.ready && !candidates.Find(player.mind) && player.client.preferences.be_wraith)
-			candidates += player.mind
+	var/list/candidates = get_possible_enemies(ROLE_WRAITH, 0)
 	if (candidates.len == 0)
 		return 0
 	var/datum/mind/twraith = pick(candidates) // Just one for now

--- a/code/datums/gamemodes/flock.dm
+++ b/code/datums/gamemodes/flock.dm
@@ -22,7 +22,7 @@
 
 	// TODO: Handle token players
 
-	possible_flockminds = get_possible_flockminds()
+	possible_flockminds = get_possible_enemies(ROLE_FLOCKMIND, 1)
 	var/list/chosen_flockminds = antagWeighter.choose(pool = possible_flockminds, role = ROLE_FLOCKMIND, amount = 1, recordChosen = 1)
 	flockminds |= chosen_flockminds
 	for (var/datum/mind/flockmind in flockminds)
@@ -44,23 +44,4 @@
 	//TODO
 	. = ..()
 
-/datum/game_mode/flock/proc/get_possible_flockminds(minimum_flockminds=1)
-	var/list/candidates = list()
-
-	for (var/mob/new_player/player in mobs)
-		if (ishellbanned(player)) continue
-		if ((player.client) && (player.ready) && !(player.mind in flockminds) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_flock)
-				candidates += player.mind
-
-	if (candidates.len < minimum_flockminds)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_flock set to yes were ready. We need [minimum_flockminds] flockminds so including players who don't want to be flockminds in the pool.")
-		for (var/mob/new_player/player in mobs)
-			if (ishellbanned(player)) continue
-			if ((player.client) && (player.ready) && !(player.mind in flockminds) && !candidates.Find(player.mind))
-				candidates += player.mind
-	if (candidates.len < 1)
-		return list()
-	else
-		return candidates
 

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -57,7 +57,7 @@
 
 	var/num_teams = max(setup_min_teams, min(round((num_players) / 9), setup_max_teams)) //1 gang per 9 players
 
-	var/list/leaders_possible = get_possible_leaders(num_teams)
+	var/list/leaders_possible = get_possible_enemies(ROLE_GANG_LEADER, num_teams)
 	if (num_teams > leaders_possible.len)
 		num_teams = length(leaders_possible)
 
@@ -187,37 +187,6 @@
 	item2_used += leaderMind.gang.item2
 
 	return
-
-
-/datum/game_mode/gang/proc/get_possible_leaders(minimum_leaders=1)
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-		if (ishellbanned(player)) continue //No treason for you
-
-		if ((player.ready) && !(player.mind in leaders) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_gangleader)
-				candidates += player.mind
-
-	if(candidates.len < minimum_leaders)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Not enough players with be_gangleader set to yes, including players who don't want to be misc enemies in the pool for Gang Leader selection.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in leaders) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-				if (candidates.len >= minimum_leaders)
-					break
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
 
 /datum/game_mode/gang/check_finished()
 	if(emergency_shuttle.location == SHUTTLE_LOC_RETURNED)

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -259,6 +259,8 @@
 					if(player.client.preferences.be_blob) candidates += player.mind
 				if(ROLE_SPY_THIEF)
 					if(player.client.preferences.be_spy) candidates += player.mind
+				if(ROLE_GANG_LEADER)
+					if(player.client.preferences.be_gangleader) candidates += player.mind
 				if(ROLE_WEREWOLF)
 					if(player.client.preferences.be_werewolf) candidates += player.mind
 				if(ROLE_ARCFIEND)

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -269,6 +269,8 @@
 					if(player.client.preferences.be_arcfiend) candidates += player.mind
 				if(ROLE_FLOCKMIND)
 					if(player.client.preferences.be_flock) candidates += player.mind
+				if(ROLE_CONSPIRATOR)
+					if(player.client.preferences.be_conspirator) candidates += player.mind
 				else
 					if(player.client.preferences.be_misc) candidates += player.mind
 

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -233,6 +233,62 @@
 
 	return 1
 
+/datum/game_mode/proc/get_possible_enemies(type,number)
+	var/list/candidates = list()
+
+	for(var/client/C)
+		var/mob/new_player/player = C.mob
+		if (!istype(player)) continue
+
+		if (ishellbanned(player)) continue //No treason for you
+		if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
+			switch(type)
+				if(ROLE_WIZARD)
+					if(player.client.preferences.be_wizard) candidates += player.mind
+				if(ROLE_TRAITOR)
+					if(player.client.preferences.be_traitor) candidates += player.mind
+				if(ROLE_NUKEOP)
+					if(player.client.preferences.be_syndicate) candidates += player.mind
+				if(ROLE_CHANGELING)
+					if(player.client.preferences.be_changeling) candidates += player.mind
+				if(ROLE_VAMPIRE)
+					if(player.client.preferences.be_vampire) candidates += player.mind
+				if(ROLE_WRAITH)
+					if(player.client.preferences.be_wraith) candidates += player.mind
+				if(ROLE_BLOB)
+					if(player.client.preferences.be_blob) candidates += player.mind
+				if(ROLE_SPY_THIEF)
+					if(player.client.preferences.be_spy) candidates += player.mind
+				if(ROLE_WEREWOLF)
+					if(player.client.preferences.be_werewolf) candidates += player.mind
+				if(ROLE_ARCFIEND)
+					if(player.client.preferences.be_arcfiend) candidates += player.mind
+				if(ROLE_FLOCKMIND)
+					if(player.client.preferences.be_flock) candidates += player.mind
+				else
+					if(player.client.preferences.be_misc) candidates += player.mind
+
+	if(candidates.len < number)
+		if(type in list(ROLE_WIZARD, ROLE_TRAITOR, ROLE_CHANGELING, ROLE_WRAITH, ROLE_BLOB, ROLE_WEREWOLF))
+			logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_[type] set to yes were ready. We need [number] so including players who don't want to be [type]s in the pool.")
+		else
+			logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Not enough players with be_misc set to yes, including players who don't want to be misc enemies in the pool for [type] assignment.")
+
+		for(var/client/C)
+			var/mob/new_player/player = C.mob
+			if (!istype(player)) continue
+
+			if (ishellbanned(player)) continue //No treason for you
+			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
+				candidates += player.mind
+				if ((number > 1) && (candidates.len >= number))
+					break
+
+	if(candidates.len < 1)
+		return list()
+	else
+		return candidates
+
 /datum/game_mode/proc/check_win()
 
 /datum/game_mode/proc/send_intercept()

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -261,6 +261,8 @@
 					if(player.client.preferences.be_spy) candidates += player.mind
 				if(ROLE_GANG_LEADER)
 					if(player.client.preferences.be_gangleader) candidates += player.mind
+				if(ROLE_HEAD_REV)
+					if(player.client.preferences.be_revhead) candidates += player.mind
 				if(ROLE_WEREWOLF)
 					if(player.client.preferences.be_werewolf) candidates += player.mind
 				if(ROLE_ARCFIEND)

--- a/code/datums/gamemodes/mixed.dm
+++ b/code/datums/gamemodes/mixed.dm
@@ -338,58 +338,6 @@
 	SPAWN_DBG (rand(waittime_l, waittime_h))
 		send_intercept()
 
-/datum/game_mode/mixed/proc/get_possible_enemies(type,number)
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			switch(type)
-				if(ROLE_WIZARD)
-					if(player.client.preferences.be_wizard) candidates += player.mind
-				if(ROLE_TRAITOR)
-					if(player.client.preferences.be_traitor) candidates += player.mind
-				if(ROLE_CHANGELING)
-					if(player.client.preferences.be_changeling) candidates += player.mind
-				if(ROLE_VAMPIRE)
-					if(player.client.preferences.be_vampire) candidates += player.mind
-				if(ROLE_WRAITH)
-					if(player.client.preferences.be_wraith) candidates += player.mind
-				if(ROLE_BLOB)
-					if(player.client.preferences.be_blob) candidates += player.mind
-				if(ROLE_SPY_THIEF)
-					if(player.client.preferences.be_spy) candidates += player.mind
-				if(ROLE_WEREWOLF)
-					if(player.client.preferences.be_werewolf) candidates += player.mind
-				if(ROLE_ARCFIEND)
-					if(player.client.preferences.be_arcfiend) candidates += player.mind
-				else
-					if(player.client.preferences.be_misc) candidates += player.mind
-
-	if(candidates.len < number)
-		if(type in list(ROLE_WIZARD, ROLE_TRAITOR, ROLE_CHANGELING, ROLE_WRAITH, ROLE_BLOB, ROLE_WEREWOLF))
-			logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_[type] set to yes were ready. We need [number] so including players who don't want to be [type]s in the pool.")
-		else
-			logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Not enough players with be_misc set to yes, including players who don't want to be misc enemies in the pool for [type] assignment.")
-
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-				if ((number > 1) && (candidates.len >= number))
-					break
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
-
 /datum/game_mode/mixed/send_intercept()
 	var/intercepttext = "Cent. Com. Update Requested staus information:<BR>"
 	intercepttext += " Cent. Com has recently been contacted by the following syndicate affiliated organisations in your area, please investigate any information you may have:"

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -41,7 +41,7 @@
 			num_players++
 	var/num_synds = clamp( round(num_players / 6 ), 1, agents_possible)
 
-	possible_syndicates = get_possible_syndicates(num_synds)
+	possible_syndicates = get_possible_enemies(ROLE_NUKEOP, num_synds)
 
 	if (!islist(possible_syndicates) || possible_syndicates.len < 1)
 		boutput(world, "<span class='alert'><b>ERROR: couldn't assign any players as Syndicate operatives, aborting nuke round pre-setup.</b></span>")
@@ -343,36 +343,6 @@
 
 	if (opcount == opdeathcount) return 1
 	else return 0
-
-/datum/game_mode/nuclear/proc/get_possible_syndicates(minimum_syndicates=1)
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in syndicates) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_syndicate)
-				candidates += player.mind
-
-	if(candidates.len < minimum_syndicates)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Not enough players with be_syndicate set to yes, including players who don't want to be syndicates in the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-			if (ishellbanned(player)) continue //No treason for you
-
-			if ((player.ready) && !(player.mind in syndicates) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-				if ((minimum_syndicates > 1) && (candidates.len >= minimum_syndicates))
-					break
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
 
 /datum/game_mode/nuclear/send_intercept()
 	var/intercepttext = "Cent. Com. Update Requested staus information:<BR>"

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -33,7 +33,7 @@
 	boutput(world, "<B>Some crewmembers are attempting to start a revolution!<BR><br>Revolutionaries - Kill the heads of staff. Convert other crewmembers (excluding synthetics and security) to your cause by flashing them. Protect your leaders.<BR><br>Personnel - Protect the heads of staff. Kill the leaders of the revolution, and brainwash the other revolutionaries (by using an electropack, electric chair or beating them in the head).</B>")
 
 /datum/game_mode/revolution/pre_setup()
-	var/list/revs_possible = get_possible_revolutionaries()
+	var/list/revs_possible = get_possible_enemies(ROLE_HEAD_REV, 1)
 
 	if (!revs_possible.len)
 		return 0
@@ -263,33 +263,6 @@
 			M.current.antagonist_overlay_refresh(1, 0)
 
 	return
-
-/datum/game_mode/revolution/proc/get_possible_revolutionaries()
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in head_revolutionaries) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_revhead)
-				candidates += player.mind
-
-	if(candidates.len < 1)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Not enough players with be_revhead set to yes, so we're adding players who don't want to be rev leaders to the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in head_revolutionaries) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
 
 /datum/game_mode/revolution/proc/get_living_heads()
 	var/list/heads = list()

--- a/code/datums/gamemodes/spy.dm
+++ b/code/datums/gamemodes/spy.dm
@@ -22,7 +22,7 @@
 	boutput(world, "<B>The Syndicate is using the [station_or_ship()] as a battleground to train elite operatives!</B>")
 
 /datum/game_mode/spy/pre_setup()
-	var/list/leaders_possible = get_possible_leaders()
+	var/list/leaders_possible = get_possible_enemies(ROLE_SPY_THIEF, 1)
 
 	if (!leaders_possible.len)
 		return 0
@@ -139,33 +139,6 @@
 	spy.mind.special_role = null
 	spy.mind.master = null
 	return 1
-
-/datum/game_mode/spy/proc/get_possible_leaders()
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in leaders) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_spy)
-				candidates += player.mind
-
-	if(candidates.len < 1)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Not enough players with be_spy set to yes, so we're adding players who don't want to be spy leaders to the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-			if (ishellbanned(player)) continue //No treason for you
-
-			if ((player.ready) && !(player.mind in leaders) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
 
 /datum/game_mode/spy/declare_completion()
 

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -155,7 +155,7 @@
 	if (traitor_scaling)
 		num_spies = max(2, min(round((num_players + randomizer) / 6), spies_possible))
 
-	var/list/possible_spies = get_possible_spies(num_spies)
+	var/list/possible_spies = get_possible_enemies(ROLE_SPY_THIEF, num_spies)
 
 	if (!possible_spies.len)
 		return 0
@@ -200,36 +200,6 @@
 
 	SPAWN_DBG (rand(waittime_l, waittime_h))
 		send_intercept()
-
-/datum/game_mode/spy_theft/proc/get_possible_spies(minimum_traitors=1)
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if (player.client.preferences.be_spy)
-				candidates += player.mind
-
-	if (candidates.len < minimum_traitors)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_spy set to yes were ready. We need [minimum_traitors] traitors so including players who don't want to be traitors in the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-				if ((minimum_traitors > 1) && (candidates.len >= minimum_traitors))
-					break
-
-	if (candidates.len < 1)
-		return list()
-	else
-		return candidates
 
 /datum/game_mode/spy_theft/process()
 	..()

--- a/code/datums/gamemodes/traitor.dm
+++ b/code/datums/gamemodes/traitor.dm
@@ -36,7 +36,7 @@
 		num_wraiths = 1
 
 
-	var/list/possible_traitors = get_possible_traitors(num_traitors)
+	var/list/possible_traitors = get_possible_enemies(ROLE_TRAITOR, num_traitors)
 
 	if (!possible_traitors.len)
 		return 0
@@ -66,7 +66,7 @@
 		possible_traitors.Remove(traitor)
 
 	if(num_wraiths)
-		var/list/possible_wraiths = get_possible_wraiths(num_wraiths)
+		var/list/possible_wraiths = get_possible_enemies(ROLE_WRAITH, num_wraiths)
 		var/list/chosen_wraiths = antagWeighter.choose(pool = possible_wraiths, role = ROLE_WRAITH, amount = num_wraiths, recordChosen = 1)
 		for (var/datum/mind/wraith in chosen_wraiths)
 			traitors += wraith
@@ -100,66 +100,6 @@
 
 	SPAWN_DBG (rand(waittime_l, waittime_h))
 		send_intercept()
-
-/datum/game_mode/traitor/proc/get_possible_traitors(minimum_traitors=1)
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_traitor)
-				candidates += player.mind
-
-	if(candidates.len < minimum_traitors)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_traitor set to yes were ready. We need [minimum_traitors] traitors so including players who don't want to be traitors in the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-				if ((minimum_traitors > 1) && (candidates.len >= minimum_traitors))
-					break
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
-
-/datum/game_mode/traitor/proc/get_possible_wraiths(minimum_traitors=1)
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_wraith)
-				candidates += player.mind
-
-	if(candidates.len < minimum_traitors)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_wraith set to yes were ready. We need [minimum_traitors] wraiths so including players who don't want to be wraiths in the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-				if ((minimum_traitors > 1) && (candidates.len >= minimum_traitors))
-					break
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
 
 /datum/game_mode/traitor/send_intercept()
 	var/intercepttext = "Cent. Com. Update Requested staus information:<BR>"

--- a/code/datums/gamemodes/waldo.dm
+++ b/code/datums/gamemodes/waldo.dm
@@ -14,7 +14,7 @@
 	boutput(world, "<B><span class='alert'>A man named Waldo</span> is likely to be somewhere on the station. You must find him (And beware of any of his compatriots!)</B>")
 
 /datum/game_mode/waldo/pre_setup()
-	var/list/possible_waldos = get_possible_waldos()
+	var/list/possible_waldos = get_possible_enemies(ROLE_MISC, 1)
 
 	if(possible_waldos.len < 1)
 		return 0
@@ -131,24 +131,6 @@
 
 	SPAWN_DBG (rand(waittime_l, waittime_h))
 		send_intercept()
-
-/datum/game_mode/waldo/proc/get_possible_waldos()
-	var/list/candidates = list()
-
-	for(var/mob/new_player/player in mobs)
-		if((player.client) &&  (player.ready))
-			if(player.client.preferences.be_syndicate)
-				candidates += player.mind
-
-	if(candidates.len < 1)
-		for(var/mob/new_player/player in mobs)
-			if((player.client) && (player.ready))
-				candidates += player.mind
-
-	if(candidates.len < 1)
-		return null
-	else
-		return candidates
 
 /datum/game_mode/waldo/proc/equip_waldo(mob/living/carbon/human/waldo_mob)
 	if (!istype(waldo_mob))

--- a/code/datums/gamemodes/wizard.dm
+++ b/code/datums/gamemodes/wizard.dm
@@ -28,7 +28,7 @@
 
 	var/num_wizards = max(1, min(round(num_players / 12), wizards_possible))
 
-	var/list/possible_wizards = get_possible_wizards(num_wizards)
+	var/list/possible_wizards = get_possible_enemies(ROLE_WIZARD, num_wizards)
 
 	if (!possible_wizards.len)
 		return 0
@@ -100,37 +100,6 @@
 
 	SPAWN_DBG (rand(waittime_l, waittime_h))
 		send_intercept()
-
-/datum/game_mode/wizard/proc/get_possible_wizards(minimum_wizards=1)
-
-	var/list/candidates = list()
-
-	for(var/client/C)
-		var/mob/new_player/player = C.mob
-		if (!istype(player)) continue
-
-		if (ishellbanned(player)) continue //No treason for you
-		if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-			if(player.client.preferences.be_wizard)
-				candidates += player.mind
-
-	if(candidates.len < minimum_wizards)
-		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [candidates.len] players with be_wizard set to yes. We need [minimum_wizards], so including players who don't want to be wizards in the pool.")
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player)) continue
-
-			if (ishellbanned(player)) continue //No treason for you
-			if ((player.ready) && !(player.mind in traitors) && !(player.mind in token_players) && !candidates.Find(player.mind))
-				candidates += player.mind
-
-				if ((minimum_wizards > 1) && (candidates.len >= minimum_wizards))
-					break
-
-	if(candidates.len < 1)
-		return list()
-	else
-		return candidates
 
 /datum/game_mode/wizard/send_intercept()
 	var/intercepttext = "Cent. Com. Update Requested staus information:<BR>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Several gamemodes define their own get_possible_"antagtype"s. They're all the same exact code copypasted with singular line changes. This PR refactors them to use a single all-purpose proc, which already existed and was in use for mixed, slightly extended to be compatible with certain antagonist types that relied on their own copypasted procs.
The PR affects code across almost if not all gamemodes and possibly some other miscallenous places that made use of looking for antagonist candidates.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Easier to debug and apply changes at a single point instead of several procs spread out across gamemodes, cleaner code.


## Extra concerns
Everything seemed to work in my few local tests, but this is the kind of change that's somewhat difficult to test on your own. Would want to keep an eye on the servers if/when it's merged to make sure everything's indeed fine.
Also with it being a PR the code is available to look through for any immediate oddities.

Also, though this is unrelated to the PR, analysing the code, some worrying things seem apparent about the already present code.
i.e., if nobody has headrev enabled in their preferences, a revolutionary round can start with just a single revhead, even if there's a lot of crew available.
This is because it starts looking for candidates before it's decided how many it wants to spawn.
The PR preserves the behaviour, albeit it might be worth looking into separately, both in context of that and any other gamemode, probably possible to fix by calculating the requested amount of antagonists first, much like how game_mode/traitor decides its num_traitors.
The forementioned is present for any get_possible_enemies call that uses a hardcoded value (preserved from old live behaviour).