### PR TITLE
Chat message fix

### DIFF
--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -29,6 +29,6 @@
 						t.icon_state = "trowel"
 						return
 				if(istype(weapon,/obj/item/seed))
-						user.visible_message("It's an empty pot, there's nowhere to plant the seed! Maybe you need to use a trowel and place an existing plant into it?")
+						boutput(user, "It's an empty pot, there's nowhere to plant the seed! Maybe you need to use a trowel and place an existing plant into it?")
 				else
 						..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Decorative pot: Changes one error message from user.visiblemessage() to boutput(user, "")

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Annoying chat message spam which should be visible only to one person
