### PR TITLE
Fix prisoner scanner runtime error on non-human targets.

### DIFF
--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -568,6 +568,10 @@ that cannot be itched
 	mats = 3
 
 	attack(mob/living/carbon/human/M as mob, mob/user as mob)
+		if (!istype(M))
+			boutput(user, "<span class='alert'>The device displays an error about an \"incompatible target\".</span>")
+			return
+
 		////General Records
 		var/found = 0
 		//if( !istype(get_area(src), /area/security/prison) && !istype(get_area(src), /area/security/main))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The prisoner scanner tool expects a human input but never validates that it gets one.
It works fine with human targets, but if it's used on a non-human target, for example a living/critter, it runs into a runtime error as it tries to access non-existent human scope variables.
Now it will display an error message when targetting non-human mobs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes a runtime error.