### PR TITLE
Arm surgery bugfixes

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1396,6 +1396,7 @@
 		boutput(attacher, "<span class='alert'>You attach [src] to your own stump. It doesn't look very secure!</span>")
 
 	attachee.set_body_icon_dirty()
+	attachee.hud.update_hands()
 
 	//qdel(src)
 

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -147,6 +147,12 @@
 			else
 				return 0
 
+		if(!isdead(holder)) //This goes up here 'cuz removing limbs nulls holder
+			if(prob(40))
+				holder.emote("scream")
+		holder.TakeDamage("chest",20,0)
+		take_bleeding_damage(holder, tool.the_mob, 15, DAMAGE_STAB, surgery_bleed = 1)
+
 		switch(remove_stage)
 			if(0)
 				tool.the_mob.visible_message("<span class'alert'>[tool.the_mob] attaches [holder.name]'s [src.name] securely with [tool].</span>", "<span class='alert'>You attach [holder.name]'s [src.name] securely with [tool].</span>")
@@ -166,11 +172,6 @@
 				logTheThing("diary", tool.the_mob, holder, "removes [constructTarget(holder,"diary")]'s [src.name]", "combat")
 				src.remove(0)
 
-		if(!isdead(holder))
-			if(prob(40))
-				holder.emote("scream")
-		holder.TakeDamage("chest",20,0)
-		take_bleeding_damage(holder, tool.the_mob, 15, DAMAGE_STAB, surgery_bleed = 1)
 
 		return 1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor][runtime]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
-Makes attaching an item as an arm update the hud image, so you don't have the no arm icon sticking around anymore.
-Puts some damage/bleeding/scream code in limb removal surgery above the switch that does text and removal, so that the last step of removal doesn't runtime because `holder` is null.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs stinky

Runtimes aside, I think the last part of limb removal is just as worthy of screaming about as the first two.


