### PR TITLE
Battle Royale mode tweaks

### DIFF
--- a/browserassets/html/traitorTips/battleTips.html
+++ b/browserassets/html/traitorTips/battleTips.html
@@ -4,7 +4,7 @@
 
 	<p>1. <em>Your goal</em> is to defeat all other battlers and be the last one standing!<br>
 	<p>2. If it is the start of the round you are on the <em>BATTLE SHUTTLE</em>! Jump out of the <em>BATTLE SHUTTLE</em> to land somewhere on the station!</p>
-	<p>3. Useful things have been hidden around the station. Rummage around in lockers and closets and see what you can find!</p>
+	<p>3. Useful things have been hidden around the station. Rummage around in lockers and crates to see what you can find!</p>
 	<p>4. Deadly <em>Battle Storms</em> occasionally ravage the station. Get to the listed areas or perish in the fire!</p>
 	<p>5. Supply drops regularly occur in random areas. Find the airdropped lootcrates for random items with special stats to help you win.</p>
 </div>

--- a/browserassets/html/traitorTips/battleTips.html
+++ b/browserassets/html/traitorTips/battleTips.html
@@ -2,7 +2,9 @@
 <div class="traitor-tips">
 	<h1 class="center">Its a Battle Royale!</h1>
 
-	<p>1. <em>Your goal</em> is to defeat all other battlers and be the last one standing!<br>			
+	<p>1. <em>Your goal</em> is to defeat all other battlers and be the last one standing!<br>
 	<p>2. If it is the start of the round you are on the <em>BATTLE SHUTTLE</em>! Jump out of the <em>BATTLE SHUTTLE</em> to land somewhere on the station!</p>
-	<p>3. Useful things have been hidden around the station. Rummage around and see what you can find!</p>
+	<p>3. Useful things have been hidden around the station. Rummage around in lockers and closets and see what you can find!</p>
+	<p>4. Deadly <em>Battle Storms</em> occasionally ravage the station. Get to the listed areas or perish in the fire!</p>
+	<p>5. Supply drops regularly occur in random areas. Find the airdropped lootcrates for random items with special stats to help you win.</p>
 </div>

--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -5,12 +5,12 @@
 var/global/area/current_battle_spawn = null
 var/global/list/datum/mind/battle_pass_holders = list()
 
-#define TIME_BETWEEN_SHUTTLE_MOVES 50
-#define MAX_TIME_ON_SHUTTLE 1 * 60 * 10
-#define MIN_TIME_BETWEEN_STORMS 4 * 60 * 10
-#define MAX_TIME_BETWEEN_STORMS 8 * 60 * 10
-#define MIN_TIME_BETWEEN_SUPPLY_DROPS 1 * 60 * 10
-#define MAX_TIME_BETWEEN_SUPPLY_DROPS 3 * 60 * 10
+#define TIME_BETWEEN_SHUTTLE_MOVES 5 SECONDS
+#define MAX_TIME_ON_SHUTTLE 60 SECONDS
+#define MIN_TIME_BETWEEN_STORMS 240 SECONDS
+#define MAX_TIME_BETWEEN_STORMS 480 SECONDS
+#define MIN_TIME_BETWEEN_SUPPLY_DROPS 60 SECONDS
+#define MAX_TIME_BETWEEN_SUPPLY_DROPS 180 SECONDS
 
 
 /datum/game_mode/battle_royale
@@ -139,7 +139,8 @@ var/global/list/datum/mind/battle_pass_holders = list()
 	// Is it time for a storm
 	if(src.next_storm < world.time)
 		src.next_storm = world.time + rand(MIN_TIME_BETWEEN_STORMS,MAX_TIME_BETWEEN_STORMS)
-		SPAWN_DBG(storm.event_effect())
+		storm.event_effect()
+		SPAWN_DBG(85 SECONDS)
 			var/you_died_good_work = recently_deceased.len > 0 ? "The following players recently died: " : ""
 			for(var/datum/mind/M in recently_deceased)
 				you_died_good_work += " [M.current.name],"
@@ -155,6 +156,10 @@ var/global/list/datum/mind/battle_pass_holders = list()
 // Does what it says on the tin
 proc/hide_weapons_everywhere()
 	boutput(world, "<span class='notice'>Now hiding a shitton of goodies on the [station_or_ship()]. Please be patient!</span>")
+	// Kill sec lockers because it's free armor that makes them too much of a no brainer
+	for_by_tcl(S, /obj/storage)
+		if(istype(S, /obj/storage/secure/closet/security/equipment))
+			qdel(S)
 	// Im stealing the list of items from the surplus crate so this check needs to happen
 	if(!syndi_buylist_cache)
 		build_syndi_buylist_cache()

--- a/code/modules/events/battle_storm.dm
+++ b/code/modules/events/battle_storm.dm
@@ -29,21 +29,18 @@
 			safe_areas.Add(safe_locations[temp])
 			safe_locations[temp].icon_state = "blue"
 
-		var/timetoreachsec = rand(30,45)
-		var/actualtime = timetoreachsec * 10
-
 		for (var/mob/N in mobs) // why N?  why not M?
 			N.flash(3 SECONDS)
 		var/sound/siren = sound('sound/misc/airraid_loop_short.ogg')
-		siren.repeat = 0
+		siren.repeat = TRUE
 		siren.channel = 5
 		siren.volume = 50 // wire note: lets not deafen players with an air raid siren
 		world << siren
-		command_alert("A BATTLE STORM is approaching the [station_or_ship()]! Impact in [timetoreachsec] seconds. You will take large amounts of damage unless you are standing in [get_battle_area_names(safe_area_names)]!", "BATTLE STORM INCOMING")
+		command_alert("A BATTLE STORM is approaching the [station_or_ship()]! Impact in 60 seconds. You will take large amounts of damage unless you are standing in [get_battle_area_names(safe_area_names)]!", "BATTLE STORM INCOMING")
 
-		SPAWN_DBG(actualtime)
+		SPAWN_DBG(60 SECONDS)
 
-			siren.repeat = 0
+			siren.repeat = FALSE
 			siren.channel = 5
 			siren.volume = 50
 

--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -22,6 +22,11 @@
 				new/obj/effect/supplymarker(pick(turfs), preDropTime)
 		for(var/datum/mind/M in battle_pass_holders)
 			boutput(M.current, "<span class='notice'>A supply drop will happen soon in the [A.name]</span>")
+		SPAWN_DBG(20 SECONDS)
+			for(var/datum/mind/M in ticker.minds)
+				if (M in battle_pass_holders)
+					continue
+				boutput(M.current, "<span class='notice'>A supply drop occured in [A.name]</span>!")
 
 /obj/effect/supplymarker
 	name = ""


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][BUG][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the Battle Storm ended message showing as soon as the storm starts.
Sets the delay before Battle Storm at a fixed 60 seconds.
Loops the Battle Storm siren sound to make it more obvious you are in danger.
Tells everyone loot crates dropped 20 seconds after battlepass holders.
Adds some more advice to the popup tips.
Removes security equipment lockers

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Players weren't that good at avoiding Battle Storms despite their risk. They are now better communicated and have 15 seconds longer to get to safety.
Loot crates were relatively invisible to anyone without a battle pass unless you stumble across them.
Security lockers were a no brainer to get hold of strong armor and a flash at the start of the round.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Battle Royale tweaks: Fixed the bugged Battle Storm ended message in BR. Raised and set storm warning period at 60 seconds. Removed security lockers.
```
