### PR TITLE
Convert admin preferences system to use clouddata

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -315,7 +315,10 @@ var/global/noir = 0
 					src.auto_alt_key_name = null
 					boutput(usr, "<span class='notice'>Auto Alt Key removed.</span>")
 					return
-
+		if ("set_auto_alias_global_save")
+			if (src.level >= LEVEL_SA)
+				usr.client.holder.auto_alias_global_save = !usr.client.holder.auto_alias_global_save
+				src.show_pref_window(usr)
 		if ("refreshoptions")
 			var/mob/M = locate(href_list["target"])
 			if (!M) return

--- a/code/modules/admin/admin_holder.dm
+++ b/code/modules/admin/admin_holder.dm
@@ -200,8 +200,12 @@
 			saved_auto_alias_global_save = FALSE
 		auto_alias_global_save = saved_auto_alias_global_save
 
-		var/saved_auto_stealth = AP["[auto_alias_global_save ? "" : "[config.server_id]_"]auto_stealth"]
-		var/saved_auto_stealth_name = AP["[auto_alias_global_save ? "" : "[config.server_id]_"]auto_stealth_name"]
+		var/list/saved_auto_aliases = AP["auto_aliases"]
+		if (!saved_auto_aliases)
+			saved_auto_aliases = list()
+
+		var/saved_auto_stealth = saved_auto_aliases["[src.auto_alias_global_save ? "" : "[config.server_id]_"]auto_stealth"]
+		var/saved_auto_stealth_name = saved_auto_aliases["[auto_alias_global_save ? "" : "[config.server_id]_"]auto_stealth_name"]
 		if (isnull(saved_auto_stealth) || !isnum(saved_auto_stealth))
 			saved_auto_stealth = 0
 			saved_auto_stealth_name = null
@@ -211,8 +215,8 @@
 		auto_stealth = saved_auto_stealth
 		auto_stealth_name = saved_auto_stealth_name
 
-		var/saved_auto_alt_key = AP["[auto_alias_global_save ? "" : "[config.server_id]_"]auto_alt_key"]
-		var/saved_auto_alt_key_name = AP["[auto_alias_global_save ? "" : "[config.server_id]_"]auto_alt_key_name"]
+		var/saved_auto_alt_key = saved_auto_aliases["[auto_alias_global_save ? "" : "[config.server_id]_"]auto_alt_key"]
+		var/saved_auto_alt_key_name = saved_auto_aliases["[auto_alias_global_save ? "" : "[config.server_id]_"]auto_alt_key_name"]
 		if (isnull(saved_auto_alt_key) || !isnum(saved_auto_alt_key))
 			saved_auto_alt_key = 0
 			saved_auto_alt_key_name = null
@@ -272,8 +276,11 @@
 	proc/save_admin_prefs()
 		if (!src.owner)
 			return
-		var/list/data = json_decode(owner.player.cloud_get("admin_preferences"))
-		var/list/auto_aliases = data["auto_aliases"]
+		var/list/data = owner.player.cloud_get("admin_preferences")
+		var/list/auto_aliases = list()
+		if (data) // decoding null will runtime
+			data = json_decode(owner.player.cloud_get("admin_preferences"))
+			auto_aliases = data["auto_aliases"]
 
 		if (auto_alias_global_save)
 			auto_aliases["auto_stealth"] = auto_stealth

--- a/code/modules/admin/admin_holder.dm
+++ b/code/modules/admin/admin_holder.dm
@@ -146,63 +146,53 @@
 	proc/load_admin_prefs()
 		if (!src.owner)
 			return
-		var/savefile/AP = new /savefile("data/AdminPrefs.sav")
-		var/ckey = src.owner:ckey
-		if (!ckey)
+		var/list/AP
+		if (!owner.player.clouddata)
+			owner.player.cloud_fetch()
+		var/json_data = src.owner.player.cloud_get("admin_preferences")
+		if (json_data)
+			AP = json_decode(json_data)
+		else
+			boutput(src.owner, "<span class='notice'>ERROR: Admin prefence data is null. You either have no saved prefs or cloud is unreachable.</span>")
 			return
-/*
-		var/saved_extratoggle
-		AP["[ckey]_extratoggle"] >> saved_extratoggle
-		if (isnull(saved_extratoggle))
-			saved_extratoggle = 0
-		if (saved_extratoggle == 1 && extratoggle != 1)
-			src.owner:toggle_extra_verbs()
-		extratoggle = saved_extratoggle
-*/
-		var/saved_popuptoggle
-		AP["[ckey]_popuptoggle"] >> saved_popuptoggle
+
+		var/saved_popuptoggle = AP["popuptoggle"]
 		if (isnull(saved_popuptoggle))
 			saved_popuptoggle = 0
 		if (saved_popuptoggle == 1 && popuptoggle != 1)
 			src.owner:toggle_popup_verbs()
 		popuptoggle = saved_popuptoggle
 
-		var/saved_servertoggles_toggle
-		AP["[ckey]_servertoggles_toggle"] >> saved_servertoggles_toggle
+		var/saved_servertoggles_toggle = AP["servertoggles_toggle"]
 		if (isnull(saved_servertoggles_toggle))
 			saved_servertoggles_toggle = 0
 		if (saved_servertoggles_toggle == 1 && servertoggles_toggle != 1)
 			src.owner:toggle_server_toggles_tab()
 		servertoggles_toggle = saved_servertoggles_toggle
 
-		var/saved_animtoggle
-		AP["[ckey]_animtoggle"] >> saved_animtoggle
+		var/saved_animtoggle = AP["animtoggle"]
 		if (isnull(saved_animtoggle))
 			saved_animtoggle = 1
 		if (saved_animtoggle == 0 && animtoggle != 0)
 			src.owner:toggle_atom_verbs()
 		animtoggle = saved_animtoggle
 
-		var/saved_attacktoggle
-		AP["[ckey]_attacktoggle"] >> saved_attacktoggle
+		var/saved_attacktoggle = AP["attacktoggle"]
 		if (isnull(saved_attacktoggle))
 			saved_attacktoggle = 1
 		if (saved_attacktoggle == 0 && attacktoggle != 0)
 			src.owner:toggle_attack_messages()
 		attacktoggle = saved_attacktoggle
 
-		var/saved_rp_word_filtering
-		AP["[ckey]_rp_word_filtering"] >> saved_rp_word_filtering
+		var/saved_rp_word_filtering = AP["rp_word_filtering"]
 		if (isnull(saved_rp_word_filtering))
 			saved_rp_word_filtering = 0
 		if (saved_rp_word_filtering == 1 && rp_word_filtering != 1)
 			src.owner:toggle_rp_word_filtering()
 		rp_word_filtering = saved_rp_word_filtering
 
-		var/saved_auto_stealth
-		var/saved_auto_stealth_name
-		AP["[ckey]_auto_stealth"] >> saved_auto_stealth
-		AP["[ckey]_auto_stealth_name"] >> saved_auto_stealth_name
+		var/saved_auto_stealth = AP["auto_stealth"]
+		var/saved_auto_stealth_name = AP["auto_stealth_name"]
 		if (isnull(saved_auto_stealth) || !isnum(saved_auto_stealth))
 			saved_auto_stealth = 0
 			saved_auto_stealth_name = null
@@ -212,10 +202,8 @@
 		auto_stealth = saved_auto_stealth
 		auto_stealth_name = saved_auto_stealth_name
 
-		var/saved_auto_alt_key
-		var/saved_auto_alt_key_name
-		AP["[ckey]_auto_alt_key"] >> saved_auto_alt_key
-		AP["[ckey]_auto_alt_key_name"] >> saved_auto_alt_key_name
+		var/saved_auto_alt_key = AP["auto_alt_key"]
+		var/saved_auto_alt_key_name = AP["auto_alt_key_name"]
 		if (isnull(saved_auto_alt_key) || !isnum(saved_auto_alt_key))
 			saved_auto_alt_key = 0
 			saved_auto_alt_key_name = null
@@ -225,46 +213,39 @@
 		auto_alt_key = saved_auto_alt_key
 		auto_alt_key_name = saved_auto_alt_key_name
 
-		var/saved_hear_prayers
-		AP["[ckey]_hear_prayers"] >> saved_hear_prayers
+		var/saved_hear_prayers = AP["hear_prayers"]
 		if (isnull(saved_hear_prayers))
 			saved_hear_prayers = 0
 		hear_prayers = saved_hear_prayers
 
-		var/saved_audible_prayers
-		AP["[ckey]_audible_prayers"] >> saved_audible_prayers
+		var/saved_audible_prayers = AP["audible_prayers"]
 		if (isnull(saved_audible_prayers))
 			saved_audible_prayers = 0
 		audible_prayers = saved_audible_prayers
 
-		var/saved_audible_ahelps
-		AP["[ckey]_audible_ahelps"] >> saved_audible_ahelps
+		var/saved_audible_ahelps = AP["audible_ahelps"]
 		if (isnull(saved_audible_ahelps))
 			saved_audible_ahelps = 0
 		audible_ahelps = saved_audible_ahelps
 
-		var/saved_atags
-		AP["[ckey]_atags"] >> saved_atags
+		var/saved_atags = AP["atags"]
 		if (isnull(saved_atags))
 			saved_atags = 1
 		see_atags = saved_atags
 
-		var/saved_buildmode_view
-		AP["[ckey]_buildmode_view"] >> saved_buildmode_view
+		var/saved_buildmode_view = AP["buildmode_view"]
 		if (isnull(saved_buildmode_view))
 			saved_buildmode_view = 0
 		buildmode_view = saved_buildmode_view
 
-		var/saved_spawn_in_loc
-		AP["[ckey]_spawn_in_loc"] >> saved_spawn_in_loc
+		var/saved_spawn_in_loc = AP["spawn_in_loc"]
 		if (isnull(saved_spawn_in_loc))
 			saved_spawn_in_loc = 0
 		spawn_in_loc = saved_spawn_in_loc
 
 		src.hidden_categories = list()
 		for(var/cat in toggleable_admin_verb_categories)
-			var/cat_hidden
-			AP["[ckey]_hidden_[cat]"] >> cat_hidden
+			var/cat_hidden = AP["hidden_[cat]"]
 			if(isnull(cat_hidden))
 				if(src.level >= LEVEL_CODER || cat == ADMIN_CAT_SELF || cat == ADMIN_CAT_SERVER || cat == ADMIN_CAT_PLAYERS)
 					cat_hidden = 0
@@ -276,38 +257,37 @@
 			else
 				src.owner?.show_verb_category(ADMIN_CAT_PREFIX + cat)
 
-		if (usr)
-			boutput(usr, "<span class='notice'>Admin preferences loaded.</span>")
+		if (src.owner)
+			boutput(src.owner, "<span class='notice'>Admin preferences loaded.</span>")
 
 	proc/save_admin_prefs()
 		if (!src.owner)
 			return
-		var/savefile/AP = new /savefile("data/AdminPrefs.sav")
-		var/ckey = src.owner:ckey
-		if (!ckey)
-			return
-		//AP["[ckey]_extratoggle"] << extratoggle
-		AP["[ckey]_popuptoggle"] << popuptoggle
-		AP["[ckey]_servertoggles_toggle"] << servertoggles_toggle
-		AP["[ckey]_animtoggle"] << animtoggle
-		AP["[ckey]_attacktoggle"] << attacktoggle
-		AP["[ckey]_rp_word_filtering"] << rp_word_filtering
-		AP["[ckey]_auto_stealth"] << auto_stealth
-		AP["[ckey]_auto_stealth_name"] << auto_stealth_name
-		AP["[ckey]_auto_alt_key"] << auto_alt_key
-		AP["[ckey]_auto_alt_key_name"] << auto_alt_key_name
-		AP["[ckey]_hear_prayers"] << hear_prayers
-		AP["[ckey]_audible_prayers"] << audible_prayers
-		AP["[ckey]_atags"] << see_atags
-		AP["[ckey]_audible_ahelps"] << audible_ahelps
-		AP["[ckey]_buildmode_view"] << buildmode_view
-		AP["[ckey]_spawn_in_loc"] << spawn_in_loc
+		var/list/AP = list()
+
+		AP["popuptoggle"] = popuptoggle
+		AP["servertoggles_toggle"] = servertoggles_toggle
+		AP["animtoggle"] = animtoggle
+		AP["attacktoggle"] = attacktoggle
+		AP["rp_word_filtering"] = rp_word_filtering
+		AP["auto_stealth"] = auto_stealth
+		AP["auto_stealth_name"] = auto_stealth_name
+		AP["auto_alt_key"] = auto_alt_key
+		AP["auto_alt_key_name"] = auto_alt_key_name
+		AP["hear_prayers"] = hear_prayers
+		AP["audible_prayers"] = audible_prayers
+		AP["atags"] = see_atags
+		AP["audible_ahelps"] = audible_ahelps
+		AP["buildmode_view"] = buildmode_view
+		AP["spawn_in_loc"] = spawn_in_loc
 
 		for(var/cat in toggleable_admin_verb_categories)
-			AP["[ckey]_hidden_[cat]"] << (cat in src.hidden_categories)
+			AP["hidden_[cat]"] = (cat in src.hidden_categories)
 
-		if (usr)
-			boutput(usr, "<span class='notice'>Admin preferences saved.</span>")
+		if (!owner.player.cloud_put("admin_preferences", json_encode(AP)))
+			tgui_alert(src.owner, "ERROR: Unable to reach cloud.")
+		else
+			boutput(src.owner, "<span class='notice'>Admin preferences saved.</span>")
 
 /client/proc/change_admin_prefs()
 	SET_ADMIN_CAT(ADMIN_CAT_SELF)

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)mon nov 08 21
+(u)Sovexe
+(*)Admin preferences have been converted to use clouddata instead of local server saves. You will need to re-set your preferences once and they will then persist.
 (t)sat oct 31 21
 (u)pali
 (*)Incoming mainframe commands are now logged (usually) in a new <i>computers</i> log cateogry


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Preferably do not merge prior to #6621 to avoid loss of local functionality
* Converts admin preferences system to use clouddata instead of local server saves
* Preferences are stored in json format under the `admin_preferences` index of `clouddata`
* Admins will need to setup their initial preferences after this is merged as the existing preferences will not be loaded in (optionally wire can also delete the save off the server, if he wants too)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Allows a single set of admin preferences to persist across all servers without the need to maintain each servers preferences individually