### PR TITLE
Syndicate antagonists can now buy Syndicate headsets from CARL, and the wiretap upgrade grants the Syndicate channel.

### DIFF
--- a/code/datums/commodity.dm
+++ b/code/datums/commodity.dm
@@ -1024,6 +1024,15 @@
 	upperfluc = 500
 	lowerfluc = -500
 
+/datum/commodity/contraband/syndicate_headset
+	comname = "Illegal Headset"
+	comtype = /obj/item/device/radio/headset/syndicate
+	desc = "This headset allows you to speak over a highly illegal Syndicate frequency."
+	price = 500
+	baseprice = 500
+	upperfluc = 250
+	lowerfluc = -250
+
 /datum/commodity/contraband/briefcase
 	comname = "Briefcase Valve Assembly"
 	comtype = /obj/item/device/transfer_valve/briefcase

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -923,7 +923,7 @@ This is basically useless for anyone but miners.
 	name = "Wiretap Radio Upgrade"
 	item = /obj/item/device/radio_upgrade
 	cost = 3
-	desc = "A small device that may be installed in a headset to grant access to all station channels."
+	desc = "A small device that may be installed in a headset to grant access to all station channels, along with one reserved for Syndicate operatives."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 	vr_allowed = 0
 

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -814,6 +814,7 @@
 					src.goods_illegal += new /datum/commodity/contraband/stealthstorage(src)
 					src.goods_illegal += new /datum/commodity/contraband/voicechanger(src)
 				src.goods_illegal += new /datum/commodity/contraband/birdbomb(src)
+				src.goods_illegal += new /datum/commodity/contraband/syndicate_headset(src)
 				src.goods_sell += new /datum/commodity/contraband/swatmask(src)
 				src.goods_sell += new /datum/commodity/contraband/spy_sticker_kit(src)
 				src.goods_sell += new /datum/commodity/contraband/flare(src)

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -31,6 +31,7 @@
 				"r" = R_FREQ_RESEARCH,
 				"m" = R_FREQ_MEDICAL,
 				"c" = R_FREQ_CIVILIAN,
+				"z" = R_FREQ_SYNDICATE,
 				)
 			src.secure_classes = list(
 				"h" = RADIOCL_COMMAND,
@@ -39,6 +40,7 @@
 				"r" = RADIOCL_RESEARCH,
 				"m" = RADIOCL_MEDICAL,
 				"c" = RADIOCL_CIVILIAN,
+				"z" = RADIOCL_SYNDICATE,
 				)
 			boutput(user, "<span class='notice'>Wiretap Radio Upgrade successfully installed in the [src].</span>")
 			playsound(src.loc ,"sound/items/Deconstruct.ogg", 80, 0)
@@ -416,7 +418,7 @@ Secure Frequency:
 
 /obj/item/device/radio_upgrade //traitor radio upgrader
 	name = "Wiretap Radio Upgrade"
-	desc = "An illegal device capable of picking up and sending all secure station radio signals. Can be installed in a radio headset. Does not actually work by wiretapping."
+	desc = "An illegal device capable of picking up and sending all secure station radio signals, along with a secure Syndicate frequency. Can be installed in a radio headset. Does not actually work by wiretapping."
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "syndie_upgr"
 	w_class = W_CLASS_TINY


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Feature] [Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR lets CARL sell syndicate headsets to Syndicate antagonists for 750 credits, along with giving the wiretap upgrade the Syndicate frequency.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More inter-traitor cooperation is good, and this should encourage it!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(*)Antagonists can buy Syndicate headsets from CARL, and the wiretap upgrade grants access to the Syndicate channel.
```
