### PR TITLE
Allow the butcher's knife and hunting spear to hit windows

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -707,7 +707,8 @@
 		take_bleeding_damage(C, null, 10, DAMAGE_CUT)
 
 		playsound(src, 'sound/impact_sounds/Flesh_Stab_3.ogg', 40, 1)
-	..()
+	else
+		..()
 
 /obj/item/knife/butcher/attack(target as mob, mob/user as mob)
 	if (!istype(src,/obj/item/knife/butcher/predspear) && ishuman(target) && ishuman(user))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the thrown butcher's knife and hunting spear to hit and damage windows.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #6245
