### PR TITLE
Optimization and improvement for camera visibility updates

### DIFF
--- a/_std/defines/sight.dm
+++ b/_std/defines/sight.dm
@@ -9,3 +9,5 @@
 #define CLIENT_IMAGE_GROUP_ARREST_ICONS "arrest_icons"
 #define CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS "health_mon_icons"
 #define CLIENT_IMAGE_GROUP_PACKETVISION "packetvision"
+
+#define CAM_RANGE 7

--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -125,7 +125,7 @@ var/datum/explosion_controller/explosions
 			makepowernets()
 
 		rebuild_camera_network()
-		world.updateCameraVisibility(queued_epicenter,queued_radius)
+		world.updateCameraVisibility(queued_epicenter, queued_radius + CAM_RANGE + 2)
 		queued_epicenter = null
 		queued_radius = INFINITY
 

--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -233,7 +233,9 @@ var/datum/explosion_controller/explosions
 				open |= target
 
 		radius += 1 // avoid a division by zero
+		var/true_radius_squared = 0
 		for (var/turf/T as anything in nodes) // inverse square law (IMPORTANT) and pre-stun
+			true_radius_squared = max(true_radius_squared, GET_SQUARED_EUCLIDEAN_DIST(epicenter, T))
 			var/p = power / ((radius-nodes[T])**2)
 			nodes[T] = p
 			blame[T] = last_touched
@@ -251,4 +253,4 @@ var/datum/explosion_controller/explosions
 		explosions.queue_damage(nodes)
 		explosions.queued_turfs_blame += blame
 		explosions.queued_epicenter = epicenter
-		explosions.queued_radius = radius
+		explosions.queued_radius = sqrt(true_radius_squared)

--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -6,6 +6,8 @@ var/datum/explosion_controller/explosions
 	var/list/queued_turfs_blame = list()
 	var/distant_sound = 'sound/effects/explosionfar.ogg'
 	var/exploding = 0
+	var/queued_epicenter = null //used for camera update optimization
+	var/queued_radius = INFINITY //ALSO used for camera update optimization
 
 	proc/explode_at(atom/source, turf/epicenter, power, brisance = 1, angle = 0, width = 360)
 		var/atom/A = epicenter
@@ -123,7 +125,9 @@ var/datum/explosion_controller/explosions
 			makepowernets()
 
 		rebuild_camera_network()
-		world.updateCameraVisibility()
+		world.updateCameraVisibility(queued_epicenter,queued_radius)
+		queued_epicenter = null
+		queued_radius = INFINITY
 
 	proc/process()
 		if (exploding)
@@ -246,3 +250,5 @@ var/datum/explosion_controller/explosions
 
 		explosions.queue_damage(nodes)
 		explosions.queued_turfs_blame += blame
+		explosions.queued_epicenter = epicenter
+		explosions.queued_radius = radius

--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -6,8 +6,6 @@ var/datum/explosion_controller/explosions
 	var/list/queued_turfs_blame = list()
 	var/distant_sound = 'sound/effects/explosionfar.ogg'
 	var/exploding = 0
-	var/queued_epicenter = null //used for camera update optimization
-	var/queued_radius = INFINITY //ALSO used for camera update optimization
 
 	proc/explode_at(atom/source, turf/epicenter, power, brisance = 1, angle = 0, width = 360)
 		var/atom/A = epicenter
@@ -125,9 +123,7 @@ var/datum/explosion_controller/explosions
 			makepowernets()
 
 		rebuild_camera_network()
-		world.updateCameraVisibility(queued_epicenter, queued_radius + CAM_RANGE + 2)
-		queued_epicenter = null
-		queued_radius = INFINITY
+		world.updateCameraVisibility()
 
 	proc/process()
 		if (exploding)
@@ -233,9 +229,7 @@ var/datum/explosion_controller/explosions
 				open |= target
 
 		radius += 1 // avoid a division by zero
-		var/true_radius_squared = 0
 		for (var/turf/T as anything in nodes) // inverse square law (IMPORTANT) and pre-stun
-			true_radius_squared = max(true_radius_squared, GET_SQUARED_EUCLIDEAN_DIST(epicenter, T))
 			var/p = power / ((radius-nodes[T])**2)
 			nodes[T] = p
 			blame[T] = last_touched
@@ -252,5 +246,3 @@ var/datum/explosion_controller/explosions
 
 		explosions.queue_damage(nodes)
 		explosions.queued_turfs_blame += blame
-		explosions.queued_epicenter = epicenter
-		explosions.queued_radius = sqrt(true_radius_squared)

--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -645,10 +645,15 @@ world/proc/updateCameraVisibility(var/update_location,var/update_radius)
 	aiDirty = 1
 
 	if(!global.explosions.exploding)
-		world.updateCameraVisibility()
+		world.updateCameraVisibility(get_turf(src), 0)
 
 /obj/machinery/camera/proc/add_to_turfs() //chck if turf cameras is 1
 	aiDirty = 1
 	if (current_state > GAME_STATE_WORLD_INIT)
-		world.updateCameraVisibility()
+		world.updateCameraVisibility(get_turf(src), 0)
+
+// to be called by admins if everything breaks. TODO move to an admin verb
+/proc/force_full_camera_rebuild()
+	aiDirty = 1
+	world.updateCameraVisibility()
 

--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -575,13 +575,15 @@ var/list/camImages = list()
 
 
 var/aiDirty = 2
-world/proc/updateCameraVisibility()
-	if(!aiDirty) return
+world/proc/updateCameraVisibility(var/update_location,var/update_radius)
+	if(!aiDirty && !update_location) return
 
 #if defined(IM_REALLY_IN_A_FUCKING_HURRY_HERE) && !defined(SPACEMAN_DMM)
 	// I don't wanna wait for this camera setup shit just GO
 	return
 #endif
+
+	var/look_range = CAM_RANGE + 2 //radius augmentation to try and ensure cameras will be updated if in line of sight of the update location
 
 	if(aiDirty == 2)
 		var/mutable_appearance/ma = new(image('icons/misc/static.dmi', icon_state = "static"))
@@ -624,6 +626,9 @@ world/proc/updateCameraVisibility()
 		aiDirty = 1
 		game_start_countdown?.update_status("Updating camera vis...\n")
 	for_by_tcl(C, /obj/machinery/camera)
+		if(update_location)
+			if(GET_SQUARED_EUCLIDEAN_DIST(get_turf(C),update_location) > (update_radius + look_range) * (update_radius + look_range))
+				continue //skip over cameras too far from an update site
 		for(var/turf/t in view(CAM_RANGE, get_turf(C)))
 			LAGCHECK(LAG_HIGH)
 			if (!t.aiImage) continue

--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -583,7 +583,7 @@ world/proc/updateCameraVisibility(var/update_location,var/update_radius)
 	return
 #endif
 
-	var/look_range = (update_radius + CAM_RANGE + 2) * (update_radius + CAM_RANGE + 2)
+	var/look_range = update_radius * update_radius
 	// squared euclidean distance for location-based updating
 
 	if(aiDirty == 2)

--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -583,7 +583,8 @@ world/proc/updateCameraVisibility(var/update_location,var/update_radius)
 	return
 #endif
 
-	var/look_range = CAM_RANGE + 2 //radius augmentation to try and ensure cameras will be updated if in line of sight of the update location
+	var/look_range = (update_radius + CAM_RANGE + 2) * (update_radius + CAM_RANGE + 2)
+	// squared euclidean distance for location-based updating
 
 	if(aiDirty == 2)
 		var/mutable_appearance/ma = new(image('icons/misc/static.dmi', icon_state = "static"))
@@ -627,7 +628,7 @@ world/proc/updateCameraVisibility(var/update_location,var/update_radius)
 		game_start_countdown?.update_status("Updating camera vis...\n")
 	for_by_tcl(C, /obj/machinery/camera)
 		if(update_location)
-			if(GET_SQUARED_EUCLIDEAN_DIST(get_turf(C),update_location) > (update_radius + look_range) * (update_radius + look_range))
+			if(GET_SQUARED_EUCLIDEAN_DIST(get_turf(C),update_location) > look_range)
 				continue //skip over cameras too far from an update site
 		for(var/turf/t in view(CAM_RANGE, get_turf(C)))
 			LAGCHECK(LAG_HIGH)

--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -1,5 +1,3 @@
-#define CAM_RANGE 7
-
 //ISSUES: Cameras inside beepsky and other bots cause issues. They move around and don't update properly. ((FIXED I THINK))
 //		  Doors sometimes for some reason fail to properly update their opacity. Investigate.
 //		  Cutting cameras is not handled. ((FIXED I THINK))

--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -441,41 +441,6 @@
 /turf/var/image/aiImage
 /turf/var/list/cameras = null
 
-/turf/proc/addCameraCoverage(var/obj/machinery/camera/C) //copy pasted for use below in updatecoverage to reduce heavy proc calls. dont change one without the other!
-	var/cam_amount = src.cameras ? src.cameras.len : 0
-	if(!src.cameras)
-		src.cameras = list(C)
-		if(!C.coveredTiles)
-			C.coveredTiles = list(src)
-		else
-			C.coveredTiles |= src
-
-	else
-		src.cameras |= C
-		if(!C.coveredTiles)
-			C.coveredTiles = list(src)
-		else
-			C.coveredTiles |= src
-
-	if (cam_amount < src.cameras.len)
-		if (src.aiImage)
-			src.aiImage.loc = null
-
-
-/turf/proc/removeCameraCoverage(var/obj/machinery/camera/C) //copy pasted for use below in updatecoverage to reduce heavy proc calls. dont change one without the other!
-	if(!src.cameras)
-		return
-
-	src.cameras -= C
-	C.coveredTiles -= src
-
-	if(!src.cameras.len)
-		src.cameras = null
-
-		if (src.aiImage)
-			src.aiImage.loc = src
-
-
 /turf/proc/adjustCameraImage()
 	if(!istype(src.aiImage)) return
 
@@ -500,91 +465,21 @@
 /obj/machinery/camera/var/list/turf/coveredTiles = null
 
 /obj/machinery/camera/proc/updateCoverage()
-	//					HEY READ THIS
-	//This proc gets called a lot and it loops through a lot of stuff so I've copy+pasted anything it invokes to cut down on proc calls
-	//					HEY READ THIS
-
-	var/list/prev_tiles = 0
-	var/list/new_tiles = list()
-
-	if (coveredTiles != null && length(coveredTiles))
-		prev_tiles = coveredTiles
-
-	for(var/turf/T in view(CAM_RANGE, get_turf(src)))
-		new_tiles |= T
-
-	if (prev_tiles)
-		for(var/turf/O as anything in (prev_tiles - new_tiles))
-			//copy+paste begin!
-			if(O.cameras == null) continue
-
-			O.cameras -= src
-			src.coveredTiles -= O
-
-			if(!O.cameras.len)
-				O.cameras = null
-
-				if (O.aiImage)
-					O.aiImage.loc = O
-
-			//copy paste end!
-
-	for(var/turf/t as anything in (new_tiles - prev_tiles))
-		//copy+paste begin!
-		var/cam_amount = t.cameras ? t.cameras.len : 0
-		if(t.cameras == null)
-			t.cameras = list(src)
-			if(src.coveredTiles == null)
-				src.coveredTiles = list(t)
-			else
-				src.coveredTiles |= t
-		else
-			t.cameras |= src
-			if(src.coveredTiles == null)
-				src.coveredTiles = list(t)
-			else
-				src.coveredTiles |= t
-
-		if (cam_amount < t.cameras.len)
-			if (t.aiImage)
-				t.aiImage.loc = null
-		//copy paste end!
-
-		//copy+paste begin!
-		if(!istype(t.aiImage)) continue
-
-		if( t.cameras.len >= 1 )
-			t.aiImage.loc = null
-		else if( t.cameras == null )
-			t.aiImage.loc = t
-
-		//copy paste end!
-
-	return
-
-
-//---CAMERA---//
-
-//---MISC---//
-var/list/camImages = list()
-
+	LAZYLISTADDUNIQUE(camerasToRebuild, src)
+	if (current_state > GAME_STATE_WORLD_INIT && !global.explosions.exploding)
+		world.updateCameraVisibility()
 
 //---MISC---//
 
-
-var/aiDirty = 2
-world/proc/updateCameraVisibility(var/update_location,var/update_radius)
-	if(!aiDirty && !update_location) return
-
+var/list/obj/machinery/camera/camerasToRebuild
+world/proc/updateCameraVisibility(generateAiImages=FALSE)
+	set waitfor = FALSE
 #if defined(IM_REALLY_IN_A_FUCKING_HURRY_HERE) && !defined(SPACEMAN_DMM)
 	// I don't wanna wait for this camera setup shit just GO
 	return
 #endif
 
-	var/look_range = update_radius * update_radius
-	// squared euclidean distance for location-based updating
-
-	if(aiDirty == 2)
+	if(generateAiImages)
 		var/mutable_appearance/ma = new(image('icons/misc/static.dmi', icon_state = "static"))
 		ma.plane = PLANE_HUD
 		ma.layer = 100
@@ -618,40 +513,42 @@ world/proc/updateCameraVisibility(var/update_location,var/update_radius)
 				game_start_countdown?.update_status("Updating cameras...\n[thispct]%")
 
 			LAGCHECK(100)
-		aiDirty = 1
+
+		for_by_tcl(cam, /obj/machinery/camera)
+			LAZYLISTADDUNIQUE(camerasToRebuild, cam)
 		game_start_countdown?.update_status("Updating camera vis...\n")
-	for_by_tcl(C, /obj/machinery/camera)
-		if(update_location)
-			if(GET_SQUARED_EUCLIDEAN_DIST(get_turf(C),update_location) > look_range)
-				continue //skip over cameras too far from an update site
-		for(var/turf/t in view(CAM_RANGE, get_turf(C)))
-			LAGCHECK(LAG_HIGH)
-			if (!t.aiImage) continue
-			if (t.cameras && length(t.cameras))
-				t.aiImage.loc = null
-			else
-				t.aiImage.loc = t
-	aiDirty = 0
+
+	var/list/turf/staticUpdateTurfs = list()
+
+	for(var/obj/machinery/camera/cam as anything in camerasToRebuild)
+		var/list/prev_tiles = cam.coveredTiles
+		var/list/new_tiles = list()
+		if(cam.camera_status && !isnull(get_turf(cam)))
+			for(var/turf/T in view(CAM_RANGE, get_turf(cam)))
+				new_tiles += T
+		if (prev_tiles)
+			for(var/turf/T as anything in (prev_tiles - new_tiles))
+				staticUpdateTurfs |= T
+				if(isnull(T.cameras)) continue
+				T.cameras -= cam
+				if(!length(T.cameras))
+					T.cameras = null
+		if (new_tiles)
+			for(var/turf/T as anything in (new_tiles - prev_tiles))
+				LAZYLISTADDUNIQUE(T.cameras, cam)
+				staticUpdateTurfs |= T
+
+		cam.coveredTiles = new_tiles
+
+	for(var/turf/T as anything in staticUpdateTurfs)
+		T.aiImage?.loc = length(T.cameras) ? null : T
+
+	camerasToRebuild = null
 #endif
-
-/obj/machinery/camera/proc/remove_from_turfs() //check if turf cameras is 0 . Maybe loop through each affected turf's cameras, and update static on them here instead of going thru updateCameraVisibility()?
-	//world << "Camera deleted! @ [src.loc]"
-	for(var/turf/t in view(CAM_RANGE,get_turf(src)))
-		LAGCHECK(LAG_HIGH)
-		if(t.aiImage)
-			t.aiImage.loc = t
-	aiDirty = 1
-
-	if(!global.explosions.exploding)
-		world.updateCameraVisibility(get_turf(src), 0)
-
-/obj/machinery/camera/proc/add_to_turfs() //chck if turf cameras is 1
-	aiDirty = 1
-	if (current_state > GAME_STATE_WORLD_INIT)
-		world.updateCameraVisibility(get_turf(src), 0)
 
 // to be called by admins if everything breaks. TODO move to an admin verb
 /proc/force_full_camera_rebuild()
-	aiDirty = 1
+	for_by_tcl(cam, /obj/machinery/camera)
+		LAZYLISTADDUNIQUE(camerasToRebuild, cam)
 	world.updateCameraVisibility()
 

--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -597,11 +597,7 @@ world/proc/updateCameraVisibility(var/update_location,var/update_radius)
 
 		// takes about one second compared to the ~12++ that the actual calculations take
 		game_start_countdown?.update_status("Updating cameras...\n(Calculating...)")
-		var/list/turf/cam_candidates = list()
-		for(var/turf/t in world) //ugh x2
-			if( t.z != 1 ) continue
-			cam_candidates += t
-
+		var/list/turf/cam_candidates = block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION))
 //pod wars has no AI so this is just a waste of time...
 #ifndef MAP_OVERRIDE_POD_WARS
 

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -559,6 +559,8 @@ proc/generate_space_color()
 	var/old_checkinghasproximity = src.checkinghasproximity
 	var/old_neighcheckinghasproximity = src.neighcheckinghasproximity
 
+	var/old_aiimage = src.aiImage
+
 #ifdef ATMOS_PROCESS_CELL_STATS_TRACKING
 	var/old_process_cell_operations = src.process_cell_operations
 #endif
@@ -629,6 +631,8 @@ proc/generate_space_color()
 	new_turf.blocked_dirs = old_blocked_dirs
 	new_turf.checkinghasproximity = old_checkinghasproximity
 	new_turf.neighcheckinghasproximity = old_neighcheckinghasproximity
+
+	new_turf.aiImage = old_aiimage
 
 #ifdef ATMOS_PROCESS_CELL_STATS_TRACKING
 	new_turf.process_cell_operations = old_process_cell_operations

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -62,14 +62,6 @@
 		SHOULD_NOT_OVERRIDE(TRUE)
 		..()
 
-	Del()
-		if (length(cameras))
-			for (var/obj/machinery/camera/C as anything in by_type[/obj/machinery/camera])
-				if(C.coveredTiles)
-					C.coveredTiles -= src
-		cameras = null
-		..()
-
 	onMaterialChanged()
 		..()
 		if(istype(src.material))
@@ -560,6 +552,7 @@ proc/generate_space_color()
 	var/old_neighcheckinghasproximity = src.neighcheckinghasproximity
 
 	var/old_aiimage = src.aiImage
+	var/old_cameras = src.cameras
 
 #ifdef ATMOS_PROCESS_CELL_STATS_TRACKING
 	var/old_process_cell_operations = src.process_cell_operations
@@ -633,6 +626,7 @@ proc/generate_space_color()
 	new_turf.neighcheckinghasproximity = old_neighcheckinghasproximity
 
 	new_turf.aiImage = old_aiimage
+	new_turf.cameras = old_cameras
 
 #ifdef ATMOS_PROCESS_CELL_STATS_TRACKING
 	new_turf.process_cell_operations = old_process_cell_operations

--- a/code/world.dm
+++ b/code/world.dm
@@ -610,8 +610,7 @@ var/f_color_selector_handler/F_Color_Selector
 
 	UPDATE_TITLE_STATUS("Calculating cameras")
 	Z_LOG_DEBUG("World/Init", "Updating camera visibility...")
-	aiDirty = 2
-	world.updateCameraVisibility()
+	world.updateCameraVisibility(TRUE)
 
 	UPDATE_TITLE_STATUS("Preloading client data...")
 	Z_LOG_DEBUG("World/Init", "Transferring manuf. icons to clients...")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[PERF]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Alters updateCameraVisibility so its use in updating after explosions should be more performant; the explosion controller now passes it an explosion location and radius, which it uses to determine which cameras might have been affected by the explosion, skipping any that are too far. Does not change the behavior of the turf visibility updates when a camera is selected.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Should, theoretically, reduce the performance impact of explosions, with a greater influence on maps with larger amounts of cameras.
