### PR TITLE
Fix people getting trapped at void diner

### DIFF
--- a/code/obj/landmark.dm
+++ b/code/obj/landmark.dm
@@ -240,6 +240,9 @@ var/global/list/job_start_locations = list()
 /obj/landmark/lrt/workshop
 	name = "Hidden Workshop"
 
+/obj/landmark/lrt/voiddiner
+	name = "Void Diner"
+
 /obj/landmark/character_preview_spawn
 	name = LANDMARK_CHARACTER_PREVIEW_SPAWN
 

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -75630,6 +75630,9 @@
 /turf/unsimulated/floor/carpet/purple/fancy/narrow/T_south,
 /area/centcom/offices/rodney)
 "hEV" = (
+/obj/landmark/lrt/workshop{
+	name = "Void Diner"
+	},
 /turf/simulated/floor/plating/damaged1,
 /area/diner/cow)
 "hHZ" = (
@@ -80240,9 +80243,6 @@
 /area/syndicate_station/battlecruiser)
 "tPE" = (
 /obj/machinery/teleport/portal_ring,
-/obj/landmark/lrt/workshop{
-	name = "Void Diner"
-	},
 /turf/unsimulated/floor/void,
 /area/diner/cow)
 "tPH" = (

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -75630,9 +75630,7 @@
 /turf/unsimulated/floor/carpet/purple/fancy/narrow/T_south,
 /area/centcom/offices/rodney)
 "hEV" = (
-/obj/landmark/lrt/workshop{
-	name = "Void Diner"
-	},
+/obj/landmark/lrt/voiddiner,
 /turf/simulated/floor/plating/damaged1,
 /area/diner/cow)
 "hHZ" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I didn't have a second player to test the receiving part of the long range teleporter and it never occurred to me that this would be an issue! Makes it so players won't get stuck. Also adds a unique landmark object instead of using the workshop landmark with a different name.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
PEOPLE CAN GET STUCK THIS IS VERY BAD but this fixes it by moving the landmark up 1 tile.
