### PR TITLE
Makes reclaimer accept anything with a set material

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -800,10 +800,6 @@
 				if (output_bar_from_item(M, 10))
 					pool(M)
 
-			else if (istype(M, /obj/item/raw_material))
-				output_bar_from_item(M)
-				pool(M)
-
 			else if (istype(M, /obj/item/sheet))
 				if (output_bar_from_item(M, 10))
 					qdel(M)
@@ -824,6 +820,10 @@
 			else if (istype(M, /obj/item/wizard_crystal))
 				if (output_bar_from_item(M))
 					qdel(M)
+
+			else
+				output_bar_from_item(M)
+				qdel(M)
 
 			sleep(smelt_interval)
 
@@ -890,7 +890,7 @@
 
 	proc/load_reclaim(obj/item/W as obj, mob/user as mob)
 		. = FALSE
-		if (istype(W,/obj/item/raw_material/) || istype(W,/obj/item/sheet/) || istype(W,/obj/item/rods/) || istype(W,/obj/item/tile/) || istype(W,/obj/item/cable_coil) || istype(W,/obj/item/wizard_crystal))
+		if ((W.material && !istype(W,/obj/item/material_piece)) || istype(W,/obj/item/wizard_crystal))
 			W.set_loc(src)
 			if (user) user.u_equip(W)
 			W.dropped()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title. Reclaimer now accepts things like honey, butts, and anything with a set material var. Including electroplated items probably, so you can get back the material piece you used to plate an item, if you made a mistake.

Lemme know if there are some potential balance issues I'm not aware of.

I removed a ton of checks because most of the items on the list of things reclaimer does accept (except wizard crystals) already have a set material var on default.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Seems like a good idea, people requested it a few times

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Portable reclaimer now accepts anything with a set material e.g. honey, butts, electroplated items.
```
