### PR TITLE
Added Charging Progress when examining a nearby recharger

### DIFF
--- a/code/obj/machinery/recharger.dm
+++ b/code/obj/machinery/recharger.dm
@@ -138,7 +138,7 @@ obj/machinery/recharger
 		// Something wrong with the item we inserted. Report an error
 		src.icon_state = sprite_error
 
-/obj/machinery/recharger/get_desc(dist ,mob/user)
+/obj/machinery/recharger/get_desc(dist)
 	. = ..()
 	if(dist > 2)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR lets you see the name of the item in the recharger as well as its progress by examining the recharger from at most 2 tiles away.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mostly just a QoL to be able to see the charge progress without needing to take out the item from the recharger.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gousaid67
(+)You can now see the charging progress of an item by examining the recharger while close!
```
