### PR TITLE
Allows disaster rounds to start even if nobody has wraith enabled

### DIFF
--- a/code/datums/gamemodes/disaster.dm
+++ b/code/datums/gamemodes/disaster.dm
@@ -20,11 +20,10 @@
 			continue
 		if (player.ready && !candidates.Find(player.mind) && player.client.preferences.be_wraith)
 			candidates += player.mind
-	if (candidates.len == 0)
-		return 0
-	var/datum/mind/twraith = pick(candidates) // Just one for now
-	twraith.special_role = ROLE_WRAITH
-	Agimmicks += twraith
+	if (candidates.len != 0)
+		var/datum/mind/twraith = pick(candidates) // Just one for now
+		twraith.special_role = ROLE_WRAITH
+		Agimmicks += twraith
 
 	return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lowpop disaster wouldn't start because nobody had wraith on. oops


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Confusing to experience. Round functions fine without a wraith