### PR TITLE
Adds reagent descriptions to medic combi-injectors.

### DIFF
--- a/code/modules/chemistry/tools/emergency_injectors.dm
+++ b/code/modules/chemistry/tools/emergency_injectors.dm
@@ -250,7 +250,7 @@
 
 /obj/item/reagent_containers/emergency_injector/high_capacity/cardiac
 	name = "cardiac combi-injector"
-	desc = "A combination medical injector containing saline and epineprine."
+	desc = "A combination medical injector containing saline and epinephrine."
 	initial_reagents = list("saline" = 25, "epinephrine" = 25)
 	label = "yellow"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds reagent descriptions to medic combi-injectors.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The injector names aren't terribly specific. This should help medics make more informed choices.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gannets
(+)Nuke ops medics can now see what reagents are contained in their combi-injectors.
```
