### PR TITLE
Unhardcode server-pick input lists in bans

### DIFF
--- a/code/modules/admin/bans.dm
+++ b/code/modules/admin/bans.dm
@@ -296,18 +296,10 @@ var/global/list/playersSeen = list()
 			return
 		data["reason"] = reason
 
-		var/server_nice = input(usr, "What server does the ban apply to?", "Ban") as null|anything in list("All", "1 Classic: Heisenbee", "2 Classic: Bombini", "3 Roleplay: Morty", "4 Roleplay: Sylvester")
-		var/server = null
-		switch (server_nice)
-			if ("1 Classic: Heisenbee")
-				server = "main1"
-			if ("2 Classic: Bombini")
-				server = "main2"
-			if ("3 Roleplay: Morty")
-				server = "main3"
-			if ("4 Roleplay: Sylvester")
-				server = "main4"
-		data["server"] = server
+		var/datum/game_server/game_server = global.game_servers.input_server(usr, "What server does the ban apply to?", "Ban", can_pick_all=TRUE)
+		if(isnull(game_server))
+			return null
+		data["server"] = istype(game_server) ? game_server.id : null // null = all servers
 
 		var/ban_time = input(usr,"How long will the ban be?","Ban") as null|anything in list("Half-hour","One Hour","Six Hours","One Day","Half a Week","One Week","One Month","Permanent","Custom")
 		var/mins = 0
@@ -437,18 +429,10 @@ var/global/list/playersSeen = list()
 			return
 		data["reason"] = reason
 
-		var/server_nice = input(usr, "What server does the ban apply to?", "Ban") as null|anything in list("All", "1 Classic: Heisenbee", "2 Classic: Bombini", "3 Roleplay: Morty", "4 Roleplay: Sylvester")
-		var/server = null
-		switch (server_nice)
-			if ("1 Classic: Heisenbee")
-				server = "main1"
-			if ("2 Classic: Bombini")
-				server = "main2"
-			if ("3 Roleplay: Morty")
-				server = "main3"
-			if ("4 Roleplay: Sylvester")
-				server = "main4"
-		data["server"] = server
+		var/datum/game_server/game_server = global.game_servers.input_server(usr, "What server does the ban apply to?", "Ban", can_pick_all=TRUE)
+		if(isnull(game_server))
+			return
+		data["server"] = istype(game_server) ? game_server.id : null // null = all servers
 
 		var/ban_time = input(usr,"How long will the ban be? (select Custom to alter existing duration)","Ban") as null|anything in list("Half-hour","One Hour","Six Hours","One Day","Half a Week","One Week","One Month","Permanent","Custom")
 		var/mins = 0

--- a/code/modules/admin/jobban.dm
+++ b/code/modules/admin/jobban.dm
@@ -5,18 +5,11 @@
 	if(ismob(M)) //Correct to ckey if provided a mob.
 		var/mob/keysource = M
 		M = keysource.ckey
-	var/server_nice = input(usr, "What server does the ban apply to?", "Ban") as null|anything in list("All", "1 Classic: Heisenbee", "2 Classic: Bombini", "3 Roleplay: Morty", "4 Roleplay: Sylvester")
-	var/server = null
-	switch (server_nice)
-		if ("1 Classic: Heisenbee")
-			server = "main1"
-		if ("2 Classic: Bombini")
-			server = "main2"
-		if ("3 Roleplay: Morty")
-			server = "main3"
-		if ("4 Roleplay: Sylvester")
-			server = "main4"
-	if(apiHandler.queryAPI("jobbans/add", list("ckey"=M,"rank"=rank, "akey"=akey, "applicable_server"=server)))
+	var/datum/game_server/game_server = global.game_servers.input_server(usr, "What server does the ban apply to?", "Ban", can_pick_all=TRUE)
+	if(isnull(game_server))
+		return null
+	var/server_id = istype(game_server) ? game_server.id : null // null = all servers
+	if(apiHandler.queryAPI("jobbans/add", list("ckey"=M,"rank"=rank, "akey"=akey, "applicable_server"=server_id)))
 		var/datum/player/player = make_player(M) //Recache the player.
 		player?.cached_jobbans = apiHandler.queryAPI("jobbans/get/player", list("ckey"=M), 1)[M]
 		return 1

--- a/code/modules/cross_server/game_servers.dm
+++ b/code/modules/cross_server/game_servers.dm
@@ -76,6 +76,20 @@ var/global/datum/game_servers/game_servers = new
 		arguments[1] = buddy // remove message_name, replace with server
 		return csm.send(arglist(arguments))
 
+	proc/input_server(mob/user, text, title, can_pick_all=FALSE, public_only=FALSE)
+		RETURN_TYPE(/datum/game_server)
+		var/list/pick_list = list()
+		if(can_pick_all)
+			pick_list["All"] = "all"
+		for(var/id in src.servers)
+			var/datum/game_server/server = src.servers[id]
+			if(public_only && !server.publ)
+				continue
+			pick_list[server.name] = server
+		var/text_result = input(user, text, title) as null|anything in pick_list
+		if(isnull(text_result))
+			return null
+		return pick_list[text_result]
 
 /datum/game_server
 	var/id


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces hardcoded lists of servers when (job)banning people with lists generated from the new `/datum/game_servers` object. As a side effect this allows per-server banning on Nightshade servers etc.

Note that this depends on goonhub actually supporting this per-server banning of Nightshade. I assume that's supported but am not sure.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Hardcoding stuff is bad because when a new server gets added etc. we'd have to modify all those hardcoded occurences manually instead of modifying the central config.


## Changelog
No changelog.
