### PR TITLE
Fixes private action bar images not garbage collecting

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -776,7 +776,7 @@ var/datum/action_controller/actions
 			icon_image.filters += filter(type="outline", size=0.5, color=rgb(255,255,255))
 			if (ismob(owner))
 				var/mob/M = owner
-				owner.client?.images += icon_image
+				M.client?.images += icon_image
 
 	onDelete()
 		if (ismob(owner))

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -739,18 +739,22 @@ var/datum/action_controller/actions
 	border_icon_state = "border-private"
 	onStart()
 		..()
-		bar.icon = null
-		border.icon = null
-		owner.images += bar.img
-		owner.images += border.img
+		if (ismob(owner))
+			var/mob/M = owner
+			bar.icon = null
+			border.icon = null
+			M.client?.images += bar.img
+			M.client?.images += border.img
 
 	onDelete()
 		bar.icon = 'icons/ui/actions.dmi'
 		border.icon = 'icons/ui/actions.dmi'
-		owner.images -= bar.img
-		owner.images -= border.img
-		qdel(bar.img)
-		qdel(border.img)
+		if (ismob(owner))
+			var/mob/M = owner
+			M.client?.images -= bar.img
+			M.client?.images -= border.img
+			qdel(bar.img)
+			qdel(border.img)
 		..()
 
 /datum/action/bar/private/icon //Only visible to the owner and has a little icon on the bar.
@@ -770,10 +774,14 @@ var/datum/action_controller/actions
 			icon_image.plane = icon_plane
 
 			icon_image.filters += filter(type="outline", size=0.5, color=rgb(255,255,255))
-			owner.images += icon_image
+			if (ismob(owner))
+				var/mob/M = owner
+				owner.client?.images += icon_image
 
 	onDelete()
-		owner.images -= icon_image
+		if (ismob(owner))
+			var/mob/M = owner
+			M.client?.images -= icon_image
 		qdel(icon_image)
 		..()
 

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -741,12 +741,14 @@ var/datum/action_controller/actions
 		..()
 		bar.icon = null
 		border.icon = null
-		owner << bar.img
-		owner << border.img
+		owner.images += bar.img
+		owner.images += border.img
 
 	onDelete()
 		bar.icon = 'icons/ui/actions.dmi'
 		border.icon = 'icons/ui/actions.dmi'
+		owner.images -= bar.img
+		owner.images -= border.img
 		qdel(bar.img)
 		qdel(border.img)
 		..()
@@ -768,9 +770,10 @@ var/datum/action_controller/actions
 			icon_image.plane = icon_plane
 
 			icon_image.filters += filter(type="outline", size=0.5, color=rgb(255,255,255))
-			owner << icon_image
+			owner.images += icon_image
 
 	onDelete()
+		owner.images -= icon_image
 		qdel(icon_image)
 		..()
 

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -101,6 +101,8 @@
 		if(cam)
 			cam.dispose()
 			cam = null
+		qdel(bot_mover)
+		bot_mover = null
 		..()
 
 	attackby(obj/item/W as obj, mob/user as mob)

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -101,8 +101,6 @@
 		if(cam)
 			cam.dispose()
 			cam = null
-		qdel(bot_mover)
-		bot_mover = null
 		..()
 
 	attackby(obj/item/W as obj, mob/user as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title
Images were being added to `client.images` and then never removed


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
GC is good
