### PR TITLE
Lets you put critter corpses into disposal units via clickdrag

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -136,14 +136,26 @@
 
 	// mouse drop another mob or self
 	//
-	MouseDrop_T(mob/target, mob/user)
+	MouseDrop_T(atom/target, mob/user)
 		//jesus fucking christ
-		if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || is_incapacitated(user) || isAI(user) || isAI(target) || isghostcritter(user))
+		if(!in_interact_range(src,user) || !in_interact_range(src,target))
+			return
+
+		if(istype(target, /obj/critter))
+			var/obj/critter/corpse = target
+			if(!corpse.alive)
+				corpse.set_loc(src)
+				user.visible_message("[user.name] places \the [corpse] into \the [src].")
+				actions.interrupt(user, INTERRUPT_ACT)
+			return
+
+		var/mob/mobtarget = target
+		if (!istype(target, /mob) || mobtarget.buckled || is_incapacitated(user) || isAI(user) || isAI(mobtarget) || isghostcritter(user))
 			return
 
 		if (istype(src, /obj/machinery/disposal/mail) && isliving(target))
 			//Is this mob allowed to ride mailchutes?
-			if (!target.canRideMailchutes())
+			if (!mobtarget.canRideMailchutes())
 				boutput(user, "<span class='alert'>That won't fit!</span>")
 				return
 

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -138,7 +138,7 @@
 	//
 	MouseDrop_T(atom/target, mob/user)
 		//jesus fucking christ
-		if (!in_interact_range(src,user) || !in_interact_range(src,target) || isAI(user) || is_incapacitated(user) || isghostcritter(user))
+		if (!IN_RANGE(src,user,1) || !IN_RANGE(src,target,1) || isAI(user) || is_incapacitated(user) || isghostcritter(user))
 			return
 
 		if (iscritter(target))

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -141,7 +141,7 @@
 		if (!in_interact_range(src,user) || !in_interact_range(src,target))
 			return
 
-		if (istype(target, /obj/critter))
+		if (iscritter(target))
 			var/obj/critter/corpse = target
 			if (!corpse.alive)
 				corpse.set_loc(src)
@@ -149,12 +149,12 @@
 				actions.interrupt(user, INTERRUPT_ACT)
 			return
 
-		if (istype(target, /mob))
+		if (isliving(target))
 			var/mob/mobtarget = target
 			if  (mobtarget.buckled || is_incapacitated(user) || isAI(user) || isAI(mobtarget) || isghostcritter(user))
 				return
 
-			if (istype(src, /obj/machinery/disposal/mail) && isliving(mobtarget))
+			if (istype(src, /obj/machinery/disposal/mail))
 				//Is this mob allowed to ride mailchutes?
 				if (!mobtarget.canRideMailchutes())
 					boutput(user, "<span class='alert'>That won't fit!</span>")

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -138,28 +138,29 @@
 	//
 	MouseDrop_T(atom/target, mob/user)
 		//jesus fucking christ
-		if(!in_interact_range(src,user) || !in_interact_range(src,target))
+		if (!in_interact_range(src,user) || !in_interact_range(src,target))
 			return
 
-		if(istype(target, /obj/critter))
+		if (istype(target, /obj/critter))
 			var/obj/critter/corpse = target
-			if(!corpse.alive)
+			if (!corpse.alive)
 				corpse.set_loc(src)
 				user.visible_message("[user.name] places \the [corpse] into \the [src].")
 				actions.interrupt(user, INTERRUPT_ACT)
 			return
 
-		var/mob/mobtarget = target
-		if (!istype(target, /mob) || mobtarget.buckled || is_incapacitated(user) || isAI(user) || isAI(mobtarget) || isghostcritter(user))
-			return
-
-		if (istype(src, /obj/machinery/disposal/mail) && isliving(target))
-			//Is this mob allowed to ride mailchutes?
-			if (!mobtarget.canRideMailchutes())
-				boutput(user, "<span class='alert'>That won't fit!</span>")
+		if (istype(target, /mob))
+			var/mob/mobtarget = target
+			if  (mobtarget.buckled || is_incapacitated(user) || isAI(user) || isAI(mobtarget) || isghostcritter(user))
 				return
 
-		actions.start(new/datum/action/bar/icon/shoveMobIntoChute(src, target, user), user)
+			if (istype(src, /obj/machinery/disposal/mail) && isliving(mobtarget))
+				//Is this mob allowed to ride mailchutes?
+				if (!mobtarget.canRideMailchutes())
+					boutput(user, "<span class='alert'>That won't fit!</span>")
+					return
+
+			actions.start(new/datum/action/bar/icon/shoveMobIntoChute(src, mobtarget, user), user)
 
 	hitby(atom/movable/MO, datum/thrown_thing/thr)
 		// This feature interferes with mail delivery, i.e. objects bouncing back into the chute.

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -138,7 +138,7 @@
 	//
 	MouseDrop_T(atom/target, mob/user)
 		//jesus fucking christ
-		if (!in_interact_range(src,user) || !in_interact_range(src,target))
+		if (!in_interact_range(src,user) || !in_interact_range(src,target) || isAI(user) || is_incapacitated(user) || isghostcritter(user))
 			return
 
 		if (iscritter(target))
@@ -151,7 +151,7 @@
 
 		if (isliving(target))
 			var/mob/mobtarget = target
-			if  (mobtarget.buckled || is_incapacitated(user) || isAI(user) || isAI(mobtarget) || isghostcritter(user))
+			if  (mobtarget.buckled || isAI(mobtarget))
 				return
 
 			if (istype(src, /obj/machinery/disposal/mail))

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -150,7 +150,7 @@
 			return
 
 		if (isliving(target))
-			var/mob/mobtarget = target
+			var/mob/living/mobtarget = target
 			if  (mobtarget.buckled || isAI(mobtarget))
 				return
 

--- a/code/obj/critter/critter_parent.dm
+++ b/code/obj/critter/critter_parent.dm
@@ -411,12 +411,6 @@
 			src.task = "thinking"
 			wander_check = rand(5,20)
 
-	MouseDrop(obj/O, mob/user)
-		if(istype(O, /obj/machinery/disposal) && !src.alive)
-			src.set_loc(O)
-			user.visible_message("[usr.name] places \the [src] into \the [O].")
-			actions.interrupt(user, INTERRUPT_ACT)
-
 	proc/patrol_to(var/towhat)
 		step_to(src, towhat)
 

--- a/code/obj/critter/critter_parent.dm
+++ b/code/obj/critter/critter_parent.dm
@@ -411,6 +411,12 @@
 			src.task = "thinking"
 			wander_check = rand(5,20)
 
+	MouseDrop(obj/O, mob/user)
+		if(istype(O, /obj/machinery/disposal) && !src.alive)
+			src.set_loc(O)
+			user.visible_message("[usr.name] places \the [src] into \the [O].")
+			actions.interrupt(user, INTERRUPT_ACT)
+
 	proc/patrol_to(var/towhat)
 		step_to(src, towhat)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title. Also makes the mousedrop proc a little less dumb, potentially allowing to use the proc in the future for things other than mobs and critters :iiam:

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Watching Tomato's stream inspired me to do the thing

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)You are now able to put critter corpses into disposal units via clickdrag.
```
