### PR TITLE
Small QoL bling blaster improvements.

### DIFF
--- a/code/WorkInProgress/HaineWhatever.dm
+++ b/code/WorkInProgress/HaineWhatever.dm
@@ -1311,6 +1311,7 @@ var/list/special_parrot_species = list("ikea" = /datum/species_info/parrot/kea/i
 	mat_changename = 0
 	mat_changedesc = 0
 	mat_appearances_to_ignore = list("gold") // we already look fine ty
+	muzzle_flash = "muzzle_flash_launch"
 	var/last_shot = 0
 	var/shot_delay = 15
 	var/cash_amt = 1000
@@ -1337,6 +1338,11 @@ var/list/special_parrot_species = list("ikea" = /datum/species_info/parrot/kea/i
 				return
 
 			last_shot = world.time
+
+			if (src.muzzle_flash)
+				if (isturf(user.loc))
+					var/turf/origin = user.loc
+					muzzle_flash_attack_particle(user, origin, target, src.muzzle_flash)
 
 			var/turf/T = get_turf(src)
 			var/chosen_bling// = pick(60;/obj/item/spacecash,20;/obj/item/coin,10;/obj/item/raw_material/gemstone,10;/obj/item/raw_material/gold)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Bling blaster mostly overrides general gun functionality due to the very unique way it works (launching various valuables at a target).
This unfortunately also means that as new features get added its own functionality can easily become outdated.

Attempting to point-blank shoot yourself or others would say that the gun is empty, as it'd try to check for internal ammo or whatnot, something which this gun does not make use of.
The PR overrides the point blank shot behaviour and forces it to call the regular shoot proc, allowing it to fire normally in point-blank scenarios unobstructed.

As an additional touch, the PR adds a muzzle flash effect (a relatively new addition for bling blaster's lifespan).
see: https://cdn.discordapp.com/attachments/412408851980222465/898261878474670190/8UFDAqrkYI.gif

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's not a full overhaul but some small quality of life touches to make the gimmicky tool less awkward to use. Created in order to resolve #6305 and slightly expanded.
note (regarding the linked issue): not being able to point-blank shoot yourself seems intentional from the gun's code, however a message has been added to indicate this. Meanwhile point-blank shooting others will launch the valuables correctly.