### PR TITLE
Stop NPC assistants talking when dead

### DIFF
--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -34,7 +34,6 @@
 
 /mob/living/carbon/human/npc/assistant
 	ai_aggressive = 1
-	var/just_got_griefed = 0
 
 	New()
 		..()
@@ -72,7 +71,7 @@
 
 	attack_hand(mob/M)
 		..()
-		if(!just_got_griefed && (M.a_intent in list(INTENT_HARM,INTENT_DISARM,INTENT_GRAB)))
+		if(M.a_intent in list(INTENT_HARM,INTENT_DISARM,INTENT_GRAB))
 			if(!ON_COOLDOWN(src, "cry_grief", 5 SECONDS))
 				SPAWN_DBG(rand(10,30))
 					src.cry_grief(M)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stops NPC assistants talking when dead.
Use a 5 second cooldown.
Change some formatting.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People can spend minutes doing surgery and the NPC assistant will be spamming dead chat. Although realistic, this is kind of annoying.