### PR TITLE
Adds the Kitchen Training trait to chefs, which lets you see the list of buffs a food grants, as well as whether or not it is of high quality

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -873,7 +873,8 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	special_setup(var/mob/living/carbon/human/M)
 		..()
 		if (!M)
-			return
+			return¨
+		M.traitHolder.addTrait("training_chef")
 
 /datum/job/civilian/bartender
 	name = "Bartender"

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -873,7 +873,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	special_setup(var/mob/living/carbon/human/M)
 		..()
 		if (!M)
-			return¨
+			return
 		M.traitHolder.addTrait("training_chef")
 
 /datum/job/civilian/bartender

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -648,6 +648,12 @@
 	desc = "Subject is proficent at haggling."
 	id = "training_quartermaster"
 
+/obj/trait/job/chef
+	name = "Kitchen Training"
+	cleanName = "Kitchen Training"
+	desc = "Subject is experienced in foodstuffs and their effects."
+	id = "training_chef"
+
 // bartender, detective, HoS
 /obj/trait/job/drinker
 	name = "Professional Drinker"

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -313,6 +313,10 @@
 		. = ..()
 		if(!usr.traitHolder?.hasTrait("training_chef"))
 			return
+
+		if(src.quality >= 5)
+			. += "<span class='notice'>This is of great quality! the gained buffs will last longer! </span>"
+
 		if(food_effects.len > 0)
 			. += "<br><span class='notice'> This food has the following effects: "
 			for(var/id as anything in src.food_effects)
@@ -332,7 +336,7 @@
 		switch(href_list["action"]) // future proofing incase someone else wants to add something to this Topic(), will remove if it noticeably slows down execution of this proc.
 			if("chefhint")
 				if(href_list["txt"] && href_list["name"])
-					boutput(usr,"<b><span class='notice'>[href_list["name"]]:</b></span> [href_list["txt"]]")
+					boutput(usr,"<span class='notice'><b>[href_list["name"]]:</b></span> [href_list["txt"]]")
 
 
 

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -311,12 +311,16 @@
 
 	get_desc(mob/user)
 		. = ..()
-		if(!user.traitHolder.hasTrait("training_chef"))
+		if(!usr.traitHolder?.hasTrait("training_chef"))
 			return
-		if(food_effects != null)
+		if(food_effects.len > 0)
 			. += "<br><span class='notice'> This food has the following effects: "
-			for(var/id as anything in food_effects)
-				. += hasStatus(id).name + "; "
+			for(var/id as anything in src.food_effects)
+				var/datum/statusEffect/S = getStatusPrototype(id)
+				if(S == null)
+					.+= "oh oh its null! report to the coders! ID:" + id //This really shouldnt happen except for var editing or other wierdness, but this is here just in case.
+					break
+				. += S.name + "; "
 			. += "</span>"
 
 

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -320,7 +320,7 @@
 				if(S == null)
 					logTheThing("debug", null, null, "the foodstuff [src] returned with a statusEffect ID that does not exist in the global prototype list! status_id : [id]") //This really shouldnt happen except for var editing, typos or other wierdness, but this is here just in case.
 					continue
-				var/Sdesc = S.getTooltip()
+				var/Sdesc = S.getChefHint()
 				. += "<a href='byond://?src=\ref[src];action=chefhint;name=[url_encode(S.name)];txt=[url_encode(Sdesc)]'>[S.name]</a>" + "; "
 			. += "</span>"
 

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -332,7 +332,7 @@
 		switch(href_list["action"]) // future proofing incase someone else wants to add something to this Topic(), will remove if it noticeably slows down execution of this proc.
 			if("chefhint")
 				if(href_list["txt"] && href_list["name"])
-					boutput(usr,"<span class='notice'>[href_list["name"]]: [href_list["txt"]]</span>")
+					boutput(usr,"<b><span class='notice'>[href_list["name"]]:</b></span> [href_list["txt"]]")
 
 
 

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -318,11 +318,21 @@
 			for(var/id as anything in src.food_effects)
 				var/datum/statusEffect/S = getStatusPrototype(id)
 				if(S == null)
-					.+= "oh oh its null! report to the coders! ID:" + id //This really shouldnt happen except for var editing or other wierdness, but this is here just in case.
-					break
-				. += S.name + "; "
+					logTheThing("debug", null, null, "the foodstuff [src] returned with a statusEffect ID that does not exist in the global prototype list! status_id : [id]") //This really shouldnt happen except for var editing, typos or other wierdness, but this is here just in case.
+					continue
+				var/Sdesc = S.getTooltip()
+				. += "<a href='byond://?src=\ref[src];action=chefhint;name=[url_encode(S.name)];txt=[url_encode(Sdesc)]'>[S.name]</a>" + "; "
 			. += "</span>"
 
+
+	Topic(href, href_list)
+		..()
+		if(!usr)
+			return
+		switch(href_list["action"]) // future proofing incase someone else wants to add something to this Topic(), will remove if it noticeably slows down execution of this proc.
+			if("chefhint")
+				if(href_list["txt"] && href_list["name"])
+					boutput(usr,"<span class='notice'>[href_list["name"]]: [href_list["txt"]]</span>")
 
 
 

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -314,13 +314,13 @@
 			return
 
 		if(src.quality >= 5)
-			. += "<br><span class='notice'>This is of great quality! the gained buffs will last longer! </span>"
+			. += "<br><span class='notice'>This is of great quality! The gained buffs will last longer! </span>"
 
-		if(food_effects.len > 0)
+		if(length(food_effects) > 0)
 			. += "<br><span class='notice'> This food has the following effects: "
 			for(var/id as anything in src.food_effects)
 				var/datum/statusEffect/S = getStatusPrototype(id)
-				if(S == null)
+				if(isnull(S))
 					logTheThing("debug", null, null, "the foodstuff [src] returned with a statusEffect ID that does not exist in the global prototype list! status_id : [id]") //This really shouldnt happen except for var editing, typos or other wierdness, but this is here just in case.
 					continue
 				var/Sdesc = S.getChefHint()

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -310,12 +310,11 @@
 		return
 
 	get_desc(mob/user)
-		. = ..()
 		if(!usr.traitHolder?.hasTrait("training_chef"))
 			return
 
 		if(src.quality >= 5)
-			. += "<span class='notice'>This is of great quality! the gained buffs will last longer! </span>"
+			. += "<br><span class='notice'>This is of great quality! the gained buffs will last longer! </span>"
 
 		if(food_effects.len > 0)
 			. += "<br><span class='notice'> This food has the following effects: "

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -309,8 +309,8 @@
 	afterattack(obj/target, mob/user , flag)
 		return
 
-	get_desc(mob/user)
-		if(!usr.traitHolder?.hasTrait("training_chef"))
+	get_desc(dist, mob/user)
+		if(!user.traitHolder?.hasTrait("training_chef"))
 			return
 
 		if(src.quality >= 5)
@@ -318,10 +318,10 @@
 
 		if(length(food_effects) > 0)
 			. += "<br><span class='notice'> This food has the following effects: "
-			for(var/id as anything in src.food_effects)
+			for(var/id in src.food_effects)
 				var/datum/statusEffect/S = getStatusPrototype(id)
 				if(isnull(S))
-					logTheThing("debug", null, null, "the foodstuff [src] returned with a statusEffect ID that does not exist in the global prototype list! status_id : [id]") //This really shouldnt happen except for var editing, typos or other wierdness, but this is here just in case.
+					stack_trace("the foodstuff [src] returned with a statusEffect ID that does not exist in the global prototype list! status_id : [id]") //This really shouldnt happen except for var editing, typos or other wierdness, but this is here just in case.
 					continue
 				var/Sdesc = S.getChefHint()
 				. += "<a href='byond://?src=\ref[src];action=chefhint;name=[url_encode(S.name)];txt=[url_encode(Sdesc)]'>[S.name]</a>" + "; "

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -309,6 +309,21 @@
 	afterattack(obj/target, mob/user , flag)
 		return
 
+	get_desc(mob/user)
+		. = ..()
+		if(!user.traitHolder.hasTrait("training_chef"))
+			return
+		if(food_effects != null)
+			. += "<br><span class='notice'> This food has the following effects: "
+			for(var/id as anything in food_effects)
+				. += hasStatus(id).name + "; "
+			. += "</span>"
+
+
+
+
+
+
 	proc/on_bite(mob/eater)
 		//if (reagents?.total_volume)
 		//	reagents.reaction(M, INGEST)

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -93,6 +93,13 @@
 	proc/getTooltip()
 		. = desc
 
+/**
+ 	* Used to generate text specifically for the chef examining food. Otherwise fallbacks to getTooltip().
+ 	*/
+	proc/getChefHint()
+		. = getTooltip()
+
+
 	/**
 		* Information that should show up when an object has this effect and is examined.
 		*/

--- a/code/modules/status_system/statusFoodBad.dm
+++ b/code/modules/status_system/statusFoodBad.dm
@@ -21,3 +21,6 @@
 
 	getTooltip()
 		. = "Dealing [damage_tox] toxin damage every [tickSpacing/(1 SECOND)] sec."
+
+	getChefHint()
+		. = "Poisons the consumer, Dealing [damage_tox] toxin damage every [tickSpacing/(1 SECOND)] sec."

--- a/code/modules/status_system/statusFoodBad.dm
+++ b/code/modules/status_system/statusFoodBad.dm
@@ -23,4 +23,4 @@
 		. = "Dealing [damage_tox] toxin damage every [tickSpacing/(1 SECOND)] sec."
 
 	getChefHint()
-		. = "Poisons the consumer, Dealing [damage_tox] toxin damage every [tickSpacing/(1 SECOND)] sec."
+		. = "Poisons the consumer, dealing [damage_tox] toxin damage every [tickSpacing/(1 SECOND)] sec."

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -96,6 +96,8 @@
 
 	getTooltip()
 		. = "Healing [heal_brute] brute damage every [tickSpacing/(1 SECOND)] sec."
+	getChefHint()
+		. = "Heals [heal_brute] brute damage every [tickspacing/ (1 SECOND)] sec."
 
 /datum/statusEffect/simplehot/foodTox
 	id = "food_tox"
@@ -110,6 +112,9 @@
 	getTooltip()
 		. = "Healing [heal_tox] toxin damage every [tickSpacing/(1 SECOND)] sec."
 
+	getChefHint()
+		. = "Heals [heal_tox] toxin damage every [tickspacing/ (1 SECOND)] sec."
+
 /datum/statusEffect/simplehot/foodBurn
 	id = "food_burn"
 	name = "Food HoT (Burn)"
@@ -122,6 +127,9 @@
 
 	getTooltip()
 		. = "Healing [heal_burn] burn damage every [tickSpacing/(1 SECOND)] sec."
+
+	getChefHint()
+		. = "Heals [heal_burn] burn damage every [tickspacing/ (1 SECOND)] sec."
 
 /datum/statusEffect/simplehot/foodAll
 	id = "food_all"
@@ -136,7 +144,10 @@
 	tickSpacing = 20
 
 	getTooltip()
-		. = "Healing 0.26 damage spread across Brute/Burn/Toxin damage [tickSpacing/(1 SECOND)] sec."
+		. = "Healing 0.26 damage spread across Brute/Burn/Toxin damage every [tickSpacing/(1 SECOND)] sec."
+
+	getChefHint()
+		. = "Heals 0.26 damage spread across Brute/Burn/Toxin damage every [tickspacing/ (1 SECOND)] sec."
 
 /datum/statusEffect/foodcold
 	id = "food_cold"
@@ -149,6 +160,10 @@
 
 	var/tickCount = 0
 	var/tickSpacing = 20 //Time between ticks.
+
+	getChefHint()
+		. = "Decreases the consumer's body temperature."
+
 
 	onUpdate(timePassed)
 		tickCount += timePassed
@@ -171,6 +186,9 @@
 
 	var/tickCount = 0
 	var/tickSpacing = 20 //Time between ticks.
+
+	getChefHint()
+		. = "Incrases the consumer's body temperature."
 
 	onUpdate(timePassed)
 		tickCount += timePassed
@@ -200,6 +218,9 @@
 	getTooltip()
 		. = "Your stamina regen is increased by [change]."
 
+	getChefHint()
+		. = "Increases stamina regen by [change]."
+
 /datum/statusEffect/foodstaminamax
 	id = "food_energized"
 	name = "Food (Energized)"
@@ -217,6 +238,9 @@
 
 	getTooltip()
 		. = "Your max. stamina is increased by [change]."
+
+	getChefHint()
+		. = "Increases max. stamina by [change]."
 
 	onAdd(optional=null)
 		. = ..()
@@ -251,6 +275,9 @@
 	getTooltip()
 		. = "Your max. health is increased by [change]."
 
+	getChefHint()
+		. = "Increases max. health by [change]"
+
 	onAdd(optional=null)
 		. = ..(change)
 
@@ -267,6 +294,9 @@
 	maxDuration = 6000
 	unique = 1
 
+	getChefHint()
+		. = "Makes the consumer feel more gassy."
+
 /datum/statusEffect/deep_burp
 	id = "food_deep_burp"
 	name = "Food (Gross Burps)"
@@ -276,6 +306,9 @@
 	maxDuration = 6000
 	unique = 1
 
+	getChefHint()
+		. = "Makes the consumer's stomach feel more gassy."
+
 /datum/statusEffect/food_cat_eyes
 	id = "food_cateyes"
 	name = "Food (Night Vision)"
@@ -284,6 +317,9 @@
 	exclusiveGroup = "Food"
 	maxDuration = 6000
 	unique = 1
+
+	getChefHint()
+		. = "Improves the consumer's vision in dark spaces"
 
 /datum/statusEffect/fire_burp
 	id = "food_fireburp"
@@ -303,6 +339,9 @@
 		id = "food_fireburp_big"
 		temp = 1800
 		range = 6
+
+	getChefHint()
+		. = "Creates fire in the consumer's stomach."
 
 	proc/cast()
 		var/turf/T = get_step(owner,owner.dir)
@@ -344,6 +383,10 @@
 	exclusiveGroup = "Food"
 	maxDuration = 6000
 	unique = 1
+
+	getChefHint()
+		. = "Increases resilience of the joints, making them somehow more resistant to \"Popping Off\"..."
+
 	onAdd(optional = 10)
 		. = ..()
 		if(ismob(owner))
@@ -365,6 +408,9 @@
 	maxDuration = 6000
 	unique = 1
 
+	getChefHint()
+		. = "Strengthens the body's resilience to diseases"
+
 /datum/statusEffect/rad_resist
 	id = "food_rad_resist"
 	name = "Food (Rad-Wick)"
@@ -373,6 +419,9 @@
 	exclusiveGroup = "Food"
 	maxDuration = 6000
 	unique = 1
+
+	getChefHint()
+		. = "Strenghtens the body's resistance to radiation."
 
 	onAdd(optional = 80)
 		. = ..()
@@ -395,6 +444,9 @@
 	maxDuration = 6000
 	unique = 1
 
+	getChefHint()
+		. = "Increase strengths of farts as to provide thrust."
+
 /datum/statusEffect/bad_breath
 	id = "food_bad_breath"
 	name = "Food (Bad Breath)"
@@ -403,6 +455,9 @@
 	exclusiveGroup = "Food"
 	maxDuration = 6000
 	unique = 1
+
+	getChefHint()
+		. = "Gives the consumer an absolutely terrible breath smell."
 
 /datum/statusEffect/sweaty
 	id = "food_sweaty"
@@ -416,12 +471,19 @@
 	var/sweat_prob = 1
 	var/tickCount = 0
 	var/static/tickSpacing = 20 //Time between ticks.
+	var/sweat_adjective = "" // used for getChefHint()
+
+
 
 	big
 		name = "Food (Sweaty+)"
 		id = "food_sweaty_big"
 		desc = "You feel really sweaty!"
 		sweat_prob = 5
+		sweat_adjective = "REALLY"
+
+	getChefHint()
+		. = "Makes the consumer [sweat_adjective] sweaty."
 
 	onUpdate(timePassed)
 		tickCount += timePassed

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -480,10 +480,10 @@
 		id = "food_sweaty_big"
 		desc = "You feel really sweaty!"
 		sweat_prob = 5
-		sweat_adjective = "REALLY"
+		sweat_adjective = "REALLY "
 
 	getChefHint()
-		. = "Makes the consumer [sweat_adjective] sweaty."
+		. = "Makes the consumer [sweat_adjective]sweaty."
 
 	onUpdate(timePassed)
 		tickCount += timePassed

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -97,7 +97,7 @@
 	getTooltip()
 		. = "Healing [heal_brute] brute damage every [tickSpacing/(1 SECOND)] sec."
 	getChefHint()
-		. = "Heals [heal_brute] brute damage every [tickspacing/ (1 SECOND)] sec."
+		. = "Heals [heal_brute] brute damage every [tickSpacing/ (1 SECOND)] sec."
 
 /datum/statusEffect/simplehot/foodTox
 	id = "food_tox"
@@ -113,7 +113,7 @@
 		. = "Healing [heal_tox] toxin damage every [tickSpacing/(1 SECOND)] sec."
 
 	getChefHint()
-		. = "Heals [heal_tox] toxin damage every [tickspacing/ (1 SECOND)] sec."
+		. = "Heals [heal_tox] toxin damage every [tickSpacing/ (1 SECOND)] sec."
 
 /datum/statusEffect/simplehot/foodBurn
 	id = "food_burn"
@@ -129,7 +129,7 @@
 		. = "Healing [heal_burn] burn damage every [tickSpacing/(1 SECOND)] sec."
 
 	getChefHint()
-		. = "Heals [heal_burn] burn damage every [tickspacing/ (1 SECOND)] sec."
+		. = "Heals [heal_burn] burn damage every [tickSpacing/ (1 SECOND)] sec."
 
 /datum/statusEffect/simplehot/foodAll
 	id = "food_all"
@@ -147,7 +147,7 @@
 		. = "Healing 0.26 damage spread across Brute/Burn/Toxin damage every [tickSpacing/(1 SECOND)] sec."
 
 	getChefHint()
-		. = "Heals 0.26 damage spread across Brute/Burn/Toxin damage every [tickspacing/ (1 SECOND)] sec."
+		. = "Heals 0.26 damage spread across Brute/Burn/Toxin damage every [tickSpacing/ (1 SECOND)] sec."
 
 /datum/statusEffect/foodcold
 	id = "food_cold"

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -238,7 +238,7 @@ var/global/list/statusGroupLimits = list("Food"=4)
 				break
 
 /**
- 	* Returns prototype of status effect with given {statusId}, or null if not found
+ 	* Returns prototype of status effect from the globalStatusPrototypes list with given {statusId}, or null if not found
 	*/
 /atom/proc/getStatusPrototype(statusId)
 	for(var/datum/statusEffect/status as anything in globalStatusPrototypes)

--- a/code/modules/status_system/statusSystem.dm
+++ b/code/modules/status_system/statusSystem.dm
@@ -13,6 +13,7 @@ var/global/list/statusGroupLimits = list("Food"=4)
 			usr.delStatus(status)
 		usr.changeStatus(inp, 15 MINUTES)
 
+
 /atom/movable/screen/statusEffect
 	name = "Status effect"
 	desc = ""
@@ -236,6 +237,14 @@ var/global/list/statusGroupLimits = list("Food"=4)
 				. = status.duration
 				break
 
+/**
+ 	* Returns prototype of status effect with given {statusId}, or null if not found
+	*/
+/atom/proc/getStatusPrototype(statusId)
+	for(var/datum/statusEffect/status as anything in globalStatusPrototypes)
+		var/datum/statusEffect/statuseffect = status
+		if(statuseffect.id == statusId)
+			return statuseffect
 /**
 	* Returns first status with given {statusId} or null if not found.
 	*


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a trait that chef spawns with, it allows them to examine food to see a list of the buffs they will grant upon consumption, as well as discerning if the food is of high quality from proper cooking.

This PR also adds a proc to grab the prototype of a status effect given an ID, without needing to instantiate it in an atom first.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This idea came from [this thread](https://forum.ss13.co/showthread.php?tid=17321) and is meant as QoL to help chefs be able to discern their food's effect without needing constant trips to the wiki. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gousaid67
(*)Chefs are now able to examine food to get additional information!

```
