### PR TITLE
Stop banning from deleting mobs

### DIFF
--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -161,12 +161,6 @@ var/global/list/playersSeen = list()
 			if (C.ckey == row["ckey"])
 				targetC = C
 
-		var/mob/targetM
-		if (!targetC)
-			for (var/mob/M in mobs) //Grab the mob if no target clients were found
-				if (M.ckey == row["ckey"])
-					targetM = M
-
 		row["reason"] = html_decode(row["reason"])
 
 		if (text2num(row["chain"]) > 0) //Prepend our evasion attempt info for: the user, admins, notes (everything except the actual ban reason in the db)

--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -214,17 +214,7 @@ var/global/list/playersSeen = list()
 		ircbot.export("ban", ircmsg)
 
 		if (targetC)
-			if (targetC.mob)
-				if (targetC.mob.contents) //for observers
-					for (var/mob/M in targetC.mob.contents)
-						M.set_loc(get_turf(M))
-				del(targetC.mob)
 			del(targetC)
-		if (targetM)
-			if (targetM.contents) //for observers
-				for (var/mob/M in targetM.contents)
-					M.set_loc(get_turf(M))
-			del(targetM)
 
 		return 0
 

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)sat sep 18 21
+(u)pali
+(*)Banning people no longer deletes their mobs.
 (t)wed sep 15 21
 (u)Gerhazo
 (*)New buildmode mode - "Paint Matrix" - similar to paint except using color matrices which allows for much cooler results.


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently banning a person deletes their mob, this PR makes it so only the client gets deleted.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I don't see a particular need to delete the mob. It can potentially remove important items from the game, like if a head of staff is getting banned or something.
Moreover, currently it's done via hard deletion which actually causes lag and runtime errors due to skipping disposing.
