### PR TITLE
Removes RNG from Pathogen Sweat Infection

### DIFF
--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -645,7 +645,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 
 /obj/decal/cleanable/pathogen_sweat
 	name = "weirdly colored sweat"
-	desc = "Ew, better not step in this stuff."
+	desc = "Ew, better not let this stuff touch your skin."
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "floor1"
 	random_icon_states = list("floor1", "floor2", "floor3", "floor4", "floor5", "floor6", "floor7")
@@ -658,8 +658,14 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 
 	Crossed(atom/movable/AM)
 		. = ..()
-		if(prob(4))
-			src.reagents.reaction(AM, TOUCH)
+		if(!ishuman(AM))
+			return
+		var/mob/living/carbon/human/H = AM
+
+		if((!H.shoes && !iscow(H)) || H.lying) //Checks if they arn't wearing shoes or are crawling through the goo.
+			src.reagents.reaction(H, TOUCH)
+		else
+			return
 
 /obj/decal/cleanable/pathogen_cloud
 	name = "disease particles"

--- a/code/obj/decal/cleanable.dm
+++ b/code/obj/decal/cleanable.dm
@@ -650,7 +650,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 	icon_state = "floor1"
 	random_icon_states = list("floor1", "floor2", "floor3", "floor4", "floor5", "floor6", "floor7")
 	color = "#12b828"
-	slippery = 5
+	slippery = 10
 	can_sample = 1
 	sample_reagent = "pathogen"
 	can_dry = 1
@@ -662,7 +662,7 @@ var/list/blood_decal_violent_icon_states = list("floor1", "floor2", "floor3", "f
 			return
 		var/mob/living/carbon/human/H = AM
 
-		if((!H.shoes && !iscow(H)) || H.lying) //Checks if they arn't wearing shoes or are crawling through the goo.
+		if((!H.shoes && !iscow(H)) || H.lying || H.slip()) //Checks if they arn't wearing shoes, are crawling through the goo, or slipped on the goo.
 			src.reagents.reaction(H, TOUCH)
 		else
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEEDBACK]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so instead of having an rng check to have the pathogen sweat apply it's on-touch effect (and, consequently, an infection chance), it instead checks if the user either has shoes on (or is a cow-person) when walking over it, or applies it's on-touch effect if crawled through.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I asked on discord about some of the problems with current patho, and one mention was that it was hard to deal with pathogens, because if you didn't have a full biosuit on all the time, you could randomly be infected. Part of this problem was that the sweat didn't check any kind of protection, unlike the pathogen clouds.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Pathogen sweat goo can now be avoided by walking over it while either wearing shoes or being a cow-person. Don't crawl in it, though. (Pathology is still not enabled)
```
