### PR TITLE
fix // rotates artlab intercom on manta

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -31973,7 +31973,9 @@
 /area/station/science/artifact)
 "bKV" = (
 /obj/landmark/artifact,
-/obj/item/device/radio/intercom/science,
+/obj/item/device/radio/intercom/science{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/science/artifact)
 "bKW" = (


### PR DESCRIPTION
## About the PR 
rotates artlab intercom on manta


## Why's this needed? 
intercom was floating ominously over your shoulder when you were at the terminal