### PR TITLE
make unfolded folded paper behave more unfolded

### DIFF
--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -1407,8 +1407,14 @@ as it may become compromised.
 	throw_spin = 0
 
 /obj/item/paper/folded/plane/hit_check(datum/thrown_thing/thr)
-	if(src.throwing)
+	if(src.throwing && src.sealed)
 		src.throw_unlimited = 1
+
+/obj/item/paper/folded/plane/attack_self(mob/user as mob)
+	if (src.sealed) //Set throwing vars when unfolding (mostly in the parent call) so that an unfolded paper "plane" behaves like regular paper
+		throw_speed = 3 //default for paper
+		throw_spin = 1
+	..()
 
 /obj/item/paper/folded/ball
 	name = "paper ball"
@@ -1416,7 +1422,7 @@ as it may become compromised.
 	icon_state = "paperball"
 
 /obj/item/paper/folded/ball/attack(mob/M as mob, mob/user as mob)
-	if (iscarbon(M) && M == user)
+	if (iscarbon(M) && M == user && src.sealed)
 		M.visible_message("<span class='notice'>[M] stuffs [src] into [his_or_her(M)] mouth and eats it.</span>")
 		playsound(M,"sound/misc/gulp.ogg", 30, 1)
 		eat_twitch(M)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Because folding paper spawns a folded subtype for the new item (until you refold it into another plane or ball) but unfolding keeps the same item (and thus subtype), this PR patches a few things so unfolded paper doesn't act unusual:

-Unfolded paper planes do not travel slower or infinitely like folded paper
-You don't eat unfolded paper balls anymore

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Closes #6697 in cold blood. I don't think the other changes have issues associated with them but it's the same principle.