### PR TITLE
Destiny fire door fix

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -48733,7 +48733,7 @@
 /obj/firedoor_spawn,
 /obj/access_spawn/maint,
 /turf/simulated/floor/black,
-/area/station/maintenance/east)
+/area/station/hallway/primary/southeast)
 "rNq" = (
 /obj/critter/turtle/sylvester/HoS,
 /turf/simulated/floor/carpet{
@@ -57508,6 +57508,9 @@
 	icon_state = "wooden"
 	},
 /area/station/crew_quarters/courtroom)
+"wyE" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/hallway/primary/southeast)
 "wyN" = (
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
@@ -114008,7 +114011,7 @@ kMA
 keu
 aQM
 rMU
-hag
+wyE
 jbg
 blM
 aAd

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -48721,7 +48721,6 @@
 	},
 /area/station/hangar/sec)
 "rMU" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FIX]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes an old fire lock that was attached to the maint door below destiny's ranch, and makes the maint door and wall there part of the s/e primary hall.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves #6059

