### PR TITLE
Fixes journalist's camera monitor to view helmet cam network

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1620,7 +1620,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 
 		var/obj/item/storage/briefcase/B = M.find_type_in_hand(/obj/item/storage/briefcase)
 		if (B && istype(B))
-			new /obj/item/device/camera_viewer(B)
+			new /obj/item/device/camera_viewer{network = "Zeta"}(B)
 			new /obj/item/clothing/head/helmet/camera(B)
 			new /obj/item/device/audio_log(B)
 			new /obj/item/clipboard/with_pen(B)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #6592 by setting the camera network of the journalist's camera monitor to "zeta", which has all the non-security camera stuff on it, like helmet cameras and gauntlet cameras.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

i Eradicate the most trivial of bugs.