### PR TITLE
Fixes humans being unable to change mutantrace in the GeneTek Scanner

### DIFF
--- a/code/modules/medical/genetics/geneticsMachines.dm
+++ b/code/modules/medical/genetics/geneticsMachines.dm
@@ -509,7 +509,7 @@
 			if (!istype(H) || isprematureclone(H))
 				return
 			var/datum/bioEffect/mutantrace/BE = locate(params["ref"])
-			if (!H.mutantrace?.genetics_removable)
+			if (H.mutantrace && !H.mutantrace?.genetics_removable)
 				//this should probably be a UI notification but I'm not touching that code with a ten foot pole
 				scanner_alert(ui.user, "Unable to purge corrupt genotype.")
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the GeneTek scanner to allow the occupant's mutantrace to be changed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Humans have no mutant race and a check that was intended to keep thralls from being made human again stops humans from being altered as well due to their mutantrace being null. This fixes that.
