### PR TITLE
Removes the code that gives the derringer an unused stun

### DIFF
--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -349,11 +349,6 @@ toxic - poisons
 	icon_turf_hit = "bhole"
 	casing = /obj/item/casing/derringer
 
-	on_hit(atom/hit)
-		if(ismob(hit) && hasvar(hit, "stunned"))
-			hit:stunned += 5
-		..()
-
 /datum/projectile/bullet/a12
 	name = "buckshot"
 	shot_sound = 'sound/weapons/shotgunshot.ogg'


### PR DESCRIPTION
[cleanliness][removal] 
## About the PR
Removes useless code that adds a stun that does nothing.

## Why's this needed?
This code is not really needed as *it does nothing*.
