### PR TITLE
Makes power monitors check powernet for null

### DIFF
--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -23,7 +23,8 @@
 
 /obj/machinery/computer/power_monitor/ui_static_data(mob/user)
 	var/datum/powernet/powernet = src.get_direct_powernet()
-
+	if (!istype(powernet))
+		return
 	. = list(
 		"type" = "apc",
 		"apcNames" = list(),
@@ -42,7 +43,8 @@
 
 /obj/machinery/computer/power_monitor/ui_data(mob/user)
 	var/datum/powernet/powernet = src.get_direct_powernet()
-
+	if (!istype(powernet))
+		return
 	. = list(
 		"available" = powernet.avail,
 		"load" = powernet.viewload,
@@ -116,6 +118,8 @@
 
 	var/list/L = list()
 	var/datum/powernet/powernet = src.get_direct_powernet()
+	if (!istype(powernet))
+		return
 	for(var/obj/machinery/power/terminal/term in powernet.nodes)
 		if(istype(term.master, /obj/machinery/power/smes))
 			var/obj/machinery/power/smes/A = term.master
@@ -133,7 +137,8 @@
 
 /obj/machinery/computer/power_monitor/smes/ui_data(mob/user)
 	var/datum/powernet/powernet = src.get_direct_powernet()
-
+	if (!istype(powernet))
+		return
 	. = list(
 		"available" = powernet.avail,
 		"load" = powernet.viewload,

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -82,7 +82,8 @@
 
 /obj/machinery/computer/power_monitor/proc/add_history()
 	var/datum/powernet/powernet = src.get_direct_powernet()
-
+	if (!istype(powernet))
+		return
 	src.history += list(list(
 		powernet.avail,
 		powernet.viewload,

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -52,7 +52,8 @@
 		// currently, just update all controllers in world
 		// ***TODO: better communication system using network
 		var/datum/powernet/powernet = src.get_direct_powernet()
-
+		if (!istype(powernet))
+			return
 		for (var/obj/machinery/computer/solar_control/C in powernet.nodes)
 			if (!isnull(src.id) && src.id == C.solar_id)
 				C.tracker_update(angle)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Basically searched for `get_direct_powernet` and put in null checks where appropriate, since that's a thing it can return.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Noticed that the power monitor comp was runtiming every process if you cut its wire(s), and then found that monitors never check for null anywhere so i guess you could make em runtime a lot if you wanted

(Also the solar tracker case that showed up in my search.)