### PR TITLE
Initiates 20 round lock on both servers instead of just RP.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -174,9 +174,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	slot_ears = list(/obj/item/device/radio/headset/command/captain)
 	slot_poc1 = list(/obj/item/disk/data/floppy/read_only/authentication)
 	items_in_backpack = list(/obj/item/storage/box/id_kit,/obj/item/device/flash)
-#ifdef RP_MODE
 	rounds_needed_to_play = 20
-#endif
 
 	New()
 		..()


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr implements Roleplays 20 round lock for both servers.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This change is to give captain a bit more credibility by ensuring that they have at least some experience under there belt.  This should make captain a bit more capable of being a leader, or at the very least, try very hard and them not doing well. Also this would likely prevent a few ahelps as a nice side effect of this.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Captain now has a 20 round lock on both servers.
```
