### PR TITLE
Makes Robotics controls standard

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -33624,9 +33624,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/robotics{
-	perma = 1
-	},
+/obj/machinery/computer/robotics,
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
 "bHf" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -44579,8 +44579,7 @@
 /area/station/medical/medbay)
 "pAh" = (
 /obj/machinery/computer/robotics{
-	dir = 8;
-	perma = 1
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -41919,9 +41919,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/computer/robotics{
-	perma = 1
-	},
+/obj/machinery/computer/robotics,
 /turf/simulated/floor/greenblack{
 	dir = 1
 	},

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -42050,9 +42050,7 @@
 /area/diner/hangar)
 "qJt" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/robotics{
-	perma = 1
-	},
+/obj/machinery/computer/robotics,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-8"

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -9856,8 +9856,7 @@
 	})
 "cOI" = (
 /obj/machinery/computer/robotics{
-	dir = 8;
-	perma = 1
+	dir = 8
 	},
 /obj/cable{
 	icon_state = "0-8"

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -21294,9 +21294,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/robotics{
-	perma = 1
-	},
+/obj/machinery/computer/robotics,
 /turf/simulated/floor/circuit/green,
 /area/station/turret_protected/Zeta)
 "aLO" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so deconstruct-able robotics controllers are standard across all maps


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The inconsistency of whether robotics controller computers can be deconstructed causes confusion and resolves #6037.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Robotics controller computers are now deconstruct-able across all stations.
```
