### PR TITLE
Add gannets as nuke ops gamemode codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,9 @@
 /code/obj/item/toys.dm @flrsh
 /maps/oshan.dmm @flrsh
 
+# Gannets 
+/code/datums/gamemodes/nuclear.dm @Gannets
+
 # Kyle
 /code/WorkInProgress/JobXpRewards.dm @Kyle2143
 /code/modules/events/gimmick/kudzu.dm @Kyle2143


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds me as the codeowner for changes to the nuke ops game mode code. 
I'd like it break out nuke specific items in to a module so I can codeown that too later. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It'd be nice to get pings for this. 



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->