### PR TITLE
Fixes guaranteed basic spawners

### DIFF
--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -588,8 +588,7 @@
 	guaranteed = list(/obj/item/clipboard,
 	/obj/item/paper_bin,
 	/obj/item/pen)
-	items2spawn = list(/obj/item/pen/fancy,
-	/obj/item/pen/red,
+	items2spawn = list(/obj/item/pen/red,
 	/obj/item/pen/pencil,
 	/obj/item/pen/marker,
 	/obj/item/pen/marker/red,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the guaranteed basic spawners only spawn basic items. Fixes #6737


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug=bad



