### PR TITLE
Puts CW overalls in engineers clothing boxes

### DIFF
--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -196,7 +196,8 @@
 	spawn_contents = list(/obj/item/clothing/under/rank/engineer,\
 	/obj/item/clothing/shoes/orange,\
 	/obj/item/device/radio/headset/engineer,\
-	/obj/item/device/pda2/engine)
+	/obj/item/device/pda2/engine,\
+	/obj/item/clothing/under/rank/orangeoveralls)
 
 /obj/item/storage/box/clothing/miner
 	name = "\improper Miner's equipment"

--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -189,7 +189,8 @@
 	spawn_contents = list(/obj/item/clothing/under/rank/mechanic,\
 	/obj/item/clothing/shoes/black,\
 	/obj/item/device/radio/headset/engineer,\
-	/obj/item/device/pda2/mechanic)
+	/obj/item/device/pda2/mechanic,\
+	/obj/item/clothing/under/rank/orangeoveralls/yellow)
 
 /obj/item/storage/box/clothing/engineer
 	name = "\improper Engineer's equipment"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol] I guess?
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As title

IDK what we'd do if the construction worker ever returns (I'd hope so), but I don't think anyone has short term plans on that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've wanted an engineering jumpsuit that's not all yellow, and this looks pretty much like serious work clothing.
Also I'm not making cargo pay 8k for the thing

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Engineers now have access to the construction worker's overalls from their lockers.
```
