### PR TITLE
Fixes the end-round crew survival rate percentage

### DIFF
--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -77,7 +77,7 @@ var/datum/score_tracker/score_tracker
 		else
 			score_enemy_failure_rate = get_percentage_of_fraction_and_whole(traitor_objectives_failed,traitor_objectives)
 
-		score_crew_survival_rate = get_percentage_of_fraction_and_whole(fatalities,crew_count)
+		score_crew_survival_rate = 100 - get_percentage_of_fraction_and_whole(fatalities,crew_count)
 
 		score_crew_survival_rate = clamp(score_crew_survival_rate,0,100)
 		score_enemy_failure_rate = clamp(score_enemy_failure_rate,0,100)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
it was tracking the fatality rate. Just subtract from 100 and we should be fine.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
wrong numbers bad
