### PR TITLE
Manta Mining Alternative Option

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -250,6 +250,10 @@
 /obj/storage/closet,
 /turf/simulated/floor/carpet/purple/fancy/narrow/sw,
 /area/station/communications/bedroom)
+"aaN" = (
+/obj/decal/poster/wallsign/poster_cool,
+/turf/simulated/wall/auto/reinforced/supernorn/orange,
+/area/station/mining/staff_room)
 "aaP" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -27329,6 +27333,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_west,
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
 "bzZ" = (
@@ -33628,6 +33633,7 @@
 /obj/machinery/door_control/podbay/mining/new_walls/west{
 	name = "Submarine Bay (Mining) door control"
 	},
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
 "fkq" = (
@@ -34025,6 +34031,7 @@
 /obj/item/shipcomponent/sensor/mining{
 	pixel_x = 6
 	},
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
 "fLG" = (
@@ -36305,7 +36312,8 @@
 /obj/disposalpipe/segment/mineral{
 	icon_state = "pipe-c"
 	},
-/obj/item/storage/wall/mining,
+/obj/decal/cleanable/dirt/jen,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
 "kIT" = (
@@ -37450,6 +37458,7 @@
 	pixel_x = 5
 	},
 /obj/table/reinforced/industrial/auto,
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
 "nuY" = (
@@ -38236,6 +38245,7 @@
 /obj/landmark/start{
 	name = "Miner"
 	},
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
 "oWc" = (
@@ -38273,6 +38283,7 @@
 /area/station/security/interrogation)
 "oXC" = (
 /obj/machinery/manufacturer/hangar,
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
 "oZK" = (
@@ -38479,6 +38490,7 @@
 /obj/landmark/start{
 	name = "Miner"
 	},
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
 "ptd" = (
@@ -38919,6 +38931,9 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment,
+/obj/landmark/start{
+	name = "Miner"
+	},
 /turf/unsimulated/floor/orange,
 /area/station/mining/staff_room)
 "qBh" = (
@@ -39194,7 +39209,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/door_control{
-	id = "securitylobby";
+	id = "letmethehelloutofmining";
 	name = "Mining Teleporter Exit Control";
 	pixel_x = -25
 	},
@@ -39204,6 +39219,11 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
 	pixel_x = -10
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/potted_plant/potted_plant4{
+	dir = 8;
+	name = "Sherby the Shrub"
 	},
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
@@ -39756,6 +39776,12 @@
 	dir = 8
 	},
 /obj/disposalpipe/segment/mineral,
+/obj/decal/cleanable/dirt/jen,
+/obj/item/storage/wall/mining{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 0
+	},
 /turf/unsimulated/floor/orange,
 /area/station/mining/staff_room)
 "skn" = (
@@ -41418,6 +41444,8 @@
 /obj/decal/tile_edge/stripe/big{
 	dir = 4
 	},
+/obj/decal/cleanable/dirt,
+/obj/decal/cleanable/dirt/jen,
 /turf/unsimulated/floor/orange,
 /area/station/mining/staff_room)
 "wdi" = (
@@ -41620,6 +41648,8 @@
 /obj/decal/poster/wallsign/poster_mining{
 	pixel_y = 32
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
 "wzU" = (
@@ -65239,7 +65269,7 @@ xba
 txQ
 meh
 xpJ
-ldA
+aaN
 kID
 siD
 okI
@@ -66751,7 +66781,7 @@ qDm
 fMm
 bOI
 bBt
-uUj
+cty
 mvU
 asB
 dqv

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -5,13 +5,6 @@
 "aab" = (
 /turf/space/fluid/manta,
 /area/station/shield_zone/manta)
-"aac" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/diner/backroom)
-"aad" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/diner/backroom)
 "aae" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/portupperhallway)
@@ -191,18 +184,10 @@
 /turf/simulated/floor/longtile,
 /area/station/bridge)
 "aaA" = (
-/obj/decal/fakeobjects{
-	anchored = 1;
-	density = 1;
-	desc = "This computer is incredibly broken.  Look at how broken it is!  Very much so.";
-	dir = 1;
-	icon = 'icons/obj/computer.dmi';
-	icon_state = "offbroken";
-	name = "broken computer";
-	tag = "icon-offbroken (NORTH)"
-	},
-/turf/simulated/floor/grime,
-/area/diner/backroom)
+/obj/decal/cleanable/dirt/jen,
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "aaB" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -265,17 +250,6 @@
 /obj/storage/closet,
 /turf/simulated/floor/carpet/purple/fancy/narrow/sw,
 /area/station/communications/bedroom)
-"aaN" = (
-/obj/decal/fakeobjects{
-	anchored = 1;
-	density = 1;
-	desc = "A large rack of server modules.  It doesn't seem to be in service.";
-	icon = 'icons/obj/networked.dmi';
-	icon_state = "server0";
-	name = "downed server"
-	},
-/turf/simulated/floor/grime,
-/area/diner/backroom)
 "aaP" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -652,9 +626,6 @@
 	dir = 1
 	},
 /area/station/security/secwing)
-"abS" = (
-/turf/simulated/floor/grime,
-/area/diner/backroom)
 "abT" = (
 /obj/decal/tile_edge/line/blue{
 	icon_state = "line1"
@@ -719,14 +690,6 @@
 	},
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
-"abY" = (
-/obj/stool/chair{
-	anchored = 0;
-	dir = 1
-	},
-/obj/decal/cleanable/dirt/dirt5,
-/turf/simulated/floor/grime,
-/area/diner/backroom)
 "abZ" = (
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
@@ -747,13 +710,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/ai_upload)
-"aca" = (
-/obj/stool/chair{
-	anchored = 0;
-	dir = 1
-	},
-/turf/simulated/floor/grime,
-/area/diner/backroom)
 "acc" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/firealarm{
@@ -771,18 +727,6 @@
 	},
 /turf/simulated/floor/wood/five,
 /area/station/chapel/sanctuary)
-"ace" = (
-/obj/decal/fakeobjects{
-	anchored = 1;
-	desc = "An old computer that doesn't appear to be plugged in.  Do you see the cord anywhere? Yes?  Oh, good...wait, where's the outlet?.";
-	icon = 'icons/obj/computer.dmi';
-	icon_state = "old0";
-	name = "inactive computer";
-	pixel_y = 8
-	},
-/obj/table/auto,
-/turf/simulated/floor/grime,
-/area/diner/backroom)
 "acf" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/crematorium)
@@ -793,10 +737,6 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen/freezer)
-"ach" = (
-/obj/decal/cleanable/dirt/dirt5,
-/turf/simulated/floor/grime,
-/area/diner/backroom)
 "aci" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/starboardtorpedoes)
@@ -804,26 +744,6 @@
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
 /area/station/security/starboardtorpedoes)
-"ack" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/grime,
-/area/diner/backroom)
-"acm" = (
-/obj/decal/fakeobjects{
-	anchored = 1;
-	desc = "An old computer that doesn't appear to be plugged in.  Do you see the cord anywhere? No? Dang.";
-	icon = 'icons/obj/computer.dmi';
-	icon_state = "old0";
-	name = "inactive computer";
-	pixel_x = 4
-	},
-/obj/table/auto,
-/turf/simulated/floor/grime,
-/area/diner/backroom)
-"acn" = (
-/obj/decal/fakeobjects/lighttube_broken,
-/turf/simulated/floor/grime,
-/area/diner/backroom)
 "aco" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/table/reinforced/auto,
@@ -844,14 +764,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/portupperhallway)
-"acw" = (
-/obj/decal/cleanable/gangtag{
-	icon_state = "gangtag16";
-	pixel_y = -28
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/grime,
-/area/diner/backroom)
 "acy" = (
 /obj/machinery/light_switch/auto{
 	pixel_x = -24
@@ -862,10 +774,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/visitation)
-"acA" = (
-/obj/decal/cleanable/dirt/dirt4,
-/turf/simulated/floor/grime,
-/area/diner/backroom)
 "acB" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/communications/bedroom)
@@ -887,16 +795,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/communications/bedroom)
-"acF" = (
-/obj/decal/cleanable/gangtag{
-	icon_state = "gangtag16";
-	pixel_y = -28
-	},
-/turf/simulated/floor/grime,
-/area/diner/backroom)
-"acG" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/skeleton_trader)
 "acH" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -907,19 +805,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
-"acI" = (
-/obj/machinery/door/airlock/pyro,
-/turf/simulated/floor/grime,
-/area/diner/backroom)
-"acJ" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/diner/bathroom)
-"acK" = (
-/obj/stool/chair/couch{
-	dir = 8
-	},
-/turf/simulated/floor/grime,
-/area/skeleton_trader)
 "acL" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -932,10 +817,6 @@
 "acO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/upperport)
-"acQ" = (
-/obj/npc/trader/skeleton,
-/turf/simulated/floor/grime,
-/area/skeleton_trader)
 "acR" = (
 /obj/machinery/junctionbox/variantb{
 	pixel_y = 32
@@ -961,98 +842,9 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crewquarters/cryotron)
-"acX" = (
-/obj/marker/supplymarker,
-/turf/simulated/floor/grime,
-/area/skeleton_trader)
-"acY" = (
-/obj/submachine/slot_machine,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"acZ" = (
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"ada" = (
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"adb" = (
-/obj/machinery/computer/tetris,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"adc" = (
-/obj/npc/trader/hand,
-/turf/simulated/floor/grime,
-/area/diner/bathroom)
-"add" = (
-/obj/submachine/chef_sink/chem_sink{
-	layer = 3;
-	pixel_y = 8
-	},
-/turf/simulated/floor/grime,
-/area/diner/bathroom)
-"ade" = (
-/obj/decal/cleanable/cobweb2,
-/obj/decal/fakeobjects/teleport_pad,
-/obj/marker/supplymarker,
-/turf/simulated/floor/damaged2,
-/area/diner/bathroom)
-"adf" = (
-/turf/simulated/floor/grime,
-/area/skeleton_trader)
-"adg" = (
-/obj/decal/cleanable/dirt/dirt4,
-/turf/simulated/floor/grime,
-/area/skeleton_trader)
-"adh" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/grime,
-/area/skeleton_trader)
-"adi" = (
-/obj/decal/cleanable/dirt/dirt4,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"adj" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4
-	},
-/turf/simulated/floor/grime,
-/area/diner/bathroom)
-"adk" = (
-/turf/simulated/floor/grime,
-/area/diner/bathroom)
-"adl" = (
-/obj/item/storage/pill_bottle/cyberpunk,
-/obj/decoration/toiletholder{
-	dir = 1
-	},
-/turf/simulated/floor/scorched2,
-/area/diner/bathroom)
-"adm" = (
-/obj/machinery/light/incandescent/small{
-	dir = 4
-	},
-/obj/decal/cleanable/dirt/dirt4,
-/turf/simulated/floor/grime,
-/area/diner/bathroom)
-"adn" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/diner/bathroom)
-"ado" = (
-/obj/machinery/door/airlock/pyro/glass,
-/turf/simulated/floor/specialroom/bar,
-/area/skeleton_trader)
-"adp" = (
-/obj/decal/cleanable/dirt/dirt5,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
 "adq" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/diner/dining)
-"adr" = (
-/turf/simulated/wall/false_wall/reinforced,
-/area/diner/bathroom)
 "ads" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -1067,102 +859,9 @@
 /obj/decal/mantaBubbles/large,
 /turf/space/fluid/manta,
 /area/mantaSpace)
-"adw" = (
-/obj/item/storage/toilet/random,
-/obj/decal/cleanable/gangtag{
-	desc = "A hastily-scrawled sequence of numbers: 1-949-415-6298. What does it mean?";
-	icon = 'icons/obj/junk.dmi';
-	icon_state = "shitty_bill";
-	name = "graffiti";
-	pixel_y = 28
-	},
-/obj/landmark{
-	name = "shitty_bill_respawn"
-	},
-/turf/simulated/floor/grime,
-/area/diner/bathroom)
 "adx" = (
 /turf/space/fluid/manta/nospawn,
 /area/mantaSpace)
-"ady" = (
-/obj/submachine/chef_sink/chem_sink{
-	layer = 3;
-	pixel_y = 8
-	},
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/grime,
-/area/diner/bathroom)
-"adz" = (
-/obj/decal/cleanable/gangtag{
-	icon_state = "gangtag22";
-	pixel_x = 28
-	},
-/obj/item/seed/cannabis,
-/obj/machinery/light/incandescent/small{
-	dir = 4
-	},
-/turf/simulated/floor/grime,
-/area/diner/bathroom)
-"adA" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/bee_trader)
-"adB" = (
-/obj/machinery/door/airlock/pyro/glass,
-/turf/simulated/floor/specialroom/bar,
-/area/bee_trader)
-"adC" = (
-/obj/item/instrument/large/jukebox,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"adD" = (
-/obj/machinery/vending/fortune,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"adE" = (
-/turf/simulated/floor/scorched,
-/area/diner/bathroom)
-"adF" = (
-/obj/critter/roach,
-/turf/simulated/floor/grime,
-/area/diner/bathroom)
-"adG" = (
-/obj/decal/cleanable/vomit,
-/obj/decoration/toiletholder{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/simulated/floor/grime,
-/area/diner/bathroom)
-"adH" = (
-/obj/table/wood/auto,
-/obj/item/reagent_containers/food/snacks/ingredient/royal_jelly{
-	pixel_y = 5
-	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
-/area/bee_trader)
-"adI" = (
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
-/area/bee_trader)
-"adJ" = (
-/obj/stool/chair/couch{
-	dir = 8
-	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
-/area/bee_trader)
-"adK" = (
-/obj/stool/chair/couch{
-	dir = 4
-	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
-/area/bee_trader)
 "adL" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -1172,26 +871,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"adM" = (
-/obj/decal/cleanable/ripped_poster,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/diner/bathroom)
-"adN" = (
-/obj/stool/chair/comfy{
-	dir = 1
-	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
-/area/bee_trader)
-"adO" = (
-/obj/npc/trader/bee{
-	name = "Bambini"
-	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
-/area/bee_trader)
 "adP" = (
 /obj/item/rubberduck,
 /obj/machinery/drainage,
@@ -1201,169 +880,22 @@
 /turf/simulated/floor/sanitary/blue,
 /area/station/crew_quarters/captain)
 "adR" = (
-/obj/decal/cleanable/dirt/dirt3,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"adT" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/diner/dining)
-"adU" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating/random,
-/area/diner/kitchen)
-"adV" = (
-/obj/table/reinforced/bar/auto,
-/obj/marker/supplymarker,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/kitchen)
-"adW" = (
-/obj/stool/chair/wooden{
+/obj/stool/chair/couch{
 	dir = 4
 	},
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"adX" = (
-/obj/table/wood/round/auto,
-/obj/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/breakfast,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"adY" = (
-/obj/stool/chair/wooden{
-	dir = 8
-	},
-/obj/landmark/spawner{
-	name = "shitty_bill"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"adZ" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/diner/kitchen)
-"aea" = (
-/obj/table/reinforced/auto,
-/obj/item/storage/box/glassbox,
-/obj/item/storage/box/cutlery,
-/obj/item/reagent_containers/food/snacks/ingredient/pancake_batter,
-/obj/item/kitchen/rollingpin,
-/obj/decal/cleanable/cobweb,
-/turf/simulated/floor/plating/random,
-/area/diner/kitchen)
-"aeb" = (
-/obj/decal/cleanable/dirt,
-/obj/kitchenspike,
-/turf/simulated/floor/plating/random,
-/area/diner/kitchen)
-"aec" = (
-/turf/simulated/floor/plating/random,
-/area/diner/kitchen)
-"aed" = (
-/obj/decal/cleanable/cobweb2,
-/obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/plating/random,
-/area/diner/kitchen)
-"aee" = (
-/obj/machinery/chem_dispenser/soda,
-/turf/simulated/floor/scorched2,
-/area/diner/kitchen)
-"aef" = (
-/obj/machinery/chem_dispenser/alcohol,
-/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
-/turf/simulated/floor/scorched2,
-/area/diner/kitchen)
-"aeg" = (
-/obj/machinery/vending/alcohol,
-/turf/simulated/floor/grime,
-/area/diner/kitchen)
-"aeh" = (
-/obj/npc/trader/chad,
-/obj/decal/cleanable/paper,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/kitchen)
-"aei" = (
-/obj/stool/chair/wooden{
-	dir = 1
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"aej" = (
-/obj/item/cigbutt,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"aek" = (
-/obj/submachine/chef_sink/chem_sink{
+/obj/machinery/light/incandescent/netural{
 	dir = 4;
-	pixel_x = -4
+	pixel_x = 10
 	},
-/turf/simulated/floor/plating/random,
-/area/diner/kitchen)
-"ael" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/plating/random,
-/area/diner/kitchen)
-"aem" = (
-/obj/decal/cleanable/blood/splatter{
-	icon_state = "floor5"
-	},
-/obj/machinery/light/incandescent/small,
-/turf/simulated/floor/plating/random,
-/area/diner/kitchen)
-"aen" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/gibber/output_west,
-/turf/simulated/floor/plating/random,
-/area/diner/kitchen)
-"aeo" = (
-/obj/item/storage/box/glassbox,
 /turf/simulated/floor/grime,
-/area/diner/kitchen)
-"aep" = (
-/turf/simulated/floor/grime,
-/area/diner/kitchen)
-"aeq" = (
-/obj/table/reinforced/bar/auto,
-/obj/machinery/glass_recycler,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/kitchen)
-"aer" = (
-/obj/stool/bar,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"aet" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"aeu" = (
-/obj/machinery/door/airlock/pyro,
-/turf/simulated/floor/plating/random,
-/area/diner/kitchen)
-"aev" = (
-/obj/decal/cleanable/rust,
+/area/skeleton_trader)
+"aej" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/diner/kitchen)
-"aex" = (
-/obj/decal/cleanable/dirt/dirt3,
-/turf/simulated/floor/grime,
-/area/diner/kitchen)
-"aey" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/shaker/pepper{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/item/shaker/salt{
-	pixel_x = 1
-	},
-/turf/simulated/floor/delivery,
-/area/diner/kitchen)
+/area/diner/backroom)
 "aez" = (
-/obj/stool/chair/wooden,
-/obj/landmark/spawner{
-	name = "don_glab"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/diner/backroom)
 "aeA" = (
 /obj/overlay{
 	density = 1;
@@ -1374,54 +906,6 @@
 	},
 /turf/simulated/floor/grime,
 /area/abandonedmedicalship/robot_trader)
-"aeB" = (
-/obj/table/reinforced/auto,
-/obj/submachine/mixer,
-/obj/decal/cleanable/cobweb,
-/turf/simulated/floor/grime,
-/area/diner/kitchen)
-"aeC" = (
-/obj/machinery/vending/kitchen,
-/turf/simulated/floor/scorched2,
-/area/diner/kitchen)
-"aeD" = (
-/obj/submachine/chef_oven,
-/obj/landmark{
-	name = "shitty_bill_respawn"
-	},
-/turf/simulated/floor/scorched,
-/area/diner/kitchen)
-"aeE" = (
-/obj/machinery/deep_fryer,
-/turf/simulated/floor/damaged2,
-/area/diner/kitchen)
-"aeF" = (
-/obj/decal/cleanable/dirt/dirt5,
-/turf/simulated/floor/grime,
-/area/diner/kitchen)
-"aeG" = (
-/obj/machinery/cashreg,
-/obj/table/reinforced/bar/auto,
-/obj/machinery/cashreg,
-/turf/simulated/floor/delivery,
-/area/diner/kitchen)
-"aeH" = (
-/obj/stool/bar,
-/obj/landmark/spawner{
-	name = "father_jack"
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
-"aeI" = (
-/obj/table/wood/round/auto,
-/obj/item/plate{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/snacks/burger/sloppyjoe{
-	pixel_y = 5
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
 "aeJ" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/chapel/office)
@@ -1446,12 +930,6 @@
 /obj/storage/secure/closet/civilian/chaplain,
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
-"aeN" = (
-/obj/stool/chair/wooden{
-	dir = 8
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
 "aeO" = (
 /obj/computer3frame,
 /turf/simulated/floor/grime,
@@ -1492,39 +970,10 @@
 /obj/decal/cleanable/dirt/dirt5,
 /turf/simulated/floor/grime,
 /area/abandonedmedicalship/robot_trader)
-"aeU" = (
-/obj/item/reagent_containers/food/snacks/ingredient/gcheese,
-/obj/item/reagent_containers/food/snacks/ingredient/gcheese,
-/obj/item/reagent_containers/food/snacks/ingredient/meatpaste,
-/obj/item/reagent_containers/food/drinks/milk/rancid,
-/obj/item/kitchen/food_box/egg_box,
-/obj/storage/secure/closet/fridge/kitchen{
-	locked = 0
-	},
-/turf/simulated/floor/scorched2,
-/area/diner/kitchen)
-"aeV" = (
-/obj/machinery/light/incandescent/warm,
-/turf/simulated/floor/grime,
-/area/diner/kitchen)
-"aeW" = (
-/obj/submachine/ice_cream_dispenser,
-/turf/simulated/floor/grime,
-/area/diner/kitchen)
-"aeX" = (
-/obj/table/reinforced/bar/auto,
-/obj/item/plate,
-/obj/decal/cleanable/molten_item,
-/obj/machinery/light/incandescent/warm,
-/turf/simulated/floor/delivery,
-/area/diner/kitchen)
 "aeY" = (
-/obj/stool/chair/wooden{
-	dir = 1
-	},
-/obj/machinery/light/incandescent/warm,
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
+/obj/marker/supplymarker,
+/turf/simulated/floor/grime,
+/area/skeleton_trader)
 "aeZ" = (
 /obj/item/device/infra,
 /obj/item/device/infra,
@@ -1568,10 +1017,6 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/kitchen/freezer)
-"afi" = (
-/obj/decal/cleanable/rust,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/diner/dining)
 "afj" = (
 /obj/item/storage/box/guardbot_kit,
 /obj/item/device/guardbot_tool/flash,
@@ -1606,36 +1051,9 @@
 	},
 /turf/simulated/floor/grime,
 /area/abandonedmedicalship/robot_trader)
-"afp" = (
-/obj/machinery/shuttle/engine/heater/seaheater_left,
-/turf/simulated/floor/plating,
-/area/diner/dining)
 "afq" = (
-/obj/machinery/shuttle/engine/heater/seaheater_middle,
-/turf/simulated/floor/plating,
-/area/diner/dining)
-"afr" = (
-/obj/machinery/shuttle/engine/heater/seaheater_right,
-/turf/simulated/floor/plating,
-/area/diner/dining)
-"afs" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/grime,
-/area/diner/kitchen)
-"aft" = (
-/obj/decal/cleanable/blood{
-	icon_state = "floor6"
-	},
-/turf/simulated/floor/grime,
-/area/diner/dining)
-"afu" = (
-/obj/decal/cleanable/blood/hurting1,
-/turf/simulated/floor/grime,
-/area/diner/dining)
-"afv" = (
-/obj/decal/cleanable/blood/splatter,
-/turf/simulated/floor/grime,
-/area/diner/dining)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/skeleton_trader)
 "afw" = (
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/grime,
@@ -1663,22 +1081,6 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
-"afD" = (
-/obj/decal/cleanable/blood/splatter,
-/obj/item/device/audio_log,
-/turf/simulated/floor/grime,
-/area/diner/dining)
-"afE" = (
-/obj/decal/cleanable/blood/hurting1/hurting2,
-/turf/simulated/floor/grime,
-/area/diner/dining)
-"afF" = (
-/obj/decal/cleanable/blood/splatter{
-	icon_state = "floor4"
-	},
-/obj/item/clothing/mask/chicken,
-/turf/simulated/floor/grime,
-/area/diner/dining)
 "afH" = (
 /obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/floor/grime,
@@ -1730,35 +1132,10 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/simulated/floor/grime,
 /area/abandonedmedicalship/robot_trader)
-"afR" = (
-/obj/decal/cleanable/blood/splatter{
-	icon_state = "floor5"
-	},
-/obj/item/clothing/suit/jacketsjacket,
-/turf/simulated/floor/grime,
-/area/diner/dining)
-"afS" = (
-/obj/decal/cleanable/blood/splatter{
-	icon_state = "gibbl2"
-	},
-/obj/item/bat,
-/turf/simulated/floor/grime,
-/area/diner/dining)
-"afT" = (
-/obj/decal/cleanable/blood,
-/obj/item/clothing/under/gimmick/shirtnjeans,
-/turf/simulated/floor/grime,
-/area/diner/dining)
-"afU" = (
-/turf/simulated/floor/stairs/wide/other,
-/area/diner/dining)
 "afV" = (
-/obj/decal/cleanable/gangtag{
-	icon_state = "gangtag12";
-	pixel_x = 28
-	},
-/turf/simulated/floor/stairs/wide/other,
-/area/diner/dining)
+/obj/machinery/door/airlock/pyro/glass,
+/turf/simulated/floor/specialroom/bar,
+/area/bee_trader)
 "afW" = (
 /obj/landmark/artifact,
 /turf/simulated/floor/grime,
@@ -1783,13 +1160,15 @@
 /obj/storage/closet/emergency,
 /turf/simulated/floor/grime,
 /area/abandonedmedicalship/robot_trader)
-"agc" = (
-/obj/machinery/door/airlock/pyro/glass,
-/turf/simulated/floor/grime,
-/area/diner/dining)
 "agd" = (
-/turf/simulated/floor/grime,
-/area/diner/dining)
+/obj/table/wood/auto,
+/obj/item/reagent_containers/food/snacks/ingredient/royal_jelly{
+	pixel_y = 5
+	},
+/turf/simulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/bee_trader)
 "age" = (
 /obj/machinery/light/small/floor/cool,
 /obj/decal/cleanable/dirt/dirt4,
@@ -1811,32 +1190,18 @@
 /obj/machinery/shuttle/engine/heater/seaheater_left,
 /turf/space/fluid/manta,
 /area/abandonedmedicalship/robot_trader)
-"agh" = (
-/obj/decal/fakeobjects/firealarm_broken{
-	pixel_y = 28
-	},
-/turf/simulated/floor/grime,
-/area/diner/dining)
-"agi" = (
-/obj/machinery/vending/cola/red,
-/obj/decal/cleanable/cobweb,
-/turf/simulated/floor/grime,
-/area/diner/dining)
 "agj" = (
-/obj/decal/cleanable/dirt/dirt3,
-/turf/simulated/floor/grime,
-/area/diner/dining)
-"agl" = (
-/obj/machinery/vending/cigarette,
-/obj/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
+/obj/machinery/light/incandescent/warm{
+	dir = 8;
+	nostick = 1;
+	pixel_x = -10
 	},
-/turf/simulated/floor/grime,
+/turf/simulated/floor/specialroom/bar,
 /area/diner/dining)
 "agn" = (
-/obj/item/cigbutt,
-/turf/simulated/floor/grime,
-/area/diner/dining)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/diner/kitchen)
 "ago" = (
 /obj/machinery/shuttle/engine/heater/seaheater_middle,
 /turf/space/fluid/manta,
@@ -1932,13 +1297,9 @@
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
 "agA" = (
-/obj/machinery/door/airlock/pyro,
+/obj/machinery/vending/alcohol,
 /turf/simulated/floor/grime,
-/area/diner/hangar)
-"agB" = (
-/obj/decal/cleanable/rust,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/diner/hangar)
+/area/diner/kitchen)
 "agD" = (
 /obj/machinery/shuttle/engine/propulsion/sea_propulsion,
 /turf/space/fluid/manta,
@@ -1954,25 +1315,13 @@
 /obj/decal/cleanable/dirt/dirt5,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
-"agG" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/diner/hangar)
-"agH" = (
-/obj/storage/closet/welding_supply,
-/turf/simulated/floor/caution/south,
-/area/diner/hangar)
 "agJ" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/grime,
-/area/diner/dining)
-"agK" = (
-/obj/machinery/drainage/big,
-/turf/simulated/floor/plating,
-/area/diner/hangar)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/bee_trader)
 "agL" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating/random,
-/area/diner/hangar)
+/obj/machinery/chem_dispenser/soda,
+/turf/simulated/floor/scorched2,
+/area/diner/kitchen)
 "agM" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -1999,28 +1348,10 @@
 /obj/item/wirecutters,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
-"agQ" = (
-/obj/storage/closet/emergency,
-/turf/simulated/floor/caution/south,
-/area/diner/hangar)
-"agR" = (
-/turf/simulated/floor/caution/south,
-/area/diner/hangar)
-"agS" = (
-/obj/decal/cleanable/dirt/dirt3,
-/turf/simulated/floor/caution/south,
-/area/diner/hangar)
 "agT" = (
-/obj/decal/cleanable/dirt/dirt3,
-/obj/machinery/vending/cola/blue,
+/obj/item/storage/box/glassbox,
 /turf/simulated/floor/grime,
-/area/diner/hangar)
-"agU" = (
-/turf/simulated/floor/grime,
-/area/diner/hangar)
-"agX" = (
-/turf/simulated/floor/plating,
-/area/diner/hangar)
+/area/diner/kitchen)
 "agZ" = (
 /obj/torpedo_tray/hiexp_loaded{
 	dir = 8
@@ -2052,28 +1383,6 @@
 /obj/random_item_spawner/med_kit,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
-"ahg" = (
-/turf/simulated/floor/shuttlebay,
-/area/diner/hangar)
-"ahh" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/electrical,
-/turf/simulated/floor/plating,
-/area/diner/hangar)
-"ahj" = (
-/obj/machinery/teleport/portal_ring,
-/turf/simulated/floor/plating,
-/area/diner/hangar)
-"ahk" = (
-/obj/stool/chair/couch/blue{
-	dir = 4
-	},
-/turf/simulated/floor/grime,
-/area/diner/hangar)
-"ahl" = (
-/obj/decal/cleanable/oil,
-/turf/simulated/floor/shuttlebay,
-/area/diner/hangar)
 "ahm" = (
 /obj/machinery/recharge_station{
 	desc = "It looks like some of the safety interlocks are damaged.";
@@ -2088,23 +1397,17 @@
 /obj/item/implanter,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
-"aho" = (
-/obj/decal/cleanable/dirt,
-/obj/machinery/shuttle/engine/propulsion/sea_propulsion,
-/turf/space/fluid/manta,
-/area/mantaSpace)
-"ahp" = (
-/obj/decal/cleanable/dirt/dirt5,
-/turf/simulated/floor/plating,
-/area/diner/hangar)
-"ahr" = (
-/obj/item/device/radio/beacon,
-/turf/simulated/floor/plating,
-/area/diner/hangar)
 "aht" = (
-/obj/stool/bench/green/auto,
+/obj/machinery/light/incandescent/warm{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/obj/stove,
+/obj/item/soup_pot,
+/obj/item/ladle,
 /turf/simulated/floor/grime,
-/area/diner/hangar)
+/area/diner/kitchen)
 "ahu" = (
 /turf/simulated/floor/carpet{
 	dir = 9;
@@ -2133,12 +1436,6 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor/plating,
 /area/abandonedmedicalship/robot_trader)
-"ahz" = (
-/obj/decal/cleanable/rust,
-/obj/wingrille_spawn/auto,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/diner/hangar)
 "ahA" = (
 /obj/machinery/door/airlock/pyro/medical{
 	req_access = null
@@ -2146,34 +1443,6 @@
 /obj/access_spawn/medical_director,
 /turf/simulated/floor/black,
 /area/station/medical/head)
-"ahB" = (
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
-	id = "diner1"
-	},
-/obj/forcefield/energyshield/perma/doorlink,
-/turf/simulated/floor/shuttlebay,
-/area/diner/hangar)
-"ahD" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/plating,
-/area/diner/hangar)
-"ahE" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/diner/hangar)
-"ahF" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir";
-	tag = "icon-lattice-dir (EAST)"
-	},
-/obj/decal/mantaBubbles/large,
-/turf/space/fluid/manta,
-/area/mantaSpace)
-"ahG" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/diner/hangar)
 "ahH" = (
 /obj/machinery/door/airlock/pyro/classic,
 /turf/simulated/floor/plating,
@@ -4729,21 +3998,6 @@
 	},
 /turf/space/fluid/manta/nospawn,
 /area/station/shield_zone/manta)
-"aoQ" = (
-/obj/decal/poster/wallsign/stencil/right/n{
-	pixel_x = 1;
-	pixel_y = 38
-	},
-/obj/decal/poster/wallsign/stencil/right/g{
-	pixel_x = 14;
-	pixel_y = 38
-	},
-/obj/decal/poster/wallsign/stencil/right/e{
-	pixel_x = -12;
-	pixel_y = 38
-	},
-/turf/space/fluid/manta/nospawn,
-/area/station/shield_zone/manta)
 "aoR" = (
 /obj/stool/chair/comfy/green,
 /obj/landmark/start{
@@ -5137,21 +4391,6 @@
 /obj/machinery/navbeacon/guardbotsecbot_circularpatrol/beacon7,
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
-"apJ" = (
-/obj/decal/poster/wallsign/stencil/right/s{
-	pixel_x = -12;
-	pixel_y = 38
-	},
-/obj/decal/poster/wallsign/stencil/right/e{
-	pixel_x = 1;
-	pixel_y = 38
-	},
-/obj/decal/poster/wallsign/stencil/right/c{
-	pixel_x = 14;
-	pixel_y = 38
-	},
-/turf/space/fluid/manta/nospawn,
-/area/station/shield_zone/manta)
 "apK" = (
 /obj/disposalpipe/segment,
 /obj/machinery/drainage/big,
@@ -5227,10 +4466,6 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/starboard)
-"apU" = (
-/obj/machinery/drainage/big,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
 "apV" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	name = "Freezer";
@@ -5594,10 +4829,6 @@
 "aqO" = (
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/turret_protected/ai_upload)
-"aqP" = (
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating,
-/area/station/seaturtlebridge)
 "aqQ" = (
 /obj/machinery/power/seaheater/big,
 /turf/space/fluid/manta,
@@ -5641,8 +4872,9 @@
 /turf/space/fluid/manta/nospawn,
 /area/mantaSpace)
 "aqW" = (
-/turf/space/fluid/manta,
-/area/shuttle/john/diner)
+/obj/machinery/shuttle/engine/heater/seaheater_left,
+/turf/simulated/floor/plating,
+/area/diner/dining)
 "aqX" = (
 /obj/lattice{
 	dir = 9;
@@ -5997,13 +5229,6 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/beepsky)
-"arP" = (
-/obj/miningteleporter,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"arQ" = (
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "arR" = (
 /obj/decal/tile_edge/check{
 	dir = 8;
@@ -6101,10 +5326,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
-"ase" = (
-/obj/item/constructioncone,
-/turf/simulated/floor,
-/area/station/construction/under_construction)
 "asg" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -6176,19 +5397,16 @@
 	},
 /turf/space/fluid/manta/nospawn,
 /area/station/shield_zone/manta)
-"ast" = (
-/obj/item/raw_material/rock,
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "asv" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/landmark/start{
+	name = "Miner"
 	},
-/obj/cable{
-	icon_state = "2-4"
+/obj/decal/cleanable/dirt,
+/obj/disposalpipe/segment/mineral{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/quartermaster/cargooffice)
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "asx" = (
 /obj/machinery/vending/pda,
 /turf/simulated/floor,
@@ -6219,11 +5437,13 @@
 /turf/simulated/floor,
 /area/station/hos)
 "asB" = (
-/obj/machinery/junctionbox/varianta{
-	pixel_y = 32
+/obj/machinery/light/incandescent/netural{
+	dir = 4;
+	pixel_x = 10
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/lowerport)
+/obj/decal/cleanable/dirt/jen,
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "asC" = (
 /obj/machinery/torpedo_tube/syndicate,
 /turf/simulated/shuttle/wall{
@@ -8651,8 +7871,17 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
 "aze" = (
+/obj/stool/chair/office/yellow{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/landmark/start{
+	name = "Quartermaster"
+	},
+/obj/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
@@ -9995,10 +9224,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
-"aCF" = (
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
 "aCG" = (
 /obj/machinery/vending/security_ammo,
 /turf/simulated/floor/black,
@@ -10023,16 +9248,6 @@
 "aCM" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
-"aCO" = (
-/obj/decal/fakeobjects{
-	desc = "Under construction";
-	dir = 1;
-	icon = 'icons/obj/junk.dmi';
-	icon_state = "constructionsign";
-	name = "construction zone"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
 "aCP" = (
 /obj/stool/bed,
 /obj/item/storage/secure/ssafe{
@@ -11679,8 +10894,8 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/quartermaster/cargobay)
+/turf/simulated/wall/auto/reinforced/supernorn/orange,
+/area/station/mining/refinery)
 "aHl" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -12946,6 +12161,10 @@
 "aKw" = (
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
+"aKx" = (
+/obj/machinery/teleport/portal_ring,
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "aKy" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	req_access = null
@@ -13320,13 +12539,6 @@
 /obj/item/reagent_containers/bath_bomb,
 /turf/simulated/floor/sanitary/blue,
 /area/station/crew_quarters/bathroom)
-"aLA" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/mineral,
-/turf/simulated/floor,
-/area/station/quartermaster/cargooffice)
 "aLB" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -14258,10 +13470,11 @@
 	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
 	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment/mineral{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
@@ -17801,10 +17014,6 @@
 	dir = 4
 	},
 /area/station/security/secoffquarters)
-"aYE" = (
-/obj/machinery/portable_reclaimer,
-/turf/simulated/floor,
-/area/station/hangar/mining)
 "aYF" = (
 /obj/table/wood/auto,
 /obj/machinery/computer3/generic/personal/personel_alt{
@@ -18563,17 +17772,16 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "baJ" = (
-/obj/decoration/clock{
-	pixel_x = 32
-	},
-/obj/table/wood/round/auto,
-/obj/machinery/networked/printer{
-	print_id = "Bridge"
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer/stockexchange{
+	dir = 8
 	},
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/data_terminal,
+/obj/decoration/clock{
+	pixel_y = 32
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargooffice)
 "baK" = (
@@ -20732,6 +19940,17 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/fitness)
+"bga" = (
+/obj/table/reinforced/bar/auto,
+/obj/item/shaker/pepper{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/shaker/salt{
+	pixel_x = 1
+	},
+/turf/simulated/floor/delivery,
+/area/diner/kitchen)
 "bgb" = (
 /obj/stool/chair/wooden,
 /obj/machinery/power/apc/autoname_west,
@@ -21917,6 +21136,9 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/junction{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "biZ" = (
@@ -22613,6 +21835,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/drainage/big,
+/obj/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "bkL" = (
@@ -22958,9 +22183,7 @@
 	name = "Submarine Bay (Mining) door control"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/area/station/mining/staff_room)
 "blA" = (
 /obj/loudspeaker,
 /obj/cable{
@@ -24763,9 +23986,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "bpY" = (
@@ -25505,15 +24725,6 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
-"brB" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/submachine/ATM/atm_alt{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
 "brC" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -25726,15 +24937,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"bsc" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/junction{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
 "bsd" = (
 /obj/decal/tile_edge/line/green{
 	dir = 4;
@@ -25814,9 +25016,6 @@
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
 "bsr" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -25887,12 +25086,6 @@
 /obj/decal/tile_edge/line/green{
 	color = "#ba9a65";
 	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
-"bsM" = (
-/obj/cable{
-	icon_state = "1-4"
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
@@ -26141,9 +25334,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
 "btx" = (
@@ -26212,56 +25402,16 @@
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
 "btH" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Mining"
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
 	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
 	},
-/obj/firedoor_spawn,
-/obj/access_spawn/cargo,
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
-"btI" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	pixel_x = 1;
-	pixel_y = 26;
-	text = "NF"
-	},
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
-"btJ" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch/auto{
-	pixel_y = 24
-	},
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
-"btK" = (
-/obj/item/storage/wall/fire{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "btM" = (
-/obj/machinery/manufacturer/hangar,
-/turf/simulated/floor/bot,
-/area/station/quartermaster/cargobay)
-"btP" = (
-/obj/machinery/manufacturer/mining,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 3;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
+/obj/storage/crate/wooden,
 /turf/simulated/floor/bot,
 /area/station/quartermaster/cargobay)
 "btS" = (
@@ -26348,13 +25498,6 @@
 	},
 /turf/simulated/floor,
 /area/station/crewquarters/garbagegarbs)
-"buc" = (
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bud" = (
 /obj/burning_barrel,
 /obj/decal/cleanable/gangtag{
@@ -26366,18 +25509,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerport)
-"bue" = (
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"buf" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light,
-/turf/space/fluid/manta,
-/area/mantaSpace)
 "bug" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail{
@@ -26623,25 +25754,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"bva" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/mining)
-"bvc" = (
-/obj/storage/crate/wooden,
-/turf/simulated/floor/bot,
-/area/station/quartermaster/cargobay)
 "bvd" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "bvf" = (
 /obj/cable{
 	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
@@ -26717,36 +25835,7 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
-"bvr" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay2,
-/turf/space/fluid/manta,
-/area/mantaSpace)
-"bvs" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay3,
-/turf/space/fluid/manta,
-/area/mantaSpace)
-"bvt" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir"
-	},
-/obj/warp_beacon/sea_turtle,
-/obj/machinery/light/runway_light/delay4,
-/turf/space/fluid/manta,
-/area/mantaSpace)
 "bvv" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/juggleplaque/manta,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
@@ -27152,25 +26241,20 @@
 /turf/simulated/floor/caution/south,
 /area/station/hangar/starboard)
 "bwE" = (
-/obj/storage/crate/wooden,
-/obj/machinery/light/incandescent/netural{
-	dir = 8
-	},
-/turf/simulated/floor/bot,
-/area/station/quartermaster/cargobay)
+/obj/decal/tile_edge/stripe/big,
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "bwF" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
+/turf/simulated/wall/auto/reinforced/supernorn/orange,
 /area/station/quartermaster/cargobay)
 "bwG" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mineral{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
@@ -27277,43 +26361,8 @@
 	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/cargobay)
-"bwY" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/announcement/console_lower{
-	dir = 4;
-	req_access = null
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bwZ" = (
-/obj/machinery/neosmelter,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
 "bxa" = (
 /turf/simulated/floor/industrial,
-/area/station/mining/refinery)
-"bxb" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/device/t_scanner,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bxc" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8
-	},
-/obj/machinery/portable_reclaimer,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orange,
 /area/station/mining/refinery)
 "bxi" = (
 /obj/chicken_nesting_box,
@@ -27730,19 +26779,19 @@
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
 "byu" = (
-/obj/disposalpipe/segment/mineral,
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs2_wide"
+/obj/cable{
+	icon_state = "1-2"
 	},
-/area/station/quartermaster/cargooffice)
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "byv" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment/mineral,
 /turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs_wide"
+	dir = 1
 	},
 /area/station/quartermaster/cargooffice)
 "byw" = (
@@ -27797,50 +26846,6 @@
 /obj/item/hand_labeler,
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
-"byE" = (
-/obj/shrub{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/drainage/big,
-/turf/simulated/floor/grass/random,
-/area/station/hallway/seaturtlehallway)
-"byF" = (
-/obj/machinery/vending/cola/red,
-/obj/decal/tile_edge/line/red{
-	color = "#e17627";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/machinery/drainage/big,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"byG" = (
-/obj/shrub{
-	dir = 1
-	},
-/obj/machinery/drainage/big,
-/turf/simulated/floor/grass/random,
-/area/station/hallway/seaturtlehallway)
-"byH" = (
-/obj/table/auto,
-/obj/item/paper/book/from_file/pocketguide/mining,
-/obj/item/storage/firstaid/toxin,
-/obj/machinery/drainage/big,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"byI" = (
-/obj/machinery/vending/cola/blue,
-/obj/machinery/drainage/big,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "byN" = (
 /obj/storage/crate/packing,
 /obj/blind_switch/area/north{
@@ -28320,40 +27325,18 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "bzY" = (
-/obj/rack,
-/obj/item/mop,
-/obj/item/storage/box/mousetraps,
-/obj/item/storage/box/biohazard_bags,
-/obj/item/storage/box/trash_bags,
-/obj/item/storage/box/trash_bags,
-/obj/item/spraybottle/cleaner,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/obj/item/sponge,
-/turf/simulated/floor/purple/checker{
-	dir = 8
-	},
-/area/station/janitor/supply)
+/obj/machinery/power/apc/autoname_west,
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "bzZ" = (
-/obj/machinery/power/apc/autoname_south,
-/obj/cable,
-/obj/storage/secure/closet/civilian/janitor,
-/obj/item/chem_grenade/cleaner,
-/obj/item/chem_grenade/cleaner,
-/turf/simulated/floor/purple/checker{
-	dir = 8
+/obj/landmark/start{
+	name = "Miner"
 	},
-/area/station/janitor/supply)
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "bAa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -28397,9 +27380,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
 "bAe" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
+/obj/machinery/power/seaheater/big{
+	pixel_y = 9
+	},
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "bAf" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -28864,63 +27849,39 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
-"bBs" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4
+"bBp" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "A large rack of server modules.  It doesn't seem to be in service.";
+	icon = 'icons/obj/networked.dmi';
+	icon_state = "server0";
+	name = "downed server"
 	},
-/obj/machinery/computer/stockexchange,
-/obj/item/clothing/head/that,
-/obj/machinery/power/data_terminal,
+/turf/simulated/floor/grime,
+/area/diner/backroom)
+"bBt" = (
+/obj/machinery/processor,
+/obj/decal/cleanable/dirt/jen,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
+"bBv" = (
 /obj/cable,
+/obj/cable,
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "red2"
 	},
 /area/station/quartermaster/cargooffice)
-"bBt" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4
-	},
-/obj/table/wood/auto,
-/obj/decoration/decorativeplant/plant3{
-	pixel_y = 16
-	},
-/obj/item/pen/pencil,
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "red2"
-	},
-/area/station/quartermaster/cargooffice)
-"bBu" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "red2"
-	},
-/area/station/quartermaster/cargooffice)
-"bBv" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
+"bBw" = (
+/obj/table/wood/round/auto,
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/carpet{
-	dir = 1;
-	icon_state = "red2"
-	},
-/area/station/quartermaster/cargooffice)
-"bBw" = (
-/obj/table/wood/auto,
-/obj/decoration/decorativeplant/plant3{
-	pixel_y = 16
-	},
-/obj/item/pen/pencil,
 /obj/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet{
 	dir = 1;
@@ -28928,23 +27889,24 @@
 	},
 /area/station/quartermaster/cargooffice)
 "bBx" = (
-/obj/machinery/computer/stockexchange,
-/obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-8"
+	},
+/obj/table/wood/round/auto,
+/obj/machinery/networked/printer{
+	pixel_x = -1;
+	pixel_y = 6
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "red2"
 	},
 /area/station/quartermaster/cargooffice)
-"bBy" = (
-/obj/vehicle/forklift,
-/turf/simulated/floor/bot,
-/area/station/quartermaster/cargobay)
 "bBz" = (
-/obj/storage/crate/packing,
-/turf/simulated/floor/bot,
+/obj/landmark/start{
+	name = "Quartermaster"
+	},
+/turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "bBA" = (
 /obj/machinery/conveyor_switch{
@@ -28995,18 +27957,11 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/starboard)
 "bBG" = (
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "stairs_middle"
+/obj/machinery/mantapropulsion/big{
+	pixel_y = 9
 	},
-/area/station/mining/refinery)
-"bBH" = (
-/obj/machinery/r_door_control/podbay/mining/new_walls{
-	id = "door4";
-	name = "Submarine Bay (Mining) door control"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/mining)
+/turf/space/fluid/manta/nospawn,
+/area/mantaSpace)
 "bBJ" = (
 /obj/item/screwdriver,
 /turf/simulated/floor/shuttlebay,
@@ -29461,59 +28416,25 @@
 /obj/machinery/plantpot,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bCP" = (
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bCS" = (
-/obj/stool/chair/office/yellow{
-	dir = 1
-	},
-/obj/machinery/light/incandescent/netural,
-/obj/landmark/start{
-	name = "Quartermaster"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+"bCU" = (
+/turf/simulated/wall/auto/reinforced/supernorn/orange,
+/area/station/quartermaster/cargooffice)
+"bCV" = (
+/obj/potted_plant/potted_plant3{
+	dir = 8
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;
 	icon_state = "red2"
 	},
 /area/station/quartermaster/cargooffice)
-"bCT" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
-	},
-/area/station/quartermaster/cargooffice)
-"bCU" = (
-/obj/machinery/light_switch/auto{
-	pixel_y = -24
-	},
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
-	},
-/area/station/quartermaster/cargooffice)
-"bCV" = (
-/obj/machinery/power/apc/autoname_south,
-/obj/cable,
-/turf/simulated/floor/carpet{
-	icon_state = "red2"
-	},
-/area/station/quartermaster/cargooffice)
 "bCX" = (
-/obj/stool/chair/office/yellow{
-	dir = 1
-	},
 /obj/machinery/light/incandescent/netural,
-/obj/landmark/start{
-	name = "Quartermaster"
+/obj/machinery/computer/stockexchange{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet{
 	dir = 6;
@@ -29934,7 +28855,6 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/port)
 "bEi" = (
-/obj/storage/cart,
 /obj/machinery/door_control/podbay/qm/new_walls/west{
 	id = "cargobaydoor";
 	name = "Cargo Bay door control"
@@ -29942,11 +28862,7 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "bEj" = (
-/obj/storage/crate/packing,
-/obj/machinery/light/incandescent/netural,
-/obj/machinery/light_switch/auto{
-	pixel_y = -24
-	},
+/obj/machinery/manufacturer/hangar,
 /turf/simulated/floor/bot,
 /area/station/quartermaster/cargobay)
 "bEl" = (
@@ -29965,9 +28881,6 @@
 /obj/decal/fakeobjects/mantacontainer/blue,
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
-"bEo" = (
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "bEq" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -30163,21 +29076,8 @@
 /obj/machinery/vehicle/tank/minisub/secsub,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/security)
-"bFc" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
 "bFe" = (
-/obj/decal/tile_edge/carpet/fancy{
-	dir = 6;
-	icon_state = "frug1"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/turf/simulated/wall/auto/reinforced/supernorn/orange,
 /area/station/hangar/port)
 "bFf" = (
 /obj/cable/reinforced{
@@ -30567,9 +29467,16 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hangar/port)
 "bGw" = (
-/obj/storage/closet/fire,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/lowerport)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 1;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/obj/machinery/manufacturer/mining,
+/obj/decal/cleanable/dirt/jen,
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "bGx" = (
 /obj/machinery/light/incandescent/blueish{
 	nostick = 1
@@ -30605,12 +29512,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
 "bGC" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
+/obj/machinery/light/small/warm,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerport)
 "bGD" = (
@@ -30626,6 +29528,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerport)
+"bGH" = (
+/obj/machinery/door/airlock/pyro/glass,
+/turf/simulated/floor/specialroom/bar,
+/area/skeleton_trader)
 "bGJ" = (
 /obj/voting_box,
 /obj/machinery/light/incandescent/netural,
@@ -31081,15 +29987,6 @@
 /obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bIC" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
 "bIF" = (
 /obj/decal/cleanable/cobweb,
 /turf/simulated/floor/plating/random,
@@ -31210,11 +30107,6 @@
 	dir = 6;
 	icon_state = "line1"
 	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
-"bIZ" = (
-/obj/disposalpipe/segment,
-/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "bJa" = (
@@ -31409,9 +30301,6 @@
 /obj/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
-"bJA" = (
-/turf/simulated/wall/asteroid,
-/area/station/mining/staff_room)
 "bJC" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -32973,12 +31862,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
-"bNC" = (
-/obj/machinery/computer/supplycomp{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
 "bND" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 10;
@@ -33035,9 +31918,9 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "bNL" = (
-/obj/machinery/computer/power_monitor/smes,
 /obj/machinery/power/data_terminal,
 /obj/cable,
+/obj/machinery/computer/power_monitor/smes,
 /turf/simulated/floor,
 /area/station/engine/power)
 "bNM" = (
@@ -33088,909 +31971,24 @@
 /obj/cable,
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
-"bNR" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/bank_data/console_upper{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bNT" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/computer/ordercomp/console_upper{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bNV" = (
-/obj/stool/chair/office/blue{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bNW" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bNX" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/seaturtle)
-"bNY" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/seaturtlebridge)
-"bOa" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bOb" = (
-/obj/item/device/matanalyzer{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/device/matanalyzer{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/obj/item/paper/book/from_file/minerals{
-	pixel_x = -4
-	},
-/obj/table/auto,
-/obj/decal/tile_edge/stripe/extra_big,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
-"bOd" = (
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bOe" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	req_access = null
-	},
-/obj/access_spawn/engineering,
-/obj/access_spawn/mining,
-/turf/simulated/floor/plating/random,
-/area/station/seaturtlebridge)
-"bOf" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bOg" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bOh" = (
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bOi" = (
-/turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/seaturtlebridge)
-"bOj" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bOk" = (
-/obj/machinery/power/apc/autoname_south,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bOm" = (
-/turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/mining/staff_room)
-"bOo" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Mining"
-	},
-/obj/access_spawn/mining,
-/obj/access_spawn/engineering,
-/obj/firedoor_spawn,
-/turf/simulated/floor/orange,
-/area/station/seaturtlebridge)
-"bOq" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
-"bOr" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bOs" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bOt" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bOu" = (
-/obj/decal/tile_edge/line/purple{
-	dir = 6;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bOv" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/janitor/supply)
-"bOx" = (
-/obj/submachine/chef_sink/chem_sink,
-/turf/simulated/floor/purple/checker{
-	dir = 8
-	},
-/area/station/janitor/supply)
-"bOy" = (
-/turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/construction)
-"bOB" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bOC" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bOD" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/disposal/small{
-	dir = 4
-	},
-/obj/disposalpipe/trunk,
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"bOE" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bOF" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Mining"
-	},
-/obj/access_spawn/mining,
-/obj/access_spawn/engineering,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/orange,
-/area/station/seaturtlebridge)
-"bOG" = (
-/obj/machinery/light/small/netural{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/stool,
-/obj/landmark/start{
-	name = "Janitor"
-	},
-/turf/simulated/floor/purple/checker{
-	dir = 8
-	},
-/area/station/janitor/supply)
-"bOH" = (
-/obj/machinery/abcu,
-/turf/simulated/floor,
-/area/station/construction)
 "bOI" = (
-/obj/machinery/nanofab/refining,
-/turf/simulated/floor/industrial,
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
+/turf/simulated/floor/stairs{
+	dir = 4
+	},
 /area/station/mining/refinery)
 "bOJ" = (
 /obj/machinery/nanofab/mining,
+/obj/decal/cleanable/dirt,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/industrial,
 /area/station/mining/refinery)
-"bOM" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bON" = (
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bOP" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bOS" = (
-/turf/simulated/floor,
-/area/station/construction)
-"bOV" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bOW" = (
-/obj/decal/tile_edge/line/green{
-	color = "#ba9a65";
-	dir = 6;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bOY" = (
-/turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/crew_quarters/bathroom)
-"bOZ" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/bathroom)
-"bPc" = (
-/obj/item/storage/wall/fire{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs2_wide"
-	},
-/area/station/mining/refinery)
-"bPg" = (
-/obj/item/storage/toilet/random,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/bathroom)
-"bPq" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bPr" = (
-/obj/storage/closet,
-/obj/item/clothing/under/rank/orangeoveralls/yellow,
-/obj/item/clothing/under/rank/orangeoveralls/yellow,
-/obj/item/clothing/under/rank/orangeoveralls,
-/obj/item/clothing/under/rank/orangeoveralls,
-/obj/item/clothing/head/helmet/hardhat,
-/obj/item/clothing/head/helmet/hardhat,
-/obj/item/clothing/head/helmet/hardhat,
-/obj/item/clothing/head/helmet/hardhat,
-/turf/simulated/floor,
-/area/station/construction)
-"bPs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 10;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bPt" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bPu" = (
-/obj/table/reinforced/industrial/auto,
-/obj/item/room_planner,
-/obj/item/room_planner,
-/turf/simulated/floor,
-/area/station/construction)
-"bPv" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 4;
-	pixel_x = -4
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/bathroom)
-"bPw" = (
-/obj/decoration/toiletholder{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/bathroom)
-"bPx" = (
-/obj/machinery/manufacturer/mining,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bPz" = (
-/obj/machinery/recharger,
-/obj/item/cargotele{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/table/auto,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bPB" = (
-/obj/storage/cart{
-	name = "ore cart"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bPF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bPG" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/tile_edge/line/purple{
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bPH" = (
-/obj/machinery/door/airlock/pyro{
-	dir = 4;
-	name = "Custodial Closet";
-	req_access_txt = "26"
-	},
-/obj/access_spawn/janitor,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/janitor/supply)
-"bPJ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/purple/checker{
-	dir = 8
-	},
-/area/station/janitor/supply)
-"bPL" = (
-/obj/mopbucket,
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/purple/checker{
-	dir = 8
-	},
-/area/station/janitor/supply)
-"bPM" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bPN" = (
-/obj/table/reinforced/industrial/auto,
-/obj/item/sheet/glass/fullstack{
-	rand_pos = 0
-	},
-/obj/item/sheet/glass/fullstack{
-	rand_pos = 0
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bPO" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bPP" = (
-/obj/machinery/power/apc/autoname_south,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bPQ" = (
-/obj/item/clothing/head/plunger,
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/bathroom)
-"bPR" = (
-/obj/machinery/light/small/netural{
-	dir = 4
-	},
-/turf/simulated/floor/sanitary,
-/area/station/crew_quarters/bathroom)
-"bPS" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hallway/seaturtlehallway)
-"bPT" = (
-/obj/machinery/door/airlock/pyro/maintenance,
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bPU" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bPV" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bPZ" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQa" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hallway/seaturtlehallway)
-"bQb" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/decal/tile_edge/line/green{
-	color = "#ba9a65";
-	dir = 5;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQc" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/construction)
-"bQd" = (
-/obj/machinery/door/airlock/pyro{
-	name = "Bathroom"
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/crew_quarters/bathroom)
-"bQf" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/potted_plant/potted_plant4{
-	dir = 1;
-	pixel_y = 28
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQg" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQj" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 9;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQk" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bQl" = (
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bQm" = (
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQn" = (
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/decoration/decorativeplant/plant7,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQp" = (
-/obj/machinery/vending/snack,
-/obj/decal/tile_edge/line/red{
-	color = "#e17627";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQq" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e17627";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/decoration/decorativeplant/plant7,
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQr" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e17627";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQt" = (
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 9;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQu" = (
-/obj/potted_plant/potted_plant4{
-	dir = 1;
-	pixel_y = 28
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQv" = (
-/obj/machinery/disposal_pipedispenser/mobile,
-/turf/simulated/floor,
-/area/station/construction)
-"bQw" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQx" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bQy" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bQz" = (
-/obj/machinery/plantpot,
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
 "bQA" = (
 /obj/item/reagent_containers/glass/wateringcan,
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bQB" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQC" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQD" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQE" = (
-/obj/machinery/drainage/big,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQF" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 6;
-	icon_state = "line1"
-	},
-/obj/potted_plant/potted_plant4,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQG" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQH" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQI" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 10;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQJ" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQK" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQL" = (
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQM" = (
-/obj/potted_plant/potted_plant4,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQN" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 6;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/junction/right/south,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQO" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQP" = (
-/obj/table/glass/auto,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQQ" = (
-/obj/table/glass/auto,
-/obj/random_item_spawner/desk_stuff/g_clip_bin_pen,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQR" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/machinery/power/apc/autoname_east,
-/obj/cable,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQS" = (
-/obj/submachine/cargopad{
-	name = "Mining Teleport Pad"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bQT" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bQV" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 10;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bQW" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -34002,703 +32000,22 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"bQX" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 10;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e17627";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#ba9a65";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bRa" = (
-/obj/item/device/gps,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bRf" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bRg" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bRh" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bRi" = (
-/obj/cable/reinforced{
-	icon_state = "4-8-thick"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bRj" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hangar/mining)
-"bRk" = (
-/obj/machinery/door_control/podbay/qm/new_walls/west{
-	id = "door4";
-	name = "Cargo Bay door control"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bRl" = (
-/obj/machinery/vehicle/tank/minisub/mining,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bRo" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Mining"
-	},
-/obj/access_spawn/mining,
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
-"bRp" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bRq" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bRt" = (
-/obj/machinery/manufacturer/general,
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bRu" = (
-/obj/item/cargotele{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/cargotele{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/machinery/recharger{
-	pixel_x = -7
-	},
-/obj/machinery/recharger{
-	pixel_x = 5
-	},
-/obj/table/reinforced/industrial/auto,
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bRv" = (
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 7
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = -2
-	},
-/obj/table/reinforced/industrial/auto,
-/turf/simulated/floor/caution/east,
-/area/station/hangar/mining)
-"bRw" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	dir = 4;
-	icon_state = "bdoormid1";
-	id = "door4"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bRx" = (
-/obj/forcefield/energyshield/perma/doorlink,
-/obj/machinery/door/poddoor/blast/pyro{
-	dir = 4;
-	icon_state = "bdoormid1";
-	id = "door4"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bRy" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 4
-	},
-/obj/storage/cart{
-	name = "ore cart"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"bRz" = (
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRA" = (
-/obj/decal/poster/wallsign/poster_mining{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRB" = (
-/obj/item/storage/wall/medical{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRC" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRD" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/disposal/small{
-	dir = 1;
-	layer = 32;
-	name = "rockworm feeding unit";
-	pixel_y = 32
-	},
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRE" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRF" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRG" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Mining"
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/mining,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRH" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bRK" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e17627";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#ba9a65";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bRL" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bRM" = (
-/obj/decal/cleanable/dirt/dirt5,
-/turf/simulated/floor/caution/east,
-/area/station/hangar/mining)
-"bRN" = (
-/obj/table/auto,
-/obj/machinery/microwave,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRO" = (
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRP" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	layer = 3.5;
-	pixel_y = -24
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRQ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRR" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Mining";
-	req_access = null
-	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bRS" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Submarine Bay (Mining)";
-	req_access = null
-	},
-/obj/access_spawn/cargo,
-/obj/access_spawn/engineering,
-/obj/access_spawn/mining,
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bRT" = (
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bRU" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bRV" = (
-/turf/simulated/floor/caution/east,
-/area/station/hangar/mining)
-"bRW" = (
-/obj/reagent_dispensers/watertank/fountain,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bRZ" = (
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs_wide"
-	},
-/area/station/hangar/mining)
-"bSa" = (
-/obj/storage/crate,
-/obj/item/shipcomponent/sensor/mining,
-/obj/item/shipcomponent/sensor/mining,
-/obj/item/shipcomponent/sensor/mining,
-/obj/item/shipcomponent/sensor/mining,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/item/shipcomponent/secondary_system/orescoop,
-/obj/item/shipcomponent/secondary_system/orescoop,
-/obj/item/shipcomponent/secondary_system/orescoop,
-/obj/item/shipcomponent/secondary_system/orescoop,
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bSb" = (
-/obj/machinery/door/poddoor/blast/pyro{
-	dir = 4;
-	icon_state = "bdoormid1";
-	id = "door4"
-	},
-/obj/forcefield/energyshield/perma/doorlink,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bSe" = (
-/obj/item/storage/wall/mining,
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
-"bSf" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bSg" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bSj" = (
-/obj/stool/chair,
-/obj/disposalpipe/segment,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bSk" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 10;
-	icon_state = "xtra_bigstripe-corner2"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bSl" = (
-/turf/simulated/floor/stairs{
-	dir = 4;
-	icon_state = "Stairs_wide"
-	},
-/area/station/hangar/mining)
-"bSm" = (
-/obj/decal/cleanable/dirt/dirt5,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bSo" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bSp" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bSq" = (
-/obj/table/auto,
-/obj/item/trench_map,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bSr" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bSs" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/mining/staff_room)
-"bSt" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 9;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bSu" = (
 /obj/table/auto,
 /obj/item/screwdriver,
 /obj/deskclutter,
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bSv" = (
-/obj/submachine/cargopad{
-	name = "Mining Cargo Teleport Pad"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bSw" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8
-	},
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bSx" = (
-/turf/simulated/floor/stairs{
-	dir = 4;
-	icon_state = "Stairs2_wide"
-	},
-/area/station/hangar/mining)
-"bSz" = (
-/obj/storage/closet/welding_supply,
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bSA" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/seaturtle/boiler)
-"bSB" = (
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSC" = (
-/obj/machinery/power/furnace,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSD" = (
-/obj/storage/crate/furnacefuel,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSH" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/construction/under_construction)
-"bSI" = (
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bSJ" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/construction/under_construction)
-"bSK" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bSL" = (
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bSM" = (
-/obj/machinery/light/incandescent/blueish{
-	nostick = 1
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bSN" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle/boiler)
-"bSO" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSP" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSQ" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSR" = (
-/obj/machinery/power/terminal,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSS" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bST" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bSU" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/access_spawn/maint,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/construction/under_construction)
-"bSV" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bSW" = (
-/obj/machinery/light/incandescent/blueish{
-	nostick = 1
-	},
-/obj/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"bSX" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSY" = (
-/obj/machinery/power/smes,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bSZ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bTa" = (
-/obj/machinery/power/furnace,
-/obj/cable,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bTb" = (
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
 "bTc" = (
 /obj/machinery/drainage/big,
 /obj/cable/reinforced{
 	icon_state = "1-2-thick"
-	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
 "bTd" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
@@ -34710,181 +32027,14 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bTf" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4
-	},
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bTg" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bTh" = (
-/obj/cable,
-/obj/machinery/power/apc/autoname_east,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bTi" = (
-/obj/machinery/power/apc/autoname_south,
-/obj/cable,
-/turf/simulated/floor,
-/area/station/construction/under_construction)
-"bTj" = (
-/obj/machinery/power/furnace,
-/obj/cable,
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bTk" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTl" = (
-/obj/machinery/mantapropulsion/big{
-	important = 0
-	},
-/turf/space/fluid/manta,
-/area/mantaSpace)
-"bTm" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
 "bTn" = (
 /obj/machinery/light/incandescent/blueish{
 	nostick = 1
 	},
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"bTo" = (
-/obj/machinery/drainage/big,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
-"bTp" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	icon_state = "line1"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTq" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTt" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
-"bTv" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bTx" = (
-/obj/rack,
-/obj/item/clothing/suit/space/diving/engineering,
-/obj/item/clothing/head/helmet/space/engineer/diving/engineering,
-/obj/item/clothing/mask/breath{
-	pixel_x = -3
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -12
-	},
-/obj/item/tank/emergency_oxygen,
-/obj/item/tank/jetpack,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
-"bTB" = (
-/obj/machinery/door/airlock/pyro/external{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTC" = (
-/obj/machinery/drainage/big,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "bTF" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -34907,17 +32057,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/security/secoffquarters)
-"bTI" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	frequency = 1455;
-	name = "Supply Intercom"
-	},
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs2_wide"
-	},
-/area/station/hangar/mining)
 "bTL" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -34929,365 +32068,30 @@
 	icon_state = "yellowblack"
 	},
 /area/station/engine/monitoring)
-"bTO" = (
-/obj/cable{
-	icon_state = "4-8"
+"bUU" = (
+/obj/machinery/manufacturer/hangar,
+/obj/machinery/light/incandescent/warm{
+	dir = 1;
+	pixel_y = 20
 	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	level = -1
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTP" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/disposalpipe/junction/left/west,
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bTQ" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bTR" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bTS" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor/orange,
-/area/station/hallway/seaturtlehallway)
-"bTT" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTV" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 6;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTX" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTY" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/junction/left/north,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bTZ" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Submarine Bay (Mining)";
-	req_access = null
-	},
-/obj/access_spawn/cargo,
-/obj/access_spawn/engineering,
-/obj/access_spawn/mining,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bUa" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bUb" = (
-/obj/decal/cleanable/dirt/dirt2,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bUc" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bUd" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bUe" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bUf" = (
+/turf/simulated/floor/caution/south,
+/area/diner/hangar)
+"bWx" = (
+/obj/landmark/gps_waypoint,
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/disposal)
+"bZu" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
 	name = "Mining"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/mining,
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
+/turf/unsimulated/floor/orange,
 /area/station/mining/staff_room)
-"bUg" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUh" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUi" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/junction/right/north,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUj" = (
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"bUk" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bUl" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bUo" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
-"bUp" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 5;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUq" = (
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUu" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bUv" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bUw" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bUx" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4
-	},
-/obj/access_spawn/maint,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle/boiler)
-"bUy" = (
-/obj/cable{
-	icon_state = "1-8"
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"bUA" = (
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/small,
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
-"bUC" = (
-/obj/table/reinforced/industrial/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/item/decoration/ashtray{
-	butts = 5;
-	name = "grubby old ashtray"
-	},
-/obj/item/cigbutt{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"bUD" = (
-/obj/table/reinforced/industrial/auto,
-/obj/item/material_shaper,
-/obj/item/material_shaper,
-/turf/simulated/floor,
-/area/station/construction)
-"bUE" = (
-/obj/table/reinforced/industrial/auto,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/item/cigbutt{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/clothing/glasses/construction,
-/obj/item/clothing/glasses/construction,
-/obj/item/clothing/glasses/construction,
-/turf/simulated/floor,
-/area/station/construction)
-"bWx" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/disposal)
-"bZu" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+"bZU" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/diner/hangar)
 "cea" = (
 /obj/decal/tile_edge/check{
 	dir = 4;
@@ -35306,6 +32110,11 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen/therustykrab)
+"ceZ" = (
+/obj/npc/trader/chad,
+/obj/decal/cleanable/paper,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/kitchen)
 "cgs" = (
 /obj/railing/orange/reinforced{
 	dir = 4
@@ -35390,13 +32199,11 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/lobby)
 "coI" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4
+/obj/machinery/arc_electroplater{
+	dir = 1
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "coR" = (
 /obj/storage/closet/dresser,
 /obj/item/clothing/shoes/mj_shoes,
@@ -35467,13 +32274,8 @@
 /turf/simulated/floor/grasstodirt,
 /area/station/ranch)
 "cty" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 10;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/portlowerhallway)
+/turf/simulated/wall/auto/reinforced/supernorn/orange,
+/area/station/mining/refinery)
 "ctG" = (
 /obj/machinery/manufacturer/uniform,
 /obj/machinery/light_switch/auto{
@@ -35502,29 +32304,12 @@
 	},
 /turf/simulated/floor/stairs/dark/wide,
 /area/station/medical/robotics)
-"cxL" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 9;
-	icon_state = "line1"
-	},
-/obj/disposalpipe/junction/left/south,
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
+"cxV" = (
+/obj/table/reinforced/auto,
+/obj/submachine/mixer,
+/obj/decal/cleanable/cobweb,
+/turf/simulated/floor/grime,
+/area/diner/kitchen)
 "cxW" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -35563,6 +32348,13 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
+"cAO" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space/fluid/manta,
+/area/diner/hangar)
 "cBz" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 4;
@@ -35570,14 +32362,12 @@
 	},
 /turf/simulated/floor/wood/six,
 /area/station/security/detectives_office_manta)
-"cDo" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
+"cBI" = (
+/obj/machinery/r_door_control{
+	id = "diner1"
 	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/diner/hangar)
 "cGD" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -35616,6 +32406,11 @@
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/elect)
+"cHj" = (
+/obj/decal/cleanable/dirt,
+/obj/machinery/shuttle/engine/propulsion/sea_propulsion,
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "cJp" = (
 /obj/landmark/start{
 	name = "Medical Doctor"
@@ -35626,12 +32421,12 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "cJM" = (
-/obj/grille/catwalk{
-	dir = 6;
-	icon_state = "catwalk_cross"
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
 	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
+/obj/item/clothing/mask/chicken,
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "cJT" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -35717,10 +32512,6 @@
 /obj/item/paper/book/from_file/cookbook,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen/therustykrab)
-"cVW" = (
-/obj/machinery/portable_reclaimer,
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
 "cYe" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/portlowerhallway)
@@ -35793,6 +32584,15 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/bathroom)
+"deh" = (
+/obj/decal/cleanable/ripped_poster,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/diner/bathroom)
+"deu" = (
+/obj/decal/cleanable/dirt,
+/obj/kitchenspike,
+/turf/simulated/floor/plating/random,
+/area/diner/kitchen)
 "deY" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -35839,6 +32639,10 @@
 	dir = 1
 	},
 /area/station/medical/medbay/surgery/storage)
+"dko" = (
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/shuttlebay,
+/area/diner/hangar)
 "dkw" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -35865,33 +32669,24 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/port)
-"dnh" = (
-/obj/decal/tile_edge/line/green{
-	color = "#ba9a65";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
-"dnT" = (
-/obj/machinery/light/incandescent/warm{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
 "doS" = (
 /obj/cable{
 	icon_state = "2-9"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
+"dqv" = (
+/obj/machinery/ore_cloud_storage_container,
+/obj/item/sticker/postit{
+	layer = 4;
+	name = "Note from the Chief Engineer";
+	pixel_x = 7;
+	pixel_y = -1;
+	words = "Hey, fill this up by the end of the shift, we've been running low on material subwide. If you do, I got something I made for you guys. - CE "
+	},
+/obj/decal/cleanable/dirt/jen,
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "dqI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -35905,14 +32700,28 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portupperhallway)
-"dqP" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	pixel_x = -10
+"dqZ" = (
+/turf/simulated/floor/scorched,
+/area/diner/bathroom)
+"drW" = (
+/obj/decal/poster/wallsign/stencil/right/n{
+	pixel_x = 7;
+	pixel_y = 38
 	},
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
+/obj/decal/poster/wallsign/stencil/right/g{
+	pixel_x = 17;
+	pixel_y = 38
+	},
+/obj/decal/poster/wallsign/stencil/right/e{
+	pixel_x = -3;
+	pixel_y = 38
+	},
+/turf/space/fluid/manta/nospawn,
+/area/station/shield_zone/manta)
+"duK" = (
+/obj/machinery/drainage/big,
+/turf/simulated/floor/grime,
+/area/diner/hangar)
 "dxF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -35936,20 +32745,8 @@
 	},
 /area/station/engine/inner)
 "dyN" = (
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	name = "Submarine Bay (Mining)";
-	req_access = null
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/engineering_mechanic,
-/obj/access_spawn/engineering_engine,
-/obj/access_spawn/mining,
-/obj/access_spawn/cargo,
-/turf/simulated/floor/plating/random,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "dAQ" = (
 /obj/shrub{
 	dir = 1;
@@ -35963,11 +32760,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"dBd" = (
+/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "dBj" = (
-/obj/stool/chair/yellow{
-	dir = 4
-	},
-/turf/simulated/floor,
+/obj/machinery/manufacturer/robotics,
+/turf/simulated/floor/bot,
 /area/station/quartermaster/cargobay)
 "dCn" = (
 /obj/disposalpipe/segment/mail{
@@ -36057,19 +32857,6 @@
 	},
 /turf/simulated/floor/wood/six,
 /area/station/security/detectives_office_manta)
-"dGn" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "dIP" = (
 /obj/cable,
 /obj/machinery/door/airlock/pyro/glass,
@@ -36102,13 +32889,6 @@
 	icon_state = "green1"
 	},
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
-"dNz" = (
-/obj/machinery/light/incandescent/warm{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
 "dNP" = (
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1;
@@ -36129,6 +32909,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"dRp" = (
+/obj/machinery/teleport/portal_generator,
+/obj/machinery/light/incandescent/netural{
+	dir = 4;
+	pixel_x = 10
+	},
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "dRs" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -36192,14 +32980,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/ai_upload)
-"dXk" = (
-/obj/machinery/light/incandescent/blueish{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
 "dXJ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -36208,29 +32988,11 @@
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
 "dXK" = (
-/obj/disposalpipe/segment/mineral{
-	dir = 4
+/obj/disposalpipe/segment/mineral,
+/turf/simulated/floor/stairs{
+	dir = 1
 	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
-"dYP" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/area/station/mining/refinery)
 "dZj" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -36336,6 +33098,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portupperhallway)
+"ejQ" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/portlowerhallway)
 "elP" = (
 /obj/decal/boxingrope,
 /obj/stool/chair/green{
@@ -36411,6 +33185,12 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/starboard)
+"evb" = (
+/obj/decal/cleanable/cobweb2,
+/obj/decal/fakeobjects/teleport_pad,
+/obj/marker/supplymarker,
+/turf/simulated/floor/damaged2,
+/area/diner/bathroom)
 "evE" = (
 /obj/storage/secure/closet/engineering/engineer,
 /obj/decal/tile_edge/line/black{
@@ -36423,6 +33203,9 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/private)
+"exs" = (
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "eyr" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -36434,11 +33217,36 @@
 /turf/simulated/floor,
 /area/station/security/starboardtorpedoes)
 "eBV" = (
-/obj/machinery/portable_reclaimer,
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/fueltank{
+	pixel_x = -10
+	},
+/obj/item/device/gps{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/device/gps{
+	pixel_x = 9
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 7
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 1
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = -2
+	},
+/obj/table/reinforced/industrial/auto,
+/obj/disposalpipe/segment,
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "eCS" = (
 /obj/storage/secure/closet/personal,
 /turf/simulated/floor/green,
@@ -36477,13 +33285,6 @@
 	icon_state = "floorgrime-w"
 	},
 /area/station/security/brig/genpop)
-"eFJ" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay2,
-/turf/space/fluid/manta,
-/area/mantaSpace)
 "eFK" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -36496,38 +33297,41 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
-"eHC" = (
-/obj/cable{
-	icon_state = "4-8"
+"eHx" = (
+/obj/item/wrench,
+/obj/item/reagent_containers/glass/oilcan{
+	pixel_x = 7;
+	pixel_y = -7
 	},
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 8;
-	layer = -1
+/obj/item/crowbar{
+	pixel_x = -13;
+	pixel_y = -1
 	},
-/obj/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/construction)
-"eIb" = (
-/obj/stool/chair/couch{
-	dir = 4
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	pixel_x = 10
+/obj/decal/cleanable/oil/streak,
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/staff_room)
+"eKN" = (
+/turf/simulated/floor/grime,
+/area/diner/bathroom)
+"eLu" = (
+/obj/stool/chair{
+	anchored = 0;
+	dir = 1
 	},
 /turf/simulated/floor/grime,
-/area/skeleton_trader)
+/area/diner/backroom)
 "eLx" = (
-/obj/vehicle/forklift,
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
 	pixel_x = -10
 	},
-/turf/simulated/floor/bot,
+/turf/simulated/floor,
 /area/station/quartermaster/cargobay)
+"eMF" = (
+/obj/machinery/chem_dispenser/alcohol,
+/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
+/turf/simulated/floor/scorched2,
+/area/diner/kitchen)
 "eNd" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/radio,
@@ -36605,13 +33409,6 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/communications/office)
-"ePj" = (
-/obj/lattice{
-	dir = 5;
-	icon_state = "lattice-dir-b"
-	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
 "eQD" = (
 /obj/machinery/computer3/generic/communications{
 	dir = 8
@@ -36758,6 +33555,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/hos)
+"fep" = (
+/obj/submachine/chef_oven,
+/obj/landmark{
+	name = "shitty_bill_respawn"
+	},
+/turf/simulated/floor/scorched,
+/area/diner/kitchen)
 "fez" = (
 /obj/storage/crate,
 /obj/item/reagent_containers/food/drinks/fueltank,
@@ -36769,6 +33573,9 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/port)
+"ffa" = (
+/turf/simulated/floor/plating/random,
+/area/diner/kitchen)
 "fih" = (
 /obj/machinery/flasher/genpop/new_walls/west{
 	id = "cell1";
@@ -36811,6 +33618,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
+"fkb" = (
+/obj/machinery/disposal/small{
+	dir = 4
+	},
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/door_control/podbay/mining/new_walls/west{
+	name = "Submarine Bay (Mining) door control"
+	},
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "fkq" = (
 /obj/table/wood/auto,
 /obj/item/device/radio/intercom/loudspeaker,
@@ -36845,16 +33664,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"fmh" = (
-/obj/marker/supplymarker,
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor/shuttle{
-	icon_state = "floor2"
-	},
-/area/bee_trader)
 "fmk" = (
 /obj/machinery/light/incandescent/blueish{
 	dir = 1;
@@ -36882,6 +33691,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
+"fnh" = (
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "fpj" = (
 /obj/disposalpipe/switch_junction/right/north,
 /turf/simulated/wall/auto/supernorn,
@@ -36929,6 +33742,20 @@
 	},
 /turf/simulated/floor/red,
 /area/station/security/beepsky)
+"fsl" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/decal/tile_edge/stripe/big{
+	dir = 6;
+	icon_state = "bigstripe-corner2"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "fsO" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -36970,6 +33797,17 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"ftK" = (
+/obj/decal/cleanable/rust,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/diner/hangar)
+"ftO" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay5,
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "ftP" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -36980,9 +33818,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
-"ftS" = (
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "fum" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 1;
@@ -37062,19 +33897,11 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/starboard)
 "fxo" = (
-/obj/grille/catwalk{
-	dir = 9;
-	icon_state = "catwalk_cross"
+/obj/decal/cleanable/blood{
+	icon_state = "floor6"
 	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
-"fyN" = (
-/obj/lattice{
-	dir = 9;
-	icon_state = "lattice-dir-b"
-	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "fCv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37095,6 +33922,24 @@
 /obj/machinery/chem_master,
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
+"fEe" = (
+/obj/stool/chair/wooden,
+/obj/machinery/light/incandescent/warm{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
+"fEM" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Refinery"
+	},
+/obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/mining/refinery)
 "fHz" = (
 /obj/stool/chair/comfy/blue{
 	dir = 1
@@ -37160,14 +34005,28 @@
 	},
 /area/station/crewquarters/garbagegarbs)
 "fLk" = (
-/obj/reagent_dispensers/fueltank,
-/obj/machinery/light/incandescent/netural{
-	dir = 8
+/obj/submachine/cargopad{
+	name = "Mining Teleport Pad"
 	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/storage/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/device/gps{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/device/gps{
+	pixel_x = -8
+	},
+/obj/item/shipcomponent/secondary_system/orescoop{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/shipcomponent/sensor/mining{
+	pixel_x = 6
+	},
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "fLG" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -37180,6 +34039,10 @@
 /obj/item/constructioncone,
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction)
+"fMm" = (
+/obj/machinery/nanofab/refining,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "fOY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37205,17 +34068,28 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
-"fTd" = (
-/obj/table/reinforced/auto,
-/obj/decoration/decorativeplant/plant4{
-	pixel_y = 12
+"fVL" = (
+/obj/table/reinforced/industrial/auto,
+/obj/machinery/recharger{
+	pixel_x = -7
 	},
-/obj/machinery/light/emergency{
-	dir = 8;
-	pixel_x = -10
+/obj/machinery/recharger{
+	pixel_x = 5
 	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
+"fVM" = (
+/obj/machinery/light/incandescent/warm,
+/turf/simulated/floor/grime,
+/area/diner/kitchen)
+"fVY" = (
+/obj/stool/chair{
+	anchored = 0;
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/dirt5,
+/turf/simulated/floor/grime,
+/area/diner/backroom)
 "fWd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37249,14 +34123,6 @@
 	},
 /turf/simulated/floor,
 /area/abandonedship)
-"fWO" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "fXz" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/security{
@@ -37282,15 +34148,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
-"fZX" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "gaD" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37361,11 +34218,6 @@
 "ghs" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crewquarters/cryotron)
-"gkj" = (
-/obj/cable,
-/obj/machinery/power/apc/autoname_south,
-/turf/simulated/floor,
-/area/station/hangar/mining)
 "glv" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
@@ -37404,6 +34256,10 @@
 	dir = 4
 	},
 /area/station/crewquarters/garbagegarbs)
+"gnA" = (
+/obj/storage/closet/emergency,
+/turf/simulated/floor/caution/south,
+/area/diner/hangar)
 "gnS" = (
 /obj/storage/cart/mechcart,
 /obj/item/storage/toolbox/mechanical,
@@ -37425,12 +34281,20 @@
 	},
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
+"goE" = (
+/obj/decal/cleanable/gangtag{
+	icon_state = "gangtag12";
+	pixel_x = 28
+	},
+/turf/simulated/floor/stairs/wide/other,
+/area/diner/dining)
 "gpN" = (
-/obj/decal/cleanable/dirt/dirt3,
-/turf/simulated/floor/caution/south,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/small,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "grW" = (
 /obj/storage/secure/closet/engineering/atmos,
 /obj/item/clothing/mask/gas/emergency,
@@ -37475,6 +34339,18 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
+"guv" = (
+/obj/decal/cleanable/oil/streak,
+/obj/item/shipcomponent/secondary_system/orescoop{
+	pixel_x = 10;
+	pixel_y = 11
+	},
+/obj/item/shipcomponent/sensor/mining{
+	pixel_x = 3
+	},
+/obj/machinery/light/small/floor/warm,
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/staff_room)
 "gvx" = (
 /obj/table/wood/auto,
 /obj/machinery/light/lamp,
@@ -37486,13 +34362,6 @@
 	dir = 4
 	},
 /area/station/medical/head/private)
-"gwa" = (
-/obj/machinery/light/incandescent/blueish{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
 "gwf" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
@@ -37508,6 +34377,18 @@
 /obj/cable,
 /turf/simulated/floor,
 /area/station/security/visitation)
+"gwI" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	desc = "An old computer that doesn't appear to be plugged in.  Do you see the cord anywhere? Yes?  Oh, good...wait, where's the outlet?.";
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "old0";
+	name = "inactive computer";
+	pixel_y = 8
+	},
+/obj/table/auto,
+/turf/simulated/floor/grime,
+/area/diner/backroom)
 "gwP" = (
 /obj/item/storage/wall/clothingrack/hatrack/hatrack_1{
 	dir = 1
@@ -37556,6 +34437,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "gAU" = (
@@ -37587,15 +34469,12 @@
 	},
 /turf/simulated/floor/bot/blue,
 /area/station/ai_monitored/storage/eva)
-"gEk" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
+"gCV" = (
+/obj/machinery/power/apc/autoname_west,
+/obj/cable,
+/turf/simulated/floor/stairs{
+	icon_state = "Stairs_wide"
 	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 6;
-	icon_state = "xtra_bigstripe-corner2"
-	},
-/turf/simulated/floor/orange,
 /area/station/mining/refinery)
 "gGq" = (
 /obj/machinery/disposal/mail/small{
@@ -37680,29 +34559,12 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
-"gNZ" = (
-/obj/machinery/manufacturer/hangar,
-/obj/machinery/light/incandescent/warm{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/caution/south,
-/area/diner/hangar)
 "gPa" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	name = "Submarine Bay (Mining)";
-	req_access = null
+/obj/disposalpipe/segment/mineral{
+	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/cargo,
-/turf/simulated/floor/orange,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "gQe" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 8;
@@ -37710,15 +34572,6 @@
 	},
 /turf/simulated/floor,
 /area/abandonedship)
-"gRw" = (
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 8;
-	name = "Mining"
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/mining,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "gRC" = (
 /obj/rack,
 /obj/item/clothing/shoes/magnetic{
@@ -37818,11 +34671,10 @@
 	},
 /area/station/crew_quarters/market)
 "gWm" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/item/storage/wall/mineralshelf,
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "gXc" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -37833,11 +34685,12 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
 "gYm" = (
-/obj/machinery/computer/shuttle_bus{
-	dir = 8
+/obj/stool/bar,
+/obj/landmark/spawner{
+	name = "father_jack"
 	},
-/turf/simulated/floor/grime,
-/area/diner/hangar)
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "hap" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -37875,6 +34728,21 @@
 	icon_state = "yellowblack"
 	},
 /area/station/engine/engineering/ce)
+"heQ" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/big,
+/obj/item/storage/wall/mining,
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
+"hgO" = (
+/obj/grille/catwalk{
+	dir = 6;
+	icon_state = "catwalk_cross"
+	},
+/turf/space/fluid/manta,
+/area/diner/hangar)
 "hhp" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -37887,6 +34755,14 @@
 /obj/machinery/manufacturer/uniform,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/bathroom)
+"hkD" = (
+/obj/submachine/chef_sink/chem_sink{
+	layer = 3;
+	pixel_y = 8
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/grime,
+/area/diner/bathroom)
 "hlB" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -37902,18 +34778,21 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"hmS" = (
-/obj/machinery/light/incandescent/blueish{
-	dir = 1;
-	nostick = 1;
-	pixel_y = 20
+"hng" = (
+/obj/decal/cleanable/dirt/dirt5,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
+"hnl" = (
+/turf/simulated/wall/false_wall/reinforced,
+/area/diner/bathroom)
+"hny" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir";
+	tag = "icon-lattice-dir (EAST)"
 	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/upperstarboard)
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "hpA" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/ammo/bullets/antisingularity{
@@ -37931,21 +34810,6 @@
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/engineering/ce/private)
-"hpN" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/obj/machinery/light/incandescent/blueish{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
 "hqw" = (
 /obj/decal/cleanable/blood{
 	icon_state = "floor6"
@@ -37961,6 +34825,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/security/brig/solitary)
+"hrH" = (
+/obj/machinery/vending/fortune,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "hsB" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -37978,6 +34846,15 @@
 /obj/window_blinds/cog2/left,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/hor)
+"htU" = (
+/obj/stool/chair/wooden{
+	dir = 8
+	},
+/obj/landmark/spawner{
+	name = "shitty_bill"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "huj" = (
 /obj/machinery/vending/medical_public,
 /obj/machinery/light/incandescent/netural{
@@ -38000,6 +34877,25 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"hwy" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "This computer is incredibly broken.  Look at how broken it is!  Very much so.";
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "dterm0";
+	name = "broken computer"
+	},
+/obj/decal/fakeobjects/lighttube_broken{
+	desc = "This light might be broken.  It's probably not wired up, though.";
+	dir = 4;
+	icon_state = "tube0";
+	layer = 4;
+	name = "inactive light tube";
+	pixel_x = 10
+	},
+/turf/simulated/floor/grime,
+/area/diner/backroom)
 "hwB" = (
 /obj/wingrille_spawn/auto,
 /obj/decal/poster/wallsign/garbagegarbssign,
@@ -38029,22 +34925,6 @@
 	dir = 1
 	},
 /area/station/ranch)
-"hDt" = (
-/obj/machinery/manufacturer/hangar,
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"hGr" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir-b"
-	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
 "hGs" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -38098,14 +34978,13 @@
 	},
 /turf/simulated/floor/blackwhite,
 /area/station/science/chemistry)
-"hNt" = (
-/obj/decal/cleanable/dirt,
-/turf/simulated/floor/grime,
-/area/diner/hangar)
 "hNN" = (
-/obj/lattice,
-/turf/space/fluid/manta,
-/area/diner/hangar)
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "gibbl2"
+	},
+/obj/item/bat,
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "hOj" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -38163,6 +35042,10 @@
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/ai_upload)
+"hRh" = (
+/obj/machinery/door/airlock/pyro,
+/turf/simulated/floor/plating/random,
+/area/diner/kitchen)
 "hRv" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -38180,13 +35063,6 @@
 	},
 /turf/simulated/floor/longtile,
 /area/station/bridge)
-"hSj" = (
-/obj/machinery/light/incandescent/netural,
-/obj/item/device/radio/intercom/cargo{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
 "hSo" = (
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -38232,12 +35108,16 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
+"hUj" = (
+/turf/simulated/floor/grime,
+/area/diner/hangar)
 "hUM" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
 	pixel_y = 20
 	},
-/turf/simulated/floor,
+/obj/vehicle/forklift,
+/turf/simulated/floor/bot,
 /area/station/quartermaster/cargobay)
 "hVI" = (
 /obj/cable{
@@ -38281,19 +35161,10 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
-"iaS" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir-b"
-	},
-/turf/space/fluid/manta,
-/area/mantaSpace)
 "ibY" = (
-/obj/grille/catwalk{
-	dir = 6
-	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
+/obj/decal/cleanable/blood/hurting1,
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "icF" = (
 /obj/shrub{
 	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
@@ -38323,14 +35194,13 @@
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "ifk" = (
-/obj/machinery/light/incandescent/warm{
-	dir = 1;
-	pixel_y = 20
-	},
-/obj/stool/chair/couch/blue{
-	dir = 8
-	},
-/turf/simulated/floor/grime,
+/obj/table/reinforced/bar/auto,
+/obj/machinery/glass_recycler,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/kitchen)
+"ifD" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/diner/hangar)
 "ifM" = (
 /obj/table/reinforced/chemistry/auto,
@@ -38365,6 +35235,16 @@
 /obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/security/interrogation)
+"igZ" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/electrical,
+/turf/simulated/floor/plating,
+/area/diner/hangar)
+"iix" = (
+/obj/machinery/vending/cola/red,
+/obj/decal/cleanable/cobweb,
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "ijo" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -38397,9 +35277,9 @@
 	},
 /area/station/security/hos)
 "ikz" = (
-/obj/machinery/drainage/big,
+/obj/submachine/ice_cream_dispenser,
 /turf/simulated/floor/grime,
-/area/diner/hangar)
+/area/diner/kitchen)
 "ila" = (
 /obj/stool/bed/moveable,
 /obj/item/clothing/suit/bedsheet/blue,
@@ -38458,15 +35338,6 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/ce)
-"irk" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "iti" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -38475,20 +35346,13 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "ivY" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay5,
-/turf/space/fluid/manta,
-/area/mantaSpace)
-"iwW" = (
-/obj/storage/crate/abcumarker,
 /obj/machinery/light/incandescent/netural{
-	dir = 4;
-	pixel_x = 10
+	dir = 8;
+	pixel_x = -10
 	},
-/turf/simulated/floor,
-/area/station/construction)
+/obj/item/cigbutt,
+/turf/simulated/floor/grime,
+/area/diner/kitchen)
 "ixV" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/revimp_kit{
@@ -38554,6 +35418,13 @@
 	},
 /turf/simulated/floor/greenblack,
 /area/station/crewquarters/garbagegarbs)
+"iFl" = (
+/obj/stool/chair/wooden,
+/obj/landmark/spawner{
+	name = "don_glab"
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "iFt" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -38582,14 +35453,20 @@
 	},
 /turf/simulated/floor/redblack,
 /area/listeningpost/syndicateassaultvessel)
-"iIZ" = (
-/obj/machinery/light/runway_light,
+"iHk" = (
 /obj/lattice{
-	dir = 8;
 	icon_state = "lattice-dir"
 	},
+/obj/machinery/light/runway_light,
 /turf/space/fluid/manta,
 /area/mantaSpace)
+"iHV" = (
+/obj/item/cigbutt,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
+"iIZ" = (
+/turf/simulated/floor/grime,
+/area/diner/kitchen)
 "iJu" = (
 /obj/machinery/light/incandescent/blueish{
 	dir = 1;
@@ -38610,6 +35487,13 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
+"iLO" = (
+/obj/grille/catwalk{
+	dir = 9;
+	icon_state = "catwalk_cross"
+	},
+/turf/space/fluid/manta,
+/area/diner/hangar)
 "iNV" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -38664,21 +35548,6 @@
 	},
 /turf/simulated/floor/longtile,
 /area/station/bridge)
-"iQa" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/hangar/mining)
-"iQM" = (
-/obj/machinery/manufacturer/robotics,
-/turf/simulated/floor/bot,
-/area/station/quartermaster/cargobay)
 "iSe" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -38699,12 +35568,41 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/private)
-"jbY" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
+"iUL" = (
+/obj/grille/catwalk{
+	dir = 4
 	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
+/turf/space/fluid/manta,
+/area/diner/hangar)
+"iVj" = (
+/obj/decal/cleanable/gangtag{
+	icon_state = "gangtag22";
+	pixel_x = 28
+	},
+/obj/item/seed/cannabis,
+/obj/machinery/light/incandescent/small{
+	dir = 4
+	},
+/turf/simulated/floor/grime,
+/area/diner/bathroom)
+"iZv" = (
+/obj/decal/cleanable/blood,
+/obj/item/clothing/under/gimmick/shirtnjeans,
+/turf/simulated/floor/grime,
+/area/diner/dining)
+"jbA" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "This computer is incredibly broken.  Look at how broken it is!  Very much so.";
+	dir = 1;
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "offbroken";
+	name = "broken computer";
+	tag = "icon-offbroken (NORTH)"
+	},
+/turf/simulated/floor/grime,
+/area/diner/backroom)
 "jfb" = (
 /obj/machinery/computer3/terminal/zeta{
 	dir = 8;
@@ -38763,14 +35661,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"jkh" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
+"jhD" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/box/glassbox,
+/obj/item/storage/box/cutlery,
+/obj/item/reagent_containers/food/snacks/ingredient/pancake_batter,
+/obj/item/kitchen/rollingpin,
+/obj/decal/cleanable/cobweb,
+/turf/simulated/floor/plating/random,
+/area/diner/kitchen)
 "jkr" = (
 /obj/stool/chair{
 	dir = 4
@@ -38790,27 +35689,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/porttorpedoes)
-"jlo" = (
-/obj/rack,
-/obj/item/clothing/suit/space/diving/engineering,
-/obj/item/clothing/head/helmet/space/engineer/diving/engineering,
-/obj/item/clothing/mask/breath{
-	pixel_x = -3
-	},
-/obj/item/clothing/shoes/flippers{
-	pixel_y = -12
-	},
-/obj/item/tank/emergency_oxygen,
-/obj/item/tank/jetpack,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "jlt" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -38867,17 +35745,6 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/communications/bedroom)
-"jpd" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/obj/item/constructioncone,
-/turf/simulated/floor,
-/area/station/construction/under_construction)
 "jqA" = (
 /obj/rack,
 /obj/item/tank/air,
@@ -38893,27 +35760,20 @@
 /turf/simulated/floor,
 /area/station/hangar/security)
 "jsD" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	name = "Submarine Bay (Mining)";
-	req_access = null
-	},
-/obj/firedoor_spawn,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/access_spawn/cargo,
+/obj/machinery/door/airlock/pyro/engineering{
+	name = "Mining"
+	},
+/obj/firedoor_spawn,
 /obj/access_spawn/mining,
-/obj/access_spawn/engineering_engine,
-/obj/access_spawn/engineering_mechanic,
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "jtU" = (
 /turf/simulated/floor,
 /area/station/crewquarters/garbagegarbs)
 "juJ" = (
-/obj/disposalpipe/junction/right/west,
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
 	pixel_y = 20
@@ -38921,16 +35781,19 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/special/submarinesdown,
 /area/station/hallway/starboardlowerhallway)
 "jvz" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/decal/tile_edge/stripe/big{
+	dir = 10;
+	icon_state = "bigstripe-corner2"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "jwm" = (
 /obj/table/auto,
 /obj/item/device/detective_scanner,
@@ -38961,20 +35824,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/power)
-"jwL" = (
-/obj/machinery/disposal/small,
-/obj/disposalpipe/trunk{
-	dir = 4
+"jyE" = (
+/obj/item/storage/toilet/random,
+/obj/decal/cleanable/gangtag{
+	desc = "A hastily-scrawled sequence of numbers: 1-949-415-6298. What does it mean?";
+	icon = 'icons/obj/junk.dmi';
+	icon_state = "shitty_bill";
+	name = "graffiti";
+	pixel_y = 28
 	},
-/obj/cable{
-	icon_state = "4-8"
+/obj/landmark{
+	name = "shitty_bill_respawn"
+	},
+/turf/simulated/floor/grime,
+/area/diner/bathroom)
+"jyS" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 4;
+	pixel_x = 10
 	},
 /turf/simulated/floor/orange,
-/area/station/mining/refinery)
-"jBB" = (
-/obj/machinery/arc_electroplater,
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
+/area/station/mining/staff_room)
+"jCl" = (
+/obj/decal/cleanable/dirt/dirt4,
+/turf/simulated/floor/grime,
+/area/diner/backroom)
 "jDq" = (
 /obj/decal/tile_edge/line/orange{
 	dir = 1;
@@ -39003,9 +35877,13 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
 "jFc" = (
-/obj/storage/secure/closet/engineering/cargo,
-/turf/simulated/floor,
+/obj/vehicle/forklift,
+/turf/simulated/floor/bot,
 /area/station/quartermaster/cargobay)
+"jFP" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/grime,
+/area/diner/kitchen)
 "jFQ" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -39013,12 +35891,6 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/starboard)
-"jKG" = (
-/obj/item/extinguisher,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "jLO" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/right{
@@ -39027,18 +35899,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
-"jMo" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/item/cigbutt,
-/turf/simulated/floor/grime,
-/area/diner/kitchen)
 "jMM" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/carpet/grime,
 /area/station/communications/bedroom)
+"jNw" = (
+/obj/machinery/computer/supplycomp,
+/turf/simulated/floor,
+/area/station/quartermaster/cargobay)
 "jOA" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/green,
@@ -39054,6 +35922,32 @@
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/ai_upload)
+"jRm" = (
+/turf/simulated/floor/shuttlebay,
+/area/diner/hangar)
+"jRZ" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
+/obj/decal/tile_edge/stripe/big,
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
+"jSa" = (
+/obj/item/reagent_containers/food/snacks/ingredient/gcheese,
+/obj/item/reagent_containers/food/snacks/ingredient/gcheese,
+/obj/item/reagent_containers/food/snacks/ingredient/meatpaste,
+/obj/item/reagent_containers/food/drinks/milk/rancid,
+/obj/item/kitchen/food_box/egg_box,
+/obj/storage/secure/closet/fridge/kitchen{
+	locked = 0
+	},
+/turf/simulated/floor/scorched2,
+/area/diner/kitchen)
+"jTO" = (
+/obj/decal/cleanable/dirt/dirt4,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "jUI" = (
 /obj/railing/orange/reinforced{
 	dir = 8
@@ -39067,6 +35961,18 @@
 	dir = 8
 	},
 /area/station/ranch)
+"jVi" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	desc = "An old computer that doesn't appear to be plugged in.  Do you see the cord anywhere? No? Dang.";
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "old0";
+	name = "inactive computer";
+	pixel_x = 4
+	},
+/obj/table/auto,
+/turf/simulated/floor/grime,
+/area/diner/backroom)
 "jXz" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
@@ -39079,16 +35985,10 @@
 	dir = 8
 	},
 /area/station/crewquarters/garbagegarbs)
-"jXP" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
+"jYk" = (
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "jYl" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -39109,14 +36009,10 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/market)
 "kai" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light/incandescent/warm{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/grime,
-/area/diner/dining)
+/obj/table/reinforced/bar/auto,
+/obj/marker/supplymarker,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/kitchen)
 "kct" = (
 /obj/stool/chair{
 	dir = 8
@@ -39129,21 +36025,14 @@
 	dir = 4
 	},
 /area/station/security/interrogation)
-"keq" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
+"ker" = (
+/obj/stool/chair/couch{
+	dir = 8
 	},
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/obj/item/constructioncone,
-/turf/simulated/floor,
-/area/station/construction)
+/turf/simulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/bee_trader)
 "keB" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -39191,6 +36080,15 @@
 	icon_state = "dark"
 	},
 /area/station/security/hos)
+"kfp" = (
+/obj/machinery/light/runway_light,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
+/obj/decal/mantaBubbles/large,
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "kfv" = (
 /obj/storage/closet{
 	name = "rancher supply closet"
@@ -39240,6 +36138,14 @@
 	dir = 10
 	},
 /area/station/crewquarters/garbagegarbs)
+"klM" = (
+/obj/decal/cleanable/dirt/dirt5,
+/turf/simulated/floor/grime,
+/area/diner/backroom)
+"kpr" = (
+/obj/machinery/door/airlock/pyro,
+/turf/simulated/floor/grime,
+/area/diner/backroom)
 "kpZ" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
@@ -39274,6 +36180,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
+"ksD" = (
+/obj/stool/chair/couch{
+	dir = 8
+	},
+/turf/simulated/floor/grime,
+/area/skeleton_trader)
 "kuo" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -39285,6 +36197,12 @@
 	dir = 1
 	},
 /area/station/crewquarters/garbagegarbs)
+"kvE" = (
+/obj/table/wood/round/auto,
+/obj/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/breakfast,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "kwr" = (
 /obj/storage/closet/office,
 /obj/machinery/light_switch/auto{
@@ -39314,17 +36232,6 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
-"kxc" = (
-/obj/machinery/power/furnace,
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
 "kxJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -39347,6 +36254,14 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/communications/office)
+"kAM" = (
+/obj/npc/trader/bee{
+	name = "Bambini"
+	},
+/turf/simulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/bee_trader)
 "kBT" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
@@ -39360,14 +36275,10 @@
 	},
 /turf/simulated/floor/bot,
 /area/station/science/bot_storage)
-"kDM" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural,
-/turf/simulated/floor,
-/area/space)
+"kDr" = (
+/obj/npc/trader/hand,
+/turf/simulated/floor/grime,
+/area/diner/bathroom)
 "kEJ" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -39387,6 +36298,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer)
+"kID" = (
+/obj/decal/tile_edge/stripe/corner/big2{
+	dir = 10
+	},
+/obj/disposalpipe/segment/mineral{
+	icon_state = "pipe-c"
+	},
+/obj/item/storage/wall/mining,
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
+"kIT" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/plating/random,
+/area/diner/kitchen)
 "kJJ" = (
 /obj/item/reagent_containers/food/snacks/beefood{
 	desc = "A little birthday cupcake for Heisenbee.  May not taste good to non-bees.";
@@ -39427,25 +36352,44 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/breakroom)
-"kRd" = (
-/obj/decal/fakeobjects{
-	anchored = 1;
-	density = 1;
-	desc = "This computer is incredibly broken.  Look at how broken it is!  Very much so.";
-	icon = 'icons/obj/computer.dmi';
-	icon_state = "dterm0";
-	name = "broken computer"
-	},
-/obj/decal/fakeobjects/lighttube_broken{
-	desc = "This light might be broken.  It's probably not wired up, though.";
-	dir = 4;
-	icon_state = "tube0";
-	layer = 4;
-	name = "inactive light tube";
-	pixel_x = 10
+"kOP" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/grime,
+/area/skeleton_trader)
+"kPb" = (
+/obj/submachine/chef_sink/chem_sink{
+	layer = 3;
+	pixel_y = 8
 	},
 /turf/simulated/floor/grime,
-/area/diner/backroom)
+/area/diner/bathroom)
+"kQo" = (
+/obj/machinery/vehicle/tank/minisub,
+/turf/simulated/floor/shuttlebay,
+/area/diner/hangar)
+"kQX" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/mining/staff_room)
+"kRu" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
+/obj/machinery/door/airlock/pyro/engineering{
+	dir = 4;
+	name = "Refinery";
+	req_access = null
+	},
+/obj/access_spawn/cargo,
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/quartermaster/cargooffice)
+"kUs" = (
+/obj/machinery/vending/cigarette,
+/obj/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "kWs" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/wood/eight{
@@ -39500,24 +36444,9 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
-"len" = (
-/obj/decal/fakeobjects{
-	anchored = 1;
-	density = 1;
-	desc = "This computer is incredibly broken.  Look at how broken it is!  Very much so.";
-	icon = 'icons/obj/computer.dmi';
-	icon_state = "dterm0";
-	name = "broken computer"
-	},
-/obj/decal/fakeobjects/lighttube_broken{
-	desc = "This light might be broken.  It's probably not wired up, though.";
-	dir = 8;
-	icon_state = "tube0";
-	name = "inactive light tube";
-	pixel_x = -10
-	},
-/turf/simulated/floor/grime,
-/area/diner/backroom)
+"ldA" = (
+/turf/simulated/wall/auto/reinforced/supernorn/orange,
+/area/station/mining/staff_room)
 "leB" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light/incandescent/netural{
@@ -39527,16 +36456,6 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/research)
-"lfC" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
 "lfN" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -39564,12 +36483,11 @@
 	},
 /turf/simulated/floor/green,
 /area/station/crewquarters/garbagegarbs)
+"lpG" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "lpQ" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	pixel_x = 10
-	},
-/obj/decal/cleanable/dirt/dirt4,
 /turf/simulated/floor/specialroom/bar,
 /area/diner/dining)
 "lqw" = (
@@ -39633,12 +36551,26 @@
 	},
 /turf/simulated/floor/wood/five,
 /area/station/chapel/sanctuary)
+"lsT" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay3,
+/turf/space/fluid/manta,
+/area/mantaSpace)
+"lwg" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay4,
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "lxB" = (
-/obj/item/device/matanalyzer,
+/obj/landmark/start{
+	name = "Miner"
+	},
 /turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/area/station/mining/staff_room)
 "lAp" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -39691,6 +36623,16 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/research)
+"lDl" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/wall/auto/reinforced/supernorn/orange,
+/area/station/mining/refinery)
+"lFv" = (
+/obj/machinery/vehicle/tank/minisub/mining,
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/staff_room)
 "lHv" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -39726,6 +36668,14 @@
 	dir = 4
 	},
 /area/station/crew_quarters/hor/horprivate)
+"lIH" = (
+/obj/decal/cleanable/gangtag{
+	icon_state = "gangtag16";
+	pixel_y = -28
+	},
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/grime,
+/area/diner/backroom)
 "lJy" = (
 /obj/machinery/door/airlock/pyro,
 /obj/cable{
@@ -39746,6 +36696,9 @@
 	},
 /turf/simulated/floor/engine/glow/blue,
 /area/station/engine/singcore)
+"lLU" = (
+/turf/space/fluid/manta,
+/area/shuttle/john/diner)
 "lNE" = (
 /obj/decal/tile_edge/check{
 	dir = 9;
@@ -39762,10 +36715,8 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen/therustykrab)
 "lNF" = (
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "lNJ" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -39840,15 +36791,6 @@
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
-"lTb" = (
-/obj/item/raw_material/rock,
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "lYo" = (
 /obj/item/device/radio/intercom/security{
 	dir = 4
@@ -39904,14 +36846,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
 "meh" = (
-/obj/table/auto,
-/obj/item/shipcomponent/secondary_system/repair,
-/obj/item/shipcomponent/secondary_system/repair,
-/obj/item/shipcomponent/secondary_system/repair,
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/disposalpipe/segment,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "mfZ" = (
 /obj/stool/chair/green{
 	dir = 8
@@ -39938,6 +36875,13 @@
 /obj/machinery/fluid_canister,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
+"mkh" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "mkL" = (
 /obj/decal/tile_edge/check{
 	dir = 8;
@@ -39961,15 +36905,6 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/captain)
-"mle" = (
-/obj/machinery/vending/snack,
-/obj/machinery/light/incandescent/warm{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/grime,
-/area/diner/dining)
 "mmh" = (
 /obj/machinery/disposal/small{
 	dir = 4
@@ -39981,6 +36916,10 @@
 	dir = 4
 	},
 /area/station/crewquarters/garbagegarbs)
+"mmj" = (
+/obj/machinery/drainage/big,
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "mmk" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -40005,20 +36944,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portupperhallway)
+"mmW" = (
+/obj/lattice{
+	icon_state = "lattice-dir"
+	},
+/obj/machinery/light/runway_light/delay2,
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "mnz" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crewquarters/garbagegarbs)
-"mqg" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 10;
-	icon_state = "xtra_bigstripe-corner2"
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "mrf" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -40027,6 +36963,10 @@
 	icon_state = "respect6"
 	},
 /area/station/security/secwing)
+"mrj" = (
+/obj/machinery/manufacturer/general,
+/turf/simulated/floor/bot,
+/area/station/quartermaster/cargobay)
 "msM" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 4;
@@ -40060,6 +37000,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
+"mvJ" = (
+/obj/decal/cleanable/rust,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/diner/kitchen)
+"mvU" = (
+/obj/miningteleporter,
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "mwg" = (
 /obj/storage/secure/closet/security/equipment,
 /obj/machinery/light/incandescent/netural{
@@ -40136,6 +37084,13 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
+"mCe" = (
+/obj/machinery/light/incandescent/warm{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "mCh" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 1;
@@ -40151,12 +37106,20 @@
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/ai_upload_foyer)
+"mCq" = (
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/caution/south,
+/area/diner/hangar)
 "mEZ" = (
 /obj/wingrille_spawn/auto,
 /obj/wingrille_spawn/auto,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crewquarters/cryotron)
+"mFh" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/diner/dining)
 "mFN" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -40164,26 +37127,18 @@
 /obj/disposalpipe/junction/right/north,
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"mGJ" = (
-/obj/machinery/light/runway_light,
-/obj/lattice{
-	dir = 8;
-	icon_state = "lattice-dir"
+"mHE" = (
+/obj/machinery/smelter,
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
 	},
-/obj/decal/mantaBubbles/large,
-/turf/space/fluid/manta,
-/area/mantaSpace)
-"mHC" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light/delay4,
-/obj/warp_beacon{
-	name = "Sea Diner"
-	},
-/turf/space/fluid/manta,
-/area/mantaSpace)
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
+"mIf" = (
+/obj/wingrille_spawn/auto,
+/obj/disposalpipe/segment,
+/turf/simulated/floor/plating/random,
+/area/station/mining/staff_room)
 "mIx" = (
 /obj/reagent_dispensers/watertank/fountain,
 /obj/disposalpipe/segment/mail{
@@ -40231,6 +37186,16 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
+"mLe" = (
+/obj/stool/chair/wooden{
+	dir = 4
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
+"mNS" = (
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "mPy" = (
 /obj/machinery/disposal/mail/small{
 	dir = 1;
@@ -40279,13 +37244,6 @@
 	dir = 4
 	},
 /area/station/crew_quarters/hor)
-"mWm" = (
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir-b"
-	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
 "mXn" = (
 /obj/railing/orange/reinforced,
 /obj/submachine/chicken_feed_grinder,
@@ -40300,6 +37258,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
+"mZu" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space/fluid/manta,
+/area/diner/hangar)
 "nav" = (
 /obj/decoration/junctionbox{
 	pixel_y = 32
@@ -40320,13 +37285,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"ncp" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
 "ndD" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle,
@@ -40413,6 +37371,17 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
+"nnc" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir-b"
+	},
+/obj/machinery/light/runway_light/delay4,
+/obj/warp_beacon{
+	name = "Sea Diner"
+	},
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "nni" = (
 /obj/stool/chair/couch/yellow{
 	dir = 8
@@ -40445,6 +37414,14 @@
 	dir = 1
 	},
 /area/station/medical/medbay/lobby)
+"nre" = (
+/obj/storage/closet/mantacontainerred/right,
+/turf/simulated/floor,
+/area/station/quartermaster/cargobay)
+"nry" = (
+/obj/npc/trader/skeleton,
+/turf/simulated/floor/grime,
+/area/skeleton_trader)
 "nrB" = (
 /obj/cable{
 	d1 = 2;
@@ -40461,22 +37438,26 @@
 /turf/simulated/floor/wood/five,
 /area/station/chapel/sanctuary)
 "ntv" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13";
-	pixel_y = 20;
-	tag = ""
+/obj/item/cargotele{
+	pixel_x = 5;
+	pixel_y = 8
 	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/item/cargotele{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/machinery/recharger{
+	pixel_x = 5
+	},
+/obj/table/reinforced/industrial/auto,
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "nuY" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
 	icon_state = "line1"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "nwA" = (
@@ -40524,6 +37505,15 @@
 	dir = 4
 	},
 /area/station/crew_quarters/hor/horprivate)
+"nxs" = (
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir";
+	tag = "icon-lattice-dir (EAST)"
+	},
+/obj/decal/mantaBubbles/large,
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "nyS" = (
 /obj/decal/tile_edge/line/green{
 	dir = 1;
@@ -40559,14 +37549,6 @@
 	},
 /turf/simulated/floor/longtile,
 /area/station/bridge)
-"nAY" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
-"nBB" = (
-/turf/simulated/floor/plating/random,
-/area/station/hangar/mining)
 "nBS" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -40580,21 +37562,6 @@
 	dir = 4
 	},
 /area/station/ranch)
-"nCe" = (
-/obj/machinery/manufacturer/hangar,
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "nFD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -40604,6 +37571,13 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
+"nGP" = (
+/obj/lattice{
+	dir = 5;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space/fluid/manta,
+/area/diner/hangar)
 "nHa" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/power/apc/autoname_east,
@@ -40612,34 +37586,6 @@
 	dir = 6
 	},
 /area/station/crewquarters/cryotron)
-"nHc" = (
-/obj/table/reinforced/auto,
-/obj/item/device/light/zippo{
-	pixel_x = -4;
-	pixel_y = 15
-	},
-/obj/item/cigpacket/propuffs{
-	pixel_x = 8;
-	pixel_y = 14
-	},
-/obj/item/decoration/ashtray{
-	butts = 5;
-	name = "grubby old ashtray"
-	},
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
-"nJx" = (
-/obj/reagent_dispensers/fueltank,
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
 "nJP" = (
 /obj/table/auto,
 /obj/item/reagent_containers/glass/beaker/large/brute,
@@ -40677,6 +37623,12 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
+"nNJ" = (
+/obj/table/auto,
+/obj/item/circuitboard/teleporter,
+/obj/item/circuitboard/teleporter,
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "nOj" = (
 /obj/machinery/conveyor/north{
 	id = "north"
@@ -40709,6 +37661,10 @@
 	dir = 8
 	},
 /area/station/ranch)
+"nQO" = (
+/obj/storage/closet/mantacontainerred,
+/turf/simulated/floor,
+/area/station/quartermaster/cargobay)
 "nRd" = (
 /obj/storage/closet/fire,
 /obj/item/clothing/suit/fire/heavy,
@@ -40727,14 +37683,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/storage)
-"nRg" = (
-/obj/stool/chair/wooden,
-/obj/machinery/light/incandescent/warm{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/specialroom/bar,
-/area/diner/dining)
 "nSv" = (
 /obj/iv_stand,
 /obj/item_dispenser/latex_gloves,
@@ -40745,10 +37693,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
-"nTP" = (
-/obj/decal/cleanable/dirt,
-/turf/space/fluid/manta,
-/area/mantaSpace)
 "nVc" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/machinery/camera{
@@ -40786,12 +37730,23 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/lowerstarboard)
 "nZD" = (
-/obj/grille/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
+/obj/decal/cleanable/blood/splatter,
+/obj/item/device/audio_log,
+/turf/simulated/floor/grime,
+/area/diner/dining)
+"nZE" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir"
 	},
 /turf/space/fluid/manta,
 /area/diner/hangar)
+"oaG" = (
+/obj/stool/chair/wooden{
+	dir = 1
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "odZ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
@@ -40826,13 +37781,6 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/construction)
-"ohO" = (
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir"
-	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
 "ohQ" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -40877,6 +37825,16 @@
 	},
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
+"okI" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
+/obj/disposalpipe/segment/mineral{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "oli" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 28
@@ -40893,11 +37851,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
-"olF" = (
-/obj/item/raw_material/rock,
-/obj/disposalpipe/trunk,
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "omt" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cell_charger,
@@ -40960,6 +37913,20 @@
 	dir = 1
 	},
 /area/station/engine/inner)
+"opZ" = (
+/obj/stool/chair/wooden{
+	dir = 1
+	},
+/obj/machinery/light/incandescent/warm,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
+"oqG" = (
+/obj/machinery/light/incandescent/netural,
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "orp" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -41067,10 +38034,17 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "ozn" = (
-/obj/wingrille_spawn/auto,
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/diner/hangar)
+/obj/machinery/deep_fryer,
+/turf/simulated/floor/damaged2,
+/area/diner/kitchen)
+"oBw" = (
+/obj/machinery/light/runway_light,
+/obj/lattice{
+	dir = 8;
+	icon_state = "lattice-dir"
+	},
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "oEq" = (
 /obj/decal/tile_edge/line/black{
 	dir = 9;
@@ -41095,12 +38069,8 @@
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "oGT" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay3,
-/turf/space/fluid/manta,
-/area/mantaSpace)
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "oIR" = (
 /obj/machinery/weapon_stand/shotgun_rack,
 /obj/machinery/power/apc/autoname_west,
@@ -41145,6 +38115,13 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/security/hos)
+"oLP" = (
+/obj/machinery/light/incandescent/small{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt/dirt4,
+/turf/simulated/floor/grime,
+/area/diner/bathroom)
 "oMG" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/red,
@@ -41202,15 +38179,6 @@
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
-"oOR" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/light/incandescent/warm{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/plating,
-/area/diner/hangar)
 "oQa" = (
 /obj/rack,
 /obj/item/clothing/shoes/white{
@@ -41238,20 +38206,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
-"oQD" = (
-/obj/stool/bed,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
-	},
-/obj/landmark/start{
-	name = "Miner"
-	},
-/obj/item/device/radio/intercom/cargo{
-	dir = 4
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "oRE" = (
 /obj/table/auto,
 /obj/machinery/cashreg{
@@ -41274,17 +38228,16 @@
 	},
 /turf/simulated/floor/longtile/black,
 /area/station/turret_protected/starboard)
-"oVc" = (
-/turf/simulated/floor/caution/south,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
-"oVY" = (
-/obj/machinery/r_door_control{
-	id = "diner1"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+"oUf" = (
+/obj/lattice,
+/turf/space/fluid/manta,
 /area/diner/hangar)
+"oVc" = (
+/obj/landmark/start{
+	name = "Miner"
+	},
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "oWc" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -41319,13 +38272,9 @@
 	},
 /area/station/security/interrogation)
 "oXC" = (
-/obj/machinery/door_control/podbay/mining/new_walls/west{
-	name = "Submarine Bay (Mining) door control"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/machinery/manufacturer/hangar,
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "oZK" = (
 /obj/item/device/audio_log,
 /obj/item/audio_tape{
@@ -41367,14 +38316,10 @@
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/security/hos)
-"pcM" = (
-/obj/machinery/door_control{
-	id = "diner1";
-	name = "Pod Door Control";
-	pixel_x = 22
-	},
-/obj/decal/cleanable/oil,
-/turf/simulated/floor/shuttlebay,
+"pbU" = (
+/obj/decal/cleanable/dirt/dirt3,
+/obj/machinery/vending/cola/blue,
+/turf/simulated/floor/grime,
 /area/diner/hangar)
 "peV" = (
 /obj/machinery/light/incandescent/netural{
@@ -41384,26 +38329,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
-"pfe" = (
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/power_monitor/console_upper,
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1;
-	pixel_y = 20
+"pfO" = (
+/obj/decal/fakeobjects/firealarm_broken{
+	pixel_y = 28
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/drainage/big,
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "pfS" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
@@ -41452,6 +38383,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"poL" = (
+/obj/grille/catwalk{
+	dir = 10;
+	icon_state = "catwalk_cross"
+	},
+/turf/space/fluid/manta,
+/area/diner/hangar)
 "ppJ" = (
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
@@ -41536,11 +38474,13 @@
 /obj/disposalpipe/segment/mineral{
 	dir = 4
 	},
-/obj/item/wrench,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/decal/tile_edge/stripe/big,
+/obj/item/storage/wall/mining,
+/obj/landmark/start{
+	name = "Miner"
+	},
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "ptd" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -41570,17 +38510,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
-"pue" = (
-/obj/machinery/nanofab/refining,
-/turf/simulated/floor,
-/area/station/quartermaster/cargobay)
-"pvN" = (
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
+"ptK" = (
+/obj/item/cigbutt,
+/turf/simulated/floor/grime,
+/area/diner/dining)
+"puQ" = (
+/obj/machinery/computer/shuttle_bus{
+	dir = 8
 	},
-/obj/decal/tile_edge/stripe/extra_big,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
+/turf/simulated/floor/grime,
+/area/diner/hangar)
 "pwc" = (
 /obj/rack,
 /obj/item/rubberduck,
@@ -41590,17 +38529,6 @@
 	},
 /turf/simulated/floor/green,
 /area/station/crew_quarters/market)
-"pws" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	name = "autoname - SS13";
-	pixel_x = 10;
-	tag = ""
-	},
-/obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor,
-/area/station/construction)
 "pwt" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41610,10 +38538,29 @@
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
+"pxQ" = (
+/obj/stool/chair/couch{
+	dir = 4
+	},
+/turf/simulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/bee_trader)
 "pyg" = (
-/obj/decal/cleanable/dirt/dirt3,
-/turf/simulated/floor/grime,
-/area/diner/hangar)
+/obj/table/reinforced/bar/auto,
+/obj/item/plate,
+/obj/decal/cleanable/molten_item,
+/obj/machinery/light/incandescent/warm,
+/turf/simulated/floor/delivery,
+/area/diner/kitchen)
+"pyu" = (
+/obj/stool/chair/comfy{
+	dir = 1
+	},
+/turf/simulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/bee_trader)
 "pAz" = (
 /obj/machinery/disposal/small/east{
 	dir = 8;
@@ -41679,6 +38626,15 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/crewquarters/cryotron)
+"pMf" = (
+/obj/machinery/door_control{
+	id = "diner1";
+	name = "Pod Door Control";
+	pixel_x = 22
+	},
+/obj/decal/cleanable/oil,
+/turf/simulated/floor/shuttlebay,
+/area/diner/hangar)
 "pNh" = (
 /obj/machinery/power/data_terminal,
 /obj/item/device/net_sniffer,
@@ -41719,9 +38675,36 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
+"pWO" = (
+/obj/decal/fakeobjects{
+	anchored = 1;
+	density = 1;
+	desc = "This computer is incredibly broken.  Look at how broken it is!  Very much so.";
+	icon = 'icons/obj/computer.dmi';
+	icon_state = "dterm0";
+	name = "broken computer"
+	},
+/obj/decal/fakeobjects/lighttube_broken{
+	desc = "This light might be broken.  It's probably not wired up, though.";
+	dir = 8;
+	icon_state = "tube0";
+	name = "inactive light tube";
+	pixel_x = -10
+	},
+/turf/simulated/floor/grime,
+/area/diner/backroom)
 "pWW" = (
 /obj/item/device/radio/intercom/cargo{
 	dir = 1
+	},
+/obj/stool/chair/office/yellow{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Quartermaster"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "red2"
@@ -41734,6 +38717,10 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
+"pZF" = (
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "qai" = (
 /obj/table/auto,
 /obj/item/remote/porter/port_a_nanomed,
@@ -41786,13 +38773,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portupperhallway)
-"qbl" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "qcy" = (
 /obj/machinery/light/incandescent/cool{
 	nostick = 1
@@ -41854,6 +38834,10 @@
 	dir = 4
 	},
 /area/station/security/secoffquarters)
+"qhK" = (
+/obj/decal/cleanable/dirt/dirt5,
+/turf/simulated/floor/grime,
+/area/diner/kitchen)
 "qkT" = (
 /obj/machinery/light_switch/auto{
 	pixel_x = 5;
@@ -41873,9 +38857,7 @@
 	},
 /obj/forcefield/energyshield/perma/doorlink,
 /turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/area/station/mining/staff_room)
 "qrl" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41889,6 +38871,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction)
+"qsn" = (
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose{
+	id = "diner1"
+	},
+/obj/forcefield/energyshield/perma/doorlink,
+/turf/simulated/floor/shuttlebay,
+/area/diner/hangar)
 "quC" = (
 /obj/storage/crate/wooden,
 /obj/machinery/light/incandescent/netural{
@@ -41897,14 +38886,9 @@
 	},
 /turf/simulated/floor/bot,
 /area/station/quartermaster/cargobay)
-"quS" = (
-/obj/machinery/teleport/portal_generator,
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	pixel_x = 10
-	},
-/turf/simulated/floor/plating,
-/area/diner/hangar)
+"qvU" = (
+/turf/simulated/wall/auto/reinforced/supernorn/orange,
+/area/station/maintenance/lowerport)
 "qyt" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/mechanical,
@@ -41915,20 +38899,28 @@
 	},
 /turf/simulated/floor,
 /area/station/security/starboardtorpedoes)
-"qyS" = (
-/obj/item/storage/wall/mining,
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
+"qyU" = (
+/obj/computerframe{
+	dir = 8
 	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
+/turf/simulated/floor/plating,
+/area/diner/hangar)
+"qzm" = (
+/obj/machinery/light/incandescent/netural,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "qAx" = (
 /turf/unsimulated/wall/setpieces/fakewindow{
 	dir = 6
 	},
 /area/listeningpost/syndicateassaultvessel)
+"qAU" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/obj/disposalpipe/segment,
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "qBh" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 8;
@@ -41987,6 +38979,30 @@
 	dir = 1
 	},
 /area/station/security/secwing)
+"qDm" = (
+/obj/storage/cart{
+	name = "ore cart"
+	},
+/obj/item/device/matanalyzer{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/device/matanalyzer{
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/item/paper/book/from_file/matsci_guide{
+	pixel_x = -7
+	},
+/obj/item/paper/book/from_file/matsci_guide,
+/obj/decal/tile_edge/stripe/big,
+/obj/machinery/light/incandescent/netural{
+	dir = 4;
+	pixel_x = 10
+	},
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/refinery)
 "qDG" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -42031,6 +39047,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
+"qGr" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
+/obj/decal/tile_edge/stripe/big,
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "qHI" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -42042,12 +39068,12 @@
 /turf/simulated/floor/blue,
 /area/station/medical/research)
 "qHY" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor5"
 	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
+/obj/item/clothing/suit/jacketsjacket,
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "qJt" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/robotics{
@@ -42080,6 +39106,10 @@
 	icon_state = "fred2"
 	},
 /area/station/science/restroom)
+"qLq" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "qMj" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42088,6 +39118,11 @@
 	icon_state = "respect2"
 	},
 /area/station/security/secwing)
+"qNL" = (
+/obj/decal/cleanable/cobweb2,
+/obj/decal/cleanable/blood/splatter,
+/turf/simulated/floor/plating/random,
+/area/diner/kitchen)
 "qOO" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2/middle{
@@ -42095,37 +39130,36 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/artifact)
-"qPu" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/obj/table/reinforced/industrial/auto,
-/obj/item/sheet/steel/fullstack{
-	rand_pos = 0
-	},
-/obj/item/sheet/steel/fullstack{
-	rand_pos = 0
-	},
-/turf/simulated/floor,
-/area/station/construction)
 "qQk" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/breakroom)
-"qSb" = (
+"qRN" = (
 /obj/decoration/decorativeplant/plant6,
 /turf/simulated/floor/grime,
 /area/diner/hangar)
+"qSb" = (
+/obj/stool/bar,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "qSo" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
+"qXs" = (
+/obj/grille/catwalk{
+	dir = 6
+	},
+/turf/space/fluid/manta,
+/area/diner/hangar)
+"qYF" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating/random,
+/area/diner/hangar)
 "qZg" = (
 /obj/wingrille_spawn/auto,
 /obj/window_blinds/cog2,
@@ -42154,27 +39188,34 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"rdu" = (
-/obj/storage/cart{
-	name = "ore cart"
-	},
-/obj/machinery/firealarm{
+"rcV" = (
+/obj/disposalpipe/segment/mineral{
 	dir = 8;
-	pixel_x = -24
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/caution/south,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
-"rdx" = (
-/obj/machinery/light/emergency{
+/obj/machinery/door_control{
+	id = "securitylobby";
+	name = "Mining Teleporter Exit Control";
+	pixel_x = -25
+	},
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
+"rdu" = (
+/obj/machinery/light/incandescent/netural{
 	dir = 8;
 	pixel_x = -10
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
+"rdx" = (
+/obj/machinery/portable_reclaimer,
+/obj/machinery/light/incandescent/netural{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "rdE" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -42224,6 +39265,16 @@
 	},
 /turf/simulated/floor/specialroom/clown,
 /area/station/crew_quarters/clown)
+"rjf" = (
+/obj/item/instrument/large/jukebox,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
+"rjT" = (
+/obj/machinery/junctionbox/varianta{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/lowerport)
 "rkw" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -42249,11 +39300,13 @@
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
 "rlZ" = (
-/obj/computerframe{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/diner/hangar)
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/diner/kitchen)
+"rmk" = (
+/obj/decal/cleanable/dirt,
+/obj/machinery/gibber/output_west,
+/turf/simulated/floor/plating/random,
+/area/diner/kitchen)
 "rnN" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 4;
@@ -42411,21 +39464,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/hos/quarter)
-"ruk" = (
-/obj/stool/bed,
-/obj/item/storage/wall/mining,
-/obj/item/clothing/suit/bedsheet{
-	bcolor = "yellow";
-	icon_state = "bedsheet-yellow"
-	},
-/obj/landmark/start{
-	name = "Miner"
-	},
-/obj/item/device/radio/intercom/cargo{
-	dir = 8
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/staff_room)
 "ruT" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -42495,6 +39533,10 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
+"rKs" = (
+/obj/machinery/shuttle/engine/heater/seaheater_right,
+/turf/simulated/floor/plating,
+/area/diner/dining)
 "rLV" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -42539,6 +39581,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
+"rOT" = (
+/obj/machinery/vending/kitchen,
+/turf/simulated/floor/scorched2,
+/area/diner/kitchen)
+"rQb" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -4
+	},
+/turf/simulated/floor/plating/random,
+/area/diner/kitchen)
 "rRP" = (
 /obj/decal/fakeobjects{
 	density = 1;
@@ -42572,32 +39625,13 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"rUD" = (
-/obj/decal/tile_edge/line/green{
-	color = "#8D8C8C";
-	dir = 9;
-	icon_state = "line1"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
+"rTD" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/diner/bathroom)
 "rVY" = (
-/obj/grille/catwalk{
-	dir = 5;
-	icon_state = "catwalk_cross"
-	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
+/obj/decal/cleanable/blood/splatter,
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "rVZ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42622,10 +39656,13 @@
 /area/station/security/checkpoint/sec_foyer)
 "rXk" = (
 /obj/decal/cleanable/dirt/dirt3,
+/obj/machinery/vehicle/tank/minisub/mining,
 /turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/area/station/mining/staff_room)
+"rXl" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/grime,
+/area/diner/hangar)
 "rXH" = (
 /obj/machinery/light/incandescent/blueish{
 	dir = 1;
@@ -42671,6 +39708,12 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/station/medical/head)
+"scN" = (
+/obj/machinery/cashreg,
+/obj/table/reinforced/bar/auto,
+/obj/machinery/cashreg,
+/turf/simulated/floor/delivery,
+/area/diner/kitchen)
 "sdw" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -42682,11 +39725,9 @@
 	},
 /area/station/security/secwing)
 "sdW" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
+/obj/decal/cleanable/blood/hurting1/hurting2,
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "sfd" = (
 /obj/decal/tile_edge/line/orange{
 	dir = 1;
@@ -42706,6 +39747,17 @@
 	dir = 8
 	},
 /area/station/medical/cdc)
+"sfP" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
+"siD" = (
+/obj/decal/tile_edge/stripe/big{
+	dir = 8
+	},
+/obj/disposalpipe/segment/mineral,
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "skn" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -42719,18 +39771,6 @@
 	},
 /turf/simulated/floor/caution/south,
 /area/station/engine/inner)
-"skN" = (
-/obj/decal/cleanable/dirt/dirt4,
-/obj/cable{
-	icon_state = "1-4"
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "slh" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42746,14 +39786,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
+"smn" = (
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/grime,
+/area/diner/kitchen)
 "smp" = (
 /obj/disposalpipe/segment/mineral{
 	dir = 4
 	},
 /turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/area/station/mining/staff_room)
 "srA" = (
 /obj/table/wood/auto,
 /obj/item/reagent_containers/glass/bottle/holywater,
@@ -42777,6 +39819,12 @@
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
+"svv" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4
+	},
+/turf/simulated/wall/auto/reinforced/supernorn/orange,
+/area/station/quartermaster/cargobay)
 "svA" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42844,20 +39892,6 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/starboard)
-"sEK" = (
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 4;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/obj/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "sFy" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -42888,6 +39922,7 @@
 	dir = 8;
 	pixel_x = -10
 	},
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/industrial,
 /area/station/mining/refinery)
 "sKg" = (
@@ -42901,6 +39936,14 @@
 	},
 /turf/simulated/floor/greenblack,
 /area/station/crewquarters/garbagegarbs)
+"sKC" = (
+/turf/simulated/floor/stairs/wide/other,
+/area/diner/dining)
+"sLL" = (
+/turf/simulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/bee_trader)
 "sLW" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -42915,9 +39958,16 @@
 /turf/simulated/floor/black,
 /area/station/security/secoffquarters)
 "sOt" = (
-/obj/decal/fakeobjects/mantacontainer/upwards,
-/turf/simulated/floor,
+/obj/machinery/manufacturer/mining,
+/turf/simulated/floor/bot,
 /area/station/quartermaster/cargobay)
+"sQQ" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 4;
+	pixel_x = 10
+	},
+/turf/simulated/floor,
+/area/station/hallway/portlowerhallway)
 "sTs" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -42928,6 +39978,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/chemistry)
+"sTP" = (
+/obj/item/storage/pill_bottle/cyberpunk,
+/obj/decoration/toiletholder{
+	dir = 1
+	},
+/turf/simulated/floor/scorched2,
+/area/diner/bathroom)
 "sUk" = (
 /obj/machinery/computer/riotgear{
 	dir = 4;
@@ -42975,12 +40032,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"sXN" = (
-/obj/table/auto,
-/obj/item/circuitboard/teleporter,
-/obj/item/circuitboard/teleporter,
-/turf/simulated/floor/plating,
-/area/diner/hangar)
 "sXW" = (
 /obj/machinery/chem_heater,
 /obj/decal/tile_edge/line/purple{
@@ -43057,6 +40108,26 @@
 	},
 /turf/simulated/floor/delivery,
 /area/station/quartermaster/cargobay)
+"tgV" = (
+/obj/machinery/light/incandescent/netural,
+/obj/table/reinforced/industrial/auto,
+/obj/item/device/gps{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/device/gps{
+	pixel_x = -7
+	},
+/obj/item/paper/book/from_file/matsci_guide{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/device/matanalyzer{
+	pixel_x = 13;
+	pixel_y = 7
+	},
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "tij" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -43081,6 +40152,10 @@
 	},
 /turf/simulated/floor/red/checker,
 /area/station/medical/medbay/treatment2)
+"tki" = (
+/obj/stool/bench/green/auto,
+/turf/simulated/floor/grime,
+/area/diner/hangar)
 "tlH" = (
 /obj/decal/cleanable/blood,
 /obj/decal/cleanable/dirt/dirt4,
@@ -43090,10 +40165,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/security/brig/solitary)
-"tmH" = (
-/obj/machinery/vehicle/tank/minisub,
-/turf/simulated/floor/shuttlebay,
-/area/diner/hangar)
 "tnB" = (
 /obj/machinery/manufacturer/hangar,
 /obj/machinery/power/apc/autoname_north,
@@ -43106,23 +40177,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/starboard)
-"tsQ" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e17627";
-	dir = 1;
-	icon_state = "line1"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/obj/decal/tile_edge/line/red{
-	color = "#ba9a65";
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
+"tsd" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor/grime,
+/area/diner/backroom)
+"ttm" = (
+/turf/simulated/floor/grime,
+/area/skeleton_trader)
 "ttM" = (
 /obj/item/device/radio/intercom/loudspeaker/speaker/north,
 /obj/machinery/guardbot_dock,
@@ -43148,25 +40209,20 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
-"txS" = (
-/obj/cable{
-	icon_state = "1-2"
+"txQ" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/stairs{
+	icon_state = "Stairs2_wide"
 	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/decal/tile_edge/line/green{
-	color = "#e7c88c";
-	dir = 8;
-	icon_state = "line1"
-	},
+/area/station/mining/refinery)
+"tyi" = (
 /obj/machinery/light/incandescent/netural{
-	dir = 8;
-	pixel_x = -10
+	dir = 4;
+	pixel_x = 10
 	},
-/obj/disposalpipe/junction/right/south,
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
+/obj/decal/cleanable/dirt/dirt4,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "tAG" = (
 /obj/shrub{
 	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
@@ -43188,14 +40244,10 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
-"tCX" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor,
-/area/station/construction)
+"tFL" = (
+/obj/critter/roach,
+/turf/simulated/floor/grime,
+/area/diner/bathroom)
 "tHn" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -43240,16 +40292,6 @@
 "tJU" = (
 /turf/simulated/floor/caution/south,
 /area/station/engine/elect)
-"tKM" = (
-/obj/critter/rockworm{
-	name = "Gary the rockworm"
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "tLe" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -43270,11 +40312,26 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/medical/head)
 "tLq" = (
-/obj/machinery/vehicle/tank/minisub,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
+"tLV" = (
+/obj/decal/tile_edge/stripe/big,
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "tNr" = (
 /obj/machinery/light/incandescent/blueish{
 	dir = 8;
@@ -43329,14 +40386,6 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"tXp" = (
-/obj/machinery/processor,
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/industrial,
-/area/station/mining/refinery)
 "tYh" = (
 /obj/machinery/computer3/generic/communications,
 /obj/machinery/weapon_stand/rifle_rack/recharger,
@@ -43346,6 +40395,17 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
+"tYp" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 4
+	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/mining/staff_room)
+"uaj" = (
+/obj/decal/cleanable/dirt/dirt5,
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "uaP" = (
 /obj/table/auto,
 /obj/item/sheet/steel/fullstack{
@@ -43412,6 +40472,19 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/communications/office)
+"udh" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/diner/bathroom)
+"ueH" = (
+/obj/storage/closet/mantacontainerred/right,
+/obj/item/instrument/harmonica,
+/turf/simulated/floor,
+/area/station/quartermaster/cargobay)
+"ufu" = (
+/obj/machinery/portable_reclaimer,
+/turf/simulated/floor,
+/area/station/quartermaster/cargobay)
 "ugl" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -43423,13 +40496,20 @@
 	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+"ugz" = (
+/obj/table/wood/round/auto,
+/obj/item/plate{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/burger/sloppyjoe{
+	pixel_y = 5
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "uhg" = (
-/obj/table/auto,
-/obj/machinery/recharger,
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/mining/staff_room)
 "uhU" = (
 /obj/table/glass/reinforced/auto,
 /obj/item/clipboard,
@@ -43462,6 +40542,15 @@
 /obj/item/toy/gooncode,
 /turf/simulated/floor,
 /area/station/storage/tech)
+"uiE" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light/incandescent/warm{
+	dir = 4;
+	nostick = 1;
+	pixel_x = 10
+	},
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "uiW" = (
 /obj/machinery/light/incandescent/cool{
 	dir = 1;
@@ -43476,17 +40565,6 @@
 /obj/item/clothing/under/swimsuit/random,
 /turf/simulated/floor/sanitary/blue,
 /area/station/crew_quarters/bathroom)
-"ujg" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "ujF" = (
 /obj/machinery/power/data_terminal,
 /obj/cable,
@@ -43498,37 +40576,36 @@
 	},
 /turf/simulated/floor/engine/glow/blue,
 /area/station/engine/singcore)
-"ulJ" = (
-/obj/decal/tile_edge/line/red{
-	color = "#e7c88c";
-	dir = 1;
-	icon_state = "line1"
-	},
+"ujV" = (
+/obj/marker/supplymarker,
 /obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
+	dir = 4;
+	pixel_x = 10
 	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
+/turf/simulated/floor/shuttle{
+	icon_state = "floor2"
+	},
+/area/bee_trader)
+"ulY" = (
+/obj/table/auto,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/light/incandescent/warm{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "unq" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/green,
 /area/station/medical/research)
 "usW" = (
+/obj/decal/tile_edge/stripe/big,
 /obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
-"utz" = (
-/obj/item/storage/wall/mineralshelf,
-/obj/item/device/radio/intercom/cargo{
-	dir = 4
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/orange,
-/area/station/mining/refinery)
+/area/station/mining/staff_room)
 "uvR" = (
 /obj/stool/bench/auto,
 /obj/decal/tile_edge/line/red{
@@ -43583,16 +40660,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
-"uEY" = (
-/obj/machinery/power/data_terminal,
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/computer/card/console_lower{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/seaturtlebridge)
 "uFt" = (
 /obj/decal/tile_edge/line/green{
 	color = "#e7c88c";
@@ -43653,6 +40720,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
+"uIn" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "uJF" = (
 /obj/machinery/door/airlock/pyro/engineering{
 	dir = 4;
@@ -43665,6 +40736,13 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/ce/private)
+"uJM" = (
+/obj/grille/catwalk{
+	dir = 5;
+	icon_state = "catwalk_cross"
+	},
+/turf/space/fluid/manta,
+/area/diner/hangar)
 "uKq" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 1;
@@ -43792,26 +40870,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
-"uTW" = (
-/obj/machinery/light/incandescent/blueish{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/seaturtle)
-"uUd" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/mining)
 "uUj" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/mining/refinery)
+"uUy" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space/fluid/manta,
+/area/diner/hangar)
 "uYi" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -43839,6 +40908,17 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperport)
+"uZI" = (
+/obj/disposalpipe/segment/mineral{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/incandescent/netural{
+	dir = 8;
+	pixel_x = -10
+	},
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "vau" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -43852,9 +40932,13 @@
 	},
 /turf/simulated/floor/wood/two,
 /area/station/captain)
-"vea" = (
-/turf/simulated/wall/auto/reinforced/supernorn/yellow,
-/area/station/mining/refinery)
+"vex" = (
+/obj/decal/cleanable/blood/splatter{
+	icon_state = "floor5"
+	},
+/obj/machinery/light/incandescent/small,
+/turf/simulated/floor/plating/random,
+/area/diner/kitchen)
 "veP" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -43864,12 +40948,6 @@
 	dir = 1
 	},
 /area/station/crewquarters/cryotron)
-"vft" = (
-/obj/decal/cleanable/oil/streak,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "vfw" = (
 /obj/decal/fakeobjects{
 	desc = "Under construction";
@@ -43895,29 +40973,24 @@
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
-"vkN" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4;
-	nostick = 1;
-	pixel_x = 10
-	},
-/turf/simulated/floor/stairs{
-	dir = 1;
-	icon_state = "Stairs_wide"
-	},
-/area/station/mining/refinery)
+"vjU" = (
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/grime,
+/area/diner/hangar)
 "vlK" = (
 /turf/simulated/floor/plating/random,
 /area/station/engine/elect)
 "vnk" = (
-/obj/machinery/light/emergency{
-	dir = 4;
-	pixel_x = 10
+/obj/machinery/door/airlock/pyro/engineering{
+	id = "letmethehelloutofmining";
+	name = "Refinery";
+	req_access = null
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/access_spawn/mining,
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment/mineral,
+/turf/simulated/floor/orange,
+/area/station/mining/refinery)
 "vop" = (
 /obj/table/reinforced/auto,
 /obj/item/paper/Port_A_Brig,
@@ -43937,15 +41010,22 @@
 	dir = 8
 	},
 /area/station/security/interrogation)
+"vpR" = (
+/obj/stool/chair/couch/blue{
+	dir = 4
+	},
+/turf/simulated/floor/grime,
+/area/diner/hangar)
 "vqB" = (
 /obj/disposalpipe/segment/mineral{
 	dir = 4
 	},
-/obj/machinery/vehicle/tank/minisub,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "vrU" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/blue,
@@ -43962,12 +41042,9 @@
 	},
 /area/station/medical/head/private)
 "vtb" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/light/runway_light/delay4,
-/turf/space/fluid/manta,
-/area/mantaSpace)
+/obj/machinery/door/airlock/pyro/glass,
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "vtm" = (
 /obj/storage/closet/dresser/random,
 /obj/item/clothing/under/shorts/red,
@@ -43996,6 +41073,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/teleporter)
+"vuU" = (
+/obj/storage/closet/welding_supply,
+/turf/simulated/floor/caution/south,
+/area/diner/hangar)
 "vvN" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -44022,13 +41103,6 @@
 	},
 /turf/simulated/floor/engine/caution/westeast,
 /area/station/science/teleporter)
-"vyz" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
 "vzu" = (
 /obj/stool/bench/auto,
 /obj/decal/tile_edge/line/red{
@@ -44058,16 +41132,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/lobby)
-"vzK" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor/plating/airless/asteroid,
-/area/station/mining/staff_room)
 "vBy" = (
 /obj/storage/secure/closet/personal,
 /obj/disposalpipe/segment/mail,
@@ -44165,13 +41229,6 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/upperstarboard)
-"vHg" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
 "vHN" = (
 /obj/machinery/manufacturer/uniform,
 /obj/machinery/light/incandescent/netural{
@@ -44207,15 +41264,10 @@
 	},
 /turf/simulated/floor/longtile,
 /area/station/bridge)
-"vMo" = (
-/obj/forcefield/energyshield/perma/doorlink,
-/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/mining_horizontal{
-	name = "Submarine Bay (Mining)"
-	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+"vKS" = (
+/obj/machinery/door/airlock/pyro,
+/turf/simulated/floor/grime,
+/area/diner/hangar)
 "vNT" = (
 /obj/machinery/networked/test_apparatus/xraymachine,
 /obj/machinery/power/data_terminal,
@@ -44313,14 +41365,6 @@
 	},
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/communications/office)
-"vWe" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir";
-	tag = "icon-lattice-dir (EAST)"
-	},
-/turf/space/fluid/manta,
-/area/mantaSpace)
 "vWV" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -44328,15 +41372,18 @@
 	},
 /turf/simulated/floor/engine/caution/corner,
 /area/station/science/teleporter)
+"vXy" = (
+/obj/decal/cleanable/dirt/dirt4,
+/turf/simulated/floor/grime,
+/area/skeleton_trader)
 "vXL" = (
 /obj/item/storage/wall/clothingrack/clothes1,
 /turf/simulated/floor/green,
 /area/station/crewquarters/garbagegarbs)
 "vYn" = (
-/obj/decal/cleanable/dirt/dirt3,
-/obj/machinery/door/airlock/pyro/external,
-/turf/simulated/floor/shuttlebay,
-/area/diner/hangar)
+/obj/decal/cleanable/rust,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/diner/dining)
 "vYL" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8;
@@ -44368,15 +41415,23 @@
 /area/station/hallway/centralhallway)
 "wbL" = (
 /obj/machinery/light/incandescent/netural,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/decal/tile_edge/stripe/big{
+	dir = 4
+	},
+/turf/unsimulated/floor/orange,
+/area/station/mining/staff_room)
 "wdi" = (
 /obj/cable,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/sec_foyer)
+"wep" = (
+/obj/forcefield/energyshield/perma/doorlink,
+/obj/machinery/door/poddoor/blast/pyro/podbay_autoclose/mining_horizontal{
+	name = "Submarine Bay (Mining)"
+	},
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/staff_room)
 "wev" = (
 /obj/submachine/cargopad/robotics,
 /obj/machinery/light/incandescent/cool{
@@ -44390,6 +41445,11 @@
 /obj/machinery/door/airlock/pyro/glass/engineering,
 /turf/simulated/floor,
 /area/station/engine/gas)
+"wiM" = (
+/obj/decal/cleanable/dirt/dirt3,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/shuttlebay,
+/area/diner/hangar)
 "wjw" = (
 /obj/stool/chair/red{
 	anchored = 0;
@@ -44419,17 +41479,6 @@
 	dir = 4
 	},
 /area/station/crew_quarters/hor)
-"wmn" = (
-/obj/machinery/light/incandescent/warm{
-	dir = 8;
-	pixel_x = -10
-	},
-/obj/decal/cleanable/dirt/dirt4,
-/obj/stove,
-/obj/item/soup_pot,
-/obj/item/ladle,
-/turf/simulated/floor/grime,
-/area/diner/kitchen)
 "wmS" = (
 /obj/disposalpipe/segment,
 /obj/machinery/camera{
@@ -44462,19 +41511,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
-"wnp" = (
-/obj/table/auto,
-/obj/machinery/coffeemaker,
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	nostick = 1;
-	pixel_x = -10
+"wnM" = (
+/obj/lattice{
+	dir = 1;
+	icon_state = "lattice-dir"
 	},
-/obj/mug_rack{
-	pixel_y = 32
-	},
-/turf/simulated/floor,
-/area/station/mining/staff_room)
+/turf/space/fluid/manta,
+/area/diner/hangar)
 "woI" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -44525,13 +41568,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/chemistry)
-"wwx" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	pixel_x = -10
-	},
-/turf/simulated/floor,
-/area/station/hallway/seaturtlehallway)
+"wwE" = (
+/obj/decal/cleanable/dirt,
+/turf/space/fluid/manta,
+/area/mantaSpace)
 "wxu" = (
 /obj/table/reinforced/bar/auto,
 /obj/decal/tile_edge/line/black{
@@ -44558,17 +41598,16 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
-"wyh" = (
-/obj/machinery/disposal/small{
-	dir = 8
+"wxX" = (
+/turf/simulated/floor/grime,
+/area/diner/backroom)
+"wze" = (
+/obj/decal/cleanable/gangtag{
+	icon_state = "gangtag16";
+	pixel_y = -28
 	},
-/obj/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/caution/south,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/grime,
+/area/diner/backroom)
 "wzn" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/machinery/light/emergency{
@@ -44578,15 +41617,11 @@
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
 "wzI" = (
-/obj/storage/closet/welding_supply,
-/obj/machinery/power/apc/autoname_north,
-/obj/cable{
-	icon_state = "0-8"
+/obj/decal/poster/wallsign/poster_mining{
+	pixel_y = 32
 	},
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "wzU" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/wood/five,
@@ -44634,6 +41669,16 @@
 /obj/window_blinds/cog2/right,
 /turf/simulated/floor/plating,
 /area/station/engine/engineering/ce)
+"wDT" = (
+/obj/machinery/light/incandescent/warm{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/stool/chair/couch/blue{
+	dir = 8
+	},
+/turf/simulated/floor/grime,
+/area/diner/hangar)
 "wHo" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4;
@@ -44678,6 +41723,17 @@
 /obj/item/device/radio/intercom/cargo,
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
+"wJb" = (
+/obj/decal/fakeobjects/lighttube_broken,
+/turf/simulated/floor/grime,
+/area/diner/backroom)
+"wKu" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/turf/space/fluid/manta,
+/area/diner/hangar)
 "wLD" = (
 /obj/table/reinforced/auto,
 /obj/item/sheet/steel/fullstack,
@@ -44689,24 +41745,17 @@
 /turf/simulated/floor,
 /area/station/engine/power)
 "wOa" = (
-/obj/machinery/manufacturer/medical,
-/turf/simulated/floor/bot,
-/area/station/quartermaster/cargobay)
-"wOL" = (
-/obj/disposalpipe/segment{
-	dir = 4
-	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/pyro/glass/engineering{
-	dir = 8;
-	name = "Mining";
-	req_access = null
-	},
-/obj/firedoor_spawn,
+/obj/indestructible/invisible_block,
 /turf/simulated/floor,
-/area/station/mining/refinery)
+/area/station/quartermaster/cargobay)
+"wQZ" = (
+/obj/decal/cleanable/vomit,
+/obj/decoration/toiletholder{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/grime,
+/area/diner/bathroom)
 "wRO" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -44743,6 +41792,20 @@
 "xaf" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/construction)
+"xba" = (
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Refinery"
+	},
+/obj/firedoor_spawn,
+/obj/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/mining/refinery)
+"xbG" = (
+/obj/stool/chair/wooden{
+	dir = 8
+	},
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "xbQ" = (
 /obj/stool/chair/wooden{
 	dir = 8
@@ -44753,6 +41816,13 @@
 	},
 /turf/simulated/floor/wood/five,
 /area/station/chapel/sanctuary)
+"xcu" = (
+/turf/simulated/floor/shuttlebay,
+/area/station/mining/staff_room)
+"xcQ" = (
+/obj/machinery/manufacturer/medical,
+/turf/simulated/floor/bot,
+/area/station/quartermaster/cargobay)
 "xdd" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 1;
@@ -44763,6 +41833,10 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/power)
+"xen" = (
+/obj/submachine/slot_machine,
+/turf/simulated/floor/specialroom/bar,
+/area/diner/dining)
 "xeX" = (
 /obj/machinery/door/airlock/pyro/security{
 	dir = 4;
@@ -44833,30 +41907,26 @@
 "xlP" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/area/station/mining/staff_room)
 "xod" = (
-/obj/machinery/manufacturer/general,
-/obj/machinery/light/incandescent/netural{
-	dir = 1;
-	pixel_y = 20
-	},
+/obj/storage/crate/packing,
 /turf/simulated/floor/bot,
 /area/station/quartermaster/cargobay)
 "xoE" = (
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
+"xpG" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/market)
+"xpJ" = (
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
-"xpG" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/market)
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/industrial,
+/area/station/mining/refinery)
 "xpQ" = (
 /obj/disposalpipe/trunk/mineral{
 	dir = 4
@@ -44864,14 +41934,17 @@
 /obj/machinery/disposal/cart_port{
 	name = "Ore cart port - to QM"
 	},
-/obj/machinery/light/incandescent/netural{
-	dir = 8;
-	pixel_x = -10
+/obj/storage/cart{
+	name = "ore cart"
 	},
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname  - SS13"
+	},
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "xqw" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -44917,17 +41990,12 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
-"xwf" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+"xwo" = (
+/obj/machinery/door/airlock/pyro{
+	dir = 4
 	},
-/obj/machinery/light/runway_light,
-/turf/space/fluid/manta,
-/area/mantaSpace)
-"xwN" = (
-/obj/machinery/ore_cloud_storage_container,
-/turf/simulated/floor/orange,
-/area/station/mining/refinery)
+/turf/simulated/floor/grime,
+/area/diner/bathroom)
 "xwV" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg{
@@ -45049,6 +42117,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/communications/office)
+"xIr" = (
+/obj/decal/cleanable/rust,
+/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/diner/hangar)
 "xIX" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -45082,13 +42156,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/medical/head)
-"xKw" = (
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
-	},
-/turf/space/fluid/manta,
-/area/diner/hangar)
 "xLK" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -45176,6 +42243,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/starboardlowerhallway)
+"xUP" = (
+/obj/disposalpipe/segment,
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "xVb" = (
 /obj/machinery/vending/security,
 /obj/machinery/light/incandescent/warm{
@@ -45270,12 +42341,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"yck" = (
-/obj/machinery/drainage/big,
-/turf/simulated/floor/shuttlebay,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
 "yea" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -45299,34 +42364,35 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/centralhallway)
+"yeC" = (
+/obj/machinery/shuttle/engine/heater/seaheater_middle,
+/turf/simulated/floor/plating,
+/area/diner/dining)
 "ygy" = (
 /obj/item/constructioncone,
 /turf/simulated/floor,
 /area/station/hallway/secondary/construction)
+"yhb" = (
+/obj/machinery/vending/snack,
+/obj/machinery/light/incandescent/warm{
+	dir = 8;
+	nostick = 1;
+	pixel_x = -10
+	},
+/turf/simulated/floor/grime,
+/area/diner/dining)
 "yhc" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/caution/south,
-/area/station/hangar/engine{
-	name = "Submarine Bay (Engineering)"
-	})
+/turf/simulated/floor/orange,
+/area/station/mining/staff_room)
 "yhC" = (
 /obj/cable{
 	icon_state = "6-8"
 	},
 /turf/simulated/floor/red,
 /area/listeningpost/syndicateassaultvessel)
-"yiv" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	pixel_x = -10;
-	tag = ""
-	},
-/turf/simulated/floor,
-/area/station/maintenance/seaturtle/boiler)
 "ykr" = (
 /obj/table/round/auto,
 /obj/towelbin{
@@ -45345,6 +42411,9 @@
 	},
 /turf/simulated/floor/sanitary/blue,
 /area/station/crew_quarters/bathroom)
+"ymd" = (
+/turf/simulated/floor/caution/south,
+/area/diner/hangar)
 
 (1,1,1) = {"
 aaa
@@ -65751,13 +62820,13 @@ bai
 bpd
 brx
 boc
-buU
-buU
-buU
-buU
-buU
-buU
-buU
+bFe
+bFe
+bFe
+bFe
+bFe
+bFe
+bFe
 bFe
 buU
 aoq
@@ -66056,12 +63125,12 @@ bqT
 xlP
 fLk
 rdu
-lNF
+bzY
 xpQ
 rdx
-lNF
+fkb
 oXC
-nAY
+kQX
 act
 aaa
 aaa
@@ -66358,9 +63427,9 @@ cxW
 xlP
 ntv
 oVc
-lNF
+fsl
 vqB
-lNF
+qAU
 tLq
 wbL
 blz
@@ -66657,14 +63726,14 @@ bqX
 biY
 gAR
 nuY
-xlP
+mIf
 eBV
-oVc
-lNF
+xUP
+tLV
 smp
-lNF
-lNF
-jKG
+xcu
+xcu
+xcu
 qlY
 act
 aaa
@@ -66960,14 +64029,14 @@ bjR
 rVZ
 lmY
 jsD
-skN
 yhc
+byu
 usW
 smp
-lNF
+xcu
 rXk
-lNF
-vMo
+xcu
+wep
 act
 aaa
 aaa
@@ -67261,15 +64330,15 @@ tPi
 bjS
 kly
 uFt
-nAY
+ldA
 wzI
-oVc
+jyS
 jvz
-smp
+qGr
 lxB
-lNF
-yck
-vMo
+guv
+xcu
+wep
 act
 aaa
 aaa
@@ -67563,15 +64632,15 @@ aAW
 bjT
 dPl
 cty
-nAY
+ldA
 uhg
-oVc
-jvz
-smp
-lNF
-lNF
-lNF
-vMo
+uhg
+ldA
+heQ
+eHx
+lFv
+xcu
+wep
 act
 aaa
 aaa
@@ -67863,17 +64932,17 @@ aXs
 baF
 bgy
 bkK
-boc
-boc
-nAY
-dYP
-oVc
-jvz
+bgy
+fEM
+gCV
+bxa
+sGr
+ldA
 psJ
-lNF
-vft
-lNF
-vMo
+xcu
+xcu
+xcu
+wep
 act
 aaa
 aaa
@@ -68164,20 +65233,20 @@ ait
 aYG
 bai
 boc
-box
-boc
-boc
-nAY
+ejQ
+bcj
+xba
+txQ
 meh
-oVc
-jvz
-smp
-lNF
-lNF
-wbL
-nAY
+xpJ
+ldA
+kID
+siD
+okI
+oqG
+kQX
 act
-aaa
+aab
 aaa
 aaa
 aaa
@@ -68466,20 +65535,20 @@ ait
 aGX
 bai
 tPi
-bsc
-bcj
-bIZ
+bqC
+sQQ
+uUj
 gWm
-xoE
+aaA
 gpN
-jvz
-vqB
-lNF
-tLq
+ldA
+ldA
+ldA
+tYp
 bZu
-nAY
-aoQ
-aaa
+kQX
+kQX
+drW
 aaa
 aaa
 aaa
@@ -68769,18 +65838,18 @@ aYH
 bbS
 bcj
 bpX
-brB
-bsM
-nAY
-nCe
-wyh
-jvz
+cty
+cty
+xoE
+bxa
+xoE
+uZI
 dXK
 vnk
-lNF
-lNF
-nAY
-act
+rcV
+dyN
+fVL
+kQX
 act
 aaa
 aaa
@@ -69073,16 +66142,16 @@ bdX
 bpe
 aHk
 btH
-nAY
-nAY
-nAY
+mHE
+jRZ
+bxa
 gPa
 coI
-nAY
-nAY
+uUj
 dyN
-nAY
-bEF
+bzZ
+tgV
+kQX
 act
 aaa
 aaa
@@ -69373,18 +66442,18 @@ bny
 aLF
 bgr
 box
-aKs
-btI
-bvc
+lDl
+bvd
+bvd
 bwE
-ayM
+xoE
 asv
-bBs
-bCS
-byw
-bFR
+bOJ
+uUj
+lNF
+dyN
 bGw
-bEF
+kQX
 act
 aaa
 aaa
@@ -69675,18 +66744,18 @@ bnz
 boP
 uLh
 box
-aKs
-btJ
+lDl
 bvd
-bvk
-ayM
-aze
+bvd
+qDm
+fMm
+bOI
 bBt
-bCT
-byw
+uUj
+mvU
 asB
-bHD
-bEF
+dqv
+kQX
 act
 aaa
 aaa
@@ -69977,17 +67046,17 @@ bnA
 aLF
 bgr
 box
-aKs
-btK
-byy
+svv
 bwF
-byu
-aLA
-bBu
+bwF
+bwF
 bCU
-byw
-bHD
-bGx
+kRu
+bCU
+bCU
+bCU
+qvU
+qvU
 bEF
 act
 aaa
@@ -70288,7 +67357,7 @@ aOy
 bBv
 bCV
 byw
-bHD
+rjT
 bGC
 bEF
 act
@@ -70884,10 +67953,10 @@ aLF
 bfl
 bpU
 aKs
-jFc
+btM
 bvh
 bwI
-ayM
+byw
 baJ
 bBx
 bCX
@@ -71190,7 +68259,7 @@ btM
 bvi
 bwJ
 byw
-byw
+ayM
 ayM
 ayM
 byw
@@ -71488,13 +68557,13 @@ aLJ
 bgr
 box
 aKs
-btP
+xod
 bvj
 bwK
 vHO
-cVW
+bvk
 eLx
-bBy
+bvk
 bEi
 bFv
 bGD
@@ -71797,7 +68866,7 @@ byy
 bvk
 bvk
 bvk
-bvk
+ufu
 bFv
 bGD
 bGD
@@ -72093,17 +69162,17 @@ xfn
 box
 aKs
 wOa
-bvk
-bvk
+wOa
+nQO
 byy
 bvk
 dBj
-bvk
-bvk
-bFv
-bGD
-bGD
-bIS
+mrj
+xcQ
+bwP
+bGE
+bHD
+bEF
 act
 act
 aaa
@@ -72394,16 +69463,16 @@ boS
 brC
 bpW
 aKs
-iQM
-bvk
-bvk
+wOa
+wOa
+nre
 byy
 bvk
-bNC
+bvk
 bBz
 bEj
 bwP
-bGE
+bHD
 bHD
 bEF
 bEF
@@ -72696,9 +69765,9 @@ boR
 bgr
 box
 aKs
-pue
-bvk
-bvk
+wOa
+wOa
+nQO
 byy
 bvk
 bvk
@@ -72998,14 +70067,14 @@ boR
 bgr
 box
 aKs
-bvk
-bvk
-bvk
+wOa
+wOa
+ueH
 byy
 bvk
 bvk
 bvk
-bvk
+jNw
 bwP
 bwP
 bwP
@@ -100199,9 +97268,9 @@ bHa
 bNe
 bEw
 aaa
-aqQ
+bAe
 adx
-aqU
+bBG
 act
 aaa
 aaa
@@ -109247,7 +106316,7 @@ bCF
 bDR
 aKN
 bGo
-bGl
+bGo
 bGl
 act
 aaa
@@ -109549,8 +106618,8 @@ aKN
 bDS
 bFa
 aKM
+aKM
 bGl
-act
 act
 aaa
 aaa
@@ -109851,9 +106920,9 @@ aKN
 bzX
 aKN
 aKM
+aKM
 bGl
 act
-aaa
 aaa
 aaa
 aaa
@@ -110154,8 +107223,8 @@ bDU
 bwm
 bGp
 bwm
-apJ
-aaa
+bwm
+act
 aaa
 aaa
 aaa
@@ -110457,7 +107526,7 @@ cPg
 bGq
 bwm
 act
-aaa
+act
 aaa
 aaa
 aaa
@@ -114371,7 +111440,7 @@ act
 aBr
 pFs
 aBw
-bFc
+aIt
 btx
 buW
 bwv
@@ -114673,7 +111742,7 @@ act
 aBr
 aBr
 rrF
-bFc
+aIt
 btx
 btx
 mbd
@@ -114975,7 +112044,7 @@ act
 act
 aBr
 aEd
-bIC
+aWe
 aPs
 btx
 bwu
@@ -115277,7 +112346,7 @@ aaa
 act
 aBr
 aBr
-bOj
+aBw
 aIt
 btx
 btx
@@ -115505,12 +112574,12 @@ aaa
 aaa
 aaa
 aaa
-agG
-agB
-agG
-agG
-agG
-oVY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115579,8 +112648,8 @@ aaa
 act
 act
 aBr
-hmS
-bOs
+pFs
+aWe
 aPs
 btx
 btx
@@ -115804,15 +112873,15 @@ aaa
 aaa
 aaa
 aaa
-adq
-adq
-adq
-agG
-agH
-ahl
-tmH
-ahg
-ahB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115883,8 +112952,8 @@ act
 aBr
 aBr
 bvv
-bOE
-bOM
+aWe
+aPs
 btx
 btx
 btx
@@ -116106,15 +113175,15 @@ aaa
 aaa
 aaa
 aaa
-adq
-agi
-mle
-agG
-gNZ
-ahg
-ahg
-ahg
-ahB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -116186,12 +113255,12 @@ act
 aBr
 aBr
 ucu
-bOP
-bPt
-bPt
-bPt
-bPt
-bQx
+aWe
+aWs
+aWs
+aWs
+aWs
+aWs
 bGy
 aut
 aBr
@@ -116408,15 +113477,15 @@ aaa
 aaa
 aaa
 aaa
-adq
-agd
-agn
-agA
-agR
-ahg
-tmH
-ahg
-ahB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -116493,7 +113562,7 @@ aBw
 aBw
 aBw
 aBw
-bQy
+aBw
 bFf
 aWg
 aBr
@@ -116710,15 +113779,15 @@ aaa
 aaa
 aaa
 aaa
-adq
-agJ
-agd
-agL
-agS
-ahg
-ahg
-ahg
-ahB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -116795,7 +113864,7 @@ apR
 aBw
 aBw
 bCL
-bQz
+bCL
 bFf
 aPb
 aBr
@@ -116994,33 +114063,33 @@ aaa
 aaa
 aaa
 aaa
-acG
-acG
-acG
-acG
-adq
-adA
-adA
-adA
-adA
-adZ
-adZ
-adZ
-adZ
-adZ
-adZ
-afp
-aap
 aaa
-adq
-agd
-agd
-agL
-agQ
-ahg
-pcM
-ahg
-ahB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117097,7 +114166,7 @@ aBr
 uKE
 bAB
 aBw
-bQy
+aBw
 bFf
 atS
 aBr
@@ -117296,33 +114365,33 @@ aaa
 aaa
 aaa
 aaa
-acG
-acK
-adf
-acG
-dnT
-adA
-adH
-adN
-adA
-aea
-aek
-adZ
-aeB
-aeU
-adZ
-afq
-aap
 aaa
-afi
-agh
-agd
-agG
-agG
-agG
-agG
-agG
-agG
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117598,42 +114667,42 @@ aaa
 aaa
 aaa
 aaa
-acG
-eIb
-adg
-ado
-ada
-adB
-adI
-adO
-adA
-aeb
-ael
-aeu
-aep
-aeV
-adZ
-afr
-aap
 aaa
-adq
-agJ
-agd
-agd
-agG
-asW
-aho
-nTP
-mGJ
-arf
-ivY
-arf
-vtb
-arf
-oGT
-arf
-eFJ
-iaS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117701,9 +114770,9 @@ act
 aBr
 aBr
 bCL
-bOB
-bRi
-bSj
+aBw
+bFf
+bHO
 bSu
 aBr
 act
@@ -117900,39 +114969,39 @@ aaa
 aaa
 aaa
 aaa
-acG
-acQ
-adf
-acG
-ada
-adA
-adJ
-fmh
-adA
-aec
-aem
-aev
-aeC
-aep
-adZ
-adZ
-adZ
-adZ
-adq
-agd
-agd
-agd
-agG
-asW
-agD
 aaa
-ahF
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118006,7 +115075,7 @@ aBr
 ion
 bFf
 aBw
-bQy
+aBw
 aBr
 aor
 aqX
@@ -118199,47 +115268,47 @@ aaa
 aaa
 aaa
 aaa
-aac
-aad
-aad
-acG
-acX
-adh
-acG
-ada
-adA
-adK
-adI
-adA
-aed
-aen
-adZ
-aeD
-aep
-aep
-afs
-jMo
-aep
-agc
-agd
-agd
-agd
-agG
-asW
-agD
 aaa
-vWe
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118500,49 +115569,49 @@ aaa
 aaa
 aaa
 aaa
-aac
-aac
-ace
-acn
-acG
-acG
-acG
-acG
-ada
-adA
-adA
-adA
-adA
-adZ
-adZ
-adZ
-aeE
-aeF
-aep
-afs
-aep
-aep
-adq
-agd
-agd
-agd
-agG
-agG
-agG
-agG
-agG
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bZU
+ftK
+bZU
+bZU
+bZU
+cBI
 aaa
 aaa
 aaa
@@ -118801,51 +115870,51 @@ aaa
 aaa
 aaa
 aaa
-aac
-aac
-aaN
-ach
-abS
-aac
-acY
-ada
-ada
-ada
-ada
-ada
-dnT
-adU
-aee
-aeo
-wmn
-aep
-aep
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 adq
 adq
 adq
-adq
-adq
-agd
-agd
-agd
-ahE
-ahh
-oOR
-sXN
-agG
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
+bZU
+vuU
+dko
+kQo
+jRm
+qsn
+aaa
 aaa
 aaa
 aaa
@@ -119103,52 +116172,52 @@ aaa
 aaa
 aaa
 aaa
-aad
-len
-abS
-abS
-acw
-aac
-acZ
-ada
-adp
-dNz
-ada
-adi
-ada
-adU
-aef
-aep
-aep
-aeF
-aep
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 adq
-aft
-afD
-afR
-adq
-agd
-agd
-agJ
-ahE
-ahp
-agX
-agX
-ahD
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
+iix
+yhb
+bZU
+bUU
+jRm
+jRm
+jRm
+qsn
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -119215,7 +116284,7 @@ act
 act
 aBr
 aBr
-bTo
+aZA
 bJT
 arb
 arb
@@ -119405,52 +116474,52 @@ aaa
 aaa
 aaa
 aaa
-aad
-aaA
-abY
-abS
-acA
-acI
-ada
-ada
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 adq
-adq
-adC
-ada
-ada
-adU
-aeg
-aep
-aex
-aep
-aeW
-afi
-afu
-afE
-afS
-adq
-agd
-agd
-agd
-ahD
-agX
-ahr
-agK
-ahE
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
+oGT
+ptK
+vKS
+ymd
+jRm
+kQo
+jRm
+qsn
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -119707,52 +116776,52 @@ aaa
 aaa
 aaa
 aaa
-aad
-aaA
-aca
-abS
-abS
-acI
-ada
-adi
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 adq
-adq
-adD
-ada
-ada
-adV
-aeh
-aeq
-aey
-aeG
-aeX
-adq
-afv
-afF
-afT
-adq
-agd
-agd
-agd
-ahE
-agX
-ahp
-agX
-ahD
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
+qLq
+oGT
+qYF
+mCq
+jRm
+jRm
+jRm
+qsn
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -119818,9 +116887,9 @@ aaa
 aaa
 aaa
 aab
-bQa
-bPF
-bQa
+act
+adx
+act
 arb
 arb
 arb
@@ -120009,51 +117078,54 @@ aaa
 aaa
 aaa
 aaa
-aad
-kRd
-abS
-ack
-acF
-aac
-acZ
-ada
-ada
-dNz
-ada
-ada
-adR
-ada
-ada
-aer
-aer
-aeH
-aer
-adq
-adq
-adq
-adq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+afq
+afq
+afq
+afq
 adq
 agJ
 agJ
-agd
-ahE
-ahj
-quS
+agJ
+agJ
 rlZ
-agG
+rlZ
+rlZ
+rlZ
+rlZ
+rlZ
 aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
+aap
+aaa
+adq
+oGT
+oGT
+qYF
+gnA
+jRm
+pMf
+jRm
+qsn
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -120120,9 +117192,6 @@ aaa
 aaa
 aaa
 aab
-bQa
-bPF
-bQa
 aab
 aab
 aab
@@ -120311,51 +117380,50 @@ aaa
 aaa
 aaa
 aaa
-aac
-aac
-aaN
-abS
-abS
-aac
-adb
-ada
-ada
-ada
-ada
-adi
-ada
-ada
-ada
-ada
-ada
-ada
-ada
-ada
-ada
-ada
-afU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+afq
+ksD
+ttm
+afq
+agj
+agJ
 agd
-agd
-agd
-agd
-agG
-agG
-agG
-agG
-agG
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
+pyu
+agJ
+jhD
+rQb
+rlZ
+cxV
+jSa
+rlZ
+yeC
+aap
 aaa
+vYn
+pfO
+oGT
+bZU
+bZU
+bZU
+bZU
+bZU
+bZU
 aaa
 aaa
 aaa
@@ -120421,11 +117489,12 @@ aaa
 aaa
 aaa
 aaa
-bPS
-bPS
-bTB
-bPS
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -120614,48 +117683,59 @@ aaa
 aaa
 aaa
 aaa
-aac
-aac
-acm
-acn
-acJ
-acJ
-adj
-acJ
-acJ
-adj
-acJ
-ada
-ada
-ada
-aet
-aej
-ada
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+afq
 adR
-ada
-ada
+vXy
+bGH
 lpQ
 afV
-agd
-agd
-agd
-agd
-agG
+sLL
+kAM
+agJ
+deu
+kIT
+hRh
+iIZ
+fVM
+rlZ
+rKs
+aap
+aaa
+adq
+qLq
+oGT
+oGT
+bZU
 asW
-agD
+cHj
+wwE
+kfp
+arf
+ftO
+arf
+lwg
+arf
+lsT
+arf
+mmW
+mkh
 aaa
-ahF
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
 aaa
 aaa
 aaa
@@ -120717,17 +117797,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bPS
-vyz
-bTC
-bON
-bPS
 aaa
 aaa
 aaa
@@ -120917,42 +117986,54 @@ aaa
 aaa
 aaa
 aaa
-aac
-aad
-aad
-acJ
-adc
-adk
-acJ
-adw
-adE
-adM
-adp
-adW
-ada
-ada
-aet
-adW
-ada
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+afq
+nry
+ttm
+afq
+lpQ
+agJ
+ker
+ujV
+agJ
+ffa
+vex
+mvJ
+rOT
+iIZ
+rlZ
+rlZ
+rlZ
+rlZ
 adq
-adq
-adq
-adq
-adq
-agd
-agd
-agd
-agG
+oGT
+oGT
+oGT
+bZU
 asW
 agD
 aaa
-ahF
-aqW
-aqW
-aqW
-aqW
-aqW
-aqW
+nxs
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
 aaa
 aaa
 aaa
@@ -121019,28 +118100,16 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bPS
-bTB
-bPS
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -121222,42 +118291,56 @@ aaa
 aaa
 aaa
 aaa
-acJ
-add
-adl
-acJ
-ady
-adF
-acJ
-nRg
-adX
-aei
-ada
-aez
-aeI
-aeY
-adq
-afp
-aap
 aaa
-adq
-agd
-agd
-agd
-agG
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aej
+aez
+aez
+afq
+aeY
+kOP
+afq
+lpQ
+agJ
+pxQ
+sLL
+agJ
+qNL
+rmk
+rlZ
+fep
+iIZ
+iIZ
+jFP
+ivY
+iIZ
+vtb
+oGT
+oGT
+oGT
+bZU
 asW
 agD
 aaa
-iIZ
-arf
-ivY
-arf
-vtb
-arf
-oGT
-arf
-eFJ
-iaS
+hny
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
 aaa
 aaa
 aaa
@@ -121320,30 +118403,16 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-jXP
-uTW
-bOd
-bOd
-bPT
-bON
-bPF
-bON
-bPT
-bOd
-dXk
-bOd
-bOd
-jXP
-bOd
-uTW
-bOd
-bOd
-bOd
-bNX
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -121524,33 +118593,57 @@ aaa
 aaa
 aaa
 aaa
-acJ
-ade
-adm
-adr
-adz
-adG
-acJ
-ada
-adY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aej
-ada
-ada
-aeN
 aej
-adq
+gwI
+wJb
 afq
-aap
-aaa
-afi
-agd
-agd
-agG
-agG
-ahz
+afq
+afq
+afq
+lpQ
+agJ
+agJ
+agJ
+agJ
+rlZ
+rlZ
+rlZ
 ozn
-ahE
-agB
+qhK
+iIZ
+jFP
+iIZ
+iIZ
+adq
+oGT
+oGT
+oGT
+bZU
+bZU
+bZU
+bZU
+bZU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
 aaa
 aaa
 aaa
@@ -121622,30 +118715,6 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-vea
-vea
-vea
-vea
-vea
-bQf
-bPF
-bQF
-bOm
-bOm
-bOm
-bOm
-bOm
-bOm
-bOm
-bOm
-bOm
-bOm
-bOd
-bSM
-bNX
 aaa
 aaa
 aaa
@@ -121826,36 +118895,58 @@ aaa
 aaa
 aaa
 aaa
-acJ
-acJ
-adn
-acJ
-acJ
-acJ
-acJ
-adT
-adT
-adT
-adq
-adT
-adT
-adT
-adq
-afr
-aap
 aaa
-adq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aej
+aej
+bBp
+klM
+wxX
+aej
+xen
+lpQ
+lpQ
+lpQ
+lpQ
+lpQ
 agj
-agd
+agn
 agL
 agT
 aht
-aht
-aht
-agG
-mWm
-ohO
-fyN
+iIZ
+iIZ
+adq
+adq
+adq
+adq
+adq
+oGT
+oGT
+oGT
+uIn
+igZ
+ulY
+nNJ
+bZU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
 aaa
 aaa
 aaa
@@ -121924,30 +119015,8 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-vea
-utz
-vHg
-bPx
-uUj
-bQg
-bPF
-bQG
-bOm
-jlo
-cDo
-bOm
-wnp
-bRN
-bOm
-qyS
-oQD
-bOm
-bOd
-bOd
-bNX
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -122135,29 +119204,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adq
-agd
+aez
+pWO
+wxX
+wxX
+lIH
+aej
+qzm
+lpQ
+hng
+mCe
+lpQ
+jTO
+lpQ
 agn
-agL
-agU
-hNt
-agU
-agU
-ahG
+eMF
+iIZ
+iIZ
+qhK
+iIZ
+adq
 fxo
 nZD
 qHY
+adq
+oGT
+oGT
+qLq
+uIn
+uaj
+exs
+exs
+mNS
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
 aaa
 aaa
 aaa
@@ -122225,32 +119317,9 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-vea
-vea
-ftS
-ftS
-xwN
-uUj
-ulJ
-bPF
-bQH
-bOm
-ruk
-bEo
-bRo
-bRz
-bRz
-bRo
-bEo
-bTx
-bOm
-bSA
-bSN
-bSA
-bSA
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -122437,33 +119506,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aez
+jbA
+fVY
+wxX
+jCl
+kpr
+lpQ
+lpQ
 adq
-agd
-agd
+adq
+rjf
+lpQ
+lpQ
+agn
 agA
-agU
-agU
-agU
+iIZ
+smn
+iIZ
 ikz
 vYn
 ibY
 sdW
 hNN
-xwf
-eFJ
+adq
 oGT
-mHC
+oGT
+oGT
+mNS
+exs
+pZF
+mmj
+uIn
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
 aaa
 aaa
 aaa
@@ -122526,34 +119614,15 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-bOd
-vea
-arP
-qbl
-ftS
-bPz
-uUj
-bQg
-bPF
-bQH
-bOm
-bOm
-bOm
-bOm
-bRA
-bRO
-bOm
-bOm
-bOm
-bOm
-yiv
-bSB
-bSB
-bSA
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -122739,29 +119808,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aez
+jbA
+eLu
+wxX
+wxX
+kpr
+lpQ
+jTO
 adq
-agl
+adq
+hrH
+lpQ
+lpQ
 kai
-agG
+ceZ
 ifk
-agU
-agU
+bga
+scN
 pyg
-agG
+adq
 rVY
 cJM
-qHY
+iZv
+adq
+oGT
+oGT
+oGT
+uIn
+exs
+uaj
+exs
+mNS
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
 aaa
 aaa
 aaa
@@ -122828,34 +119920,11 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-vea
-vea
-vea
-vea
-gRw
-vea
-vea
-bQg
-bPF
-bQH
-bOm
-jlo
-bEo
-bOm
-bRz
-bRz
-bOm
-bSe
-oQD
-bOm
-bSC
-bSO
-bSX
-bTa
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123041,29 +120110,51 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adq
-adq
-adq
-agB
-ahk
-agU
+aez
+hwy
+wxX
+tsd
+wze
+aej
+qzm
+lpQ
+lpQ
+mCe
+lpQ
+lpQ
+jYk
+lpQ
+lpQ
+qSb
+qSb
 gYm
 qSb
-agG
-hGr
-xKw
-ePj
+adq
+adq
+adq
+adq
+adq
+qLq
+qLq
+oGT
+uIn
+aKx
+dRp
+qyU
+bZU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
 aaa
 aaa
 aaa
@@ -123130,34 +120221,12 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-vea
-bOI
-dqP
-bPc
-jbY
-bxb
-uUj
-bQg
-bPF
-bTp
-bOm
-ruk
-fWO
-bRo
-bRz
-bRz
-bRo
-fWO
-bTx
-bOm
-bSD
-bSP
-bSB
-bSD
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123343,6 +120412,50 @@ aaa
 aaa
 aaa
 aaa
+aej
+aej
+bBp
+wxX
+wxX
+aej
+lpG
+lpQ
+lpQ
+lpQ
+lpQ
+jTO
+lpQ
+lpQ
+lpQ
+lpQ
+lpQ
+lpQ
+lpQ
+lpQ
+lpQ
+lpQ
+sKC
+oGT
+oGT
+oGT
+oGT
+bZU
+bZU
+bZU
+bZU
+bZU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
 aaa
 aaa
 aaa
@@ -123357,12 +120470,6 @@ aaa
 aaa
 aaa
 aaa
-agG
-agG
-agG
-agG
-agG
-agG
 aaa
 aaa
 aaa
@@ -123423,44 +120530,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-adx
-bNX
-bNX
-bOd
-vea
-vea
-bOJ
-bAe
-bBG
-jbY
-bPB
-uUj
-ulJ
-bPF
-bQG
-bOm
-bOm
-bOm
-bOm
-bRB
-bRP
-bOm
-bOm
-bOm
-bOm
-ncp
-bSP
-bSB
-bTb
-bSA
-bSA
 aaa
 aaa
 aaa
@@ -123646,7 +120715,48 @@ aaa
 aaa
 aaa
 aaa
+aej
+aej
+jVi
+wJb
+rTD
+rTD
+xwo
+rTD
+rTD
+xwo
+rTD
+lpQ
+lpQ
+lpQ
+sfP
+iHV
+lpQ
+jYk
+lpQ
+lpQ
+tyi
+goE
+oGT
+oGT
+oGT
+oGT
+bZU
+asW
+agD
 aaa
+nxs
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
 aaa
 aaa
 aaa
@@ -123732,50 +120842,9 @@ aaa
 aaa
 aaa
 aaa
-adx
-bNX
-gwa
-bOd
-vea
-sGr
-bwZ
-bAe
-bBG
-gEk
-bRy
-uUj
-bQg
-bPF
-bQH
-bOm
-vzK
-lTb
-bPU
-bRz
-bRz
-bRW
-bSf
-hSj
-bOm
-bSC
-bSQ
-bSX
-bSX
-bTa
-bSA
 aaa
-aqQ
 aaa
-bTl
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-arz
 aaa
 aaa
 aaa
@@ -123949,7 +121018,42 @@ aaa
 aaa
 aaa
 aaa
+aej
+aez
+aez
+rTD
+kDr
+eKN
+rTD
+jyE
+dqZ
+deh
+hng
+mLe
+lpQ
+lpQ
+sfP
+mLe
+lpQ
+adq
+adq
+adq
+adq
+adq
+oGT
+oGT
+oGT
+bZU
+asW
+agD
 aaa
+nxs
+lLU
+lLU
+lLU
+lLU
+lLU
+lLU
 aaa
 aaa
 aaa
@@ -124030,41 +121134,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-adx
-bNX
-bOd
-bOd
-vea
-bxa
-bxa
-bAe
-bBG
-pvN
-bQS
-uUj
-bQg
-bPF
-bQH
-bOm
-bJA
-ast
-bPV
-bRC
-bRQ
-bRQ
-bSg
-bSp
-bOm
-bSD
-bSP
-bSB
-bSB
-bSD
-bSA
 aaa
 aaa
 aaa
@@ -124254,8 +121323,42 @@ aaa
 aaa
 aaa
 aaa
+rTD
+kPb
+sTP
+rTD
+hkD
+tFL
+rTD
+fEe
+kvE
+oaG
+lpQ
+iFl
+ugz
+opZ
+adq
+aqW
+aap
 aaa
+adq
+oGT
+oGT
+oGT
+bZU
+asW
+agD
 aaa
+oBw
+arf
+ftO
+arf
+lwg
+arf
+lsT
+arf
+mmW
+mkh
 aaa
 aaa
 aaa
@@ -124334,40 +121437,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-bNX
-bNX
-bOd
-vea
-vea
-bxa
-bxa
-bAe
-bBG
-mqg
-bxc
-uUj
-bQg
-bPF
-bQH
-bOm
-tKM
-olF
-bRp
-bRD
-bRz
-bRz
-byH
-bSq
-bOm
-bSB
-bSP
-bSB
-bUu
-bUA
-bSA
-bSA
 aaa
 aaa
 aaa
@@ -124556,7 +121625,33 @@ aaa
 aaa
 aaa
 aaa
+rTD
+evb
+oLP
+hnl
+iVj
+wQZ
+rTD
+lpQ
+htU
+iHV
+lpQ
+lpQ
+xbG
+iHV
+adq
+yeC
+aap
 aaa
+vYn
+oGT
+oGT
+bZU
+bZU
+xIr
+dBd
+uIn
+ftK
 aaa
 aaa
 aaa
@@ -124638,38 +121733,12 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-vea
-tXp
-bxa
-bxa
-bAe
-bBG
-jbY
-jwL
-uUj
-ulJ
-bPF
-bQH
-bOm
-arQ
-arQ
-bPV
-bRE
-bUd
-bUk
-bUl
-bUo
-bOm
-kxc
-bSQ
-bSX
-bUv
-bSX
-bTj
-bSA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124858,7 +121927,36 @@ aaa
 aaa
 aaa
 aaa
+rTD
+rTD
+udh
+rTD
+rTD
+rTD
+rTD
+mFh
+mFh
+mFh
+adq
+mFh
+mFh
+mFh
+adq
+rKs
+aap
 aaa
+adq
+fnh
+oGT
+qYF
+pbU
+tki
+tki
+tki
+bZU
+uUy
+nZE
+mZu
 aaa
 aaa
 aaa
@@ -124940,38 +122038,9 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-vea
-bOq
-bxa
-jBB
-bOb
-vkN
-bPq
-irk
-uUj
-bQg
-bPF
-kDM
-bOm
-arQ
-bJA
-bRq
-bRF
-bUe
-lfC
-bTv
-bSr
-bOm
-bSD
-bSR
-bSY
-bUw
-bTh
-bSD
-bSA
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125178,6 +122247,18 @@ aaa
 aaa
 aaa
 aaa
+adq
+oGT
+ptK
+qYF
+hUj
+rXl
+hUj
+hUj
+ifD
+iLO
+poL
+wKu
 aaa
 aaa
 aaa
@@ -125239,43 +122320,31 @@ aaa
 aaa
 aaa
 aaa
-aqP
-aqP
-aqP
-bNY
-bOe
-bOi
-bOi
-uUj
-uUj
-uUj
-uUj
-uUj
-vea
-wOL
-vea
-bQj
-bTO
-bQI
-bOm
-bOr
-bRf
-bOm
-bRG
-bUf
-bOm
-bOr
-bSs
-bOm
-bSA
-bSA
-bSA
-bUx
-bSA
-bSA
-bSA
-bPS
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125480,6 +122549,22 @@ aaa
 aaa
 aaa
 aaa
+adq
+oGT
+oGT
+vKS
+hUj
+hUj
+hUj
+duK
+wiM
+qXs
+iUL
+oUf
+iHk
+mmW
+lsT
+nnc
 aaa
 aaa
 aaa
@@ -125541,43 +122626,27 @@ aaa
 aaa
 aaa
 aaa
-aqP
-bNR
-bwY
-fTd
-bOf
-bOD
-bOF
-bPs
-txS
-bQw
-bQw
-bQw
-bQN
-cxL
-bSo
-bTm
-bTP
-bQk
-bPZ
-bQV
-bRg
-bOV
-bRH
-bUg
-bOV
-bOV
-bSt
-bPZ
-bQK
-dGn
-bUs
-bUy
-wwx
-bON
-bPS
-bON
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125782,6 +122851,18 @@ aaa
 aaa
 aaa
 aaa
+adq
+kUs
+uiE
+bZU
+wDT
+hUj
+hUj
+vjU
+bZU
+uJM
+hgO
+wKu
 aaa
 aaa
 aaa
@@ -125843,43 +122924,31 @@ aaa
 aaa
 aaa
 aaa
-aqP
-pfe
-bNV
-bOa
-bOg
-bOk
-bNY
-bOt
-bPF
-bON
-bON
-bON
-bQT
-byE
-bQa
-bQl
-bTQ
-bQl
-bQa
-byG
-bRh
-bON
-bOC
-bUh
-bON
-bON
-bON
-bQa
-byI
-bON
-bUh
-bOC
-bON
-bON
-bTk
-bQE
-bTk
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -126084,6 +123153,18 @@ aaa
 aaa
 aaa
 aaa
+adq
+adq
+adq
+ftK
+vpR
+hUj
+puQ
+qRN
+bZU
+cAO
+wnM
+nGP
 aaa
 aaa
 aaa
@@ -126145,43 +123226,31 @@ aaa
 aaa
 aaa
 aaa
-aqP
-bNT
-uEY
-nHc
-bOh
-jkh
-bOo
-bOu
-bPG
-bNW
-bOW
-dnh
-bQX
-bRK
-bQb
-bQl
-bTR
-bTS
-bTT
-bTV
-rUD
-bTX
-bTY
-bUi
-bTX
-sEK
-bUp
-bTT
-bUq
-fZX
-buc
-bOC
-bue
-bON
-bPS
-bON
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -126389,6 +123458,12 @@ aaa
 aaa
 aaa
 aaa
+bZU
+bZU
+bZU
+bZU
+bZU
+bZU
 aaa
 aaa
 aaa
@@ -126447,43 +123522,37 @@ aaa
 aaa
 aaa
 aaa
-aqP
-aqP
-aqP
-bNY
-bOe
-bNY
-bNY
-bOv
-bPH
-bOv
-bOy
-bOy
-bOy
-bRR
-bOy
-bQm
-bQB
-bQJ
-bPS
-bPS
-bva
-bva
-bTZ
-bRS
-bva
-bva
-bva
-bva
-bSH
-bSH
-bSH
-bTf
-bSH
-bSH
-bSJ
-bPS
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -126752,38 +123821,38 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-bNX
-bzY
-bPJ
-bPL
-bOy
-bOS
-tCX
-eHC
-bOy
-bQn
-bOC
-bON
-bQO
-bQO
-bRj
-hDt
-bUa
-bRT
-bTI
-iQa
-bSv
-bva
-jpd
-bSI
-aCO
-bST
-aCO
-ase
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127054,38 +124123,38 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-bNX
-bOx
-bOG
-bzZ
-bOy
-bOS
-bOS
-bPM
-bQc
-byF
-bOC
-bON
-bQP
-bQP
-bRj
-aYE
-bUb
-bRT
-bRZ
-bSk
-bSw
-bva
-bSI
-bSI
-bSI
-bST
-bSI
-bSI
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127356,38 +124425,38 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-bNX
-bOy
-bOy
-bOy
-bOy
-bPr
-bOS
-bUC
-bQc
-bQp
-bOC
-bON
-bQQ
-bQP
-bRj
-bRt
-bUc
-bUj
-bRj
-bSl
-bSx
-bva
-bSI
-bSI
-bSI
-bST
-bSI
-bSJ
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127659,40 +124728,6 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-bOy
-bOH
-keq
-bOS
-bOS
-bOS
-bUE
-bQc
-bQq
-bQC
-bQK
-bQR
-ujg
-bRj
-bRu
-bRL
-bRU
-bSa
-bSm
-gkj
-bva
-bSI
-bSI
-bSI
-bST
-bSI
-bSJ
-aaa
-aqQ
-aaa
-bTl
 aaa
 aaa
 aaa
@@ -127701,7 +124736,41 @@ aaa
 aaa
 aaa
 aaa
-arz
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -127961,36 +125030,36 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-bOy
-bOH
-bOS
-bOS
-bOS
-bOS
-bPO
-bQc
-bQr
-bON
-bON
-bva
-bva
-bva
-bRv
-bRM
-bRV
-bRV
-bRV
-bRV
-bva
-bSI
-bSS
-bSZ
-bTg
-bTi
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -128263,36 +125332,36 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-bOy
-bOy
-bQv
-bOS
-bOS
-bOS
-bPP
-bOy
-bQr
-bON
-bON
-bva
-uUd
-bRk
-bCP
-bCP
-bCP
-bCP
-bCP
-aCF
-bva
-bSI
-bST
-bSI
-bSI
-bSJ
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -128566,34 +125635,34 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-bOy
-pws
-bOS
-bPu
-qPu
-bPN
-bOy
-tsQ
-bON
-bTq
-bva
-bRa
-bRl
-bCP
-bCP
-bCP
-bCP
-bRl
-bRa
-bva
-bSI
-bST
-bSI
-bSI
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -128868,34 +125937,34 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-bOy
-bOy
-bOS
-bUD
-bOy
-bOy
-bOy
-bQt
-bON
-bON
-bva
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bva
-bSI
-bST
-bSI
-bSI
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129170,34 +126239,34 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-bOd
-bOy
-iwW
-bOy
-bOy
-bPQ
-bOZ
-bON
-bON
-bQL
-bva
-bTt
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bva
-ase
-bST
-ase
-bSJ
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129473,32 +126542,32 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-bOy
-bOY
-bOY
-bPv
-aLQ
-bQd
-bON
-bON
-bON
-bva
-bRa
-bRl
-bCP
-bCP
-bCP
-bCP
-bRl
-bRa
-bva
-bSJ
-bSU
-bSJ
-bSJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129776,30 +126845,30 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bOd
-bOd
-bOZ
-bPg
-bPw
-bPR
-bOZ
-vyz
-bON
-bON
-bva
-nJx
-bCP
-bCP
-bCP
-bCP
-bCP
-bCP
-bSz
-bva
-bOd
-bSV
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130078,30 +127147,30 @@ aaa
 aaa
 aaa
 aaa
-bNX
-gwa
-bOd
-bOZ
-bOZ
-bOZ
-bOZ
-bOZ
-bQu
-bON
-bQM
-bva
-bva
-bBH
-bRw
-bRw
-bRw
-bRw
-bva
-bva
-bva
-bSK
-bSW
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130380,30 +127449,30 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bOd
-jXP
-dXk
-bOd
-bOd
-bPT
-bON
-bON
-bON
-bPT
-dXk
-nBB
-bCP
-apU
-apU
-bCP
-bOd
-hpN
-bOd
-bSL
-bNX
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130683,28 +127752,28 @@ aaa
 aaa
 aaa
 aaa
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bNX
-bPS
-bQD
-bPS
-bNX
-bNX
-bBH
-bRx
-bRx
-bRx
-bSb
-bNX
-bNX
-bNX
-bNX
-bNX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130991,11 +128060,11 @@ aaa
 aaa
 aaa
 aaa
-bPS
-vyz
-bQE
-bON
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -131293,11 +128362,11 @@ aaa
 aaa
 aaa
 aaa
-bPS
-bPS
-bQD
-bPS
-bPS
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -131597,7 +128666,7 @@ aaa
 aaa
 aaa
 aaa
-buf
+aaa
 aaa
 aaa
 aaa
@@ -131899,7 +128968,7 @@ aaa
 aaa
 aaa
 aaa
-bvr
+aaa
 aaa
 aaa
 aaa
@@ -132201,7 +129270,7 @@ aaa
 aaa
 aaa
 aaa
-bvs
+aaa
 aaa
 aaa
 aaa
@@ -132503,7 +129572,7 @@ aaa
 aaa
 aaa
 aaa
-bvt
+aaa
 aaa
 aaa
 aaa

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -250,10 +250,6 @@
 /obj/storage/closet,
 /turf/simulated/floor/carpet/purple/fancy/narrow/sw,
 /area/station/communications/bedroom)
-"aaN" = (
-/obj/decal/poster/wallsign/poster_cool,
-/turf/simulated/wall/auto/reinforced/supernorn/orange,
-/area/station/mining/staff_room)
 "aaP" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -34017,13 +34013,6 @@
 /obj/storage/crate{
 	icon_state = "crateopen"
 	},
-/obj/item/device/gps{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/device/gps{
-	pixel_x = -8
-	},
 /obj/item/shipcomponent/secondary_system/orescoop{
 	pixel_x = 2;
 	pixel_y = 4
@@ -36314,6 +36303,9 @@
 	},
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/decal/poster/wallsign/mantaposter{
+	pixel_y = 32
+	},
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
 "kIT" = (
@@ -41648,7 +41640,6 @@
 /obj/decal/poster/wallsign/poster_mining{
 	pixel_y = 32
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
@@ -65269,7 +65260,7 @@ xba
 txQ
 meh
 xpJ
-aaN
+ldA
 kID
 siD
 okI


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPING] [XXL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Major Differences
Nerd dungoen not in maint (People Like Nice Things and will improve their situation)
Refinery is smaller, although not spread out. 
Mining is larger
Mining hanger is only able to be access by miners, (however this can be changed. Of the possible layouts I put up on discord, the current one was the most voted for)
Gary left with the Sea Turtle :(
Sherby the Shrub has been adopted in their place
Minor differences
LRMT now has a let me out button near it if you get stuck in mining
Note reminding miners to fill the rock box
Moved around cargo layout as a result of mining changes
2 O2 Tanks!
Lots of Dirt.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Alterinative option to Ikea's PR. Previous PR was asked to be split in half by Emily, so I have done so.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Eagle
(*) Manta Mining is now back on ship. The Sea Turtle has undocked and has left the vicinity of the Manta for now.
```
