### PR TITLE
Gives the spy thief an Orion on spawn

### DIFF
--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -182,6 +182,16 @@
 		var/obj/F2 = new /obj/item/camera/spy(get_turf(traitor_mob))
 		traitor_mob.put_in_hand_or_drop(F2)
 
+	if (!traitor_mob.r_store)
+		traitor_mob.equip_if_possible(new /obj/item/gun/kinetic/silenced_22(traitor_mob), traitor_mob.slot_r_store)
+	else if (!traitor_mob.l_store)
+		traitor_mob.equip_if_possible(new /obj/item/gun/kinetic/silenced_22(traitor_mob), traitor_mob.slot_l_store)
+	else if (istype(traitor_mob.back, /obj/item/storage/) && traitor_mob.back.contents.len < 7)
+		traitor_mob.equip_if_possible(new /obj/item/gun/kinetic/silenced_22(traitor_mob), traitor_mob.slot_in_backpack)
+	else
+		var/obj/F3 = new /obj/item/gun/kinetic/silenced_22(get_turf(traitor_mob))
+		traitor_mob.put_in_hand_or_drop(F3)
+
 	var/pda_pass = null
 
 	//find a PDA, hide the uplink inside


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an Orion Silenced Pistol to a Spy Thief's inventory at the start of a round. 



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some folks from the discord a while back were talking about how they felt it was sad that spy thief's could be beaten easily with just your fists. From what I gathered, they would prefer spy thief to have a bit more help in the murder department at round start to make it more viable to attack people for bounties - such limbs. The idea of letting the them start with a gun was thrown around, and the Orion seems thematic. 

Might be a bit too imbalanced?Perhaps another gun or weapon would be more appropriate? 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)HauntedAngel
(+)Spy thief now starts with an Orion Silenced Pistol, just like a real spy!
```
