### PR TITLE
Cryo Manifest Fix

### DIFF
--- a/code/WorkInProgress/cryospawn.dm
+++ b/code/WorkInProgress/cryospawn.dm
@@ -266,8 +266,8 @@
 				L.removeOverlayComposition(/datum/overlayComposition/blinded)
 				stored_mobs[L] = null
 				stored_mobs -= L
-				if(isnull(L.loc)) // loc only goes null when you ghost, probably
-					stored_crew_names -= L.real_name // we want to keep people logged as being in cryo even when ghosted after all
+				if(!isnull(L.loc)) // loc only goes null when you ghost, probably
+					stored_crew_names -= L.real_name // you shouldn't be removed from the list when you ghost
 					var/datum/db_record/crew_record = data_core.general.find_record("id", L.datacore_id)
 					if (!isnull(crew_record))
 						crew_record["p_stat"] = "Active"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Ghosted crew now properly stay in the cryo manifest. Previously a missing `!` resulted in crew *with* null locations being removed from the cryo manifest, and presumably crew without null locs (aka anyone that was yoinked out of cryo by an artifact or something) not being removed from the cryo manifest.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

bug, i squash.