### PR TITLE
Fix Waistcoat Typo

### DIFF
--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -1293,7 +1293,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves/ring)
 	item_state = "red_wcoat"
 
 /obj/item/clothing/under/gimmick/blue_wcoat
-	name = "dress shirt and red waistcoat"
+	name = "dress shirt and blue waistcoat"
 	desc = "A formal blue waistcoat meant to be worn alongside an overcoat."
 	icon_state = "blue_wcoat"
 	item_state = "blue_wcoat"


### PR DESCRIPTION
[Bug - Trivial]

## About the PR
Fixes the blue waistcoat being named "dress shirt and red waistcoat" to "dress shirt and  blue waistcoat".



## Why's this needed?
Product not as described.

