### PR TITLE
Destiny Fire Door Fix: Food and Drinks Edition

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -4939,6 +4939,7 @@
 	name = "Kitchen"
 	},
 /obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/kitchen)
 "atv" = (
@@ -5973,7 +5974,6 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
 "axG" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/window/reinforced/north,
 /obj/machinery/door/window/eastleft{
@@ -6172,7 +6172,6 @@
 /turf/simulated/floor,
 /area/station/medical/medbay/lobby)
 "ayu" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/table/reinforced/auto,
 /obj/window/reinforced/south,
 /obj/machinery/door/window/eastright{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes fire doors at the bar's windows being misturned, and adds a missing fire door spawner at the kitchen.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes some misturned fire doors, and adds a missing one.

