### PR TITLE
Only spy_thieves can activate their camera flash

### DIFF
--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -92,7 +92,7 @@
 	var/wait_cycle = 0
 
 	attack_self(mob/user)
-		if (user.find_in_hand(src))
+		if (user.find_in_hand(src) && user.mind && user.mind.special_role == ROLE_SPY_THIEF) // No metagming this
 			if (!src.flash_mode)
 				user.show_text("You use the secret switch to set the camera to flash mode.", "blue")
 				playsound(user, "sound/items/pickup_defib.ogg", 100, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL] [Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Only spy thieves are capable of deploying/closing up their camera flash.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bit lame to have an easily found method of "this person's a spy". The camera simply existing is already enough of an indication.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Only spy_thieves can deploy/undeploy their camera's flash. 
```
