### PR TITLE
Type-level Information

### DIFF
--- a/_std/types.dm
+++ b/_std/types.dm
@@ -196,3 +196,87 @@ var/list/list/by_cat = list()
 #define TR_CAT_CLOWN_DISBELIEF_MOBS "clown_disbelief_mobs"
 // powernets? processing_items?
 // mobs? ai-mobs?
+
+
+/// type-level information type
+/typeinfo
+	parent_type = /datum
+
+/typeinfo/datum
+
+/typeinfo/atom
+	parent_type = /typeinfo/datum
+
+/typeinfo/turf
+	parent_type = /typeinfo/atom
+
+/typeinfo/area
+	parent_type = /typeinfo/atom
+
+/typeinfo/atom/movable
+
+/typeinfo/obj
+	parent_type = /typeinfo/atom/movable
+
+/typeinfo/mob
+	parent_type = /typeinfo/atom/movable
+
+/**
+ * Declares typeinfo for some type.
+ *
+ * Example:
+ * ```
+ * TYPEINFO(/atom)
+ * 	var/monkeys_hate = FALSE
+ *
+ * TYPEINFO(/obj/item/clothing/glasses/blindfold)
+ * 	monkeys_hate = TRUE
+ * ```
+ *
+ * Treat this as if you were defining a type. You can add vars and procs, override vars and procs etc.
+ * There might be minor issues if you define TYPEINFO of one type multiple times. Consider using `/typeinfo/THE_TYPE` for subsequent additions
+ * to the object's typeinfo **if you know it has already been declared once using TYPEINFO**.
+*/
+#define TYPEINFO(TYPE) \
+	TYPE/typeinfo_type = /typeinfo ## TYPE; \
+	TYPE/get_typeinfo() { /* maybe unnecessary, possibly replace the proc with a macro */ \
+		RETURN_TYPE(/typeinfo ## TYPE); \
+		return get_singleton(src.typeinfo_type); \
+	} \
+	/typeinfo ## TYPE
+
+
+/// var storing the subtype of /typeinfo relevant for this object
+/datum/var/typeinfo_type = /typeinfo/datum
+
+/**
+ * Retrieves the typeinfo datum for this datum's type.
+ *
+ * Example:
+ * ```
+ * var/obj/item/item_in_hand = src.equipped()
+ * var/typeinfo/atom/typeinfo = item_in_hand.get_typeinfo()
+ * if(typeinfo.monkeys_hate)
+ * 	src.throw(src.equipped(), somewhere)
+ * ```
+*/
+/datum/proc/get_typeinfo()
+	RETURN_TYPE(/typeinfo/datum)
+	return get_singleton(src.typeinfo_type)
+
+/**
+ * Retrieves the typeinfo datum for a given type.
+ *
+ * Example:
+ * ```
+ * for(var/type in types)
+ * 	var/typeinfo/atom/typeinfo = get_type_typeinfo(type)
+ * 	if(!typeinfo.admin_spawnable)
+ * 		continue
+ * 	valid_types += type
+ * ```
+*/
+proc/get_type_typeinfo(type)
+	RETURN_TYPE(/typeinfo/datum) // change to /typeinfo if we ever implement /typeinfo for non-datums for some reason
+	var/datum/type_dummy = type
+	return get_singleton(initial(type_dummy.typeinfo_type))

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -1,3 +1,6 @@
+TYPEINFO(/atom)
+	var/admin_spawnable = TRUE
+
 /**
   * The base type for nearly all physical objects in SS13
 	*

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -918,7 +918,7 @@
 			boutput(usr, "<span class='hint'>Type part of the path of the type.</span>")
 			var/typename = input("Part of type path.", "Part of type path.", "/obj") as null|text
 			if (typename)
-				var/match = get_one_match(typename, /datum, use_concrete_types = FALSE)
+				var/match = get_one_match(typename, /datum, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 				if (match)
 					if (set_global)
 						for (var/datum/x in world)
@@ -1086,7 +1086,7 @@
 				var/basetype = /obj
 				if (src.holder.rank in list("Host", "Coder", "Administrator"))
 					basetype = /datum
-				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
+				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 				if (match)
 					if (set_global)
 						for (var/datum/x in world)

--- a/code/mob/living/critter/aquatic.dm
+++ b/code/mob/living/critter/aquatic.dm
@@ -5,6 +5,7 @@
 //	-etc
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+ABSTRACT_TYPE(/mob/living/critter/aquatic)
 /mob/living/critter/aquatic
 	name = "aquatic mobcritter"
 	real_name = "aquatic mobcritter"

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -44,6 +44,7 @@
   - figures
 todo: add more small animals!
 */
+ABSTRACT_TYPE(/mob/living/critter/small_animal)
 /mob/living/critter/small_animal
 	name = "critter"
 	real_name = "critter"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -4700,7 +4700,7 @@ var/global/noir = 0
 
 	return chosen
 
-/proc/get_matches(var/object, var/base = /atom, use_concrete_types = TRUE)
+/proc/get_matches(var/object, var/base = /atom, use_concrete_types=TRUE, only_admin_spawnable=TRUE)
 	var/list/types
 	if(use_concrete_types)
 		types = concrete_typesof(base)
@@ -4710,13 +4710,17 @@ var/global/noir = 0
 	var/list/matches = new()
 
 	for(var/path in types)
+		if(only_admin_spawnable)
+			var/typeinfo/atom/typeinfo = get_type_typeinfo(path)
+			if(!typeinfo.admin_spawnable)
+				continue
 		if(findtext("[path]", object))
 			matches += path
 
 	. = matches
 
-/proc/get_one_match(var/object, var/base = /atom, use_concrete_types = TRUE)
-	var/list/matches = get_matches(object, base, use_concrete_types)
+/proc/get_one_match(var/object, var/base = /atom, use_concrete_types=TRUE, only_admin_spawnable=TRUE)
+	var/list/matches = get_matches(object, base, use_concrete_types, only_admin_spawnable)
 
 	if(!matches.len)
 		return null

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1832,10 +1832,6 @@ var/global/noir = 0
 			var/CT = input("Enter a /mob/living/critter path or partial name.", "Make Critter", null) as null|text
 
 			var/list/matches = get_matches(CT, "/mob/living/critter")
-			matches -= list(/mob/living/critter, /mob/living/critter/small_animal, /mob/living/critter/aquatic) //blacklist
-#ifdef SECRETS_ENABLED
-			matches -= list(/mob/living/critter/vending) //secret repo blacklist
-#endif
 
 			if (!length(matches))
 				return

--- a/code/modules/admin/atom_verbs.dm
+++ b/code/modules/admin/atom_verbs.dm
@@ -34,7 +34,7 @@ var/global/atom_emergency_stop = 0
 		var/transmute_thing = input("enter path of the things you want to transmute", "Enter Path", pick("/obj", "/mob", "/turf")) as null|text
 		if (!transmute_thing)
 			return
-		var/transmute_path = get_one_match(transmute_thing, /atom, use_concrete_types = FALSE)
+		var/transmute_path = get_one_match(transmute_thing, /atom, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 		if (!transmute_path)
 			return
 
@@ -139,7 +139,7 @@ var/global/atom_emergency_stop = 0
 		var/emag_thing = input("enter path of the things you want to emag", "Enter Path", pick("/obj", "/mob", "/turf")) as null|text
 		if (!emag_thing)
 			return
-		var/emag_path = get_one_match(emag_thing, /atom, use_concrete_types = FALSE)
+		var/emag_path = get_one_match(emag_thing, /atom, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 		if (!emag_path)
 			return
 
@@ -264,7 +264,7 @@ var/global/atom_emergency_stop = 0
 		var/scale_thing = input("enter path of the things you want to scale", "Enter Path", pick("/obj", "/mob", "/turf")) as null|text
 		if (!scale_thing)
 			return
-		var/scale_path = get_one_match(scale_thing, /atom, use_concrete_types = FALSE)
+		var/scale_path = get_one_match(scale_thing, /atom, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 		if (!scale_path)
 			return
 
@@ -397,7 +397,7 @@ var/global/atom_emergency_stop = 0
 		var/rotate_thing = input("enter path of the things you want to rotate", "Enter Path", pick("/obj", "/mob", "/turf")) as null|text
 		if (!rotate_thing)
 			return
-		var/rotate_path = get_one_match(rotate_thing, /atom, use_concrete_types = FALSE)
+		var/rotate_path = get_one_match(rotate_thing, /atom, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 		if (!rotate_path)
 			return
 
@@ -537,7 +537,7 @@ var/global/atom_emergency_stop = 0
 		var/spin_thing = input("enter path of the things you want to spin", "Enter Path", pick("/obj", "/mob", "/turf")) as null|text
 		if (!spin_thing)
 			return
-		var/spin_path = get_one_match(spin_thing, /atom, use_concrete_types = FALSE)
+		var/spin_path = get_one_match(spin_thing, /atom, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 		if (!spin_path)
 			return
 
@@ -686,7 +686,7 @@ var/global/atom_emergency_stop = 0
 		var/get_thing = input("enter path of the things you want to get", "Enter Path", pick("/obj", "/mob")) as null|text
 		if (!get_thing)
 			return
-		var/get_path = get_one_match(get_thing, /atom, use_concrete_types = FALSE)
+		var/get_path = get_one_match(get_thing, /atom, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 		if (!get_path)
 			return
 

--- a/code/modules/admin/buildmodes/varedit.dm
+++ b/code/modules/admin/buildmodes/varedit.dm
@@ -94,7 +94,7 @@ Hold down CTRL, ALT or SHIFT to modify, call or reset variable bound to those ke
 					var/basetype = /obj
 					if (holder.owner.holder.rank in list("Host", "Coder", "Administrator"))
 						basetype = /datum
-					var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
+					var/match = get_one_match(typename, basetype, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 					if (match)
 						newvalue = match
 						is_newinst = 1

--- a/code/modules/admin/debug.dm
+++ b/code/modules/admin/debug.dm
@@ -195,7 +195,7 @@ var/global/debug_messages = 0
 
 	if (!typename)
 		return
-	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE)
+	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 	if (thetype)
 		var/counter = 0
 		var/procname = input("Procpath","path:", null) as text
@@ -368,7 +368,7 @@ var/global/debug_messages = 0
 				boutput(usr, "<span class='notice'>Type part of the path of the type.</span>")
 				var/typename = input("Part of type path.", "Part of type path.", "/obj") as null|text
 				if (typename)
-					var/match = get_one_match(typename, /datum, use_concrete_types = FALSE)
+					var/match = get_one_match(typename, /datum, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 					if (match)
 						listargs += match
 
@@ -805,7 +805,7 @@ body
 	set name = "Find One"
 	set desc = "Show the location of one instance of type."
 
-	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE)
+	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 	if (thetype)
 		var/atom/theinstance = locate(thetype) in world
 		if (!theinstance)
@@ -822,7 +822,7 @@ body
 	set name = "Find All"
 	set desc = "Show the location of all instances of a type. Performance warning!!"
 
-	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE)
+	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 	if (thetype)
 		var/counter = 0
 		boutput(usr, "<span class='notice'><b>All instances of [thetype]: </b></span>")
@@ -854,7 +854,7 @@ body
 	set name = "Count All"
 	set desc = "Returns the number of all instances of a type that exist."
 
-	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE)
+	var/thetype = get_one_match(typename, /atom, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 	if (thetype)
 		var/counter = 0
 		for (var/atom/theinstance in world)

--- a/code/modules/admin/modifyvariables.dm
+++ b/code/modules/admin/modifyvariables.dm
@@ -113,7 +113,7 @@
 				var/basetype = /obj
 				if (src.holder.rank in list("Host", "Coder", "Administrator"))
 					basetype = /datum
-				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
+				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 				if (match)
 					var_value = new match()
 
@@ -197,7 +197,7 @@
 				var/basetype = /obj
 				if (src.holder.rank in list("Host", "Coder", "Administrator"))
 					basetype = /datum
-				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
+				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 				if (match)
 					var_value = new match()
 
@@ -354,7 +354,7 @@
 			boutput(usr, "<span class='notice'>Type part of the path of the type.</span>")
 			var/typename = input("Part of type path.", "Part of type path.", "/obj") as null|text
 			if (typename)
-				var/match = get_one_match(typename, /datum, use_concrete_types = FALSE)
+				var/match = get_one_match(typename, /datum, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 				if (match)
 					L[variable_index] = match
 
@@ -404,7 +404,7 @@
 				var/basetype = /obj
 				if (src.holder.rank in list("Host", "Coder", "Administrator"))
 					basetype = /datum
-				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
+				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 				if (match)
 					L[variable_index] = new match()
 
@@ -683,7 +683,7 @@
 				var/basetype = /obj
 				if (src.holder.rank in list("Host", "Coder", "Administrator"))
 					basetype = /datum
-				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE)
+				var/match = get_one_match(typename, basetype, use_concrete_types = FALSE, only_admin_spawnable = FALSE)
 				if (match)
 					O.vars[variable] = new match(O)
 


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a handy way to store information about a *type* that's not just adding new vars to the type (which causes the information to be redundantly stored across all instances of the type). This is achieved by creating a new type `/typeinfo` which can be derived using a `TYPEINFO` macro and accessed through an instance of an object or a type of an object.

As an example a type-level constant / variable `admin_spawnable` has been added which can mark objects as non-spawnable via admin commands.

Example usage:
```
TYPEINFO(/atom)
	var/monkeys_hate = FALSE

TYPEINFO(/obj/item/clothing/glasses/blindfold)
 	monkeys_hate = TRUE

/mob/living/carbon/human/npc/monkey/proc/maybe_throw_item()
 	var/obj/item/item_in_hand = src.equipped()
 	var/typeinfo/atom/typeinfo = item_in_hand.get_typeinfo()
 	if(typeinfo.monkeys_hate)
 	 	 src.throw(src.equipped(), somewhere)
```

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The usual practice of adding information about a type was generally to add a new variable and/or flag to the type. This causes this value to be redundantly stored across all instances of the type. Depending on the complexity of the value this might slow down instantiation of those instances (for example if it's a list) and causes unnecessary memory usage. The alternative this PR proposes is likely a tiny bit slower when it comes to accessing the type-level variables but now for each type there exists at most one /typeinfo object containing the relevant values. /typeinfo objects still have inheritance to mirror one on the base type level.

This can potentially lead to more widespread usage of variables defined for types. For example stuff like monkey item preferences which would otherwise be maybe too silly to have on every /obj/item instance could happily live on the /typeinfo level.
