### PR TITLE
Makes artguns unswappable

### DIFF
--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -8,7 +8,7 @@
 	is_syndicate = 1
 	mat_changename = 0
 	mat_changedesc = 0
-	var/can_swap_cell = 0
+	can_swap_cell = 0
 
 	New(var/loc, var/forceartiorigin, var/list/datum/projectile/artifact/forceBullets)
 		..()

--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -9,6 +9,7 @@
 	mat_changename = 0
 	mat_changedesc = 0
 	can_swap_cell = 0
+	item_function_flags = IMMUNE_TO_ACID
 
 	New(var/loc, var/forceartiorigin, var/list/datum/projectile/artifact/forceBullets)
 		..()

--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -9,7 +9,6 @@
 	mat_changename = 0
 	mat_changedesc = 0
 	can_swap_cell = 0
-	item_function_flags = IMMUNE_TO_ACID
 
 	New(var/loc, var/forceartiorigin, var/list/datum/projectile/artifact/forceBullets)
 		..()
@@ -85,10 +84,6 @@
 			user.visible_message("<span class='alert'>[src] emits a terrible cracking noise.</span>")
 
 		return
-
-	ArtifactDestroyed()
-		SEND_SIGNAL(src, COMSIG_CELL_SWAP, null, null) //swap cell with nothing (drop cell on flooor)
-		. = ..()
 
 	ArtifactActivated()
 		. = ..()

--- a/code/obj/artifacts/artifact_items/energy_gun.dm
+++ b/code/obj/artifacts/artifact_items/energy_gun.dm
@@ -8,6 +8,7 @@
 	is_syndicate = 1
 	mat_changename = 0
 	mat_changedesc = 0
+	var/can_swap_cell = 0
 
 	New(var/loc, var/forceartiorigin, var/list/datum/projectile/artifact/forceBullets)
 		..()


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Artcells in artguns are balanced for the most part, however in eguns or sec weaponry they behave as basically rampage weaponry, thanks to the insane self recharge of artcells. This pr makes artguns unable to have there cell swapped.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Artgun cells are now unswappable.
```
