### PR TITLE
Adds Medical Lollipop Dispenser To Mediborgs

### DIFF
--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -146,6 +146,7 @@
 		/obj/item/reagent_containers/mender/burn/medbot,
 		/obj/item/robospray, // TODO: make large version
 		/obj/item/reagent_containers/hypospray, // TODO: make large version
+		/obj/item/device/lollipopmaker/md,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/glass/beaker/large,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the lollipop dispenser to the mediborg module.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Adds a bit of rp and utility to mediborgs, while not being to gamechanging since there isn't many chems in the lollipops.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)Added the medical lollipop dispenser to the medical cyborg module.
```
