### PR TITLE
Donut 2 minor assorted fixes

### DIFF
--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -14024,9 +14024,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
 "aHr" = (
@@ -40427,6 +40424,17 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"hOB" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/substation/north)
 "hOE" = (
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment/mail,
@@ -42227,7 +42235,7 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-4"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
@@ -42272,6 +42280,12 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"nCu" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/substation/north)
 "nDi" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro{
@@ -44640,6 +44654,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/quartermaster/refinery)
+"umC" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/substation/north)
 "umD" = (
 /obj/cable{
 	d1 = 2;
@@ -74605,7 +74625,7 @@ aBP
 aBP
 aBP
 nps
-aBP
+umC
 eAg
 eAg
 aaa
@@ -74907,7 +74927,7 @@ aCx
 aFM
 aGy
 aHq
-aBP
+nCu
 aaa
 adQ
 aaa
@@ -75209,7 +75229,7 @@ aEU
 aFN
 aGz
 aHr
-aBP
+nCu
 aaa
 adQ
 aaa
@@ -75511,7 +75531,7 @@ aDZ
 aFO
 aGA
 aGA
-aGA
+hOB
 aGC
 aGC
 aGC

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -5312,12 +5312,7 @@
 /area/station/turret_protected/Zeta)
 "amv" = (
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
@@ -7221,12 +7216,18 @@
 	layer = 3.5;
 	pixel_y = -24
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
 "arc" = (
 /obj/machinery/camera{
 	c_tag = "Escape Hallway";
 	dir = 10
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -7490,6 +7491,9 @@
 "arM" = (
 /obj/item/device/radio/intercom{
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -7795,6 +7799,9 @@
 /obj/machinery/light/emergency{
 	dir = 4;
 	icon_state = "ebulb1"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/shuttle)
@@ -8266,14 +8273,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
-"atB" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/hallway/secondary/shuttle)
 "atC" = (
 /obj/stool/chair{
 	dir = 4
@@ -8471,10 +8470,6 @@
 /turf/simulated/grimycarpet,
 /area/ghostdrone_factory)
 "aua" = (
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/computer/research_shuttle{
 	dir = 4
@@ -8779,8 +8774,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/ghostdrone_factory)
 "auN" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
+/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "auO" = (
@@ -10199,10 +10193,7 @@
 /area/space)
 "ayH" = (
 /obj/cable{
-	icon_state = "0-4"
-	},
-/obj/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -10550,14 +10541,11 @@
 /area/station/hangar/science)
 "azz" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-8"
 	},
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "2-8"
 	},
-/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "azA" = (
@@ -12206,6 +12194,9 @@
 	dir = 4
 	},
 /obj/access_spawn/engineering_power,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/station/engine/substation/north)
 "aDo" = (
@@ -12477,6 +12468,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
 "aDY" = (
@@ -12891,41 +12883,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aES" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/storage/crate,
 /obj/item/dice,
 /obj/item/mousetrap,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aET" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/grime,
-/area/station/engine/substation/north)
 "aEU" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
@@ -14041,6 +14012,7 @@
 	dir = 8
 	},
 /obj/item/sheet/steel/reinforced/fullstack,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/orangeblack/side{
 	dir = 4
 	},
@@ -14050,6 +14022,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
@@ -14843,17 +14818,13 @@
 /area/station/teleporter)
 "aIY" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "2-8"
 	},
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
 /area/station/teleporter)
@@ -16982,15 +16953,6 @@
 "aNE" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/morgue)
-"aNF" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/spook,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aNG" = (
 /obj/machinery/manufacturer/robotics,
 /turf/simulated/floor/black/side{
@@ -20421,6 +20383,9 @@
 	},
 /obj/access_spawn/maint,
 /obj/firedoor_spawn,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/shuttle)
 "aVe" = (
@@ -22017,18 +21982,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aYC" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/camera{
 	c_tag = "West Electrical Substation";
 	dir = 8
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/substation/west)
@@ -22806,37 +22768,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/substation/east)
-"aZU" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/engine/substation/east)
-"aZV" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aZW" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -23103,16 +23034,14 @@
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
 "bat" = (
-/obj/cable,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "E APC";
 	pixel_x = 24;
 	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/engine/substation/west)
@@ -23189,6 +23118,9 @@
 "baz" = (
 /obj/cable,
 /obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "baA" = (
@@ -26348,12 +26280,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/engine/substation/pylon)
-"bht" = (
-/obj/grille/steel,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/AIbasecore1{
-	name = "Upload Station"
-	})
 "bhu" = (
 /obj/machinery/light{
 	dir = 1;
@@ -27527,17 +27453,15 @@
 	})
 "bkr" = (
 /obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-4"
 	},
 /obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "2-8"
 	},
-/obj/cable,
 /obj/cable{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/circuit/off,
 /area/station/turret_protected/AIbasecore1{
@@ -31841,11 +31765,6 @@
 	name = "Hydroponics APC";
 	pixel_y = 24
 	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4";
-	pixel_y = 0
-	},
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1"
@@ -31853,16 +31772,14 @@
 /obj/machinery/plantpot{
 	anchored = 1
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
 /area/station/hydroponics/bay)
 "buv" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/phone/wall{
 	pixel_y = 30
 	},
@@ -31872,11 +31789,6 @@
 /area/station/hydroponics/bay)
 "buw" = (
 /obj/disposalpipe/segment/mail,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/plantpot{
 	anchored = 1
 	},
@@ -31891,11 +31803,6 @@
 /obj/machinery/camera{
 	c_tag = "Hydroponics";
 	dir = 2
-	},
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -32134,20 +32041,19 @@
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
-/obj/submachine/chef_sink{
-	desc = "A common utility sink.";
-	name = "utility sink";
-	pixel_y = 7
-	},
+/obj/vehicle/floorbuffer,
+/obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/white/checker{
 	dir = 4
 	},
 /area/station/janitor/office)
 "buY" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/vehicle/floorbuffer,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 4
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
@@ -32327,6 +32233,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/green/side{
 	dir = 4
 	},
@@ -32337,6 +32246,9 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "bvD" = (
@@ -32344,12 +32256,21 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/green,
 /area/station/hydroponics/bay)
 "bvE" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -32362,21 +32283,14 @@
 	mail_tag = "hydroponics";
 	name = "hydroponics mail router"
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
 /area/station/hydroponics/bay)
 "bvG" = (
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/hydroponics/bay)
-"bvH" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -33316,6 +33230,10 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "bxw" = (
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/grasstodirt{
 	icon_state = "swampgrass"
 	},
@@ -33643,6 +33561,11 @@
 "byh" = (
 /obj/railing/orange/reinforced{
 	dir = 4
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grasstodirt{
 	dir = 4;
@@ -38675,6 +38598,15 @@
 	},
 /turf/simulated/floor/escape/corner,
 /area/station/hallway/primary/east)
+"bYJ" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/AIbasecore1{
+	name = "Upload Station"
+	})
 "bZx" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/storage/toolbox/mechanical{
@@ -38902,6 +38834,19 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"dlq" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/grasstodirt{
+	icon_state = "swampgrass"
+	},
+/area/station/ranch)
 "dlx" = (
 /turf/simulated/wall/false_wall,
 /area/station/maintenance/inner/central)
@@ -39065,6 +39010,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/science)
+"dNm" = (
+/obj/wingrille_spawn/auto,
+/obj/cable,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/ranch)
 "dRq" = (
 /obj/cable{
 	d1 = 1;
@@ -39201,6 +39154,12 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/black,
 /area/station/security/brig)
+"elW" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "enT" = (
 /obj/stool/chair/syndicate,
 /obj/npc/trader/exclown{
@@ -39340,6 +39299,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
+"eEh" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/grime,
+/area/station/engine/substation/north)
 "eFB" = (
 /obj/machinery/phone/wall{
 	pixel_y = 30
@@ -39545,6 +39510,12 @@
 	},
 /turf/simulated/floor/white,
 /area/station/science/lab)
+"fat" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
 "fcs" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light,
@@ -39713,6 +39684,12 @@
 /turf/simulated/floor/airless/plating/catwalk,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/station/quartermaster/refinery)
+"fKn" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/shuttle)
 "fRa" = (
 /obj/cable{
 	d1 = 1;
@@ -39777,6 +39754,19 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/quartermaster/refinery)
+"fUr" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/circuit/off,
+/area/station/turret_protected/AIbasecore1{
+	name = "Upload Station"
+	})
 "fUX" = (
 /obj/securearea{
 	desc = "";
@@ -40066,11 +40056,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "gRT" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/plantpot{
 	anchored = 1
 	},
@@ -40362,6 +40347,18 @@
 	dir = 8
 	},
 /area/station/maintenance/inner/central)
+"hDm" = (
+/obj/disposalpipe/segment/mail{
+	dir = 4;
+	icon_state = "pipe-s"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/hydroponics/bay)
 "hEw" = (
 /obj/cable{
 	d1 = 1;
@@ -40442,6 +40439,13 @@
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
+"hSd" = (
+/obj/machinery/light/emergency,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/shuttle)
 "hUF" = (
 /obj/decal/tile_edge/floorguide/evac{
 	dir = 8
@@ -40550,6 +40554,12 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
+"iiM" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
 "ilJ" = (
 /obj/cable{
 	d1 = 1;
@@ -40875,6 +40885,14 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/science/lab)
+"iZS" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hydroponics/bay)
 "jbL" = (
 /obj/machinery/shower,
 /turf/simulated/floor/white,
@@ -40975,6 +40993,17 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
+"jAI" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "jDc" = (
 /obj/cable{
 	d2 = 4;
@@ -41435,6 +41464,14 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
+"kSv" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/grass{
+	name = "astroturf"
+	},
+/area/station/hydroponics/bay)
 "kUH" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -41931,9 +41968,6 @@
 	},
 /area/station/solar/west)
 "myA" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
@@ -42102,6 +42136,12 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"mYF" = (
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "mZV" = (
 /obj/machinery/drainage,
 /obj/machinery/light/small,
@@ -42180,6 +42220,16 @@
 /obj/item/clothing/mask/gas/emergency,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
+"nps" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engine/substation/north)
 "nqY" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -42200,6 +42250,12 @@
 /obj/machinery/light/runway_light/delay5,
 /turf/space,
 /area/space)
+"nwY" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/shuttle)
 "nzf" = (
 /turf/simulated/wall{
 	desc = "Upon closer inspection, you see that this is a cleverly painted wall.";
@@ -42641,6 +42697,14 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
+"oSe" = (
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/ranch)
 "oTS" = (
 /obj/cable{
 	d1 = 4;
@@ -42704,10 +42768,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "pgc" = (
-/obj/machinery/power/apc/autoname_east,
-/obj/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -42715,6 +42775,10 @@
 	tag = ""
 	},
 /obj/decal/cleanable/dirt,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
 "pii" = (
@@ -42880,6 +42944,23 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
+"pBG" = (
+/obj/machinery/light,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/shuttle)
+"pDR" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/shuttle)
 "pGy" = (
 /obj/decal/cleanable/cobweb2,
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide,
@@ -43235,9 +43316,6 @@
 	},
 /area/station/quartermaster/refinery)
 "qHs" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/pyro/classic,
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating,
@@ -43337,11 +43415,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "qUk" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -43454,6 +43527,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
+"rkp" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/shuttle)
 "rme" = (
 /obj/machinery/door/airlock/pyro/security/alt,
 /obj/access_spawn/brig,
@@ -43472,6 +43551,10 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/engine/elect)
+"rrM" = (
+/obj/spook,
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "ruf" = (
 /obj/table/auto,
 /obj/machinery/recharger{
@@ -44200,6 +44283,15 @@
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
+"tmM" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "tmU" = (
 /obj/cable{
 	d1 = 1;
@@ -44257,6 +44349,12 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/east)
+"tvA" = (
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/shuttle)
 "tvL" = (
 /obj/disposalpipe/segment,
 /obj/machinery/light/small/floor,
@@ -44528,6 +44626,13 @@
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
+"uiX" = (
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/autoname_south,
+/turf/simulated/floor,
+/area/station/hallway/secondary/shuttle)
 "ukm" = (
 /obj/submachine/cargopad{
 	name = "Mineral Magnet Pad"
@@ -44542,6 +44647,13 @@
 	},
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
+"unR" = (
+/obj/machinery/light/small,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "uof" = (
 /obj/grille/catwalk,
 /obj/cable{
@@ -44654,9 +44766,6 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "uzJ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/item/bananapeel,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
@@ -44835,6 +44944,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
+"vdf" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "vdH" = (
 /obj/submachine/cargopad{
 	name = "Security Pad"
@@ -44893,6 +45013,11 @@
 /obj/railing/orange/reinforced{
 	dir = 4
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/grasstodirt{
 	dir = 4;
 	icon_state = "swampgrass_edge"
@@ -44902,6 +45027,14 @@
 /obj/machinery/manufacturer/mining,
 /turf/simulated/floor/yellow/side,
 /area/station/mining/staff_room)
+"vmy" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/AIbasecore1{
+	name = "Upload Station"
+	})
 "vmR" = (
 /obj/cable,
 /obj/cable{
@@ -45031,17 +45164,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/black,
 /area/station/security/armory)
-"vJq" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "vLf" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -45328,6 +45450,17 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"wHa" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "wHG" = (
 /obj/machinery/light{
 	dir = 1;
@@ -57567,7 +57700,7 @@ aaA
 avq
 avq
 avq
-arN
+rrM
 arN
 aOZ
 arN
@@ -61191,7 +61324,7 @@ arN
 asv
 aQv
 aQv
-aNF
+aQv
 aOt
 gja
 aPR
@@ -64796,7 +64929,7 @@ aqI
 aqI
 awR
 arN
-asx
+ayH
 arN
 arN
 aBu
@@ -65098,7 +65231,7 @@ aqI
 aqI
 awR
 arN
-asw
+unR
 azA
 azA
 aBv
@@ -65400,7 +65533,7 @@ aqI
 aqI
 awR
 arN
-asx
+ayH
 azA
 aAI
 aBw
@@ -65702,7 +65835,7 @@ aqI
 aaa
 awS
 arN
-asx
+ayH
 azA
 aAJ
 aBw
@@ -66381,7 +66514,7 @@ bAC
 pLc
 bAC
 bAC
-bxx
+oSe
 bis
 bis
 blZ
@@ -66676,14 +66809,14 @@ bEF
 bjo
 btt
 bup
-bts
-bts
-bxw
+fat
+iZS
+dlq
 byh
 vke
 byh
 byh
-bxx
+dNm
 bis
 bis
 blZ
@@ -66905,7 +67038,7 @@ kCD
 aqY
 atx
 aua
-atB
+aqh
 qUk
 aQv
 aQv
@@ -66978,7 +67111,7 @@ bjo
 bjo
 btu
 buq
-bts
+iiM
 tLJ
 bxx
 bAB
@@ -67200,12 +67333,12 @@ aaa
 aaa
 app
 aqK
-aom
-aom
+tvA
+rkp
 arM
 asu
-apA
-aom
+pDR
+nwY
 aub
 aqh
 asx
@@ -67280,7 +67413,7 @@ bEG
 bsy
 bts
 bur
-bts
+iiM
 bwE
 bGd
 bCS
@@ -67502,7 +67635,7 @@ aaa
 aap
 app
 aqK
-aom
+fKn
 aqh
 aqh
 aqh
@@ -67804,12 +67937,12 @@ app
 app
 jqk
 aqL
-aqZ
+pBG
 aqh
 arN
 arN
 arN
-arN
+ayH
 arN
 arN
 asx
@@ -68106,12 +68239,12 @@ apz
 aom
 anp
 kMA
-ara
+hSd
 aqh
 arN
 asv
 aQv
-aQv
+wHa
 aQv
 aQv
 avs
@@ -68710,7 +68843,7 @@ adQ
 aaa
 app
 aqL
-aom
+fKn
 app
 arN
 asx
@@ -68762,8 +68895,8 @@ aaa
 hou
 nzf
 qWA
-szc
 qWA
+szc
 qWA
 qWA
 qWA
@@ -68790,7 +68923,7 @@ bjo
 bjo
 btx
 buv
-bvE
+hDm
 bvG
 bvG
 bvG
@@ -69012,7 +69145,7 @@ adQ
 aaa
 app
 aqL
-aom
+fKn
 app
 arN
 asx
@@ -69394,7 +69527,7 @@ bhm
 bsD
 btx
 bux
-bvG
+kSv
 bwK
 bxA
 byj
@@ -69616,7 +69749,7 @@ apA
 aom
 anp
 hUF
-aom
+uiX
 aqh
 arN
 asx
@@ -69696,7 +69829,7 @@ bhm
 bsD
 btx
 gRT
-bvG
+kSv
 bwL
 bwI
 bvG
@@ -69997,8 +70130,8 @@ bhm
 bhm
 bsD
 btx
+bvG
 buz
-bvH
 bwM
 bxB
 bvG
@@ -73559,9 +73692,9 @@ aBS
 aAR
 aBL
 aCu
+jAI
 aBS
-aBS
-aER
+mYF
 azU
 eAg
 dnV
@@ -73861,9 +73994,9 @@ azR
 aAS
 azU
 azU
+mmb
 azU
 azU
-vJq
 uzJ
 qHs
 myA
@@ -74163,7 +74296,7 @@ azS
 aAS
 aDd
 aCv
-azU
+mmb
 azU
 aES
 azU
@@ -74467,10 +74600,10 @@ aBM
 aBP
 aDn
 aBP
-aDZ
 aBP
 aBP
 aBP
+nps
 aBP
 eAg
 eAg
@@ -74767,9 +74900,9 @@ azU
 aAS
 aBN
 aCw
-aCw
+eEh
 aDX
-aET
+aCx
 aFM
 aGy
 aHq
@@ -78135,14 +78268,14 @@ aaa
 aaa
 aaa
 aaa
-bht
-bht
-bht
-bht
-bht
-bht
-bht
-bht
+bhY
+bhY
+bhY
+bhY
+bhY
+bhY
+bhY
+bhY
 adQ
 aaa
 adQ
@@ -78437,7 +78570,7 @@ aaa
 aaa
 aaa
 aaa
-bht
+bhY
 bhY
 bhY
 bhY
@@ -78739,7 +78872,7 @@ aaa
 aaa
 aaa
 aaa
-bht
+bhY
 bhY
 biz
 bjw
@@ -79041,7 +79174,7 @@ aaa
 aaa
 aaa
 aaa
-bht
+bhY
 bhY
 biA
 bjw
@@ -79343,12 +79476,12 @@ aaa
 aaa
 aaa
 aaa
-bht
+bhY
 bhY
 biB
 blw
 bkr
-blw
+fUr
 blw
 blw
 bqa
@@ -79645,12 +79778,12 @@ aaa
 aaa
 aaa
 aaa
-bht
+bhY
 bhY
 biA
 bjw
 bkq
-bjw
+vmy
 bjw
 bna
 bnb
@@ -79947,12 +80080,12 @@ aaa
 aaa
 aaa
 aaa
-bht
+bhY
 bhY
 biC
 bjw
 bks
-bjw
+bYJ
 bhY
 bhY
 bhY
@@ -80249,7 +80382,7 @@ aaa
 aaa
 aaa
 aaa
-bht
+bhY
 bhY
 bhY
 bhY
@@ -84764,10 +84897,10 @@ azU
 aXT
 aYL
 aZp
-aZU
+bay
 bay
 baX
-aEY
+vdf
 azU
 azU
 azU
@@ -85066,10 +85199,10 @@ aBQ
 aXU
 aXT
 aXT
-aZn
 aXT
 aXT
-azR
+aXT
+tmM
 azU
 aXV
 aXV
@@ -85368,10 +85501,10 @@ aTK
 aBS
 aBS
 aBS
-aZV
+aBS
 baz
-azU
-azU
+elW
+mYF
 bbX
 aXV
 bcS

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -13389,7 +13389,7 @@
 	foldable = 0;
 	icon_state = "chair_pool"
 	},
-/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/sunglasses/tanning,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aFV" = (
@@ -13399,6 +13399,7 @@
 	icon_state = "chair_pool"
 	},
 /obj/item/reagent_containers/food/drinks/water,
+/obj/item/clothing/glasses/sunglasses/tanning,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aFW" = (
@@ -15243,7 +15244,7 @@
 /obj/machinery/door/airlock/pyro/external,
 /obj/access_spawn/engineering_power,
 /turf/simulated/floor/plating,
-/area/station/solar/west)
+/area/station/maintenance/solar/west)
 "aJW" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -15419,7 +15420,7 @@
 	foldable = 0;
 	icon_state = "chair_pool"
 	},
-/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/sunglasses/tanning,
 /turf/simulated/floor/grass{
 	name = "astroturf"
 	},
@@ -37864,7 +37865,7 @@
 "bHX" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/space)
+/area/station/maintenance/solar/west)
 "bHY" = (
 /obj/table/auto,
 /obj/item/storage/firstaid/regular,
@@ -57395,8 +57396,8 @@ aaa
 aaa
 aaa
 aaa
-adQ
-aJS
+avq
+avq
 avq
 arN
 arN
@@ -57698,8 +57699,8 @@ aaa
 aaa
 aaA
 avq
-avq
-avq
+arN
+arN
 rrM
 arN
 aOZ
@@ -58600,7 +58601,7 @@ iyl
 azI
 hfI
 aHN
-anM
+aJT
 aJT
 aJT
 aJT
@@ -60110,7 +60111,7 @@ iyl
 aAG
 hfI
 aaa
-anM
+aJT
 aJT
 aJT
 aJT
@@ -62220,7 +62221,7 @@ aaa
 aaa
 aaa
 aap
-acK
+avq
 avq
 arN
 arN
@@ -62521,9 +62522,9 @@ aaa
 aaa
 aae
 acK
-acK
-acK
+aGj
 avq
+arN
 arN
 arN
 avq
@@ -62824,9 +62825,9 @@ aas
 avq
 aEx
 avq
-aGj
 avq
 aOp
+arN
 arN
 avq
 aJY
@@ -63127,7 +63128,7 @@ avq
 arN
 avq
 avq
-avq
+aHO
 aHO
 aID
 aID
@@ -63429,7 +63430,7 @@ avq
 aEx
 avq
 aGk
-aGk
+arN
 arN
 aID
 aJk

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -11824,14 +11824,22 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aCw" = (
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/computer/power_monitor,
 /turf/simulated/floor/grime,
 /area/station/engine/substation/north)
 "aCx" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/power/smes{
+	chargelevel = 5000;
+	chargemode = 0;
+	online = 0;
+	output = 2500;
+	tag = ""
 	},
+/obj/cable,
 /turf/simulated/floor/grime,
 /area/station/engine/substation/north)
 "aCy" = (
@@ -12200,15 +12208,13 @@
 /turf/simulated/floor,
 /area/station/engine/substation/north)
 "aDo" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light_switch{
 	name = "E light switch";
 	pixel_x = 24;
 	pixel_y = 0
+	},
+/obj/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/substation/north)
@@ -12463,51 +12469,17 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/storage/eva)
 "aDX" = (
-/obj/machinery/computer/power_monitor,
 /obj/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/cable,
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
 "aDY" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/grime,
 /area/station/engine/substation/north)
-"aDZ" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/substation/north)
-"aEa" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/central)
-"aEb" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/maintenance/inner/central)
 "aEc" = (
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -12893,26 +12865,13 @@
 	dir = 4
 	},
 /obj/cable{
-	icon_state = "2-4"
-	},
-/obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/grime,
 /area/station/engine/substation/north)
-"aEV" = (
-/obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/central)
 "aEW" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/inner/central)
@@ -13324,45 +13283,35 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aFM" = (
+/obj/machinery/power/terminal{
+	dir = 1;
+	icon_state = "term"
+	},
+/obj/cable{
+	icon_state = "0-4"
+	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/cable,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "W APC";
-	pixel_x = -24;
-	pixel_y = 0
-	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
 "aFN" = (
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/cable,
-/obj/machinery/power/terminal,
 /obj/machinery/camera{
 	c_tag = "North Electrical Substation";
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/engine/substation/north)
-"aFO" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/grime,
 /area/station/engine/substation/north)
 "aFP" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/central)
@@ -13669,24 +13618,18 @@
 /area/station/maintenance/inner/central)
 "aGy" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 2;
+	icon_state = "1-4"
+	},
+/obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
 "aGz" = (
-/obj/machinery/power/smes{
-	chargelevel = 5000;
-	chargemode = 0;
-	online = 0;
-	output = 2500;
-	tag = ""
-	},
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/grime,
 /area/station/engine/substation/north)
 "aGA" = (
 /obj/cable{
@@ -14020,21 +13963,20 @@
 /area/station/ai_monitored/storage/eva)
 "aHq" = (
 /obj/cable{
-	d1 = 1;
-	d2 = 4;
+	icon_state = "4-8"
+	},
+/obj/cable{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
 "aHr" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/light/small{
 	brightness = 2;
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
@@ -39299,6 +39241,9 @@
 /area/station/security/detectives_office)
 "eEh" = (
 /obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/grime,
@@ -40161,6 +40106,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"haP" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/engine/substation/north)
 "hbS" = (
 /obj/storage/crate,
 /obj/item/body_bag,
@@ -40424,17 +40375,6 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"hOB" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/substation/north)
 "hOE" = (
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment/mail,
@@ -42235,7 +42175,7 @@
 	icon_state = "0-8"
 	},
 /obj/cable{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
@@ -43198,6 +43138,12 @@
 	},
 /turf/simulated/floor/circuit/red,
 /area/station/turret_protected/AIsat)
+"qhP" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/space)
 "qmH" = (
 /obj/cable{
 	d2 = 2;
@@ -44654,12 +44600,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/quartermaster/refinery)
-"umC" = (
-/obj/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/substation/north)
 "umD" = (
 /obj/cable{
 	d1 = 2;
@@ -74625,7 +74565,7 @@ aBP
 aBP
 aBP
 nps
-umC
+aBP
 eAg
 eAg
 aaa
@@ -74927,7 +74867,7 @@ aCx
 aFM
 aGy
 aHq
-nCu
+aBP
 aaa
 adQ
 aaa
@@ -75222,14 +75162,14 @@ ayT
 azU
 aAS
 aBO
-aCx
+aDY
 aDo
 aDY
 aEU
 aFN
 aGz
 aHr
-nCu
+aBP
 aaa
 adQ
 aaa
@@ -75526,12 +75466,12 @@ aAT
 aBP
 aBP
 aBP
-aDZ
-aDZ
-aFO
+aBP
+aBP
+nCu
+nCu
+haP
 aGA
-aGA
-hOB
 aGC
 aGC
 aGC
@@ -75828,10 +75768,10 @@ aAU
 aBQ
 aCy
 aCy
-aEa
-aEV
+aCy
+aCy
 aFP
-aGB
+qhP
 aGB
 aGB
 aGB
@@ -76130,8 +76070,8 @@ aAS
 aBQ
 aBQ
 aBQ
-aEb
-aEW
+aBQ
+aBQ
 aEW
 aGC
 aGC


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
-Adds missing APCs to AI Upload (not my fault), Escape (also not my fault), and Ranch (my fault)

-Clean up wiring in a lot of places. Mostly removing groups of wire nubs and making them continuous for better looks.

-Wired the clown hole directly to the engine output because funny

-Move robotics ghost a little further away from their window in maint so it doesn't annoy them all round

-Replace and move sink in janitor's closet with smaller sink, also moved the floor buffer. As it was the big sink was dense and if you jumped on the floor buffer you were stuck there.

-Removed grilles over the rwalls in AI upload. Looked weird and didn't make sense

-Gave EVA an oxygen canister, further adding to the horrible mess

-Replaced windows on ghost drone factory with wingrille spawners

-Expanded maint a little near robotics

-Fixed tiny area issue in west solar controls

-Moved table with owl suits and masks down so it wasn't hidden by the tree

-Replaced the NORMAL sunglasses that spawned in the pool with the "doesn't block flashes" variety

-Probably something else that I already forgot about and will edit into this post


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fix map good, map get gooder