### PR TITLE
attempting to reopen a multicontext menu now closes it

### DIFF
--- a/code/modules/interface/multiContext/multiContext.dm
+++ b/code/modules/interface/multiContext/multiContext.dm
@@ -26,6 +26,7 @@
 /mob/proc/showContextActions(list/datum/contextAction/applicable, atom/target, datum/contextLayout/customContextLayout)
 	if(length(contextButtons))
 		closeContextActions()
+		return
 
 	var/list/buttons = list()
 	for(var/datum/contextAction/C as anything in applicable)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Before, when opening a multicontext menu again, it would close the first one and immediately open the new one.
Now, it would just close the existing one.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This makes it so you can close multicontext menus easily.
Say, you are in a pod, accidentally click the pod. Now you can just click the pod again to close the menu.
The same applies to other multicontext menus, though for a lot of those it matters less, since you could close them by moving before.