### PR TITLE
Lungs suck

### DIFF
--- a/code/modules/atmospherics/FEA_gas_mixture.dm
+++ b/code/modules/atmospherics/FEA_gas_mixture.dm
@@ -342,7 +342,7 @@ What are the archived variables for?
 	var/datum/gas_mixture/removed = unpool(/datum/gas_mixture)
 
 	#define _REMOVE_GAS_RATIO(GAS, ...) \
-		removed.GAS = min(GAS*ratio, GAS); \
+		removed.GAS = min(QUANTIZE(GAS*ratio), GAS); \
 		GAS -= removed.GAS/group_multiplier;
 	APPLY_TO_GASES(_REMOVE_GAS_RATIO)
 	#undef _REMOVE_GAS_RATIO

--- a/code/obj/item/organs/lung.dm
+++ b/code/obj/item/organs/lung.dm
@@ -89,7 +89,6 @@
 				donor.take_oxygen_deprivation(-6 * mult/LUNG_COUNT)
 				oxygen_used = breath.oxygen/6
 
-			oxygen_used /= LUNG_COUNT
 			breath.oxygen -= oxygen_used
 			breath.carbon_dioxide += oxygen_used
 

--- a/code/obj/item/organs/lung.dm
+++ b/code/obj/item/organs/lung.dm
@@ -12,7 +12,7 @@
 	failure_disease = /datum/ailment/disease/respiratory_failure
 	var/temp_tolerance = T0C+66
 
-	var/safe_oxygen_min = 17 // Minimum safe partial pressure of O2, in kPa
+	var/safe_oxygen_min = 16 // Minimum safe partial pressure of O2, in kPa
 	var/safe_co2_max = 9 // Yes it's an arbitrary value who cares?
 	var/safe_toxins_max = 0.4
 	var/SA_para_min = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes O² partial pressure to values Wikipedia says is the safest, this allows existing objects and behavior to continue while giving a safer boundary for quantized rounding to occur with sufficient margins. 17 -> 16
Re-enabled atmos ratio quantization.
Removed gas exchange scalar used when calculations were being performed on the same gas_mixture, now they are two distinct mixtures.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Minor fix and addressed band-aid Pali had to put on over my changes. 😿 
