### PR TITLE
Fixes arms not getting replaced with zombies ones on conversion

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -900,9 +900,9 @@
 
 			//give em zombie arms if they don't have em...
 			if (!istype(M.limbs.r_arm, /obj/item/parts/human_parts/arm/right/zombie))
-				M.limbs.replace_with("r-arm", /obj/item/parts/human_parts/arm/right/zombie, M, 0)
+				M.limbs.replace_with("r_arm", /obj/item/parts/human_parts/arm/right/zombie, M, 0)
 			if (!istype(M.limbs.l_arm, /obj/item/parts/human_parts/arm/left/zombie))
-				M.limbs.replace_with("l-arm", /obj/item/parts/human_parts/arm/left/zombie, M, 0)
+				M.limbs.replace_with("l_arm", /obj/item/parts/human_parts/arm/left/zombie, M, 0)
 
 			SPAWN_DBG(rand(4, 30))
 				M.emote("scream")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
just fixes a typo, the proc checks for l_arm and r_arm, and it was receiving l-arm and r-arm 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #6116 
