### PR TITLE
AI map

### DIFF
--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -447,10 +447,11 @@
 
 	verb/ai_open_map()
 		set category = "AI Commands"
-		set name = "Open map"
+		set name = "Open AI map"
 		set desc = "Open a map of the station, double click on the map to teleport"
 
 		//default to cogmap if somehow the map settings go missing
+		//currently only Ozymandias and Icarus are unsupported
 		var/map_name = "cogmap"
 		if (map_settings)
 			var/position = findtext(map_settings.goonhub_map, "/maps/")
@@ -463,8 +464,6 @@
 					<title>AI map</title>
 
 					<link rel="stylesheet" href="https://goonhub.com/css/map.css">
-
-					<script src="https://goonhub.com/js/modernizr.min.js"></script>
 				</head>
 				<body>
 				<div id="mapcontainer">
@@ -500,9 +499,9 @@
 						e.stopPropagation()
 
 						//horrible string mess to get the tile coords from the image url
+						//urls have the form https://goonhub.com/images/maps/<map name>/z1/<y>,<x>.png
 						var split_array = target.src.split("/")
 						var tile_coords = split_array\[split_array.length - 1].split(".")\[0].split(",")
-						//image tiles use y,x for some reason
 						var x = Number(tile_coords\[1])
 						var y = Number(tile_coords\[0])
 
@@ -514,7 +513,7 @@
 						x += e.offsetX / 32
 						y += e.offsetY / 32
 						//the map has inverted y coordinates
-						y = 300 - y //this assumes all maps are 300x300, and map.dm doesn't say otherwise so probably okay
+						y = 300 - y //this assumes all maps are 300x300, I think the only one that isn't is Pod Wars and I don't think that has an AI?
 						//correct southwest bias
 						y += 0.5
 						x += 0.5


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE] [FREEZE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Integrates the goonhub.com interactive maps into the game as a map the AI can double click on to teleport its eye around. The map is opened from a verb "Open AI map" and can then be resized, zoomed etc.
This could also be made into a ghost or admin feature as well as, or instead of if you think giving this to the AI will make them a little _too_ omniscient.

![map initial size](https://user-images.githubusercontent.com/20713227/143594152-c85d3efb-0a9b-4439-b5c8-c58b19f62f40.png)

I haven't found any exploits with it so far, and it should be reasonably robust against them as it calls back to specifically the AI eye class, but I'm still a little paranoid that this could somehow introduce an arbitrary teleport exploit.
As for browser compatibility, it works on IE11 and should work on any browser the goonhub.com map works with. (Not sure what browsers goonstation/byond support)
The only known issue so far is that scrolling scrolls the map rather than zooming it. None of the usual JS/CSS tricks seem to fix this and it's difficult to diagnose as the scroll capture code for the map is in a minified JS file. Maybe someone who knows more about Byond window quirks can offer insight.
Performance impacts server-side should be minor as it's just serving a small HTML page. Client-side the map can take a few seconds to load the first time it's opened, but seems to be cached fine after that so re-opening it doesn't download the entire map again.
The code is mostly just a lot of HTML dumped directly into a string in ai-camera.dm, which makes me a little queasy but that's how QM terminals are implemented so I built off that.

Even better with multiple monitors
![AI setup](https://user-images.githubusercontent.com/20713227/143596875-b7bc4221-757f-4d30-a8f1-b3d39b4c5017.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Moving your camera around as AI can feel sluggish and clunky when you want to head to a specific spot rather than person. Viewports help with this, but you can only open so many.
A minimap is the only thing missing to complete my AI RTS fantasy.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(*)Added a map for the AI to move around with. Open with the "Open AI map" verb and double click to teleport.
```
