### PR TITLE
Disables captain from rolling antag on both servers

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -156,9 +156,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	wages = PAY_EXECUTIVE
 	high_priority_job = 1
 	recieves_miranda = 1
-#ifdef RP_MODE
 	allow_traitors = 0
-#endif
 	cant_spawn_as_rev = 1
 	announce_on_join = 1
 	allow_spy_theft = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
## About the PR <!-- [FEEDBACK] Describe the Pull Request here. What does it change? What other things could this impact? -->

Reopenning as a seperate pr as per Emily's request, title.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The reasoning as to why I think this would be a good change is two reasons. One, credibility, this would help give captain a bit more credibility allowing them to guide the station better, (or at the very least make it more obvious to ahelp them.) Second, balance, captain has by far the most advantages of any job for antagging. 

To give a list of every advantage Cap has, immediate access to AA, great armor, a taser that can deal 45 damage, as consequence of AA easy access to sec gear. all comms access, massive security influence allowing them to get away with a lot more shit compared to other jobs (this allows captains to easily turn security into there own hit squad by giving false accusations), and being able to basically take advantage of any jobs strengths (ie being able to make chems, being able to get access to meds, etc) as consequence of AA. Needless to say, captain has a lot of advantages that allows them to very easily steamroll.  


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Captain is unable to roll antag on both servers.
```
