### PR TITLE
Adds a general fabricator to public tool storage.

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -24138,7 +24138,6 @@
 /area/station/storage/emergency)
 "bhY" = (
 /obj/machinery/light_switch/auto,
-/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "bhZ" = (
@@ -25798,6 +25797,7 @@
 /area/station/storage/emergency)
 "bmd" = (
 /obj/machinery/light/incandescent/warm,
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/yellow,
 /area/station/storage/emergency)
 "bme" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -12484,6 +12484,7 @@
 /area/station/storage/tools)
 "aDk" = (
 /obj/machinery/light/incandescent/harsh,
+/obj/machinery/manufacturer/general,
 /turf/simulated/floor,
 /area/station/storage/tools)
 "aDl" = (
@@ -25793,12 +25794,10 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/portable_reclaimer,
 /turf/simulated/floor/yellow,
 /area/station/storage/emergency)
 "bmd" = (
 /obj/machinery/light/incandescent/warm,
-/obj/machinery/manufacturer/general,
 /turf/simulated/floor/yellow,
 /area/station/storage/emergency)
 "bme" = (
@@ -48507,6 +48506,10 @@
 /obj/item/mop,
 /turf/simulated/floor/grime,
 /area/station/maintenance/inner/central)
+"wGh" = (
+/obj/machinery/portable_reclaimer,
+/turf/simulated/floor,
+/area/station/storage/tools)
 "wGG" = (
 /obj/stool/chair/office/purple{
 	dir = 4
@@ -87173,7 +87176,7 @@ aAG
 aBJ
 aCu
 aDj
-aCs
+wGh
 aRs
 aFA
 aBG

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -24137,6 +24137,7 @@
 /area/station/storage/emergency)
 "bhY" = (
 /obj/machinery/light_switch/auto,
+/obj/reagent_dispensers/foamtank,
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "bhZ" = (
@@ -25614,11 +25615,15 @@
 /turf/simulated/floor/plating/random,
 /area/station/engine/elect)
 "blF" = (
-/obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/yellow/side,
-/area/station/storage/emergency)
-"blG" = (
-/obj/item/sheet/steel/fullstack,
+/obj/table/auto,
+/obj/item/sheet/steel/fullstack{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/sheet/glass/fullstack{
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/yellow/side,
 /area/station/storage/emergency)
 "blH" = (
@@ -25788,11 +25793,12 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/item/sheet/glass/fullstack,
+/obj/machinery/portable_reclaimer,
 /turf/simulated/floor/yellow,
 /area/station/storage/emergency)
 "bmd" = (
 /obj/machinery/light/incandescent/warm,
+/obj/machinery/manufacturer/general,
 /turf/simulated/floor/yellow,
 /area/station/storage/emergency)
 "bme" = (
@@ -104109,7 +104115,7 @@ bhX
 bjr
 bkg
 blc
-blG
+blH
 bmb
 arm
 bnm


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title, this changes the other tool storage a little bit too because overall the movements of things were nice and I feel like they work better (also too lazy to fix it),
![image](https://user-images.githubusercontent.com/73148980/134787339-8bdca712-a3b6-4be4-b571-db20af1e0eff.png)
![image](https://user-images.githubusercontent.com/73148980/134787354-ec69777b-31d4-4db4-9c30-8a4578cc8713.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Oshan lacks any public access general fabricator and this seems like nice quality of life. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)Oshan now has an additional general fabricator in public tool storage.
```
