### PR TITLE
Fixes bug with critter cleanbots and steam

### DIFF
--- a/code/mob/living/critter/mob_bots.dm
+++ b/code/mob/living/critter/mob_bots.dm
@@ -227,6 +227,7 @@ ABSTRACT_TYPE(/datum/targetable/critter/bot/fill_with_chem)
 				var/cleaner_amt = master.reagents.get_reagent_amount(cleaning_reagent)
 				if (cleaner_amt <= 10)
 					master.reagents.add_reagent(cleaning_reagent, 10 - cleaner_amt)
+				master.reagents.del_reagent("water")
 				master.reagents.reaction(T, TOUCH, 10)
 
 			if (T.active_liquid)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When a critter cleanbot tries to mop the floor, all water is removed from its reagent container. This prevents some potential issues with steam and frees up the internal reservoir for other chemicals.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #6477. 

Steam is weird. Rather than being its own reagent, it's water with a new name and description. When a cleanbot mops with steam in it, the abstract fluid parent ends up on the tile. This prevents this behavior.

