### PR TITLE
Fixes pod wars accidentally changing the price of plasma cutters

### DIFF
--- a/code/datums/gamemodes/pod_wars/pw_manufacturing_.dm
+++ b/code/datums/gamemodes/pod_wars/pw_manufacturing_.dm
@@ -28,10 +28,9 @@
 		/datum/manufacture/orescoop,
 		/datum/manufacture/conclave,
 		/datum/manufacture/communications/mining,
-		/datum/manufacture/pod/weapon/mining,
+		/datum/manufacture/pod/weapon/mining_podwars,
 		/datum/manufacture/pod/weapon/mining/drill,
 		/datum/manufacture/pod/weapon/ltlaser,
-		/datum/manufacture/pod/weapon/mining,
 		/datum/manufacture/pod/weapon/mining_weak,
 		/datum/manufacture/pod/weapon/taser,
 		/datum/manufacture/pod/weapon/laser/short,
@@ -83,7 +82,7 @@
 	create = 1
 	category = "Tool"
 
-/datum/manufacture/pod/weapon/mining
+/datum/manufacture/pod/weapon/mining_podwars
 	name = "Plasma Cutter System"
 	item_paths = list("MET-2","CON-2", "telecrystal")
 	item_amounts = list(50,50,10)


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] [BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When commit 39ac373288a1bd5819ba1056783cdd93d19317d8 got commited, it ended up accidentally changing the price of plasma cutters. Talked to Kyle and have confirmed this is unintentional. This makes them not do that. Fixes #5610


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, unintentional change that increased price of plasma cutters a lot.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)Nanotrasen has noticed they were using an older recipe of plasma cutters for there ship manufacturers and has begin using the modern cheaper recipe again.
```
