### PR TITLE
Increases changeling sting to 140 second cooldown

### DIFF
--- a/code/modules/antagonists/changeling/abilities/stings.dm
+++ b/code/modules/antagonists/changeling/abilities/stings.dm
@@ -4,7 +4,7 @@
 	var/stealthy = 1
 	var/venom_id = "toxin"
 	var/inject_amount = 50
-	cooldown = 900
+	cooldown = 1400
 	targeted = 1
 	target_anything = 1
 	target_in_inventory = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This applies to both the RP and Classic servers. It takes 90 seconds for neuro/capu sting to drain completely, and it takes you an additional ~20 seconds for you to regain conciousness. This change gives the ling around 30 seconds after a sting wears out and the person gets back up to be able to sting again.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, a ling has around 110 seconds to kill someone (takes around 30 seconds after being stung to knock out, so 80 seconds of them being passed out) after they sting them, if they fail this, they can merely sting them again with basically no penelty. This is incredibly forgiving for an antag that already has a lot of mechanical forgiveness. This change makes failing to kill within the time of a sting somewhat punishing.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Neurotoxin and capulettium sting cooldown has been increased to 140 seconds.
```
