### PR TITLE
SWAT gloves now have 25% conductivity instead of 30% (shock protection)

### DIFF
--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -347,7 +347,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	setupProperties()
 		..()
 		setProperty("heatprot", 10)
-		setProperty("conductivity", 0.3)
+		setProperty("conductivity", 0.2)
 		setProperty("deflection", 20)
 
 /obj/item/clothing/gloves/swat/knight

--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -347,7 +347,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	setupProperties()
 		..()
 		setProperty("heatprot", 10)
-		setProperty("conductivity", 0.2)
+		setProperty("conductivity", 0.25)
 		setProperty("deflection", 20)
 
 /obj/item/clothing/gloves/swat/knight


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR sets the conductivity of SWAT gloves to 25% (insuls are 20%), pushing them into the range of being immune to shocks from doors and such.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As-is, SWAT gloves feel like downgrades to insulated gloves, since shocks are so prevalent. Take nukies, where the shock protection of insuls means that they are always nearly taken, since it regularly occurs where the AI gets lawed to non-human nukeops, and shocks doors that they are going to touch. In addition, this is meant to synergize with #6801.

Small note: NTSO gloves were also affected, unsure if that should be changed; left it the same so the only difference is the color, as before.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)SWAT gloves now are insulated against most regular forms of shocking (such as doors).
```
