### PR TITLE
Small backpack/belt opening QoL

### DIFF
--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -150,6 +150,8 @@
 					if(src.check_can_hold(I) > 0)
 						src.Attackby(I, user, S)
 				return
+			if(!does_not_open_in_pocket)
+				attack_hand(user)
 			switch (canhold)
 				if(0)
 					boutput(user, "<span class='alert'>[src] cannot hold [W].</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Clicking backpacks/satchels/belts with an item that does not fit in them (either because of item w_class or simply because they're full) will now open them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I've seen numerous new players getting confused when trying to access their backpacks with no free slots left while also having their hands full. Hopefully this change will make messing with equipment a bit more intuitive

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Clicking backpacks/satchels/belts with an item that does not fit in them will now open them.
```
