### PR TITLE
buffs antag cleanbots and firebots

### DIFF
--- a/code/mob/living/critter/mob_bots.dm
+++ b/code/mob/living/critter/mob_bots.dm
@@ -49,7 +49,7 @@ ABSTRACT_TYPE(/mob/living/critter/bot)
 		HH.can_range_attack = 0
 		if(src.emagged == TRUE)
 			var/datum/limb/small_critter/L = HH.limb
-			L.max_wclass = W_CLASS_BULKY
+			L.max_wclass = W_CLASS_SMALL
 
 	setup_healths()
 		add_hh_robot(brute_hp, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cleanbots/firebots that start emagged will have a hand that can pick up small items instead of tiny items.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Antag cleanbots are easily the worst antag critter. They cant pick anything up and are almost unable to defend themselves due to only having abilities. This change makes it so they can set up neat traps and defend themselves with things other than abilities. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)UnfunnyPerson
(+)Antag cleanbots and firebots can now pick up small-tiny items instead of only being able to pick up tiny items.
```
