### PR TITLE
Destiny Medbay/Science Access Fix

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -17831,6 +17831,7 @@
 	name = "Test Chamber"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/chemistry,
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "bMy" = (
@@ -22606,6 +22607,7 @@
 	req_access_txt = null
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor/stairs{
 	dir = 4;
 	icon_state = "medstairs_alone"
@@ -39047,6 +39049,7 @@
 	name = "Guardbot Depot"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "mFb" = (
@@ -48526,6 +48529,7 @@
 	name = "Chemistry"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/chemistry,
 /turf/simulated/floor/purple,
 /area/station/science/chemistry)
 "rRk" = (
@@ -49905,6 +49909,7 @@
 	name = "Guardbot Depot"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor,
 /area/station/science/bot_storage)
 "sJu" = (
@@ -52726,6 +52731,7 @@
 	name = "Research"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor/sanitary,
 /area/station/science/restroom)
 "uhv" = (
@@ -54863,6 +54869,7 @@
 	req_access_txt = null
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/research,
 /turf/simulated/floor/black,
 /area/station/science/teleporter)
 "vgb" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -4889,7 +4889,6 @@
 	name = "Medbay"
 	},
 /obj/firedoor_spawn,
-/obj/access_spawn/medical,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "atc" = (
@@ -7926,6 +7925,7 @@
 	name = "Medbay"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -38896,7 +38896,6 @@
 	name = "Medbay"
 	},
 /obj/firedoor_spawn,
-/obj/access_spawn/medical,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/lobby)
 "mAO" = (
@@ -52292,6 +52291,7 @@
 	name = "Medbay"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/medical,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds multiple access spawners on Destiny to doors in science. Also removes medical access spawners from the medbay lobby entrance and puts them onto the entrance to the medbay treatment center.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Multiple doors were missing access spawners, resulting in a fair amount of science being public access, especially telesci. Medbay changes were done under the request of the person with yellow symbols for a name in Discord.

## Changelog

```changelog
(u)Wisemonster
(+)Destiny's science department no longer has as many public access doors.
(+)Destiny's Medbay lobby is now accessible to the public.
```