### PR TITLE
bulk-removing sheet reinforcement

### DIFF
--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -573,15 +573,18 @@ MATERIAL
 
 				if("remetal")
 					// what the fuck is this
+					var/input = input("Use how many sheets?","Max: [src.amount]",1) as num
+					if (input < 1) return
+					input = min(input,src.amount)
 					var/obj/item/sheet/C = new /obj/item/sheet(usr.loc)
 					var/obj/item/rods/R = new /obj/item/rods(usr.loc)
 					if(src.material)
 						C.setMaterial(src.material)
 					if(src.reinforcement)
 						R.setMaterial(src.reinforcement)
-					C.amount = 1
-					R.amount = 1
-					src.change_stack_amount(-1)
+					C.amount = input
+					R.amount = input
+					src.change_stack_amount(-input)
 			if (a_type)
 				actions.start(new /datum/action/bar/icon/build(src, a_type, a_cost, src.material, a_amount, a_icon, a_icon_state, a_name, a_callback), usr)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets you specify an amount when separating reinforced sheets into parts.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Breaking down a stack of reinforced metal one by one is tedious.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)You can now remove reinforcement from material sheets in bulk
```
