### PR TITLE
Corrects bald cost inconsistency

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -553,7 +553,7 @@
 	category = "trinkets"
 
 /obj/trait/bald
-	name = "Bald (-1) \[Trinkets\]"
+	name = "Bald (0) \[Trinkets\]"
 	cleanName = "Bald"
 	desc = "Start your shift with a wig instead of hair. I'm sure no one will be able to tell."
 	id = "bald"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the name of the bald trait to reflect the fact it is a 0 pointer.

Fixes #6401


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs/Inconsistencies bad
