### PR TITLE
Reduces default manta auxilarry smes output to reduce singularity looses.

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -7176,7 +7176,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/power/smes{
-	name = "emitter auxiliary power storage unit"
+	name = "emitter auxiliary power storage unit";
+	output = 25000
 	},
 /obj/cable,
 /obj/cable{


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
So uhh, for some preface, when smes's output is equal to input, they wont actually charge. The way it is now the output and input for the aux are equal, meaning the aux wont charge by default. This should have the singularity grid be powered as long as engineers set up power, with no need for them to tinker with the auxilary smes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Manta is plagued with constant singulooses and I think this'll help prevent that.
