### PR TITLE
Fixes #6611: Makes syndicate weapons vendors explosion immnue

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -84,8 +84,7 @@
 		else
 			..()
 
-	ex_act()
-		return
+
 
 	proc/accepted_token(var/token, var/mob/user)
 		src.ui_interact(user)
@@ -153,6 +152,9 @@
 	desc = "An automated quartermaster service for supplying your nuclear operative team with weapons and gear."
 	token_accepted = /obj/item/requisition_token/syndicate
 	log_purchase = TRUE
+
+	ex_act()
+		return
 
 	New()
 		..()

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -84,6 +84,9 @@
 		else
 			..()
 
+	ex_act()
+		return
+
 	proc/accepted_token(var/token, var/mob/user)
 		src.ui_interact(user)
 		playsound(src.loc, sound_token, 80, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Closes #6611 by making vendors not respond to explosive damage.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These should probably be permanent.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Gannets
(+)Syndicate weapons vendors are now explosion immune.
```
