### PR TITLE
Nukeman Nuke Announcement

### DIFF
--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1281,9 +1281,14 @@
 							admessage += "<b> ([T.x],[T.y],[T.z])</b>"
 						message_admins(admessage)
 						//World announcement.
-						boutput(world, "<span class='alert'><b>Alert: Self-Destruct Sequence has been engaged.</b></span>")
-						boutput(world, "<span class='alert'><b>Detonation in T-[src.time] seconds!</b></span>")
-						return
+						if(station_or_ship() == "ship")
+							command_alert("The ship's self-destruct sequence has been activated, please evacuate the ship or abort the sequence as soon as possible. Detonation in T-[src.time] seconds", "Self-Destruct Activated")
+							playsound_global(world, 'sound/machines/engine_alert2.ogg', 40)
+							return
+						if(station_or_ship() == "station")
+							command_alert("The station's self-destruct sequence has been activated, please evacuate the station or abort the sequence as soon as possible. Detonation in T-[src.time] seconds", "Self-Destruct Activated")
+							playsound_global(world, 'sound/machines/engine_alert2.ogg', 40)
+							return
 					if("deact")
 						if(data["auth"] != netpass_heads)
 							src.post_status(target,"command","term_message","data","command=status&status=badauth&session=[sessionid]")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an announcement to the on-station self-destruction device (AKA, the nuclear charge activated through the nukeman program) with a sound effect.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, activating the station self-destruct nuke gives an announcement about the size of normal chat. Due to can bombs and art bombs having their own announcements, despite causing the same, if not less damage, this change aims to make the self-destruct nuke on par with them in terms of visibility, announcement wise.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)On-board self-destruction devices (AKA, nukes activated through the nukeman program) will now have a more noticeable announcement when activated.
```
