### PR TITLE
Donut3 Railing Direction Fix

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -11312,7 +11312,6 @@
 /area/station/crew_quarters/market)
 "cZx" = (
 /obj/railing/orange{
-	dir = 6;
 	layer = 4
 	},
 /obj/decal/cleanable/dirt/jen,
@@ -15170,9 +15169,7 @@
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
 "efz" = (
-/obj/railing/orange{
-	dir = 10
-	},
+/obj/railing/orange,
 /obj/table/auto,
 /obj/item/storage/toolbox/emergency{
 	pixel_x = -2;
@@ -17369,9 +17366,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/lobby)
 "eOa" = (
-/obj/railing/orange{
-	dir = 6
-	},
+/obj/railing/orange,
 /obj/decal/cleanable/dirt/jen,
 /obj/railing/orange{
 	dir = 4
@@ -30823,7 +30818,6 @@
 	},
 /obj/decal/cleanable/rust/jen,
 /obj/railing/orange{
-	dir = 6;
 	layer = 4
 	},
 /turf/simulated/floor/plating/jen,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #6664  
3 railings, including the 2 listed in the issue/conversation, had a dir of 6 (Southeast) instead of 2 (South), leading to the railing not properly rendering due to lack of Southeast rail sprite, though it still blocked traversal Southwards. The third unlisted rail seems to have been just a few tiles south of the one listed in Northwest Maintenance between EVA and the Janitor's Office.

One railing also has a dir of 10 (Southwest) which I also fixed. This one was in Northwest Outer Maintenance, on the same tile as the table with the emergency toolbox on it.

Used regex search to find these, and I couldn't find any other rails facing any other improper directions at all, so I'm safely assuming these are the only rails facing a non-NESW direction.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

invisible rails bad, make sad :(