### PR TITLE
Start ghost respawn wiz on wiz shuttle

### DIFF
--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -170,7 +170,6 @@
 		var/objective_path = null
 		var/send_to = 1 // 1: arrival shuttle/latejoin missile | 2: wizard shuttle | 3: safe start for incorporeal antags
 		var/ASLoc = pick_landmark(LANDMARK_LATEJOIN)
-		var/WSLoc = job_start_locations["wizard"] ? pick(job_start_locations["wizard"]) : null
 		var/failed = 0
 
 		switch (src.antagonist_type)
@@ -219,7 +218,7 @@
 				if (R && istype(R))
 					M3 = R
 					R.unequip_all(1)
-					equip_wizard(R)
+					equip_wizard(R, 1)
 					send_to = 2
 					role = ROLE_WIZARD
 					objective_path = pick(typesof(/datum/objective_set/traitor/rp_friendly))
@@ -328,7 +327,7 @@
 			else
 				failed = 1
 
-		if (!ASLoc && !WSLoc)
+		if (!ASLoc)
 			failed = 1
 
 		if (failed != 0)
@@ -365,10 +364,11 @@
 				else
 					M3.set_loc(ASLoc)
 			if (2)
-				if (!WSLoc)
+				if (!job_start_locations["wizard"])
+					boutput(M3, "<B><span class='alert'>A starting location for you could not be found, please report this bug!</span></B>")
 					M3.set_loc(ASLoc)
 				else
-					M3.set_loc(WSLoc)
+					M3.set_loc(pick(job_start_locations["wizard"]))
 			if (3)
 				M3.set_loc(ASLoc)
 		//nah


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wizards from the ghost respawn event now get placed on the wizard shuttle.
Wizards are force spawned with robe in case another wizard has taken all the robes.
Warning given if job start location is missing, this shouldn't happen as this is the same method round start wizards use.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wizards could teleport there anyway with the scroll, we might as well start them in a consistent environment with potential extra equipment.