### PR TITLE
Disables Miscreants

### DIFF
--- a/_std/setup.dm
+++ b/_std/setup.dm
@@ -51,7 +51,7 @@
 
 #define CREW_OBJECTIVES
 
-#define MISCREANTS
+//#define MISCREANTS //uncomment to re-enable miscreants
 
 //#define RESTART_WHEN_ALL_DEAD 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR disables miscreants without removing the code for them, in case public opinion changes again.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

- I have seen many, many Mentorhelps and questions from new people about what a miscreant *is* and what they do. As such, it seems that the existence of miscreants confuses new players.
- Multiple long-time players have expressed that they don't like miscreants, or that miscreants don't bring much to the table.
- As far as I know, miscreants don't get much, if any, leeway compared to a non-antag doing the same thing as them.
- Going hand-in-hand with point 3, you can do pretty much anything a miscreant can do, be it normally or through their objectives.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Miscreants have been disabled.
```
