### PR TITLE
Make ling absorb add the target to the transformation list at the START of the action

### DIFF
--- a/code/modules/antagonists/changeling/abilities/absorb.dm
+++ b/code/modules/antagonists/changeling/abilities/absorb.dm
@@ -149,10 +149,17 @@
 
 		var/mob/ownerMob = owner
 		target.vamp_beingbitten = 1
-		ownerMob.show_message("<span class='notice'>We must hold still...</span>", 1)
 
 		if (isliving(target))
 			target:was_harmed(owner, special = "ling")
+
+		var/datum/abilityHolder/changeling/C = devour.holder
+		if (istype(C))
+			C.addDna(target)
+			var/datum/bioHolder/originalBHolder = new/datum/bioHolder(target)
+			originalBHolder.CopyOther(target.bioHolder)
+			C.absorbed_dna[target.real_name] = originalBHolder
+			ownerMob.show_message("<span class='notice'>We can now transform into [target.real_name], we must hold still...</span>", 1)
 
 	onEnd()
 		..()

--- a/code/modules/antagonists/changeling/abilities/absorb.dm
+++ b/code/modules/antagonists/changeling/abilities/absorb.dm
@@ -155,7 +155,6 @@
 
 		var/datum/abilityHolder/changeling/C = devour.holder
 		if (istype(C))
-			C.addDna(target)
 			var/datum/bioHolder/originalBHolder = new/datum/bioHolder(target)
 			originalBHolder.CopyOther(target.bioHolder)
 			C.absorbed_dna[target.real_name] = originalBHolder


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently when ling absorb finishes you receive DNA points, they get turned into a husk, they get moved to your hivemind and their bioHolder gets added to your list of transformation targets. This PR moves the last of those things to the **start** of the action instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being able to transform into people without killing them could provide some good RP opportunities. Also this way you get a consolation prize if your absorption gets interrupted.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)pali
(*)Changeling absorb ability now adds a the person to your list of transformation targets immediately, no matter whether you finish the absorption or not
```
