### PR TITLE
Fixes batons being silent when used on clowns

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -174,10 +174,9 @@
 			if ("stun")
 				user.visible_message("<span class='alert'><B>[victim] has been stunned with the [src.name] by [user]!</B></span>")
 				logTheThing("combat", user, victim, "stuns [constructTarget(victim,"combat")] with the [src.name] at [log_loc(victim)].")
+				playsound(src, "sound/impact_sounds/Energy_Hit_3.ogg", 50, 1, -1)
+				flick(flick_baton_active, src)
 				JOB_XP(victim, "Clown", 3)
-				else
-					flick(flick_baton_active, src)
-					playsound(src, "sound/impact_sounds/Energy_Hit_3.ogg", 50, 1, -1)
 
 			else
 				logTheThing("debug", user, null, "<b>Convair880</b>: stun baton ([src.type]) do_stun() was called with an invalid argument ([type]), aborting. Last touched by: [src.fingerprintslast ? "[src.fingerprintslast]" : "*null*"]")
@@ -190,7 +189,7 @@
 		else
 			dude_to_stun = victim
 
-	
+
 		dude_to_stun.do_disorient(src.disorient_stamina_damage, weakened = src.stun_normal_weakened * 10, disorient = 60)
 
 		if (isliving(dude_to_stun))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The baton sound only happened if the person getting stunned failed the JOB_XP check, I don't know why it was coded that way, now it happens regardless of it along with the baton flicker.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

So I can hear it when the clown gets batoned.