### PR TITLE
Removes the multitool mechcomp popup menu from vending machines if the panel is open

### DIFF
--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -301,6 +301,10 @@
 		var/obj/machinery/door/hacked_door = comsig_target
 		if(hacked_door.p_open)
 			return
+	if(istype(comsig_target, /obj/machinery/vending))
+		var/obj/machinery/vending/hacked_vendor = comsig_target
+		if(hacked_vendor.panel_open)
+			return
 	if(!ispulsingtool(W) || !isliving(user) || user.stat)
 		return 0
 	if(length(src.configs))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

A follow-up PR to #5844. I also checked other hackable machinery, but only vending machines seem to be the issue.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

For the exact same reason I made the previous PR. Annoying popups bad
