### PR TITLE
Prevents errors when an AI dies while deployed to a shell

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -772,7 +772,6 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	if (deployed_shell)
 		src.return_to(deployed_shell)
 
-	qdel(src.eyecam)
 	src.lastgasp() // calling lastgasp() here because we just died
 	setdead(src)
 	src.canmove = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When an AI dies, it will now check if the AI is deployed to a shell and correctly handle those cases so that players do not get stuck in limbo.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #4514. 

Currently, if the core is destroyed while deployed, the player cannot become a ghost and gets stuck in the corner of the map after the game tries to undelete the destroyed AI core. Now, when an AI dies it pulls the mind back to the core before dying to avoid errors.

