### PR TITLE
Makes quartermasters have smooth tongue effects by default

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -730,6 +730,12 @@ ABSTRACT_TYPE(/datum/job/engineering)
 		src.access = get_access("Quartermaster")
 		return
 
+	special_setup(var/mob/living/carbon/human/M)
+		..()
+		if (!M)
+			return
+		M.traitHolder.addTrait("training_quartermaster")
+
 /datum/job/engineering/miner
 	name = "Miner"
 	#ifdef UNDERWATER_MAP

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -632,6 +632,12 @@
 	desc = "Subject is trained in generalized robustness and asskicking."
 	id = "training_security"
 
+/obj/trait/job/quartermaster
+	name = "Quartermaster Training"
+	cleanName = "Quartermaster Training"
+	desc = "Subject is proficent at haggling."
+	id = "training_quartermaster"
+
 // bartender, detective, HoS
 /obj/trait/job/drinker
 	name = "Professional Drinker"

--- a/code/modules/economy/traders/trader.dm
+++ b/code/modules/economy/traders/trader.dm
@@ -143,7 +143,7 @@
 
 		if(ishuman(usr))
 			var/mob/living/carbon/human/H = usr
-			if(H.traitHolder && H.traitHolder.hasTrait("smoothtalker"))
+			if (H.traitHolder.hasTrait("smoothtalker") || H.traitHolder.hasTrait("training_quartermaster"))
 				adjustedTolerance = round(adjustedTolerance * 1.5)
 
 		var/hikeperc = askingprice - goods.price


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds quartermaster training, which is given to quartermasters, this trait does the exact same thing as smooth talking trait and does not stack with it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This prevents smooth talking from being a meta trait for qms by having qms have the effects by default. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Quartermasters now get quartermaster training, this has the exact same effects of smooth talking trait.
```
