### PR TITLE
Fix disease reagent thresholds changing with server lag

### DIFF
--- a/code/modules/chemistry/Reagents-Diseases.dm
+++ b/code/modules/chemistry/Reagents-Diseases.dm
@@ -23,15 +23,15 @@ datum
 			*/
 
 			on_mob_life(var/mob/M, var/mult = 1)
-				..()
 				if(!M)
 					M = holder.my_atom
 				if (!isliving(M) || !ispath(disease))
 					return
-				if (src.volume + depletion_rate*(mult-1) < minimum_to_infect)
+				if (src.volume < minimum_to_infect)
 					return
 				var/mob/living/L = M
 				L.contract_disease(disease, null, null, 1)
+				..()
 
 		disease/rainbow_fluid // Clowning Around
 			name = "rainbow fluid"

--- a/code/modules/chemistry/Reagents-Diseases.dm
+++ b/code/modules/chemistry/Reagents-Diseases.dm
@@ -28,7 +28,7 @@ datum
 					M = holder.my_atom
 				if (!isliving(M) || !ispath(disease))
 					return
-				if (src.volume < minimum_to_infect)
+				if (src.volume + depletion_rate*(mult-1) < minimum_to_infect)
 					return
 				var/mob/living/L = M
 				L.contract_disease(disease, null, null, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes disease reagent thresholds to apply before chem depletion. 
Disease infection thresholds are now exactly their described values in the code.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So that server lag is no longer relevant in infection thresholds.
