### PR TITLE
Anchor heavenly_light

### DIFF
--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -1222,6 +1222,7 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 /obj/heavenly_light
 	icon = 'icons/obj/large/32x192.dmi'
 	icon_state = "heavenlight"
+	anchored = 1
 	layer = EFFECTS_LAYER
 	blend_mode = BLEND_ADD
 

--- a/code/WorkInProgress/AnimationLibrary.dm
+++ b/code/WorkInProgress/AnimationLibrary.dm
@@ -1192,7 +1192,7 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 	sleep(1.5 SECONDS)
 
 /proc/heavenly_spawn(var/atom/movable/A)
-	var/obj/heavenly_light/lightbeam = new /obj/heavenly_light
+	var/obj/effects/heavenly_light/lightbeam = new /obj/effects/heavenly_light
 	lightbeam.set_loc(A.loc)
 	var/was_anchored = A.anchored
 	var/oldlayer = A.layer
@@ -1219,10 +1219,9 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 		var/mob/M = A
 		REMOVE_MOB_PROPERTY(M, PROP_CANTMOVE, M.type)
 
-/obj/heavenly_light
+/obj/effects/heavenly_light
 	icon = 'icons/obj/large/32x192.dmi'
 	icon_state = "heavenlight"
-	anchored = 1
 	layer = EFFECTS_LAYER
 	blend_mode = BLEND_ADD
 

--- a/code/WorkInProgress/GerhazoStuff.dm
+++ b/code/WorkInProgress/GerhazoStuff.dm
@@ -788,7 +788,7 @@
 		if (did_something)
 			var/turf/T = get_turf(target)
 			T.visible_message("<span class='notice'>As [user] brings \the [src] near [target], \the [src] spontaneously bursts into flames and [target]'s wounds appear to fade away!</span>")
-			var/obj/heavenly_light/lightbeam = new /obj/heavenly_light
+			var/obj/effects/heavenly_light/lightbeam = new /obj/effects/heavenly_light
 			lightbeam.set_loc(T)
 			lightbeam.alpha = 0
 			playsound(T, "sound/voice/heavenly.ogg", 100, 1, 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Anchors heavenly_light.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It can be pulled and moved around.
This could have been anchored elsewhere like the effect but why would you ever want a light beam effect like this to not be anchored?