### PR TITLE
Fix butt disappearing when replacement fails

### DIFF
--- a/code/obj/item/organs/butt.dm
+++ b/code/obj/item/organs/butt.dm
@@ -112,6 +112,7 @@
 			H, "<span class='alert'>[H == user ? "You" : "<b>[user]</b>"] [fluff]s [src] onto the [fluff2] where your butt used to be, but the [fluff2] has been cauterized closed and [src] falls right off!</span>")
 			if (user.find_in_hand(src))
 				user.u_equip(src)
+				set_loc(get_turf(H))
 			return null
 		else
 			return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Attempting to replace someone's butt when the incision has been cauterized would cause the butt to disappear, this PR sets it to the turf of the patient (where it'd probably end up) instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've had a patient's butt disappear on me like this a few days ago, when butts are integral to high-level gameplay.

Technically a memory leak fix I guess? Since the butt would remain in the surgeon's contents but inaccessible for players.