### PR TITLE
Reduces Access of Discount Superheroes

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2125,7 +2125,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween)
 
 	New()
 		..()
-		src.access = get_access("Security Officer")
+		src.access = get_access("Security Assistant")
 		return
 
 	special_setup(var/mob/living/carbon/human/M)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL] [Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR reduces the access of Discount Superheroes from Security Officer to Security Assistant.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's extremely annoying to the rest of security when a Discount Superhero runs in, unlocks the lockers, distributes sec gear, uses their lethal abilities to detain people, etc.

Also, on RP, they are even worse since they have near-AA due to the increased amount of access officers have.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Discount Superheroes have their access reduced to Security Assistant.
```
