### PR TITLE
Changes portabrig shove in timer from 1 second to 3 seconds

### DIFF
--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -461,7 +461,7 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 		return
 
 /datum/action/bar/portabrig_shove_in
-	duration = 5 SECOND
+	duration = 3 SECONDS
 	var/mob/victim
 	var/obj/item/grab/G
 	var/obj/machinery/port_a_brig/brig


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [INPUT WANTED]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes time when grabbing someone and shoving them in the portabrig from 1 second to 3 seconds


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As of right now someone can slip for 1 second and you can easily shove them in without them being able to react or fight back at all. Also the portabrig is faster than handcuffs, better at restraining people than handcuffs, more mobile than handcuffs, and faster to apply than hancuffs making it a little op.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)It now takes 3 seconds to shove someone in the portabrig instead of 1 second.
```
