### PR TITLE
Shield Generator Power Usage when Attacked

### DIFF
--- a/code/datums/abilities/wizard/forcewall.dm
+++ b/code/datums/abilities/wizard/forcewall.dm
@@ -57,6 +57,11 @@
 	opacity = 0
 	density = 1
 	luminosity = 3
+	flags = USEDELAY
+
+	attackby(obj/item/I, mob/user)
+		. = ..()
+		user.lastattacked = src
 
 /obj/forcefield/artifact
 	var/obj/artifact/forcefield_generator/source = null

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -22,7 +22,7 @@
 	var/image/display_panel = null
 	var/sound/sound_on = "sound/effects/shielddown.ogg"
 	var/sound/sound_off = "sound/effects/shielddown2.ogg"
-	var/sound/sound_shieldhit = "sound/effects/shieldhit2.ogg"
+	var/sound/sound_shieldhit = "sound/impact_sounds/Energy_Hit_1.ogg"
 	var/sound/sound_battwarning = "sound/machines/pod_alarm.ogg"
 	var/list/deployed_shields = list()
 	var/direction = ""	//for building the icon, always north or directional
@@ -148,7 +148,7 @@
 				playsound(src.loc, src.sound_battwarning, 50, 1)
 				src.visible_message("<span class='alert'>The <b>[src.name] emits a low battery alarm!</b></span>")
 
-		if(PCEL.charge < 0)
+		if(PCEL.charge <= 0)
 			src.visible_message("The <b>[src.name]</b> runs out of power and shuts down.")
 			src.shield_off()
 			return
@@ -334,8 +334,44 @@
 	desc = "A force field deployed to stop meteors and other high velocity masses."
 	icon = 'icons/obj/meteor_shield.dmi'
 	icon_state = "shield"
-	var/sound/sound_shieldhit = "sound/effects/shieldhit2.ogg"
+	var/sound/sound_shieldhit = "sound/impact_sounds/Energy_Hit_1.ogg"
 	var/obj/machinery/shieldgenerator/meteorshield/deployer = null
+
+	attackby(obj/item/W, mob/user)
+		. = ..()
+		if(istype(deployer, /obj/machinery/shieldgenerator/meteorshield))
+			var/obj/machinery/shieldgenerator/meteorshield/MS = deployer
+			//blocks solid objects
+			var/force_value = clamp(W.force/4, 1, 10)
+			if(MS.PCEL && !MS.connected && MS.active)
+				MS.PCEL.use(force_value * MS.range * (MS.power_level * MS.power_level))
+			else if(MS.connected)
+				MS.use_power(MS.power_usage + force_value )
+
+			playsound(src, src.sound_shieldhit, 20, 1)
+			return
+
+	bullet_act(var/obj/projectile/P)
+		var/damage = 0
+		damage = round(((P.power/6)*P.proj_data.ks_ratio), 1.0)
+		if (!damage)
+			return
+
+		if(istype(deployer, /obj/machinery/shieldgenerator/meteorshield))
+			var/obj/machinery/shieldgenerator/meteorshield/MS = deployer
+			//blocks solid objects
+			var/force_value
+			if((P.proj_data.damage_type == D_PIERCING) || (P.proj_data.damage_type == D_ENERGY))
+				force_value = damage
+			else if (P.proj_data.damage_type == D_KINETIC)
+				force_value = damage / 1.7
+
+			if(MS.PCEL && !MS.connected && MS.active)
+				MS.PCEL.use(force_value * MS.range * (MS.power_level * MS.power_level))
+			else if(MS.connected)
+				MS.use_power(MS.power_usage + force_value )
+
+			playsound(src, src.sound_shieldhit, 20, 1)
 
 	meteorhit(obj/O as obj)
 		if(istype(deployer, /obj/machinery/shieldgenerator/meteorshield))
@@ -393,7 +429,7 @@
 	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
 	var/powerlevel //Stores the power level of the deployer
 
-	var/sound/sound_shieldhit = "sound/effects/shieldhit2.ogg"
+	var/sound/sound_shieldhit = "sound/impact_sounds/Energy_Hit_1.ogg"
 	var/obj/machinery/shieldgenerator/deployer = null
 	var/update_tiles
 
@@ -484,6 +520,44 @@
 			if(ismob(A)) return 1
 			if(isobj(A)) return 1
 		else return 0
+
+	attackby(obj/item/W, mob/user)
+		. = ..()
+		if(istype(deployer, /obj/machinery/shieldgenerator/energy_shield))
+			var/obj/machinery/shieldgenerator/energy_shield/ES = deployer
+			//blocks solid objects
+			if(ES.power_level == 3)
+				var/force_value = clamp(W.force/4, 1, 20)
+				if(ES.PCEL && !ES.connected && ES.active)
+					ES.PCEL.use(force_value * ES.range * (ES.power_level * ES.power_level))
+				else if(ES.connected)
+					ES.use_power(ES.power_usage + force_value )
+
+				playsound(src, src.sound_shieldhit, 20, 1)
+			return
+
+	bullet_act(var/obj/projectile/P)
+		var/damage = 0
+		damage = round((P.power/3), 1.0)
+		if (!damage)
+			return
+
+		if(istype(deployer, /obj/machinery/shieldgenerator/energy_shield))
+			var/obj/machinery/shieldgenerator/energy_shield/ES = deployer
+			//blocks solid objects
+			if(ES.power_level == 3)
+				var/force_value
+				if((P.proj_data.damage_type == D_PIERCING) || (P.proj_data.damage_type == D_ENERGY))
+					force_value = damage
+				else if (P.proj_data.damage_type == D_KINETIC)
+					force_value = damage / 1.7
+
+				if(ES.PCEL && !ES.connected && ES.active)
+					ES.PCEL.use(force_value * ES.range * (ES.power_level * ES.power_level))
+				else if(ES.connected)
+					ES.use_power(ES.power_usage * (0.5 * force_value) )
+
+				playsound(src, src.sound_shieldhit, 20, 1)
 
 	meteorhit(obj/O as obj)
 		if(istype(deployer, /obj/machinery/shieldgenerator/energy_shield))

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -470,7 +470,7 @@
 			src.icon_state = "shieldw"
 			src.color = "#FF3333"
 			src.powerlevel = 3
-			flags = ALWAYS_SOLID_FLUID
+			flags = ALWAYS_SOLID_FLUID | USEDELAY
 
 	disposing()
 		if(update_tiles)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Meteor Generators lose power when blocking melee strikes and projectiles.
Energy Shields lose power when blocking melee strikes and projectiles when blocking solid objects
Shield Generators will turn OFF when they run out of power [bug]
Resolves runtimes for Shield Generators doing THEIR JOB [bug]


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://user-images.githubusercontent.com/1017374/133216550-66e20150-e190-4dfe-9aae-87eb5ee1543a.png)
"Quick"


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(+)Shield Generator and Meteor Generators use power to block melee and projectile attacks.
```
