### PR TITLE
Reduce wish granter artifact riches

### DIFF
--- a/code/obj/artifacts/artifact_objects/wish_granter.dm
+++ b/code/obj/artifacts/artifact_objects/wish_granter.dm
@@ -76,11 +76,11 @@
 			switch(wish)
 				if("I wish to become rich!")
 					O.visible_message("<span class='alert'>A ton of money falls out of thin air! Woah!</span>")
-					for(var/turf/T in range(user,3))
+					for(var/turf/T in range(user,2))
 						if (T.density)
 							continue
-						var/obj/item/spacecash/million/S = unpool(/obj/item/spacecash/million)
-						S.setup(T)
+						var/obj/item/material_piece/gold/G = new /obj/item/material_piece/gold()
+						G.set_loc(T)
 
 				if("I wish for great power!")
 					O.visible_message("<span class='alert'><b>[O]</b> envelops [user] in a brilliant light!</span>")

--- a/code/obj/artifacts/artifact_objects/wish_granter.dm
+++ b/code/obj/artifacts/artifact_objects/wish_granter.dm
@@ -75,8 +75,8 @@
 		else
 			switch(wish)
 				if("I wish to become rich!")
-					O.visible_message("<span class='alert'>A ton of money falls out of thin air! Woah!</span>")
-					for(var/turf/T in range(user,2))
+					O.visible_message("<span class='alert'>A ton of gold falls out of thin air! Woah!</span>")
+					for(var/turf/T in range(user,1))
 						if (T.density)
 							continue
 						var/obj/item/material_piece/gold/G = new /obj/item/material_piece/gold()

--- a/code/obj/artifacts/artifact_objects/wish_granter.dm
+++ b/code/obj/artifacts/artifact_objects/wish_granter.dm
@@ -75,12 +75,12 @@
 		else
 			switch(wish)
 				if("I wish to become rich!")
-					O.visible_message("<span class='alert'>A ton of gold falls out of thin air! Woah!</span>")
-					for(var/turf/T in range(user,1))
+					O.visible_message("<span class='alert'>A ton of money falls out of thin air! Woah!</span>")
+					for(var/turf/T in range(user,2))
 						if (T.density)
 							continue
-						var/obj/item/material_piece/gold/G = new /obj/item/material_piece/gold()
-						G.set_loc(T)
+						var/obj/item/spacecash/fiftythousand/S = unpool(/obj/item/spacecash/fiftythousand)
+						S.setup(T)
 
 				if("I wish for great power!")
 					O.visible_message("<span class='alert'><b>[O]</b> envelops [user] in a brilliant light!</span>")

--- a/code/obj/item/space_cash.dm
+++ b/code/obj/item/space_cash.dm
@@ -140,6 +140,10 @@
 	default_min_amount = 1000
 	default_max_amount = 1000
 
+/obj/item/spacecash/fiftythousand
+	default_min_amount = 50000
+	default_max_amount = 50000
+
 /obj/item/spacecash/million
 	default_min_amount = 1000000
 	default_max_amount = 1000000


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes wish granter riches to 50K credit notes.
Reduce number of notes resulting in 1.25 million instead of 49 million?!

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Holy moly that was a lot of credits.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Wish granters now give out a total of 1.25 million due to space inflation.
```
