### PR TITLE
Exempt firelocks from ion storm fuckery

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -202,7 +202,7 @@
 				for_by_tcl (foundDoor, /obj/machinery/door)
 					if (foundDoor.z != 1)
 						continue
-					if (istype(foundDoor, /obj/machinery/door/poddoor) || istype(foundDoor, /obj/machinery/door/firedoor))
+					if (foundDoor.cant_emag)
 						continue
 					T = get_turf(foundDoor)
 					if (!istype(T.loc,/area/station/))

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -202,7 +202,7 @@
 				for_by_tcl (foundDoor, /obj/machinery/door)
 					if (foundDoor.z != 1)
 						continue
-					if (istype(foundDoor, /obj/machinery/door/poddoor))
+					if (istype(foundDoor, /obj/machinery/door/poddoor) || istype(foundDoor, /obj/machinery/door/firedoor))
 						continue
 					T = get_turf(foundDoor)
 					if (!istype(T.loc,/area/station/))

--- a/code/obj/machinery/door/firedoor.dm
+++ b/code/obj/machinery/door/firedoor.dm
@@ -36,6 +36,7 @@
 	var/image/welded_image = null
 	var/welded_icon_state = "welded"
 	has_crush = 0
+	cant_emag = 1
 
 /obj/machinery/door/firedoor/border_only
 	name = "Firelock"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Exempts firelocks from being affected by ion storms.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
One of the effects for doors is that `locked` gets set, which for normal airlocks means they're bolted. For firelocks this does nothing except set the sprite to something nonexistent when they close (this is firelock specific code even, seems like they used to be more complicated mechanically) which just results in an invisible thing that blocks your movement. The other possible effect (electrifying, which does nothing, or opening/closing) aren't very interesting for firelocks either.

On the upside considering the proportion of firelocks to doors on a station, ion storms should also mess with a bunch more airlocks now!
