### PR TITLE
Makes fabric commodity sell cloth.

### DIFF
--- a/code/modules/economy/traders/generic.dm
+++ b/code/modules/economy/traders/generic.dm
@@ -61,7 +61,7 @@
 
 /datum/commodity/trader/generic/fabric
 	comname = "Cloth Fabric"
-	comtype = /obj/item/raw_material/fabric
+	comtype = /obj/item/material_piece/cloth/cottonfabric
 	price_boundary = list(5,7)
 	possible_names = list("We have lots of cloth for sale. Good for making clothes with.",
 	"We have a great deal of cloth we need to shift soon, so please buy it!")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Swaps out the raw fabric that smelts down into filbrith cloth with just pure cloth. The description of this commodity says it sells cloth fabric why did it sell filbrith???


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think filbrith is intended to be somewhat rare with how rarely it comes from asteroids (same chance as uqill iirc). I want to use this material for expensive stuff and I need it to be expensive in order to do that.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)Cargo traders have realized they were accidentally selling fibrilith and will now sell cloth fabric instead.
```
