### PR TITLE
Allows hiding of spy camera in clothing

### DIFF
--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -933,6 +933,16 @@
 				m_type = 1
 
 			if ("raisehand")
+				for (var/obj/item/C as anything in src.get_equipped_items())
+					if ((locate(/obj/item/camera/spy) in C) != null)
+						var/obj/item/camera/spy/D = (locate(/obj/item/camera/spy) in C)
+						var/drophand = (src.hand == 0 ? slot_r_hand : slot_l_hand)
+						drop_item()
+						D.set_loc(src)
+						equip_if_possible(D, drophand)
+						src.visible_message("<span class='alert'><B>[src] pulls a camera out of \the [C]!</B></span>")
+						playsound(src.loc, "rustle", 60, 1)
+						break
 				if (!src.restrained())
 					message = "<B>[src]</B> raises a hand."
 					maptext_out = "<I>raises a hand</I>"

--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -160,7 +160,7 @@
 	if (istype(target, /obj))
 		var/obj/O = target
 		if (O.loc == user && O != src && istype(O, /obj/item/clothing))
-			boutput(user, "<span class='hint'>You hide the camera inside \the [O]. (Use the wink emote while wearing the clothing item to retrieve it.)</span>")
+			boutput(user, "<span class='hint'>You hide the camera inside \the [O]. (Use the raisehand emote while wearing the clothing item to retrieve it.)</span>")
 			user.u_equip(src)
 			src.set_loc(O)
 			src.dropped(user)

--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -156,7 +156,14 @@
 	else
 		. = ..()
 
-/obj/item/camera/spy/afterattack(atom/target, mob/user, flag)
+/obj/item/camera/spy/afterattack(atom/target, mob/user as mob, flag)
+	if (istype(target, /obj))
+		var/obj/O = target
+		if (O.loc == user && O != src && istype(O, /obj/item/clothing))
+			boutput(user, "<span class='hint'>You hide the camera inside \the [O]. (Use the wink emote while wearing the clothing item to retrieve it.)</span>")
+			user.u_equip(src)
+			src.set_loc(O)
+			src.dropped(user)
 	if (!can_use || ismob(target.loc))
 		return
 	if (src.flash_mode)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BALANCE] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->Makes it so that the spy camera can be hidden in clothing like the derringer and omnitool. Use the Raisehand emote (Ctrl + H) to take it out.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
An idea from the forums to help spy be less obvious in general, and make them more sneaky. Can also help spies who may get caught and have their camera taken away by sec. Helps ensure that you're not locked out of a good chunk of your bounties in that instance.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)HauntedAngel
(+)Spy camera can now be hidden in clothing. Use the Handraise emote to retrieve it.
```
