### PR TITLE
Help intent shake-up no longer gets you up if you're voluntarily resting

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -65,7 +65,6 @@
 			H.add_fingerprint(src) // Just put 'em on the mob itself, like pulling does. Simplifies forensic analysis a bit (Convair880).
 
 	target.sleeping = 0
-	target.delStatus("resting")
 
 	target.changeStatus("stunned", -5 SECONDS)
 	target.changeStatus("paralysis", -5 SECONDS)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance] [feedback] [QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Does just that. Help intent shakes no longer remove the resting status, so if you're voluntarily lying on the floor you won't be shaken upright.
If there's still a want/need for a way to get laid-down people up, I could add some other method- maybe an aggressive grab always stands a person up if they're resting but not stunned/weakened?
Do note that if you're stunned AND resting, you'll have to manually stand up even after the stun is removed (by the shakes).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's annoying when you're intentionally trying to lie on the floor for whatever reason and people keep shaking you upright. Also annoying when you're trying to fake death and people keep RUINING IT


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) aloe
(+) Using help intent to shake a prone person upright will no longer stand them up if they're voluntarily resting (still removes stuns, etc)
```
