### PR TITLE
Corrects nukeop assault rifle ammo capacity

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1560,7 +1560,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 	force = MELEE_DMG_RIFLE
 	contraband = 8
 	caliber = 0.223
-	max_ammo_capacity = 30
+	max_ammo_capacity = 20
 	auto_eject = 1
 
 	two_handed = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR corrects the nukeop AR's ammo capacity to 20, from 30.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Tarm recently changed the magazines to 20 rounds, and when asked on discord said the AR still using 30 rounds was an oversight