### PR TITLE
fixes ptl runtime if no engineering staff exists

### DIFF
--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -203,7 +203,9 @@
 		else if(t.fields["job"] == "Engineer")
 			accounts += t
 
-	if(abs(generated_moolah) >= accounts.len*2) //otherwise not enough to split evenly so don't bother I guess
+	if(!accounts.len) // no engineering staff but someone still started the PTL
+		wagesystem.station_budget += generated_moolah
+	else if(abs(generated_moolah) >= accounts.len*2) //otherwise not enough to split evenly so don't bother I guess
 		wagesystem.station_budget += round(generated_moolah/2)
 		generated_moolah -= round(generated_moolah/2) //no coming up with $$$ out of air!
 

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -203,7 +203,7 @@
 		else if(t.fields["job"] == "Engineer")
 			accounts += t
 
-	if(!accounts.len) // no engineering staff but someone still started the PTL
+	if(!length(accounts)) // no engineering staff but someone still started the PTL
 		wagesystem.station_budget += generated_moolah
 	else if(abs(generated_moolah) >= accounts.len*2) //otherwise not enough to split evenly so don't bother I guess
 		wagesystem.station_budget += round(generated_moolah/2)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When no one to give the money to existed, the code divided by zero. 
Now it should just put all the money into the station budget instead.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
runtime bad