### PR TITLE
Initiates round lock and unable to roll antag for captain on both servers.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -156,9 +156,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	wages = PAY_EXECUTIVE
 	high_priority_job = 1
 	recieves_miranda = 1
-#ifdef RP_MODE
 	allow_traitors = 0
-#endif
 	cant_spawn_as_rev = 1
 	announce_on_join = 1
 	allow_spy_theft = 0
@@ -174,9 +172,8 @@ ABSTRACT_TYPE(/datum/job/command)
 	slot_ears = list(/obj/item/device/radio/headset/command/captain)
 	slot_poc1 = list(/obj/item/disk/data/floppy/read_only/authentication)
 	items_in_backpack = list(/obj/item/storage/box/id_kit,/obj/item/device/flash)
-#ifdef RP_MODE
 	rounds_needed_to_play = 20
-#endif
+
 
 	New()
 		..()


### PR DESCRIPTION
<!-- [Feedback] [Wiki] The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Captain is now round locked for 20 rounds on both RP and classic, instead of just RP. Theyre also unable to roll antag on both servers.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is going to be a contreversial one. Know PRs like this have been made in the past however resuggested this and got approval of the idea, so things may have changed. The idea for this is to make captain more credible, with the lack of antag status and the round lock theyll be competent more often. Not to mention the easy curbstomp being an antag captain is with the armor, AA, and taser with lethals.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Captain is unable to roll antag and has a round lock of 20 rounds on both servers.
```
