### PR TITLE
fix runtime when riotgun uses ammo with no casing set

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -714,7 +714,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 				src.casings_to_eject = 0
 				if (src.ammo.amount_left < 8) // Do not eject shells if you're racking a full "clip"
 					var/turf/T = get_turf(src)
-					if (T) // Eject shells on rack instead of on shoot()
+					if (T && src.current_projectile.casing) // Eject shells on rack instead of on shoot()
 						var/obj/item/casing/C = new src.current_projectile.casing(T)
 						C.forensic_ID = src.forensic_ID
 						C.set_loc(T)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pretty much the title. Riotgun can use stuff like buckshot_burst, but it has no casing set, so runtime when racking.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
runtime bad
