### PR TITLE
Allow energy shields and meteor shields to be connected to wires while battery is installed

### DIFF
--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -243,10 +243,6 @@
 
 		else if(src.coveropen && !src.PCEL)
 			if(istype(W,/obj/item/cell/))
-				if(connected)
-					boutput(user, "You think it's a bad idea to attach a battery to the [src.name] while it's connected to a wire.")
-					return
-
 				user.drop_item()
 				W.set_loc(src)
 				src.PCEL = W

--- a/code/obj/machinery/shield_generators/portable_shield_generator.dm
+++ b/code/obj/machinery/shield_generators/portable_shield_generator.dm
@@ -228,9 +228,6 @@
 			if(active)
 				boutput(user, "Disconnecting [src.name] from the power source while active doesn't sound like the best idea.")
 				return
-			if(PCEL)
-				boutput(user, "You can't think of a reason to attach the [src.name] to a wire when it already has a battery.")
-				return
 
 			//just checking if it's placed on any wire, like powersink
 			var/obj/cable/C = locate() in get_turf(src)
@@ -427,7 +424,7 @@
 	desc = "A force field that can block various states of matter."
 	icon = 'icons/obj/meteor_shield.dmi'
 	icon_state = "shieldw"
-	event_handler_flags = USE_FLUID_ENTER 
+	event_handler_flags = USE_FLUID_ENTER
 	var/powerlevel //Stores the power level of the deployer
 	density = 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][FEATURE][QOL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Players are no longer forced to remove the battery from the machines in order to use them with the station powernet

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* less obtuse usage


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(+)You no longer need to remove the battery from an energy/meteor shield generator to connect it to a wire.
```
