### PR TITLE
Drinking via hotkey

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1151,7 +1151,14 @@
 		if (src.wedge)
 			choices += "remove [src.wedge]"
 			choices += "eat [src.wedge]"
+		if (reagents.total_volume > 0)
+			if (!choices.len)
+				if (!ON_COOLDOWN(src, "hotkey_drink", 0.6 SECONDS))
+					attack(user, user) //Most glasses people use won't have fancy cocktail stuff, so just skip the crap and drink for dear life
+				return
+			choices += "drink from it"
 		if (!choices.len)
+
 			boutput(user, "<span class='notice'>You can't think of anything to do with [src].</span>")
 			return
 
@@ -1175,6 +1182,10 @@
 			else
 				boutput(H, "<span class='alert'>You don't feel like you need to go.</span>")
 			return
+
+		else if (selection == "drink from it")
+			if (!ON_COOLDOWN(src, "hotkey_drink", 0.6 SECONDS))
+				attack(user, user)
 
 		else if (selection == "remove [src.in_glass]")
 			remove_thing = src.in_glass

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1152,7 +1152,7 @@
 			choices += "remove [src.wedge]"
 			choices += "eat [src.wedge]"
 		if (reagents.total_volume > 0)
-			if (!choices.len)
+			if (!length(choices))
 				if (!ON_COOLDOWN(src, "hotkey_drink", 0.6 SECONDS))
 					attack(user, user) //Most glasses people use won't have fancy cocktail stuff, so just skip the crap and drink for dear life
 				return

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -1158,7 +1158,6 @@
 				return
 			choices += "drink from it"
 		if (!choices.len)
-
 			boutput(user, "<span class='notice'>You can't think of anything to do with [src].</span>")
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets players drink from glasses via the attack_self proc, either automatically if none of the cocktail accoutrements are present, or as an option in the list if there is.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I keep wanting to shove liquids into myself with the C hotkey, like you can with foods, but currently that just gives you "you can't think of anything to do with X". Surely getting hammered is one of the easiest things for spacepeople to grasp.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)You can use the hotkey to drink from glasses now.
```
