### PR TITLE
Adds interactions for slipping/chairflipping/being thrown into the torpedo tube and torpedo trays 

### DIFF
--- a/code/WorkInProgress/torpedoes.dm
+++ b/code/WorkInProgress/torpedoes.dm
@@ -410,8 +410,9 @@
 			thrown_person.set_loc(src.loc)
 			parent?.close()
 			if (prob(25) || thrown_person.bioHolder.HasEffect("clumsy"))
-				JOB_XP(thrown_person, "Clown", 5)
-				src.parent?.launch()
+				SPAWN_DBG(0.5 SECONDS)
+					JOB_XP(thrown_person, "Clown", 5)
+					src.parent?.launch()
 		else
 			..()
 

--- a/code/WorkInProgress/torpedoes.dm
+++ b/code/WorkInProgress/torpedoes.dm
@@ -517,6 +517,18 @@
 			else if(istype(trg, /obj/torpedo_tube_tray))
 				remove(get_turf(over_object), trg.dir)
 
+	hitby(var/atom/movable/M, var/datum/thrown_thing/thr)
+		if (src.loaded && ishuman(M) && M.throwing)
+			var/mob/living/carbon/human/thrown_person = M
+			if (thrown_person.throwing & THROW_CHAIRFLIP)
+				logTheThing("combat", thrown_person, null, " flips into \the [src] at [showCoords(src.x, src.y, src.z)], setting it off.")
+				loaded.breakLaunch()
+			else if (prob(25) || thrown_person.bioHolder.HasEffect("clumsy"))
+				logTheThing("combat", thrown_person, null, " is thrown into \the [src] at [showCoords(src.x, src.y, src.z)], setting it off. (likely thrown by [thr?.user ? constructName(thr.user) : "a non-mob"])")
+				loaded.breakLaunch()
+				JOB_XP(thrown_person, "Clown", 5)
+		..()
+
 /obj/torpedo_tray/explosive_loaded
 	icon = 'icons/obj/large/32x64.dmi'
 	icon_state = "emptymissiletray"

--- a/code/WorkInProgress/torpedoes.dm
+++ b/code/WorkInProgress/torpedoes.dm
@@ -492,9 +492,10 @@
 		changeIcon()
 		return
 
-	proc/remove(var/turf/target, var/direction = null)
+	proc/remove(var/turf/target, var/direction = null, var/force = FALSE)
 		if(loaded == null) return
-		if(!can_act(usr) || !can_reach(usr, src) || !can_reach(usr, target)) return
+		if(!force && (!can_act(usr) || !can_reach(usr, src) || !can_reach(usr, target)))
+			return
 		var/obj/torpedo/T = loaded
 		loaded = null
 		T.set_dir((direction ? direction : src.dir))
@@ -705,7 +706,7 @@
 	proc/breakLaunch()
 		var/obj/torpedo_tray/T = src.loc
 		if(istype(T))
-			T.remove(get_turf(src))
+			T.remove(get_turf(src), force = TRUE)
 		var/atom/target = get_edge_target_turf(src, src.dir)
 		src.lockdir = src.dir
 		src.fired = 1

--- a/code/WorkInProgress/torpedoes.dm
+++ b/code/WorkInProgress/torpedoes.dm
@@ -416,7 +416,6 @@
 		else
 			..()
 
-
 /obj/torpedo_tray
 	name = "torpedo tray"
 	desc = "A tray for wheeling around torpedos."

--- a/code/WorkInProgress/torpedoes.dm
+++ b/code/WorkInProgress/torpedoes.dm
@@ -410,9 +410,8 @@
 			thrown_person.set_loc(src.loc)
 			parent?.close()
 			if (prob(25) || thrown_person.bioHolder.HasEffect("clumsy"))
-				SPAWN_DBG(0.5 SECONDS)
-					JOB_XP(thrown_person, "Clown", 5)
-					src.parent?.launch()
+				JOB_XP(thrown_person, "Clown", 5)
+				src.parent?.launch()
 		else
 			..()
 

--- a/code/WorkInProgress/torpedoes.dm
+++ b/code/WorkInProgress/torpedoes.dm
@@ -402,6 +402,21 @@
 		else
 			return ..(I,user)
 
+	hitby(var/atom/movable/M, var/datum/thrown_thing/thr)
+		if (ishuman(M) && M.throwing)
+			var/mob/living/carbon/human/thrown_person = M
+			M.visible_message("<span class='alert'><b>[thrown_person] [thrown_person.throwing & THROW_SLIP ? "slips" : "falls"] onto [src]! [src] slams closed!</b></span>")
+			logTheThing("combat", thrown_person, null, " falls into \the [src] at [showCoords(src.x, src.y, src.z)] (likely thrown by [thr?.user ? constructName(thr.user) : "a non-mob"])")
+			thrown_person.set_loc(src.loc)
+			parent?.close()
+			if (prob(25) || thrown_person.bioHolder.HasEffect("clumsy"))
+				SPAWN_DBG(0.5 SECONDS)
+					JOB_XP(thrown_person, "Clown", 5)
+					src.parent?.launch()
+		else
+			..()
+
+
 /obj/torpedo_tray
 	name = "torpedo tray"
 	desc = "A tray for wheeling around torpedos."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
and by "Adds interactions" I mean "causes you to slam into the torpedo tube and possibly be fired out" and "causes the torpedo to fire" respectively.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's funny.
I don't have any real balance concerns, as torpedo trays don't have any click delay, so you can already activate torpedos near-instantly if you want to.