### PR TITLE
Reduces old hunting rifle cost to 3 tc 

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -988,7 +988,7 @@ This is basically useless for anyone but miners.
 	spy
 		cost = 5
 		blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
-		not_in_crates = FALSE
+		not_in_crates = TRUE
 
 /datum/syndicate_buylist/surplus/bananagrenades
 	name = "Banana Grenades"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the old hunting rifle surplus crate item to cost 3 tc instead of 7. Makes the rifle worth 5 tc if its spy theft to prevent it from being too common.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The rifle is worth 7 tc and for that much it really doesnt have enough ammo to kill more than 2 people. This aims to make it less overpriced.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)Old hunting rifle surplus item cost reduced to 3 tc. Spy bounty for old hunting rifle made slightly more common.
```
