### PR TITLE
Makes strange reagent require a shock to activate

### DIFF
--- a/_std/defines/component_defines.dm
+++ b/_std/defines/component_defines.dm
@@ -152,7 +152,6 @@
 // ---- human signals ----
 
 // ---- mob signals ----
-
 /// When a client logs into a mob
 #define COMSIG_MOB_LOGIN "mob_login"
 /// When a client logs out of a mob
@@ -176,10 +175,11 @@
 #define COMSIG_MOB_GEIGER_TICK "mob_geiger"
 /// on mouseup
 #define COMSIG_MOUSEUP "mouseup"
+/// sent when defibbed status is added to a mob
+#define COMSIG_MOB_SHOCKED_DEFIB "mob_shocked"
 // ---- mob/living signals ----
 /// When a Life tick occurs
 #define COMSIG_LIVING_LIFE_TICK "human_life_tick"
-
 // ---- mob property signals ----
 /// When invisibility of a mob gets updated (old_value)
 #define COMSIG_MOB_PROP_INVISIBILITY "mob_prop_invis"

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1920,8 +1920,6 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 /mob/living/shock(var/atom/origin, var/wattage, var/zone = "chest", var/stun_multiplier = 1, var/ignore_gloves = 0)
 	if (!wattage)
 		return 0
-	if (isdead(src) && !src.bioHolder.HasEffect("resist_electric"))
-		src.setStatus("defibbed", 1.5 SECONDS)
 	var/prot = 1
 
 	var/mob/living/carbon/human/H = null //ughhh sort this out with proper inheritance later
@@ -1964,7 +1962,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 	else if (src.bioHolder.HasEffect("resist_electric"))
 		boutput(src, "<span class='notice'>You feel electricity course through you harmlessly!</span>")
 		return 0
-
+	src.setStatus("defibbed", sqrt(shock_damage) SECONDS)
 	switch(shock_damage)
 		if (0 to 25)
 			playsound(src.loc, "sound/effects/electric_shock.ogg", 50, 1)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1920,7 +1920,8 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 /mob/living/shock(var/atom/origin, var/wattage, var/zone = "chest", var/stun_multiplier = 1, var/ignore_gloves = 0)
 	if (!wattage)
 		return 0
-
+	if (isdead(src) && !src.bioHolder.HasEffect("resist_electric"))
+		src.setStatus("defibbed", 1.5 SECONDS)
 	var/prot = 1
 
 	var/mob/living/carbon/human/H = null //ughhh sort this out with proper inheritance later

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -521,17 +521,24 @@ datum
 			depletion_rate = 0.2
 			value = 28 // 3 3 22
 			viscosity = 0.5
+			on_add()
+				..()
+				if(ismob(src.holder?.my_atom))
+					RegisterSignal(holder.my_atom, COMSIG_MOB_SHOCKED_DEFIB, .proc/revive)
 
-			reaction_mob(var/mob/target, var/method=TOUCH, var/volume_passed)
-				. = ..()
-				if (!volume_passed)
-					return
-				var/mob/living/M = target
+			on_remove()
+				..()
+				UnregisterSignal(holder.my_atom, COMSIG_MOB_SHOCKED_DEFIB)
+			proc/revive(source)
+				var/mob/living/M = source
+				var/volume_passed = M.get_reagent_amount("strange_reagent")
 				if (!iscarbon(M) && !ismobcritter(M))
+					return
+				if (!volume_passed)
 					return
 				if (volume_passed < 1)
 					return
-				if ((method == INGEST || (method == TOUCH && prob(25))) && (isdead(M) || istype(get_area(M),/area/afterlife/bar)))
+				if (isdead(M) || istype(get_area(M),/area/afterlife/bar))
 					var/came_back_wrong = 0
 					if (M.get_brute_damage() + M.get_burn_damage() >= 150)
 						came_back_wrong = 1

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -531,7 +531,7 @@ datum
 				UnregisterSignal(holder.my_atom, COMSIG_MOB_SHOCKED_DEFIB)
 			proc/revive(source)
 				var/mob/living/M = source
-				var/volume_passed = M.get_reagent_amount("strange_reagent")
+				var/volume_passed = holder.get_reagent_amount("strange_reagent")
 				if (!iscarbon(M) && !ismobcritter(M))
 					return
 				if (!volume_passed)

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -489,6 +489,7 @@ CONTAINS:
 		else if (isdead(patient))
 			patient.visible_message("<span class='alert'><b>[patient]</b> doesn't respond at all!</span>")
 			speak("ERROR: Patient is deceased.")
+			patient.setStatus("defibbed", 1.5 SECONDS)
 			return 1
 
 		else
@@ -581,6 +582,8 @@ CONTAINS:
 				patient.changeStatus("weakened", 0.1 SECONDS)
 				patient.force_laydown_standup()
 				patient.remove_stamina(45)
+				if (isdead(patient) && !patient.bioHolder.HasEffect("resist_electric"))
+					patient.setStatus("defibbed", 1.5 SECONDS)
 
 		return 0
 

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -125,10 +125,12 @@
 		icon_state = "heart+"
 		unique = 1
 		maxDuration = 12 SECONDS // Just slightly longer than a defib's charge cycle
-
 		getTooltip()
 			. = "You've been zapped in a way your heart seems to like!<br>You feel more resistant to cardiac arrest, and more likely for subsequent defibrillating shocks to restart your heart if it stops!"
-
+		onAdd(optional=null) // added so strange reagent can be triggered by shocking someone's heart to restart it
+			..()
+			var/mob/M = owner
+			SEND_SIGNAL(M, COMSIG_MOB_SHOCKED_DEFIB)
 	staminaregen
 		id = "staminaregen"
 		name = ""


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes Strange Reagent require a shock that gives the "defibbed" status effect with at minimum 1 unit of the chemical in the body to cause its effects.

Methods i have tested of reviving people include:
Batons, Electric Chairs, Grilles, Defibrillators, Arcfiends, and Buildmode arcflashes

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It seems nice, possibly could allow people to pretend to be Dr. Frankenstein.
also blame yass
![image](https://user-images.githubusercontent.com/64938519/141703764-97755f17-2046-43b6-8c71-ba9cc34c087a.png)



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Skeletonman0
(*)Made Strange Reagent require an electric shock to restart people's hearts.
```
