### PR TITLE
Chair flipping nerf

### DIFF
--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -901,6 +901,7 @@
 		if (src.c_color)
 			C.icon_state = src.c_color
 		C.set_dir(user.dir)
+		ON_COOLDOWN(user, "chair_stand", 1 SECOND)
 		boutput(user, "You unfold [C].")
 		user.drop_item()
 		qdel(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just makes putting down a chair start the chair_stand cooldown, I didn't want to go with an action bar because it would make organizing a bunch of chairs insanely slow, and I think placing down chairs happens way too often for an action bar.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Instantly chair flipping people is a very cheap way to disarm them. 
Created based on the discussion on this thread: https://forum.ss13.co/showthread.php?tid=17177
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Arthur Holiday
(+)When putting down a chair you will have to wait 1 second before climbing on it.
```
