### PR TITLE
Negative Oxygen on Breathing Edgecase

### DIFF
--- a/code/obj/item/organs/lung.dm
+++ b/code/obj/item/organs/lung.dm
@@ -81,7 +81,7 @@
 				if (O2_pp > 0)
 					var/ratio = round(safe_oxygen_min/(O2_pp + 0.1))
 					donor.take_oxygen_deprivation(min(5*ratio, 5)/LUNG_COUNT) // Don't fuck them up too fast (space only does 7 after all!)
-					oxygen_used = breath.oxygen*ratio/6
+					oxygen_used = min(breath.oxygen*ratio/6, breath.oxygen)
 				else
 					donor.take_oxygen_deprivation(3 * mult/LUNG_COUNT)
 				update.show_oxy_indicator = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Remove case where negative molar quantities could be introduced into the atmos simulation.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolved bug described in #6075 with no other changes.
