### PR TITLE
Fix slot machines always eating people's money on card ejection.

### DIFF
--- a/code/obj/submachine/slots.dm
+++ b/code/obj/submachine/slots.dm
@@ -88,6 +88,8 @@
 		if("eject")
 			usr.put_in_hand_or_eject(src.scan)
 			src.scan = null
+			src.working = FALSE
+			src.icon_state = "[icon_base]-off" // just in case, some fucker broke it earlier
 			if(!src.accessed_record)
 				src.visible_message("<span class='subtle'><b>[src]</b> says, 'Winnings not transferred, thank you for playing!'</span>")
 				return TRUE // jerks doing that "hide in a chute to glitch auto-update windows out" exploit caused a wall of runtime errors
@@ -95,8 +97,6 @@
 			src.available_funds = 0
 			src.accessed_record = null
 			src.visible_message("<span class='subtle'><b>[src]</b> says, 'Winnings transferred, thank you for playing!'</span>")
-			src.working = FALSE
-			src.icon_state = "[icon_base]-off" // just in case, some fucker broke it earlier
 			. = TRUE
 
 		if("cashin")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Shuffles the slot machine code around to avoid an issue making it so that it always discards the player's winnings instead of transfering them to the inserted ID card's bank account as intended when the ID is ejected.
Forementioned issue is caused by c3a9acfc10c1de60c7c59407176685b279406461, which seems to have been trying to fix a different issue of cards not being ejected (though the circumstances in which that could happen is unknown to me), but unintentionally organised the code in such a way leading to an always true condition and unreachable code.
The PR fixes the forementioned mistake while also preserving the ID ejection happening first, which should hopefully fix both of the issues.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes slot machines not transferring deposited money and/or winnings upon ejection as they should.