### PR TITLE
Debug Hydroponics Tray Runtime Error Fix

### DIFF
--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -19,6 +19,7 @@
 	proc/update_maptext()
 		if (!src.current)
 			src.maptext = "<span class='pixel ol c vb'></span>"
+			return
 		maptext_width = 96
 		maptext_y = 32
 		maptext_x = -32


### PR DESCRIPTION
[BUG][RUNTIME]

## About the PR
The `update_maptext()` proc for the high-tech hydroponics tray would produce a runtime error, because the proc didn't return early when current was null, which then allowed it to try and read variables from current while it was null:
https://github.com/goonstation/goonstation/blob/a6e726a34584b8ebad470aa5c9ac24506bc0c93d/code/obj/machinery/plantpot.dm#L20-L22

Thus, I went ahead and added this return there.

Fixes #1643.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This would get rid of a runtime error from someone using this particular debug hydroponics tray when said tray's `update_maptext()` proc gets called while it has nothing planted.
