### PR TITLE
make it possible to get brains from all polymorph critters

### DIFF
--- a/code/datums/abilities/wizard/animal.dm
+++ b/code/datums/abilities/wizard/animal.dm
@@ -86,6 +86,7 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/mous
 
 				H.unequip_all()
 				var/mob/living/critter/C = H.make_critter(pick(animal_spell_critter_paths))
+				C.butcherable = 1 // we would like the brain to be recoverable, please
 				if (istype(C, /mob/living/critter/small_animal/bee))
 					var/mob/living/critter/small_animal/bee/B = C
 					B.non_admin_bee_allowed = 1

--- a/code/mob/living/critter/spider.dm
+++ b/code/mob/living/critter/spider.dm
@@ -299,6 +299,7 @@
 					var/turf/T = get_edge_target_turf(I, pick(alldirs))
 					if (T)
 						I.throw_at(T, 12, 3)
+			src.organHolder.drop_and_throw_organ("brain")
 			src.gib(1)
 
 	cluwne


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Some of the critters (seals, walrus, possibly others) had butcherable set to 0, so you could not butcher them, making it impossible to get their brains to clone or borg them.

Clownspiders just popped when they died, not dropping their brains.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's good for it to be consistent that polymorphed critters can be cloned or borged, instead of it being RNG.
