### PR TITLE
Adds DECON DESTRUCT and was_deconstructed_to_frame to several machinery

### DIFF
--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -841,7 +841,7 @@
 	var/powerdownsfx = 'sound/machines/engine_alert3.ogg'
 
 	mats = 8
-	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS
+	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS | DECON_DESTRUCT
 	flags = FPRINT
 
 	var/mode_toggle = 0

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -678,7 +678,7 @@ datum/chemicompiler_core/stationaryCore
 	mats = 15
 	flags = NOSPLASH
 	processing_tier = PROCESSING_FULL
-	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL | DECON_DESTRUCT
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
 	var/datum/chemicompiler_executor/executor
 	var/datum/light/light
 
@@ -706,6 +706,9 @@ datum/chemicompiler_core/stationaryCore
 	meteorhit()
 		qdel(src)
 		return
+
+	was_deconstructed_to_frame(mob/user)
+		status = NOPOWER // If it works.
 
 	attack_ai(mob/user as mob)
 		return src.Attackhand(user)

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -678,7 +678,7 @@ datum/chemicompiler_core/stationaryCore
 	mats = 15
 	flags = NOSPLASH
 	processing_tier = PROCESSING_FULL
-	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL | DECON_DESTRUCT
 	var/datum/chemicompiler_executor/executor
 	var/datum/light/light
 

--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -13,7 +13,7 @@
 	var/stoked = 0 // engine ungrump
 	mats = 20
 	event_handler_flags = NO_MOUSEDROP_QOL | USE_FLUID_ENTER
-	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
+	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_DESTRUCT
 
 	process()
 		if(status & BROKEN) return

--- a/code/modules/power/furnace.dm
+++ b/code/modules/power/furnace.dm
@@ -13,7 +13,7 @@
 	var/stoked = 0 // engine ungrump
 	mats = 20
 	event_handler_flags = NO_MOUSEDROP_QOL | USE_FLUID_ENTER
-	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_DESTRUCT
+	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 
 	process()
 		if(status & BROKEN) return
@@ -60,6 +60,9 @@
 				else //Clear the overlay
 					UpdateOverlays(null, okey, 0, 1)
 
+
+	was_deconstructed_to_frame(mob/user)
+		src.active = 0
 
 	attack_hand(var/mob/user as mob)
 		if (!src.fuel) boutput(user, "<span class='alert'>There is no fuel in the furnace!</span>")

--- a/code/obj/item/device/powersink.dm
+++ b/code/obj/item/device/powersink.dm
@@ -12,6 +12,7 @@
 	throw_range = 2
 	m_amt = 750
 	w_amt = 750
+	deconstruct_flags = DECON_DESTRUCT
 	var/drain_rate = 400000		// amount of power to drain per tick
 	var/power_drained = 0 		// has drained this much power
 	var/max_power = 2e8		// maximum power that can be drained before exploding

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -213,7 +213,7 @@
 	anchored = 0
 	density = 1
 	mats = 2
-	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_DESTRUCT
 	flags = NOSPLASH
 	processing_tier = PROCESSING_SIXTEENTH
 	machine_registry_idx = MACHINES_PLANTPOTS

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -324,7 +324,7 @@
 		update_icon()
 
 	was_deconstructed_to_frame(mob/user)
-		var/datum/plant/current = null // Dont think this would lead to any frustrations, considering like, youre chopping the machine up of course itd destroy the plant.
+		src.current = null // Dont think this would lead to any frustrations, considering like, youre chopping the machine up of course itd destroy the plant.
 		boutput( user, "<span class='alert'>In the process of deconstructing the tray you destroy the plant.</span>" )
 
 	process()

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -213,7 +213,7 @@
 	anchored = 0
 	density = 1
 	mats = 2
-	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_DESTRUCT
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR
 	flags = NOSPLASH
 	processing_tier = PROCESSING_SIXTEENTH
 	machine_registry_idx = MACHINES_PLANTPOTS
@@ -322,6 +322,10 @@
 	power_change()
 		. = ..()
 		update_icon()
+
+	was_deconstructed_to_frame(mob/user)
+		var/datum/plant/current = null // Dont think this would lead to any frustrations, considering like, youre chopping the machine up of course itd destroy the plant.
+		boutput( user, "<span class='alert'>In the process of deconstructing the tray you destroy the plant.</span>" )
 
 	process()
 		..()

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -9,6 +9,7 @@
 	anchored = 0
 	mats = 50
 	layer = FLOOR_EQUIP_LAYER1
+	deconstruct_flags = DECON_DESTRUCT
 	var/obj/item/cell/PCEL = null
 	var/coveropen = 0
 	var/active = 0


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents objects from still working while inside there frames, fixes bugs. (To explain a little bit further, decon destruct saves items in frames by there path instead of the object itself, this prevents things like Stompers being set to auto and being deconstructed still stomping even though it got deconstructed.)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix

