### PR TITLE
clamp growth reset for harvested plants

### DIFF
--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1077,7 +1077,7 @@
 		else
 			logTheThing("debug", null, null, "<b>Hydro Controls</b>: Could not access Hydroponics Controller to get Harvest cap.")
 
-		src.growth = growing.growtime - DNA.growtime
+		src.growth = max(0, growing.growtime - DNA.growtime)
 		// Reset the growth back to the beginning of maturation so we can wait out the
 		// harvest time again.
 		var/getamount = growing.cropsize + DNA.cropsize


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a plant is harvested, the growth is reset to the amount that is needed for the plant to count as mature.
(The base time from the plant type minus the modifier due to maturation rate.)

For plants with a high modifier due to lots of love from botanists, this could go into negative growth, making it so that the plant instantly died due to negative growth at the next growth cycle, even if the plant had the immortal strain and stuff.

This clamps the growth reset to 0, so the plant should not go into negative growth from it.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So that plants do not randomly die from their stats being too high.

This shouldn't make mass producing produce too easy, as there is still a 30 second hard cooldown between harvests and previously that bug could be avoided by having a growth modifier that was just below the growtime of the plant, so it doesn't make anything faster possible than what was already possible.

fixes #6083 