### PR TITLE
Makes AI firelock control dependent on airlock, also silicon hacked door QOL

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1305,7 +1305,7 @@ About the new airlock wires panel:
 		if(world.time - src.last_bump <= 30)
 			return
 
-		if (issilicon(AM) && (aiControlDisabled > 0 || cant_emag))
+		if (issilicon(AM) && (aiControlDisabled == 1 || cant_emag))
 			return
 
 		src.last_bump = world.time
@@ -1334,7 +1334,7 @@ About the new airlock wires panel:
 			if (src.shock(user, 100))
 				interact_particle(user,src)
 				return
-	else if (aiControlDisabled > 0 || cant_emag)
+	else if (aiControlDisabled == 1 || cant_emag)
 		return
 
 	if (ishuman(user) && src.density && src.brainloss_stumble && src.do_brainstumble(user) == 1)
@@ -1801,7 +1801,7 @@ obj/machinery/door/airlock
 	if (!isAI(user) && !issilicon(user))
 		return
 
-	if (src.aiControlDisabled) return
+	if (src.aiControlDisabled == 1) return
 
 	if (user.client.check_key(KEY_OPEN) && user.client.check_key(KEY_BOLT))
 		. = 1

--- a/code/obj/machinery/door/firedoor.dm
+++ b/code/obj/machinery/door/firedoor.dm
@@ -160,6 +160,9 @@
 
 
 /obj/machinery/door/firedoor/attack_ai(mob/user as mob)
+	var/obj/machinery/door/airlock/mydoor = locate(/obj/machinery/door/airlock) in src.loc
+	if(mydoor?.aiControlDisabled == 1)
+		return
 	if(!blocked && !operating)
 		if(density)
 			set_open()

--- a/code/obj/machinery/door/firedoor.dm
+++ b/code/obj/machinery/door/firedoor.dm
@@ -162,6 +162,7 @@
 /obj/machinery/door/firedoor/attack_ai(mob/user as mob)
 	var/obj/machinery/door/airlock/mydoor = locate(/obj/machinery/door/airlock) in src.loc
 	if(mydoor?.aiControlDisabled == 1)
+		boutput(user, "<span class='notice'>You cannot control this firelock because its associated airlock's AI control is disabled!</span>")
 		return
 	if(!blocked && !operating)
 		if(density)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes silicons unable to toggle firedoors the airlock they're on has its AI control wire disabled. (suggestion courtesy of NOOT - https://forum.ss13.co/showthread.php?tid=8020&pid=170469#pid170469)

Changes some checks to more specifically only block silicons when AI control is disabled and the door isn't hacked, so that silicons can hotkey/bump AI-control-hacked doors open again (otherwise they need to use the UI).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
NOOT's thing seemed pretty sensible to me, and the hacking thing is a personal annoyance with hacking doors. Seems to me that if you've hacked into a door's controls they should be available as normal.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Batelite
(+)Silicons no longer have control over the firelocks of airlocks with disabled AI control.
```
