### PR TITLE
Adds Missing Fire Extinguishers to Cyborg Modules

### DIFF
--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -30,6 +30,7 @@
 		/obj/item/device/camera_viewer,
 		/obj/item/hand_labeler,
 		/obj/item/device/ticket_writer,
+		/obj/item/extinguisher, // TODO: make large version
 	)
 
 // scientist.
@@ -151,6 +152,7 @@
 		/obj/item/reagent_containers/glass/beaker/large,
 		/obj/item/reagent_containers/glass/beaker/large,
 		/obj/item/reagent_containers/dropper,
+		/obj/item/extinguisher, // TODO: make large version
 	)
 
 // miner.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a fire extinguisher to the brobocop and medical cyborg modules


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bit odd that some cyborg modules that don't necessarily deal with fighting fires (such as the mining module and arguably the civilian module) do have fire extinguisher and modules that encounter them more (such as medical and security) don't.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)Added a fire extinguisher to the brobocop and medical cyborg modules
```
