### PR TITLE
Prevents mining borgs from detaching their satchels onto the floor (or, ore scoop De-QoL)

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -2365,14 +2365,17 @@ var/global/list/cargopads = list()
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W,/obj/item/satchel/mining/))
-			var/obj/item/satchel/mining/S = W
-			user.drop_item()
-			if (satchel)
-				user.put_in_hand_or_drop(satchel)
-			S.set_loc(src)
-			satchel = S
-			icon_state = "scoop-bag"
-			user.visible_message("[user] inserts [S] into [src].", "You insert [S] into [src].")
+			if (!issilicon(usr))
+				var/obj/item/satchel/mining/S = W
+				user.drop_item()
+				if (satchel)
+					user.put_in_hand_or_drop(satchel)
+				S.set_loc(src)
+				satchel = S
+				icon_state = "scoop-bag"
+				user.visible_message("[user] inserts [S] into [src].", "You insert [S] into [src].")
+			else
+				boutput(user, "<span class='alert'>The satchel is firmly secured to the scoop.</span>")
 		else
 			..()
 			return
@@ -2387,7 +2390,7 @@ var/global/list/cargopads = list()
 			else
 				boutput(user, "<span class='alert'>There's no satchel in [src] to unload.</span>")
 		else
-			boutput(user, "<span class='alert'>The satchel is firmly secured.</span>")
+			boutput(user, "<span class='alert'>The satchel is firmly secured to the scoop.</span>")
 
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
 		if(isturf(target))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I didn't consider that `put_in_hand_or_drop` would allow borgs to drop their stuff. oops.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Unremovable satchels stuck in people's inventories are Probably Bad. Also, the satchel-switching flow doesn't really work with borg modules as they currently exist- might try and create a cleaner solution later, but for now I'm just disabling the satchel-swaps for borgs.

