### PR TITLE
ijkl to Stop Drop and Roll

### DIFF
--- a/code/datums/components/ijkl_to_stop_drop_and_roll.dm
+++ b/code/datums/components/ijkl_to_stop_drop_and_roll.dm
@@ -1,3 +1,4 @@
+ABSTRACT_TYPE(datum/component/filtered_accumulator_trigger)
 datum/component/filtered_accumulator_trigger
 	var/list/timestamps = new/list()
 	var/list/valid_inputs

--- a/code/datums/components/ijkl_to_stop_drop_and_roll.dm
+++ b/code/datums/components/ijkl_to_stop_drop_and_roll.dm
@@ -1,0 +1,75 @@
+datum/component/filtered_accumulator_trigger
+	var/list/timestamps = new/list()
+	var/list/valid_inputs
+	var/count_required_to_trigger = 10
+	var/required_time_interval = 10 SECONDS
+	var/index_in_list = 0
+
+/datum/component/filtered_accumulator_trigger/Initialize()
+	timestamps.len = count_required_to_trigger
+	..()
+
+/datum/component/filtered_accumulator_trigger/RegisterWithParent()
+	RegisterSignal(parent, list(COMSIG_ATOM_DIR_CHANGED), .proc/receive_input)
+	return  //No need to ..()
+
+/datum/component/mechanics_holder/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_ATOM_DIR_CHANGED))
+	return  //No need to ..()
+
+/datum/component/filtered_accumulator_trigger/proc/receive_input(var/comsig_target, var/input)
+	if(!(input in valid_inputs))
+		return
+	if(!precondition())
+		return
+	log_timestamp()
+	if(trigger_condition())
+		on_trigger()
+
+/datum/component/filtered_accumulator_trigger/proc/log_timestamp()
+	timestamps[index_in_list + 1] = world.time //"+ 1" because of goddamned 1-count lists
+	index_in_list = ++index_in_list % count_required_to_trigger
+
+/datum/component/filtered_accumulator_trigger/proc/trigger_condition()
+	. = FALSE
+	var/oldest_timestamp = world.time
+	for(var/timestamp in timestamps)
+		if(isnull(timestamp))
+			return
+		oldest_timestamp = min(timestamp, oldest_timestamp)
+	if(oldest_timestamp >= world.time - required_time_interval)
+		return TRUE
+
+/datum/component/filtered_accumulator_trigger/proc/on_trigger()
+	return
+
+/datum/component/filtered_accumulator_trigger/proc/precondition()
+	return TRUE
+
+
+
+
+/datum/component/filtered_accumulator_trigger/ijkl_to_stop_drop_and_roll
+	count_required_to_trigger = 5
+	required_time_interval = 2 SECONDS
+	valid_inputs = list(NORTH, SOUTH, EAST, WEST)
+
+/datum/component/filtered_accumulator_trigger/ijkl_to_stop_drop_and_roll/precondition()
+	. = FALSE
+	var/mob/living/L = parent
+	if(!istype(L))
+		return
+	if (L.getStatusDuration("burning"))// && L.hasStatus("resting"))
+		if (!actions.hasAction(L, "fire_roll"))
+			return TRUE //No need to ..()
+
+/datum/component/filtered_accumulator_trigger/ijkl_to_stop_drop_and_roll/on_trigger()
+	var/mob/living/L = parent
+	if(!istype(L))
+		return
+	//fire_roll checks these conditions itself during on_update(),
+	//but more performant to check now than after action creation.
+	if (L.getStatusDuration("burning"))// && L.hasStatus("resting"))
+		if (!actions.hasAction(L, "fire_roll"))
+			actions.start(new/datum/action/fire_roll(), L)
+	return  //No need to ..()

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -139,6 +139,8 @@
 		//stamina bar gets added to the hud in subtypes human and critter... im sorry.
 		//eventual hud merger pls
 
+	AddComponent(/datum/component/filtered_accumulator_trigger/ijkl_to_stop_drop_and_roll)
+
 	SPAWN_DBG(0)
 		src.get_static_image()
 		sleep_bubble.appearance_flags = RESET_TRANSFORM

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -262,6 +262,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\components\food_stuff.dm"
 #include "code\datums\components\fullauto.dm"
 #include "code\datums\components\geiger_counter.dm"
+#include "code\datums\components\ijkl_to_stop_drop_and_roll.dm"
 #include "code\datums\components\legs.dm"
 #include "code\datums\components\light.dm"
 #include "code\datums\components\loc_invisibility.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Rapidly changing directions while on fire will start the Stop Drop and Roll action.
Currently: this starts as soon as going into rest-position.

This could be a problem from people panicking/running around while alight - unintentionally laying down.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
@UrsulaMejor requested it long ago. So long ago that the method has since changed (for the better).
Might help new players STaR easier, but I doubt this is a good addition as is. Submitting this to open review regardless.

Voice in my head tells me performance could be better.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)MarkNstein
(+)Rapidly changing directions while on fire will start the Stop Drop and Roll action.
```
