### PR TITLE
Replace CanPass with Cross()

### DIFF
--- a/_std/defines/atom.dm
+++ b/_std/defines/atom.dm
@@ -23,7 +23,7 @@
 #define HANDLE_STICKER 8	//Atom implements var/active = XXX and responds to sticker removal methods (burn-off + acetone). this atom MUST have an 'active' var. im sory.
 // 16 UNUSED
 #define USE_CHECKEXIT 32	//Atom implements CheckExit() call in some way.
-#define USE_CANPASS 64		//Atom implements Cross() call in some way. (doesnt affect turfs, put this on mobs or objs)
+// 64 UNUSED
 #define IMMUNE_MANTA_PUSH 128			//cannot be pushed by MANTAwaters
 #define IMMUNE_SINGULARITY 256
 #define IMMUNE_SINGULARITY_INACTIVE 512

--- a/_std/defines/atom.dm
+++ b/_std/defines/atom.dm
@@ -23,7 +23,7 @@
 #define HANDLE_STICKER 8	//Atom implements var/active = XXX and responds to sticker removal methods (burn-off + acetone). this atom MUST have an 'active' var. im sory.
 // 16 UNUSED
 #define USE_CHECKEXIT 32	//Atom implements CheckExit() call in some way.
-#define USE_CANPASS 64		//Atom implements CanPass() call in some way. (doesnt affect turfs, put this on mobs or objs)
+#define USE_CANPASS 64		//Atom implements Cross() call in some way. (doesnt affect turfs, put this on mobs or objs)
 #define IMMUNE_MANTA_PUSH 128			//cannot be pushed by MANTAwaters
 #define IMMUNE_SINGULARITY 256
 #define IMMUNE_SINGULARITY_INACTIVE 512

--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -1916,7 +1916,7 @@
 		density = 1
 		del_self = 0
 		clash_time = -1
-		event_handler_flags = USE_CANPASS
+	
 
 		//mouse_opacity = 1
 		var/bump_count = 0

--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -3266,7 +3266,7 @@ Returns:
 	flags = FPRINT | ALWAYS_SOLID_FLUID | IS_PERSPECTIVE_FLUID
 	event_handler_flags = USE_CANPASS
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if (mover?.throwing)
 			return 1
 		return ..()

--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -3266,7 +3266,7 @@ Returns:
 	flags = FPRINT | ALWAYS_SOLID_FLUID | IS_PERSPECTIVE_FLUID
 	event_handler_flags = USE_CANPASS
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if (mover?.throwing)
 			return 1
 		return ..()

--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -3264,7 +3264,7 @@ Returns:
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "pool"
 	flags = FPRINT | ALWAYS_SOLID_FLUID | IS_PERSPECTIVE_FLUID
-	event_handler_flags = USE_CANPASS
+
 
 	Cross(atom/movable/mover)
 		if (mover?.throwing)

--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -740,7 +740,7 @@ var/obj/manta_speed_lever/mantaLever = null
 	var/database_id = null
 	var/random_color = 1
 	var/drop_type = 0
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 
 	New()
 		..()

--- a/code/WorkInProgress/optics/beam.dm
+++ b/code/WorkInProgress/optics/beam.dm
@@ -77,19 +77,19 @@
 	//Next, check objects to block entry that are on the border
 	for(var/obj/border_obstacle in src)
 		if(border_obstacle.flags & ON_BORDER)
-			if(!border_obstacle.CanPass(mover, mover.loc, 1, 0) && (forget != border_obstacle))
+			if(!border_obstacle.Cross(mover, mover.loc, 1, 0) && (forget != border_obstacle))
 				mover.Bump(border_obstacle, 1)
 				return 0
 
 	//Then, check the turf itself
-	if (!src.CanPass(mover, src))
+	if (!src.Cross(mover, src))
 		mover.Bump(src, 1)
 		return 0
 
 	//Finally, check objects/mobs to block entry that are not on the border
 	for(var/atom/movable/obstacle in src)
 		if(obstacle.flags & ~ON_BORDER)
-			if(!obstacle.CanPass(mover, mover.loc, 1, 0) && (forget != obstacle))
+			if(!obstacle.Cross(mover, mover.loc, 1, 0) && (forget != obstacle))
 				mover.Bump(obstacle, 1)
 				return 0
 	return 1 //Nothing found to block so return success!

--- a/code/WorkInProgress/pali.dm
+++ b/code/WorkInProgress/pali.dm
@@ -147,7 +147,7 @@
 		. = ..()
 		src.fix_pulling_sprite()
 
-	Bump(atom/movable/AM as mob|obj, yes)
+	Bump(atom/movable/AM as mob|obj)
 		. = ..()
 		src.fix_pulling_sprite()
 
@@ -298,7 +298,7 @@
 		access.uses = -1
 		access.implanted = 1
 
-	Bump(atom/movable/AM, yes)
+	Bump(atom/movable/AM, yes = 1)
 		. = ..()
 		if(src.contents && !istype(AM, /obj/table) && !ON_COOLDOWN(src, "bump_attack", 0.5 SECONDS))
 			var/obj/item/I = pick(src.contents)

--- a/code/WorkInProgress/previouslyKeelinsStuff.dm
+++ b/code/WorkInProgress/previouslyKeelinsStuff.dm
@@ -673,8 +673,8 @@ var/reverse_mode = 0
 	while(current != target_turf)
 		if (steps > length) return 0
 		if (!current) return 0
-		if (current.density) return 0 //If we can avoid the more expensive CanPass check, let's
-		if (!current.CanPass(source, target_turf)) return 0
+		if (current.density) return 0 //If we can avoid the more expensive Cross check, let's
+		if (!current.Cross(source, target_turf)) return 0
 
 		current = get_step_towards(current, target_turf)
 		steps++

--- a/code/WorkInProgress/previouslyKeelinsStuff.dm
+++ b/code/WorkInProgress/previouslyKeelinsStuff.dm
@@ -674,7 +674,7 @@ var/reverse_mode = 0
 		if (steps > length) return 0
 		if (!current) return 0
 		if (current.density) return 0 //If we can avoid the more expensive Cross check, let's
-		if (!current.Cross(source, target_turf)) return 0
+		if (!current.Cross(source)) return 0
 
 		current = get_step_towards(current, target_turf)
 		steps++

--- a/code/WorkInProgress/recycling/conveyor.dm
+++ b/code/WorkInProgress/recycling/conveyor.dm
@@ -360,8 +360,8 @@
 	set_divert()
 
 // don't allow movement into the 'backwards' direction if deployed
-/obj/machinery/diverter/Cross(atom/movable/O, var/turf/target)
-	var/direct = get_dir(O, target)
+/obj/machinery/diverter/Cross(atom/movable/O)
+	var/direct = get_dir(O, src)
 	if(direct == divert_to)	// prevent movement through body of diverter
 		return 0
 	if(!deployed)

--- a/code/WorkInProgress/recycling/conveyor.dm
+++ b/code/WorkInProgress/recycling/conveyor.dm
@@ -360,7 +360,7 @@
 	set_divert()
 
 // don't allow movement into the 'backwards' direction if deployed
-/obj/machinery/diverter/CanPass(atom/movable/O, var/turf/target)
+/obj/machinery/diverter/Cross(atom/movable/O, var/turf/target)
 	var/direct = get_dir(O, target)
 	if(direct == divert_to)	// prevent movement through body of diverter
 		return 0

--- a/code/WorkInProgress/recycling/conveyor.dm
+++ b/code/WorkInProgress/recycling/conveyor.dm
@@ -554,7 +554,7 @@
 	desc = "All power dumped into this power unit will boost the speed of the station's cargo carousel."
 	density = 1
 	anchored = 1
-	event_handler_flags = USE_CANPASS | USE_FLUID_ENTER
+	event_handler_flags =  USE_FLUID_ENTER
 
 	var/icon_base = "battery-"
 	var/icon_levels = 6 //there are 7 icons of power levels (6 + 1 for unpowered)

--- a/code/WorkInProgress/recycling/crusher.dm
+++ b/code/WorkInProgress/recycling/crusher.dm
@@ -8,7 +8,7 @@
 	anchored = 1.0
 	mats = 20
 	is_syndicate = 1
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	var/osha_prob = 40 //How likely it is anyone touching it is to get dragged in
 	var/list/poking_jerks = null //Will be a list if need be
 

--- a/code/WorkInProgress/recycling/scrap.dm
+++ b/code/WorkInProgress/recycling/scrap.dm
@@ -207,7 +207,7 @@
 
 // if other pile of scrap tries to enter the same turf, then add that pile to this one
 
-/obj/item/scrap/CanPass(var/obj/item/scrap/O)
+/obj/item/scrap/Cross(var/obj/item/scrap/O)
 
 	if(istype(O))
 

--- a/code/WorkInProgress/torpedoes.dm
+++ b/code/WorkInProgress/torpedoes.dm
@@ -698,7 +698,7 @@
 			for(var/atom/movable/M in T)
 				if(M == src) continue
 				if(istype(M, /obj/machinery/the_singularity)) numPierce = 0 //detonate instantly on the singularity
-				if(!M.CanPass(src, T)) return 1
+				if(!M.Cross(src, T)) return 1
 				if(M.density) return 1
 		return 0
 

--- a/code/WorkInProgress/torpedoes.dm
+++ b/code/WorkInProgress/torpedoes.dm
@@ -698,7 +698,7 @@
 			for(var/atom/movable/M in T)
 				if(M == src) continue
 				if(istype(M, /obj/machinery/the_singularity)) numPierce = 0 //detonate instantly on the singularity
-				if(!M.Cross(src, T)) return 1
+				if(!M.Cross(src)) return 1
 				if(M.density) return 1
 		return 0
 

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -784,9 +784,9 @@
 /atom/proc/Bumped(AM as mob|obj)
 	return
 
-/atom/movable/Bump(var/atom/A as mob|obj|turf|area, yes)
+/atom/movable/Bump(var/atom/A as mob|obj|turf|area)
 	SPAWN_DBG( 0 )
-		if ((A && yes)) //wtf
+		if (A)
 			A.last_bumped = world.timeofday
 			A.Bumped(src)
 		return

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -265,7 +265,7 @@
 
 //atom.event_handler_flags & USE_CHECKEXIT MUST EVALUATE AS TRUE OR THIS PROC WONT BE CALLED
 /atom/proc/CheckExit(atom/mover, turf/target)
-	//return !(src.flags & ON_BORDER) || src.CanPass(mover, target, 1, 0)
+	//return !(src.flags & ON_BORDER) || src.Cross(mover, target, 1, 0)
 	return 1 // fuck it
 
 /atom/Crossed(atom/movable/AM)

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -374,12 +374,7 @@
 		var/turf/T = src.loc
 		if (src.event_handler_flags & USE_CHECKEXIT)
 			T.checkingexit++
-		if (src.event_handler_flags & USE_CANPASS || src.density)
-			if (bound_width + bound_height > 64)
-				for(var/turf/BT in bounds(src))
-					BT.checkingcanpass++
-			else
-				T.checkingcanpass++
+
 		if (src.event_handler_flags & USE_PROXIMITY)
 			T.checkinghasproximity++
 			for (var/turf/T2 in range(1, T))
@@ -490,21 +485,6 @@
 
 	if(last_turf == src.loc)
 		return
-
-	if(src.density || src.event_handler_flags & USE_CANPASS)
-		if (bound_width + bound_height > 64)
-			if(isturf(last_turf))
-				for(var/turf/T in bounds(last_turf.x*32, last_turf.y*32, bound_width/2, bound_height/2, last_turf.z))
-					T.checkingcanpass = max(T.checkingcanpass-1, 0)
-			if(isturf(src.loc)) // ..() calls Crossed() which can change location to a non-turf for example in floor flushers
-				for(var/turf/BT in bounds(src))
-					BT.checkingcanpass++
-		else
-			if(isturf(last_turf))
-				last_turf.checkingcanpass = max(last_turf.checkingcanpass-1, 0)
-			if(isturf(src.loc))
-				var/turf/locturf = src.loc
-				locturf.checkingcanpass++
 
 	if (src.event_handler_flags & (USE_CHECKEXIT | USE_PROXIMITY))
 		if (isturf(last_turf))
@@ -864,17 +844,11 @@
 
 
 	// We only need to do any of these checks if one of the flags is set OR density = 1
-	var/do_checks = (src.event_handler_flags & (USE_CHECKEXIT | USE_CANPASS | USE_PROXIMITY)) || src.density == 1
+	var/do_checks = (src.event_handler_flags & (USE_CHECKEXIT  | USE_PROXIMITY)) || src.density == 1
 
 	if (do_checks && last_turf && isturf(last_turf))
 		if (src.event_handler_flags & USE_CHECKEXIT)
 			last_turf.checkingexit = max(last_turf.checkingexit-1, 0)
-		if (src.event_handler_flags & USE_CANPASS || src.density)
-			if (bound_width + bound_height > 64)
-				for(var/turf/T in bounds(last_turf.x*32, last_turf.y*32, bound_width/2, bound_height/2, last_turf.z))
-					T.checkingcanpass = max(T.checkingcanpass-1, 0)
-			else
-				last_turf.checkingcanpass = max(last_turf.checkingcanpass-1, 0)
 		if (src.event_handler_flags & USE_PROXIMITY)
 			last_turf.checkinghasproximity = max(last_turf.checkinghasproximity-1, 0)
 			for (var/turf/T2 in range(1, last_turf))
@@ -884,12 +858,6 @@
 		last_turf = src.loc
 		if (src.event_handler_flags & USE_CHECKEXIT)
 			last_turf.checkingexit++
-		if (src.event_handler_flags & USE_CANPASS || src.density)
-			if (bound_width + bound_height > 64)
-				for(var/turf/T in bounds(src))
-					T.checkingcanpass++
-			else
-				last_turf.checkingcanpass++
 		if (src.event_handler_flags & USE_PROXIMITY)
 			last_turf.checkinghasproximity++
 			for (var/turf/T2 in range(1, last_turf))
@@ -909,28 +877,6 @@
 	src.density = newdensity
 
 /atom/movable/set_density(var/newdensity)
-	//BASICALLY : if we dont have the USE_CANPASS flag, turf's checkingcanpass value relies entirely on our density.
-	//It is probably important that we update this as density changes immediately. I don't think it breaks anything currently if we dont, but still important for future.
-	if (src.density != newdensity)
-		if (isturf(src.loc))
-			if (!(src.event_handler_flags & USE_CANPASS))
-				if(newdensity == 1)
-					var/turf/T = src.loc
-					if (T)
-						if (bound_width + bound_height > 64)
-							for(var/turf/BT in bounds(src))
-								BT.checkingcanpass++
-						else
-							T.checkingcanpass++
-
-				else
-					var/turf/T = src.loc
-					if (T)
-						if (bound_width + bound_height > 64)
-							for(var/turf/BT in bounds(src))
-								BT.checkingcanpass = max(BT.checkingcanpass-1, 0)
-						else
-							T.checkingcanpass = max(T.checkingcanpass-1, 0)
 	..()
 
 // standardized damage procs

--- a/code/atom/throwing.dm
+++ b/code/atom/throwing.dm
@@ -21,7 +21,7 @@
 			// **TODO: Better behaviour for windows
 			// which are dense, but shouldn't always stop movement
 			if(isobj(A))
-				if(!A.CanPass(src, src.loc))
+				if(!A.Cross(src, src.loc))
 					src.throw_impact(A, thr)
 					. = TRUE
 

--- a/code/atom/throwing.dm
+++ b/code/atom/throwing.dm
@@ -21,7 +21,7 @@
 			// **TODO: Better behaviour for windows
 			// which are dense, but shouldn't always stop movement
 			if(isobj(A))
-				if(!A.Cross(src, src.loc))
+				if(!A.Cross(src))
 					src.throw_impact(A, thr)
 					. = TRUE
 

--- a/code/datums/abilities/wizard/phaseshift.dm
+++ b/code/datums/abilities/wizard/phaseshift.dm
@@ -311,11 +311,10 @@
 						vampholder.do_bite(atom, mult = 0.25)
 						playsound(src.loc,"sound/impact_sounds/Flesh_Crush_1.ogg", 35, 1, pitch = 1.3)
 						break
-				if (src.loc:checkingcanpass)
-					if (istype(atom,/obj/machinery/door))
-						var/obj/machinery/door/D = atom
-						//D.bumpopen(owner)
-						D.try_force_open(owner)
+				if (istype(atom,/obj/machinery/door))
+					var/obj/machinery/door/D = atom
+					//D.bumpopen(owner)
+					D.try_force_open(owner)
 				i++
 				if (i > 20)
 					break

--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -213,7 +213,7 @@ var/datum/explosion_controller/explosions
 			var/value = nodes[T] - 1 - T.explosion_resistance
 			var/value2 = nodes[T] - 1.4 - T.explosion_resistance
 			for (var/atom/A as anything in T)
-				if (A.density/* && !A.CanPass(null, target)*/) // nothing actually used the CanPass check
+				if (A.density/* && !A.Cross(null, target)*/) // nothing actually used the Cross check
 					value -= A.explosion_resistance
 					value2 -= A.explosion_resistance
 			if (value < 0)

--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -220,7 +220,7 @@
 	var/team_num = 0		//1 = NT, 2 = SY
 	gas_impermeable = TRUE
 
-	CanPass(atom/A, turf/T)
+	Cross(atom/A, turf/T)
 		if (ismob(A))
 			var/mob/M = A
 			if (team_num == get_pod_wars_team_num(M))
@@ -750,7 +750,7 @@
 
 		return
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if (!src.density || (mover.flags & TABLEPASS || istype(mover, /obj/newmeteor)) )
 			return 1
 		else

--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -730,7 +730,7 @@
 	density = 1
 	anchored = 1.0
 	flags = NOSPLASH
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	layer = OBJ_LAYER-0.1
 	stops_space_move = TRUE
 

--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -220,7 +220,7 @@
 	var/team_num = 0		//1 = NT, 2 = SY
 	gas_impermeable = TRUE
 
-	Cross(atom/A, turf/T)
+	Cross(atom/A)
 		if (ismob(A))
 			var/mob/M = A
 			if (team_num == get_pod_wars_team_num(M))
@@ -750,7 +750,7 @@
 
 		return
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if (!src.density || (mover.flags & TABLEPASS || istype(mover, /obj/newmeteor)) )
 			return 1
 		else

--- a/code/datums/gauntlet/podcolosseum.dm
+++ b/code/datums/gauntlet/podcolosseum.dm
@@ -486,7 +486,7 @@ var/global/datum/arena/colosseumController/colosseum_controller = new()
 	name = "Colosseum Hangar Floor"
 	desc = "You wonder if that little flashing white thing is a pod or a butt."
 	icon_state = "gauntfloorPod"
-	event_handler_flags = USE_CANPASS
+
 
 	Cross(atom/movable/mover)
 		if (istype(mover, /obj/machinery/colosseum_putt))

--- a/code/datums/gauntlet/podcolosseum.dm
+++ b/code/datums/gauntlet/podcolosseum.dm
@@ -477,7 +477,7 @@ var/global/datum/arena/colosseumController/colosseum_controller = new()
 
 	src.debug_variables(colosseum_controller)
 
-/turf/unsimulated/floor/setpieces/gauntlet/CanPass(atom/movable/mover, turf/target)
+/turf/unsimulated/floor/setpieces/gauntlet/Cross(atom/movable/mover, turf/target)
 	if (istype(mover, /obj/machinery/colosseum_putt))
 		return 0
 	return ..()
@@ -488,7 +488,7 @@ var/global/datum/arena/colosseumController/colosseum_controller = new()
 	icon_state = "gauntfloorPod"
 	event_handler_flags = USE_CANPASS
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/machinery/colosseum_putt))
 			return 1
 		return ..()

--- a/code/datums/gauntlet/podcolosseum.dm
+++ b/code/datums/gauntlet/podcolosseum.dm
@@ -477,7 +477,7 @@ var/global/datum/arena/colosseumController/colosseum_controller = new()
 
 	src.debug_variables(colosseum_controller)
 
-/turf/unsimulated/floor/setpieces/gauntlet/Cross(atom/movable/mover, turf/target)
+/turf/unsimulated/floor/setpieces/gauntlet/Cross(atom/movable/mover)
 	if (istype(mover, /obj/machinery/colosseum_putt))
 		return 0
 	return ..()
@@ -488,7 +488,7 @@ var/global/datum/arena/colosseumController/colosseum_controller = new()
 	icon_state = "gauntfloorPod"
 	event_handler_flags = USE_CANPASS
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if (istype(mover, /obj/machinery/colosseum_putt))
 			return 1
 		return ..()

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -5,7 +5,7 @@
 	soundproofing = 10
 
 	flags = FPRINT | FLUID_SUBMERGE
-	event_handler_flags = USE_CANPASS
+
 	appearance_flags = KEEP_TOGETHER | PIXEL_SCALE | LONG_GLIDE
 
 	var/datum/mind/mind

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -584,8 +584,8 @@
 /mob/proc/onMouseUp(object,location,control,params)
 	return
 
-/mob/Bump(atom/A, yes)
-	if ((!( yes ) || src.now_pushing))
+/mob/Bump(atom/A)
+	if (src.now_pushing)
 		return
 
 	var/atom/movable/AM = A

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1525,7 +1525,7 @@
 	if (!isliving(src))
 		src.sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF | SEE_BLACKNESS
 
-/mob/CanPass(atom/movable/mover, turf/target)
+/mob/Cross(atom/movable/mover, turf/target)
 	if (istype(mover, /obj/projectile))
 		return !projCanHit(mover:proj_data)
 

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1525,7 +1525,7 @@
 	if (!isliving(src))
 		src.sight = SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF | SEE_BLACKNESS
 
-/mob/Cross(atom/movable/mover, turf/target)
+/mob/Cross(atom/movable/mover)
 	if (istype(mover, /obj/projectile))
 		return !projCanHit(mover:proj_data)
 

--- a/code/mob/dead.dm
+++ b/code/mob/dead.dm
@@ -11,7 +11,7 @@
 /mob/dead/ex_act(severity)
 	return
 
-/mob/dead/Cross(atom/movable/mover, turf/target)
+/mob/dead/Cross(atom/movable/mover)
 	return 1
 
 /mob/dead/say_understands()

--- a/code/mob/dead.dm
+++ b/code/mob/dead.dm
@@ -11,7 +11,7 @@
 /mob/dead/ex_act(severity)
 	return
 
-/mob/dead/CanPass(atom/movable/mover, turf/target)
+/mob/dead/Cross(atom/movable/mover, turf/target)
 	return 1
 
 /mob/dead/say_understands()

--- a/code/mob/dead.dm
+++ b/code/mob/dead.dm
@@ -1,6 +1,6 @@
 /mob/dead
 	stat = 2
-	event_handler_flags = USE_CANPASS | IMMUNE_MANTA_PUSH
+	event_handler_flags =  IMMUNE_MANTA_PUSH
 
 // dead
 /mob/dead/New()

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -144,7 +144,7 @@
 
 
 //#ifdef HALLOWEEN
-/mob/dead/observer/CanPass(atom/movable/mover, turf/target)
+/mob/dead/observer/Cross(atom/movable/mover, turf/target)
 	if (src.icon_state != "doubleghost" && istype(mover, /obj/projectile))
 		var/obj/projectile/proj = mover
 		if (proj.proj_data?.hits_ghosts)

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -144,7 +144,7 @@
 
 
 //#ifdef HALLOWEEN
-/mob/dead/observer/Cross(atom/movable/mover, turf/target)
+/mob/dead/observer/Cross(atom/movable/mover)
 	if (src.icon_state != "doubleghost" && istype(mover, /obj/projectile))
 		var/obj/projectile/proj = mover
 		if (proj.proj_data?.hits_ghosts)

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -5,7 +5,7 @@
 	icon_state = "ghost"
 	layer = NOLIGHT_EFFECTS_LAYER_BASE
 	plane = PLANE_NOSHADOW_ABOVE
-	event_handler_flags = USE_CANPASS | IMMUNE_MANTA_PUSH | USE_FLUID_ENTER //maybe?
+	event_handler_flags =  IMMUNE_MANTA_PUSH | USE_FLUID_ENTER //maybe?
 	density = 0
 	canmove = 1
 	blinded = 0

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1,7 +1,7 @@
 // living
 
 /mob/living
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS | IS_FARTABLE
+	event_handler_flags = USE_FLUID_ENTER  | IS_FARTABLE
 	var/spell_soulguard = 0		//0 = none, 1 = normal_soulgruard, 2 = wizard_ring_soulguard
 
 	// this is a read only variable. do not set it directly.

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -9,7 +9,7 @@
 	throw_range = 4
 	p_class = 1.5 // 1.5 while standing, 2.5 while resting (see update_icon.dm for the place where this change happens)
 
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS | IS_FARTABLE
+	event_handler_flags = USE_FLUID_ENTER  | IS_FARTABLE
 	mob_flags = IGNORE_SHIFT_CLICK_MODIFIER
 
 	var/dump_contents_chance = 20

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2964,7 +2964,7 @@
 		return 1
 	return .
 
-/mob/living/carbon/human/Bump(atom/movable/AM as mob|obj, yes)
+/mob/living/carbon/human/Bump(atom/movable/AM as mob|obj)
 	if (wearing_football_gear())
 		src.tackle(AM)
 	..()

--- a/code/mob/living/carbon/human/glitchy.dm
+++ b/code/mob/living/carbon/human/glitchy.dm
@@ -31,7 +31,7 @@
 			var/turf/T = get_turf(src)
 			src.glitch_up(T)
 
-	Bump(atom/movable/AM, yes)
+	Bump(atom/movable/AM)
 		..()
 		src.glitch_up(AM)
 

--- a/code/mob/living/carbon/human/machoman.dm
+++ b/code/mob/living/carbon/human/machoman.dm
@@ -85,9 +85,9 @@ var/list/snd_macho_idle = list('sound/voice/macho/macho_alert16.ogg', 'sound/voi
 		..()
 		return
 
-	Bump(atom/movable/AM, yes)
+	Bump(atom/movable/AM)
 		if (src.stance == "offensive")
-			if ((!( yes ) || src.now_pushing))
+			if ( src.now_pushing)
 				return
 			now_pushing = 1
 			if (ismob(AM))

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -895,7 +895,7 @@
 		if(!W.CheckExit(src,targetturf)) return 0
 
 	for (var/obj/machinery/door/window/W in targetturf)
-		if(!W.CanPass(src,targetturf)) return 0
+		if(!W.Cross(src,targetturf)) return 0
 
 	return 1
 

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -895,7 +895,7 @@
 		if(!W.CheckExit(src,targetturf)) return 0
 
 	for (var/obj/machinery/door/window/W in targetturf)
-		if(!W.Cross(src,targetturf)) return 0
+		if(!W.Cross(src)) return 0
 
 	return 1
 

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1210,7 +1210,7 @@
 	proc/on_wake()
 		return
 
-/mob/living/critter/Bump(atom/A, yes)
+/mob/living/critter/Bump(atom/A)
 	var/atom/movable/AM = A
 	if(issmallanimal(src) && src.ghost_spawned && istype(AM) && !AM.anchored)
 		return

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -202,7 +202,7 @@
 
 /mob/living/critter/flock/drone/is_spacefaring() return 1
 
-/mob/living/critter/flock/drone/CanPass(atom/movable/mover)
+/mob/living/critter/flock/drone/Cross(atom/movable/mover)
 	if(isflock(mover))
 		return 1
 	else
@@ -389,7 +389,7 @@
 	else
 		return ..()
 
-/mob/living/critter/flock/drone/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/mob/living/critter/flock/drone/Cross(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(floorrunning)
 		return 1
 	else

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -93,7 +93,7 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 		add_health_holder(/datum/healthHolder/toxin)
 		add_health_holder(/datum/healthHolder/brain)
 
-	Cross(atom/mover, turf/target)
+	Cross(atom/mover)
 		if (!src.density && istype(mover, /obj/projectile))
 			return prob(50)
 		else

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -93,7 +93,7 @@ ABSTRACT_TYPE(/mob/living/critter/small_animal)
 		add_health_holder(/datum/healthHolder/toxin)
 		add_health_holder(/datum/healthHolder/brain)
 
-	CanPass(atom/mover, turf/target)
+	Cross(atom/mover, turf/target)
 		if (!src.density && istype(mover, /obj/projectile))
 			return prob(50)
 		else

--- a/code/mob/living/intangible.dm
+++ b/code/mob/living/intangible.dm
@@ -6,7 +6,7 @@
 	canmove = 1
 	blinded = 0
 	anchored = 1
-	event_handler_flags = USE_CANPASS | IMMUNE_MANTA_PUSH
+	event_handler_flags =  IMMUNE_MANTA_PUSH
 
 	New()
 		. = ..()

--- a/code/mob/living/intangible.dm
+++ b/code/mob/living/intangible.dm
@@ -24,7 +24,7 @@
 		return 0
 	say_understands(var/other)
 		return 1
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		return 1
 
 	meteorhit()

--- a/code/mob/living/intangible.dm
+++ b/code/mob/living/intangible.dm
@@ -24,7 +24,7 @@
 		return 0
 	say_understands(var/other)
 		return 1
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		return 1
 
 	meteorhit()

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -109,7 +109,7 @@
 /mob/living/intangible/flock/projCanHit(datum/projectile/P)
 	return P.hits_ghosts
 
-/mob/living/intangible/flock/CanPass(atom/movable/mover, turf/target)
+/mob/living/intangible/flock/Cross(atom/movable/mover, turf/target)
 	if (istype(mover, /obj/projectile))
 		var/obj/projectile/proj = mover
 		if (istype(proj.proj_data, /datum/projectile/energy_bolt_antighost))

--- a/code/mob/living/intangible/flockmob_parent.dm
+++ b/code/mob/living/intangible/flockmob_parent.dm
@@ -109,7 +109,7 @@
 /mob/living/intangible/flock/projCanHit(datum/projectile/P)
 	return P.hits_ghosts
 
-/mob/living/intangible/flock/Cross(atom/movable/mover, turf/target)
+/mob/living/intangible/flock/Cross(atom/movable/mover)
 	if (istype(mover, /obj/projectile))
 		var/obj/projectile/proj = mover
 		if (istype(proj.proj_data, /datum/projectile/energy_bolt_antighost))

--- a/code/mob/living/seanceghost.dm
+++ b/code/mob/living/seanceghost.dm
@@ -37,7 +37,7 @@
 	click(atom/target)
 		src.examine_verb(target)
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		return 1
 
 	say_understands(var/other)

--- a/code/mob/living/seanceghost.dm
+++ b/code/mob/living/seanceghost.dm
@@ -37,7 +37,7 @@
 	click(atom/target)
 		src.examine_verb(target)
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		return 1
 
 	say_understands(var/other)

--- a/code/mob/living/silicon/ai/mobile.dm
+++ b/code/mob/living/silicon/ai/mobile.dm
@@ -58,8 +58,8 @@
 		return
 
 
-	Bump(atom/movable/AM as mob|obj, yes)
-		if ((!( yes ) || src.now_pushing))
+	Bump(atom/movable/AM as mob|obj)
+		if (src.now_pushing)
 			return
 		src.now_pushing = 1
 
@@ -264,7 +264,7 @@
 		src.dependent = 0
 		return 0
 
-	Bump(atom/movable/AM as mob|obj, yes)
+	Bump(atom/movable/AM as mob|obj, yes = 1)
 		if ((!( yes ) || src.now_pushing))
 			return
 		src.now_pushing = 1

--- a/code/mob/living/silicon/drone.dm
+++ b/code/mob/living/silicon/drone.dm
@@ -200,9 +200,9 @@
 				src.next_click = world.time + (equipped ? max(equipped.click_delay,src.combat_click_delay) : src.combat_click_delay)
 				src.lastattacked = null
 
-	Bump(atom/movable/AM as mob|obj, yes)
+	Bump(atom/movable/AM as mob|obj)
 		SPAWN_DBG( 0 )
-			if ((!( yes ) || src.now_pushing))
+			if (src.now_pushing)
 				return
 			..()
 			if (!istype(AM, /atom/movable))

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -399,9 +399,9 @@
 		else
 			stat("No Cell Inserted!")
 
-	Bump(atom/movable/AM as mob|obj, yes)
+	Bump(atom/movable/AM as mob|obj)
 		SPAWN_DBG( 0 )
-			if ((!( yes ) || src.now_pushing))
+			if ( src.now_pushing)
 				return
 			//..()
 			if (!istype(AM, /atom/movable))

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -482,9 +482,9 @@
 		health_update_queue |= src
 	return
 
-/mob/living/silicon/hivebot/Bump(atom/movable/AM as mob|obj, yes)
+/mob/living/silicon/hivebot/Bump(atom/movable/AM as mob|obj)
 	SPAWN_DBG( 0 )
-		if ((!( yes ) || src.now_pushing))
+		if (src.now_pushing)
 			return
 		if (!istype(AM, /atom/movable))
 			return

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1002,9 +1002,9 @@
 					qdel (src.cell)
 					src.cell = null
 
-	Bump(atom/movable/AM as mob|obj, yes)
+	Bump(atom/movable/AM as mob|obj)
 		SPAWN_DBG( 0 )
-			if ((!( yes ) || src.now_pushing))
+			if ( src.now_pushing)
 				return
 			//..()
 			if(AM)

--- a/code/mob/living/silicon/shell-JUNK.dm
+++ b/code/mob/living/silicon/shell-JUNK.dm
@@ -106,9 +106,9 @@
 			return null
 		return active_tools[active_tool]
 
-	Bump(atom/movable/AM as mob|obj, yes)
+	Bump(atom/movable/AM as mob|obj)
 		SPAWN_DBG( 0 )
-			if ((!( yes ) || src.now_pushing))
+			if (src.now_pushing)
 				return
 			..()
 			if (!istype(AM, /atom/movable))

--- a/code/mob/wraith.dm
+++ b/code/mob/wraith.dm
@@ -17,7 +17,7 @@
 	blinded = 0
 	anchored = 1
 	alpha = 180
-	event_handler_flags = USE_CANPASS | IMMUNE_MANTA_PUSH
+	event_handler_flags =  IMMUNE_MANTA_PUSH
 	plane = PLANE_NOSHADOW_ABOVE
 
 	var/deaths = 0

--- a/code/mob/wraith.dm
+++ b/code/mob/wraith.dm
@@ -235,7 +235,7 @@
 			for (var/datum/objective/specialist/wraith/WO in src.mind.objectives)
 				WO.onAbsorb(M)
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if (istype(mover, /obj/projectile))
 			var/obj/projectile/proj = mover
 			if (proj.proj_data.hits_wraiths)

--- a/code/mob/wraith.dm
+++ b/code/mob/wraith.dm
@@ -235,7 +235,7 @@
 			for (var/datum/objective/specialist/wraith/WO in src.mind.objectives)
 				WO.onAbsorb(M)
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			var/obj/projectile/proj = mover
 			if (proj.proj_data.hits_wraiths)

--- a/code/mob/zoldorfmob.dm
+++ b/code/mob/zoldorfmob.dm
@@ -151,7 +151,7 @@
 		else
 			src.examine_verb(target)
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		return 1
 
 	say_understands(var/other)

--- a/code/mob/zoldorfmob.dm
+++ b/code/mob/zoldorfmob.dm
@@ -151,7 +151,7 @@
 		else
 			src.examine_verb(target)
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		return 1
 
 	say_understands(var/other)

--- a/code/modules/admin/diagnostics.dm
+++ b/code/modules/admin/diagnostics.dm
@@ -825,12 +825,6 @@ proc/debug_map_apc_count(delim,zlim)
 		proc/is_ok(atom/A)
 			return TRUE
 
-	checkingcanpass
-		name = "checkingcanpass"
-		help = "Green = yes."
-		GetInfo(var/turf/theTurf, var/image/debugoverlay/img)
-			img.app.color = theTurf.checkingcanpass ? "#0f0" : "#f00"
-
 	checkingexit
 		name = "checkingexit"
 		help = "Green = yes."

--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -29,11 +29,11 @@ Important variables:
 		This stores all data for.
 		If you modify, make sure to update the archived_cycle to prevent race conditions and maintain symmetry
 
-	atom/CanPass(atom/movable/mover, turf/target, height, air_group)
+	atom/Cross(atom/movable/mover, turf/target, height, air_group)
 		returns 1 for allow pass and 0 for deny pass
 		Turfs automatically call this for all objects/mobs in its turf.
-		This is called both as source.CanPass(target, height, air_group)
-			and  target.CanPass(source, height, air_group)
+		This is called both as source.Cross(target, height, air_group)
+			and  target.Cross(source, height, air_group)
 
 		Cases for the parameters
 		1. This is called with args (mover, location, height>0, air_group=0) for normal objects.
@@ -52,15 +52,15 @@ Important Procedures
 
 */
 
-/atom/proc/CanPass(atom/movable/mover)
+/atom/Cross(atom/movable/mover)
 	return (!density)
 
 /atom/proc/gas_cross(turf/target)
 	return !src.gas_impermeable
 
-/turf/CanPass(atom/movable/mover, turf/target)
+/turf/Cross(atom/movable/mover, turf/target)
 	. = ..()
-	if(!target) return 0
+	//if(!target) return 0
 
 /turf/gas_cross(turf/target)
 	if(target?.gas_impermeable || src.gas_impermeable)

--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -58,10 +58,6 @@ Important Procedures
 /atom/proc/gas_cross(turf/target)
 	return !src.gas_impermeable
 
-/turf/Cross(atom/movable/mover, turf/target)
-	. = ..()
-	//if(!target) return 0
-
 /turf/gas_cross(turf/target)
 	if(target?.gas_impermeable || src.gas_impermeable)
 		return 0

--- a/code/modules/economy/supply_misc.dm
+++ b/code/modules/economy/supply_misc.dm
@@ -51,7 +51,7 @@
 	density = 0
 	anchored = 1
 	layer = EFFECTS_LAYER_UNDER_1
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WIRECUTTERS
 
 /obj/plasticflaps/Cross(atom/A)

--- a/code/modules/economy/supply_misc.dm
+++ b/code/modules/economy/supply_misc.dm
@@ -54,7 +54,7 @@
 	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WIRECUTTERS
 
-/obj/plasticflaps/Cross(atom/A, turf/T)
+/obj/plasticflaps/Cross(atom/A)
 	if (isliving(A)) // You Shall Not Pass!
 		var/mob/living/M = A
 		if (isghostdrone(M)) // except for drones

--- a/code/modules/economy/supply_misc.dm
+++ b/code/modules/economy/supply_misc.dm
@@ -54,7 +54,7 @@
 	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WIRECUTTERS
 
-/obj/plasticflaps/CanPass(atom/A, turf/T)
+/obj/plasticflaps/Cross(atom/A, turf/T)
 	if (isliving(A)) // You Shall Not Pass!
 		var/mob/living/M = A
 		if (isghostdrone(M)) // except for drones

--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -125,7 +125,7 @@
 			if (21 to INFINITY) flavor = "vivacious"
 		return "[..()] It looks [flavor]."
 
-	Cross(atom/A, turf/T)
+	Cross(atom/A)
 		//kudzumen can pass through dense kudzu
 		if (current_stage == 3)
 			if (ishuman(A) &&  istype(A:mutantrace, /datum/mutantrace/kudzu))

--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -125,7 +125,7 @@
 			if (21 to INFINITY) flavor = "vivacious"
 		return "[..()] It looks [flavor]."
 
-	CanPass(atom/A, turf/T)
+	Cross(atom/A, turf/T)
 		//kudzumen can pass through dense kudzu
 		if (current_stage == 3)
 			if (ishuman(A) &&  istype(A:mutantrace, /datum/mutantrace/kudzu))

--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -104,7 +104,7 @@
 	icon_state = "vine-light1"
 	anchored = 1
 	density = 0
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	var/static/ideal_temp = 310		//same as blob, why not? I have no other reference point.
 	var/growth = 0
 	var/waittime = 40

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -913,9 +913,9 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 		. = ..()
 
 
-	Bump(atom/movable/AM, yes)
+	Bump(atom/movable/AM)
 		if(src.stance == "krampage")
-			if ((!( yes ) || src.now_pushing))
+			if (src.now_pushing)
 				return
 			now_pushing = 1
 			var/attack_strength = 2

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -354,7 +354,7 @@
 		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="GENEBOOTH-MAILBOT", "group"=list(MGD_MEDRESEACH, MGA_SALES), "sender"="00000000", "message"=string)
 		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, pdaSignal)
 
-	CanPass(var/mob/M, var/atom/oldloc)
+	Cross(var/mob/M, var/atom/oldloc)
 		.= ..()
 		if (oldloc && oldloc.y == src.y)
 			if (!occupant && selected_product && ishuman(M))

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -40,7 +40,7 @@
 	pixel_x = -3
 	anchored = 1
 	density = 1
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	appearance_flags = TILE_BOUND | PIXEL_SCALE | LONG_GLIDE
 	req_access = list(access_captain, access_head_of_personnel, access_maxsec, access_medical_director)
 

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -354,13 +354,13 @@
 		pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="GENEBOOTH-MAILBOT", "group"=list(MGD_MEDRESEACH, MGA_SALES), "sender"="00000000", "message"=string)
 		SEND_SIGNAL(src, COMSIG_MOVABLE_POST_RADIO_PACKET, pdaSignal)
 
-	Cross(var/mob/M, var/atom/oldloc)
+	Cross(var/mob/M)
 		.= ..()
-		if (oldloc && oldloc.y == src.y)
+		if (M && M.y == src.y)
 			if (!occupant && selected_product && ishuman(M))
 				var/mob/living/carbon/human/H = M
 				if (H.bioHolder && !H.bioHolder.HasEffect(selected_product.id))
-					eject_dir = get_dir(oldloc,src)
+					eject_dir = get_dir(M,src)
 					M.set_loc(src)
 					occupant = M
 					letgo_hp = initial(letgo_hp)

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -182,7 +182,7 @@
 			if(sigreturn & PROJ_ATOM_PASSTHROUGH || (pierces_left != 0 && first && !(sigreturn & PROJ_ATOM_CANNOT_PASS))) //try to hit other targets on the tile
 				for (var/mob/X in T.contents)
 					if(!(X in src.hitlist))
-						if (!X.CanPass(src, get_step(src, X.dir)))
+						if (!X.Cross(src, get_step(src, X.dir)))
 							src.collide(X, first = 0)
 					if(QDELETED(src))
 						return
@@ -204,7 +204,7 @@
 			if(first && (sigreturn & PROJ_OBJ_HIT_OTHER_OBJS))
 				for (var/obj/X in T.contents)
 					if(!(X in src.hitlist))
-						if (!X.CanPass(src, get_step(src, X.dir)))
+						if (!X.Cross(src, get_step(src, X.dir)))
 							src.collide(X, first = 0)
 					if(QDELETED(src))
 						return
@@ -323,7 +323,7 @@
 		..()
 		if (!istype(A))
 			return // can't happen will happen
-		if (!A.CanPass(src, get_step(src, A.dir)))
+		if (!A.Cross(src, get_step(src, A.dir)))
 			src.collide(A)
 
 		if (collide_with_other_projectiles && A.type == src.type)
@@ -336,7 +336,7 @@
 		for(var/thing as mob|obj|turf|area in T)
 			var/atom/A = thing
 			if (A == src) continue
-			if (!A.CanPass(src, get_step(src, A.dir)))
+			if (!A.Cross(src, get_step(src, A.dir)))
 				src.collide(A)
 
 			if (collide_with_other_projectiles && A.type == src.type)

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -182,7 +182,7 @@
 			if(sigreturn & PROJ_ATOM_PASSTHROUGH || (pierces_left != 0 && first && !(sigreturn & PROJ_ATOM_CANNOT_PASS))) //try to hit other targets on the tile
 				for (var/mob/X in T.contents)
 					if(!(X in src.hitlist))
-						if (!X.Cross(src, get_step(src, X.dir)))
+						if (!X.Cross(src))
 							src.collide(X, first = 0)
 					if(QDELETED(src))
 						return
@@ -204,7 +204,7 @@
 			if(first && (sigreturn & PROJ_OBJ_HIT_OTHER_OBJS))
 				for (var/obj/X in T.contents)
 					if(!(X in src.hitlist))
-						if (!X.Cross(src, get_step(src, X.dir)))
+						if (!X.Cross(src))
 							src.collide(X, first = 0)
 					if(QDELETED(src))
 						return
@@ -323,7 +323,7 @@
 		..()
 		if (!istype(A))
 			return // can't happen will happen
-		if (!A.Cross(src, get_step(src, A.dir)))
+		if (!A.Cross(src))
 			src.collide(A)
 
 		if (collide_with_other_projectiles && A.type == src.type)
@@ -336,7 +336,7 @@
 		for(var/thing as mob|obj|turf|area in T)
 			var/atom/A = thing
 			if (A == src) continue
-			if (!A.Cross(src, get_step(src, A.dir)))
+			if (!A.Cross(src))
 				src.collide(A)
 
 			if (collide_with_other_projectiles && A.type == src.type)

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -72,7 +72,7 @@
 	power_change()
 		return
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if (istype(mover, /obj/projectile))
 			return 0
 		return ..()

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -3,7 +3,7 @@
 /obj/machinery/bot
 	icon = 'icons/obj/bots/aibots.dmi'
 	layer = MOB_LAYER
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	flags = FPRINT | FLUID_SUBMERGE | TGUI_INTERACTIVE
 	object_flags = CAN_REPROGRAM_ACCESS
 	machine_registry_idx = MACHINES_BOTS

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -72,7 +72,7 @@
 	power_change()
 		return
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			return 0
 		return ..()

--- a/code/modules/robotics/bot/firebot.dm
+++ b/code/modules/robotics/bot/firebot.dm
@@ -10,7 +10,7 @@
 	desc = "A little fire-fighting robot!  He looks so darn chipper."
 	icon = 'icons/obj/bots/aibots.dmi'
 	icon_state = "firebot0"
-	event_handler_flags = USE_PROXIMITY | USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_PROXIMITY | USE_FLUID_ENTER 
 	flags =  FPRINT | FLUID_SUBMERGE | TGUI_INTERACTIVE | DOORPASS
 	layer = 5.0 //TODO LAYER
 	density = 0

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -774,7 +774,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 			t2 = get_step(t1, NORTH)
 			t3 = get_step(t1, SOUTH)
 
-	if (!t1 || !t2 || !t3 || !t1.Cross(src, t1) || !t2.Cross(src, t2) || !t3.Cross(src, t3))
+	if (!t1 || !t2 || !t3 || !t1.Cross(src) || !t2.Cross(src) || !t3.Cross(src))
 		if (t1) Bump(t1)
 		if (t2) Bump(t2)
 		if (t3) Bump(t3)

--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -774,7 +774,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 			t2 = get_step(t1, NORTH)
 			t3 = get_step(t1, SOUTH)
 
-	if (!t1 || !t2 || !t3 || !t1.CanPass(src, t1) || !t2.CanPass(src, t2) || !t3.CanPass(src, t3))
+	if (!t1 || !t2 || !t3 || !t1.Cross(src, t1) || !t2.Cross(src, t2) || !t3.Cross(src, t3))
 		if (t1) Bump(t1)
 		if (t2) Bump(t2)
 		if (t3) Bump(t3)

--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -77,7 +77,7 @@
 		else
 			..()
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		. = ..()
 		var/obj/projectile/P = mover
 		if (istype(P) && P.proj_data) //Wire note: Fix for Cannot read null.type

--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -12,7 +12,7 @@
 	density = 1
 	opacity = 0
 	anchored = 1
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	var/health = 30         // current health of the blob
 	var/health_max = 30     // health cap
 	var/armor = 1           // how much incoming damage gets divided by unless it bypasses armor

--- a/code/obj/blob.dm
+++ b/code/obj/blob.dm
@@ -77,7 +77,7 @@
 		else
 			..()
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		. = ..()
 		var/obj/projectile/P = mover
 		if (istype(P) && P.proj_data) //Wire note: Fix for Cannot read null.type

--- a/code/obj/cement.dm
+++ b/code/obj/cement.dm
@@ -28,7 +28,7 @@
 		processing_items -= src
 		..()
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if(istype(mover, /mob))
 			var/mob/M = mover
 			M.setStatus(statusId = "slowed", duration = 0.5 SECONDS, optional = 4)

--- a/code/obj/cement.dm
+++ b/code/obj/cement.dm
@@ -28,7 +28,7 @@
 		processing_items -= src
 		..()
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if(istype(mover, /mob))
 			var/mob/M = mover
 			M.setStatus(statusId = "slowed", duration = 0.5 SECONDS, optional = 4)

--- a/code/obj/cement.dm
+++ b/code/obj/cement.dm
@@ -5,7 +5,7 @@
 	anchored = 1
 	density = 0
 	layer = OBJ_LAYER + 0.9
-	event_handler_flags = USE_CANPASS
+
 	var/const/initial_health = 10
 	_health = initial_health
 	_max_health = initial_health

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -618,7 +618,7 @@
 		else
 			return ..()
 
-	CanPass(atom/mover, turf/target)
+	Cross(atom/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			return prob(50)
 		else

--- a/code/obj/critter/bee.dm
+++ b/code/obj/critter/bee.dm
@@ -618,7 +618,7 @@
 		else
 			return ..()
 
-	Cross(atom/mover, turf/target)
+	Cross(atom/mover)
 		if (istype(mover, /obj/projectile))
 			return prob(50)
 		else

--- a/code/obj/critter/critter_parent.dm
+++ b/code/obj/critter/critter_parent.dm
@@ -10,7 +10,7 @@
 	density = 1
 	anchored = 0
 	flags = FPRINT | CONDUCT | USEDELAY | FLUID_SUBMERGE
-	event_handler_flags = USE_PROXIMITY | USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_PROXIMITY | USE_FLUID_ENTER 
 	var/is_template = 0
 	var/alive = 1
 	var/health = 10

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -377,7 +377,7 @@
 		else
 			..()
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			var/obj/projectile/proj = mover
 			if (istype(proj.proj_data, /datum/projectile/energy_bolt_antighost))
@@ -1425,7 +1425,7 @@
 			else
 				src.visible_message("[src] slithers around happily!")
 
-	CanPass(atom/mover, turf/target)
+	Cross(atom/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			return prob(50)
 		else

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -377,7 +377,7 @@
 		else
 			..()
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if (istype(mover, /obj/projectile))
 			var/obj/projectile/proj = mover
 			if (istype(proj.proj_data, /datum/projectile/energy_bolt_antighost))
@@ -1425,7 +1425,7 @@
 			else
 				src.visible_message("[src] slithers around happily!")
 
-	Cross(atom/mover, turf/target)
+	Cross(atom/mover)
 		if (istype(mover, /obj/projectile))
 			return prob(50)
 		else

--- a/code/obj/decal.dm
+++ b/code/obj/decal.dm
@@ -409,7 +409,7 @@ obj/decal/fakeobjects/teleport_pad
 	icon = 'icons/obj/decoration.dmi'
 	icon_state = "ringrope"
 	layer = OBJ_LAYER
-	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT 
 
 	Cross(atom/movable/mover) // stolen from window.dm
 		if (mover && mover.throwing & THROW_CHAIRFLIP)
@@ -437,7 +437,7 @@ obj/decal/fakeobjects/teleport_pad
 	icon = 'icons/obj/decoration.dmi'
 	icon_state = "ringrope"
 	layer = OBJ_LAYER
-	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT 
 
 	rotatable = 0
 	foldable = 0

--- a/code/obj/decal.dm
+++ b/code/obj/decal.dm
@@ -411,7 +411,7 @@ obj/decal/fakeobjects/teleport_pad
 	layer = OBJ_LAYER
 	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
 
-	CanPass(atom/movable/mover, turf/target) // stolen from window.dm
+	Cross(atom/movable/mover, turf/target) // stolen from window.dm
 		if (mover && mover.throwing & THROW_CHAIRFLIP)
 			return 1
 		if (src.dir == SOUTHWEST || src.dir == SOUTHEAST || src.dir == NORTHWEST || src.dir == NORTHEAST || src.dir == SOUTH || src.dir == NORTH)
@@ -458,7 +458,7 @@ obj/decal/fakeobjects/teleport_pad
 			user.visible_message("<span class='notice'><b>[M]</b> climbs up on [src]!</span>", "<span class='notice'>You climb up on [src].</span>")
 			buckle_in(M, user, 1)
 
-	CanPass(atom/movable/mover, turf/target) // stolen from window.dm
+	Cross(atom/movable/mover, turf/target) // stolen from window.dm
 		if (mover && mover.throwing & THROW_CHAIRFLIP)
 			return 1
 		if (src.dir == SOUTHWEST || src.dir == SOUTHEAST || src.dir == NORTHWEST || src.dir == NORTHEAST || src.dir == SOUTH || src.dir == NORTH)

--- a/code/obj/decal.dm
+++ b/code/obj/decal.dm
@@ -411,12 +411,12 @@ obj/decal/fakeobjects/teleport_pad
 	layer = OBJ_LAYER
 	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
 
-	Cross(atom/movable/mover, turf/target) // stolen from window.dm
+	Cross(atom/movable/mover) // stolen from window.dm
 		if (mover && mover.throwing & THROW_CHAIRFLIP)
 			return 1
 		if (src.dir == SOUTHWEST || src.dir == SOUTHEAST || src.dir == NORTHWEST || src.dir == NORTHEAST || src.dir == SOUTH || src.dir == NORTH)
 			return 0
-		if(get_dir(loc, target) == dir)
+		if(get_dir(loc, mover) == dir)
 
 			return !density
 		else
@@ -458,12 +458,12 @@ obj/decal/fakeobjects/teleport_pad
 			user.visible_message("<span class='notice'><b>[M]</b> climbs up on [src]!</span>", "<span class='notice'>You climb up on [src].</span>")
 			buckle_in(M, user, 1)
 
-	Cross(atom/movable/mover, turf/target) // stolen from window.dm
+	Cross(atom/movable/mover) // stolen from window.dm
 		if (mover && mover.throwing & THROW_CHAIRFLIP)
 			return 1
 		if (src.dir == SOUTHWEST || src.dir == SOUTHEAST || src.dir == NORTHWEST || src.dir == NORTHEAST || src.dir == SOUTH || src.dir == NORTH)
 			return 0
-		if(get_dir(loc, target) == dir)
+		if(get_dir(loc, mover) == dir)
 
 			return !density
 		else

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -1225,7 +1225,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	layer = MOB_LAYER-1
 	icon = 'icons/obj/decals/cleanables.dmi'
 	icon_state = "cobweb_floor-c"
-	event_handler_flags = USE_CANPASS
+
 
 	Cross(atom/A)
 		if (ismob(A))

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -1227,7 +1227,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	icon_state = "cobweb_floor-c"
 	event_handler_flags = USE_CANPASS
 
-	Cross(atom/A, turf/T)
+	Cross(atom/A)
 		if (ismob(A))
 			A.changeStatus("slowed", 0.2 SECONDS)
 			SPAWN_DBG(-1)

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -1227,7 +1227,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	icon_state = "cobweb_floor-c"
 	event_handler_flags = USE_CANPASS
 
-	CanPass(atom/A, turf/T)
+	Cross(atom/A, turf/T)
 		if (ismob(A))
 			A.changeStatus("slowed", 0.2 SECONDS)
 			SPAWN_DBG(-1)

--- a/code/obj/decal/tile_edge.dm
+++ b/code/obj/decal/tile_edge.dm
@@ -140,7 +140,7 @@
 	dir = NORTH
 	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			return 1
 		if (get_dir(loc, target) == dir)

--- a/code/obj/decal/tile_edge.dm
+++ b/code/obj/decal/tile_edge.dm
@@ -138,7 +138,7 @@
 	density = 1
 	anchored = 1
 	dir = NORTH
-	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT 
 
 	Cross(atom/movable/mover)
 		if (istype(mover, /obj/projectile))

--- a/code/obj/decal/tile_edge.dm
+++ b/code/obj/decal/tile_edge.dm
@@ -140,10 +140,10 @@
 	dir = NORTH
 	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if (istype(mover, /obj/projectile))
 			return 1
-		if (get_dir(loc, target) == dir)
+		if (get_dir(loc, mover) == dir)
 			return !density
 		else
 			return 1

--- a/code/obj/effects/foam.dm
+++ b/code/obj/effects/foam.dm
@@ -11,7 +11,7 @@
 	layer = OBJ_LAYER + 0.9
 	plane = PLANE_NOSHADOW_BELOW
 	mouse_opacity = 0
-	event_handler_flags = USE_CANPASS
+
 	var/foamcolor
 	var/amount = 3
 	var/expand = 1

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -283,7 +283,7 @@
 
 
 // flockdrones can always move through
-/obj/grille/flock/Cross(atom/movable/mover, turf/target)
+/obj/grille/flock/Cross(atom/movable/mover)
 	. = ..()
 	var/mob/living/critter/flock/drone/drone = mover
 	if(istype(drone) && !drone.floorrunning)

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -283,7 +283,7 @@
 
 
 // flockdrones can always move through
-/obj/grille/flock/CanPass(atom/movable/mover, turf/target)
+/obj/grille/flock/Cross(atom/movable/mover, turf/target)
 	. = ..()
 	var/mob/living/critter/flock/drone/drone = mover
 	if(istype(drone) && !drone.floorrunning)

--- a/code/obj/flock/structure/collector.dm
+++ b/code/obj/flock/structure/collector.dm
@@ -13,7 +13,7 @@
 	/// the tiles its connected to
 	var/list/turf/simulated/floor/feather/connectedto = list()
 
-	event_handler_flags = USE_CANPASS //needed for passthrough
+ //needed for passthrough
 	// drones can pass through this, might change this later, as balance point
 	passthrough = TRUE
 

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -205,7 +205,7 @@
 	takeDamage("mixed", damage)
 	src.visible_message("<span class='alert'>[src] is hit by the blob!/span>")
 
-/obj/flock_structure/Cross(atom/movable/mover, turf/target)
+/obj/flock_structure/Cross(atom/movable/mover)
 	. = ..()
 	var/mob/living/critter/flock/drone/drone = mover
 	if(src.passthrough && istype(drone) && !drone.floorrunning)

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -205,7 +205,7 @@
 	takeDamage("mixed", damage)
 	src.visible_message("<span class='alert'>[src] is hit by the blob!/span>")
 
-/obj/flock_structure/CanPass(atom/movable/mover, turf/target)
+/obj/flock_structure/Cross(atom/movable/mover, turf/target)
 	. = ..()
 	var/mob/living/critter/flock/drone/drone = mover
 	if(src.passthrough && istype(drone) && !drone.floorrunning)

--- a/code/obj/flock/structure/sentinel.dm
+++ b/code/obj/flock/structure/sentinel.dm
@@ -16,7 +16,7 @@
 	var/charge = 0
 	var/powered = FALSE
 
-	event_handler_flags = USE_CANPASS
+
 	// flockdrones can pass through this
 	passthrough = TRUE
 

--- a/code/obj/foamedmetal.dm
+++ b/code/obj/foamedmetal.dm
@@ -10,7 +10,7 @@
 	name = "foamed metal"
 	desc = "A lightweight foamed metal wall."
 	flags = FPRINT | CONDUCT | USEDELAY
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	var/metal = 1		// 1=aluminium, 2=iron
 	gas_impermeable = TRUE
 

--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -517,7 +517,7 @@
 
 		return src.electrocute(user, prb, net, ignore_gloves)
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			if (density)
 				return prob(50)

--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -21,7 +21,7 @@
 	flags = FPRINT | CONDUCT | USEDELAY
 	pressure_resistance = 5*ONE_ATMOSPHERE
 	layer = GRILLE_LAYER
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 
 	New()
 		..()

--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -517,7 +517,7 @@
 
 		return src.electrocute(user, prb, net, ignore_gloves)
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if (istype(mover, /obj/projectile))
 			if (density)
 				return prob(50)

--- a/code/obj/item/device/energy_shield_gen.dm
+++ b/code/obj/item/device/energy_shield_gen.dm
@@ -152,7 +152,7 @@
 	var/broken = 0
 	gas_impermeable = TRUE
 
-	CanPass(atom/A, turf/T)
+	Cross(atom/A, turf/T)
 		if (broken) return 1
 		if (ismob(A)) return 1
 		else return 0

--- a/code/obj/item/device/energy_shield_gen.dm
+++ b/code/obj/item/device/energy_shield_gen.dm
@@ -152,7 +152,7 @@
 	var/broken = 0
 	gas_impermeable = TRUE
 
-	Cross(atom/A, turf/T)
+	Cross(atom/A)
 		if (broken) return 1
 		if (ismob(A)) return 1
 		else return 0

--- a/code/obj/item/device/energy_shield_gen.dm
+++ b/code/obj/item/device/energy_shield_gen.dm
@@ -146,7 +146,7 @@
 	opacity = 0
 	anchored = 1
 	layer=12
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	var/health_max = 10
 	var/health = 10
 	var/broken = 0

--- a/code/obj/machinery/atmos_field.dm
+++ b/code/obj/machinery/atmos_field.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "atmos_field"
 	layer = OBJ_LAYER+0.5
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	gas_impermeable = TRUE
 
 	New()

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -389,7 +389,7 @@ proc/find_ghost_by_key(var/find_key)
 	var/mob/occupant = null
 	anchored = 1.0
 	soundproofing = 10
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	var/obj/machinery/computer/cloning/connected = null
 
 	// In case someone wants a perfectly safe device. For some weird reason.

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -117,7 +117,7 @@
 				return 1
 	return 0
 
-/obj/machinery/door/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+/obj/machinery/door/Cross(atom/movable/mover, turf/target, height=0, air_group=0)
 	//if(air_group) return 0
 	if(istype(mover, /obj/projectile))
 		var/obj/projectile/P = mover

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -6,7 +6,7 @@
 	opacity = 1
 	density = 1
 	flags = FPRINT | ALWAYS_SOLID_FLUID
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	object_flags = BOTS_DIRBLOCK
 	text = "<font color=#D2691E>+"
 	var/secondsElectrified = 0

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -117,8 +117,7 @@
 				return 1
 	return 0
 
-/obj/machinery/door/Cross(atom/movable/mover, turf/target, height=0, air_group=0)
-	//if(air_group) return 0
+/obj/machinery/door/Cross(atom/movable/mover)
 	if(istype(mover, /obj/projectile))
 		var/obj/projectile/P = mover
 		if(P.proj_data.window_pass)

--- a/code/obj/machinery/door/window.dm
+++ b/code/obj/machinery/door/window.dm
@@ -97,13 +97,13 @@
 		close()
 		return 1
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if (istype(mover, /obj/projectile))
 			var/obj/projectile/P = mover
 			if (P.proj_data.window_pass)
 				return 1
 
-		if (get_dir(loc, target) == dir) // Check for appropriate border.
+		if (get_dir(loc, mover) == dir) // Check for appropriate border.
 			if(density && mover && mover.flags & DOORPASS && !src.cant_emag)
 				if (ismob(mover) && mover:pulling && src.bumpopen(mover))
 					// If they're pulling something and the door would open anyway,

--- a/code/obj/machinery/door/window.dm
+++ b/code/obj/machinery/door/window.dm
@@ -18,7 +18,7 @@
 	opacity = 0
 	brainloss_stumble = 1
 	autoclose = 1
-	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT 
 	object_flags = CAN_REPROGRAM_ACCESS
 
 	New()

--- a/code/obj/machinery/door/window.dm
+++ b/code/obj/machinery/door/window.dm
@@ -97,7 +97,7 @@
 		close()
 		return 1
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if (istype(mover, /obj/projectile))
 			var/obj/projectile/P = mover
 			if (P.proj_data.window_pass)

--- a/code/obj/machinery/optable.dm
+++ b/code/obj/machinery/optable.dm
@@ -6,7 +6,7 @@
 	density = 1
 	anchored = 1.0
 	mats = 25
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	var/mob/living/carbon/human/victim = null
 	var/strapped = 0.0
 

--- a/code/obj/machinery/optable.dm
+++ b/code/obj/machinery/optable.dm
@@ -45,7 +45,7 @@
 		qdel(src)
 	return
 
-/obj/machinery/optable/CanPass(atom/movable/O as mob|obj, target as turf)
+/obj/machinery/optable/Cross(atom/movable/O as mob|obj, target as turf)
 	if (!O)
 		return 0
 	if ((O.flags & TABLEPASS || istype(O, /obj/newmeteor)))

--- a/code/obj/machinery/optable.dm
+++ b/code/obj/machinery/optable.dm
@@ -45,7 +45,7 @@
 		qdel(src)
 	return
 
-/obj/machinery/optable/Cross(atom/movable/O as mob|obj, target as turf)
+/obj/machinery/optable/Cross(atom/movable/O as mob|obj)
 	if (!O)
 		return 0
 	if ((O.flags & TABLEPASS || istype(O, /obj/newmeteor)))

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -526,7 +526,7 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 	anchored = 0
 	p_class = 1.2
 	mats = 30
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	var/mob/occupant = null
 	var/homeloc = null
 

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -554,7 +554,7 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 		..()
 		animate_bumble(src, Y1 = 1, Y2 = -1, slightly_random = 0)
 
-	CanPass(atom/movable/O as mob|obj, target as turf, height=0, air_group=0)
+	Cross(atom/movable/O as mob|obj, target as turf, height=0, air_group=0)
 		if (air_group || (height==0))
 			return 1
 		..()

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -620,7 +620,7 @@
 	name = "Permanent Vehicular Forcefield"
 	desc = "A permanent force field that prevents gas, liquids, and vehicles from passing through it."
 
-	CanPass(atom/A, turf/T)
+	Cross(atom/A, turf/T)
 		return ..() && !istype(A,/obj/machinery/vehicle)
 
 /obj/forcefield/energyshield/perma/doorlink

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -620,7 +620,7 @@
 	name = "Permanent Vehicular Forcefield"
 	desc = "A permanent force field that prevents gas, liquids, and vehicles from passing through it."
 
-	Cross(atom/A, turf/T)
+	Cross(atom/A)
 		return ..() && !istype(A,/obj/machinery/vehicle)
 
 /obj/forcefield/energyshield/perma/doorlink

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -427,7 +427,7 @@
 	desc = "A force field that can block various states of matter."
 	icon = 'icons/obj/meteor_shield.dmi'
 	icon_state = "shieldw"
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	var/powerlevel //Stores the power level of the deployer
 	density = 0
 
@@ -591,7 +591,7 @@
 	powerlevel = 2
 	layer = 2.5 //sits under doors if we want it to
 	flags = ALWAYS_SOLID_FLUID
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 
 	proc/setactive(var/a = 0) //this is called in a bunch of diff. door open procs. because the code was messy when i made this and i dont wanna redo door open code
 		if(a)

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -874,7 +874,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	src.gen_secondary.power -= 3
 	return
 
-/obj/machinery/containment_field/CanPass(atom/movable/O as mob|obj, target as turf)
+/obj/machinery/containment_field/Cross(atom/movable/O as mob|obj, target as turf)
 	if(iscarbon(O) && prob(80))
 		shock(O)
 	..()

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -768,7 +768,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	icon_state = "Contain_F"
 	anchored = 1
 	density = 0
-	event_handler_flags = USE_FLUID_ENTER | IMMUNE_SINGULARITY | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER | IMMUNE_SINGULARITY 
 	var/active = 1
 	var/power = 10
 	var/delay = 5

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -874,7 +874,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	src.gen_secondary.power -= 3
 	return
 
-/obj/machinery/containment_field/Cross(atom/movable/O as mob|obj, target as turf)
+/obj/machinery/containment_field/Cross(atom/movable/O as mob|obj)
 	if(iscarbon(O) && prob(80))
 		shock(O)
 	..()

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -240,7 +240,7 @@
 	anchored = 1
 	mats = 25
 	deconstruct_flags = DECON_CROWBAR | DECON_WIRECUTTERS | DECON_MULTITOOL
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	var/mob/occupant = null
 	var/image/image_lid = null
 	var/obj/machinery/power/data_terminal/link = null

--- a/code/obj/morgue.dm
+++ b/code/obj/morgue.dm
@@ -145,7 +145,7 @@
 		src.connected = null
 		. = ..()
 
-/obj/m_tray/CanPass(atom/movable/mover, turf/target)
+/obj/m_tray/Cross(atom/movable/mover, turf/target)
 	if (istype(mover, /obj/item/dummy))
 		return 1
 	else
@@ -389,7 +389,7 @@
 		src.connected = null
 		. = ..()
 
-/obj/c_tray/CanPass(atom/movable/mover, turf/target)
+/obj/c_tray/Cross(atom/movable/mover, turf/target)
 	if (istype(mover, /obj/item/dummy))
 		return 1
 	else

--- a/code/obj/morgue.dm
+++ b/code/obj/morgue.dm
@@ -145,7 +145,7 @@
 		src.connected = null
 		. = ..()
 
-/obj/m_tray/Cross(atom/movable/mover, turf/target)
+/obj/m_tray/Cross(atom/movable/mover)
 	if (istype(mover, /obj/item/dummy))
 		return 1
 	else
@@ -389,7 +389,7 @@
 		src.connected = null
 		. = ..()
 
-/obj/c_tray/Cross(atom/movable/mover, turf/target)
+/obj/c_tray/Cross(atom/movable/mover)
 	if (istype(mover, /obj/item/dummy))
 		return 1
 	else

--- a/code/obj/morgue.dm
+++ b/code/obj/morgue.dm
@@ -137,7 +137,7 @@
 	layer = FLOOR_EQUIP_LAYER1
 	var/obj/morgue/connected = null
 	anchored = 1.0
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 
 	disposing()
 		src.connected?.connected = null
@@ -380,7 +380,7 @@
 	var/obj/crematorium/connected = null
 	anchored = 1.0
 	var/datum/light/light //Only used for tanning beds.
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 
 	disposing()
 		src.connected?.connected = null

--- a/code/obj/rack.dm
+++ b/code/obj/rack.dm
@@ -49,7 +49,7 @@
 		rackbreak()
 		return
 
-/obj/rack/Cross(atom/movable/mover, turf/target)
+/obj/rack/Cross(atom/movable/mover)
 	if (mover.flags & TABLEPASS)
 		return 1
 	else

--- a/code/obj/rack.dm
+++ b/code/obj/rack.dm
@@ -6,7 +6,7 @@
 	flags = FPRINT | NOSPLASH
 	anchored = 1.0
 	desc = "A metal frame used to hold objects. Can be wrenched and made portable."
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	proc/rackbreak()
 		icon_state += "-broken"
 		src.set_density(0)

--- a/code/obj/rack.dm
+++ b/code/obj/rack.dm
@@ -49,7 +49,7 @@
 		rackbreak()
 		return
 
-/obj/rack/CanPass(atom/movable/mover, turf/target)
+/obj/rack/Cross(atom/movable/mover, turf/target)
 	if (mover.flags & TABLEPASS)
 		return 1
 	else

--- a/code/obj/railing.dm
+++ b/code/obj/railing.dm
@@ -8,7 +8,7 @@
 	layer = OBJ_LAYER
 	color = "#ffffff"
 	flags = FPRINT | USEDELAY | ON_BORDER
-	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT 
 	object_flags = HAS_DIRECTIONAL_BLOCKING
 	dir = SOUTH
 	custom_suicide = 1

--- a/code/obj/railing.dm
+++ b/code/obj/railing.dm
@@ -92,7 +92,7 @@
 		..()
 		layerify()
 
-	Cross(atom/movable/O as mob|obj, turf/target)
+	Cross(atom/movable/O as mob|obj)
 		if (O == null)
 			return 0
 		if (!src.density || (O.flags & TABLEPASS && !src.is_reinforced) || istype(O, /obj/newmeteor) || istype(O, /obj/lpt_laser) )

--- a/code/obj/railing.dm
+++ b/code/obj/railing.dm
@@ -92,7 +92,7 @@
 		..()
 		layerify()
 
-	CanPass(atom/movable/O as mob|obj, turf/target)
+	Cross(atom/movable/O as mob|obj, turf/target)
 		if (O == null)
 			return 0
 		if (!src.density || (O.flags & TABLEPASS && !src.is_reinforced) || istype(O, /obj/newmeteor) || istype(O, /obj/lpt_laser) )

--- a/code/obj/sealab_objects.dm
+++ b/code/obj/sealab_objects.dm
@@ -59,7 +59,7 @@
 
 
 //mbc : added dumb layer code to keep perspective intact *most of the time*
-/obj/sea_plant/Cross(atom/A, turf/T)
+/obj/sea_plant/Cross(atom/A)
 	if (ismob(A))
 
 		var/mob/M = A

--- a/code/obj/sealab_objects.dm
+++ b/code/obj/sealab_objects.dm
@@ -59,7 +59,7 @@
 
 
 //mbc : added dumb layer code to keep perspective intact *most of the time*
-/obj/sea_plant/CanPass(atom/A, turf/T)
+/obj/sea_plant/Cross(atom/A, turf/T)
 	if (ismob(A))
 
 		var/mob/M = A

--- a/code/obj/sealab_objects.dm
+++ b/code/obj/sealab_objects.dm
@@ -37,7 +37,7 @@
 	var/database_id = null
 	var/random_color = 1
 	var/drop_type = 0
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 
 	New()
 		..()

--- a/code/obj/shieldgen.dm
+++ b/code/obj/shieldgen.dm
@@ -135,7 +135,7 @@ Shield and graivty well generators
 	density = 1
 	opacity = 0
 	anchored = 1
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	gas_impermeable = TRUE
 
 	New()

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -9,7 +9,7 @@
 	soundproofing = 3
 	throwforce = 50 //ouch
 	can_flip_bust = 1
-	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS | NO_MOUSEDROP_QOL
+	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT  | NO_MOUSEDROP_QOL
 
 	get_desc()
 		. = ..()

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -24,7 +24,7 @@
 			src.UpdateOverlays(null, "barcode")
 
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if(istype(mover, /obj/projectile))
 			return 1
 		return ..()

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -24,7 +24,7 @@
 			src.UpdateOverlays(null, "barcode")
 
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if(istype(mover, /obj/projectile))
 			return 1
 		return ..()

--- a/code/obj/storage/floor_closets.dm
+++ b/code/obj/storage/floor_closets.dm
@@ -34,7 +34,7 @@
 	recalcPClass()
 		p_class = initial(p_class)
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		return 1
 
 /obj/storage/closet/syndi/hidden

--- a/code/obj/storage/floor_closets.dm
+++ b/code/obj/storage/floor_closets.dm
@@ -34,7 +34,7 @@
 	recalcPClass()
 		p_class = initial(p_class)
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		return 1
 
 /obj/storage/closet/syndi/hidden

--- a/code/obj/storage/floor_closets.dm
+++ b/code/obj/storage/floor_closets.dm
@@ -8,7 +8,7 @@
 	soundproofing = 15
 	p_class = 1
 	plane = PLANE_DEFAULT
-	event_handler_flags = USE_CANPASS
+
 
 	close()
 		var/turf/T = get_turf(src)

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -425,7 +425,7 @@
 	alter_health()
 		. = get_turf(src)
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		. = open
 		if (src.is_short)
 			return 0

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -12,7 +12,7 @@
 	name = "storage"
 	desc = "this is a parent item you shouldn't see!!"
 	flags = FPRINT | NOSPLASH | FLUID_SUBMERGE
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS | NO_MOUSEDROP_QOL
+	event_handler_flags = USE_FLUID_ENTER  | NO_MOUSEDROP_QOL
 	icon = 'icons/obj/large_storage.dmi'
 	icon_state = "closed"
 	density = 1

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -425,7 +425,7 @@
 	alter_health()
 		. = get_turf(src)
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		. = open
 		if (src.is_short)
 			return 0

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -311,7 +311,7 @@
 				actions.start(new /datum/action/bar/icon/railing_jump/table_jump(user, src), user)
 		return
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if (!src.density || (mover.flags & TABLEPASS || istype(mover, /obj/newmeteor)) )
 			return 1
 		else

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -311,7 +311,7 @@
 				actions.start(new /datum/action/bar/icon/railing_jump/table_jump(user, src), user)
 		return
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if (!src.density || (mover.flags & TABLEPASS || istype(mover, /obj/newmeteor)) )
 			return 1
 		else

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -6,7 +6,7 @@
 	density = 1
 	anchored = 1.0
 	flags = NOSPLASH
-	event_handler_flags = USE_FLUID_ENTER | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER 
 	layer = OBJ_LAYER-0.1
 	stops_space_move = TRUE
 	mat_changename = 1

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -287,7 +287,7 @@
 			the_text += " ...you can't see through it at all. What kind of idiot made this?"
 		return the_text
 
-	CanPass(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover, turf/target)
 		if(istype(mover, /obj/projectile))
 			var/obj/projectile/P = mover
 			if(P.proj_data.window_pass)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -287,14 +287,14 @@
 			the_text += " ...you can't see through it at all. What kind of idiot made this?"
 		return the_text
 
-	Cross(atom/movable/mover, turf/target)
+	Cross(atom/movable/mover)
 		if(istype(mover, /obj/projectile))
 			var/obj/projectile/P = mover
 			if(P.proj_data.window_pass)
 				return 1
 		if (src.dir == SOUTHWEST || src.dir == SOUTHEAST || src.dir == NORTHWEST || src.dir == NORTHEAST)
 			return 0 //full tile window, you can't move into it!
-		if(get_dir(loc, target) == dir)
+		if(get_dir(loc, mover) == dir)
 
 			return !density
 		else

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -7,7 +7,7 @@
 	stops_space_move = 1
 	dir = 5 //full tile
 	flags = FPRINT | USEDELAY | ON_BORDER | ALWAYS_SOLID_FLUID
-	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT | USE_CANPASS
+	event_handler_flags = USE_FLUID_ENTER | USE_CHECKEXIT 
 	object_flags = HAS_DIRECTIONAL_BLOCKING
 	text = "<font color=#aaf>#"
 	var/health = 30

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -149,7 +149,7 @@ var/obj/item/dummy/click_dummy = new
 				return 0
 	for (var/atom/A in target)
 		if (A.flags & ON_BORDER)
-			if (!A.CanPass(click_dummy, from))
+			if (!A.Cross(click_dummy, from))
 				return 0
 	return 1
 

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -149,7 +149,7 @@ var/obj/item/dummy/click_dummy = new
 				return 0
 	for (var/atom/A in target)
 		if (A.flags & ON_BORDER)
-			if (!A.Cross(click_dummy, from))
+			if (!A.Cross(click_dummy))
 				return 0
 	return 1
 

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1324,18 +1324,18 @@ DEFINE_FLOORS(grasslush/thin,
 	else
 		boutput(user, "Your attack bounces off the foamed metal floor.")
 
-/turf/simulated/floor/Cross(atom/movable/mover, turf/target)
+/turf/simulated/floor/Cross(atom/movable/mover)
 	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
 		if (!( locate(/obj/machinery/mass_driver, src) ))
 			return 0
 	return ..()
 
-/turf/simulated/shuttle/Cross(atom/movable/mover, turf/target,)
+/turf/simulated/shuttle/Cross(atom/movable/mover)
 	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
 		return 0
 	return ..()
 
-/turf/unsimulated/floor/Cross(atom/movable/mover, turf/target)
+/turf/unsimulated/floor/Cross(atom/movable/mover)
 	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
 		if (!( locate(/obj/machinery/mass_driver, src) ))
 			return 0

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1324,18 +1324,18 @@ DEFINE_FLOORS(grasslush/thin,
 	else
 		boutput(user, "Your attack bounces off the foamed metal floor.")
 
-/turf/simulated/floor/CanPass(atom/movable/mover, turf/target)
+/turf/simulated/floor/Cross(atom/movable/mover, turf/target)
 	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
 		if (!( locate(/obj/machinery/mass_driver, src) ))
 			return 0
 	return ..()
 
-/turf/simulated/shuttle/CanPass(atom/movable/mover, turf/target,)
+/turf/simulated/shuttle/Cross(atom/movable/mover, turf/target,)
 	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
 		return 0
 	return ..()
 
-/turf/unsimulated/floor/CanPass(atom/movable/mover, turf/target)
+/turf/unsimulated/floor/Cross(atom/movable/mover, turf/target)
 	if (!src.allows_vehicles && (istype(mover, /obj/machinery/vehicle) && !istype(mover,/obj/machinery/vehicle/tank)))
 		if (!( locate(/obj/machinery/mass_driver, src) ))
 			return 0

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -310,6 +310,7 @@ proc/generate_space_color()
 	if(!RL_Started)
 		RL_Init()
 
+
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	if (!mover)
 		return 1
@@ -334,51 +335,21 @@ proc/generate_space_color()
 							mover.Bump(obstacle, 1)
 							return 0
 
-	//Then, check the turf itself
-	if (!src.CanPass(mover, src))
-		mover.Bump(src, 1)
-		return 0
-
-	//Finally, check objects/mobs to block entry
-	if (src.checkingcanpass > 0)  //dont bother checking unless the turf actually contains a checkable :)
-		for(var/thing in src)
-			var/atom/movable/obstacle = thing
-			if(obstacle == mover) continue
-			if(!mover)	return 0
-			if ((forget != obstacle))
-				if(obstacle.event_handler_flags & USE_CANPASS)
-					if(!obstacle.CanPass(mover, cturf))
-
-						mover.Bump(obstacle, 1)
-						return 0
-				else //cheaper, skip proc call lol lol
-					if (obstacle.density)
-
-						mover.Bump(obstacle,1)
-						return 0
-
 	if (mirrored_physical_zone_created) //checking visual mirrors for blockers if set
 		if (length(src.vis_contents))
 			var/turf/T = locate(/turf) in src.vis_contents
 			if (T)
 				for(var/thing in T)
-
 					var/atom/movable/obstacle = thing
 					if(obstacle == mover) continue
 					if(!mover)	return 0
 					if ((forget != obstacle))
-						if(obstacle.event_handler_flags & USE_CANPASS)
-							if(!obstacle.CanPass(mover, cturf))
+						if(!obstacle.Cross(mover))
+							mover.Bump(obstacle)
+							return 0
 
-								mover.Bump(obstacle, 1)
-								return 0
-						else //cheaper, skip proc call lol lol
-							if (obstacle.density)
+	return ..() //Nothing found to block so return success!
 
-								mover.Bump(obstacle,1)
-								return 0
-
-	return 1 //Nothing found to block so return success!
 
 /turf/Exited(atom/movable/Obj, atom/newloc)
 	//MBC : nothing in the game even uses PrxoimityLeave meaningfully. I'm disabling the proc call here.

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -39,7 +39,6 @@
 	var/can_write_on = 0
 	var/tmp/messy = 0 //value corresponds to how many cleanables exist on this turf. Exists for the purpose of making fluid spreads do less checks.
 	var/tmp/checkingexit = 0 //value corresponds to how many objs on this turf implement checkexit(). lets us skip a costly loop later!
-	var/tmp/checkingcanpass = 0 // "" how many implement canpass()
 	var/tmp/checkinghasproximity = 0
 	var/tmp/neighcheckinghasproximity = 0
 	/// directions of this turf being blocked by directional blocking objects. So we don't need to loop through the entire contents
@@ -516,7 +515,6 @@ proc/generate_space_color()
 	var/old_opacity = src.opacity
 
 	var/old_checkingexit = src.checkingexit
-	var/old_checkingcanpass = src.checkingcanpass
 	var/old_blocked_dirs = src.blocked_dirs
 	var/old_checkinghasproximity = src.checkinghasproximity
 	var/old_neighcheckinghasproximity = src.neighcheckinghasproximity
@@ -590,7 +588,6 @@ proc/generate_space_color()
 
 
 	new_turf.checkingexit = old_checkingexit
-	new_turf.checkingcanpass = old_checkingcanpass
 	new_turf.blocked_dirs = old_blocked_dirs
 	new_turf.checkinghasproximity = old_checkinghasproximity
 	new_turf.neighcheckinghasproximity = old_neighcheckinghasproximity

--- a/code/world.dm
+++ b/code/world.dm
@@ -19,6 +19,7 @@
 	#endif
 
 	area = /area/space
+	movement_mode = TILE_MOVEMENT_MODE
 
 	view = "15x15"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes old legacy CanPass code and slaps shiny new Cross() calls in
Use tile movement mode

will require a followup PR in secrets

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows us to use TILE_MOVEMENT_MODE
