### PR TITLE
Fixes General Alert Computer deconstruction

### DIFF
--- a/code/obj/machinery/computer.dm
+++ b/code/obj/machinery/computer.dm
@@ -88,6 +88,7 @@
 /obj/machinery/computer/general_alert
 	name = "General Alert Computer"
 	icon_state = "alert:0"
+	circuit_type = /obj/item/circuitboard/general_alert
 	var/list/priority_alarms = list()
 	var/list/minor_alarms = list()
 	var/receive_frequency = FREQ_ALARM


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Bug - Minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows general alert computers to be deconned.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugs bad, fixes #6716
