### PR TITLE
Ghostdrones can no longer spawn in Battle Royale

### DIFF
--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -584,6 +584,10 @@
 	set name = "Enter Ghostdrone Queue"
 	set category = "Ghost"
 
+	if(master_mode == "battle_royale")
+		boutput(usr, "You can't respawn as a ghost drone during Battle Royale!")
+		return
+
 	if (!src.can_respawn_as_ghost_critter())
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR blocks ghosts from respawning as ghostdrones in battle royale.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is needed because the dead shouldn't be able to come back and impact a (usually) short battle royale game by repairing the damage done to the station. In addition, their laws leave much up in the air considering how it's everyone's affair that they're killing eachother and blowing up the station.
