### PR TITLE
The "FREEZE🧊" label now prevents staling of PRs.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,4 +14,4 @@ jobs:
         days-before-stale: 14
         days-before-close: 7
         stale-pr-label: 'stale'
-        exempt-pr-labels: 'Certified Organic'
+        exempt-pr-labels: 'Certified Organic,FREEZE🧊'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes the "FREEZE🧊" label prevent the staling of pull requests.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Getting your PRs staled while they're not going to be reviewed/merged isn't ideal.