### PR TITLE
Changes Capsaicin On-Touch Protection Requirement

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -1950,7 +1950,7 @@ datum
 				else if (method == TOUCH)
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
-						if((H.wear_mask?.c_flags & COVERSEYES) || (H.head?.c_flags & COVERSEYES))
+						if((H.wear_mask?.c_flags & COVERSEYES) || (H.head?.c_flags & COVERSEYES) || H.glasses && istype(H.glasses, /obj/item/clothing/glasses/sunglasses/sechud))
 							return
 						else H.reagents.add_reagent("capsaicin",round(volume_passed/5))
 						if(prob(50))

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -1948,16 +1948,29 @@ datum
 
 
 				else if (method == TOUCH)
-					if(iscarbon(M))
-						if(!M.wear_mask)
-							M.reagents.add_reagent("capsaicin",round(volume_passed/5))
-							if(prob(50))
-								M.emote("scream")
-								boutput(M, "<span class='alert'><b>Your eyes hurt!</b></span>")
-								M.take_eye_damage(1, 1)
-							M.change_eye_blurry(3)
-							M.changeStatus("stunned", 2 SECONDS)
-							M.change_misstep_chance(10)
+					if(ishuman(M))
+						var/mob/living/carbon/human/H = M
+						if((H.wear_mask?.c_flags & COVERSEYES) || (H.head?.c_flags & COVERSEYES))
+							return
+						else H.reagents.add_reagent("capsaicin",round(volume_passed/5))
+						if(prob(50))
+							H.emote("scream")
+							boutput(H, "<span class='alert'><b>Your eyes hurt!</b></span>")
+							H.take_eye_damage(1, 1)
+						H.change_eye_blurry(3)
+						H.changeStatus("stunned", 2 SECONDS)
+						H.change_misstep_chance(10)
+					else if(iscarbon(M))
+						if(M.wear_mask?.c_flags & COVERSEYES)
+							return
+						else M.reagents.add_reagent("capsaicin",round(volume_passed/5))
+						if(prob(50))
+							M.emote("scream")
+							boutput(M, "<span class='alert'><b>Your eyes hurt!</b></span>")
+							M.take_eye_damage(1, 1)
+						M.change_eye_blurry(3)
+						M.changeStatus("stunned", 2 SECONDS)
+						M.change_misstep_chance(10)
 
 
 		fooddrink/el_diablo


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUFF]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes capsaicin's on-touch protection to require eye cover to prevent it's effect. The eye cover is the same that prevents eye surgery, and sechuds.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, the only thing you need to protect yourself from the on-touch effect of capsaicin is any kind of mask, including the one everyone spawns with in their bag. This aims to make capsaicin more useful, by requiring more protection to prevent harm from it.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Capsaicin now requires eye covering to avoid it's On-touch effect. (For reference, if it blocks eye surgery, or it's sechuds, it'll block the on-touch effect of capsaicin.)
```
