### PR TITLE
Bubsium splash on map vote button picks Ozymandias

### DIFF
--- a/code/mapSwitching.dm
+++ b/code/mapSwitching.dm
@@ -606,6 +606,8 @@ var/global/datum/mapSwitchHandler/mapSwitcher
 				//chosenMap = "Density"
 			if(istype(I, /obj/item/reagent_containers/food/snacks/donut))
 				chosenMap = "Donut 2"
+			if(istype(I, /obj/item/reagent_containers) && I:reagents:has_reagent("bubsium"))
+				chosenMap = "Ozymandias"
 
 		if (mapSwitcher.playersVoting)
 			if(chosenMap)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a response to /obj/mapVoteLink when bubsium is splashed, picking Ozymandias as the voted map.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The map may not be quite suitable for regular rotation, but some folks have been expressing interest in being able to reach it, and the challenge of attaining bubsium and distributing it to enough people before map vote goes off should temper its rate of appearance. Don't have a strong conviction about this one, but I figured I'd explore the possibility.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(+)Bubsium may now widen a path to the king of kings.
```
