### PR TITLE
Nukeman Nuke Self-Destruct Announcement

### DIFF
--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1280,10 +1280,15 @@
 						if(T)
 							admessage += "<b> ([T.x],[T.y],[T.z])</b>"
 						message_admins(admessage)
-						//World announcement.
-						boutput(world, "<span class='alert'><b>Alert: Self-Destruct Sequence has been engaged.</b></span>")
-						boutput(world, "<span class='alert'><b>Detonation in T-[src.time] seconds!</b></span>")
-						return
+							//World announcement.
+						if(station_or_ship() == "ship")
+							command_alert("The ship's self-destruct sequence has been activated, please evacuate the ship or abort the sequence as soon as possible. Detonation in T-[src.time] seconds", "Self-Destruct Activated")
+							playsound_global(world, 'sound/machines/engine_alert2.ogg', 40)
+							return
+						if(station_or_ship() == "station")
+							command_alert("The station's self-destruct sequence has been activated, please evacuate the station or abort the sequence as soon as possible. Detonation in T-[src.time] seconds", "Self-Destruct Activated")
+							playsound_global(world, 'sound/machines/engine_alert2.ogg', 40)
+							return
 					if("deact")
 						if(data["auth"] != netpass_heads)
 							src.post_status(target,"command","term_message","data","command=status&status=badauth&session=[sessionid]")

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -392,7 +392,7 @@
 	var/turf/T = get_turf(src)
 
 	var/datum/artifact/A = src.artifact
-	if(!istype(A))
+	if(!istype(A) || !A.artitype)
 		return
 
 	// Possible stimuli = force, elec, radiate, heat


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a station announcement and sound effect for activating on-station self-destruct nukes (AKA, the nukes activated through the nukeman program)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, the announcement for the on-station self-destruct being activated is only a some red text on the side thats about the size of normal chat. Considering can bombs and art bombs get an announcement despite doing the same, if not less damage than the on-station nuke, this change aims to make it on par with the two previous bombs in terms of importance and notability.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Activation of on-station self-destruction devices (AKA, nukes activated through the nukeman program) will now be followed by a more noticeable announcement
```
