### PR TITLE
Makes nobium key visible

### DIFF
--- a/code/obj/item/keys.dm
+++ b/code/obj/item/keys.dm
@@ -142,8 +142,6 @@
 /obj/item/device/key/hospital
 	desc = "What does this go to?"
 	name = "niobium key"
-	item_state = ""
-	icon = null
 
 //Something for the solarium nerds to obsess over for a month
 /obj/item/device/key/filing_cabinet


### PR DESCRIPTION
[Trivial]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I dunno why it's icon_state was set to null, but now it uses the default key sprite.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This must have been really annoying for sol nerds.
