### PR TITLE
Hand tele/teleporter ring balance 

### DIFF
--- a/code/modules/telescience/teleporter_old.dm
+++ b/code/modules/telescience/teleporter_old.dm
@@ -167,9 +167,6 @@
 	if (!istype(destturf))
 		return
 
-	if (isrestrictedz(destturf.z))
-		precision = 0
-
 	var/tx = destturf.x + rand(precision * -1, precision)
 	var/ty = destturf.y + rand(precision * -1, precision)
 
@@ -215,7 +212,7 @@
 
 	//if((istype(tmploc,/area/wizard_station)) || (istype(tmploc,/area/syndicate_station)))
 	var/area/myArea = get_area(tmploc)
-	if (myArea?.teleport_blocked || m_blocked)
+	if (myArea?.teleport_blocked || isrestrictedz(myArea.z) || m_blocked)
 		if(use_teleblocks)
 			if(isliving(M))
 				boutput(M, "<span class='alert'><b>Teleportation failed!</b></span>")

--- a/code/z_adventurezones/hospital.dm
+++ b/code/z_adventurezones/hospital.dm
@@ -205,7 +205,7 @@ var/list/hospital_fx_sounds = list('sound/ambience/spooky/Hospital_Chords.ogg', 
 			if (LANDMARK_SAMOSTREL_WARP in landmarks)
 				var/target_original_loc = target.loc
 				target.setStatus("paralysis", max(target.getStatusDuration("paralysis"), 10 SECONDS))
-				do_teleport(target, pick_landmark(LANDMARK_SAMOSTREL_WARP), 0)
+				do_teleport(target, pick_landmark(LANDMARK_SAMOSTREL_WARP), 0, 0)
 
 				if (ishuman(target))
 					var/atom/movable/overlay/animation = new(target_original_loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Prevents teleporting to the tracking beacon location via hand tele/portal ring if it's in restricted Z level

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Cheesing azones bad