### PR TITLE
Misc destiny fixes

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -325,12 +325,23 @@ var/global/list/mapNames = list(
 	arrivals_type = MAP_SPAWN_CRYO
 	dir_fore = NORTH
 
-	walls = /turf/simulated/wall/auto/gannets
-	rwalls = /turf/simulated/wall/auto/reinforced/gannets
+	walls = /turf/simulated/wall/auto/supernorn
+	rwalls = /turf/simulated/wall/auto/reinforced/supernorn
 	auto_walls = 1
 
 	ext_airlocks = /obj/machinery/door/airlock/pyro/external
 	airlock_style = "pyro"
+
+	windows = /obj/window/auto
+	windows_thin = /obj/window/pyro
+	rwindows = /obj/window/auto/reinforced
+	rwindows_thin = /obj/window/reinforced/pyro
+	windows_crystal = /obj/window/auto/crystal
+	windows_rcrystal = /obj/window/auto/crystal/reinforced
+	window_layer_full = COG2_WINDOW_LAYER
+	window_layer_north = GRILLE_LAYER+0.1
+	window_layer_south = FLY_LAYER+1
+	auto_windows = 1
 
 	escape_centcom = /area/shuttle/escape/centcom/destiny
 	escape_transit = /area/shuttle/escape/transit/destiny

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -618,14 +618,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
+/obj/cable,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
 /area/station/hallway/primary/southeast)
 "acp" = (
 /obj/cable{
@@ -6621,7 +6616,6 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/shrub,
 /obj/machinery/light/incandescent/harsh{
 	dir = 1;
 	nostick = 1
@@ -9935,6 +9929,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
+"aMQ" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "aMR" = (
 /obj/table/reinforced/auto,
 /obj/machinery/glass_recycler,
@@ -15614,7 +15615,6 @@
 	name = "autoname  - SS13"
 	},
 /obj/machinery/turret,
-/obj/machinery/turretcover,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "bvn" = (
@@ -25200,7 +25200,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/drainage,
+/obj/shrub,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "eYI" = (
@@ -26768,7 +26768,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/drainage,
+/obj/shrub,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "fLO" = (
@@ -35326,6 +35326,7 @@
 /obj/machinery/light/emergency{
 	dir = 4
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "kvY" = (
@@ -36549,11 +36550,11 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/food,
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating/random,
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "leR" = (
 /obj/machinery/light{
@@ -37863,11 +37864,11 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
+/obj/cable{
+	icon_state = "0-4"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
 /area/station/hallway/primary/west)
 "lRE" = (
 /obj/cable,
@@ -38331,7 +38332,6 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/shrub,
 /obj/decal/tile_edge/line/green{
 	dir = 1;
 	icon_state = "line1"
@@ -38471,6 +38471,14 @@
 /obj/potted_plant/potted_plant2,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
+"mic" = (
+/obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/drainage,
+/turf/simulated/floor/black,
+/area/station/hallway/primary/central)
 "mil" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -39373,9 +39381,11 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating/random,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "mGL" = (
 /obj/machinery/shipalert{
@@ -39394,9 +39404,11 @@
 	},
 /area/station/bridge)
 "mGQ" = (
-/obj/cable,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating/random,
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "mGU" = (
 /obj/decal/tile_edge/stripe{
@@ -41969,6 +41981,7 @@
 /obj/machinery/light/emergency{
 	dir = 8
 	},
+/obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "oem" = (
@@ -54118,12 +54131,14 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/cable,
-/obj/cable{
-	icon_state = "0-2"
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating/random,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/firedoor_spawn,
+/turf/simulated/floor/black,
 /area/station/hallway/primary/southeast)
 "uJT" = (
 /obj/disposalpipe/segment/mail{
@@ -55389,9 +55404,6 @@
 	},
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/supply)
-"vpb" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/solar/east)
 "vpo" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -56686,11 +56698,6 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/west)
 "wdt" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=sec";
-	location = "courtroom";
-	name = "bot navigation beacon"
-	},
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
@@ -60664,9 +60671,6 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
 /area/station/engine/gas)
-"yfE" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/solar/west)
 "yfL" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -103089,7 +103093,7 @@ aaa
 uNs
 aWn
 aXq
-yfE
+arP
 arP
 bkt
 bkt
@@ -103391,7 +103395,7 @@ arP
 arP
 asz
 arP
-yfE
+arP
 awP
 cEG
 glY
@@ -106149,7 +106153,7 @@ vry
 uSJ
 uSJ
 wjb
-vry
+aMQ
 oPl
 amJ
 aCZ
@@ -107357,7 +107361,7 @@ akB
 akB
 akB
 aTR
-omH
+mic
 akA
 amJ
 mDJ
@@ -109727,7 +109731,7 @@ vvE
 rWB
 apR
 apR
-vpb
+nrA
 vne
 uGe
 vVd
@@ -110029,12 +110033,12 @@ aaa
 aaa
 aaa
 aaa
-vpb
-vpb
-vpb
-vpb
+nrA
+nrA
+nrA
+nrA
 iqW
-vpb
+nrA
 nnS
 tFq
 aSo
@@ -110338,7 +110342,7 @@ uNs
 kga
 aXT
 nrA
-vpb
+nrA
 aAM
 aAM
 ast


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
-The most major change this makes is turning the central hub exits to the east and west halls from single to double door gates, which involved shuffling some bushes & drains around
-Removes a turret cover in the AI upload
-Removes a duplicate (in terms of settings) bot nav beacon from under a courtroom table
-Also sets the walls and windows in the map settings to perspective stuff (mostly copied from cog1, why do we have so many window vars?)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
-I found that as a borg it's fairly easy to end up in a jam with crew trying to get through the door at the same time. They're major routes as well.
-Turrets spawn their own covers, and this one ended up hiding the upload turret.
-I've seen beepsky get stuck trying to move to the inaccessible beacon.
-Seeing yourself make non-perspective walls is sad, also the RCD's window mode didn't work for the map.

## Changelog
Probably none necessary?
