### PR TITLE
AI Secondary Radio Recolor

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -223,6 +223,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 		src.cell.charge = src.cell.maxcharge
 		src.radio1.name = "Primary Radio"
 		src.radio2.name = "AI Intercom Monitor"
+		src.radio2.device_color = "#7F7FE2"
 		src.radio3.name = "Secure Channels Monitor"
 		src.radio1.broadcasting = 1
 		src.radio2.set_frequency(R_FREQ_INTERCOM_AI)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjusts the AI's Secondary Radio's (aka AI Intercom Monitor) color from the default green radio to the color used by AI intercoms.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
For communication via AI Intercoms to be more consistent visually, and, more importantly, to reduce the likelihood that someone will mistake speech from the AI over its intercoms as being from the main radio, or even outright ignoring it. (This is a common issue experienced when trying to communicate to people via intercoms)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Nexusuxen
(+)Recolored AI Intercom Monitor text from default green to color used by AI Intercoms
```
