### PR TITLE
Always add people to the respawn controller on ghostize

### DIFF
--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -287,7 +287,6 @@
 		O.bioHolder.CopyOther(src.bioHolder, copyActiveEffects = 0)
 		if (isghostrestrictedz(O.z) && !restricted_z_allowed(O, get_turf(O)) && !(src.client && src.client.holder))
 			O.set_loc(pick_landmark(LANDMARK_OBSERVER, locate(150, 150, 1)))
-		if (client) client.color = null  //needed for mesons dont kill me thx - ZeWaka
 
 		src.mind?.transfer_to(O)
 		src.ghost = O

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -288,15 +288,6 @@
 		if (isghostrestrictedz(O.z) && !restricted_z_allowed(O, get_turf(O)) && !(src.client && src.client.holder))
 			O.set_loc(pick_landmark(LANDMARK_OBSERVER, locate(150, 150, 1)))
 		if (client) client.color = null  //needed for mesons dont kill me thx - ZeWaka
-		if (src.client && src.client.holder && src.stat !=2)
-			// genuinely not sure what this is here for since we're setting the
-			// alive/dead status of the *ghost*.
-			// this seems to have made bizarre issues where
-			// some parts would think you were still alive even as a ghost
-			setalive(O)
-
-		// so, fuck that, you're dead, shithead. get over it.
-		setdead(O)
 
 		src.mind?.transfer_to(O)
 		src.ghost = O

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -293,7 +293,7 @@
 		if(istype(get_area(src),/area/afterlife))
 			qdel(src)
 
-		respawn_controller.subscribeNewRespawnee(src.ckey)
+		respawn_controller.subscribeNewRespawnee(O.ckey)
 		var/datum/respawnee/respawnee = global.respawn_controller.respawnees[O.ckey]
 		if(istype(respawnee))
 			respawnee.update_time_display()

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -293,6 +293,7 @@
 		if(istype(get_area(src),/area/afterlife))
 			qdel(src)
 
+		respawn_controller.subscribeNewRespawnee(src.ckey)
 		var/datum/respawnee/respawnee = global.respawn_controller.respawnees[O.ckey]
 		if(istype(respawnee))
 			respawnee.update_time_display()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug] [cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently there's a bunch of niche things that Just Delete You (science ghost, macho man slim jim, etc). Now whenever you get turned into a ghost for any reason, you get added to the respawn controller.

Note that ghostize is also used for things like turning target observers into regular observer ghosts; in this case they'll already be in the respawn controller, but the check in `subscribeNewRespawnee` is super cheap, so that shouldn't be an issue.

Also removed some un-needed code from `ghostize` because why not.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bunch of niche things or weird interactions weren't subscribing people to the controller. Now you'll always get it UNLESS something is deleting your mob without ghosting you, but that's a whole other problem.