### PR TITLE
Blocks syndicate hat purchase on nuke ops.

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -232,7 +232,7 @@ proc/build_syndi_buylist_cache()
 	cost = 12
 	desc = "Think you're tough shit buddy?"
 	not_in_crates = 1 //see /datum/syndicate_buylist/surplus/bighat
-	blockedmode = list(/datum/game_mode/spy_theft, /datum/game_mode/revolution)
+	blockedmode = list(/datum/game_mode/spy_theft, /datum/game_mode/revolution, /datum/game_mode/nuclear)
 
 //////////////////////////////////////////////////// Standard items (traitor uplink) ///////////////////////////////////
 


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the syndicate hat from the buylist for nuclear operatives.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Encouraging messing around and being useless in team based game modes is really bad. Removing it should hopefully stop it from sabotaging nuke rounds for the other team members.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)Nuclear Operatives can no longer purchase the syndie hat.
```
