### PR TITLE
Kondaru armory nano-fixbatch

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -45442,6 +45442,7 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
+/obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "gOo" = (
@@ -56920,7 +56921,6 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "thw" = (
@@ -59622,7 +59622,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "vXP" = (
-/obj/storage/secure/crate/plasma/armory/anti_biological,
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "vYc" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Kondaru armory was apparently changed at some point to include a special equipment locker, with the N2O canister moved to a position directly obstructing vital equipment; this PR reorganizes the armory to once again have a clear 3x3 in the center, doing the following changes.

- Anti-biological crate relocated to the open tile in the Armory authorization lobby; several other rotation maps feature a "freely accessible" anti-biological crate, presumably for faster threat response, so this seemed a reasonable approach.
- The N2O canister previously occupying the southeast corner of the center 3x3 has been moved to the location by the door that the anti-biological crate was moved out of.
- An additional wall-mounted recharger has been installed opposite the existing one.

If for some reason this is not permitted under feature freeze, please disregard.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Improves usability of Kondaru's armory.