### PR TITLE
Antag candidate picking fill-in logic to pick actual random candidates instead of iterating over clients.

### DIFF
--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -243,7 +243,8 @@
   */
 /datum/game_mode/proc/get_possible_enemies(type,number)
 	var/list/candidates = list()
-	var/list/unpicked_clients = list() // used to fill in the quota if we can't find enough players with the antag preference on
+	/// Used to fill in the quota if we can't find enough players with the antag preference on.
+	var/list/unpicked_candidate_minds = list()
 
 	for(var/client/C)
 		var/mob/new_player/player = C.mob
@@ -254,19 +255,18 @@
 			if (player.client.preferences.vars[get_preference_for_role(type)])
 				candidates += player.mind
 			else // eligible but has the preference off, keeping in mind in case we don't find enough candidates with it on to fill the gap
-				unpicked_clients.Add(player)
+				unpicked_candidate_minds.Add(player.mind)
 
 	if(length(candidates) < number) // ran out of eligible players with the preference on, filling the gap with other players
 		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [length(candidates)] players with be_[type] set to yes were ready. We need [number] so including players who don't want to be [type]s in the pool.")
 
-		if(length(unpicked_clients))
-			shuffle_list(unpicked_clients)
+		if(length(unpicked_candidate_minds))
+			shuffle_list(unpicked_candidate_minds)
 			var/iteration = 1
 			while(length(candidates) < number)
-				var/client/random_client = unpicked_clients[iteration]
-				var/mob/new_player/player = random_client.mob
-				candidates += player.mind
-				if (iteration > length(unpicked_clients)) // ran out of eligible clients
+				candidates += unpicked_candidate_minds[iteration]
+				iteration++
+				if (iteration > length(unpicked_candidate_minds)) // ran out of eligible clients
 					break
 
 	if(length(candidates) < number) // somehow failed to meet our candidate amount quota

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -259,16 +259,18 @@
 	if(length(candidates) < number) // ran out of eligible players with the preference on, filling the gap with other players
 		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [length(candidates)] players with be_[type] set to yes were ready. We need [number] so including players who don't want to be [type]s in the pool.")
 
-		while(length(candidates) < number)
-			var/client/random_client = pick(unpicked_clients)
-			unpicked_clients.Remove(random_client)
-			var/mob/new_player/player = random_client.mob
-			candidates += player.mind
-			if (!length(unpicked_clients)) // ran out of clients
-				if(length(candidates) < number) // somehow ran out of clients without filling our candidate quota
-					message_admins("<span class='alert'><b>WARNING:</b> get_possible_enemies was asked for more antagonists ([number]) than it could find candidates ([length(candidates)]) for. This could be a freak accident or an error in the code requesting more antagonists than possible. The round may have an irregular number of antagonists of type [type].")
-					logTheThing("debug", null, null, "<b>WARNING:</b> get_possible_enemies was asked for more antagonists ([number]) than it could find candidates ([length(candidates)]) for. This could be a freak accident or an error in the code requesting more antagonists than possible. The round may have an irregular number of antagonists of type [type].")
-				break
+		if(length(unpicked_clients))
+			while(length(candidates) < number)
+				var/client/random_client = pick(unpicked_clients)
+				unpicked_clients.Remove(random_client)
+				var/mob/new_player/player = random_client.mob
+				candidates += player.mind
+				if (!length(unpicked_clients)) // ran out of eligible clients
+					break
+
+	if(length(candidates) < number) // somehow failed to meet our candidate amount quota
+		message_admins("<span class='alert'><b>WARNING:</b> get_possible_enemies was asked for more antagonists ([number]) than it could find candidates ([length(candidates)]) for. This could be a freak accident or an error in the code requesting more antagonists than possible. The round may have an irregular number of antagonists of type [type].")
+		logTheThing("debug", null, null, "<b>WARNING:</b> get_possible_enemies was asked for more antagonists ([number]) than it could find candidates ([length(candidates)]) for. This could be a freak accident or an error in the code requesting more antagonists than possible. The round may have an irregular number of antagonists of type [type].")
 
 	if(length(candidates) < 1)
 		return list()

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -260,12 +260,13 @@
 		logTheThing("debug", null, null, "<b>Enemy Assignment</b>: Only [length(candidates)] players with be_[type] set to yes were ready. We need [number] so including players who don't want to be [type]s in the pool.")
 
 		if(length(unpicked_clients))
+			shuffle_list(unpicked_clients)
+			var/iteration = 1
 			while(length(candidates) < number)
-				var/client/random_client = pick(unpicked_clients)
-				unpicked_clients.Remove(random_client)
+				var/client/random_client = unpicked_clients[iteration]
 				var/mob/new_player/player = random_client.mob
 				candidates += player.mind
-				if (!length(unpicked_clients)) // ran out of eligible clients
+				if (iteration > length(unpicked_clients)) // ran out of eligible clients
 					break
 
 	if(length(candidates) < number) // somehow failed to meet our candidate amount quota


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When picking candidates for an antagonist role, candidates are picked based on whether they have the preference for that role enabled.

However, if not enough candidates are found it has to fill in the rest from those who don't have the preference set.
The current way that's done is just plainly iterating through clients until it gets enough, which is probably deterministic and not very random, presumably based on connection order or something similar.

This PR generates a list of viable clients that haven't been picked as candidates yet and picks randomly from that instead to fill the quota if needed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Making the antag candidate picking logic not potentially deterministic.