### PR TITLE
Medkits now properly give feedback for when small items won't fit into them

### DIFF
--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -827,7 +827,7 @@
 		if (src.contents.len >= 7)
 			return
 		if ((S.w_class >= W_CLASS_SMALL || istype(S, /obj/item/storage)))
-			if (!istype(S,/obj/item/storage/pill_bottle) && !istype(S,/obj/item/chem_pill_bottle))
+			if (!istype(S,/obj/item/storage/pill_bottle))
 				boutput(user, "<span class='alert'>[S] won't fit into [src]!</span>")
 				return
 		..()

--- a/code/modules/robotics/bot/medbot.dm
+++ b/code/modules/robotics/bot/medbot.dm
@@ -827,7 +827,8 @@
 		if (src.contents.len >= 7)
 			return
 		if ((S.w_class >= W_CLASS_SMALL || istype(S, /obj/item/storage)))
-			if (!istype(S,/obj/item/storage/pill_bottle))
+			if (!istype(S,/obj/item/storage/pill_bottle) && !istype(S,/obj/item/chem_pill_bottle))
+				boutput(user, "<span class='alert'>[S] won't fit into [src]!</span>")
 				return
 		..()
 		return

--- a/code/obj/item/storage/med_chem.dm
+++ b/code/obj/item/storage/med_chem.dm
@@ -7,7 +7,7 @@
 	inhand_image_icon = 'icons/mob/inhand/hand_storage.dmi'
 	throw_speed = 2
 	throw_range = 8
-	max_wclass = 2 // medbot.dm modifies attackby() for firstaid, which effectively reduces max_wclass to 1, EXCEPT for pill bottles
+	max_wclass = 2 // medbot.dm modifies attackby() for firstaid, which effectively reduces max_wclass to 1, EXCEPT for non-chemmaster pill bottles
 	var/list/kit_styles = null
 
 	New()

--- a/code/obj/item/storage/med_chem.dm
+++ b/code/obj/item/storage/med_chem.dm
@@ -7,7 +7,7 @@
 	inhand_image_icon = 'icons/mob/inhand/hand_storage.dmi'
 	throw_speed = 2
 	throw_range = 8
-	max_wclass = 2
+	max_wclass = 2 // medbot.dm modifies attackby() for firstaid, which effectively reduces max_wclass to 1, EXCEPT for pill bottles
 	var/list/kit_styles = null
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

~Inventory-based pill bottles, `/obj/item/storage/pill_bottle`, may fit inside of medkits. However, all other small items, including ChemMaster pill bottles, may not.~ There is also no feedback telling the user that the small item they are trying to put into the medkit won't fit.

~Pill bottles made from a ChemMaster may now fit into Medkits, and as they are intended to hold only Tiny items (despite their wclass),~ A boutput() alert has been added to alert the user that small items won't fit into the medkit.

Adds a comment to med_chem.dm under `/obj/item/storage/firstaid` explaining the effective decrease in max_wclass due to the outside proc in medbot.dm.

EDIT: ChemMaster pill bottles are no longer included in this