### PR TITLE
Fix #5946 - Port-a-Brig teleporting

### DIFF
--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -385,6 +385,15 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 		src.go_out()
 		return
 
+	Exited(atom/movable/Obj)
+		..()
+		src.occupant = null
+		build_icon()
+		for (var/obj/item/I in src)
+			I.set_loc(src.loc)
+		if (processing)
+			UnsubscribeProcess()
+
 	attackby(obj/item/W, mob/user as mob)
 		if (istype(W, /obj/item/device/pda2) && W:ID_card)
 			W = W:ID_card

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -437,8 +437,11 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 		if (src.locked)
 			boutput(usr, "<span class='alert'>The Port-A-Brig is locked!</span>")
 			return
-		src.occupant.set_loc(src.loc)
-		src.occupant.changeStatus("weakened", 2 SECONDS)
+		if(src.occupant.loc == src)
+			src.occupant.set_loc(src.loc)
+			src.occupant.changeStatus("weakened", 2 SECONDS)
+		else
+			src.visible_message("<span class='notice'>The [src] is mysteriously empty.</span>")
 		src.occupant = null
 		build_icon()
 		for (var/obj/item/I in src) //What if you drop something while inside? WHAT THEN HUH?

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -387,10 +387,11 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 
 	Exited(atom/movable/Obj)
 		..()
-		src.occupant = null
-		build_icon()
-		for (var/obj/item/I in src) //What if you drop something while inside? WHAT THEN HUH?
-			I.set_loc(src.loc)
+		if(Obj == src.occupant)
+			src.occupant = null
+			build_icon()
+			for (var/obj/item/I in src) //What if you drop something while inside? WHAT THEN HUH?
+				I.set_loc(src.loc)
 
 		if (processing)
 			UnsubscribeProcess()

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -389,8 +389,9 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 		..()
 		src.occupant = null
 		build_icon()
-		for (var/obj/item/I in src)
+		for (var/obj/item/I in src) //What if you drop something while inside? WHAT THEN HUH?
 			I.set_loc(src.loc)
+
 		if (processing)
 			UnsubscribeProcess()
 
@@ -441,24 +442,12 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 			icon_state = "port_a_brig_0"
 
 	proc/go_out()
-		if (!src.occupant)
-			return
 		if (src.locked)
 			boutput(usr, "<span class='alert'>The Port-A-Brig is locked!</span>")
 			return
-		if(src.occupant.loc == src)
+		if(src.occupant)
 			src.occupant.set_loc(src.loc)
 			src.occupant.changeStatus("weakened", 2 SECONDS)
-		else
-			src.visible_message("<span class='notice'>The [src] is mysteriously empty.</span>")
-		src.occupant = null
-		build_icon()
-		for (var/obj/item/I in src) //What if you drop something while inside? WHAT THEN HUH?
-			I.set_loc(src.loc)
-
-		if (processing)
-			UnsubscribeProcess()
-
 		return
 
 	verb/move_eject()

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -393,8 +393,8 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 			for (var/obj/item/I in src) //What if you drop something while inside? WHAT THEN HUH?
 				I.set_loc(src.loc)
 
-		if (processing)
-			UnsubscribeProcess()
+			if (processing)
+				UnsubscribeProcess()
 
 	attackby(obj/item/W, mob/user as mob)
 		if (istype(W, /obj/item/device/pda2) && W:ID_card)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #5946

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If for whatever reason, such as recall artifact or admin intervention, a mob was teleported out of the port-a-brig it would still set their loc back to the port-a-brig tile when emptied.