### PR TITLE
Implement tail disposing

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -513,7 +513,7 @@
 				//////////////HEAD//////////////////
 				L.organHolder?.head?.MakeMutantHead(HEAD_HUMAN, 'icons/mob/human_head.dmi', "head")
 
-	proc/organ_mutator(var/mob/living/carbon/human/O, var/mode as text, var/drop_tail)
+	proc/organ_mutator(var/mob/living/carbon/human/O, var/mode as text)
 		if(!ishuman(O) || !(O?.organHolder))
 			return // hard to mess with someone's organs if they can't have any
 
@@ -527,11 +527,8 @@
 					for(var/mutorgan in src.mutant_organs)
 						if (mutorgan == "tail") // Not everyone has a tail. So just force it in
 							if (OHM.tail)
-								var/obj/item/organ/tail/organ_drop = OHM.tail
-								organ_drop.donor = null // Humanizing tail-havers made them clumsy otherwise
-								OHM.drop_organ("tail")
-								if (!drop_tail)
-									qdel(organ_drop)
+								OHM.tail.donor = null // Humanizing tail-havers made them clumsy otherwise
+								qdel(OHM.tail)
 						else if(mutorgan == "butt") // butts arent organs
 							var/obj/item/clothing/head/butt/org = OHM.get_organ(mutorgan)
 							if(!org || istype(org, /obj/item/clothing/head/butt/cyberbutt)) // No free butts, keep your robutt too
@@ -547,10 +544,7 @@
 				if(!src.mutant_organs.len)
 					return // All done!
 				if (OHM.tail) // mutant to human, drop the tail. Unless you're a changer, then your butt just eats it
-					var/obj/organ_drop = OHM.tail
-					OHM.drop_organ("tail")
-					if (!drop_tail)
-						qdel(organ_drop)
+					qdel(OHM.tail)
 				else
 					for(var/mutorgan in src.mutant_organs)
 						if(mutorgan == "butt") // butts arent organs

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -527,7 +527,6 @@
 					for(var/mutorgan in src.mutant_organs)
 						if (mutorgan == "tail") // Not everyone has a tail. So just force it in
 							if (OHM.tail)
-								OHM.tail.donor = null // Humanizing tail-havers made them clumsy otherwise
 								qdel(OHM.tail)
 						else if(mutorgan == "butt") // butts arent organs
 							var/obj/item/clothing/head/butt/org = OHM.get_organ(mutorgan)

--- a/code/obj/item/organs/tail.dm
+++ b/code/obj/item/organs/tail.dm
@@ -39,8 +39,6 @@
 		if(holder)
 			holder.tail = null
 			holder.donor.update_body()
-			holder.organ_list["tail"] = null
-			holder = null
 		. = ..()
 
 	proc/colorize_tail(var/datum/appearanceHolder/AHL)

--- a/code/obj/item/organs/tail.dm
+++ b/code/obj/item/organs/tail.dm
@@ -38,7 +38,6 @@
 			on_removal()
 			holder.tail = null
 			holder.donor.update_body()
-		donor = null
 		. = ..()
 
 	proc/colorize_tail(var/datum/appearanceHolder/AHL)

--- a/code/obj/item/organs/tail.dm
+++ b/code/obj/item/organs/tail.dm
@@ -33,6 +33,14 @@
 			build_mob_tail_image()
 			update_tail_icon()
 
+	disposing()
+		on_removal()
+		holder.tail = null
+		holder.donor.update_body()
+		holder.organ_list["tail"] = null
+		holder = null
+		. = ..()
+
 	proc/colorize_tail(var/datum/appearanceHolder/AHL)
 		if(src.colorful)
 			if (AHL && istype(AHL, /datum/appearanceHolder))

--- a/code/obj/item/organs/tail.dm
+++ b/code/obj/item/organs/tail.dm
@@ -35,6 +35,7 @@
 
 	disposing()
 		on_removal()
+		donor = null
 		holder.tail = null
 		holder.donor.update_body()
 		holder.organ_list["tail"] = null

--- a/code/obj/item/organs/tail.dm
+++ b/code/obj/item/organs/tail.dm
@@ -34,11 +34,11 @@
 			update_tail_icon()
 
 	disposing()
-		on_removal()
-		donor = null
 		if(holder)
+			on_removal()
 			holder.tail = null
 			holder.donor.update_body()
+		donor = null
 		. = ..()
 
 	proc/colorize_tail(var/datum/appearanceHolder/AHL)

--- a/code/obj/item/organs/tail.dm
+++ b/code/obj/item/organs/tail.dm
@@ -36,10 +36,11 @@
 	disposing()
 		on_removal()
 		donor = null
-		holder.tail = null
-		holder.donor.update_body()
-		holder.organ_list["tail"] = null
-		holder = null
+		if(holder)
+			holder.tail = null
+			holder.donor.update_body()
+			holder.organ_list["tail"] = null
+			holder = null
 		. = ..()
 
 	proc/colorize_tail(var/datum/appearanceHolder/AHL)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][CHORE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Implements disposing proc for tails
* Removes support for tail dropping on mutant race change. This was otherwise unimplemented and causing qdeled tail objects to be pulled from null space when mutant were crushered. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Crushing a mutant race mob deleted their tail, then called a proc to drop their tail which pulled it out of null space, which then got the crusher attempting to delete it, while at the same time the tail was also  attempting to qdel it's already qdel'd self again in a giant mess of  deletion nonsense.