### PR TITLE
Tweaks splash damage for holy water and foam for elementals. + flavour text

### DIFF
--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -835,7 +835,7 @@ datum
 							O.show_message(text("<span class='alert'><b>[] begins to crisp and burn!</b></span>", M), 1)
 						boutput(M, "<span class='alert'>Holy Water! It burns!</span>")
 						var/burndmg = volume * 1.25
-						burndmg = min(burndmg, 110) //cap burn at 110 so we can't instant-kill vampires. just crit em ok.
+						burndmg = min(burndmg, 80) //cap burn at 110(80 now >:) so we can't instant-kill vampires. just crit em ok.
 						M.TakeDamage("chest", 0, burndmg, 0, DAMAGE_BURN)
 						M.change_vampire_blood(-burndmg)
 						reacted = 1

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -658,9 +658,15 @@ datum
 						L.changeStatus("burning", -30 SECONDS)
 						playsound(L, "sound/impact_sounds/burn_sizzle.ogg", 50, 1, pitch = 0.8)
 					if (istype(L,/mob/living/critter/fire_elemental) && !ON_COOLDOWN(L, "fire_elemental_fffoam", 5 SECONDS))
+						L.emote("scream")
+						for(var/mob/O in AIviewers(M, null))
+							O.show_message(text("<span class='alert'><b>[] sputters and begins to dim!</b></span>", M), 1)
+							boutput(L, "<span class='alert'>The foam starts to smother your flames!</span>")
 						L.changeStatus("weakened", 2 SECONDS)
 						L.force_laydown_standup()
-						L.TakeDamage("All", volume * 1.5, 0, 0, DAMAGE_BLUNT)
+						var/brutedmg = volume * 1.5 //elementals take 1.15x damage, 65 is 74.75. 2 maxcap pitchers goes to .50 brute under death.
+						brutedmg = min(brutedmg, 65) //Ideally acts like vampire with holy water, capping it so they don't instadie.
+						L.TakeDamage("chest", brutedmg, 0, 0, DAMAGE_BLUNT) //120u pitcher of fffoam instantly killed elementals, lol.
 						playsound(L, "sound/impact_sounds/burn_sizzle.ogg", 50, 1, pitch = 0.5)
 				return
 


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [SMALL] [INPUT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tweaked the damage cap values for Holy Water and FireFighting Foam for vampire and fire elemental respectively. 
Vampire is now 80 burn max from a single application of holy water, down from 110 burn.

Fire elemental could be instantly killed in one hit from a pitcher of Firefighting Foam, with 120u doing (120 * 1.5) * 1.15 = 207 Brute. Added a damage cap similar to Holy Water with Vampire, the cap is 65 * 1.15 = 74.75, which ends up being .50 brute under the death threshold for Fire elemental. With pitcher brute damage on collision, and the 5 second interval between applications, this is just barely squeaking under 150 brute with 2 pitchers. 

Also added flavour text for a fire elemental being hit by firefighting foam, both for spectators and the Fire elemental. This obeys the 5 second cooldown, so it shouldn't be an issue with spamming.
https://i.gyazo.com/806523b2fb8ae7e0e4a102e493c62e7f.png

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As it stands right now, I don't think being able to instantly kill a fire elemental with a single thrown pitcher is very fun for either party, but especially not the player behind the Fire elemental. These changes should still make pitchers a big threat, but they shouldn't be a "Turn the corner and instantly die without any input." anymore. The flavour text is more just to add some nice interaction with Fire Elementals, as they have somewhat limited flavour text for most things.

Vampire is in the same vein as the fire elemental, just not quite as severe. With two 120u pitchers being able to put you into hard crit 220 burn damage in the blink of an eye, I figured we could relax it a bit considering vampire has many weaknesses as it is, making them generally weaker than a standard crew member in terms of resistances and space faring. Although, another reason is that 90u hits the burn cap as it stands, but it's also the highest amount that can be 3-click created with chem without having to do any portioning. Also 80 * 5 = 400, which is nice.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)MomoBerry
(+)Holy water and Firefighting Foam damage caps are now 80 and 74.75, respective to their antags.
```
