### PR TITLE
Adds a singular deconstuction device to mechanics reconstruction kits from QM

### DIFF
--- a/code/datums/supply_packs.dm
+++ b/code/datums/supply_packs.dm
@@ -1353,7 +1353,8 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	desc = "1x Ruckingenur frame, 1x Manufacturer frame, 1x reclaimer frame, 1x device analyzer, 1x soldering iron"
 	category = "Engineering Department"
 	contains = list(/obj/item/electronics/scanner,
-					/obj/item/electronics/soldering)
+					/obj/item/electronics/soldering,
+					/obj/item/deconstructor)
 	frames = list(/obj/machinery/rkit,
 					/obj/machinery/manufacturer/mechanic,
 					/obj/machinery/portable_reclaimer)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Decon devices are non-renewable, meaning if you run out... you're out. They're a powerful weapon, but considering the whole kit is 35K, I don't see people ordering this as a shank when security crates are much more enticing.

Mostly adding because of a case during a VERY long round where we just... ran out of decon devices and had no way to get more. Also just useful for general construction, which you'll likely be doing with this crate.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)aloe
(+)Mechanics Reconstruction Kits from QM now include one deconstruction device.
```
