### PR TITLE
fix a bug when deconstructing crushers

### DIFF
--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -857,7 +857,8 @@
 		playsound(user.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		user.visible_message("<B>[user.name]</B> deconstructs [target].")
 
-		var/obj/item/electronics/frame/F = new(get_turf(target))
+		var/obj/item/electronics/frame/F = new
+		var/turf/target_loc = get_turf(target)
 		F.name = "[target.name] frame"
 		if(O.deconstruct_flags & DECON_DESTRUCT)
 			F.store_type = O.type
@@ -865,6 +866,8 @@
 		else
 			F.deconstructed_thing = target
 			O.set_loc(F)
+		// move frame to the location after object is gone, so crushers do not crusher themselves
+		F.set_loc(target_loc)
 		F.viewstat = 2
 		F.secured = 2
 		F.icon_state = "dbox_big"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The frame would come into existence on the crusher tile, and then the crusher would be moved inside after that.
Due to this, the frame basically crushered itself.

With this change the frame is only moved there after the object is moved inside the frame, so this should no longer happen.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It doesn't seem intended, or logical.
