### PR TITLE
Delete frames correctly on failed robot build (incompatible brain)

### DIFF
--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -1079,10 +1079,12 @@
 				O.ai_interface = src.head.ai_interface
 			else
 				O.death()
+				qdel(src)
 				return
 		else
 			// how the fuck did you even do this
 			O.death()
+			qdel(src)
 			return
 
 		if(O.brain?.owner?.key)
@@ -1094,6 +1096,7 @@
 			if (!M) // if we couldn't find them (i.e. they're still alive), don't pull them into this borg
 				src.visible_message("<span class='alert'><b>[src]</b> remains inactive, as the conciousness associated with that brain could not be reached.</span>")
 				O.death()
+				qdel(src)
 				return
 			if (!isdead(M)) // so if they're in VR, the afterlife bar, or a ghostcritter
 				boutput(M, "<span class='notice'>You feel yourself being pulled out of your current plane of existence!</span>")
@@ -1115,6 +1118,7 @@
 			playsound(src, "sound/weapons/radxbow.ogg", 40, 1)
 		else
 			O.death()
+			qdel(src)
 			return
 
 		if (src.chest && src.chest.cell)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Correctly deletes the frame when you try to activate a robot with a slimy brain. Oops!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Frames weren't being removed correctly on a failed robot activation, meaning all the parts got reference-duped. Inflation!