### PR TITLE
Fixed spy PDAs getting deleted by delivering the storage they are in

### DIFF
--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -758,6 +758,9 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 					var/turf/end = B.delivery_area.spyturf
 					user.gpsToTurf(end, doText = 0) // spy thieves probably need to break in anyway, so screw access check
 					return 0
+				for (var/obj/item/device/pda2/P in delivery.contents) //make sure we don't delete the PDA
+					if (P.uplink == src)
+						return 0
 				user.removeGpsPath(doText = 0)
 				B.claimed = 1
 				for (var/mob/M in delivery.contents) //make sure we dont delete mobs inside the stolen item
@@ -778,7 +781,6 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 							user.show_text("That isn't the right limb!", "red")
 					else
 						M.drop_from_slot(delivery,get_turf(M))
-
 				qdel(delivery)
 				if (user.mind && user.mind.special_role == ROLE_SPY_THIEF)
 					user.mind.spy_stolen_items += B.name


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
Fixes #6754
fixes #1533
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Now the PDA swaps with the storage item and immediately starts delivering it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As funny as delivering a bag with the PDA that is inside it is, you probably shouldn't have your PDA deleted over it.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)You can no longer accidentally deliver your PDA to the syndicate as spy.
```
