### PR TITLE
Correct gas mixture calculation for EPPD

### DIFF
--- a/code/modules/atmospherics/portable/portable_pressurizer.dm
+++ b/code/modules/atmospherics/portable/portable_pressurizer.dm
@@ -291,20 +291,22 @@
 		var/turf/simulated/T = get_turf(src)
 		if(T && istype(T))
 			if(T.air)
+				// Use temporary gas mixture to not dispose air_contents through merge
+				var/datum/gas_mixture/temp = air_contents.remove_ratio(1)
 				if(T.parent?.group_processing)
-					T.parent.air.merge(src.air_contents)
+					T.parent.air.merge(temp)
 				else
 					var/count = length(T.parent?.members)
 					if(count)
 						if(count>1)
-							src.air_contents = src.air_contents.remove_ratio(count-1/count)
+							temp = temp.remove_ratio(1/count)
 						var/datum/gas_mixture/GM
 						for(var/turf/simulated/MT as() in T.parent.members)
 							GM = unpool(/datum/gas_mixture)
-							GM.copy_from(src.air_contents)
+							GM.copy_from(temp)
 							MT.assume_air(GM)
 					else
-						T.assume_air(src.air_contents)
+						T.assume_air(temp)
 
 			if(pressure > (maximum_pressure * BLAST_EFFECT_RATIO))
 				for(var/mob/living/HH in range(8, src))


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Avoid merging the gas mixture represents the device itself, as that disposes the gas mixture causing loss of initial volume.  Caused subsequent use of the machine to reach higher pressures.
Correct calculation of fraction of gas mixture to distribute across an air group.  Caused more gas to be distributed than was present in EPPD. (Calculation appears to have merged two different methodologies which introduced the issue.)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Correct gas distribution when spreading across an airgroup.
