### PR TITLE
Fixes a radio VR exploit

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -927,6 +927,7 @@ This is basically useless for anyone but miners.
 	cost = 3
 	desc = "A small device that may be installed in a headset to grant access to all station channels."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
+	vr_allowed = 0
 
 /datum/syndicate_buylist/traitor/tape
 	name = "Ducktape"

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -45,6 +45,8 @@
 		. = list("stock" = list())
 
 		for (var/datum/materiel/M as anything in materiel_stock)
+			if(!M.vr_allowed && istype(get_area(src), /area/sim))
+				continue
 			.["stock"] += list(list(
 				"ref" = "\ref[M]",
 				"name" = M.name,
@@ -195,6 +197,7 @@
 	var/category = null
 	var/path = null
 	var/description = "If you see me, gannets is an idiot."
+	var/vr_allowed = TRUE
 
 /datum/materiel/sidearm
 	category = WEAPON_VENDOR_CATEGORY_SIDEARM
@@ -429,6 +432,7 @@
 	name = "Military Headset"
 	path = /obj/item/device/radio/headset/syndicate/comtac
 	description = "A two-way radio headset designed to protect against any incoming hazardous noise, including flashbangs."
+	vr_allowed = FALSE
 // Requisition tokens
 
 /obj/item/requisition_token


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Bug - major]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes the comtac syndicate headset & the wiretap upgrade unobtainable in the murderbox.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
you could check for nukies using the comtac, and with the wiretap you could access all channels in VR



