### PR TITLE
Prevents long distance drag-drop filling of plantmasters, satchels, and reagent extractors

### DIFF
--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -113,7 +113,7 @@
 
 
 	MouseDrop_T(atom/movable/O as obj, mob/user as mob)
-		if (get_dist(src, user) > 1 || get_dist(user, O) > 1)
+		if (!in_interact_range(src, user)  || !IN_RANGE(user, O, 1))
 			return
 		var/proceed = 0
 		for(var/check_path in src.allowed)

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -113,6 +113,8 @@
 
 
 	MouseDrop_T(atom/movable/O as obj, mob/user as mob)
+		if (get_dist(src, user) > 1 || get_dist(user, O) > 1)
+			return
 		var/proceed = 0
 		for(var/check_path in src.allowed)
 			var/obj/item/W = O

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -685,6 +685,8 @@
 	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 		if (!O || !user)
 			return
+		if (get_dist(src, user) > 1 || get_dist(user, O) > 1)
+			return
 		if (!isitem(O))
 			return
 		if (istype(O, /obj/item/reagent_containers/glass/) || istype(O, /obj/item/reagent_containers/food/drinks/) || istype(O,/obj/item/satchel/hydro))
@@ -1038,6 +1040,8 @@
 			return
 
 	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+		if (get_dist(src, user) > 1 || get_dist(user, O) > 1)
+			return
 		if (istype(O, /obj/item/reagent_containers/glass/) || istype(O, /obj/item/reagent_containers/food/drinks/) || istype(O, /obj/item/satchel/hydro))
 			return src.Attackby(O, user)
 		if (!src.canExtract(O)) ..()

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -685,7 +685,7 @@
 	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 		if (!O || !user)
 			return
-		if (get_dist(src, user) > 1 || get_dist(user, O) > 1)
+		if (!in_interact_range(src, user)  || !IN_RANGE(user, O, 1))
 			return
 		if (!isitem(O))
 			return

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -1040,7 +1040,7 @@
 			return
 
 	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
-		if (get_dist(src, user) > 1 || get_dist(user, O) > 1)
+		if (!in_interact_range(src, user)  || !IN_RANGE(user, O, 1))
 			return
 		if (istype(O, /obj/item/reagent_containers/glass/) || istype(O, /obj/item/reagent_containers/food/drinks/) || istype(O, /obj/item/satchel/hydro))
 			return src.Attackby(O, user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents satchels, plantmasters, and reagent extractors from accepting drag and dropped items when the user is more than a tile away or the item to be inserted is more than a tile away from the user.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes  #6583