### PR TITLE
Adds a new chem, Syndicate Sarin! Normal Chem Made Sarin no longer skin penetrates.

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1856,8 +1856,8 @@ datum
 
 		sarin // oh god why am i adding this
 			name = "Sarin"
-			id = "sarin"
-			result = "sarin"
+			id = "sarin_weak"
+			result = "sarin_weak"
 			required_reagents = list("chlorine" = 1, "fuel" = 1, "oxygen" = 1, "phosphorus" = 1, "fluorine" = 1, "hydrogen" = 1, "acetone" = 1, "weedkiller" = 1)
 			result_amount = 3 // it is super potent
 			mix_phrase = "The mixture yields a colorless, odorless liquid."
@@ -1870,7 +1870,7 @@ datum
 				if(holder?.my_atom?.is_open_container())
 					// A slightly less stupid way of smoking contents. Maybe.
 					var/datum/reagents/smokeContents = new/datum/reagents/
-					smokeContents.add_reagent("sarin", holder.reagent_list["sarin"].volume / 6)
+					smokeContents.add_reagent("sarin_weak", holder.reagent_list["sarin_weak"].volume / 6)
 					//particleMaster.SpawnSystem(new /datum/particleSystem/chemSmoke(location, smokeContents, 10, 2))
 					smoke_reaction(smokeContents, 2, location)
 					/*

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1476,7 +1476,7 @@ datum
 						boutput(M, "<span class='alert'><b>You feel like you're dying!</b></span>")
 
 		harmful/sarin // yet another thing that will put ol' cogwerks on a watch list probably
-			name = "sarin"
+			name = "syndicate sarin"
 			id = "sarin"
 			description = "A lethal organophosphate nerve agent. Can be neutralized with atropine."
 			reagent_state = LIQUID
@@ -1549,6 +1549,10 @@ datum
 				..()
 				return
 
+			weak
+				name = "sarin"
+				id = "sarin_weak"
+				penetrates_skin = 0
 		harmful/dna_mutagen
 			name = "stable mutagen"
 			id = "dna_mutagen"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [WIKI] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sarin made from chemistry no longer skin pens, sarin from all other sources (sarin grenades, biological weapon torpedoes, etc.) has the same behavior as before, however it is now named syndicate sarin.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This change is designed to effect hellglasses/beaker splashes, a sarin, cyanide, forma, acte hellglass was an incredibly easy and incredibly effective weapon that was unfun to fight against. This change effects the chem carrying the most work for hellglasses by making it no longer work for hellglasses. Those other chems may need looking at later, but atomization and all that jazz.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Chem made sarin no longer penetrates skin. Sarin from all other sources has been renamed Syndicate sarin and has not had there behavior altered.
```
