### PR TITLE
Haunted TEG Fix

### DIFF
--- a/code/modules/events/vamp_teg.dm
+++ b/code/modules/events/vamp_teg.dm
@@ -2,7 +2,11 @@
 	name = "Haunted TEG"
 	required_elapsed_round_time = 40 MINUTES
 	customization_available = 1
+#ifdef HALLOWEEN
+	weight = 75
+#else
 	weight = 50
+#endif
 	var/obj/machinery/power/generatorTemp/generator
 	var/list/circulators_to_relube
 	var/event_active
@@ -283,10 +287,10 @@ datum/teg_transformation/vampire
 					enthrall(H)
 			else
 				if(isalive(target))
-					if( !ON_COOLDOWN(target,"teg_glare", 30 SECONDS) )
+					if( prob(80) && !ON_COOLDOWN(target,"teg_glare", 30 SECONDS) )
 						glare(target)
 
-					if(!abilities["Blood Steal"].actions.hasAction(src.teg, "vamp_blood_suck_ranged") && !ON_COOLDOWN(src.teg,"vamp_blood_suck_ranged", 10 SECONDS))
+					if(!actions.hasAction(src.teg, "vamp_blood_suck_ranged") && !ON_COOLDOWN(src.teg,"vamp_blood_suck_ranged", 10 SECONDS))
 						actions.start(new/datum/action/bar/private/icon/vamp_ranged_blood_suc(src.teg,abilityHolder, target, abilities["Blood Steal"]), src.teg)
 
 			if(ishuman(target))


### PR DESCRIPTION
[bug]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Resolves Vampire TEG runtime inhibiting the TEG from feeding.  Thereby inhibiting it from enthralling.
Makes it so there a chance you won't get glared + blood sucked immediately. 🧛 
Increase event weight in spooktober 👻 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtime bad.