### PR TITLE
Removing A Miscreant Objective

### DIFF
--- a/code/datums/miscreant_objectives.dm
+++ b/code/datums/miscreant_objectives.dm
@@ -164,9 +164,6 @@ ABSTRACT_TYPE(/datum/objective/miscreantrp)
 	detective
 		explanation_text = "Found a private detective agency and attempt to solve cases before the detective can. Come up with absurd explanations for crimes and insist that security is secretly in on it."
 
-	exterminator
-		explanation_text = "Kill as many non-monkey, non-pet animals aboard the station as possible and bring their corpses to the bridge. Once finished, claim to be a trained exterminator and demand payment for your services."
-
 	business
 		explanation_text = "Establish a business and attempt to convince the command staff and security to recognize the legitimacy of your emerging enterprise."
 


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR 

Gets rid of the miscreant objective to go around killing animals.

## Why's this needed? 

People running into the ranch to ruin all the rancher's hard work isn't very fun. This objective tends to just tell players to kill people's animals (both chickens and others) which isn't very conducive to rp. It's redundant if the PR to remove miscreants altogether (#6365) gets merged, but at the very least this objective should be taken out of the game.