### PR TITLE
Update cigpacket icon after emptying into det gadget hat

### DIFF
--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -381,6 +381,7 @@ proc/filter_trait_hats(var/type)
 					C.set_loc(src)
 					cigs.Add(C)
 					packet.cigcount--
+				packet.update_icon()
 				success = 1
 
 		if(success)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updates the cigpacket icon when it is emptied into the detective's gadget hat.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Icon didn't update.