### PR TITLE
Allows Security Assistants to Access the Clarion's Equipment/Locker Room

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -44363,24 +44363,6 @@
 	icon_state = "blue1"
 	},
 /area/station/hallway/secondary/central)
-"chw" = (
-/obj/disposalpipe/segment,
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/airlock/pyro/glass/security{
-	name = "Locker Room";
-	req_access = null
-	},
-/obj/access_spawn/sec_lockers,
-/obj/firedoor_spawn,
-/turf/simulated/floor,
-/area/station/security/main)
 "chL" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
@@ -46573,7 +46555,7 @@
 	},
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingun;
+	displayed = new /obj/item/captaingun();
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -48096,6 +48078,24 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/central)
+"lXI" = (
+/obj/disposalpipe/segment,
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/airlock/pyro/glass/security{
+	name = "Locker Room";
+	req_access = null
+	},
+/obj/access_spawn/security,
+/obj/firedoor_spawn,
+/turf/simulated/floor,
+/area/station/security/main)
 "mct" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/decal/poster/wallsign/fire,
@@ -80760,7 +80760,7 @@ aQR
 bRg
 rSK
 kCY
-chw
+lXI
 eFS
 tbZ
 ban


### PR DESCRIPTION
[Bug] [QoL]


## About the PR:
Replaces '/obj/access_spawn/sec_lockers' with '/obj/access_spawn/security' in Clarion's Equipment/Locker Room, so that Security Assistants may access it, and use the vendor.



## Why's this needed?
As it is, Security Assistants cannot retrieve their gear from the vendor without the help of an officer or the HoS. I have also heard that SecAssistants not having access to the equipment room is a relic of a time before them, hence the bug label.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)The NSS Clarion now trusts Security Assistants enough to allow them to retrieve their own gear without supervision from a superior officer.
```
