### PR TITLE
Dead people do not show typing speech bubbles

### DIFF
--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -23,7 +23,7 @@
 		M = src
 
 	var/current_time = TIME
-	if (M)
+	if (M && isalive(M))
 		M.speech_bubble.icon_state = "typing"
 		UpdateOverlays(M.speech_bubble, "speech_bubble")
 		M.last_typing = current_time


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If a character is dead or unconscious and their ghost is still in their body, they currently show a typing speech bubble if the player is typing in dead chat. This prevents that bubble from showing up.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #6581
