### PR TITLE
make genetics abilities show up more responsively

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -30,9 +30,9 @@
 	OnAdd()
 		..()
 		if (ishuman(owner))
+			check_ability_owner()
 			var/mob/living/carbon/human/H = owner
 			H.hud.update_ability_hotbar()
-			check_ability_owner()
 		return
 
 	OnRemove()
@@ -50,8 +50,7 @@
 			AB.linked_power = src
 			icon = AB.icon
 			icon_state = AB.icon_state
-			SPAWN_DBG(0)
-				AB.owner = src.owner
+			AB.owner = src.owner
 
 /datum/targetable/geneticsAbility/cryokinesis
 	name = "Cryokinesis"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Before, you would often need to click the ABIL button twice to make new powers actually appear, when acquiring them via stuff like the gene booth or the admin menu.
This is because the owner of the ability wasn't properly set yet, hindering the process of displaying the icons.

I have no idea why this SPAWN_DBG was there.
I tested with some active abilities and various ways of gaining them though, and did not encounter any errors.
I tested:
- admin menu
- gene booth
- activator

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because them not showing up immediately is super annoying.
