### PR TITLE
Minor mechscan changes to botany clutter

### DIFF
--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -425,7 +425,6 @@
 
 	flags = FPRINT | TABLEPASS | ONBELT
 	w_class = W_CLASS_TINY
-	mats = list("MET-1" = 1)
 
 	force = 5.0
 	throwforce = 5.0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes decorative plant pots from the same as real plant pots (3 metal, 1 crystal, 1 conductive)  to 1 of any material

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Thanks to vending machine nerf, you can't make fun gimmicks where you could make lots of garden gears and create a lot of plantpots to decorate the station. Reducing mat cost on decorative pots should make this more affordable.

## Changelog
don't think this need changelog
