### PR TITLE
Ghosting in cryo starts respawn timer on RP

### DIFF
--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -263,6 +263,7 @@
 		if (src.hibernating == 1)
 			var/confirm = alert("Are you sure you want to ghost? You won't be able to exit cryogenic storage, and will be an observer the rest of the round.", "Observe?", "Yes", "No")
 			if(confirm == "Yes")
+				respawn_controller.subscribeNewRespawnee(src.ckey)
 				src.ghostize()
 				qdel(src)
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently the respawn timer only starts when you die. This PR makes it start when you ghost in cryo too.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's weirdly inconsistent now and sorta incentivizes people wanting to respawn to suicide.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)pali
(+)Ghosting in cryo now starts respawn countdown on RP
```
