### PR TITLE
taste reagents when drinking

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -1002,6 +1002,38 @@ datum
 			var/datum/color/average = get_average_color()
 			return rgb(average.r, average.g, average.b)
 
+		/// give a list of the n tastes that are most present in this mixture
+		/// takes argument of how many tastes
+		proc/get_prevalent_tastes(var/num_val)
+			RETURN_TYPE(/list)
+			// create associative list with key = taste, val = total volume
+			var/list/reag_list = list()
+			for (var/current_id in src.reagent_list)
+				var/datum/reagent/current_reagent = src.reagent_list[current_id]
+				if (current_reagent.taste)
+					reag_list[current_reagent.taste] += current_reagent.volume
+			// restrict number of tastes
+			num_val = min(num_val, length(reag_list))
+			// make empty lists for results
+			var/list/result_name[num_val]
+			var/list/result_amount[num_val]
+			// go through all tastes
+			for (var/current_taste in reag_list)
+				// check if it is higher than one of our top values
+				for (var/top_index in 1 to num_val)
+					if (reag_list[current_taste] > result_amount[top_index])
+						// move all the values down
+						for (var/i = num_val; i >= (top_index+1); i--)
+							result_name[i] = result_name[i-1]
+							result_amount[i] = result_amount[i-1]
+						// set new top value
+						result_name[top_index] = current_taste
+						result_amount[top_index] = reag_list[current_taste]
+						break
+			// create associative list for result
+			. = list()
+			for (var/i in 1 to num_val)
+				.[result_name[i]] = result_amount[i]
 
 		//returns whether reagents are solid, liquid, gas, or mixture
 		proc/get_state_description()

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -31,7 +31,7 @@ datum
 		var/depletion_rate = 0.4 // this much goes away per tick
 		var/penetrates_skin = 0 //if this reagent can enter the bloodstream through simple touch.
 		var/touch_modifier = 1 //If this does penetrate skin, how much should be transferred by default (assuming naked dude)? 1 = transfer full amount, 0.5 = transfer half, etc.
-		var/taste = "uninteresting"
+		var/taste = null
 		var/value = 1 // how many credits this is worth per unit
 		var/thirst_value = 0
 		var/hunger_value = 0

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -514,23 +514,16 @@
 				reag_list = copytext(reag_list, 3)
 				boutput(M, "<span class='notice'>Tastes like there might be some [reag_list] in this.</span>")
 			else
-				var/list/reag_list = list()
-
-				for (var/current_id in reagents.reagent_list)
-					var/datum/reagent/current_reagent = reagents.reagent_list[current_id]
-					if (current_reagent.taste)
-						reag_list[current_reagent.taste] += current_reagent.volume
-
-				reag_list = reverse_list(sortList(reag_list))
-				switch (length(reag_list))
+				var/tastes = src.reagents.get_prevalent_tastes(3)
+				switch (length(tastes))
 					if (0)
 						boutput(M, "<span class='notice'>Tastes pretty bland.</span>")
 					if (1)
-						boutput(M, "<span class='notice'>Tastes kind of [reag_list[1]].</span>")
+						boutput(M, "<span class='notice'>Tastes kind of [tastes[1]].</span>")
 					if (2)
-						boutput(M, "<span class='notice'>Tastes kind of [reag_list[1]] and [reag_list[2]].</span>")
+						boutput(M, "<span class='notice'>Tastes kind of [tastes[1]] and [tastes[2]].</span>")
 					else
-						boutput(M, "<span class='notice'>Tastes kind of [reag_list[1]], [reag_list[2]], and a little bit [reag_list[3]].</span>")
+						boutput(M, "<span class='notice'>Tastes kind of [tastes[1]], [tastes[2]], and a little bit [tastes[3]].</span>")
 
 			if (src.reagents.total_volume)
 				logTheThing("combat", user, M, "[user == M ? "takes a sip from" : "makes [constructTarget(M,"combat")] drink from"] [src] [log_reagents(src)] at [log_loc(user)].")

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -488,8 +488,31 @@
 			return 0
 
 		if (iscarbon(M) || ismobcritter(M))
+			var/tasteMessage
+			if (M.mind && M.mind.assigned_role == "Bartender")
+				var/reag_list = ""
+				for (var/current_id in reagents.reagent_list)
+					var/datum/reagent/current_reagent = reagents.reagent_list[current_id]
+					if (reagents.reagent_list.len > 1 && reagents.reagent_list[reagents.reagent_list.len] == current_id)
+						reag_list += " and [current_reagent.name]"
+						continue
+					reag_list += ", [current_reagent.name]"
+				reag_list = copytext(reag_list, 3)
+				tasteMessage = "<span class='notice'>Tastes like there might be some [reag_list] in this.</span>"
+			else
+				var/tastes = src.reagents.get_prevalent_tastes(3)
+				switch (length(tastes))
+					if (0)
+						tasteMessage = "<span class='notice'>Tastes pretty bland.</span>"
+					if (1)
+						tasteMessage = "<span class='notice'>Tastes kind of [tastes[1]].</span>"
+					if (2)
+						tasteMessage = "<span class='notice'>Tastes kind of [tastes[1]] and [tastes[2]].</span>"
+					else
+						tasteMessage = "<span class='notice'>Tastes kind of [tastes[1]], [tastes[2]], and a little bit [tastes[3]].</span>"
+
 			if (M == user)
-				M.visible_message("<span class='notice'>[M] takes a sip from [src].</span>")
+				M.visible_message("<span class='notice'>[M] takes a sip from [src].</span>\n[tasteMessage]", group = "drinkMessages")
 			else
 				user.visible_message("<span class='alert'>[user] attempts to force [M] to drink from [src].</span>")
 				logTheThing("combat", user, M, "attempts to force [constructTarget(M,"combat")] to drink from [src] [log_reagents(src)] at [log_loc(user)].")
@@ -501,29 +524,9 @@
 				if (!src.reagents || !src.reagents.total_volume)
 					boutput(user, "<span class='alert'>Nothing left in [src], oh no!</span>")
 					return
-				user.visible_message("<span class='alert'>[user] makes [M] drink from the [src].</span>")
-
-			if (M.mind && M.mind.assigned_role == "Bartender")
-				var/reag_list = ""
-				for (var/current_id in reagents.reagent_list)
-					var/datum/reagent/current_reagent = reagents.reagent_list[current_id]
-					if (reagents.reagent_list.len > 1 && reagents.reagent_list[reagents.reagent_list.len] == current_id)
-						reag_list += " and [current_reagent.name]"
-						continue
-					reag_list += ", [current_reagent.name]"
-				reag_list = copytext(reag_list, 3)
-				boutput(M, "<span class='notice'>Tastes like there might be some [reag_list] in this.</span>")
-			else
-				var/tastes = src.reagents.get_prevalent_tastes(3)
-				switch (length(tastes))
-					if (0)
-						boutput(M, "<span class='notice'>Tastes pretty bland.</span>")
-					if (1)
-						boutput(M, "<span class='notice'>Tastes kind of [tastes[1]].</span>")
-					if (2)
-						boutput(M, "<span class='notice'>Tastes kind of [tastes[1]] and [tastes[2]].</span>")
-					else
-						boutput(M, "<span class='notice'>Tastes kind of [tastes[1]], [tastes[2]], and a little bit [tastes[3]].</span>")
+				M.visible_message("<span class='alert'>[user] makes [M] drink from the [src].</span>",
+				"<span class='alert'>[user] makes you drink from the [src].</span>\n[tasteMessage]",
+				 group = "drinkMessages")
 
 			if (src.reagents.total_volume)
 				logTheThing("combat", user, M, "[user == M ? "takes a sip from" : "makes [constructTarget(M,"combat")] drink from"] [src] [log_reagents(src)] at [log_loc(user)].")

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -513,15 +513,25 @@
 					reag_list += ", [current_reagent.name]"
 				reag_list = copytext(reag_list, 3)
 				boutput(M, "<span class='notice'>Tastes like there might be some [reag_list] in this.</span>")
-/*			else
-				var/reag_list = ""
+			else
+				var/list/reag_list = list()
 
 				for (var/current_id in reagents.reagent_list)
 					var/datum/reagent/current_reagent = reagents.reagent_list[current_id]
-					reag_list += "[current_reagent.taste], "
+					if (current_reagent.taste)
+						reag_list[current_reagent.taste] += current_reagent.volume
 
-				boutput(M, "<span class='notice'>You taste [reag_list]in this.</span>")
-*/
+				reag_list = reverse_list(sortList(reag_list))
+				switch (length(reag_list))
+					if (0)
+						boutput(M, "<span class='notice'>Tastes pretty bland.</span>")
+					if (1)
+						boutput(M, "<span class='notice'>Tastes kind of [reag_list[1]].</span>")
+					if (2)
+						boutput(M, "<span class='notice'>Tastes kind of [reag_list[1]] and [reag_list[2]].</span>")
+					else
+						boutput(M, "<span class='notice'>Tastes kind of [reag_list[1]], [reag_list[2]], and a little bit [reag_list[3]].</span>")
+
 			if (src.reagents.total_volume)
 				logTheThing("combat", user, M, "[user == M ? "takes a sip from" : "makes [constructTarget(M,"combat")] drink from"] [src] [log_reagents(src)] at [log_loc(user)].")
 				src.reagents.reaction(M, INGEST, max(min(reagents.total_volume, gulp_size, (M.reagents?.maximum_volume-M.reagents?.total_volume)), CHEM_EPSILON))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes use of the taste var set on many reagents already to let non-bartenders taste the 3 most present tastes in what they drink. 
This goes by volume, and if several different beverages have the same taste, they will be added up.
(For instance, sugar, sweet tea, and vermouth are all sweet, apparently.)

I remove the default value of the var ("uninteresting") so that it isn't strictly necessary for all chems to have a taste.
There are probably a lot that don't yet, and the "uninteresting" taste may overpower other tastes right now, which would be annoying.

There's probably a more performant way to make sure the list is sorted in reverse order in the first place, I will look into that as soon as I can, but if someone already knows a way, I am open to code suggestions.^^
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it's a pity that all these neat taste descriptions are not used!
And it kind of makes sense that I'd be able to tell the difference between drinking pure sugar or pure silver.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) Non-bartenders will now be able to taste some of the reagents they drink. (Bartenders will continue to know exactly what they drink.)
```
