### PR TITLE
Change cancel stuns to use animate

### DIFF
--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -659,25 +659,16 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 // for vampire standup :)
 /proc/violent_standup_twitch(var/atom/A)
 	SPAWN_DBG(-1)
-		var/matrix/start = matrix(A.transform)
-		var/matrix/target = matrix(A.transform)
-		var/last_angle = rand(-45,45)
-		target.Turn(last_angle)
-		A.transform = target
-		var/orig_x = A.pixel_x
-		var/orig_y = A.pixel_y
-
+		var/offx
+		var/offy
+		var/angle
 		for (var/i = 0, (i < 7 && A), i++)
-			var/new_angle = rand(-45, 45)
-			target = A.transform.Turn(-last_angle + new_angle)
-			last_angle = new_angle
-			A.transform = target
-
-			A.pixel_x = orig_x + rand(-3,3)
-			A.pixel_y = orig_y + rand(-2,2)
+			offx = rand(-3,3)
+			offy = rand(-2,2)
+			angle = rand(-45,45)
+			animate(A, time = 0.5, transform = matrix().Turn(angle), easing = JUMP_EASING, pixel_x = offx, pixel_y = offy, flags = ANIMATION_PARALLEL|ANIMATION_RELATIVE)
+			animate(time = 0.5, transform = matrix().Turn(-angle), easing = JUMP_EASING, pixel_x = -offx, pixel_y = -offy, flags = ANIMATION_RELATIVE)
 			sleep(0.1 SECONDS)
-
-		animate(A, pixel_x = orig_x, pixel_y = orig_y, transform = UNDO_TRANSFORMATION(start, target, A.transform), time = 1, easing = LINEAR_EASING, flags=ANIMATION_PARALLEL)
 
 /proc/eat_twitch(var/atom/A)
 	var/matrix/squish_matrix = matrix(A.transform)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Changes cancel stuns to use animate calls instead of a series of manually applied transformations and pixel offsets that are then reversed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Players could exploit the nature of the old method by spamming rest to place their mob into rotated transformation states (i.e. appear to be resting while standing)