### PR TITLE
Bar wraiths from various eject verbs

### DIFF
--- a/code/modules/medical/genetics/geneticsScanner.dm
+++ b/code/modules/medical/genetics/geneticsScanner.dm
@@ -153,7 +153,7 @@ var/list/genetek_hair_styles = list()
 
 
 	verb/eject_occupant(var/mob/user)
-		if (!isalive(user))
+		if (!isalive(user) || iswraith(user))
 			return
 		if (src.locked)
 			boutput(user, "<span class='alert'><b>The scanner door is locked!</b></span>")

--- a/code/modules/medical/genetics/portagene.dm
+++ b/code/modules/medical/genetics/portagene.dm
@@ -203,7 +203,7 @@
 		set src in oview(1)
 		set category = "Local"
 
-		if (!isalive(usr))
+		if (!isalive(usr) || iswraith(usr))
 			return
 		if (src.locked)
 			boutput(usr, "<span class='alert'><b>The scanner door is locked!</b></span>")

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -655,7 +655,7 @@
 		set src in oview(1)
 		set category = "Local"
 
-		if (!isalive(usr))
+		if (!isalive(usr) || iswraith(usr))
 			return
 		src.go_out()
 		add_fingerprint(usr)
@@ -852,7 +852,7 @@
 	verb/eject()
 		set src in oview(1)
 		set category = "Local"
-		if (!isalive(usr)) return
+		if (!isalive(usr) || iswraith(usr)) return
 		if (src.process_timer > 0) return
 		src.eject_meats()
 		src.go_out()

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -506,7 +506,7 @@ proc/find_ghost_by_key(var/find_key)
 		return
 
 	verb/eject_occupant(var/mob/user)
-		if (!isalive(user))
+		if (!isalive(user) || iswraith(user))
 			return
 		src.go_out()
 		add_fingerprint(user)

--- a/code/obj/machinery/gibber.dm
+++ b/code/obj/machinery/gibber.dm
@@ -75,7 +75,7 @@
 	set src in oview(1)
 	set category = "Local"
 
-	if (!isalive(usr)) return
+	if (!isalive(usr) || iswraith(usr)) return
 	if (src.operating) return
 	src.go_out()
 	add_fingerprint(usr)

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -614,7 +614,7 @@
 		return
 
 	verb/eject_occupant(var/mob/user)
-		if (!isalive(user)) return
+		if (!isalive(user) || iswraith(user)) return
 		src.go_out()
 		add_fingerprint(user)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Bars wraiths from several eject verbs (searched on "verb/eject" and poked most of the results) on sleepers and pods and whatnot, since wraiths are neither alive nor dead but too ghostly to operate machinery.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #6222 and also the same problem for some related machinery (sleepers/scanners/pods could probably have some of their code refactored into a parent object)
