### PR TITLE
Fix incorrect note syntax creating an error for pianos 

### DIFF
--- a/code/obj/playable_piano.dm
+++ b/code/obj/playable_piano.dm
@@ -199,7 +199,7 @@
 
 		for (var/string in piano_notes)
 			var/list/curr_notes = splittext("[string]", ",")
-			if (curr_notes.len < 4) // Music syntax not followed
+			if (length(curr_notes) < 4) // Music syntax not followed
 				break
 			note_names += curr_notes[1]
 			switch(lowertext(curr_notes[4]))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Discovered this bug when playing a piano with less than 4 chars in a note

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes list index call going above the actual list size.