### PR TITLE
Renames honey, the material, to refined honey

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2,7 +2,10 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 	if(mat in material_category_names)
 		return material_category_names[mat]
 	else
-		return capitalize(mat)
+		var/datum/material/nice_mat = getMaterial(mat)
+		if (istype(nice_mat))
+			return capitalize(nice_mat.name)
+		return capitalize(mat) //if all else fails (also presumably not a valid material then)
 
 /datum/manufacture
 	var/name = null                // Name of the schematic

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -5,7 +5,7 @@ proc/get_nice_mat_name_for_manufacturers(mat)
 		var/datum/material/nice_mat = getMaterial(mat)
 		if (istype(nice_mat))
 			return capitalize(nice_mat.name)
-		return capitalize(mat) //if all else fails (also presumably not a valid material then)
+		return capitalize(mat) //if all else fails (probably a category instead of a material)
 
 /datum/manufacture
 	var/name = null                // Name of the schematic

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -1076,7 +1076,7 @@
 
 /datum/material/organic/honey
 	mat_id = "honey"
-	name = "honey"
+	name = "refined honey" //Look calling both the globs and the material just "honey" isn't helping people's confusion wrt making clone pods
 	desc = ""
 	color = "#f1da10"
 	material_flags = MATERIAL_ORGANIC


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Renames honey, the material, to refined honey.

Also had to expand a proc for manufacturers to try and retrieve a material's proper name, so that the tooltip displaying an item's requirements also says refined honey. I think this was technically wonky for any material, it's just that almost all of them have the same mat ID and name.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There's a lot of mentorhelps about getting honey into a manufacturer for clone pod production (presumably), which seems to mainly stem from the beepuke globs and the material having identical names. I don't think "refined honey" is a very elegant name, but hopefully it makes it clear what needs to be done to the globs.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Honey, the material, has been renamed to refined honey for all the cloning pod enthusiasts out there.
```
