### PR TITLE
fix who-list formatting with highlighting

### DIFF
--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -346,7 +346,6 @@ img.emoji {
 h1.alert, h2.alert {color: #000000;}
 .bigPM {font-size: 1.2em;}
 .adminHearing .name[data-ctx] {border-bottom: 1px dotted black;}
-.highlight {background: yellow;}
 .blobalert {color: #4c00ff; font-size: 1.5em; font-weight: bold;}
 
 .rstandard {color: #008000;}
@@ -378,6 +377,11 @@ h1.alert, h2.alert {color: #000000;}
 .who-list span, .who-list a {
 	display: inline-block;
 	margin-right: 10px;
+}
+.highlight {
+	background: yellow;
+	margin-left: 0px !important;
+	margin-right: 0px !important;
 }
 
 /* bog-standard dark theme with easy, unsaturated colors */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #6686 
The <span> for the highlighting inherited the margin-right: 10px of the who-list div above it.
I tried to make the highlighting thing more specific so it would take priority, but I failed. So now I made it !important, so it would work!

If anyone who is actually competent in this css stuff knows a better solution, please comment.^^
