### PR TITLE
Powersinks now are more expensive

### DIFF
--- a/code/obj/item/device/powersink.dm
+++ b/code/obj/item/device/powersink.dm
@@ -18,7 +18,7 @@
 	var/max_power = 2e8		// maximum power that can be drained before exploding
 	var/mode = 0		// 0 = off, 1=clamped (off), 2=operating
 	is_syndicate = 1
-	mats = 16
+	mats = list("MET-2"=20, "CON-2"=20, "CRY-1"=10)
 	rand_pos = 0
 
 	var/obj/cable/attached		// the attached cable


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR sets the power sink fabrication cost to "CON-2" = 20, "MET-2" = 20, "CRY-1" = 10. This is from the original 16 generic materials required.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Spamming powersinks through a syndicate scanner isn't fun, there should be at least some pre-requisite preparation before you begin sucking the fun and power out of a round.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Powersinks now need tier 2 conductors and tier 2 metals to fabricate.
```
