### PR TITLE
adjust regex for mhelp urls

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -534,7 +534,7 @@ var/f_color_selector_handler/F_Color_Selector
 			Ar.build_sims_score()
 
 	url_regex = new("(https?|byond|www)(\\.|:\\/\\/)", "i")
-	full_url_regex = new(@"(https?:\/\/)?((www\.)?[\d\l\.]+\.[\d\l]+(\/\S+)*\/?)","ig")
+	full_url_regex = new(@"(https?:\/\/)?((www\.)?([-\d\l]+\.)+[\d\l]+(\/\S+)*\/?)","ig")
 
 	UPDATE_TITLE_STATUS("Updating status")
 	Z_LOG_DEBUG("World/Init", "Updating status...")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so the middle part of the url (www.THISPART.com) needs at least one symbol between dots.
Also allows dashes in this part as well.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Apparently people really like to start their sentences with ellipses, and "..a" does not turn into a great link.
And some websites use dashes in their domain names, I guess.
