### PR TITLE
Don't explosion/grenade log sim areas

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -44,6 +44,9 @@ ABSTRACT_TYPE(/area) // don't instantiate this directly dummies, use /area/space
 	/// for escape checks
 	var/is_centcom = 0
 
+	/// Don't combat/explosion log this area (for VR and other gimmicks)
+	var/dont_log_combat = FALSE
+
 	level = null
 	#ifdef UNDERWATER_MAP
 	name = "Ocean"
@@ -1384,6 +1387,7 @@ ABSTRACT_TYPE(/area/sim)
 	skip_sims = 1
 	sims_score = 100
 	sound_group = "vr"
+	dont_log_combat = TRUE
 
 
 

--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -158,7 +158,7 @@ var/datum/explosion_controller/explosions
 
 	proc/logMe(var/power)
 		//I do not give a flying FUCK about what goes on in the colosseum and sims. =I
-		if((!istype(get_area(epicenter), /area/colosseum) || !istype(get_area(epicenter), /area/sim)) && istype(src.source))
+		if(istype(src.source))
 			// Cannot read null.name
 			var/logmsg = "Explosion with power [power] (Source: [source ? "[source.name]" : "*unknown*"])  at [log_loc(epicenter)]. Source last touched by: [key_name(source?.fingerprintslast)] (usr: [ismob(user) ? key_name(user) : user])"
 			if(power > 10)

--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -157,8 +157,8 @@ var/datum/explosion_controller/explosions
 		src.user = user
 
 	proc/logMe(var/power)
-		//I do not give a flying FUCK about what goes on in the colosseum. =I
-		if(!istype(get_area(epicenter), /area/colosseum) && istype(src.source))
+		//I do not give a flying FUCK about what goes on in the colosseum and sims. =I
+		if((!istype(get_area(epicenter), /area/colosseum) || !istype(get_area(epicenter), /area/sim)) && istype(src.source))
 			// Cannot read null.name
 			var/logmsg = "Explosion with power [power] (Source: [source ? "[source.name]" : "*unknown*"])  at [log_loc(epicenter)]. Source last touched by: [key_name(source?.fingerprintslast)] (usr: [ismob(user) ? key_name(user) : user])"
 			if(power > 10)

--- a/code/datums/gauntlet/crittergauntlet.dm
+++ b/code/datums/gauntlet/crittergauntlet.dm
@@ -2,6 +2,7 @@
 	name = "The Gauntlet"
 	icon_state = "dk_yellow"
 	virtual = 1
+	dont_log_combat = TRUE
 
 	Entered(var/atom/A)
 		..()

--- a/code/datums/gauntlet/podcolosseum.dm
+++ b/code/datums/gauntlet/podcolosseum.dm
@@ -2,6 +2,8 @@
 	name = "The Colosseum"
 	virtual = 1
 	ambient_light = "#bfbfbf"
+	dont_log_combat = TRUE
+
 
 	Entered(var/atom/A)
 		..()

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -161,8 +161,7 @@
 			for (var/obj/item/reagent_containers/glass/G in src.beakers)
 				if (G.reagents.total_volume) log_reagents += "[log_reagents(G)] "
 
-		//I do not give a flying FUCK about what goes on in the sims. =I
-		if(!istype(A, /area/sim))
+		if(!A.dont_log_combat)
 			message_admins("[log_reagents ? "Custom grenade" : "Grenade ([src])"] primed at [log_loc(src)] by [key_name(user)].")
 			logTheThing("combat", user, null, "primes a [log_reagents ? "custom grenade" : "grenade ([src.type])"] at [log_loc(user)].[log_reagents ? " [log_reagents]" : ""]")
 

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -152,8 +152,9 @@
 	proc/arm(mob/user as mob)
 		if (src.state || src.stage != 2)
 			return 1
-		var/area/a = get_area(src)
-		if(a.sanctuary) return
+		var/area/A = get_area(src)
+		if(A.sanctuary)
+			return
 		// Custom grenades only. Metal foam etc grenades cannot be modified (Convair880).
 		var/log_reagents = null
 		if (src.name == "grenade")
@@ -161,7 +162,7 @@
 				if (G.reagents.total_volume) log_reagents += "[log_reagents(G)] "
 
 		//I do not give a flying FUCK about what goes on in the sims. =I
-		if(!istype(get_area(epicenter), /area/sim)) && istype(src.source))
+		if(!istype(A, /area/sim))
 			message_admins("[log_reagents ? "Custom grenade" : "Grenade ([src])"] primed at [log_loc(src)] by [key_name(user)].")
 			logTheThing("combat", user, null, "primes a [log_reagents ? "custom grenade" : "grenade ([src.type])"] at [log_loc(user)].[log_reagents ? " [log_reagents]" : ""]")
 
@@ -171,8 +172,6 @@
 		playsound(src, "sound/weapons/armbomb.ogg", 75, 1, -3)
 		SPAWN_DBG(3 SECONDS)
 			if (src && !src.disposed)
-				a = get_area(src)
-				if(a.sanctuary) return
 				if(user?.equipped() == src)
 					user.u_equip(src)
 				explode()

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -159,8 +159,11 @@
 		if (src.name == "grenade")
 			for (var/obj/item/reagent_containers/glass/G in src.beakers)
 				if (G.reagents.total_volume) log_reagents += "[log_reagents(G)] "
-		message_admins("[log_reagents ? "Custom grenade" : "Grenade ([src])"] primed at [log_loc(src)] by [key_name(user)].")
-		logTheThing("combat", user, null, "primes a [log_reagents ? "custom grenade" : "grenade ([src.type])"] at [log_loc(user)].[log_reagents ? " [log_reagents]" : ""]")
+
+		//I do not give a flying FUCK about what goes on in the sims. =I
+		if(!istype(get_area(epicenter), /area/sim)) && istype(src.source))
+			message_admins("[log_reagents ? "Custom grenade" : "Grenade ([src])"] primed at [log_loc(src)] by [key_name(user)].")
+			logTheThing("combat", user, null, "primes a [log_reagents ? "custom grenade" : "grenade ([src.type])"] at [log_loc(user)].[log_reagents ? " [log_reagents]" : ""]")
 
 		boutput(user, "<span class='alert'>You prime the grenade! 3 seconds!</span>")
 		src.state = 1

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -100,7 +100,7 @@ PIPE BOMBS + CONSTRUCTION
 
 	proc/logGrenade(mob/user)
 		var/area/A = get_area(src)
-		if(!istype(A, /area/sim))
+		if(!A.dont_log_combat)
 			message_admins("Grenade ([src]) primed at [log_loc(src)] by [key_name(user)].")
 			logTheThing("combat", user, null, "primes a grenade ([src.type]) at [log_loc(user)].")
 
@@ -1153,7 +1153,9 @@ PIPE BOMBS + CONSTRUCTION
 					return
 				if (user.bioHolder && user.bioHolder.HasEffect("clumsy"))
 					boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
-					logTheThing("combat", user, null, "accidentally triggers [src] (clumsy bioeffect) at [log_loc(user)].")
+					var/area/A = get_area(src)
+					if(!A.dont_log_combat)
+						logTheThing("combat", user, null, "accidentally triggers [src] (clumsy bioeffect) at [log_loc(user)].")
 					SPAWN_DBG(0.5 SECONDS)
 						user.u_equip(src)
 						src.boom()
@@ -1168,7 +1170,9 @@ PIPE BOMBS + CONSTRUCTION
 					src.state = 1
 
 					// Yes, please (Convair880).
-					logTheThing("combat", user, null, "attaches a [src] to [target] at [log_loc(target)].")
+					var/area/A = get_area(src)
+					if(!A.dont_log_combat)
+						logTheThing("combat", user, null, "attaches a [src] to [target] at [log_loc(target)].")
 
 					SPAWN_DBG (src.det_time)
 						if (src)
@@ -1254,7 +1258,9 @@ PIPE BOMBS + CONSTRUCTION
 					return
 				if (user.bioHolder && user.bioHolder.HasEffect("clumsy"))
 					boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
-					logTheThing("combat", user, null, "accidentally triggers [src] (clumsy bioeffect) at [log_loc(user)].")
+					var/area/A = get_area(src)
+					if(!A.dont_log_combat)
+						logTheThing("combat", user, null, "accidentally triggers [src] (clumsy bioeffect) at [log_loc(user)].")
 					SPAWN_DBG(0.5 SECONDS)
 						user.u_equip(src)
 						src.boom()
@@ -1269,7 +1275,9 @@ PIPE BOMBS + CONSTRUCTION
 					src.state = 1
 
 					// Yes, please (Convair880).
-					logTheThing("combat", user, null, "attaches a [src] to [target] at [log_loc(target)].")
+					var/area/A = get_area(src)
+					if(!A.dont_log_combat)
+						logTheThing("combat", user, null, "attaches a [src] to [target] at [log_loc(target)].")
 
 					SPAWN_DBG (src.det_time)
 						if (src)
@@ -1572,7 +1580,7 @@ PIPE BOMBS + CONSTRUCTION
 		boutput(user, "<span class='alert'>You activate the pipe bomb! 5 seconds!</span>")
 		armed = 1
 		var/area/A = get_area(src)
-		if(!istype(A, /area/sim))
+		if(!A.dont_log_combat)
 			message_admins("[key_name(user)] arms a pipe bomb (power [strength]) at [log_loc(src)] by [key_name(user)].")
 			logTheThing("combat", user, null, "arms a pipe bomb (power [strength]) at [log_loc(src)])")
 

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -746,7 +746,7 @@ PIPE BOMBS + CONSTRUCTION
 					user.mind.transfer_to(newmob)
 					qdel(user)
 				else
-					logTheThing("combat", user, null, "was teleported by touching a [src] at [log_loc(src)].")
+					logTheThing("combat", user, null, "was teleported by touching [src] ([src.type]) at [log_loc(src)].")
 					if (destination)
 						user.set_loc(destination)
 					else

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -39,8 +39,7 @@ PIPE BOMBS + CONSTRUCTION
 			if (!isturf(user.loc))
 				src.state = 0
 				return
-			message_admins("Grenade ([src]) primed at [log_loc(src)] by [key_name(user)].")
-			logTheThing("combat", user, null, "primes a grenade ([src.type]) at [log_loc(user)].")
+			logGrenade(user)
 			if (user?.bioHolder.HasEffect("clumsy"))
 				boutput(user, "<span class='alert'>Huh? How does this thing work?!</span>")
 				src.icon_state = src.icon_state_armed
@@ -68,8 +67,7 @@ PIPE BOMBS + CONSTRUCTION
 			if (!src.state)
 				src.state = 1
 				src.icon_state = src.icon_state_armed
-				message_admins("Grenade ([src]) primed at [log_loc(src)] by [key_name(user)].")
-				logTheThing("combat", user, null, "primes a grenade ([src.type]) at [log_loc(user)].")
+				logGrenade(user)
 				boutput(user, "<span class='alert'>You prime [src]! [det_time/10] seconds!</span>")
 				playsound(src.loc, src.sound_armed, 75, 1, -3)
 				SPAWN_DBG(src.det_time)
@@ -99,6 +97,12 @@ PIPE BOMBS + CONSTRUCTION
 			return null
 		else
 			return T
+
+	proc/logGrenade(mob/user)
+		var/area/A = get_area(src)
+		if(!istype(A, /area/sim))
+			message_admins("Grenade ([src]) primed at [log_loc(src)] by [key_name(user)].")
+			logTheThing("combat", user, null, "primes a grenade ([src.type]) at [log_loc(user)].")
 
 /obj/item/old_grenade/banana
 	desc = "It is set to detonate in 3 seconds."
@@ -190,8 +194,7 @@ PIPE BOMBS + CONSTRUCTION
 			if (!isturf(user.loc))
 				src.state = 0
 				return
-			message_admins("Grenade ([src]) primed at [log_loc(src)] by [key_name(user)].")
-			logTheThing("combat", user, null, "primes a grenade ([src.type]) at [log_loc(user)].")
+			logGrenade(user)
 			if (user?.bioHolder.HasEffect("clumsy"))
 				boutput(user, "<span style=\"color:red\">Huh? How does this thing work?!</span>")
 				src.icon_state = src.icon_state_exploding
@@ -256,8 +259,7 @@ PIPE BOMBS + CONSTRUCTION
 			if (!isturf(user.loc))
 				src.state = 0
 				return
-			message_admins("Grenade ([src]) primed at [log_loc(src)] by [key_name(user)].")
-			logTheThing("combat", user, null, "primes a grenade ([src.type]) at [log_loc(user)].")
+			logGrenade(user)
 			if (user?.bioHolder.HasEffect("clumsy"))
 				boutput(user, "<span style=\"color:red\">Huh? How does this thing work?!</span>")
 				src.icon_state = src.icon_state_exploding
@@ -685,7 +687,7 @@ PIPE BOMBS + CONSTRUCTION
 			return
 		if (istype(target, /obj/item/storage)) return ..()
 		if (src.state == 0)
-			message_admins("Grenade ([src]) primed in [get_area(src)] [log_loc(src)] by [key_name(user)].")
+			message_admins("Grenade ([src]) primed at [log_loc(src)] by [key_name(user)].")
 			logTheThing("combat", user, null, "primes a grenade ([src.type]) at [log_loc(user)].")
 			boutput(user, "<span class='alert'>You pull the pin on [src]. You're not sure what that did, but you throw it anyway.</span>")
 			src.state = 1
@@ -698,7 +700,7 @@ PIPE BOMBS + CONSTRUCTION
 		if (!isturf(user.loc))
 			return
 		if (src.state == 0)
-			message_admins("Grenade ([src]) primed in [get_area(src)] [log_loc(src)] by [key_name(user)].")
+			message_admins("Grenade ([src]) primed at [log_loc(src)] by [key_name(user)].")
 			logTheThing("combat", user, null, "primes a grenade ([src.type]) at [log_loc(user)].")
 			boutput(user, "<span class='alert'>You pull the pin on [src]. You're not sure what that did. Maybe you should throw it?</span>")
 			src.state = 1
@@ -744,6 +746,7 @@ PIPE BOMBS + CONSTRUCTION
 					user.mind.transfer_to(newmob)
 					qdel(user)
 				else
+					logTheThing("combat", user, null, "was teleported by touching a [src] at [log_loc(src)].")
 					if (destination)
 						user.set_loc(destination)
 					else
@@ -1568,8 +1571,10 @@ PIPE BOMBS + CONSTRUCTION
 			return
 		boutput(user, "<span class='alert'>You activate the pipe bomb! 5 seconds!</span>")
 		armed = 1
-		message_admins("[key_name(user)] arms a pipe bomb (power [strength]) in [user.loc.loc], [showCoords(user.x, user.y, user.z)].")
-		logTheThing("combat", user, null, "arms a pipe bomb (power [strength]) in [user.loc.loc] ([showCoords(user.x, user.y, user.z)])")
+		var/area/A = get_area(src)
+		if(!istype(A, /area/sim))
+			message_admins("[key_name(user)] arms a pipe bomb (power [strength]) at [log_loc(src)] by [key_name(user)].")
+			logTheThing("combat", user, null, "arms a pipe bomb (power [strength]) at [log_loc(src)])")
 
 		if (sound_effect)
 			SPAWN_DBG(4 SECONDS) //you can use a sound effect to hold a bomb in hand and throw it at the very last moment!

--- a/code/z_adventurezones/afterlife.dm
+++ b/code/z_adventurezones/afterlife.dm
@@ -5,6 +5,7 @@ Afterlife bar areas
 Hell area (send people here if they die in a shameful way)
 */
 /area/afterlife
+	dont_log_combat = TRUE
 
 /area/afterlife/bar
 	name = "The Afterlife Bar"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes explosion, pipebomb, grenade logging for sims.
Logs light grenade teleports.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
VR area information is irrelevant.
It's probably useful to know if someone was teleported by a light grenade.