### PR TITLE
Security Training halves handcuff removal time

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1114,6 +1114,11 @@ var/datum/action_controller/actions
 			var/mob/living/carbon/human/H = target
 			duration = round(duration * H.handcuffs.remove_other_multiplier)
 
+		if(ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			if(H.traitHolder.hasTrait("training_security"))
+				duration = round(duration / 2)
+
 		for(var/mob/O in AIviewers(owner))
 			O.show_message("<span class='alert'><B>[owner] attempts to remove [target]'s handcuffs!</B></span>", 1)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL] [Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR halves the amount of time to remove handcuffs from others, if you have security training (7 seconds to 3.5)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Requested on forums, and it makes sense for people who can already cuff 2x as fast, to be able to remove them from others 2x as fast.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)With security training, you can remove handcuffs from other people twice as fast.
```
