### PR TITLE
makes extinguishers toggle being an open container based on safety, replaced the SAFETY = 0 and SAFETY = 1 with FALSE and TRUE

### DIFF
--- a/code/modules/chemistry/tools/extinguisher.dm
+++ b/code/modules/chemistry/tools/extinguisher.dm
@@ -9,7 +9,7 @@
 	var/const/max_distance = 5
 	var/const/reagents_per_dist = 5
 	hitsound = 'sound/impact_sounds/Metal_Hit_1.ogg'
-	flags = FPRINT | EXTRADELAY | TABLEPASS | CONDUCT | OPENCONTAINER
+	flags = FPRINT | EXTRADELAY | TABLEPASS | CONDUCT
 	tooltip_flags = REBUILD_DIST
 	throwforce = 10
 	w_class = W_CLASS_NORMAL
@@ -196,14 +196,16 @@
 		user.update_inhands()
 		src.desc = "The safety is off."
 		boutput(user, "The safety is off.")
-		safety = 0
+		ADD_FLAG(src.flags,OPENCONTAINER)
+		safety = FALSE
 	else
 		src.item_state = "fireextinguisher0"
 		set_icon_state("fire_extinguisher0")
 		user.update_inhands()
 		src.desc = "The safety is on."
 		boutput(user, "The safety is on.")
-		safety = 1
+		REMOVE_FLAG(src.flags,OPENCONTAINER)
+		safety = TRUE
 	return
 
 /obj/item/extinguisher/move_trigger(var/mob/M, kindof)

--- a/code/modules/chemistry/tools/extinguisher.dm
+++ b/code/modules/chemistry/tools/extinguisher.dm
@@ -9,7 +9,7 @@
 	var/const/max_distance = 5
 	var/const/reagents_per_dist = 5
 	hitsound = 'sound/impact_sounds/Metal_Hit_1.ogg'
-	flags = FPRINT | EXTRADELAY | TABLEPASS | CONDUCT
+	flags = FPRINT | EXTRADELAY | TABLEPASS | CONDUCT | OPENCONTAINER
 	tooltip_flags = REBUILD_DIST
 	throwforce = 10
 	w_class = W_CLASS_NORMAL

--- a/code/modules/chemistry/tools/extinguisher.dm
+++ b/code/modules/chemistry/tools/extinguisher.dm
@@ -196,7 +196,7 @@
 		user.update_inhands()
 		src.desc = "The safety is off."
 		boutput(user, "The safety is off.")
-		ADD_FLAG(src.flags,OPENCONTAINER)
+		ADD_FLAG(src.flags, OPENCONTAINER)
 		safety = FALSE
 	else
 		src.item_state = "fireextinguisher0"
@@ -204,9 +204,8 @@
 		user.update_inhands()
 		src.desc = "The safety is on."
 		boutput(user, "The safety is on.")
-		REMOVE_FLAG(src.flags,OPENCONTAINER)
+		REMOVE_FLAG(src.flags, OPENCONTAINER)
 		safety = TRUE
-	return
 
 /obj/item/extinguisher/move_trigger(var/mob/M, kindof)
 	if (..() && reagents)


### PR DESCRIPTION
…eplaces the 0 and 1 with TRUE and FALSE

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[XS] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Made fire extinguisher toggle between being an open/closed container based on the safety
this change has a side effect of allowing steam in fire extinguishers

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

i hated the fact that smoke powder could get out of an obviously closed container

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) ZWRh3
(+) Extinguishers with the safety on will no longer count as an open container.
```
