### PR TITLE
Shows LOOC text overhead

### DIFF
--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -657,6 +657,7 @@
 			continue
 
 		var looc_class = ""
+		var looc_style = ""
 		var display_name = src.key
 
 		if (src.client.stealth || src.client.alt_key)
@@ -668,10 +669,13 @@
 		if (src.client.holder && (!src.client.stealth || C.holder))
 			if (src.client.holder.level == LEVEL_BABBY)
 				looc_class = "gfartlooc"
+				looc_style = "color: #4cb7db;"
 			else
 				looc_class = "adminlooc"
+				looc_style = "color: #cd6c4c;"
 		else if (src.client.is_mentor() && !src.client.stealth)
 			looc_class = "mentorlooc"
+			looc_style = "color: #a24cff;"
 
 		var/rendered = "<span class=\"looc [looc_class]\"><span class=\"prefix\">LOOC:</span> <span class=\"name\" data-ctx='\ref[src.mind]'>[display_name]:</span> <span class=\"message\">[msg]</span></span>"
 
@@ -679,6 +683,16 @@
 			rendered = "<span class='adminHearing' data-ctx='[C.chatOutput.getContextFlags()]'>[rendered]</span>"
 
 		boutput(C, rendered)
+		var/mob/M = C.mob
+		if(speechpopups && M.chat_text && !C.preferences?.flying_chat_hidden)
+			var/image/chat_maptext/looc_text = null
+			looc_text = make_chat_maptext(src, "\[LOOC] [msg]", looc_style)
+			if(looc_text)
+				looc_text.measure(C)
+				for(var/image/chat_maptext/I in M.chat_text.lines)
+					if(I != looc_text)
+						I.bump_up(looc_text.measured_height)
+				looc_text.show_to(C)
 
 	logTheThing("ooc", src, null, "LOOC: [msg]")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When typing in LOOC, the text is displayed over the speaker's head prefixed with [LOOC]. Admins have orange text, mentors have purple text, and other players have blue text. The choice for text color follows the same rules as those already existing for coloring the text in the side-bar.

The overhead text can be disabled by the client with the same toggle flying text option and it can be disabled globally by an admin with toggle global flying text. The overhead text also follows the user preferences to see or hide LOOC text.

Normal LOOC
![normaltext](https://user-images.githubusercontent.com/22460970/135922426-bbbb2f39-390a-4a7f-8635-db0832c937dd.PNG)
Mentor LOOC
![mentortext](https://user-images.githubusercontent.com/22460970/135922435-e0d4385b-8211-4991-a7a8-72e582219199.PNG)
Admin LOOC
![admintext](https://user-images.githubusercontent.com/22460970/135922507-d6eeeb3e-6f56-4dfa-9f92-189145443fdd.PNG)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
New players often do not check the scrolling text and can miss LOOC comments. Helping new players is one of the major uses of LOOC on the RP servers. This change will help make LOOC advice more visible.

This will also help players identify who is talking as LOOC is identified by a ckey rather than by player name. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)112358sam
(+)Made LOOC text visible over the head of the speaker.
```
