### PR TITLE
change genetics ability bar visibility

### DIFF
--- a/code/datums/hud/human.dm
+++ b/code/datums/hud/human.dm
@@ -42,7 +42,7 @@
 	var/list/atom/movable/screen/hud/inventory_bg = list()
 	var/list/obj/item/inventory_items = list()
 	var/show_inventory = 1
-	var/current_ability_set = 1
+	var/show_genetics_abilities = TRUE
 	var/icon/icon_hud = 'icons/mob/hud_human_new.dmi'
 
 	var/list/statusUiElements = list() //Assoc. List  STATUS EFFECT INSTANCE : UI ELEMENT add_screen(atom/movable/screen/S). Used to hold the ui elements since they shouldnt be on the status effects themselves.
@@ -462,15 +462,14 @@
 				//src.update_sprinting()
 
 			if ("ability")
-				switch(current_ability_set)
-					if(1)
-						current_ability_set = 2
-						boutput(master, "Now viewing genetic powers hotbar.")
-					else
-						current_ability_set = 1
-						boutput(master, "Now viewing standard hotbar.")
+				if(show_genetics_abilities)
+					show_genetics_abilities = FALSE
+					boutput(master, "No longer showing genetic abilities.")
+				else
+					show_genetics_abilities = TRUE
+					boutput(master, "Now showing genetic abilities.")
 
-				ability_toggle.icon_state = "[layouts[layout_style]["ability_icon"]][current_ability_set]"
+				ability_toggle.icon_state = "[layouts[layout_style]["ability_icon"]][show_genetics_abilities]"
 				update_ability_hotbar()
 
 			if ("health")
@@ -834,16 +833,17 @@
 			if (master.abilityHolder.any_abilities_displayed)
 				pos_y = master.abilityHolder.y_occupied + 1
 
-		if (current_ability_set == 1) // items + standard
-			for(var/obj/ability_button/B2 in master.item_abilities)
-				B2.screen_loc = "NORTH-[pos_y],[pos_x]"
-				master.client.screen += B2
-				pos_x++
-				if(pos_x > 15)
-					pos_x = 1
-					pos_y++
+		// always show regular abilities
+		for(var/obj/ability_button/B2 in master.item_abilities)
+			B2.screen_loc = "NORTH-[pos_y],[pos_x]"
+			master.client.screen += B2
+			pos_x++
+			if(pos_x > 15)
+				pos_x = 1
+				pos_y++
 
-		if (current_ability_set == 2) // genetics
+		// if toggled off, do not show genetics abilities
+		if (show_genetics_abilities)
 			var/datum/bioEffect/power/P
 			for(var/ID in master.bioHolder.effects)
 				P = master.bioHolder.GetEffect(ID)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Genetics abilities are now visible by default, next to item and other abilities.
Clicking the button makes it so that genetics abilities are not shown, in case anyone feels like they have so many genetic powers that they want to not see them.
ON:
![image](https://user-images.githubusercontent.com/35579460/138456285-5d0c55bc-e1a9-43ac-8c8a-2445f17ba527.png)
OFF:
![image](https://user-images.githubusercontent.com/35579460/138456415-de1329cd-c06f-40f4-9289-4dab338527d9.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We got, like, at least 3 mhelps a day about where genetic abilities are, so the current system seems to not be very intuitive for new players.

I think you'd have a hard time acquiring so many genetic powers and item abilities that they wouldn't fit into a neat row.

Also, sometimes having to switch between them if you wanted to use both kinds of abilities was kinda annoying.

Bonus: this person but as a changeling with emagged cyberorgans
![image](https://user-images.githubusercontent.com/35579460/138457250-15b58894-f490-4bcf-9ce5-4dafba667f5b.png)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) Genetics abilities are now displayed by default, clicking the button now hides them.
```
