### PR TITLE
Stop Bards from being jerks in the murderbox!

### DIFF
--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -341,6 +341,12 @@
 			..()
 			setProperty("disorient_resist_ear", 100)
 
+		pickup(mob/user)
+			if(isVRghost(user))
+				secure_frequencies = null
+				secure_classes = null
+				locked_frequency = TRUE
+
 	comtac
 		name = "Military Headset"
 		icon_state = "comtac"

--- a/code/obj/item/device/studio_monitor.dm
+++ b/code/obj/item/device/studio_monitor.dm
@@ -199,6 +199,15 @@
 			boutput(src.the_mob, "<span class='alert'>You are already playing something...</span>")
 			. = FALSE
 
+	proc/is_rock_immune(mob/living/target)
+		if(isVRghost(target))
+			var/mob/living/carbon/human/H
+			if(istype(target, /mob/living/carbon/human))
+				H = target
+			. = istype(target.ears, /obj/item/device/radio/headset/syndicate) || istype(H?.head, /obj/item/clothing/head/helmet/space/syndicate)
+		else
+			. = istype(target.ears, /obj/item/device/radio/headset/syndicate)
+
 	shred
 		name = "Shred"
 		desc = "Lightbreaker Effect"
@@ -216,7 +225,7 @@
 					L.broken(1)
 
 			for(var/mob/living/HH in I.get_speaker_targets())
-				if(istype(HH.ears, /obj/item/device/radio/headset/syndicate))
+				if(is_rock_immune(HH))
 					continue
 
 				HH.apply_sonic_stun(0, 0, 30, 0, 5, 4, 6)
@@ -233,7 +242,7 @@
 			var/obj/item/breaching_hammer/rock_sledge/I = the_item
 
 			for(var/mob/living/HH in I.get_speaker_targets(2))
-				if(istype(HH.ears, /obj/item/device/radio/headset/syndicate))
+				if(is_rock_immune(HH))
 					continue
 
 				HH.take_brain_damage(15)
@@ -254,7 +263,7 @@
 		execute_ability()
 			var/obj/item/breaching_hammer/rock_sledge/I = the_item
 			for(var/mob/living/HH in I.get_speaker_targets(-2))
-				if(istype(HH.ears, /obj/item/device/radio/headset/syndicate))
+				if(is_rock_immune(HH))
 					continue
 				HH.apply_sonic_stun(0, 0, 0, 0, 2, 8, 5)
 				HH.organHolder.damage_organs(brute=10, organs=list("liver", "heart", "left_kidney", "right_kidney", "stomach", "intestines","appendix", "pancreas", "tail"), probability=90)
@@ -271,7 +280,7 @@
 		execute_ability()
 			var/obj/item/breaching_hammer/rock_sledge/I = the_item
 			for(var/mob/living/HH in I.get_speaker_targets())
-				if(istype(HH.ears, /obj/item/device/radio/headset/syndicate))
+				if(is_rock_immune(HH))
 					HH.delStatus("stunned")
 					HH.delStatus("weakened")
 					HH.delStatus("paralysis")
@@ -401,7 +410,7 @@
 	proc/blast_to_speakers()
 		for(var/mob/living/HH in instrument.get_speaker_targets())
 			// Beneficial Effects
-			if(istype(HH.ears, /obj/item/device/radio/headset/syndicate))
+			if(song.is_rock_immune(HH))
 				for(var/E in src.song.status_effect_ids)
 					HH.setStatus(E, 10 SECONDS)
 			//else
@@ -457,6 +466,10 @@
 		desc = "Refreshed and Hastened!"
 		change = 4
 		movement_modifier = /datum/movement_modifier/death_march
+
+		getTooltip()
+			. = ..()
+			. += " You are moving faster."
 
 	getTooltip()
 		. = "Your stamina regen is increased by [change]."
@@ -545,7 +558,7 @@
 /datum/statusEffect/simplehot/chill_murder // totally not mild stimulants...
 		id = "chill_murder"
 		name = "Murder Beats"
-		desc = "You feel on top of the world!"
+		desc = "Mending tunes to keep on killing to!"
 		exclusiveGroup = "Music"
 		unique = 1
 		tickSpacing = 4 SECONDS
@@ -630,14 +643,14 @@ obj/effects/music
 	New()
 		..()
 		add_filter("outline", 1, outline_filter(size=0.5, color="#444"))
-		src.particles.lifespan = 0
+		src.particles.spawning = 0
 
 	proc/is_playing()
-		. = src.particles.lifespan == 2 SECONDS
+		. = src.particles.spawning == 0.1
 
 	proc/play_notes()
-		src.particles.lifespan = 2 SECONDS
+		src.particles.spawning = 0.1
 
 	proc/stop_notes()
-		src.particles.lifespan = 0
+		src.particles.spawning = 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Utilize spawning rate instead of lifespan so particles behave more like as expected.
- Allow VRGhosts to be immune to negative songs and get benefits of positive songs with syndicate headgear to allow for Murderbox Fun.
  - Moves logic of how to determination of who can benefit from Bard to a single location.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves issue of Bards hurting other Nukies in the murder box OR not giving them any buffs.
Improves particle as it disables spawning when not necessarily instead of immediately de-spawning them.
Improves a couple Bard tooltips.
