### PR TITLE
Adds Kitchen Dispensers to all maps

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -16769,6 +16769,10 @@
 	dir = 9
 	},
 /area/station/mining/staff_room)
+"Pr" = (
+/obj/machinery/chem_dispenser/chef,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "Ps" = (
 /obj/lattice,
 /turf/space,
@@ -70223,7 +70227,7 @@ cw
 dH
 em
 fA
-gT
+Pr
 hF
 iF
 jF

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -13274,6 +13274,7 @@
 	pixel_y = 21
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
+/obj/machinery/vending/monkey,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen)
 "azR" = (
@@ -14943,7 +14944,7 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "aDC" = (
-/obj/machinery/vending/monkey,
+/obj/machinery/chem_dispenser/chef,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "aDD" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -3896,12 +3896,13 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "alh" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21
+	},
+/obj/submachine/chef_sink/chem_sink{
+	pixel_y = 17;
+	tag = "icon-sink (NORTH)"
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -6414,6 +6415,11 @@
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -3479,7 +3479,7 @@
 	},
 /area/station/security/checkpoint/arrivals)
 "akc" = (
-/obj/submachine/chef_sink,
+/obj/machinery/chem_dispenser/chef,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "akd" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -9840,10 +9840,9 @@
 /turf/simulated/floor/white,
 /area/station/crew_quarters/kitchen)
 "awp" = (
-/obj/window/auto/reinforced,
-/obj/grille/steel,
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/simulated/floor/plating,
+/obj/machinery/chem_dispenser/chef,
+/turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "awq" = (
 /obj/disposalpipe/segment/mail/horizontal,
@@ -78824,6 +78823,14 @@
 	icon_state = "blue5"
 	},
 /area/station/crew_quarters/arcade/dungeon)
+"jTn" = (
+/obj/disposalpipe/segment/mail/horizontal,
+/obj/submachine/chef_sink{
+	dir = 4;
+	name = "bar sink"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/bar)
 "jUq" = (
 /obj/machinery/atmospherics/pipe/manifold/west,
 /turf/simulated/floor/orangeblack,
@@ -112956,7 +112963,7 @@ ard
 asf
 atz
 aoD
-awr
+jTn
 axP
 azD
 aAW

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -12339,6 +12339,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"baN" = (
+/obj/machinery/chem_dispenser/chef,
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "baO" = (
 /obj/cable,
 /obj/wingrille_spawn/auto/crystal,
@@ -110429,7 +110433,7 @@ wNu
 wNu
 wNu
 fWu
-wNu
+baN
 cor
 fGo
 auT

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -54622,6 +54622,11 @@
 /area/station/ranch)
 "hjl" = (
 /obj/disposalpipe/segment/bent/south,
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 9;
+	pixel_y = -2
+	},
 /turf/simulated/floor/white/checker{
 	dir = 6
 	},

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -60850,11 +60850,11 @@
 /turf/simulated/floor/plating/random,
 /area/station/security/main)
 "wUP" = (
-/obj/submachine/chef_sink,
 /obj/noticeboard/persistent{
 	name = "Kitchen persistent notice board";
 	persistent_id = "kitchen"
 	},
+/obj/machinery/chem_dispenser/chef,
 /turf/simulated/floor/white/checker{
 	dir = 6
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -47953,6 +47953,10 @@
 /obj/machinery/drainage/big,
 /turf/simulated/floor/shuttlebay,
 /area/shuttle/sea_elevator_room)
+"sbw" = (
+/obj/machinery/chem_dispenser/chef,
+/turf/simulated/floor/white,
+/area/station/crew_quarters/kitchen)
 "scc" = (
 /obj/table/wood/auto,
 /obj/machinery/door/airlock/pyro/glass/windoor{
@@ -78724,7 +78728,7 @@ bmU
 bhC
 bhC
 bkL
-bhC
+nab
 bhC
 bhC
 bmW
@@ -79328,7 +79332,7 @@ bhC
 aQH
 bhC
 bkN
-nab
+sbw
 blR
 bhC
 bmW


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] --> [MAPPING]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds Kitchen Dispensers to all maps that lack them. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Its a useful and good dispenser that should be on more maps. It's especially useful on lower pops. It also allows the bartender and chef to have more ingredients to work with at round start.  

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Eagletanker
(+)Nanotrasen has allocated enough room allow the chef to install a kitchen dispenser on all maps. 
```
