### PR TITLE
Removes cast time on prismatic spray

### DIFF
--- a/code/datums/abilities/wizard/prismatic_spray.dm
+++ b/code/datums/abilities/wizard/prismatic_spray.dm
@@ -41,10 +41,7 @@
 			if(!istype(get_area(holder.owner), /area/sim/gunsim))
 				holder.owner.say("PROJEHK TUL IHNFERNUS") //incantation credit to Grifflez
 			//var/mob/living/carbon/human/O = holder.owner
-			if(!istype(src, /datum/targetable/spell/prismatic_spray/admin))
-				if( !do_after( holder.owner, 12 ) )
-					boutput( holder.owner, "<b>You need to stand still to channel your spell!</b>" )
-					return 1
+
 			// Put voice stuff here in the future
 			if(src.random == 0)
 				for(var/i=0, i<num_projectiles, i++)


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[FEATURE] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the cast time from prismatic spray, allowing wizards to cast it on the move. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->Since the nerf to prismatic spray that reduced its chance to hit people who are prone on the ground, the spell has been incredibly weak for two reasons. 

1: You have to stand still for a couple of seconds to cast it. This is rough due to the fact that standing still on wizard is the last thing you want to do. In addition, having to stand still makes it much more difficult for it to be effective as a crowd control spell. 

2: It has a spell cost of two. In it's current state, It would be difficult to justify taking it over other spells even if it costed one instead of two. 

Thus, I think a buff of some sort is necessary. I think removing the cast time and enabling you to cast it while on the run will make it a more desirable spell in general so that it justifies the two-point spell cost. 

Any thoughts on this? Perhaps other ways the spell could be buffed/adjusted?



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)HauntedAngel
(+)Removes cast time from the prismatic spray spell, allowing you to cast it while on the go. 
```
