### PR TITLE
Adds The "Protect Stirstir" Objective To Security Assistants

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -188,6 +188,17 @@ ABSTRACT_TYPE(/datum/objective/crew/securityofficer)
 					return 1
 			return 0
 
+ABSTRACT_TYPE(/datum/objective/crew/securityassistant)
+/datum/objective/crew/securityassistant
+	brigstir
+		explanation_text = "Keep Monsieur Stirstir brigged but also make sure that he comes to absolutely no harm."
+		medal_name = "Monkey Duty"
+		check_completion()
+			for(var/mob/living/carbon/human/npc/monkey/stirstir/M in mobs)
+				if(!isdead(M) && (M.get_brute_damage() + M.get_oxygen_deprivation() + M.get_burn_damage() + M.get_toxin_damage()) == 0 && istype(get_area(M),/area/station/security/brig))
+					return 1
+			return 0
+
 ABSTRACT_TYPE(/datum/objective/crew/quartermaster)
 /datum/objective/crew/quartermaster
 	profit


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CONTENT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the "Protect Stirstir" security objective to security assistants.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gives security assistants a crew objective that isn't to demanding/obtrusive.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)Security Assistants may spawn with a new(ish) objective.
```
