### PR TITLE
Reduce use of bold on end of round information

### DIFF
--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -194,9 +194,9 @@
 					traitor.current.unlock_medal("You're no Elminster!", 1)
 				if (traitor.special_role == ROLE_WRESTLER && traitor.current)
 					traitor.current.unlock_medal("Cream of the Crop", 1)
-				stuff_to_output += "The [traitor.special_role] was <span class='success'>successful!</span>"
+				stuff_to_output += "<span class='success'>The [traitor.special_role] was successful!</span>"
 			else
-				stuff_to_output += "The [traitor.special_role] has <span class='alert'>failed!</span>"
+				stuff_to_output += "<span class='alert'>The [traitor.special_role] has failed!</span>"
 
 	#ifdef DATALOGGER
 			if (traitorwin)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduces the amount of bold used in end of round antag listings.
![image](https://user-images.githubusercontent.com/70909958/136666088-bae73b77-fe22-41a6-b7db-1e5ae710fd10.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Legibility.