### PR TITLE
Adds a new miner crew objective 

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -314,6 +314,20 @@ ABSTRACT_TYPE(/datum/objective/crew/miner)
 				suitcount++
 			if(suitcount > 2) return 1
 			else return 0
+	forsale
+		explanation_text = "Have at least five different ores available for purchase from the Rockbox at the end of the round."
+		check_completion()
+			var/orecount = 0
+			for_by_tcl(S, /obj/machinery/ore_cloud_storage_container)
+				if(S.broken)
+					continue
+				var/list/ores = S.ores
+				for(var/ore in ores)
+					var/datum/ore_cloud_data/OCD = ores[ore]
+					if(OCD.for_sale && OCD.amount)
+						orecount++
+			return orecount >= 5
+
 
 ABSTRACT_TYPE(/datum/objective/crew/mechanic)
 /datum/objective/crew/mechanic


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new miner crew objective. "Have at least five different ores available for purchase from the Rockbox at the end of the round."

I'm happy to change the number required if someone has a better suggestion. Five keeps the task easy. I think moving it up as high as ten would be reasonable to make the objective more difficult.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the miner only has one crew objective, make 3 suits of industrial armor. It would be nice to have some variability there. This would also hopefully encourage miners to put some ores up for sale so there could be some more inter-department cooperation


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Added a new crew objective for miners
```
