### PR TITLE
Makes the power pick more effective

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -1617,7 +1617,7 @@ obj/item/clothing/gloves/concussive
 	item_state = "ppick1"
 	flags = ONBELT
 	dig_strength = 2
-	digcost = 2
+	digcost = 1
 	cell_type = /obj/item/ammo/power_cell
 	hitsound_charged = 'sound/impact_sounds/Metal_Hit_Heavy_1.ogg'
 	hitsound_uncharged = 'sound/impact_sounds/Stone_Cut_1.ogg'


### PR DESCRIPTION
[BALANCE]

## About the PR
This PR reduces the digcost for the power pick from 2 to 1.
## Why's this needed? 
Recently, the power pick was refactored to use standard cells instead of run off of an internal counter. After talking with some other mining players, I've found that this acted as an unintentional nerf of the power pick, as it runs out way quicker than it used to. This brings it back in line with how it used to behave and reduces tedious trips back to mining.
## Changelog

```changelog
(u)Fosstar
(+)The power pick now lasts twice as long when mining.
```
