### PR TITLE
Misc loot crate loot balancing.

### DIFF
--- a/code/modules/projectiles/laser.dm
+++ b/code/modules/projectiles/laser.dm
@@ -275,14 +275,11 @@ toxic - poisons
 	shot_sound = 'sound/weapons/snipershot.ogg'
 	dissipation_delay = 8
 	dissipation_rate = 5
-	cost = 50
+	cost = 25
 	power = 35
 	color_red = 0.4
 	color_green = 0.5
 	color_blue = 0.7
-
-/datum/projectile/laser/pred/cheap // For loot crate pred rifle
-	cost = 25
 
 // These are for custom antique laser guns repaired with high-quality components.
 // See displaycase.dm for details (Convair880).

--- a/code/modules/projectiles/laser.dm
+++ b/code/modules/projectiles/laser.dm
@@ -281,6 +281,9 @@ toxic - poisons
 	color_green = 0.5
 	color_blue = 0.7
 
+/datum/projectile/laser/pred/cheap // For loot crate pred rifle
+	cost = 25
+
 // These are for custom antique laser guns repaired with high-quality components.
 // See displaycase.dm for details (Convair880).
 /datum/projectile/laser/old

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1009,6 +1009,16 @@
 	charge = 300.0
 	max_charge = 300.0
 
+/obj/item/ammo/power_cell/higherish_power
+	name = "Power Cell - 400"
+	desc = "A power cell that holds a max of 400PU"
+	icon = 'icons/obj/items/ammo.dmi'
+	icon_state = "power_cell"
+	m_amt = 20000
+	g_amt = 40000
+	charge = 400.0
+	max_charge = 400.0
+
 /obj/item/ammo/power_cell/self_charging
 	name = "Power Cell - Atomic"
 	desc = "A self-contained radioisotope power cell that slowly recharges an internal capacitor. Holds 40PU."

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1098,12 +1098,19 @@
 
 /obj/item/ammo/power_cell/self_charging/medium
 	name = "Power Cell - Hicap RTG"
-	desc = "A self-contained radioisotope power cell that slowly recharges an internal capacitor. Holds 100PU."
+	desc = "A self-contained radioisotope power cell that slowly recharges an internal capacitor. Holds 200PU."
 	icon = 'icons/obj/items/ammo.dmi'
 	icon_state = "recharger_cell"
 	charge = 200
 	max_charge = 200
 	recharge_rate = 7.5
+
+/obj/item/ammo/power_cell/self_charging/mediumbig
+	name = "Power Cell - Fission"
+	desc = "Half the power of a Fusion model power cell with a tenth of the cost. Holds 200PU"
+	max_charge = 200
+	charge = 200
+	recharge_rate = 20
 
 /obj/item/ammo/power_cell/self_charging/big
 	name = "Power Cell - Fusion"

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1034,6 +1034,9 @@
 			src.icon_state = "bullpup[ratio]"
 			return
 
+/obj/item/gun/energy/laser_gun/pred/lowcharge
+	cell_type = /obj/item/ammo/power_cell/self_charging/pod_wars_standard// If the shoe fits, 50 charge per shot so only 6 shots, with 15 self recharge. Not bad at all.
+
 /obj/item/gun/energy/laser_gun/pred/vr
 	name = "advanced laser gun"
 	icon = 'icons/effects/VR.dmi'

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1035,7 +1035,9 @@
 			return
 
 /obj/item/gun/energy/laser_gun/pred/lowcharge
-	cell_type = /obj/item/ammo/power_cell/self_charging/pod_wars_standard// If the shoe fits, 50 charge per shot so only 6 shots, with 15 self recharge. Not bad at all.
+	name = "dusty laser rifle"
+	desc = "This model appears to cut costs of production severely by using a cheaper power cell."
+	cell_type = /obj/item/ammo/power_cell/self_charging/mediumbig // 4 shots but with 20 self recharge, same chance to get as phaser so it should be as strong as one, trading less shots for more damage and self recharge.
 
 /obj/item/gun/energy/laser_gun/pred/vr
 	name = "advanced laser gun"

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1016,7 +1016,7 @@
 	item_state = "bullpup"
 	uses_multiple_icon_states = 1
 	force = 5.0
-	cell_type = /obj/item/ammo/power_cell/self_charging/big
+	cell_type = /obj/item/ammo/power_cell/self_charging/mediumbig
 	muzzle_flash = "muzzle_flash_plaser"
 	mats = list("MET-3"=7, "CRY-1"=13, "POW-2"=10)
 
@@ -1033,17 +1033,6 @@
 			ratio = round(ratio, 0.25) * 100
 			src.icon_state = "bullpup[ratio]"
 			return
-
-/obj/item/gun/energy/laser_gun/pred/lowcharge
-	name = "shiny laser rifle"
-	desc = "This is a newer model of laser rifles focusing on power efficency. Thanks to this reduced cost of firing, a weaker and far cheaper battery can be used to get the same performance as older models at a lesser cost."
-	cell_type = /obj/item/ammo/power_cell/self_charging/mediumbig // Same performance as normal one due to halved laser cost.
-
-	New()
-		..()
-		set_current_projectile(new/datum/projectile/laser/pred/cheap)
-		projectiles = list(new/datum/projectile/laser/pred/cheap)
-
 
 /obj/item/gun/energy/laser_gun/pred/vr
 	name = "advanced laser gun"

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1035,9 +1035,15 @@
 			return
 
 /obj/item/gun/energy/laser_gun/pred/lowcharge
-	name = "dusty laser rifle"
-	desc = "This model appears to cut costs of production severely by using a cheaper power cell."
-	cell_type = /obj/item/ammo/power_cell/self_charging/mediumbig // 4 shots but with 20 self recharge, same chance to get as phaser so it should be as strong as one, trading less shots for more damage and self recharge.
+	name = "shiny laser rifle"
+	desc = "This is a newer model of laser rifles focusing on power efficency. Thanks to this reduced cost of firing, a weaker and far cheaper battery can be used to get the same performance as older models at a lesser cost."
+	cell_type = /obj/item/ammo/power_cell/self_charging/mediumbig // Same performance as normal one due to halved laser cost.
+
+	New()
+		..()
+		set_current_projectile(new/datum/projectile/laser/pred/cheap)
+		projectiles = list(new/datum/projectile/laser/pred/cheap)
+
 
 /obj/item/gun/energy/laser_gun/pred/vr
 	name = "advanced laser gun"

--- a/code/obj/item/space_cash.dm
+++ b/code/obj/item/space_cash.dm
@@ -140,6 +140,10 @@
 	default_min_amount = 1000
 	default_max_amount = 1000
 
+/obj/item/spacecash/hundredthousand
+	default_min_amount = 100000
+	default_max_amount = 100000
+
 /obj/item/spacecash/million
 	default_min_amount = 1000000
 	default_max_amount = 1000000

--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -40,7 +40,7 @@
 							items += /obj/item/clothing/gloves/psylink_bracelet
 							item_amounts += 1
 						if(2)
-							items += /obj/item/artifact/teleport_wand
+							items += pick(/obj/item/artifact/teleport_wand, /obj/item/artifact/activator_key, /obj/item/gun/energy/artifact, /obj/item/artifact/melee_weapon, /obj/item/artifact/forcewall_wand) // All of these are pretty useful and it heavily reduces chances of telewand.
 							item_amounts += 1
 						else
 							items += /obj/item/device/voltron
@@ -171,9 +171,9 @@
 							items += /obj/item/device/voltron
 							item_amounts += 1
 						if(2)
-							items += /obj/item/ammo/power_cell/self_charging/disruptor
+							items += /obj/item/ammo/power_cell/self_charging/pod_wars_standard
 							item_amounts += 1
-							items += /obj/item/ammo/power_cell/self_charging
+							items += /obj/item/ammo/power_cell/higherish_power // 400 pu charge, designed to be able to be a trade off of higher capacity at the cost of no self recharging, or vice versa.
 							item_amounts += 1
 						else
 							items += /obj/item/clothing/gloves/ring/titanium
@@ -182,7 +182,7 @@
 					picker = rand(1,10)
 					switch(picker)
 						if(1)
-							items += pick(/obj/item/gun/energy/teleport,/obj/item/gun/energy/laser_gun/pred)
+							items += pick(/obj/item/gun/energy/laser_gun/pred/lowcharge) // Just has different cell (standard pod wars cell) with 300 pu (50 pu per shot for this gun) and 15 self recharge.
 							item_amounts += 1
 						if(2 to 6)
 							items += /obj/item/gun/energy/phaser_gun
@@ -226,8 +226,8 @@
 							items += /obj/item/gun/bling_blaster
 							item_amounts += 1
 						else
-							items += /obj/item/spacecash/million
-							item_amounts += 1
+							items += /obj/item/spacecash/hundredthousand
+							item_amounts += 3
 				else if (tier == 2)
 					picker = rand(1,4)
 					switch(picker)

--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -182,7 +182,7 @@
 					picker = rand(1,10)
 					switch(picker)
 						if(1)
-							items += pick(/obj/item/gun/energy/laser_gun/pred/lowcharge) // Just has different cell (standard pod wars cell) with 300 pu (50 pu per shot for this gun) and 15 self recharge.
+							items += pick(/obj/item/gun/energy/laser_gun/pred)
 							item_amounts += 1
 						if(2 to 6)
 							items += /obj/item/gun/energy/phaser_gun


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr partially changes the rewards for several crates. For t3 science crates, instead of just a telewand, it will now roll between a telewand, artifact activator, artgun, meleeart, and a handheld forcefield art. This should reduce the chance of a telewand from crates greatly. This pr swaps the atomic cell and the disruptor cell with the standard pod wars cell (300 pu 15 self recharge) and a 400 pu cell. Disruptor cell and atomic cell are pretty useless for most weapons, it doesnt make sense for these to be from a t3 crate. The telegun has been removed from tier 2 military crates, and the predator rifle from tier 2 military crates now come with a fission cell (200 pu 20 self recharge), and has half the fire cost. The one million credits from crates have been swapped with three stacks of one hundred thousand credits.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

**Voltron is pretty bad in regard of crates, its just Id need to add a lot more content to justify removing them from crates right now. So uhh yeah thats why this pr doesnt do that before that gets brought up.**

Most of this pr is to simply nerf the usefulness of loot crates. A 7 traitor credit weapon being crew accessible is pretty bad, hence telegun removal. Laser rifle was a mainstay of predator, biggest strength is its very high self recharge. In the context of loot crates this makes it basically a better phaser with less shots but with self recharge and more expensive. Telewands are very powerful, them being less common is good. The atomic cells and disruptor cells were basically useless, especially considering this is supposed to be a tier 3 drop. Economy is shifting away slowly from low effort get rich quick shit to now its a lot harder to get rich, the three hundred credits instead of one million should accompany itself nicely with this trend.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Loot crates contents have undergone some balance changes, check minor changes for more details.
(*)Predator rifles now come with half the charge and half the self recharge rate, but with half the firing costs.
(+) Crates will now pull from a pool of handheld arts instead of just telewands. Telegun has been completely removed from loot crates. The atomic cell and disruptor cell have been replaced with better cells. The one million crates from loot crates has been replaced with three hundred thousand credits.
```
