### PR TITLE
Refactor CanPass into CanPass and gas_cross

### DIFF
--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -3266,7 +3266,7 @@ Returns:
 	flags = FPRINT | ALWAYS_SOLID_FLUID | IS_PERSPECTIVE_FLUID
 	event_handler_flags = USE_CANPASS
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		if (mover?.throwing)
 			return 1
 		return ..()

--- a/code/WorkInProgress/simroom.dm
+++ b/code/WorkInProgress/simroom.dm
@@ -397,11 +397,6 @@
 		src.updateUsrDialog()
 	return
 
-/obj/machinery/sim/vr_bed/CanPass(atom/movable/O as mob|obj, target as turf, height=0, air_group=0)
-	if (air_group || (height==0))
-		return 1
-	..()
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /obj/machinery/sim/programcomp

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -39,6 +39,9 @@
 	proc/RawClick(location,control,params)
 		return
 
+	/// If atmos should be blocked by this - special behaviours handled in gas_cross() overrides
+	var/gas_impermeable = FALSE
+
 /* -------------------- name stuff -------------------- */
 	/*
 	to change names: either add or remove something with the appropriate proc(s) and then call atom.UpdateName()

--- a/code/atom/throwing.dm
+++ b/code/atom/throwing.dm
@@ -21,7 +21,7 @@
 			// **TODO: Better behaviour for windows
 			// which are dense, but shouldn't always stop movement
 			if(isobj(A))
-				if(!A.CanPass(src, src.loc, 1.5))
+				if(!A.CanPass(src, src.loc))
 					src.throw_impact(A, thr)
 					. = TRUE
 

--- a/code/datums/components/mob_pierce.dm
+++ b/code/datums/components/mob_pierce.dm
@@ -10,7 +10,7 @@
 
 /datum/component/gaseous_projectile/proc/update_pierces(var/obj/projectile/P, var/atom/hit)
 	var/turf/T = get_turf(hit)
-	return PROJ_ATOM_PASSTHROUGH * !!T.CanPass(null, get_turf(P), 0, 1)
+	return PROJ_ATOM_PASSTHROUGH * !!T.gas_cross(get_turf(P))
 
 /datum/component/gaseous_projectile/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_PROJ_COLLIDE)

--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -218,6 +218,7 @@
 	name = "Permanent Military-Grade Forcefield"
 	desc = "A permanent force field that prevents non-authorized entities from passing through it."
 	var/team_num = 0		//1 = NT, 2 = SY
+	gas_impermeable = TRUE
 
 	CanPass(atom/A, turf/T)
 		if (ismob(A))
@@ -745,9 +746,7 @@
 
 		return
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-		if(air_group || (height==0)) return 1
-
+	CanPass(atom/movable/mover, turf/target)
 		if (!src.density || (mover.flags & TABLEPASS || istype(mover, /obj/newmeteor)) )
 			return 1
 		else

--- a/code/datums/gauntlet/podcolosseum.dm
+++ b/code/datums/gauntlet/podcolosseum.dm
@@ -477,7 +477,7 @@ var/global/datum/arena/colosseumController/colosseum_controller = new()
 
 	src.debug_variables(colosseum_controller)
 
-/turf/unsimulated/floor/setpieces/gauntlet/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/turf/unsimulated/floor/setpieces/gauntlet/CanPass(atom/movable/mover, turf/target)
 	if (istype(mover, /obj/machinery/colosseum_putt))
 		return 0
 	return ..()
@@ -488,7 +488,7 @@ var/global/datum/arena/colosseumController/colosseum_controller = new()
 	icon_state = "gauntfloorPod"
 	event_handler_flags = USE_CANPASS
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/machinery/colosseum_putt))
 			return 1
 		return ..()

--- a/code/datums/pipeline.dm
+++ b/code/datums/pipeline.dm
@@ -209,7 +209,7 @@ datum/pipeline
 			var/turf/simulated/modeled_location = target
 
 			// Turf with walls or without air
-			if(modeled_location.blocks_air || !modeled_location.air)
+			if(modeled_location.gas_impermeable || !modeled_location.air)
 				if((modeled_location.heat_capacity>0) && (partial_heat_capacity>0))
 					delta_temperature = src.air.temperature - modeled_location.temperature
 

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1525,9 +1525,7 @@
 	if (!isliving(src))
 		src.sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF | SEE_BLACKNESS
 
-/mob/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if (air_group || (height==0)) return 1
-
+/mob/CanPass(atom/movable/mover, turf/target)
 	if (istype(mover, /obj/projectile))
 		return !projCanHit(mover:proj_data)
 

--- a/code/mob/dead.dm
+++ b/code/mob/dead.dm
@@ -11,7 +11,7 @@
 /mob/dead/ex_act(severity)
 	return
 
-/mob/dead/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/mob/dead/CanPass(atom/movable/mover, turf/target)
 	return 1
 
 /mob/dead/say_understands()

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -144,7 +144,7 @@
 
 
 //#ifdef HALLOWEEN
-/mob/dead/observer/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/mob/dead/observer/CanPass(atom/movable/mover, turf/target)
 	if (src.icon_state != "doubleghost" && istype(mover, /obj/projectile))
 		var/obj/projectile/proj = mover
 		if (proj.proj_data?.hits_ghosts)

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -93,7 +93,7 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 		add_health_holder(/datum/healthHolder/toxin)
 		add_health_holder(/datum/healthHolder/brain)
 
-	CanPass(atom/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/mover, turf/target)
 		if (!src.density && istype(mover, /obj/projectile))
 			return prob(50)
 		else

--- a/code/mob/living/intangible.dm
+++ b/code/mob/living/intangible.dm
@@ -24,7 +24,7 @@
 		return 0
 	say_understands(var/other)
 		return 1
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		return 1
 
 	meteorhit()

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -109,7 +109,7 @@
 /mob/living/intangible/flock/projCanHit(datum/projectile/P)
 	return P.hits_ghosts
 
-/mob/living/intangible/flock/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/mob/living/intangible/flock/CanPass(atom/movable/mover, turf/target)
 	if (istype(mover, /obj/projectile))
 		var/obj/projectile/proj = mover
 		if (istype(proj.proj_data, /datum/projectile/energy_bolt_antighost))

--- a/code/mob/living/seanceghost.dm
+++ b/code/mob/living/seanceghost.dm
@@ -37,7 +37,7 @@
 	click(atom/target)
 		src.examine_verb(target)
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		return 1
 
 	say_understands(var/other)

--- a/code/mob/wraith.dm
+++ b/code/mob/wraith.dm
@@ -235,7 +235,7 @@
 			for (var/datum/objective/specialist/wraith/WO in src.mind.objectives)
 				WO.onAbsorb(M)
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			var/obj/projectile/proj = mover
 			if (proj.proj_data.hits_wraiths)

--- a/code/mob/zoldorfmob.dm
+++ b/code/mob/zoldorfmob.dm
@@ -151,7 +151,7 @@
 		else
 			src.examine_verb(target)
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		return 1
 
 	say_understands(var/other)

--- a/code/modules/atmospherics/FEA_group_helpers.dm
+++ b/code/modules/atmospherics/FEA_group_helpers.dm
@@ -9,13 +9,13 @@
 	var/turf/simulated/floor/west = get_step(src,WEST)
 
 	//Clear those we do not have access to
-	if(!CanPass(null, north, null, 1) || !istype(north))
+	if(!gas_cross(north) || !istype(north))
 		north = null
-	if(!CanPass(null, south, null, 1) || !istype(south))
+	if(!gas_cross(south) || !istype(south))
 		south = null
-	if(!CanPass(null, east, null, 1) || !istype(east))
+	if(!gas_cross(east) || !istype(east))
 		east = null
-	if(!CanPass(null, west, null, 1) || !istype(west))
+	if(!gas_cross(west) || !istype(west))
 		west = null
 
 	var/new_group_possible = 0

--- a/code/modules/atmospherics/FEA_turf_tile.dm
+++ b/code/modules/atmospherics/FEA_turf_tile.dm
@@ -174,7 +174,7 @@ turf
 		New()
 			..()
 
-			if(!blocks_air)
+			if(!gas_impermeable)
 				air = new /datum/gas_mixture
 
 				#define _TRANSFER_GAS_TO_AIR(GAS, ...) air.GAS = GAS;
@@ -209,10 +209,10 @@ turf
 					active_hotspot = null
 			if(being_superconductive)
 				air_master.active_super_conductivity.Remove(src)
-			if(blocks_air)
+			if(gas_impermeable)
 				for(var/direction in cardinal)
 					var/turf/simulated/tile = get_step(src,direction)
-					if(air_master && istype(tile) && !tile.blocks_air)
+					if(air_master && istype(tile) && !tile.gas_impermeable)
 						air_master.tiles_to_update |= tile
 			qdel(air)
 			if (gas_icon_overlay)
@@ -289,7 +289,7 @@ turf
 
 			for(var/direction in cardinal)
 				LAGCHECK(LAG_REALTIME)
-				if(CanPass(null, get_step(src,direction), 0, 0))
+				if(gas_cross(get_step(src,direction)))
 					air_check_directions |= direction
 
 			if(parent)
@@ -413,7 +413,7 @@ turf
 
 		super_conduct()
 			var/conductivity_directions = 0
-			if(blocks_air)
+			if(gas_impermeable)
 				//Does not participate in air exchange, so will conduct heat across all four borders at this time
 				conductivity_directions = NORTH|SOUTH|EAST|WEST
 

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -288,7 +288,7 @@ obj/machinery/atmospherics/pipe
 				var/environment_temperature = 0
 
 				if(istype(loc, /turf/simulated/))
-					if(loc:blocks_air)
+					if(loc:gas_impermeable)
 						environment_temperature = loc:temperature
 					else
 						var/datum/gas_mixture/environment = loc.return_air()

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -367,7 +367,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 			return
 		for (var/turf/simulated/floor/target in range(1,location))
 			if(ON_COOLDOWN(target, "plasmastone_plasma_generate", 10 SECONDS)) continue
-			if(!target.blocks_air && target.air)
+			if(!target.gas_impermeable && target.air)
 				if(target.parent?.group_processing)
 					target.parent.suspend_group_processing()
 

--- a/code/modules/medical/genetics/geneticsScanner.dm
+++ b/code/modules/medical/genetics/geneticsScanner.dm
@@ -257,10 +257,6 @@ var/list/genetek_hair_styles = list()
 		playsound(src.loc, "sound/machines/sleeper_open.ogg", 50, 1)
 		return
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-		if (air_group || (height==0))
-			return 1
-		..()
 
 	proc/update_occupant()
 		var/mob/living/carbon/human/H = src.occupant

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -182,7 +182,7 @@
 			if(sigreturn & PROJ_ATOM_PASSTHROUGH || (pierces_left != 0 && first && !(sigreturn & PROJ_ATOM_CANNOT_PASS))) //try to hit other targets on the tile
 				for (var/mob/X in T.contents)
 					if(!(X in src.hitlist))
-						if (!X.CanPass(src, get_step(src, X.dir), 1, 0))
+						if (!X.CanPass(src, get_step(src, X.dir)))
 							src.collide(X, first = 0)
 					if(QDELETED(src))
 						return
@@ -204,7 +204,7 @@
 			if(first && (sigreturn & PROJ_OBJ_HIT_OTHER_OBJS))
 				for (var/obj/X in T.contents)
 					if(!(X in src.hitlist))
-						if (!X.CanPass(src, get_step(src, X.dir), 1, 0))
+						if (!X.CanPass(src, get_step(src, X.dir)))
 							src.collide(X, first = 0)
 					if(QDELETED(src))
 						return
@@ -323,7 +323,7 @@
 		..()
 		if (!istype(A))
 			return // can't happen will happen
-		if (!A.CanPass(src, get_step(src, A.dir), 1, 0))
+		if (!A.CanPass(src, get_step(src, A.dir)))
 			src.collide(A)
 
 		if (collide_with_other_projectiles && A.type == src.type)
@@ -336,7 +336,7 @@
 		for(var/thing as mob|obj|turf|area in T)
 			var/atom/A = thing
 			if (A == src) continue
-			if (!A.CanPass(src, get_step(src, A.dir), 1, 0))
+			if (!A.CanPass(src, get_step(src, A.dir)))
 				src.collide(A)
 
 			if (collide_with_other_projectiles && A.type == src.type)

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -72,7 +72,7 @@
 	power_change()
 		return
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			return 0
 		return ..()

--- a/code/modules/transport/shuttle/shuttle_turfobjs.dm
+++ b/code/modules/transport/shuttle/shuttle_turfobjs.dm
@@ -185,7 +185,7 @@
 	var/icon_style = "wall"
 	opacity = 1
 	density = 1
-	blocks_air = 1
+	gas_impermeable = 1
 	pathable = 0
 
 	New()

--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -36,7 +36,6 @@
 	var/poison_depletion = 1
 	var/heat_divisor = 15
 	var/temp_tolerance = 40
-	var/gas_impermeable = FALSE
 	mat_changename = 0
 	mat_changedesc = 0
 	var/runOnLife = 0 //Should this obj run Life?
@@ -78,11 +77,9 @@
 		else
 			..()
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		. = ..()
 		var/obj/projectile/P = mover
-		if((!mover || air_group) && src.gas_impermeable)
-			return 0
 		if (istype(P) && P.proj_data) //Wire note: Fix for Cannot read null.type
 			if (P.proj_data.type == /datum/projectile/slime)
 				return 1

--- a/code/obj/cement.dm
+++ b/code/obj/cement.dm
@@ -11,6 +11,7 @@
 	_max_health = initial_health
 	var/c_quality = 0
 	var/created_time = 0
+	gas_impermeable = TRUE
 
 	New()
 		..()
@@ -26,8 +27,8 @@
 	disposing()
 		processing_items -= src
 		..()
-		
-	CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+
+	CanPass(atom/movable/mover, turf/target)
 		if(istype(mover, /mob))
 			var/mob/M = mover
 			M.setStatus(statusId = "slowed", duration = 0.5 SECONDS, optional = 4)

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -618,7 +618,7 @@
 		else
 			return ..()
 
-	CanPass(atom/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			return prob(50)
 		else

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -377,7 +377,7 @@
 		else
 			..()
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			var/obj/projectile/proj = mover
 			if (istype(proj.proj_data, /datum/projectile/energy_bolt_antighost))
@@ -1425,7 +1425,7 @@
 			else
 				src.visible_message("[src] slithers around happily!")
 
-	CanPass(atom/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			return prob(50)
 		else

--- a/code/obj/decal.dm
+++ b/code/obj/decal.dm
@@ -411,7 +411,7 @@ obj/decal/fakeobjects/teleport_pad
 	layer = OBJ_LAYER
 	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0) // stolen from window.dm
+	CanPass(atom/movable/mover, turf/target) // stolen from window.dm
 		if (mover && mover.throwing & THROW_CHAIRFLIP)
 			return 1
 		if (src.dir == SOUTHWEST || src.dir == SOUTHEAST || src.dir == NORTHWEST || src.dir == NORTHEAST || src.dir == SOUTH || src.dir == NORTH)
@@ -458,7 +458,7 @@ obj/decal/fakeobjects/teleport_pad
 			user.visible_message("<span class='notice'><b>[M]</b> climbs up on [src]!</span>", "<span class='notice'>You climb up on [src].</span>")
 			buckle_in(M, user, 1)
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0) // stolen from window.dm
+	CanPass(atom/movable/mover, turf/target) // stolen from window.dm
 		if (mover && mover.throwing & THROW_CHAIRFLIP)
 			return 1
 		if (src.dir == SOUTHWEST || src.dir == SOUTHEAST || src.dir == NORTHWEST || src.dir == NORTHEAST || src.dir == SOUTH || src.dir == NORTH)

--- a/code/obj/decal/tile_edge.dm
+++ b/code/obj/decal/tile_edge.dm
@@ -140,7 +140,7 @@
 	dir = NORTH
 	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			return 1
 		if (get_dir(loc, target) == dir)

--- a/code/obj/effects/foam.dm
+++ b/code/obj/effects/foam.dm
@@ -163,7 +163,7 @@
 
 			M.show_text("You slip on the foam!", "red")
 
-/obj/effects/foam/CanPass(atom/movable/mover, turf/target)
-	if (src.metal && !mover)
-		return 0 // completely opaque to air
-	return 1
+
+/obj/effects/foam/gas_cross(turf/target)
+	if(src.metal)
+		return 0 //opaque to air

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -2,7 +2,7 @@
 	name = "wall"
 	icon = 'icons/obj/doors/Doorf.dmi'
 	icon_state = "door1"
-	blocks_air = 0
+	gas_impermeable = 0
 	var/operating = null
 	var/visible = 1
 	var/floorname
@@ -30,7 +30,7 @@
 		..()
 		//Hide the wires or whatever THE FUCK
 		src.levelupdate()
-		src.blocks_air = 1
+		src.gas_impermeable = 1
 		src.layer = src.layer - 0.1
 		SPAWN_DBG(0)
 			src.find_icon_state()
@@ -162,7 +162,7 @@
 			//we want to return 1 without waiting for the animation to finish - the textual cue seems sloppy if it waits
 			//actually do the opening things
 			src.set_density(0)
-			src.blocks_air = 0
+			src.gas_impermeable = 0
 			src.pathable = 1
 			src.update_air_properties()
 			src.RL_SetOpacity(0)
@@ -181,7 +181,7 @@
 		src.name = "wall"
 		animate(src, time = delay, pixel_x = 0, easing = BACK_EASING)
 		src.set_density(1)
-		src.blocks_air = 1
+		src.gas_impermeable = 1
 		src.pathable = 0
 		src.update_air_properties()
 		if (src.visible)
@@ -238,7 +238,7 @@
 		animate(src, time = delay, pixel_x = 0, easing = BACK_EASING)
 		src.icon_state = "door1"
 		src.set_density(1)
-		src.blocks_air = 1
+		src.gas_impermeable = 1
 		src.pathable = 0
 		src.update_air_properties()
 		if (src.visible)

--- a/code/obj/foamedmetal.dm
+++ b/code/obj/foamedmetal.dm
@@ -12,6 +12,7 @@
 	flags = FPRINT | CONDUCT | USEDELAY
 	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
 	var/metal = 1		// 1=aluminium, 2=iron
+	gas_impermeable = TRUE
 
 	New()
 		..()
@@ -70,10 +71,6 @@
 			dispose()
 		else
 			boutput(user, "<span class='notice'>You hit the metal foam to no effect.</span>")
-
-	// only air group geometry can pass
-	CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
-		return air_group
 
 	proc/update_nearby_tiles(need_rebuild)
 		var/turf/simulated/source = loc

--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -517,7 +517,7 @@
 
 		return src.electrocute(user, prb, net, ignore_gloves)
 
-	CanPass(atom/movable/mover, turf/target, height=1.5, air_group = 0)
+	CanPass(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			if (density)
 				return prob(50)

--- a/code/obj/item/decorative_pot.dm
+++ b/code/obj/item/decorative_pot.dm
@@ -7,8 +7,6 @@
 		density = 1
 		mats = list("ALL" = 1)
 
-		CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-				return 0
 		attackby(obj/item/weapon as obj,mob/user as mob)
 				if((iswrenchingtool(weapon)) || isscrewingtool(weapon))
 						if(!src.anchored)

--- a/code/obj/item/device/energy_shield_gen.dm
+++ b/code/obj/item/device/energy_shield_gen.dm
@@ -150,11 +150,17 @@
 	var/health_max = 10
 	var/health = 10
 	var/broken = 0
+	gas_impermeable = TRUE
 
 	CanPass(atom/A, turf/T)
 		if (broken) return 1
 		if (ismob(A)) return 1
 		else return 0
+
+	gas_cross(turf/target)
+		. = ..()
+		if(broken)
+			. = 1
 
 	ex_act(severity)
 		if(broken) return

--- a/code/obj/item/grenades.dm
+++ b/code/obj/item/grenades.dm
@@ -1698,7 +1698,7 @@ PIPE BOMBS + CONSTRUCTION
 
 			if (plasma)
 				for (var/turf/simulated/floor/target in range(1,src.loc))
-					if(!target.blocks_air && target.air)
+					if(!target.gas_impermeable && target.air)
 						if(target.parent?.group_processing)
 							target.parent.suspend_group_processing()
 

--- a/code/obj/machinery/atmos_field.dm
+++ b/code/obj/machinery/atmos_field.dm
@@ -5,6 +5,7 @@
 	icon_state = "atmos_field"
 	layer = OBJ_LAYER+0.5
 	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	gas_impermeable = TRUE
 
 	New()
 		..()
@@ -13,11 +14,6 @@
 	disposing()
 		..()
 		update_nearby_tiles()
-
-	CanPass(atom/movable/mover, turf/target)
-		if (!mover)
-			return 0 // completely opaque to air
-		return 1
 
 	Crossed(atom/movable/A)
 		..()

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -562,11 +562,6 @@ proc/find_ghost_by_key(var/find_key)
 			playsound(src, 'sound/machines/click.ogg', 50, 1)
 			bo(occupant, "<span class='notice'>\The [src] unlocks!</span>")
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-		if (air_group || (height==0))
-			return 1
-		..()
-
 	// Meat grinder functionality.
 	proc/find_pods()
 		if (!islist(src.pods))

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -136,6 +136,12 @@
 
 	return !density
 
+/obj/machinery/door/gas_cross(turf/target)
+	if (density && next_timeofday_opened)
+		return (world.timeofday >= next_timeofday_opened) //Hey this is a really janky fix. Makes it so the door 'opens' on realtime even if the animations and sounds are laggin
+
+	return !density
+
 /obj/machinery/door/proc/update_nearby_tiles(need_rebuild)
 	var/turf/simulated/source = loc
 	if (istype(source))

--- a/code/obj/machinery/door/firedoor.dm
+++ b/code/obj/machinery/door/firedoor.dm
@@ -188,18 +188,8 @@
 	check_nextstate()
 
 /obj/machinery/door/firedoor/border_only
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-		if(air_group)
-			var/direction = get_dir(src,target)
-			return (dir != direction)
-		else if(density)
-			if(!height)
-				var/direction = get_dir(src,target)
-				return (dir != direction)
-			else
-				return 0
-
-		return 1
+	gas_cross(turf/target)
+		return (dir != get_dir(src,target))
 
 	update_nearby_tiles(need_rebuild)
 		if(!air_master) return 0

--- a/code/obj/machinery/door/window.dm
+++ b/code/obj/machinery/door/window.dm
@@ -97,7 +97,7 @@
 		close()
 		return 1
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			var/obj/projectile/P = mover
 			if (P.proj_data.window_pass)
@@ -114,6 +114,12 @@
 			return !density
 		else
 			return 1
+
+	gas_cross(turf/target)
+		if(get_dir(loc, target) == dir)
+			return !density
+		else
+			return TRUE
 
 	CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
 		if (istype(mover, /obj/projectile))

--- a/code/obj/machinery/optable.dm
+++ b/code/obj/machinery/optable.dm
@@ -45,9 +45,7 @@
 		qdel(src)
 	return
 
-/obj/machinery/optable/CanPass(atom/movable/O as mob|obj, target as turf, height=0, air_group=0)
-	if (air_group || (height==0))
-		return 1
+/obj/machinery/optable/CanPass(atom/movable/O as mob|obj, target as turf)
 	if (!O)
 		return 0
 	if ((O.flags & TABLEPASS || istype(O, /obj/newmeteor)))

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -429,6 +429,7 @@
 	icon_state = "shieldw"
 	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
 	var/powerlevel //Stores the power level of the deployer
+	density = 0
 
 	var/sound/sound_shieldhit = "sound/impact_sounds/Energy_Hit_1.ogg"
 	var/obj/machinery/shieldgenerator/deployer = null
@@ -458,6 +459,7 @@
 			src.color = "#3333FF" //change colour for different power levels
 			src.powerlevel = 1
 			flags = 0
+			gas_impermeable = TRUE
 		else if(deployer != null && deployer.power_level == 2)
 			src.name = "Atmospheric/Liquid Forcefield"
 			src.desc = "A force field that prevents gas and liquids from passing through it."
@@ -465,6 +467,7 @@
 			src.color = "#33FF33"
 			src.powerlevel = 2
 			flags = ALWAYS_SOLID_FLUID
+			gas_impermeable = TRUE
 		else if(deployer != null)
 			src.name = "Energy Forcefield"
 			src.desc = "A force field that prevents matter from passing through it."
@@ -472,6 +475,7 @@
 			src.color = "#FF3333"
 			src.powerlevel = 3
 			flags = ALWAYS_SOLID_FLUID | USEDELAY
+			density = 1
 
 	disposing()
 		if(update_tiles)
@@ -486,41 +490,6 @@
 			return source.update_nearby_tiles(need_rebuild)
 
 		return 1
-
-	CanPass(atom/A, turf/T)
-		var/level = 0
-		if(deployer == null)
-			level = powerlevel
-		else
-			level = deployer.power_level
-
-		switch(level)
-			if(0)
-				return 1
-			//power level one, atmos shield. Only atmos is blocked by this forcefield
-			if(1)
-				if(ismob(A)) return 1
-				if(isobj(A)) return 1
-				//Has a liquid check in IS_SOLID_TO_FLUID
-
-			//power level 2, liquid shield. Only liquids are blocked by this forcefield
-			if(2)
-				if(ismob(A)) return 1
-				if(isobj(A)) return 1
-				//Has a liquid check in IS_SOLID_TO_FLUID
-
-			//power level 3, solid shield. Nothing can pass by this shield
-			if(3)
-				return 0
-
-			// liquid-only shield, allows atmos etc
-			if(4)
-				return 1
-
-		if(level == 1 || level == 2)
-			if(ismob(A)) return 1
-			if(isobj(A)) return 1
-		else return 0
 
 	attackby(obj/item/W, mob/user)
 		. = ..()

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -874,7 +874,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	src.gen_secondary.power -= 3
 	return
 
-/obj/machinery/containment_field/CanPass(atom/movable/O as mob|obj, target as turf, height=0, air_group=0)
+/obj/machinery/containment_field/CanPass(atom/movable/O as mob|obj, target as turf)
 	if(iscarbon(O) && prob(80))
 		shock(O)
 	..()

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -290,11 +290,6 @@
 		src.UpdateOverlays(src.image_lid, "lid")
 		return
 
-	CanPass(atom/movable/O as mob|obj, target as turf, height=0, air_group=0)
-		if (air_group || (height==0))
-			return 1
-		..()
-
 	ex_act(severity)
 		switch (severity)
 			if (1.0)

--- a/code/obj/morgue.dm
+++ b/code/obj/morgue.dm
@@ -145,7 +145,7 @@
 		src.connected = null
 		. = ..()
 
-/obj/m_tray/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/m_tray/CanPass(atom/movable/mover, turf/target)
 	if (istype(mover, /obj/item/dummy))
 		return 1
 	else
@@ -389,7 +389,7 @@
 		src.connected = null
 		. = ..()
 
-/obj/c_tray/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/c_tray/CanPass(atom/movable/mover, turf/target)
 	if (istype(mover, /obj/item/dummy))
 		return 1
 	else

--- a/code/obj/rack.dm
+++ b/code/obj/rack.dm
@@ -49,9 +49,7 @@
 		rackbreak()
 		return
 
-/obj/rack/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0)) return 1
-
+/obj/rack/CanPass(atom/movable/mover, turf/target)
 	if (mover.flags & TABLEPASS)
 		return 1
 	else

--- a/code/obj/railing.dm
+++ b/code/obj/railing.dm
@@ -92,14 +92,10 @@
 		..()
 		layerify()
 
-	CanPass(atom/movable/O as mob|obj, turf/target, height=0, air_group=0)
-		if(air_group)
-			return 1
+	CanPass(atom/movable/O as mob|obj, turf/target)
 		if (O == null)
 			return 0
 		if (!src.density || (O.flags & TABLEPASS && !src.is_reinforced) || istype(O, /obj/newmeteor) || istype(O, /obj/lpt_laser) )
-			return 1
-		if(height==0)
 			return 1
 		if (dir & get_dir(loc, O))
 			return !density

--- a/code/obj/shieldgen.dm
+++ b/code/obj/shieldgen.dm
@@ -5,19 +5,19 @@ Shield and graivty well generators
 */
 
 /obj/shieldgen
-		name = "shield generator"
-		desc = "Used to seal minor hull breaches."
-		icon = 'icons/obj/objects.dmi'
-		icon_state = "shieldoff"
+	name = "shield generator"
+	desc = "Used to seal minor hull breaches."
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "shieldoff"
 
-		density = 1
-		opacity = 0
-		anchored = 0
-		pressure_resistance = 2*ONE_ATMOSPHERE
+	density = 1
+	opacity = 0
+	anchored = 0
+	pressure_resistance = 2*ONE_ATMOSPHERE
 
-		var/active = 0
-		var/health = 100
-		var/malfunction = 0
+	var/active = 0
+	var/health = 100
+	var/malfunction = 0
 
 
 
@@ -128,25 +128,16 @@ Shield and graivty well generators
 		shields_up()
 
 /obj/shield
-		name = "shield"
-		desc = "An energy shield."
-		icon = 'icons/effects/effects.dmi'
-		icon_state = "shieldsparkles"
-		density = 1
-		opacity = 0
-		anchored = 1
-		event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	name = "shield"
+	desc = "An energy shield."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "shieldsparkles"
+	density = 1
+	opacity = 0
+	anchored = 1
+	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	gas_impermeable = TRUE
 
-/obj/shieldwall
-		name = "shield"
-		desc = "An energy shield."
-		icon = 'icons/effects/effects.dmi'
-		icon_state = "test"
-		density = 1
-		opacity = 0
-		anchored = 1
-
-/obj/shield
 	New()
 		src.set_dir(pick(1,2,3,4))
 
@@ -158,11 +149,6 @@ Shield and graivty well generators
 		update_nearby_tiles()
 
 		..()
-
-	CanPass(atom/movable/mover, turf/target, height, air_group)
-		if(!height || air_group) return 0
-		else return ..()
-
 	proc/update_nearby_tiles(need_rebuild)
 		var/turf/simulated/source = loc
 		if (istype(source))
@@ -170,20 +156,30 @@ Shield and graivty well generators
 
 		return 1
 
+/obj/shieldwall
+	name = "shield"
+	desc = "An energy shield."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "test"
+	density = 1
+	opacity = 0
+	anchored = 1
+
+
 /obj/gravity_well_generator
-		name = "gravity well generator"
-		desc = "A complex piece of machinery that alters gravity."
-		icon = 'icons/obj/stationobjs.dmi'
-		icon_state = "gravgen-off"
-		mats = 14
+	name = "gravity well generator"
+	desc = "A complex piece of machinery that alters gravity."
+	icon = 'icons/obj/stationobjs.dmi'
+	icon_state = "gravgen-off"
+	mats = 14
 
-		density = 1
-		opacity = 0
-		anchored = 0
-		pressure_resistance = 2*ONE_ATMOSPHERE
+	density = 1
+	opacity = 0
+	anchored = 0
+	pressure_resistance = 2*ONE_ATMOSPHERE
 
-		var/active = 0
-		var/strength = 144		//strength is basically G if you know your newton law of gravitation
+	var/active = 0
+	var/strength = 144		//strength is basically G if you know your newton law of gravitation
 
 /obj/gravity_well_generator
 

--- a/code/obj/storage/floor_closets.dm
+++ b/code/obj/storage/floor_closets.dm
@@ -34,7 +34,7 @@
 	recalcPClass()
 		p_class = initial(p_class)
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		return 1
 
 /obj/storage/closet/syndi/hidden

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -425,10 +425,8 @@
 	alter_health()
 		. = get_turf(src)
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		. = open
-		if (air_group || (height==0))
-			return 1
 		if (src.is_short)
 			return 0
 

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -311,9 +311,7 @@
 				actions.start(new /datum/action/bar/icon/railing_jump/table_jump(user, src), user)
 		return
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-		if(air_group || (height==0)) return 1
-
+	CanPass(atom/movable/mover, turf/target)
 		if (!src.density || (mover.flags & TABLEPASS || istype(mover, /obj/newmeteor)) )
 			return 1
 		else

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -28,6 +28,7 @@
 	var/reinf = 0 // cant figure out how to remove this without the map crying aaaaa - ISN
 	var/deconstruct_time = 0//20
 	pressure_resistance = 4*ONE_ATMOSPHERE
+	gas_impermeable = TRUE
 	anchored = 1
 	the_tuff_stuff
 		explosion_resistance = 3
@@ -286,7 +287,7 @@
 			the_text += " ...you can't see through it at all. What kind of idiot made this?"
 		return the_text
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	CanPass(atom/movable/mover, turf/target)
 		if(istype(mover, /obj/projectile))
 			var/obj/projectile/P = mover
 			if(P.proj_data.window_pass)
@@ -298,6 +299,11 @@
 			return !density
 		else
 			return 1
+
+	gas_cross(turf/target)
+		. = TRUE
+		if (src.dir == SOUTHWEST || src.dir == SOUTHEAST || src.dir == NORTHWEST || src.dir == NORTHEAST || get_dir(loc, target) == dir)
+			. = ..()
 
 	CheckExit(atom/movable/O as mob|obj, target as turf)
 		if (!src.density)

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -149,7 +149,7 @@ var/obj/item/dummy/click_dummy = new
 				return 0
 	for (var/atom/A in target)
 		if (A.flags & ON_BORDER)
-			if (!A.CanPass(click_dummy, from, 1, 0))
+			if (!A.CanPass(click_dummy, from))
 				return 0
 	return 1
 

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1324,18 +1324,18 @@ DEFINE_FLOORS(grasslush/thin,
 	else
 		boutput(user, "Your attack bounces off the foamed metal floor.")
 
-/turf/simulated/floor/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/turf/simulated/floor/CanPass(atom/movable/mover, turf/target)
 	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
 		if (!( locate(/obj/machinery/mass_driver, src) ))
 			return 0
 	return ..()
 
-/turf/simulated/shuttle/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/turf/simulated/shuttle/CanPass(atom/movable/mover, turf/target,)
 	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
 		return 0
 	return ..()
 
-/turf/unsimulated/floor/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/turf/unsimulated/floor/CanPass(atom/movable/mover, turf/target)
 	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
 		if (!( locate(/obj/machinery/mass_driver, src) ))
 			return 0

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -32,7 +32,6 @@
 	//Properties for both
 	var/temperature = T20C
 
-	var/blocks_air = 0
 	var/icon_old = null
 	var/name_old = null
 	var/tmp/pathweight = 1
@@ -68,7 +67,7 @@
 			if(initial(src.opacity))
 				src.RL_SetOpacity(src.material.alpha <= MATERIAL_ALPHA_OPACITY ? 0 : 1)
 
-		blocks_air = material.hasProperty("permeable") ? material.getProperty("permeable") >= 33 : blocks_air
+		gas_impermeable = material.hasProperty("permeable") ? material.getProperty("permeable") >= 33 : gas_impermeable
 		return
 
 	serialize(var/savefile/F, var/path, var/datum/sandbox/sandbox)
@@ -348,7 +347,7 @@ proc/generate_space_color()
 			if(!mover)	return 0
 			if ((forget != obstacle))
 				if(obstacle.event_handler_flags & USE_CANPASS)
-					if(!obstacle.CanPass(mover, cturf, 1, 0))
+					if(!obstacle.CanPass(mover, cturf))
 
 						mover.Bump(obstacle, 1)
 						return 0
@@ -369,7 +368,7 @@ proc/generate_space_color()
 					if(!mover)	return 0
 					if ((forget != obstacle))
 						if(obstacle.event_handler_flags & USE_CANPASS)
-							if(!obstacle.CanPass(mover, cturf, 1, 0))
+							if(!obstacle.CanPass(mover, cturf))
 
 								mover.Bump(obstacle, 1)
 								return 0

--- a/code/turf/turf_drawbridge.dm
+++ b/code/turf/turf_drawbridge.dm
@@ -13,7 +13,7 @@
 	var/icon_style = "wall"
 	opacity = 0
 	density = 1
-	blocks_air = 1
+	gas_impermeable = 1
 	pathable = 0
 
 /turf/simulated/drawbridge/floor

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -9,7 +9,7 @@
 #endif
 	opacity = 1
 	density = 1
-	blocks_air = 1
+	gas_impermeable = 1
 	pathable = 1
 	flags = ALWAYS_SOLID_FLUID
 	text = "<font color=#aaa>#"

--- a/code/z_adventurezones/debris.dm
+++ b/code/z_adventurezones/debris.dm
@@ -24,7 +24,7 @@
 	icon_state = "wall1"
 	opacity = 1
 	density = 1
-	blocks_air = 1
+	gas_impermeable = 1
 
 	var/health = 40
 

--- a/code/z_adventurezones/icemoon.dm
+++ b/code/z_adventurezones/icemoon.dm
@@ -146,7 +146,7 @@ Contents:
 	name = "deep abyss"
 	desc = "You can't see the bottom."
 	icon_state = "void_gray"
-	blocks_air = 1
+	gas_impermeable = 1
 	opacity = 1
 	density = 1
 	fullbright = 0

--- a/code/z_adventurezones/mad_mars.dm
+++ b/code/z_adventurezones/mad_mars.dm
@@ -244,7 +244,7 @@
 	desc = "Hey, it's not red at all!"
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "mars"
-	blocks_air = 1
+	gas_impermeable = 1
 	opacity = 1
 	density = 1
 	fullbright = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pulls gas permeability checks out of CanPass and into a new proc, gas_cross

This is gonna want some testing to make sure things work right

- [x] Something weird happened with plasma going into windows in one test. Confirm? Fix?
        I'm pretty sure this one was just from plasmastone being silly and spawning plasma under windows
- [ ] Make sure that whatever was going on in  `code\modules\atmospherics\FEA_turf_tile.dm:292` isn't broken

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes any future changes to CanPass simpler, (e.g.: changing over to Cross()).

