### PR TITLE
Make nukie headset ; messages be the same colour as other nukie messages

### DIFF
--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -299,6 +299,7 @@
 	name = "Radio Headset"
 	desc = "A radio headset that is also capable of communicating over... wait, isn't that frequency illegal?"
 	icon_state = "headset"
+	chat_class = RADIOCL_SYNDICATE
 	secure_frequencies = list("z" = R_FREQ_SYNDICATE)
 	secure_classes = list(RADIOCL_SYNDICATE)
 	protected_radio = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The messages you say over the default channel when pressing `;` are currently green for nukie and for normal headsets.
This PR makes it so they are the nukie rusty reddish chat colour.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So many times I've seen nukies panic when they talked over the `;` channel thinking they accidentally talked to the crew. That's reinforced by the fact that the channel is green unlike :z and :g channels. Changing this would be good for consistency imo.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)pali
(+)Nukie default radio channel is now in Syndicate red instead of being green.
```
