### PR TITLE
Fix asylum shuttle transitions when terrainified

### DIFF
--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -396,9 +396,6 @@
 		var/list/turf/turfs_to_fix = get_area_turfs(start_location)
 		if(length(turfs_to_fix))
 			station_repair.repair_turfs(turfs_to_fix)
-		turfs_to_fix = get_area_turfs(end_location)
-		if(length(turfs_to_fix))
-			station_repair.repair_turfs(turfs_to_fix)
 
 	for(var/obj/machinery/computer/prison_shuttle/C in machine_registry[MACHINES_SHUTTLECOMPS])
 		active = 0
@@ -491,9 +488,6 @@
 
 	if(station_repair.station_generator)
 		var/list/turf/turfs_to_fix = get_area_turfs(start_location)
-		if(length(turfs_to_fix))
-			station_repair.repair_turfs(turfs_to_fix)
-		turfs_to_fix = get_area_turfs(end_location)
 		if(length(turfs_to_fix))
 			station_repair.repair_turfs(turfs_to_fix)
 
@@ -600,9 +594,6 @@
 
 			if(station_repair.station_generator)
 				var/list/turf/turfs_to_fix = get_area_turfs(start_location)
-				if(length(turfs_to_fix))
-					station_repair.repair_turfs(turfs_to_fix)
-				turfs_to_fix = get_area_turfs(end_location)
 				if(length(turfs_to_fix))
 					station_repair.repair_turfs(turfs_to_fix)
 

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -363,15 +363,17 @@
 	//Prison -> Station -> Outpost -> Prison.
 	//Skip outpost if there's a lockdown there.
 	//drsingh took outpost out for cogmap prison shuttle
+	var/area/start_location
+	var/area/end_location
 	switch(brigshuttle_location)
 		if(0)
-			var/area/start_location = locate(/area/shuttle/brig/prison)
-			var/area/end_location = locate(/area/shuttle/brig/station)
+			start_location = locate(/area/shuttle/brig/prison)
+			end_location = locate(/area/shuttle/brig/station)
 			start_location.move_contents_to(end_location)
 			brigshuttle_location = 1
 		if(1)
-			var/area/start_location = locate(/area/shuttle/brig/station)
-			var/area/end_location = null
+			start_location = locate(/area/shuttle/brig/station)
+			end_location = null
 			//if(researchshuttle_lockdown)
 			end_location = locate(/area/shuttle/brig/prison)
 			//else
@@ -389,6 +391,14 @@
 			start_location.move_contents_to(end_location)
 			brigshuttle_location = 0
 		*/
+
+	if(station_repair.station_generator)
+		var/list/turf/turfs_to_fix = get_area_turfs(start_location)
+		if(length(turfs_to_fix))
+			station_repair.repair_turfs(turfs_to_fix)
+		turfs_to_fix = get_area_turfs(end_location)
+		if(length(turfs_to_fix))
+			station_repair.repair_turfs(turfs_to_fix)
 
 	for(var/obj/machinery/computer/prison_shuttle/C in machine_registry[MACHINES_SHUTTLECOMPS])
 		active = 0
@@ -587,6 +597,14 @@
 					qdel(S)
 
 			start_location.move_contents_to(end_location)
+
+			if(station_repair.station_generator)
+				var/list/turf/turfs_to_fix = get_area_turfs(start_location)
+				if(length(turfs_to_fix))
+					station_repair.repair_turfs(turfs_to_fix)
+				turfs_to_fix = get_area_turfs(end_location)
+				if(length(turfs_to_fix))
+					station_repair.repair_turfs(turfs_to_fix)
 
 			for(var/obj/machinery/computer/asylum_shuttle/C in machine_registry[MACHINES_SHUTTLECOMPS])
 				C.active = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Repair space turfs left as a result of shuttle `move_contents_to`.  

For some reason I was repairing source AND destination turfs for shuttles for maps that are not supported.... fixed those because they caused me to propagate copy-paste errors when fixing this.  And it may be a happy surprise of working properly if anyone re-uses those shuttles. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Facilitate fun for admins and thereby fun for players.
![image](https://user-images.githubusercontent.com/1017374/135794629-0f33c675-5d16-4727-a7b2-f02e8e3bb8a2.png)
