### PR TITLE
Removes Ghost Chili Juice from Devil Dan's Brimstone BBQ Noodles, replaces it with El Diablo Chili

### DIFF
--- a/code/modules/food_and_drink/discount_dans.dm
+++ b/code/modules/food_and_drink/discount_dans.dm
@@ -140,7 +140,7 @@
 				src.real_name = "Devil Dan's Quik-Noodles - Brimstone BBQ Flavor"
 				src.initial_reagents["sulfur"] = 5
 				src.initial_reagents["beff"] = 5
-				src.initial_reagents["ghostchilijuice"] = 5
+				src.initial_reagents["el_diablo"] = 5
 /*				R.add_reagent("sulfur",5)
 				R.add_reagent("beff",5)
 				R.add_reagent("ghostchilijuice",5)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does what the title says.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having something that can instantly, permanently kill someone beyond revival (or even leaving a body) in something as innocuous as a publically accessible foodstuff seems both far, far too unbalanced, as well as a 'noob trap' that will ruin someone's round because they rolled poorly on something that shouldn't be dangerous (at least, not "you literally get incinerated and cannot be revived, ever" dangerous)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)FlamingLily
(+)After a long and intense class action legal battle, Discount Dan's has finally removed Ghost Chili Juice from their products, dine away without fear of incineration!
```
