### PR TITLE
Increases result volume of Fruit and Milk Punch

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -505,7 +505,7 @@ datum
 			id = "milk_punch"
 			result = "milk_punch"
 			required_reagents = list("simplesyrup" = 1, "juice_lime" = 1, "juice_apple" = 1, "ginger_ale" = 1, "juice_pineapple" = 1, "milk" = 1)
-			result_amount = 2
+			result_amount = 6
 			mix_phrase = "You wonder why you made this drink at all."
 			mix_sound = 'sound/misc/drinkfizz.ogg'
 			drinkrecipe = 1
@@ -513,14 +513,14 @@ datum
 		milk_punch/milk_punch2
 			id = "milk_punch2"
 			required_reagents = list("fruit_punch" = 5, "milk" = 1)
-			result_amount = 2
+			result_amount = 6
 
 		fruit_punch
 			name = "Fruit Punch"
 			id = "fruit punch"
 			result = "fruit_punch"
 			required_reagents = list("simplesyrup" = 1, "juice_apple" = 1, "juice_lime" = 1, "ginger_ale" = 1, "juice_pineapple" = 1)
-			result_amount = 3
+			result_amount = 5
 			mix_phrase = "You are reminded of family picnics and school functions as the syrup mixes with the juices."
 			mix_sound = 'sound/misc/drinkfizz.ogg'
 			drinkrecipe = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This just increases the output volume of Fruit Punch and Milk Punch to match the total volume of their ingredients. This is a minor change, but given the intense nature of these recipes (requiring a combination of Botany-exclusive ingredients and vending machine-exclusive ingredients) and the fact that in real life, non-alcoholic punch is usually made as a large-volume drink recipe, it just makes sense to me.

This especially applies to the secondary recipe for Milk Punch, which requires 5u of Fruit Punch to 1u of Milk, but then previously only output 2u of Milk Punch.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Most drink recipes already output their original ingredient volume, and this makes the recipe more realistic and less punishing for the bartender.
