### PR TITLE
Checks power before activating shield generators

### DIFF
--- a/code/obj/machinery/shield_generators/shield_generator.dm
+++ b/code/obj/machinery/shield_generators/shield_generator.dm
@@ -127,7 +127,7 @@
 	// for testing atm
 	attack_hand(mob/user as mob)
 		if (status & (NOPOWER|BROKEN) || !src.link)
-			user.show_text("The device seems inoperable, as pressing the button does nothing.")
+			user.show_text("[src] seems inoperable, as pressing the button does nothing.")
 			return
 
 		var/diff = world.timeofday - lastuse


### PR DESCRIPTION
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

you were previously able to turn shields off/on while the computer had no power or was broken

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

not ideal