### PR TITLE
Increase max blob count to 4

### DIFF
--- a/code/datums/gamemodes/blob.dm
+++ b/code/datums/gamemodes/blob.dm
@@ -4,7 +4,7 @@
 	shuttle_available = 2
 
 	var/const/blobs_minimum = 2
-	var/const/blobs_possible = 3
+	var/const/blobs_possible = 4
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 	var/finish_counter = 0
@@ -26,7 +26,7 @@
 			num_players++
 
 	var/i = rand(-5, 0)
-	var/num_blobs = max(2, min(round((num_players + i) / 20), blobs_possible))
+	var/num_blobs = clamp(round((num_players + i) / 20), blobs_minimum, blobs_possible)
 
 	var/list/possible_blobs = get_possible_enemies(ROLE_BLOB, num_blobs)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BALANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Increases the number of possible blobs `3 -> 4`
* rewrites a `max(min())` to use `clamp()`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* 3 blobs isn't much against 115 players
* clamp looks nicer


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(*)Blob rounds can now have up to 4 blobs at once.
```
