### PR TITLE
Changes robust(ed) donuts to come in a colorful lunchbox instead of a standard grey box

### DIFF
--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -32,7 +32,7 @@
 
 /obj/item/storage/lunchbox/robustdonuts
 	name = "robust donuts lunchbox"
-	icon_state = "box"
+	icon_state = "lunchbox"
 	desc = "Contains two robust donuts and two robusted donuts, for security use"
 	spawn_contents = list(/obj/item/reagent_containers/food/snacks/donut/custom/robust = 2, /obj/item/reagent_containers/food/snacks/donut/custom/robusted = 2)
 

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -30,8 +30,8 @@
 	desc = "Contains four morphine autoinjectors, for security use"
 	spawn_contents = list(/obj/item/reagent_containers/emergency_injector/morphine = 4)
 
-/obj/item/storage/box/robustdonuts
-	name = "robust donuts box"
+/obj/item/storage/lunchbox/robustdonuts
+	name = "robust donuts lunchbox"
 	icon_state = "box"
 	desc = "Contains two robust donuts and two robusted donuts, for security use"
 	spawn_contents = list(/obj/item/reagent_containers/food/snacks/donut/custom/robust = 2, /obj/item/reagent_containers/food/snacks/donut/custom/robusted = 2)

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -265,7 +265,7 @@
 
 /datum/materiel/utility/donuts
 	name = "Robust(ed) Donuts"
-	path = /obj/item/storage/box/robustdonuts
+	path = /obj/item/storage/lunchbox/robustdonuts
 	description = "Two Robust Donuts and two Robusted Donuts, which are loaded with helpful chemicals that help you resist stuns and heal you!"
 
 /datum/materiel/utility/crowdgrenades


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes those typical grey boxes security gets their donuts in to colorful lunchboxes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Requested by DeadSilent#9523
Its hard to tell which grey box has your internals, and which grey box has your yummy donuts.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sbmhawk
(+)Security vendors now come stocked with colorful lunchboxes of donuts, instead of boring grey boxes!
```
