### PR TITLE
Fixes cough emote cooldown for smoke

### DIFF
--- a/code/obj/effects/bad_smoke.dm
+++ b/code/obj/effects/bad_smoke.dm
@@ -26,7 +26,8 @@
 			if (prob(25))
 				M.changeStatus("stunned", 1 SECOND)
 			M.take_oxygen_deprivation(1)
-			M.emote("cough")
+			if(!ON_COOLDOWN(M, "bad_smoke_cough", 0.2 SECONDS))
+				M.emote("cough")
 	return
 
 /obj/effects/bad_smoke/HasEntered(mob/living/carbon/M as mob )


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug] I guess?

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As the title says, now the cooldown will get applied both to Move() and HasEntered()

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Emote spam bad!