### PR TITLE
fix AIs being unable to hear with their mainframe

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -264,7 +264,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 		return src.eyecam
 	return src
 
-/mob/living/silicon/ai/show_message(msg, type, alt, alt_type, group = 0, var/image/chat_maptext/assoc_maptext = null)
+/mob/living/silicon/ai/show_message(msg, type, alt, alt_type, group = "", var/just_maptext, var/image/chat_maptext/assoc_maptext = null)
 	..()
 	if (deployed_to_eyecam && src.eyecam)
 		src.eyecam.show_message(msg, 1, 0, 0, group)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Seems that /mob/living/silicon/ai/show_message() was missing the just_maptext argument that /mob/show_message() had, so the maptext was used for that argument instead. 
This resulted in it basically always being true, so AIs would only get the maptext instead of hearing things in the chatbox.
Sadly, said maptext was already used for the just_maptext argument, so all in all the AIs didn't really hear anything while in the core.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So AIs can hear if someone talks near their core, for shuttle rides and stuff.