### PR TITLE
Minor nuke text clarification

### DIFF
--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -93,7 +93,7 @@
 					. += "The authenticaion disk has been inserted."
 
 			if (!src.anchored)
-				. += "The floor bolts have been unsecured. The bomb can be moved around."
+				. += "The floor bolts are unsecured. The bomb can be moved around."
 			else
 				. += "It is firmly anchored to the floor by its floor bolts."
 

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -93,7 +93,7 @@
 					. += "The authenticaion disk has been inserted."
 
 			if (!src.anchored)
-				. += "The floor bolts are unsecured. The bomb can be moved around."
+				. += "The floor bolts are unsecure. The bomb can be moved around."
 			else
 				. += "It is firmly anchored to the floor by its floor bolts."
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Minor changes to text when looking at an unanchored nuke.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The previous text made it seem like the nuke could be/was unanchored, when this is no longer possible.

