### PR TITLE
Adjust bald trait cost to be consistent with loyalist, petasusaphilic, conspiracytheorist, pawnstar, etc

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -561,7 +561,7 @@
 	desc = "Start your shift with a wig instead of hair. I'm sure no one will be able to tell."
 	id = "bald"
 	icon_state = "placeholder"
-	points = 0
+	points = -1
 	isPositive = 1
 	category = list("trinkets")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Change from 0 to -1
* Players who already have the trait might be able to go negative, no idea, if they do it can be easily corrected later.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Consistent cost with the other traits in the trinket category

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(+)Bald now costs -1 trait points consistent with other traits of the trinket class.
```
