### PR TITLE
Reduces Syndicate Wiretap Upgrade to 2 TC from 3

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -922,7 +922,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/wiretap
 	name = "Wiretap Radio Upgrade"
 	item = /obj/item/device/radio_upgrade
-	cost = 3
+	cost = 2
 	desc = "A small device that may be installed in a headset to grant access to all station channels."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 	vr_allowed = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR reduces the cost of wiretaps from 3 to 2 TC.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The wiretap upgrade feels like a waste of TC at the moment, considering the only worthwhile channel is security (and _maybe_ command), and it's trivial to get security comms (lockers, killing a secoff are two). This should hopefully bring it into use a bit more, without being a massive TC hog.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Syndicate Wiretaps cost 2 TC, down from 3.
```
