### PR TITLE
Atlas improvements by an anonymous contributor

### DIFF
--- a/code/map.dm
+++ b/code/map.dm
@@ -569,7 +569,18 @@ var/global/list/mapNames = list(
 	walls = /turf/simulated/wall/auto/supernorn
 	rwalls = /turf/simulated/wall/auto/reinforced/supernorn
 	auto_walls = 1
+	ext_airlocks = /obj/machinery/door/airlock/pyro/external
 	airlock_style = "pyro"
+
+	windows = /obj/window/auto
+	windows_thin = /obj/window/pyro
+	rwindows = /obj/window/auto/reinforced
+	rwindows_thin = /obj/window/reinforced/pyro
+	windows_crystal = /obj/window/auto/crystal
+	windows_rcrystal = /obj/window/auto/crystal/reinforced
+	window_layer_full = COG2_WINDOW_LAYER
+	window_layer_north = GRILLE_LAYER+0.1
+	window_layer_south = FLY_LAYER+1
 
 	escape_centcom = /area/shuttle/escape/centcom/cogmap2
 	escape_transit = /area/shuttle/escape/transit/cogmap2

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -2038,6 +2038,18 @@
 	name = "Dented Crate"
 	},
 /obj/machinery/light_switch/auto,
+/obj/item/fish/bass,
+/obj/item/fish/bass,
+/obj/item/fish/carp,
+/obj/item/fish/carp,
+/obj/item/fish/salmon,
+/obj/item/fish/salmon,
+/obj/item/reagent_containers/food/snacks/ingredient/meat{
+	desc = "Ew.";
+	name = "meat of questionable origin"
+	},
+/obj/item/raw_material/ice,
+/obj/item/raw_material/ice,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "fi" = (
@@ -2848,6 +2860,7 @@
 /obj/item/storage/belt/utility,
 /obj/machinery/shieldgenerator/meteorshield,
 /obj/machinery/shieldgenerator/meteorshield,
+/obj/machinery/shieldgenerator/energy_shield,
 /obj/item/extinguisher,
 /obj/item/reagent_containers/glass/oilcan,
 /turf/simulated/floor/black,
@@ -3185,9 +3198,9 @@
 	},
 /obj/table/auto,
 /obj/machinery/networked/printer{
-	name = "Printer - Escape Checkpoint";
+	name = "Printer - Quartermaster's Office";
 	pixel_y = 5;
-	print_id = "EscapeCheckpoint"
+	print_id = "QuartermastersOffice"
 	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -9474,6 +9487,11 @@
 /turf/simulated/floor/bot,
 /area/station/medical/medbay/cloner)
 "wW" = (
+/obj/submachine/chef_sink/chem_sink{
+	desc = "A water-filled unit intended for hand-washing purposes.";
+	dir = 4;
+	pixel_x = -4
+	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/surgery)
 "wX" = (
@@ -10539,6 +10557,17 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
+"zB" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/green/side{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
 "zD" = (
 /obj/machinery/atmospherics/pipe/simple/junction{
 	dir = 8
@@ -12084,6 +12113,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/research,
 /obj/firedoor_spawn,
 /turf/simulated/floor/purple,
 /area/station/science/teleporter)
@@ -12836,6 +12866,7 @@
 /obj/table/auto,
 /obj/random_item_spawner/medicine,
 /obj/item/storage/box/health_upgrade_kit,
+/obj/item/robodefibrillator,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -12845,6 +12876,8 @@
 	pixel_y = 25
 	},
 /obj/storage/cart/medcart,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -13693,14 +13726,6 @@
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "HC" = (
-/obj/surgery_tray,
-/obj/item/storage/box/evidence,
-/obj/item/hand_labeler,
-/obj/item/reagent_containers/glass/bottle/formaldehyde,
-/obj/item/body_bag,
-/obj/item/clothing/under/suit{
-	name = "Mortician Suit"
-	},
 /obj/machinery/light_switch/auto,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -13709,6 +13734,11 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 4
+	},
+/obj/critter/opossum/morty,
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "HD" = (
@@ -13861,7 +13891,14 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/critter/opossum/morty,
+/obj/surgery_tray,
+/obj/item/storage/box/evidence,
+/obj/item/hand_labeler,
+/obj/item/reagent_containers/glass/bottle/formaldehyde,
+/obj/item/body_bag,
+/obj/item/clothing/under/suit{
+	name = "Mortician Suit"
+	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/morgue)
 "HY" = (
@@ -16672,13 +16709,13 @@
 /turf/simulated/floor/purplewhite,
 /area/station/science/teleporter)
 "Pe" = (
+/obj/machinery/power/data_terminal,
 /obj/table/auto,
 /obj/machinery/networked/printer{
-	name = "Printer - Escape Checkpoint";
+	name = "Printer - Research";
 	pixel_y = 5;
-	print_id = "EscapeCheckpoint"
+	print_id = "Research"
 	},
-/obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -16894,24 +16931,15 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/audio_tape{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/audio_tape,
-/obj/item/device/audio_log{
-	pixel_x = -7;
-	pixel_y = -1
-	},
+/obj/machinery/power/data_terminal,
+/obj/cable,
 /obj/table/auto,
-/obj/item/audio_tape{
-	pixel_x = 3;
-	pixel_y = 7
+/obj/machinery/networked/storage/scanner{
+	bank_id = "research";
+	pixel_y = 5
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/purplewhite,
 /area/station/science/teleporter)
@@ -16924,6 +16952,20 @@
 /obj/machinery/light{
 	layer = 3;
 	light_type = /obj/item/light/tube/light_purpleish
+	},
+/obj/table/auto,
+/obj/item/audio_tape{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/audio_tape,
+/obj/item/device/audio_log{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/audio_tape{
+	pixel_x = 3;
+	pixel_y = 7
 	},
 /turf/simulated/floor/purplewhite{
 	dir = 6
@@ -17121,7 +17163,9 @@
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "Qc" = (
-/obj/machinery/networked/storage/bomb_tester,
+/obj/machinery/networked/storage/bomb_tester{
+	bank_id = "Mixer"
+	},
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/purplewhite{
@@ -17165,6 +17209,7 @@
 /obj/machinery/networked/storage/tape_drive{
 	bank_id = "Artlab";
 	locked = 0;
+	name = "Databank - Artlab";
 	setup_drive_type = /obj/item/disk/data/tape/artifact_research
 	},
 /turf/simulated/floor/plating,
@@ -17531,6 +17576,18 @@
 	icon_state = "fgreen2"
 	},
 /area/station/crew_quarters/heads)
+"Rf" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "Rg" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	icon_state = "delivery2"
@@ -17680,10 +17737,7 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "RE" = (
-/obj/stool/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
-	},
+/obj/machinery/photocopier,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -17785,6 +17839,12 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engine/combustion_chamber)
+"RX" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "RY" = (
 /obj/item/reagent_containers/food/snacks/burger/moldy{
 	pixel_x = -9;
@@ -18275,8 +18335,13 @@
 /area/station/science/lab)
 "Tu" = (
 /obj/table/auto,
-/obj/item/game_kit,
-/obj/item/card_group/plain,
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer3/generic/personal{
+	pixel_y = 5
+	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "Tv" = (
@@ -19358,6 +19423,17 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/hangar/main)
+"WD" = (
+/obj/potted_plant{
+	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/stairs/wide/other{
+	dir = 1
+	},
+/area/station/hallway/primary/east)
 "WF" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -19810,6 +19886,20 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
+"XO" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "XQ" = (
 /obj/machinery/light{
 	dir = 4;
@@ -62696,11 +62786,11 @@ uM
 vH
 qD
 Tu
-VZ
-Zy
-Xx
-RZ
-Rp
+Rf
+RX
+WD
+zB
+XO
 CA
 De
 DO


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added a energy shield generator to the Tool Storage, same place as the meteor shield generators. (153, 191)
Reasoning: There's none available on Atlas or the Debris Field and it can be useful for Engineering or construction projects.

Renamed Printer in Cargo to "Printer - Quartermaster's Office" and its printID to "QuartermastersOffice".
Renamed Printer in Research to "Printer - Research" and its printID to "Research".
Reasoning: They were both named "Printer - Escape Checkpoint" with the "EscapeCheckpoint" printID.

Added a table to Research (137, 163) and moved the audio tapes from the adjacent table over to it.
Added a Scanner to Research (136, 163) with its own data terminal. Moved wires around a bit to adjust.
Replaced a chair with a Photocopier in the East Primary Hallway. (137, 176)
Reasoning: There's no Scanner or Photocopier on Atlas and only a Scanner can be found in the Debris Field. They can be useful for various RP related events as well as DWAINE scripting.

Added a Personal Computer in the East Primary Hallway (140, 176), removed a gaming kit and deck of cards as there's one of each nearby already.
Reasoning: There's no personal computer on Atlas and no guaranteed way to get WizWrite.

Added two sinks to Medbay. One in the Operating Threatre (163, 174) and one in the Morgue. (167, 162)
Swapped the positions of Morty and the tray with Morgue supplies as to place the sink over an empty wall instead of on an APC.
Reasoning: Hygiene! And no sinks in Medbay stink, closes #6556

Renamed a databank in Technical Storage (119, 174) to "Databank - Artlab".
Reasoning: The artlab databank is usually named as such and this was not, occasionally causing confusion.

Assigned "Mixer" bank_id to the Explosive Simulator in Toxin Lab. (138, 156)
Reasoning: It was missing a bank_id, causing it to appear as "generic" on the mainframe.

Added a Research access spawn on a door in Research. (135, 168)
Reasoning: It requires no access and since it is connected to the Teleporter with its public Teleporter Pad door, Staff Assistants were able to enter Research through it.

Added supplies to a crate in the Kitchen Freezer. (159, 196) Two salmon, carp, bass. One questionable meat and two ice chunks.
Reasoning: Chefs start without any fish on Atlas and the dented crate is entirely empty, seems like an oversight to me.

Added a defibrillator to Medbay (166, 166) and two straightjackets in the cart in Medbay (167, 166)
Reasoning: Outside of a mounted defib, there are none and I feel like there should at least be one in case of no doctor spawns. And there's no straightjackets on Atlas and they aren't able to be fabricated.

Adjusted code/map.dm Atlas settings to perspective window settings copied from Kondaru. (seems everyone just copies the same settings?? ok ill do that)
Reasoning: Creating new windows would make non-perspective windows due to the settings default to the non-perspective ones. Closes #6485


## Why's this needed? <!-- Describe why you think this should be added to the game. -->



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)anonymous
(+)Atlas got a bunch of small improvements
```
