### PR TITLE
Fixes headspider spawning after a changeling is gibbed

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -656,11 +656,11 @@
 		else
 		//Changelings' heads pop off and crawl away - but only if they're not gibbed and have some spare DNA points. Oy vey!
 			SPAWN_DBG(0)
-				var/datum/mind/M = src.mind
 				emote("deathgasp")
 				src.visible_message("<span class='alert'><B>[src]</B> head starts to shift around!</span>")
 				src.show_text("<b>We begin to grow a headspider...</b>", "blue")
 				sleep(20 SECONDS)
+				var/datum/mind/M = src.mind
 				if(!M || M.disposed)
 					return
 				if (M?.current)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If a changeling is gibbed after death but before it can release a headspider, the headspider never spawns. This prevents run time errors.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #6375. Currently, if a changeling is gibbed after death, the headspider continues to spawn but ends up in the corner of the map as it loses references to its old body. This prevents that issue.
