### PR TITLE
Breathing Subpar Air 😮‍💨😕

### DIFF
--- a/code/obj/item/organs/lung.dm
+++ b/code/obj/item/organs/lung.dm
@@ -79,8 +79,8 @@
 					else
 						update.emotes |= "gasp"
 				if (O2_pp > 0)
-					var/ratio = round(safe_oxygen_min/(O2_pp + 0.1))
-					donor.take_oxygen_deprivation(min(5*ratio, 5)/LUNG_COUNT) // Don't fuck them up too fast (space only does 7 after all!)
+					var/ratio = min(((O2_pp + 0.1)/safe_oxygen_min),1)
+					donor.take_oxygen_deprivation(clamp(round(5*(1-ratio)), 1, 5)/LUNG_COUNT) // Don't fuck them up too fast (space only does 7 after all!)
 					oxygen_used = breath.oxygen*ratio/6
 				else
 					donor.take_oxygen_deprivation(3 * mult/LUNG_COUNT)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug][balance][help wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Scales oxygen damage linearly based on amount of oxygen in mixture. 0.5-2.5 **per lung**.
Scales oxygen usage linearly based on the amount of oxygen in mixture. 

Previous Behavior:
>var/ratio = round(safe_oxygen_min/(O2_pp + 0.1))
>donor.take_oxygen_deprivation(min(5*ratio, 5))
>oxygen_used = breath.oxygen * ratio/6

- This provides 4-5 oxygen damage, and only 4 when O2_pp is within 0.1 of safe_oxygen_min.  Is that the desired behavior?

- That ratio calculation becomes problematic when the ratio exceeds 6 as the oxygen used will exceed the amount of oxygen present.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves cases where negative molar quantities would be be calculated.
Adjusts calculations based on my perceived intent.
