### PR TITLE
Prevent shell casings from burning

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -248,6 +248,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 	icon_state = "medium"
 	w_class = W_CLASS_TINY
 	var/forensic_ID = null
+	burn_possible = 0
 
 	small
 		icon_state = "small"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets burn_possible to false on shell casings.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Heavy client side lag spikes in fires on nuclear emergency.
Spent casings are made of brass and wouldn't catch fire (although they would melt at 930 degrees C~ depending upon composition).