### PR TITLE
fix autocapitalization option for AEyes

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -652,6 +652,21 @@
 			else
 				src.emote("handpuppet")
 
+/// returns true if first letter of things that person says should be capitalized
+/mob/living/proc/capitalize_speech()
+	if (!client)
+		return FALSE
+	if (!client.preferences)
+		return FALSE
+	. = src.client.preferences.auto_capitalization
+
+/// special behavior for AIs to make sure it still works in eyecam form
+/mob/living/silicon/ai/capitalize_speech()
+	if (!client)
+		if (src?.eyecam?.client?.preferences)
+			return src.eyecam.client.preferences
+	. = ..()
+
 /mob/living/say(var/message, ignore_stamina_winded)
 	message = strip_html(trim(copytext(sanitize_noencode(message), 1, MAX_MESSAGE_LEN)))
 
@@ -806,7 +821,7 @@
 	if (!message)
 		return
 
-	if(src?.client?.preferences.auto_capitalization)
+	if(src.capitalize_speech())
 		message = capitalize(message)
 
 	if (src.voice_type && world.time > last_voice_sound + 8)

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -77,7 +77,11 @@
 	set name = "say_main_radio"
 	set hidden = 1
 	var/text = input("", "Speaking on the main radio frequency") as null|text
-	if (client.preferences.auto_capitalization)
+	var/capitalize = client ? client.preferences.auto_capitalization : FALSE
+	if (!client && istype(src, /mob/living/silicon/ai))
+		var/mob/living/silicon/ai/src_ai = src
+		capitalize = src_ai.eyecam.client.preferences.auto_capitalization
+	if (capitalize)
 		var/i = 1
 		while (copytext(text, i, i+1) == " ")
 			i++

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -77,11 +77,7 @@
 	set name = "say_main_radio"
 	set hidden = 1
 	var/text = input("", "Speaking on the main radio frequency") as null|text
-	var/capitalize = client ? client.preferences.auto_capitalization : FALSE
-	if (!client && istype(src, /mob/living/silicon/ai))
-		var/mob/living/silicon/ai/src_ai = src
-		capitalize = src_ai.eyecam.client.preferences.auto_capitalization
-	if (capitalize)
+	if (src.capitalize_speech())
 		var/i = 1
 		while (copytext(text, i, i+1) == " ")
 			i++
@@ -133,8 +129,7 @@
 			boutput(src, "Somehow '[choice]' didn't match anything. Welp. Probably busted.")
 		var/text = input("", "Speaking over [choice] ([token])") as null|text
 		if (text)
-
-			if(src?.client?.preferences.auto_capitalization)
+			if (src.capitalize_speech())
 				text = capitalize(text)
 
 			src.say_verb(token + " " + text)
@@ -170,7 +165,7 @@
 			token = ":" + R.secure_frequencies[choice_index - 1]
 
 		var/text = input("", "Speaking to [choice] frequency") as null|text
-		if (client.preferences.auto_capitalization)
+		if (src.capitalize_speech())
 			var/i = 1
 			while (copytext(text, i, i+1) == " ")
 				i++


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The option that automatically capitalizes the first letter of your messages wasn't working for AEyes, since their client was in the ghost and not their mainframe.

This also caused a runtime on the new say_main_radio verb, so this also fixes #6658 .


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
it's good if features work
