### PR TITLE
Returning MechComps to the Vending Machine

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1426,8 +1426,8 @@
 		product_list += new/datum/data/vending_product(/obj/item/mechanics/wificomp, 30)
 		product_list += new/datum/data/vending_product(/obj/item/mechanics/wifisplit, 30)
 /obj/machinery/vending/mechanics/attackby(obj/item/W as obj, mob/user as mob)
-	..()
 	if(!istype(W,/obj/item/mechanics))
+		..()
 		return
 	for(var/datum/data/vending_product/product in product_list)
 		if(W.type == product.product_path)

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1425,6 +1425,17 @@
 		product_list += new/datum/data/vending_product(/obj/item/mechanics/triplaser, 30)
 		product_list += new/datum/data/vending_product(/obj/item/mechanics/wificomp, 30)
 		product_list += new/datum/data/vending_product(/obj/item/mechanics/wifisplit, 30)
+/obj/machinery/vending/mechanics/attackby(obj/item/W as obj, mob/user as mob)
+	..()
+	if(!istype(W,/obj/item/mechanics))
+		return
+	for(var/datum/data/vending_product/product in product_list)
+		if(W.type == product.product_path)
+			boutput(user, "<span class='notice'>You return the [W] to the vending machine.</span>")
+			product.product_amount += 1
+			qdel(W)
+			generate_HTML(1)
+			return
 
 /obj/machinery/vending/computer3
 	name = "CompTech"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
MechComps can now be "returned" to the MechComp vending machine by hitting it with the mechcomp

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Helps not clutter the floor when you have to remove your contraption (or when you dispense too many mechcomps).


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Jimmyl
(+)MechComps can now be returned to the Vending Machine
```
