### PR TITLE
add recovery tapes for artlab/buddies to rd locker on donut3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -70827,6 +70827,8 @@
 /obj/item/reagent_containers/hypospray,
 /obj/item/remote/porter/port_a_sci,
 /obj/machinery/light/incandescent/netural,
+/obj/item/disk/data/tape/artifact_research,
+/obj/item/disk/data/tape/master,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "uEg" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds tapes with the files for prman/gptio to the RD locker, since it didn't seem like there were any recovery tapes for that on the map.

If that makes the RD locker too cluttered, I am open to suggestions for where else to stick them!
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Kinda sucks when a random person deletes gptio at the start of the round and then you can't use the artlab machines properly for the rest of the round.
