### PR TITLE
Requisition list printing for cargo computer

### DIFF
--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -59,7 +59,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item)
 		. = ..()
 		if(rollcount >= count) return // standard skip-if-complete
 		if(src.exactpath && eval_item.type != typepath) return // more fussy type evaluation
-		else if(!istype(eval_item)) return // if it's not an object, it's definitely not an item
+		else if(!istype(eval_item,typepath)) return // regular type evaluation
 		src.rollcount++
 		. = TRUE
 

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -125,6 +125,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 	var/hacked = 0
 	var/tradeamt = 1
 	var/in_dialogue_box = 0
+	var/printing = 0
 	var/obj/item/card/id/scan = null
 	var/list/datum/supply_pack
 
@@ -1028,6 +1029,11 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 				return
 			src.requisitions_update()
 
+		if ("print_req")
+			if(!src.printing)
+				var/datum/req_contract/RC = locate(href_list["subaction"]) in shippingmarket.req_contracts
+				src.print_requisition(RC)
+
 		if ("mainmenu")
 			src.temp = null
 
@@ -1062,11 +1068,23 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 		src.temp += "Requisition Code: [RC.req_code]<br><br>"
 		if(RC.flavor_desc) src.temp += "[RC.flavor_desc]<br><br>"
 		src.temp += "[RC.requis_desc]"
+		src.temp += "<A href='[topicLink("print_req","\ref[RC]")]'>Print List</A><br>"
 		if(RC.req_class == AID_CONTRACT)
 			src.temp += "URGENT - Cannot Be Reserved"
 		else
 			src.temp += "<A href='[topicLink("pin_contract","\ref[RC]")]'>[RC.pinned ? "Unpin Contract" : "Pin Contract"]</A>"
 
+/obj/machinery/computer/supplycomp/proc/print_requisition(var/datum/req_contract/contract)
+	src.printing = 1
+	playsound(src.loc, "sound/machines/printer_thermal.ogg", 60, 0)
+	SPAWN_DBG(2 SECONDS)
+		var/obj/item/paper/thermal/P = new/obj/item/paper/thermal(src.loc)
+		P.info = "<font face='System' size='2'><center>REQUISITION CONTRACT MANIFEST<br>"
+		P.info += "FOR SUPPLIER REFERENCE ONLY<br><br>"
+		P.info += uppertext(contract.requis_desc)
+		P.info += "</center>"
+		P.name = "Requisition: [contract.name]"
+		src.printing = 0
 
 /obj/machinery/computer/supplycomp/proc/trader_dialogue_update(var/dialogue,var/datum/trader/T)
 	if (!dialogue || !T)

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -1068,11 +1068,11 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 		src.temp += "Requisition Code: [RC.req_code]<br><br>"
 		if(RC.flavor_desc) src.temp += "[RC.flavor_desc]<br><br>"
 		src.temp += "[RC.requis_desc]"
-		src.temp += "<A href='[topicLink("print_req","\ref[RC]")]'>Print List</A><br>"
 		if(RC.req_class == AID_CONTRACT)
-			src.temp += "URGENT - Cannot Be Reserved"
+			src.temp += "URGENT - Cannot Be Reserved<br>"
 		else
-			src.temp += "<A href='[topicLink("pin_contract","\ref[RC]")]'>[RC.pinned ? "Unpin Contract" : "Pin Contract"]</A>"
+			src.temp += "<A href='[topicLink("pin_contract","\ref[RC]")]'>[RC.pinned ? "Unpin Contract" : "Pin Contract"]</A><br>"
+		src.temp += "<A href='[topicLink("print_req","\ref[RC]")]'>Print List</A>"
 
 /obj/machinery/computer/supplycomp/proc/print_requisition(var/datum/req_contract/contract)
 	src.printing = 1

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -1082,7 +1082,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 		P.info = "<font face='System' size='2'><center>REQUISITION CONTRACT MANIFEST<br>"
 		P.info += "FOR SUPPLIER REFERENCE ONLY<br><br>"
 		P.info += uppertext(contract.requis_desc)
-		P.info += "</center>"
+		P.info += "</center></font>"
 		P.name = "Requisition: [contract.name]"
 		src.printing = 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a Print List button for requisition contracts in the cargo computer's requisition screen, printing out (nominally from a small slot just past the "keyboard") a sheet with the requisition contract's name and requirements. This sheet **is not required for shipping**; its main function is to let QMs more easily inform people of the details of the contract in order to get help fulfilling it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Was requested by some community members and significantly improves QM's capability to collaborate with other departments for order fulfillment.