### PR TITLE
Wet ants

### DIFF
--- a/_std/defines/slipping.dm
+++ b/_std/defines/slipping.dm
@@ -1,0 +1,6 @@
+// the different levels of slip for reagents, used in block_slippy
+#define SUPER_LUBE_SLIP -2
+#define LUBE_SLIP -1
+#define NORMAL_SLIP 0
+#define NO_SLIP 1
+#define ANT_NO_SLIP 2

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -40,7 +40,7 @@ datum
 		var/energy_value = 0
 		var/blob_damage = 0 // If this is a poison, it may be useful for poisoning the blob.
 		var/viscosity = 0 // determines interactions in fluids. 0 for least viscous, 1 for most viscous. use decimals!
-		var/block_slippy = REGULAR_SLIP //fluid flag for slippage control
+		var/block_slippy = NORMAL_SLIP //fluid flag for slippage control
 		var/list/target_organs
 		var/heat_capacity = 100 /* how much heat a reagent can hold */ // ACTUALLY, THIS IS SPECIFIC HEAT CAPACITY, HOPE THIS HELPS!! - Emily
 		var/blocks_sight_gas = 0 //opacity

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -40,7 +40,7 @@ datum
 		var/energy_value = 0
 		var/blob_damage = 0 // If this is a poison, it may be useful for poisoning the blob.
 		var/viscosity = 0 // determines interactions in fluids. 0 for least viscous, 1 for most viscous. use decimals!
-		var/block_slippy = 0 //fluid flag for slippage control
+		var/block_slippy = REGULAR_SLIP //fluid flag for slippage control
 		var/list/target_organs
 		var/heat_capacity = 100 /* how much heat a reagent can hold */ // ACTUALLY, THIS IS SPECIFIC HEAT CAPACITY, HOPE THIS HELPS!! - Emily
 		var/blocks_sight_gas = 0 //opacity

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -3783,6 +3783,14 @@ datum
 			result_amount = 2
 			mix_phrase = "The ants arachnify. What?"
 
+		wet_ants
+			name = "wet ants"
+			id = "wet_ants"
+			result = "wet_ants"
+			required_reagents = list("ants" = 1, "water" = 1)
+			result_amount = 2
+			mix_phrase = "The ants mix into the water, forming a suspension."
+
 		thalmerite_heat
 			name = "thalmerite heating"
 			id = "thalmerite_heat"

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -893,7 +893,7 @@ datum
 			name = "seawater"
 			id = "seawater"
 			description = "A little strange. Not like any seawater you've seen. But definitely OSHA approved."
-			block_slippy = 1
+			block_slippy = NO_SLIP
 			reagent_state = LIQUID
 			thirst_value = -0.3 //Sea water actually slowly dehydrates you because you use more liquid to get rid of the salt then you gain.
 			hygiene_value = 0.3

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -723,7 +723,7 @@ datum
 			fluid_g = 255
 			value = 3 // 1 1 1
 			hygiene_value = 0.25
-			block_slippy = -1
+			block_slippy = LUBE_SLIP
 
 			reaction_turf(var/turf/target, var/volume)
 				var/list/covered = holder.covered_turf()
@@ -757,7 +757,7 @@ datum
 			fluid_g = 255
 			value = 4 // 1 1 1
 			hygiene_value = 0.25
-			block_slippy = -2
+			block_slippy = SUPER_LUBE_SLIP
 			var/visible = 1
 
 			reaction_turf(var/turf/target, var/volume)

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1581,11 +1581,11 @@ datum
 		ants/wet
 			name = "wet ants"
 			id = "wet_ants"
-			description = "A suspension of Space Ants (formicidae bastardium tyrannus) in regular water (H₂O) at about a 50/50 ratio."
+			description = "A suspension of Space Ants (formicidae bastardium tyrannus) in regular water (H₂O) at about a 50/50 ratio. It seems like it'd be pretty hard to slip on!"
 			viscosity = 0.4
 			value = 1
 			transparency = 127
-			block_slippy = 2
+			block_slippy = ANT_NO_SLIP
 
 		spiders
 			name = "spiders"

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1578,6 +1578,15 @@ datum
 				..()
 				return
 
+		ants/wet
+			name = "wet ants"
+			id = "wet_ants"
+			description = "A suspension of Space Ants (formicidae bastardium tyrannus) in regular water (H₂O) at about a 50/50 ratio."
+			viscosity = 0.4
+			value = 1
+			transparency = 127
+			block_slippy = 2
+
 		spiders
 			name = "spiders"
 			id = "spiders"

--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -729,6 +729,8 @@ var/mutable_appearance/fluid_ma
 		if (F.amt > 0 && F.amt <= F.max_slip_volume && F.avg_viscosity <= F.max_slip_viscosity)
 			var/master_block_slippy = F.group.reagents.get_master_reagent_slippy(F.group)
 			switch(master_block_slippy)
+				if(2) // wet ants
+					boutput(src, "<span class='notice'>The high amount of ants in [F] prevents you from slipping, but you crushed [rand(2,1337)] ants in the process!</class>")
 				if(0)
 					var/slippery =  (1 - (F.avg_viscosity/F.max_slip_viscosity)) * 50
 					var/checks = 10

--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -729,10 +729,8 @@ var/mutable_appearance/fluid_ma
 		if (F.amt > 0 && F.amt <= F.max_slip_volume && F.avg_viscosity <= F.max_slip_viscosity)
 			var/master_block_slippy = F.group.reagents.get_master_reagent_slippy(F.group)
 			switch(master_block_slippy)
-				if(ANT_NO_SLIP)
-					boutput(src, "<span class='notice'>The high amount of ants in [F] prevents you from slipping, but you crushed [rand(2,1337)] ants in the process!</class>", "wet_ants")
 				// NO_SLIP is omitted here, because it just does literally nothing
-				if(REGULAR_SLIP)
+				if(REGULAR_SLIP, ANT_NO_SLIP)
 					var/slippery =  (1 - (F.avg_viscosity/F.max_slip_viscosity)) * 50
 					var/checks = 10
 					for (var/thing in oldloc)
@@ -740,9 +738,12 @@ var/mutable_appearance/fluid_ma
 							slippery = 0
 						checks--
 						if (checks <= 0) break
-					if (prob(slippery) && src.slip())
-						src.visible_message("<span class='alert'><b>[src]</b> slips on [F]!</span>",\
-						"<span class='alert'>You slip on [F]!</span>")
+					if (prob(slippery))
+						if (master_block_slippy == ANT_NO_SLIP)
+							boutput(src, "<span class='notice'>The high amount of ants in [F] prevents you from slipping, but you crushed [rand(2,1337)] ants in the process!</class>", "wet_ants")
+						else if (src.slip())
+							src.visible_message("<span class='alert'><b>[src]</b> slips on [F]!</span>",\
+							"<span class='alert'>You slip on [F]!</span>")
 				if(LUBE_SLIP)
 					src.remove_pulling()
 					src.changeStatus("weakened", 3.5 SECONDS)

--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -729,9 +729,10 @@ var/mutable_appearance/fluid_ma
 		if (F.amt > 0 && F.amt <= F.max_slip_volume && F.avg_viscosity <= F.max_slip_viscosity)
 			var/master_block_slippy = F.group.reagents.get_master_reagent_slippy(F.group)
 			switch(master_block_slippy)
-				if(2) // wet ants
-					boutput(src, "<span class='notice'>The high amount of ants in [F] prevents you from slipping, but you crushed [rand(2,1337)] ants in the process!</class>")
-				if(0)
+				if(ANT_NO_SLIP)
+					boutput(src, "<span class='notice'>The high amount of ants in [F] prevents you from slipping, but you crushed [rand(2,1337)] ants in the process!</class>", "wet_ants")
+				// NO_SLIP is omitted here, because it just does literally nothing
+				if(REGULAR_SLIP)
 					var/slippery =  (1 - (F.avg_viscosity/F.max_slip_viscosity)) * 50
 					var/checks = 10
 					for (var/thing in oldloc)
@@ -742,14 +743,14 @@ var/mutable_appearance/fluid_ma
 					if (prob(slippery) && src.slip())
 						src.visible_message("<span class='alert'><b>[src]</b> slips on [F]!</span>",\
 						"<span class='alert'>You slip on [F]!</span>")
-				if(-1) //space lube. this code bit is shit but i'm too lazy to make it Real right now. the proper implementation should also make exceptions for ice and stuff.
+				if(LUBE_SLIP)
 					src.remove_pulling()
 					src.changeStatus("weakened", 3.5 SECONDS)
 					boutput(src, "<span class='notice'>You slipped on [F]!</span>")
 					playsound(T, "sound/misc/slip.ogg", 50, 1, -3)
 					var/atom/target = get_edge_target_turf(src, src.dir)
 					src.throw_at(target, 12, 1, throw_type = THROW_SLIP)
-				if(-2) //superlibe
+				if(SUPER_LUBE_SLIP)
 					src.remove_pulling()
 					src.changeStatus("weakened", 6 SECONDS)
 					playsound(T, "sound/misc/slip.ogg", 50, 1, -3)

--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -739,7 +739,7 @@ var/mutable_appearance/fluid_ma
 						checks--
 						if (checks <= 0) break
 					if (prob(slippery))
-						if (master_block_slippy == ANT_NO_SLIP)
+						if (master_block_slippy == ANT_NO_SLIP && src.slip(do_slip = FALSE))
 							boutput(src, "<span class='notice'>The high amount of ants in [F] prevents you from slipping, but you crushed [rand(2,1337)] ants in the process!</class>", "wet_ants")
 						else if (src.slip())
 							src.visible_message("<span class='alert'><b>[src]</b> slips on [F]!</span>",\

--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -730,7 +730,7 @@ var/mutable_appearance/fluid_ma
 			var/master_block_slippy = F.group.reagents.get_master_reagent_slippy(F.group)
 			switch(master_block_slippy)
 				// NO_SLIP is omitted here, because it just does literally nothing
-				if(REGULAR_SLIP, ANT_NO_SLIP)
+				if(NORMAL_SLIP, ANT_NO_SLIP)
 					var/slippery =  (1 - (F.avg_viscosity/F.max_slip_viscosity)) * 50
 					var/checks = 10
 					for (var/thing in oldloc)

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -112,7 +112,7 @@
 	return 1
 
 
-/mob/proc/slip(walking_matters = 0, running = 0, ignore_actual_delay = 0)
+/mob/proc/slip(walking_matters = 0, running = 0, ignore_actual_delay = 0, do_slip = TRUE)
 	.= 0
 
 	if (!src.can_slip())
@@ -128,25 +128,26 @@
 		movedelay = movement_delay_real
 
 	if (movedelay < slip_delay)
-		var/intensity = (-0.33)+(6.033763-(-0.33))/(1+(movement_delay_real/(0.4))-1.975308)  //y=d+(6.033763-d)/(1+(x/c)-1.975308)
-		var/throw_range = min(round(intensity),50)
-		if (intensity < 1 && intensity > 0 && throw_range <= 0)
-			throw_range = max(throw_range,1)
-		else
-			throw_range = max(throw_range,0)
+		if (do_slip)
+			var/intensity = (-0.33)+(6.033763-(-0.33))/(1+(movement_delay_real/(0.4))-1.975308)  //y=d+(6.033763-d)/(1+(x/c)-1.975308)
+			var/throw_range = min(round(intensity),50)
+			if (intensity < 1 && intensity > 0 && throw_range <= 0)
+				throw_range = max(throw_range,1)
+			else
+				throw_range = max(throw_range,0)
 
-		if (intensity <= 2.4)
-			playsound(src.loc, "sound/misc/slip.ogg", 50, 1, -3)
-		else
-			playsound(src.loc, "sound/misc/slip_big.ogg", 50, 1, -3)
-		src.remove_pulling()
+			if (intensity <= 2.4)
+				playsound(src.loc, "sound/misc/slip.ogg", 50, 1, -3)
+			else
+				playsound(src.loc, "sound/misc/slip_big.ogg", 50, 1, -3)
+			src.remove_pulling()
 
-		var/turf/T = get_ranged_target_turf(src, src.last_move_dir, throw_range)
-		src.throw_at(T, intensity, 2, list("stun"=clamp(1.1 SECONDS * intensity, 1 SECOND, 5 SECONDS)), src.loc, throw_type = THROW_SLIP)
+			var/turf/T = get_ranged_target_turf(src, src.last_move_dir, throw_range)
+			src.throw_at(T, intensity, 2, list("stun"=clamp(1.1 SECONDS * intensity, 1 SECOND, 5 SECONDS)), src.loc, throw_type = THROW_SLIP)
 		.= 1
 
-/mob/living/carbon/human/slip(walking_matters = 0, running = 0, ignore_actual_delay = 0)
-	. = ..(walking_matters, (src.client?.check_key(KEY_RUN) && src.get_stamina() > STAMINA_SPRINT), ignore_actual_delay)
+/mob/living/carbon/human/slip(walking_matters = 0, running = 0, ignore_actual_delay = 0, do_slip = TRUE)
+	. = ..(walking_matters, (src.client?.check_key(KEY_RUN) && src.get_stamina() > STAMINA_SPRINT), ignore_actual_delay, do_slip)
 
 
 /mob/living/carbon/human/proc/skeletonize()

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -30,6 +30,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // BEGIN_INCLUDE
+#include "_std\defines\slipping.dm"
 #include "code\area.dm"
 #include "code\atom.dm"
 #include "code\base_lighting.dm"


### PR DESCRIPTION
[FEATURE]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds a new wet ants chemical consisting of water and ants that prevents slippage. 

Example can be seen here;
https://streamable.com/itpp40

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If this chemical is the most present one in a puddle, you can't slip on it. Creating an anti-slip chemical for space maps. It also applies the touch effect of regular ants upon contact, using up a portion of the chemical in the process. 


Full credit goes to zjdtmkhzt for bringing my dream to life by providing the code.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
```
(u) Egg
(+) Added new "wet ants" chem that prevents you from slipping on puddles that have it as most common reagent.


