### PR TITLE
Standardizing Robotics Controls Deconstructability

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -9369,7 +9369,9 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/Zeta)
 "wI" = (
-/obj/machinery/computer/robotics,
+/obj/machinery/computer/robotics{
+	perma = 1
+	},
 /obj/machinery/light{
 	light_type = /obj/item/light/tube/blueish
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -30208,7 +30208,8 @@
 /area/station/turret_protected/Zeta)
 "blx" = (
 /obj/machinery/computer/robotics{
-	dir = 8
+	dir = 8;
+	perma = 1
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -2487,7 +2487,9 @@
 	},
 /area/station/turret_protected/ai_upload)
 "afo" = (
-/obj/machinery/computer/robotics,
+/obj/machinery/computer/robotics{
+	perma = 1
+	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"

--- a/maps/density.dmm
+++ b/maps/density.dmm
@@ -3591,7 +3591,7 @@
 "hX" = (
 /obj/machinery/computer/robotics{
 	dir = 4;
-	icon_state = "robotics"
+	perma = 1
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -41124,7 +41124,8 @@
 	icon_state = "2-5"
 	},
 /obj/machinery/computer/robotics{
-	dir = 4
+	dir = 4;
+	perma = 1
 	},
 /obj/cable{
 	d2 = 2;

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -24757,7 +24757,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/computer/robotics{
-	dir = 4
+	dir = 4;
+	perma = 1
 	},
 /obj/disposalpipe/segment/transport{
 	dir = 4

--- a/maps/icarus.dmm
+++ b/maps/icarus.dmm
@@ -8343,7 +8343,8 @@
 /area/station/maintenance/solar/east)
 "asy" = (
 /obj/machinery/computer/robotics{
-	dir = 4
+	dir = 4;
+	perma = 1
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -8112,7 +8112,8 @@
 /area/station/turret_protected/Zeta)
 "asP" = (
 /obj/machinery/computer/robotics{
-	dir = 8
+	dir = 8;
+	perma = 1
 	},
 /obj/machinery/light/incandescent/greenish,
 /turf/simulated/floor/circuit/green,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so most (if not all) maps' robotics control computers are unable to be deconstructed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it more consistent, resolving #6037.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Made the inability to deconstruct the robotics control standardized across all stations.
```
