### PR TITLE
make long range tele scannable, deconstructable, and make it actually work with mechcomp

### DIFF
--- a/code/WorkInProgress/telescope/telescopeMisc.dm
+++ b/code/WorkInProgress/telescope/telescopeMisc.dm
@@ -13,7 +13,6 @@ var/list/magnet_locations = list()
 	flags = FPRINT | CONDUCT | TGUI_INTERACTIVE
 	var/busy = 0
 	layer = 2
-	mats = list("telecrystal"=10, "MET-1"=10, "CON-1"=10)
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 
 	New()

--- a/code/WorkInProgress/telescope/telescopeMisc.dm
+++ b/code/WorkInProgress/telescope/telescopeMisc.dm
@@ -30,16 +30,12 @@ var/list/magnet_locations = list()
 	proc/mechcompsend(var/datum/mechanicsMessage/input)
 		if(!input)
 			return
-		var/place = special_places[input.signal]
-		if(place)
-			lrtsend(place)
+		lrtsend(input.signal)
 
 	proc/mechcomprecieve(var/datum/mechanicsMessage/input)
 		if(!input)
 			return
-		var/place = special_places[input.signal]
-		if(place)
-			lrtrecieve(place)
+		lrtrecieve(input.signal)
 
 	proc/is_good_location(var/place)
 		if(special_places.len)

--- a/code/WorkInProgress/telescope/telescopeMisc.dm
+++ b/code/WorkInProgress/telescope/telescopeMisc.dm
@@ -13,6 +13,8 @@ var/list/magnet_locations = list()
 	flags = FPRINT | CONDUCT | TGUI_INTERACTIVE
 	var/busy = 0
 	layer = 2
+	mats = list("telecrystal"=10, "MET-1"=10, "CON-1"=10)
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Seems like the mechcomp stuff tried to treat the (normal) list of long range tele locations as an associated list with the elements as the key. This did not work.

Now it just directly uses the given element to send it there. I did not see a need to check them, because the lrtsend() and lrtreceive() procs already do that via is_good_location().

Since I felt it would be pretty annoying for both scientists and mechanics to always have to do the stuff in the telesci room, I propose making the long range teleporter both scannable and deconstructable.
I made it so the recipe requires a telecrystal.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
- It's good if features work.
- Having to do all the mechanics contraptions that involve a long range teleporter in telesci is restrictive and annoying.
- I can't really think of any possible abuse cases with long range teles that you couldn't do better with a command teleporter, telesci teleporter, or teleport components.
- It's nice if more things are deconstructable by means that are not explosions, in case people want to do station remodeling.
- experimental wide-range teleporter
<!-- ![image](https://user-images.githubusercontent.com/35579460/141223137-c46dd503-2c08-402a-b4cf-6571f0e4a0c4.png) --!>


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) Long range teleporters are now deconstructable, and their mechcomp integration should now work.
```
