### PR TITLE
fix some name changes not updating nameplates

### DIFF
--- a/code/datums/gamemodes/mixed.dm
+++ b/code/datums/gamemodes/mixed.dm
@@ -272,7 +272,6 @@
 						if (length(newname) >= 26) newname = copytext(newname, 1, 26)
 						newname = strip_html(newname)
 						traitor.current.real_name = newname
-						traitor.current.name = newname
 						traitor.current.UpdateName()
 
 			if (ROLE_WRAITH)

--- a/code/datums/gamemodes/mixed.dm
+++ b/code/datums/gamemodes/mixed.dm
@@ -273,6 +273,7 @@
 						newname = strip_html(newname)
 						traitor.current.real_name = newname
 						traitor.current.name = newname
+						traitor.current.UpdateName()
 
 			if (ROLE_WRAITH)
 				generate_wraith_objectives(traitor)

--- a/code/datums/gamemodes/wizard.dm
+++ b/code/datums/gamemodes/wizard.dm
@@ -97,6 +97,7 @@
 				newname = strip_html(newname)
 				wizard.current.real_name = newname
 				wizard.current.name = newname
+				wizard.current.UpdateName()
 
 	SPAWN_DBG (rand(waittime_l, waittime_h))
 		send_intercept()

--- a/code/datums/gamemodes/wizard.dm
+++ b/code/datums/gamemodes/wizard.dm
@@ -96,7 +96,6 @@
 				if (length(newname) >= 26) newname = copytext(newname, 1, 26)
 				newname = strip_html(newname)
 				wizard.current.real_name = newname
-				wizard.current.name = newname
 				wizard.current.UpdateName()
 
 	SPAWN_DBG (rand(waittime_l, waittime_h))

--- a/code/mob/living/critter/martian.dm
+++ b/code/mob/living/critter/martian.dm
@@ -65,6 +65,7 @@
 			if (newname)
 				if (length(newname) >= 26) newname = copytext(newname, 1, 26)
 				src.real_name = strip_html(newname)
+				src.UpdateName()
 
 	say(message, involuntary = 0)
 		message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -506,7 +506,7 @@ var/global/list/module_editors = list()
 				phrase_log.log_phrase("name-cyborg", newname, no_duplicates=TRUE)
 		if (!newname)
 			src.real_name = borgify_name("Robot")
-			src.name = src.real_name
+			src.UpdateName()
 			return
 		else
 			newname = strip_html(newname, MOB_NAME_MAX_LENGTH, 1)
@@ -516,7 +516,6 @@ var/global/list/module_editors = list()
 			else
 				if (alert(src, "Use the name [newname]?", newname, "Yes", "No") == "Yes")
 					src.real_name = newname
-					src.name = newname
 					src.UpdateName()
 					return 1
 				else

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -517,6 +517,7 @@ var/global/list/module_editors = list()
 				if (alert(src, "Use the name [newname]?", newname, "Yes", "No") == "Yes")
 					src.real_name = newname
 					src.name = newname
+					src.UpdateName()
 					return 1
 				else
 					continue

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2199,6 +2199,7 @@ proc/get_mobs_trackable_by_AI()
 			src.name = src.real_name
 			src.internal_pda.name = "[src]'s Internal PDA Unit"
 			src.internal_pda.owner = "[src]"
+			src.UpdateName()
 			return
 		else
 			newname = strip_html(newname, MOB_NAME_MAX_LENGTH, 1)
@@ -2214,6 +2215,7 @@ proc/get_mobs_trackable_by_AI()
 					src.name = newname
 					src.internal_pda.name = "[src]'s Internal PDA Unit"
 					src.internal_pda.owner = "[src]"
+					src.UpdateName()
 					return 1
 				else
 					continue

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2196,7 +2196,6 @@ proc/get_mobs_trackable_by_AI()
 			return
 		if (!newname)
 			src.real_name = default_name
-			src.name = src.real_name
 			src.internal_pda.name = "[src]'s Internal PDA Unit"
 			src.internal_pda.owner = "[src]"
 			src.UpdateName()
@@ -2212,7 +2211,6 @@ proc/get_mobs_trackable_by_AI()
 			else
 				if (alert(src, "Use the name [newname]?", newname, "Yes", "No") == "Yes")
 					src.real_name = newname
-					src.name = newname
 					src.internal_pda.name = "[src]'s Internal PDA Unit"
 					src.internal_pda.owner = "[src]"
 					src.UpdateName()

--- a/code/mob/living/silicon/hivebot/mainframe.dm
+++ b/code/mob/living/silicon/hivebot/mainframe.dm
@@ -151,3 +151,4 @@
 		newname = strip_html(newname)
 		src.real_name = newname
 		src.name = newname
+		src.UpdateName()

--- a/code/mob/living/silicon/hivebot/mainframe.dm
+++ b/code/mob/living/silicon/hivebot/mainframe.dm
@@ -150,5 +150,4 @@
 			newname = copytext(newname, 1, 26)
 		newname = strip_html(newname)
 		src.real_name = newname
-		src.name = newname
 		src.UpdateName()

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -706,7 +706,7 @@
 					phrase_log.log_phrase("name-cyborg", newname, no_duplicates=TRUE)
 			if (!newname)
 				src.real_name = borgify_name("Cyborg")
-				src.name = src.real_name
+				src.UpdateName()
 				src.internal_pda.name = "[src]'s Internal PDA Unit"
 				src.internal_pda.owner = "[src]"
 				return
@@ -721,7 +721,6 @@
 				else
 					if (alert(src, "Use the name [newname]?", newname, "Yes", "No") == "Yes")
 						src.real_name = newname
-						src.name = newname
 						src.internal_pda.name = "[src]'s Internal PDA Unit"
 						src.internal_pda.owner = "[src]"
 						src.UpdateName()
@@ -730,7 +729,7 @@
 						continue
 		if (!newname)
 			src.real_name = borgify_name("Cyborg")
-			src.name = src.real_name
+			src.UpdateName()
 			src.internal_pda.name = "[src.name]'s Internal PDA Unit"
 			src.internal_pda.owner = "[src]"
 
@@ -742,7 +741,7 @@
 
 		if (src.real_name == "Cyborg")
 			src.real_name = borgify_name(src.real_name)
-			src.name = src.real_name
+			src.UpdateName()
 			src.internal_pda.name = "[src.name]'s Internal PDA Unit"
 			src.internal_pda.owner = "[src]"
 		if (!src.syndicate && !src.connected_ai)
@@ -753,7 +752,7 @@
 
 		if (src.shell && src.mainframe)
 			src.real_name = "SHELL/[src.mainframe]"
-			src.name = src.real_name
+			src.UpdateName()
 
 		update_clothing()
 		update_appearance()

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -724,6 +724,7 @@
 						src.name = newname
 						src.internal_pda.name = "[src]'s Internal PDA Unit"
 						src.internal_pda.owner = "[src]"
+						src.UpdateName()
 						return 1
 					else
 						continue


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Some of the jobs and beings that can update their name when coming into existence did not update their name plates properly.
Hopefully at some point we can make this all be under the main mob/choose_name() proc, not sure if that is viable with different special behaviors, but in the meantime people should be able to enjoy their nameplates.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's good if features work properly.
fixes #6656