### PR TITLE
Synthrubber insulative value 20 -> 30 (RIP synthrubber insuls)

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -1190,7 +1190,7 @@
 	New()
 		setProperty("density", 26)
 		setProperty("hard", 11)
-		setProperty("electrical", 20)
+		setProperty("electrical", 30)
 		setProperty("thermal", 40)
 		return ..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes the insulative value of synthrubber go to 30, from 20.
**This is fully intended to remove low-effort synthrubber insulated gloves.**


Edit for clarification: synthrubber insuls will still reduce the amount of shock damage taken, just that they do not provide full shock protection, like they used to.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being able to make insuls with 2 coils (30 per coil) of cable is a fair bit unbalanced, considering how it can be done in under a minute. In addition, it skips nearly all the important parts of matsci, such as getting materials and alloying. (Meant to synergize with #6801)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Synthrubber conductivity 20 -> 30
```
