### PR TITLE
Fixes a couple wolf bugs, slightly reduces aconite stun time

### DIFF
--- a/code/datums/abilities/werewolf/werewolf_throw.dm
+++ b/code/datums/abilities/werewolf/werewolf_throw.dm
@@ -2,15 +2,16 @@
 	name = "Throw"
 	desc = "Spin a grabbed opponent around and throw them."
 	icon_state = "throw"
-	targeted = 1
-	target_anything = 0
-	target_nodamage_check = 0
-	target_selection_check = 0
+	targeted = TRUE
+	target_anything = FALSE
+	target_nodamage_check = FALSE
+	target_selection_check = FALSE
 	max_range = 1
 	cooldown = 300
 	pointCost = 0
-	when_stunned = 0
-	not_when_handcuffed = 1
+	when_stunned = FALSE
+	not_when_handcuffed = TRUE
+	werewolf_only = TRUE
 	//throw mostly stolen from macho man. Doesn't spin as fast and doesn't deal with grabs, it's just a targetable ability.
 	cast(mob/target)
 		if (!holder)

--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -351,8 +351,8 @@
 	// module_research_type = /obj/item/plant/herb/cannabis
 	attack_hand(var/mob/user as mob)
 		if (iswerewolf(user))
-			user.changeStatus("weakened", 8 SECONDS)
-			user.take_toxin_damage(-10)
+			user.changeStatus("weakened", 3 SECONDS)
+			user.TakeDamage("All", 0, 5, 0, DAMAGE_BURN)
 			boutput(user, "<span class='alert'>You try to pick up [src], but it hurts and you fall over!</span>")
 			return
 		else ..()
@@ -362,7 +362,7 @@
 		if(iswerewolf(M))
 			M.changeStatus("weakened", 3 SECONDS)
 			M.force_laydown_standup()
-			M.take_toxin_damage(-10)
+			M.TakeDamage("All", 0, 5, 0, DAMAGE_BURN)
 			M.visible_message("<span class='alert'>The [M] steps too close to [src] and falls down!</span>")
 			return
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance] [minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1. Instead of being healed 10 tox when they touch or walk over an aconite flower, wolves now take 5 burn damage. The stun timer for picking one up has also been reduced a bit, considering if you try to do that you likely either misclicked or are new to wolfing- 8 seconds felt like a bit much, and the stun for walking over aconite was 3, so I set them both to that.
2. Wolves can no longer use their throw in normal person form. Werewolves seem to be normal people when they aren't transformed, so I dunno why they were getting a super throw.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugszcs
Reasons for balance changes outlined above.