### PR TITLE
Fix restricted z-level check for pod and sub teleportation

### DIFF
--- a/code/modules/telescience/teleporter_old.dm
+++ b/code/modules/telescience/teleporter_old.dm
@@ -212,7 +212,7 @@
 
 	//if((istype(tmploc,/area/wizard_station)) || (istype(tmploc,/area/syndicate_station)))
 	var/area/myArea = get_area(tmploc)
-	if (myArea?.teleport_blocked || isrestrictedz(myArea.z) || m_blocked)
+	if (myArea?.teleport_blocked || isrestrictedz(tmploc.z) || m_blocked)
 		if(use_teleblocks)
 			if(isliving(M))
 				boutput(M, "<span class='alert'><b>Teleportation failed!</b></span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the restricted z level check for pod/sub teleportation. This will make sure non-restricted z levels can still be properly teleported to and restricted z levels cannot.

When isrestrictedz takes an area's z value, it doesn't look at the correct z level. For example, space areas return z level 1 even off the station level. Swapping the check to the turf properly finds the buoy z level.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #6567

