### PR TITLE
Adds 1 second firing delay to Betelgeuse sniper rifle

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1735,6 +1735,8 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 	two_handed = 1
 	w_class = W_CLASS_BULKY
 
+	shoot_delay = 1 SECOND
+
 	var/datum/movement_controller/snipermove = null
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
No longer can you fire the Marksman's rifle as quickly as you can pull the trigger. Now you have to wait a second.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They just got a pile of extra ammo, which is great. But they really shouldn't be able to fire off the whole mag in 2 seconds.
Is one second too much? Maybe, felt good in testing.



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gannets 
(+)Added a one second firing delay to the Betelgeuse sniper rifle.
```
