### PR TITLE
Give radio chat icons tooltips

### DIFF
--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -145,6 +145,41 @@ img.emoji {
 }
 #options .decreaseFont {border-top: 0;}
 
+/* TOOLTIPS */
+.tooltip {
+	position: relative;
+	display: inline-block;
+}
+
+.tooltip .tooltiptext {
+	visibility: hidden;
+	background-color: #555;
+	color: #fff;
+	text-align: center;
+	border-radius: 6px;
+	padding: 5px 5px;
+	position: absolute;
+	z-index: 1;
+	bottom: 100%;
+	left: 50%;
+	white-space: nowrap;
+}
+
+.tooltip .tooltiptext::after {
+	content: " ";
+	position: absolute;
+	top: 100%;
+	left: 50%;
+	margin-left: -5px;
+	border-width: 5px;
+	border-style: solid;
+	border-color:#555 transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext {
+	visibility: visible;
+}
+
 /* POPUPS */
 .popup {
 	position: fixed;

--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -567,10 +567,12 @@
 	secure_classes = list(RADIOCL_COMMAND)
 	secure_colors = list("#0099cc")
 	icon_override = "nt"
+	icon_tooltip = "NanoTrasen"
 	team = TEAM_NANOTRASEN
 
 	commander
 		icon_override = "cap"	//get better thingy
+		icon_tooltip = "NanoTrasen Commander"
 
 /obj/item/device/radio/headset/pod_wars/syndicate
 	name = "Radio Headset"
@@ -581,10 +583,12 @@
 	secure_colors = list("#ff69b4")
 	protected_radio = 1
 	icon_override = "syndie"
+	icon_tooltip = "Syndicate"
 	team = TEAM_SYNDICATE
 
 	commander
 		icon_override = "syndieboss"
+		icon_tooltip = "Syndicate Commander"
 
 
 /////////shit//////////////

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -33,6 +33,7 @@
 	mats = 3
 
 	var/icon_override = 0
+	var/icon_tooltip = null // null = use name, "" = no tooltip
 
 	var/const
 		WIRE_SIGNAL = 1 //sends a signal, like to set off a bomb or electrocute someone
@@ -241,7 +242,12 @@ var/list/headset_channel_lookup
 	if(.)
 		. = {"<img style=\"position: relative; left: -1px; bottom: -3px;\" class=\"icon misc\" src="[resource("images/radio_icons/[.].png")]">"}
 	else
-		return bicon(src)
+		. = bicon(src)
+	var/tooltip = src.icon_tooltip
+	if(isnull(tooltip))
+		tooltip = src.name
+	if(src.icon_tooltip)
+		. = {"<div class='tooltip'>[.]<span class="tooltiptext">[tooltip]</span></div>"}
 
 /obj/item/device/radio/talk_into(mob/M as mob, messages, secure, real_name, lang_id)
 	// According to a pair of DEBUG calls set up for testing, no radio jammer check for the src radio was performed.

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -246,7 +246,7 @@ var/list/headset_channel_lookup
 	var/tooltip = src.icon_tooltip
 	if(isnull(tooltip))
 		tooltip = src.name
-	if(src.icon_tooltip)
+	if(tooltip)
 		. = {"<div class='tooltip'>[.]<span class="tooltiptext">[tooltip]</span></div>"}
 
 /obj/item/device/radio/talk_into(mob/M as mob, messages, secure, real_name, lang_id)

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -13,6 +13,7 @@
 	desc = "A standard-issue device that can be worn on a crewmember's ear to allow hands-free communication with the rest of the crew."
 	flags = FPRINT | TABLEPASS | CONDUCT | ONBELT
 	icon_override = "civ"
+	icon_tooltip = "Civilian"
 	wear_layer = MOB_EARS_LAYER
 	var/haswiretap
 	hardened = 0
@@ -54,6 +55,7 @@
 	secure_frequencies = list("h" = R_FREQ_COMMAND)
 	secure_classes = list("h" = RADIOCL_COMMAND)
 	icon_override = "head"
+	icon_tooltip = "Head of Staff"
 
 /obj/item/device/radio/headset/command/ai
 	name = "AI Headset"
@@ -75,6 +77,7 @@
 		"c" = RADIOCL_CIVILIAN,
 		)
 	icon_override = "ai"
+	icon_tooltip = "Artificial Intelligence"
 
 /obj/item/device/radio/headset/command/nt
 	name = "NT Headset"
@@ -87,6 +90,7 @@
 		"g" = RADIOCL_SECURITY,
 		)
 	icon_override = "nt"
+	icon_tooltip = "NanoTrasen Special Operative"
 
 /obj/item/device/radio/headset/command/captain
 	name = "Captain's Headset"
@@ -108,6 +112,7 @@
 		"c" = RADIOCL_CIVILIAN,
 		)
 	icon_override = "cap"
+	icon_tooltip = "Captain"
 
 /obj/item/device/radio/headset/command/radio_show_host
 	name = "Radio show host's Headset"
@@ -129,6 +134,7 @@
 		"c" = RADIOCL_CIVILIAN,
 		)
 	icon_override = "civ"
+	icon_tooltip = "Civilian"
 
 /obj/item/device/radio/headset/command/hos
 	name = "Head of Security's Headset"
@@ -141,6 +147,7 @@
 		"g" = RADIOCL_SECURITY,
 		)
 	icon_override = "hos"
+	icon_tooltip = "Head of Security"
 
 /obj/item/device/radio/headset/command/hop
 	name = "Head of Personnel's Headset"
@@ -160,6 +167,7 @@
 		"c" = RADIOCL_CIVILIAN,
 		)
 	icon_override = "hop"
+	icon_tooltip = "Head of Personnel"
 
 /obj/item/device/radio/headset/command/rd
 	name = "Research Director's Headset"
@@ -174,6 +182,7 @@
 		"m" = RADIOCL_MEDICAL,
 		)
 	icon_override = "rd"
+	icon_tooltip = "Research Director"
 
 /obj/item/device/radio/headset/command/md
 	name = "Medical Director's Headset"
@@ -188,6 +197,7 @@
 		"m" = RADIOCL_MEDICAL,
 		)
 	icon_override = "md"
+	icon_tooltip = "Medical Director"
 
 /obj/item/device/radio/headset/command/ce
 	name = "Chief Engineer's Headset"
@@ -200,6 +210,7 @@
 		"e" = RADIOCL_ENGINEERING,
 		)
 	icon_override = "ce"
+	icon_tooltip = "Chief Engineer"
 
 /obj/item/device/radio/headset/security
 	name = "Security Headset"
@@ -210,6 +221,7 @@
 		"g" = RADIOCL_SECURITY,
 		)
 	icon_override = "sec"
+	icon_tooltip = "Security"
 
 /obj/item/device/radio/headset/detective
 	name = "Detective's Headset"
@@ -224,6 +236,7 @@
 		"d" = RADIOCL_DETECTIVE,
 		)
 	icon_override = "det" //neat little magnifying glass sprite I made
+	icon_tooltip = "Detective"
 
 /obj/item/device/radio/headset/engineer
 	name = "Engineering Headset"
@@ -234,6 +247,7 @@
 		"e" = RADIOCL_ENGINEERING,
 		)
 	icon_override = "eng"
+	icon_tooltip = "Engineer"
 
 /obj/item/device/radio/headset/medical
 	name = "Medical Headset"
@@ -244,6 +258,7 @@
 		"m" = RADIOCL_MEDICAL,
 		)
 	icon_override = "med"
+	icon_tooltip = "Medical"
 
 /obj/item/device/radio/headset/research
 	name = "Research Headset"
@@ -254,6 +269,7 @@
 		"r" = RADIOCL_RESEARCH,
 		)
 	icon_override = "sci"
+	icon_tooltip = "Scientist"
 
 /obj/item/device/radio/headset/civilian
 	name = "Civilian Headset"
@@ -263,6 +279,7 @@
 	secure_classes = list(
 		"c" = RADIOCL_CIVILIAN,
 		)
+	icon_tooltip = "Civilian"
 
 /obj/item/device/radio/headset/shipping
 	name = "Shipping Headset"
@@ -276,6 +293,7 @@
 		"c" = RADIOCL_CIVILIAN,
 		)
 	icon_override = "qm"
+	icon_tooltip = "Quartermaster"
 
 /obj/item/device/radio/headset/mail
 	name = "Mailman's Headset"
@@ -289,11 +307,13 @@
 		"e" = RADIOCL_ENGINEERING,
 		)
 	icon_override = "mail"
+	icon_tooltip = "Mailman"
 
 /obj/item/device/radio/headset/clown
 	name = "Clown's Headset"
 	desc = "A standard-issue device that can be worn on a crewmember's ear to allow hands-free communication with the rest of the crew. Anybody using this one is unlikely to be taken seriously."
 	icon_override = "clown"
+	icon_tooltip = "Clown"
 
 /obj/item/device/radio/headset/syndicate
 	name = "Radio Headset"
@@ -304,9 +324,11 @@
 	secure_classes = list(RADIOCL_SYNDICATE)
 	protected_radio = 1
 	icon_override = "syndie"
+	icon_tooltip = "Syndicate Operative"
 
 	leader
 		icon_override = "syndieboss"
+		icon_tooltip = "Syndicate Commander"
 
 	bard
 		name = "Military Headset"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://user-images.githubusercontent.com/358431/137561249-7ffbcdc7-2e82-4c87-9e47-1bb548570b84.png)
This PR makes it so if you hover over the chat icon of radio communication you get a tooltip telling you what it means. By default it shows the name of the object that's the source but this can be overriden.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nihisohel mentioned making radio icons specific for each job which could be interesting but also might make it harder to figure out and remember what the icons mean at first since there are gonna be so many if that gets added. I think this adds a nice way of inspecting the source of the radio chatter and could potentially be used to give more details with the right override of the tooltip.
I don't think this will be annoying for established players as the tooltip only appears when you hover over the icon.
One issue is that the icon currently doesn't look like something hoverable-over but I think I'll leave it as it is for now.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)pali
(+)Hovering over radio icons now shows their name.
```
