### PR TITLE
Renames the item path of the hos uniform and the dirty vest.

### DIFF
--- a/code/WorkInProgress/rewardsLocker.dm
+++ b/code/WorkInProgress/rewardsLocker.dm
@@ -687,7 +687,7 @@
 			var/mob/living/carbon/human/H = activator
 			if (H.w_uniform)
 				var/obj/item/clothing/under/rank/M = H.w_uniform
-				if (istype(M, /obj/item/clothing/under/rank/head_of_securityold))
+				if (istype(M, /obj/item/clothing/under/rank/head_of_security))
 					M.icon_state = "hos-old"
 					H.set_clothing_icon_dirty()
 					return 1

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -255,7 +255,7 @@ ABSTRACT_TYPE(/datum/job/command)
 
 
 #ifdef SUBMARINE_MAP
-	slot_jump = list(/obj/item/clothing/under/rank/head_of_securityold/fancy_alt)
+	slot_jump = list(/obj/item/clothing/under/rank/head_of_security/fancy_alt)
 	slot_suit = list(/obj/item/clothing/suit/armor/vest)
 	slot_back = list(/obj/item/storage/backpack/security)
 	slot_belt = list(/obj/item/device/pda2/hos)
@@ -272,7 +272,7 @@ ABSTRACT_TYPE(/datum/job/command)
 	slot_belt = list(/obj/item/device/pda2/hos)
 	slot_poc1 = list(/obj/item/requisition_token/security)
 	slot_poc2 = list(/obj/item/storage/security_pouch) //replaces sec starter kit
-	slot_jump = list(/obj/item/clothing/under/rank/head_of_securityold)
+	slot_jump = list(/obj/item/clothing/under/rank/head_of_security)
 	slot_suit = list(/obj/item/clothing/suit/armor/vest)
 	slot_foot = list(/obj/item/clothing/shoes/swat)
 	slot_head = list(/obj/item/clothing/head/hos_hat)

--- a/code/mob/living/carbon/human/gimmick.dm
+++ b/code/mob/living/carbon/human/gimmick.dm
@@ -381,7 +381,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 		..()
 		START_TRACKING_CAT(TR_CAT_SHITTYBILLS)
 		src.equip_new_if_possible(/obj/item/clothing/shoes/brown, slot_shoes)
-		src.equip_new_if_possible(/obj/item/clothing/under/misc/head_of_security, slot_w_uniform)
+		src.equip_new_if_possible(/obj/item/clothing/under/misc/dirty_vest, slot_w_uniform)
 		src.equip_new_if_possible(/obj/item/paper/postcard/owlery, slot_l_hand)
 		//src.equip_new_if_possible(/obj/item/device/radio/headset/civilian, slot_ears)
 		//src.equip_new_if_possible(/obj/item/clothing/suit, slot_wear_suit)

--- a/code/modules/economy/traders/josh.dm
+++ b/code/modules/economy/traders/josh.dm
@@ -101,7 +101,7 @@
 
 /datum/commodity/trader/josh/hosuniform
 	comname = "HoS' Uniform"
-	comtype = /obj/item/clothing/under/rank/head_of_securityold
+	comtype = /obj/item/clothing/under/rank/head_of_security
 	price_boundary = list(700,7000)
 	possible_names = list("I'm going to a fancy party tonight. Got a slick nasty security uniform for me?",
 	"Got a spare uniform from the HoS? They're fancy as heck.")

--- a/code/modules/vending/clothingbooth_items.dm
+++ b/code/modules/vending/clothingbooth_items.dm
@@ -241,7 +241,7 @@ ABSTRACT_TYPE(/datum/clothingbooth_item/casual)
 
 /datum/clothingbooth_item/casual/dirtyvest
 	name = "Dirty Tank Top Vest"
-	path = /obj/item/clothing/under/misc/head_of_security
+	path = /obj/item/clothing/under/misc/dirty_vest
 
 /datum/clothingbooth_item/casual/bandshirt
 	name = "Band Shirt"

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -319,7 +319,7 @@
 	dress
 		icon_state = "hop-dress"
 
-/obj/item/clothing/under/rank/head_of_securityold
+/obj/item/clothing/under/rank/head_of_security
 	name = "head of security's uniform"
 	desc = "It's bright red and rather crisp, much like security's victims tend to be."
 	icon_state = "hos"
@@ -341,7 +341,7 @@
 		icon_state = "hos-fancy-alt"
 		item_state = "hos-fancy-alt"
 
-/obj/item/clothing/under/misc/head_of_security
+/obj/item/clothing/under/misc/dirty_vest //HoS uniform from the Elite Security era
 	name = "dirty vest"
 	desc = "This outfit has seen better days."
 	icon_state = "vest"

--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -18,11 +18,11 @@
 
 /obj/item/storage/box/clothing/hos
 	name = "\improper Head of Security's clothing"
-	spawn_contents = list(/obj/item/clothing/under/rank/head_of_securityold,
-	/obj/item/clothing/under/rank/head_of_securityold/dress,
+	spawn_contents = list(/obj/item/clothing/under/rank/head_of_security,
+	/obj/item/clothing/under/rank/head_of_security/dress,
 	/obj/item/clothing/under/suit/hos,
 	/obj/item/clothing/under/suit/hos/dress,
-	/obj/item/clothing/under/rank/head_of_securityold/fancy,
+	/obj/item/clothing/under/rank/head_of_security/fancy,
 	/obj/item/clothing/suit/wintercoat/command)
 
 /obj/item/storage/box/clothing/hop

--- a/code/obj/storage/wardrobes.dm
+++ b/code/obj/storage/wardrobes.dm
@@ -170,7 +170,7 @@
 	spawn_contents = list(/obj/item/clothing/shoes/brown = 4,
 	/obj/item/clothing/under/color/red,
 	/obj/item/clothing/under/gimmick/police,
-	/obj/item/clothing/under/misc/head_of_security,
+	/obj/item/clothing/under/misc/dirty_vest,
 	/obj/item/clothing/under/misc/tourist,
 	/obj/item/clothing/under/misc/tourist/max_payne,
 	/obj/item/clothing/under/misc/serpico,


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title says it all.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Well the head of security uniform isn't exactly the old one anymore since it's used by current Heads of Security. The dirty vest having the path is merely confusing when looking into the code. So this should help out a little bit.