### PR TITLE
Sbriefcase bug

### DIFF
--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -149,6 +149,7 @@
 				if (istype(W, /obj/item/storage/secure))
 					var/obj/item/storage/secure/S = W
 					if (S.locked)
+						boutput(user, "<span class='alert'>[S] is locked and cannot be opened!</span>")
 						return
 				var/obj/item/storage/S = W
 				for (var/obj/item/I in S.get_contents())

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -145,6 +145,11 @@
 		var/canhold = src.check_can_hold(W,user)
 		if (canhold <= 0)
 			if(istype(W, /obj/item/storage) && (canhold == 0 || canhold == -1))
+				//is the storage locked?
+				if (istype(W, /obj/item/storage/secure))
+					var/obj/item/storage/secure/S = W
+					if (S.locked)
+						return
 				var/obj/item/storage/S = W
 				for (var/obj/item/I in S.get_contents())
 					if(src.check_can_hold(I) > 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #6585
Note that this doesn't fix the separate bug of the briefcase's inventory not closing when locked, but since only the person who locked it can access it this way it's not a huge problem.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previously you could dump the contents of a locked secure briefcase into another storage item even while locked.
