### PR TITLE
Cargo Mass Loader/Driver Fix/Speedup

### DIFF
--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -65,11 +65,11 @@
 						SPAWN_DBG(0)
 							if (door)
 								door.open()
-						SPAWN_DBG(10 SECONDS)
+						SPAWN_DBG(3 SECONDS)
 							if (door)
-								door.close() //this may need some adjusting still
+								door.close()
 
-				SPAWN_DBG(door ? 55 : 20) driver_operating = 0
+				SPAWN_DBG(door ? 25 : 20) driver_operating = 0
 
 				sleep(door ? 20 : 10)
 				if (driver)

--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -40,7 +40,7 @@
 				src.set_dir(get_dir(src,driver))
 
 	proc/activate()
-		if(operating || !isturf(src.loc)) return
+		if(operating || !isturf(src.loc) || driver_operating) return
 		operating = 1
 		flick("launcher_loader_1",src)
 		playsound(src, "sound/effects/pump.ogg",50, 1)
@@ -69,7 +69,7 @@
 							if (door)
 								door.close()
 
-				SPAWN_DBG(door ? 25 : 20) driver_operating = 0
+				SPAWN_DBG(door ? 30 : 20) driver_operating = 0
 
 				sleep(door ? 20 : 10)
 				if (driver)

--- a/code/obj/machinery/launcherloader.dm
+++ b/code/obj/machinery/launcherloader.dm
@@ -69,7 +69,7 @@
 							if (door)
 								door.close()
 
-				SPAWN_DBG(door ? 30 : 20) driver_operating = 0
+				SPAWN_DBG(door ? 30 : 20) driver_operating = FALSE
 
 				sleep(door ? 20 : 10)
 				if (driver)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

A few tweaks to timing (and a check to see if the mass driver is operating) has made cargo's mass driver *significantly* speedier and more reliable by about 2-3x. The driver now, when multiple crates are queued, will take 5 to 6 seconds between crates. (barring minor exceptions where process() executes just a moment before the driver finishes operating, causing an additional 2 or so seconds in wait time)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently, the blast door for the mass driver closes like a second before the driver attempts to shoot again, requiring you to wait until process() sees that something is on the loader, the loader attempts to push it onto the driver, which then sends the command to the driver after some delay to actually fire, which can potentially take about 18 seconds, compared to the roughly 5-6 seconds it now takes. Rinse and repeat if you have several crates queued for export.

This also fixes the issue where, occasionally, a crate would be loaded onto the driver before the driver finished operating but after the previous crate was ejected, leaving the crate to sit on the driver until manually triggered or a new crate is sent in.

## Videos

The following video demonstrates both the increased speed of the loader/driver, as well as that minor issue where process() seems to tick just a moment before the driver finishes operating, hence the initial delay.

https://streamable.com/aw2bhu

I'm adding the following video since someone requested I add some context to this PR regarding how cargo currently works. So, if you haven't played cargo in a while, please examine how Fucking Awful this is:

https://puu.sh/IlSTd/37ef46768d.webm

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Nexusuxen
(+) Cargo mass drivers/loaders now operate significantly faster and are generally more reliable now.
```
