### PR TITLE
Requisition payout buff pass

### DIFF
--- a/code/modules/economy/requisition/rc_aid.dm
+++ b/code/modules/economy/requisition/rc_aid.dm
@@ -327,7 +327,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 /datum/rc_entry/reagent/fuel
 	name = "welding-grade liquid fuel"
 	chemname = "fuel"
-	feemod = 4
+	feemod = 6
 
 /datum/rc_entry/reagent/coffee
 	name = "coffee"

--- a/code/modules/economy/requisition/rc_aid.dm
+++ b/code/modules/economy/requisition/rc_aid.dm
@@ -4,7 +4,7 @@ ABSTRACT_TYPE(/datum/req_contract/aid)
 
 /datum/req_contract/aid/wrecked
 	//name = "Breach Recovery"
-	payout = 1200
+	payout = 3000
 	var/list/namevary = list("Breach Recovery","Breach Response","Integrity Failure","Crisis Response","Disaster Assistance","Disaster Response")
 	var/list/desc_placejob = list("research","mining","security","cargo transfer")
 	var/list/desc_placetype = list("vessel","ship","station","outpost")
@@ -75,7 +75,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/basictool)
 
 /datum/req_contract/aid/triage
 	//name = "Medical Aid"
-	payout = 1100
+	payout = 3000
 	var/list/namevary = list("Medical Aid","Medical Emergency","Triage Support","Aid Request","Critical Condition")
 	var/list/desc_helpsite = list("A medical facility","An affiliated station's medical bay","A triage center","A medical outpost","Our nearest station")
 	var/list/desc_tense = list("to assist with","after heavy load due to","to restock after")
@@ -118,7 +118,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/basictool)
 
 ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 /datum/rc_entry/item/surgical
-	feemod = 130
+	feemod = 180
 
 	scalpel
 		name = "scalpel"
@@ -126,7 +126,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 
 	saw
 		name = "circular saw"
-		feemod = 140
+		feemod = 190
 		typepath = /obj/item/circular_saw
 
 	scissors
@@ -143,17 +143,17 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 
 	stapler
 		name = "staple gun"
-		feemod = 230
+		feemod = 330
 		typepath = /obj/item/staple_gun
 
 /datum/rc_entry/item/bandage
 	name = "bandage roll"
-	feemod = 150
+	feemod = 210
 	typepath = /obj/item/bandage
 
 /datum/rc_entry/item/lgloves
 	name = "latex glove pair"
-	feemod = 110
+	feemod = 150
 	typepath = /obj/item/clothing/gloves/latex
 
 /datum/rc_entry/item/hypospray
@@ -163,14 +163,14 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 
 /datum/rc_entry/item/med_analyzer
 	name = "health analyzer"
-	feemod = 450
+	feemod = 600
 	typepath = /obj/item/device/analyzer/healthanalyzer
 
 
 
 /datum/req_contract/aid/geeksquad
 	//name = "Computer Failure"
-	payout = 900
+	payout = 2500
 	var/list/namevary = list("Systems Failure","Short Circuit","Computer Overload","Electronics Failure","Systems Breakdown")
 	var/list/desc_wherebork = list("research","mining","security","cargo transfer","communications","deep-space survey")
 	var/list/desc_whobork = list("vessel","ship","station","outpost")
@@ -268,7 +268,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 
 /datum/req_contract/aid/supplyshort
 	//name = "Supply Chain Failure"
-	payout = 900
+	payout = 2400
 	var/list/namevary = list("Urgent Restock","Supply Crisis","Supply Chain Failure","Short Stock","Emergency Resupply")
 	var/list/desc_placejob = list("research","mining","hydroponics","civilian","Nanotrasen")
 	var/list/desc_place = list("vessel","station","outpost","colony")

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -4,7 +4,7 @@ ABSTRACT_TYPE(/datum/req_contract/civilian)
 
 /datum/req_contract/civilian/event_catering
 	name = "Event Catering"
-	payout = 500
+	payout = 6000
 	var/list/desc_event = list("reception","formal event","welcoming party","going-away party","commemorative dinner","dinner")
 	var/list/desc_honorific = list("an esteemed","an infamous","a famous","a renowned")
 	var/list/desc_origin = list(" Nanotrasen"," Martian"," freelancing"," frontier"," - if only barely -"," retired")
@@ -87,7 +87,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 
 /datum/req_contract/civilian/furnishing
 	//name = "Interior Outfitting"
-	payout = 800
+	payout = 2200
 	var/list/namevary = list("Interior Outfitting","Furnishing Assistance","Interior Decorating","Occupancy Preparations","Last-Minute Furnishing")
 	var/list/desc_whatitdoes = list("A new gaming","An extraction","A medical","A research","A cartographic","A transit")
 	var/list/desc_whatitis = list("vessel","station","platform","outpost")
@@ -160,7 +160,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 
 /datum/req_contract/civilian/greytide
 	//name = "Crew Embarcation"
-	payout = 700
+	payout = 1500
 	var/list/namevary = list("Crew Embarcation","Crew Onboarding","New Hands on Deck","Expedited Outfitting","Personnel Rotation")
 	var/list/desc_task = list("mining","hydroponics","cargo handling","engineering","medical","research","cartographic")
 	var/list/desc_place = list("vessel","station","platform","outpost")
@@ -171,9 +171,9 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 		src.name = pick(namevary)
 		var/task = pick(desc_task) //subvariation
 		src.flavor_desc = "An affiliated [task] [pick(desc_place)] requires sets of attire for newly [pick(desc_hiring)] [pick(desc_noobs)]."
-		src.payout += rand(0,20) * 10
 
 		var/crewcount = rand(4,12)
+		src.payout += rand(3,4) * 10 * crewcount
 
 		//uniform pickin
 		if(prob(70))
@@ -262,12 +262,12 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/reagent/water
 	name = "water"
 	chemname = "water"
-	feemod = 4
+	feemod = 5
 
 
 /datum/req_contract/civilian/birthdaybash
 	//name = "Birthday Party"
-	payout = 900
+	payout = 3500
 	hide_item_payouts = TRUE
 	var/list/namevary = list("Birthday Party","Birthday Bash","Surprise Party","One Year Older")
 	var/list/desc_event = list("party","celebration","gathering","party","event") //yes party twice

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -5,6 +5,7 @@ ABSTRACT_TYPE(/datum/req_contract/civilian)
 /datum/req_contract/civilian/event_catering
 	name = "Event Catering"
 	payout = 6000
+	weight = 70
 	var/list/desc_event = list("reception","formal event","welcoming party","going-away party","commemorative dinner","dinner")
 	var/list/desc_honorific = list("an esteemed","an infamous","a famous","a renowned")
 	var/list/desc_origin = list(" Nanotrasen"," Martian"," freelancing"," frontier"," - if only barely -"," retired")
@@ -267,7 +268,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 
 /datum/req_contract/civilian/birthdaybash
 	//name = "Birthday Party"
-	payout = 3500
+	payout = 2000
 	hide_item_payouts = TRUE
 	var/list/namevary = list("Birthday Party","Birthday Bash","Surprise Party","One Year Older")
 	var/list/desc_event = list("party","celebration","gathering","party","event") //yes party twice
@@ -384,7 +385,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/item/cookie
 	name = "cookie"
 	typepath = /obj/item/reagent_containers/food/snacks/cookie
-	feemod = 160
+	feemod = 240
 
 /datum/rc_entry/stack/pizza
 	name = "slices' worth of pizza"

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -114,7 +114,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 
 /datum/req_contract/scientific/botanical
 	//name = "Feed Me, Seymour (Butz)"
-	payout = 2500
+	payout = 3500
 	var/list/namevary = list("Botanical Prototyping","Hydroponic Acclimation","Cultivar Propagation","Plant Genotype Study")
 	var/list/desc_wherestudy = list(
 		"An affiliated hydroponics lab",
@@ -152,7 +152,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 /datum/rc_entry/seed/scientific
 	name = "genetically fussy seed"
 	cropname = "Durian"
-	feemod = 800
+	feemod = 900
 	var/crop_genpath = /datum/plant
 
 	fruit

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -4,7 +4,7 @@ ABSTRACT_TYPE(/datum/req_contract/scientific)
 
 /datum/req_contract/scientific/internalaffairs //get it?
 	//name = "Don't Ask Too Many Questions"
-	payout = 1750
+	payout = 2500
 	weight = 80
 	var/list/namevary = list("Organ Analysis","Organ Research","Biolab Supply","Biolab Partnership","ERROR: CANNOT VERIFY ORIGIN")
 	var/list/desc_begins = list("conducting","performing","beginning","initiating","seeking supplies for","organizing")
@@ -48,7 +48,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 
 /datum/req_contract/scientific/spectrometry
 	//name = "Totally Will Not Result In A Resonance Cascade"
-	payout = 750
+	payout = 1200
 	var/list/namevary = list("Beamline Calibration","Spectral Analysis","Chromatic Analysis","Refraction Survey")
 	var/list/desc_wherestudy = list(
 		"Optics calibration laboratory",
@@ -114,7 +114,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 
 /datum/req_contract/scientific/botanical
 	//name = "Feed Me, Seymour (Butz)"
-	payout = 950
+	payout = 2500
 	var/list/namevary = list("Botanical Prototyping","Hydroponic Acclimation","Cultivar Propagation","Plant Genotype Study")
 	var/list/desc_wherestudy = list(
 		"An affiliated hydroponics lab",
@@ -152,7 +152,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 /datum/rc_entry/seed/scientific
 	name = "genetically fussy seed"
 	cropname = "Durian"
-	feemod = 300
+	feemod = 800
 	var/crop_genpath = /datum/plant
 
 	fruit


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Buffs the new QM requisitions to a state where they're a bit more competitive with other sources of income:

**Civilian: Event Catering**
- Baseline fee increased from 500 to 6,000.
- Weight decreased to 70.
- This is a rather heavy load on the Kitchen even in the minimum scenario, so less frequency and better reward should make sense.

**Civilian: Interior Outfitting**
- Baseline fee increased from 800 to 2,200.

**Civilian: Crew Embarcation**
- Baseline fee increased from 700 to 1,500.
- Payout randomization now scales with crew count, up to a peak of 4,800 additional credits when making 12 gear sets.
- While fairly straightforward to assemble, this one can grow quite tedious considering the heavy volume of cloth input and manufacture required, and can require infrastructure that doesn't start in QM, hence the higher peak reward.
- Payout per unit of water increased from 4 to 5.

**Civilian: Birthday Party**
- Baseline fee increased from 900 to 2,000.
- Fee per cookie in cookie variants increased from 160 to 240.
- Bigger increase for cookie variants due to the amount of labor involved in them.

**Aid: Breach Recovery**
- Baseline fee increased from 1,200 to 3,000.

**Aid: Medical Aid**
- Baseline fee increased from 1,100 to 3,000.
- Pay per surgical item buffed: 180 for most types, 190 for circular saws (bit of variance), 330 for staple guns (cost more to manufacture).
- Pay per health analyzer increased from 450 to 600.
- Pay per bandage increased from 150 to 210.
- Pay per latex glove pair increased from 110 to 150.
- Individual items paid out a bit stingy given you'll probably have to manufacture them yourself and can't just dump them out of a toolbox, ergo buffs.

**Aid: Computer Core Failure**
- Baseline fee increased from 900 to 2,500.

**Aid: Supply Chain Failure**
- Baseline fee increased from 900 to 2,400.
- Payout per unit of welding fuel increased from 4 to 6.

**Scientific: Organ Analysis**
- Baseline fee increased from 1,750 to 2,500.

**Scientific: Spectrometry**
- Baseline fee increased from 750 to 1,200.
- Relatively small increase is due to the already good payout from individual items.

**Scientific: Botanical**

- Payout increased from 950 to 3,500.
- Per-seed payout increased from 300 to 900.
- This requires a fair bit of dedication to accomplish compared to alternatives, and even with the vendor refill reward, its previous state was not even close to appealing as a long-term goal to pin.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Requisitions are a bit undertuned in their launch state, and after assessment of how rewarding they've felt post-launch, a bit of an upward bump seemed suitable. These shouldn't outcompete other options by miles, but the payouts should feel much better after assembling the necessary items.
