### PR TITLE
Fix armory/HoS office access on Destiny

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -22706,6 +22706,7 @@
 	req_access = null
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/hos,
 /turf/simulated/floor/red,
 /area/station/security/hos)
 "dVf" = (
@@ -29977,6 +29978,7 @@
 	},
 /obj/machinery/door/airlock/pyro/weapons,
 /obj/firedoor_spawn,
+/obj/access_spawn/hos,
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "hoL" = (
@@ -56944,6 +56946,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/hos,
 /turf/simulated/floor/red,
 /area/station/security/hos)
 "wiU" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds missing HoS access spawners to the Destiny armory doors + the door between the HoS office and the sec hangar.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We need to keep the secasses out
closes #5989 