### PR TITLE
make destiny patho not require genetics access

### DIFF
--- a/code/obj/access_spawn.dm
+++ b/code/obj/access_spawn.dm
@@ -101,8 +101,6 @@
 	req_access = list(access_pathology)
 	#elif defined(SCIENCE_PATHO_MAP)
 	req_access = list(access_research)
-	#elif defined(MAP_OVERRIDE_DESTINY) // stupid destiny has patho in genetics
-	req_access = list(access_medlab)
 	#else
 	req_access = list(access_medical)
 	#endif


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If I remember correctly, these used to be in the same room, but apparently some time back Destiny was updated and now patho is no longer merged with genetics?
So now pathology on destiny should require medical access, as normal.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes little sense for it to need genetics access when it does not on other maps.
