### PR TITLE
Prevents AIs from deploying to qdel'd shells

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2888,6 +2888,11 @@
 	get_valid_target_zones()
 		return list("head", "chest", "l_leg", "r_leg", "l_arm", "r_arm")
 
+	disposing()
+		if (src.shell)
+			available_ai_shells -= src
+		..()
+
 	proc/compborg_lose_limb(var/obj/item/parts/robot_parts/part)
 		if(!part) return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently AIs can deploy to those, causing Mob Panic.
Notably DOESN'T fix the issue where an AI core being deleted (not killed, deleted) while the AI is deployed causes a similar thing on the core. I'll get to that soon.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug. Confusing for AIs, leads to half-baked mobs coming back into existence.