### PR TITLE
Adds the ability to combine a breathing mask with a clown/mime mask to create a mask with internals

### DIFF
--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -1021,6 +1021,13 @@
 	icon_state = "mime"
 	see_face = 0.0
 
+	attackby(obj/item/W as obj, mob/user as mob)
+		if(istype(W,/obj/item/clothing/mask/breath))
+			user.show_message("You carefully attach the breathing mask onto the underside of your mask.")
+			src.desc = "The charming mask of the mime. Very emotive! A breathing mask has been carefully attached to the underside."
+			src.c_flags|= COVERSMOUTH | MASKINTERNALS
+			qdel(W)
+
 /obj/item/clothing/under/misc/mime
 	name = "mime suit"
 	desc = "The signature striped uniform of the mime. Not necessarily French."

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -151,8 +151,8 @@
 	icon_state = "moustache"
 	item_state = "moustache"
 	see_face = 1
-	
-/obj/item/clothing/mask/moustache/Italian 
+
+/obj/item/clothing/mask/moustache/Italian
 	name = "fake Italian moustache"
 	desc = "For those who can't cut the lasagna."
 	icon_state = "moustache-i"
@@ -289,9 +289,8 @@
 		..()
 		setProperty("meleeprot_head", 4)
 
-
 /obj/item/clothing/mask/clown_hat
-	name = "clown wig and mask"
+	name = "Clown wig and mask"
 	desc = "Clowns are dumb and so are you for even considering wearing this."
 	icon_state = "clown"
 	item_state = "clown_hat"
@@ -313,6 +312,13 @@
 				spam_flag = 0
 			return 1
 		return 0
+
+	attackby(obj/item/W as obj, mob/user as mob)
+		if(istype(W,/obj/item/clothing/mask/breath))
+			user.show_message("You carefully attach the breathing mask onto the underside of your mask.")
+			src.desc = "Clowns are dumb and so are you for even considering wearing this. A breathing mask has been clumsily attached to the underside."
+			src.c_flags|= COVERSMOUTH | MASKINTERNALS
+			qdel(W)
 
 /obj/item/clothing/mask/gas/syndie_clown
 	name = "clown wig and mask"


### PR DESCRIPTION
<!-- [BALANCE] [QOL] -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds functionality for putting a breathing mask into a mime/clown mask to act as a mask with internals. They do not start with them. Ideally will make it less restrictive to play the jobs. They still have their thematic handicaps, such as the mime cannot speak, and the clown is clumsy, etc. Honestly, this wouldn't even really affect much balance wise, would just let the players not have to spend a portion of their round just getting countermeasures to not being able to have internals. Not exactly many clowns and mimes, after all.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While this is pretty hotly debated, I think generally people would like to be able to play the roles they most enjoy without having to be so handicapped they have to spend a significant amount of time just making counter measures to survive depressurization or gas leaks/floods. I know I'm tired of having to do a niche mechanic of suiciding to get through a gas flood as a Mime.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)MomoBerry
(+)Clowns and Mimes can now combine a breathing mask with their own to create a mask with internals.
```
