### PR TITLE
Adds easy beaker swapping to chem dispenser

### DIFF
--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -99,9 +99,10 @@
 			B.reagents.handle_reactions()
 			return
 		*/
+		var/ejected_beaker = null
 		if (src.beaker)
-			boutput(user, "A [glass_name] is already loaded into the machine.")
-			return
+			ejected_beaker = src.beaker
+			user.put_in_hand_or_drop(ejected_beaker)
 
 		src.beaker =  B
 		if(!B.cant_drop)
@@ -111,7 +112,10 @@
 		if(B.qdeled)
 			B = null
 		else
-			boutput(user, "You add the [glass_name] to the machine!")
+			if(ejected_beaker)
+				boutput(user, "You swap the [B] with the [glass_name] already loaded into the machine.")
+			else
+				boutput(user, "You add the [glass_name] to the machine!")
 		src.update_icon()
 		src.ui_interact(user)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Try to insert a beaker into a chem dispenser that's already got one in, you'll swap them out
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QoL, scichem is too clunky

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)FlamingLily
(+)Added hot-swapping of beakers to chem dispensers, no need to eject when replacing a beaker
```
