### PR TITLE
Fixes borgs permanently stuttering after being crushed by an airlock

### DIFF
--- a/code/mob/living/silicon/robot_statusupdate.dm
+++ b/code/mob/living/silicon/robot_statusupdate.dm
@@ -1,8 +1,14 @@
 /datum/lifeprocess/robot_statusupdate
 	process(var/datum/gas_mixture/environment)
+
+		var/mult = get_multiplier()
+
 		if(!robot_owner.part_chest)
 			// this doesn't even make any sense unless you're rayman or some shit
 			robot_owner.death()
 
 		else if (!robot_owner.part_head)
 			robot_owner.death()
+
+		if (owner.stuttering)
+			owner.stuttering = max(owner.stuttering - 0.33*mult, 0) // for some reason this makes borg stammer go away way faster than human stammer without the 0.33* despite being otherwise identical


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a check to `lifeprocess/robot_statusupdate` to incrementally reduce the 'stuttering' var for a borg, identical to how the regular `lifeprocess/statusupdate` does it (though with a multiplier to account for the fact that the stutter was being removed far too quickly).
(The code on line 13 and 14 is ripped straight from the current lines 112 and 113 of `statusupdate`)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #6479 
Lets borgs actually speak after being pancaked by a temperamental airlock.