### PR TITLE
Blobs can no longer spawn inside arrivals

### DIFF
--- a/code/modules/antagonists/blob/blob_abilities.dm
+++ b/code/modules/antagonists/blob/blob_abilities.dm
@@ -202,6 +202,10 @@
 				boutput(owner, __red("You need to start on the [station_or_ship()]!"))
 				return
 
+			if(IS_ARRIVALS(T.loc))
+				boutput(owner, "<spawn class='alert'>You can't start inside arrivals!</span>")
+				return
+
 			if (istype(T,/turf/unsimulated/))
 				boutput(owner, "<span class='alert'>This kind of tile cannot support a blob.</span>")
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. Note that this restriction does not apply to admins.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Demolishing arrivals is against the rules, so may as well enforce it in gameplay.

