### PR TITLE
Implements local clouddata simulation

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -522,10 +522,14 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 			src.cmd_rp_rules()
 #endif
 		//Cloud data
+#ifdef LIVE_SERVER
 		if (cdn)
 			if(!cloud_available())
 				src.player.cloud_fetch()
-
+#else
+		// dev server, uses local save file to simulate clouddata
+		if (src.player.cloud_fetch()) // might needlessly reload, but whatever.
+#endif
 			if(cloud_available())
 				src.load_antag_tokens()
 				src.load_persistent_bank()

--- a/code/player.dm
+++ b/code/player.dm
@@ -124,10 +124,18 @@
 			return FALSE
 		clouddata[key] = "[value]"
 
+#ifdef LIVE_SERVER
 		// Via rust-g HTTP
 		var/datum/http_request/request = new() //If it fails, oh well...
 		request.prepare(RUSTG_HTTP_METHOD_GET, "https://spacebee.goonhub.com/api/cloudsave?dataput&api_key=[config.spacebee_api_key]&ckey=[ckey]&key=[url_encode(key)]&value=[url_encode(clouddata[key])]", "", "")
 		request.begin_async()
+#else
+		// dev server, save to a local save file instead to simulate clouddata
+		var/savefile/simulated_cloud = new ("data/simulated_cloud.sav")
+		// need to wrap the clouddata within index named cdata
+		var/list/wrapper = list(cdata = clouddata)
+		simulated_cloud["[ckey]"] << json_encode(wrapper)
+#endif
 		return TRUE // I guess
 
 	/// Sets a cloud key value pair and sends it to goonhub for a target ckey
@@ -137,10 +145,16 @@
 			return FALSE
 		data[key] = "[value]"
 
+#ifdef LIVE_SERVER
 		// Via rust-g HTTP
 		var/datum/http_request/request = new() //If it fails, oh well...
 		request.prepare(RUSTG_HTTP_METHOD_GET, "https://spacebee.goonhub.com/api/cloudsave?dataput&api_key=[config.spacebee_api_key]&ckey=[target]&key=[url_encode(key)]&value=[url_encode(data[key])]", "", "")
 		request.begin_async()
+#else
+		// dev server, save to a local save file instead to simulate clouddata
+		var/savefile/simulated_cloud = new ("data/simulated_cloud.sav")
+		simulated_cloud["[ckey(target)]"] << json_encode(data)
+#endif
 		return TRUE // I guess
 
 	/// Returns some cloud data on the client
@@ -178,6 +192,7 @@
 
 	/// Returns cloud data and saves from goonhub for the target ckey in list form
 	proc/cloud_fetch_target_ckey(target)
+#ifdef LIVE_SERVER
 		if(!cdn) return
 		target = ckey(target)
 		if (!target) return
@@ -198,6 +213,18 @@
 			return
 		else
 			return ret
+#else
+		// local dev server, use a save file to simulate cloud
+		if (!target) return
+		var/savefile/simulated_cloud = new ("data/simulated_cloud.sav")
+		var/data
+		simulated_cloud["[ckey(target)]"] >> data
+		if (data)
+			return json_decode(data)
+		else
+			// we need to return a list with a list in the cdata index or it causes a deadlock where we can't save
+			return list(cdata = list())
+#endif
 
 /// returns a reference to a player datum based on the ckey you put into it
 /proc/find_player(key)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Implements local cloud simulation
* Only handles clouddata, does not include cloudsaves (aka character save data)
* Allows persistence of all cloud data in a local environment without the requirement of the cdn 
* Saved data includes custom keybinds, spacebux, antag tokens, persistent bank purchases, volume controls, etc.
* Saves are saved per-ckey in a local save file. In theory this same system will also allow hosted servers to enjoy a psuedo-cloudsave system
* All save data can be cleared by deleting `data/simulated_cloud.sav`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Customize your dev environment to your liking with keybinds and such, and have the stick
* Easier debugging and testing of clouddata code by allowing you to do it in a local dev environment