### PR TITLE
Fixed the door and changed some pixels.

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -36072,11 +36072,11 @@
 "kut" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger{
-	pixel_x = -13;
+	pixel_x = -8;
 	pixel_y = 5
 	},
 /obj/machinery/recharger{
-	pixel_x = 6;
+	pixel_x = 10;
 	pixel_y = 5
 	},
 /turf/simulated/floor/black,
@@ -69349,6 +69349,8 @@
 	},
 /obj/disposalpipe/segment/ejection,
 /obj/firedoor_spawn,
+/obj/decal/mule/dropoff,
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "ucZ" = (


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR is made purely to fix mistakes that went unnoticed in the previous one, where I added a Solitary cell to security on donut3 and a round table (https://github.com/goonstation/goonstation/pull/5436). Specifically, the new Solitary door lacking an access spawn, and also one of those hazard decals that every other door has. On top of this, I shifted the recharger sprites to the right a few pixels since they overlapped with the printer and it was mildly annoying to look at.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

To fix quite an important thing, and a not-so important thing.
