### PR TITLE
Allows item specials to smack bots (secbots/medibots/etc)

### DIFF
--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -1088,7 +1088,7 @@
 			if (ismob(hit))
 				var/mob/M = hit
 				M.TakeDamage("chest", 0, rand(2 * mult, 5 * mult), 0, DAMAGE_BLUNT)
-				M.bodytemperature += 4 * mult
+				M.bodytemperature += (4 * mult)
 				playsound(hit, 'sound/effects/electric_shock.ogg', 60, 1, 0.1, 2.8)
 
 	double

--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -1085,8 +1085,19 @@
 				var/mob/living/carbon/human/H = hit
 				H.do_disorient(src.stamina_damage * mult, weakened = 10)
 
-			hit.TakeDamage("chest", 0, rand(2 * mult,5 * mult), 0, DAMAGE_BLUNT)
-			hit.bodytemperature += 4 * mult
+			if (ismob(hit))
+					var/mob/M = hit
+					M.TakeDamage("chest", 0	, rand(2 * mult,5 * mult), 0, DAMAGE_BLUNT)
+					M.bodytemperature += 4 * mult
+				else if (iscritter(hit))
+					var/obj/critter/C = hit
+					C.health -= 10
+					C.check_health()
+				else //bot
+					var/obj/machinery/bot/B = hit
+					B.health -= 10
+					if (B.health <= 0)
+						B.explode()
 
 			playsound(hit, 'sound/effects/electric_shock.ogg', 60, 1, 0.1, 2.8)
 
@@ -1409,14 +1420,25 @@
 					return 0
 			return 1
 
-		on_hit(var/mob/hit, var/mult = 1)
+		on_hit(var/hit, var/mult = 1)
 			//maybe add this in, chance to weaken. I dunno a good amount offhand so leaving out for now - kyle
 			// if (ishuman(hit))
 			// 	var/mob/living/carbon/human/H = hit
 			// 	H.do_disorient(src.stamina_damage * mult, weakened = 10)
 			if(istype(master, /obj/item))
-				hit.TakeDamage("chest", 0/*master.force*/, rand(2 * mult,5 * mult), 0, DAMAGE_BLUNT)
-				hit.bodytemperature += 4 * mult
+				if (ismob(hit))
+					var/mob/M = hit
+					M.TakeDamage("chest", 0/*master.force*/, rand(2 * mult,5 * mult), 0, DAMAGE_BLUNT)
+					M.bodytemperature += 4 * mult
+				else if (iscritter(hit))
+					var/obj/critter/C = hit
+					C.health -= 10
+					C.check_health()
+				else //bot
+					var/obj/machinery/bot/B = hit
+					B.health -= 10
+					if (B.health <= 0)
+						B.explode()
 
 			playsound(hit, 'sound/effects/electric_shock.ogg', 60, 1, 0.1, 2.8)
 

--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -1419,7 +1419,7 @@
 				if (ismob(hit))
 					var/mob/M = hit
 					M.TakeDamage("chest", 0, rand(2 * mult,5 * mult), 0, DAMAGE_BLUNT)
-					M.bodytemperature += 4 * mult
+					M.bodytemperature += (4 * mult)
 					playsound(hit, 'sound/effects/electric_shock.ogg', 60, 1, 0.1, 2.8)
 
 	katana_dash

--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -1086,18 +1086,18 @@
 				H.do_disorient(src.stamina_damage * mult, weakened = 10)
 
 			if (ismob(hit))
-					var/mob/M = hit
-					M.TakeDamage("chest", 0	, rand(2 * mult,5 * mult), 0, DAMAGE_BLUNT)
-					M.bodytemperature += 4 * mult
-				else if (iscritter(hit))
-					var/obj/critter/C = hit
-					C.health -= 10
-					C.check_health()
-				else //bot
-					var/obj/machinery/bot/B = hit
-					B.health -= 10
-					if (B.health <= 0)
-						B.explode()
+				var/mob/M = hit
+				M.TakeDamage("chest", 0	, rand(2 * mult,5 * mult), 0, DAMAGE_BLUNT)
+				M.bodytemperature += 4 * mult
+			else if (iscritter(hit))
+				var/obj/critter/C = hit
+				C.health -= 10
+				C.check_health()
+			else //bot
+				var/obj/machinery/bot/B = hit
+				B.health -= 10
+				if (B.health <= 0)
+					B.explode()
 
 			playsound(hit, 'sound/effects/electric_shock.ogg', 60, 1, 0.1, 2.8)
 

--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -1080,26 +1080,16 @@
 			return
 
 
-		proc/on_hit(var/mob/hit, var/mult = 1)
+		proc/on_hit(var/hit, var/mult = 1)
 			if (ishuman(hit))
 				var/mob/living/carbon/human/H = hit
 				H.do_disorient(src.stamina_damage * mult, weakened = 10)
 
 			if (ismob(hit))
 				var/mob/M = hit
-				M.TakeDamage("chest", 0	, rand(2 * mult,5 * mult), 0, DAMAGE_BLUNT)
+				M.TakeDamage("chest", 0, rand(2 * mult, 5 * mult), 0, DAMAGE_BLUNT)
 				M.bodytemperature += 4 * mult
-			else if (iscritter(hit))
-				var/obj/critter/C = hit
-				C.health -= 10
-				C.check_health()
-			else //bot
-				var/obj/machinery/bot/B = hit
-				B.health -= 10
-				if (B.health <= 0)
-					B.explode()
-
-			playsound(hit, 'sound/effects/electric_shock.ogg', 60, 1, 0.1, 2.8)
+				playsound(hit, 'sound/effects/electric_shock.ogg', 60, 1, 0.1, 2.8)
 
 	double
 		cooldown = 0
@@ -1428,19 +1418,9 @@
 			if(istype(master, /obj/item))
 				if (ismob(hit))
 					var/mob/M = hit
-					M.TakeDamage("chest", 0/*master.force*/, rand(2 * mult,5 * mult), 0, DAMAGE_BLUNT)
+					M.TakeDamage("chest", 0, rand(2 * mult,5 * mult), 0, DAMAGE_BLUNT)
 					M.bodytemperature += 4 * mult
-				else if (iscritter(hit))
-					var/obj/critter/C = hit
-					C.health -= 10
-					C.check_health()
-				else //bot
-					var/obj/machinery/bot/B = hit
-					B.health -= 10
-					if (B.health <= 0)
-						B.explode()
-
-			playsound(hit, 'sound/effects/electric_shock.ogg', 60, 1, 0.1, 2.8)
+					playsound(hit, 'sound/effects/electric_shock.ogg', 60, 1, 0.1, 2.8)
 
 	katana_dash
 		cooldown = 9

--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -213,7 +213,7 @@
 		if (istype(A, /obj/itemspecialeffect))
 			var/obj/itemspecialeffect/E = A
 			return (E.can_clash && world.time != E.create_time && E.clash_time > 0 && world.time <= E.create_time + E.clash_time)
-		.= ((istype(A, /obj/critter) || (ismob(A) && isliving(A))) && A != usr && A != user)
+		.= ((istype(A, /obj/critter) || (isliving(A)) || istype(A, /obj/machinery/bot)) && A != usr && A != user)
 
 	proc/showEffect(var/name = null, var/direction = NORTH, var/mob/user, alpha=255)
 		if(name == null || master == null) return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fighting emagged/evil medibots can be annoying because special attacks don't work. Ditto for secbots.


```changelog
(u)aloe
(+)Special attacks can now be used to bonk securitrons, medibots, and other small robots.
```
