### PR TITLE
makes garlic spliceable properly

### DIFF
--- a/code/modules/hydroponics/plants_veg.dm
+++ b/code/modules/hydroponics/plants_veg.dm
@@ -86,3 +86,4 @@ ABSTRACT_TYPE(/datum/plant/veg)
 	endurance = 3
 	genome = 13
 	commuts = list(/datum/plant_gene_strain/growth_fast,/datum/plant_gene_strain/terminator)
+	assoc_reagents = list("water_holy")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Garlic didn't seem to actually have holy water set as an associated reagent, it was just added into the garlic object itself, so you couldn't splice it into other plants.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think not allowing one to splice this is pretty unintuitive and boring. 
Holy water is already pretty trivial to get in arbitrary amounts via the bar, so I don't feel like this will be a big nerf to vampires, but if it turns out to be, I think it should be balanced in some different way that doesn't remove the option for botany.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) Splicing garlic should now properly give the resulting plant the holy water reagent.
```
