### PR TITLE
Semicolon shortcut for radio

### DIFF
--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -258,6 +258,9 @@
 	say_radio()
 		src.mainframe.say_radio()
 
+	say_main_radio()
+		src.mainframe.say_main_radio()
+
 	emote(var/act, var/voluntary = 0)
 		if (mainframe)
 			mainframe.emote(act, voluntary)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -428,6 +428,8 @@
 			src.toggle_point_mode()
 		if ("say_radio")
 			src.say_radio()
+		if ("say_main_radio")
+			src.say_radio()
 		else
 			. = ..()
 

--- a/code/modules/interface/action_associations.dm
+++ b/code/modules/interface/action_associations.dm
@@ -37,6 +37,7 @@ var/list/action_names = list(
 
 	"say" = "Say",
 	"say_radio" = "Say Radio",
+	"say_main_radio" = "Say Main Radio",
 	"dsay" = "Dead Say",
 	"asay" = "Admin Say",
 	"whisper" = "Whisper",
@@ -93,6 +94,7 @@ var/list/action_names = list(
 var/list/action_verbs = list(
 	"say" = "start-say",	// lord forgive me for i have sinned
 	"say_radio" = "say_radio",
+	"say_main_radio" = "say_main_radio",
 	"emote" = "say *customv",
 	"salute" = "me_hotkey salute",
 	"burp" = "me_hotkey burp",

--- a/code/modules/interface/keybind_style.dm
+++ b/code/modules/interface/keybind_style.dm
@@ -80,6 +80,7 @@ var/global/list/datum/keybind_style/keybind_styles = null
 	"EAST" = KEY_RIGHT,
 	"B" = KEY_POINT,
 	"T" = "say",
+	";" = "say_main_radio",
 	"Y" = "say_radio",
 	"ALT+W" = "whisper",
 	"O" = "ooc",

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -65,6 +65,21 @@
 	set name = "say_radio"
 	set hidden = 1
 
+/mob/verb/say_main_radio()
+	set name = "say_main_radio"
+	set hidden = 1
+
+/mob/living/say_main_radio()
+	set name = "say_main_radio"
+	set hidden = 1
+	var/text = input("", "Speaking on the main radio frequency") as null|text
+	if (client.preferences.auto_capitalization)
+		var/i = 1
+		while (copytext(text, i, i+1) == " ")
+			i++
+		text = capitalize(copytext(text, i))
+	src.say_verb(";" +text)
+
 /mob/living/say_radio()
 	set name = "say_radio"
 	set hidden = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a new keybinding `;` which lets you say stuff over your "main" radio channel (it just asks for input and then says what you entered with a ";" prefix as if you used T and then typed in ; first).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think it's a neat QoL change. People have to press T + ; often, now they can skip the T.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)pali
(*)You can now press ; directly to talk over the main radio channel instead of having to press T and then type in ;.
```
