### PR TITLE
Fixes a bug with torpedo tube slipping

### DIFF
--- a/code/WorkInProgress/torpedoes.dm
+++ b/code/WorkInProgress/torpedoes.dm
@@ -317,7 +317,7 @@
 			if(targetTurf)
 				target = targetTurf
 			else
-				target = get_edge_target_turf(src, src.dir)
+				target = get_steps(start, src.dir, 3)
 
 			if(ismob(loaded))
 				var/mob/M = loaded


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Apparently throwing someone at the edge turf with a torpedo tube phases them through the z-level boundary and dumps them in the trench. Oops. Now the default shot point (if nobody has used the periscope yet) is the same as the default after you use the periscope.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Phasing people through the north Z boundary is Probably Bad