### PR TITLE
Fixes the radio scanner mechcomp component

### DIFF
--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -2471,7 +2471,7 @@
 		..()
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_INPUT,"set frequency", "setfreq")
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_ADD_CONFIG,"Set Frequency","setFreqMan")
-		// TODO: analog registration
+		MAKE_DEFAULT_RADIO_PACKET_COMPONENT("main", frequency)
 
 	proc/setFreqMan(obj/item/W as obj, mob/user as mob)
 		var/inp = input(user, "New frequency ([R_FREQ_MINIMUM] - [R_FREQ_MAXIMUM]):", "Enter new frequency", frequency) as num
@@ -2495,7 +2495,7 @@
 		new_frequency = sanitize_frequency(new_frequency)
 		componentSay("New frequency: [new_frequency]")
 		frequency = new_frequency
-		// TODO: analog registration
+		get_radio_connection_by_id(src, "main").update_frequency(frequency)
 		tooltip_rebuild = 1
 	proc/hear_radio(atom/movable/AM, msg, lang_id)
 		if (level == 2) return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The radio scanner mechcomp component is not working, this fixes it so that it properly receives signals. The radio packet component wasn't added to it in the refactor. This adds that component to let it interact with the station radio.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The radio scanner component is not able to hear the station radio, this fixes it.
