### PR TITLE
Makes artpitchers chuggable again

### DIFF
--- a/code/obj/artifacts/artifact_items/pitcher.dm
+++ b/code/obj/artifacts/artifact_items/pitcher.dm
@@ -5,7 +5,6 @@
 	artifact = 1
 	mat_changename = 0
 	can_recycle = 0
-	can_chug = 0
 
 	New(var/loc, var/forceartiorigin)
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
They were made unchuggable in the large container balance pass when everything drinkable was made chuggable. I made these specifically to chug!!!!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Reasonably rare compared to fuel tanks and jugs, fun to chug without checking the contents.