### PR TITLE
Only list human richest/damaged escapees

### DIFF
--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -233,6 +233,8 @@ var/datum/score_tracker/score_tracker
 		richest_total = 0
 		//search mobs in centcom
 		for (var/mob/M in mobs)
+			if (!ishuman(M))
+				continue
 			if(in_centcom(M))
 				if (!most_damaged_escapee)
 					most_damaged_escapee = M


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Only counts humans for most damaged and richest escapee.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ghosts and critters were being counted.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Most damaged and richest escapee now only tracks humans.
```
