### PR TITLE
Resolve job controller log spam

### DIFF
--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -984,7 +984,12 @@ var/datum/job_controller/job_controls
 		logTheThing("debug", null, null, "<b>Job Controller:</b> Attempt to find job with bad string in controller detected")
 		return null
 	var/list/excluded_strings = list("Special Respawn","Custom Names","Everything Except Assistant",
-	"Engineering Department","Security Department","Heads of Staff", "Pod_Wars")
+	"Engineering Department","Security Department","Heads of Staff", "Pod_Wars", "Syndicate", "Construction Worker")
+	#ifdef MAP_OVERRIDE_MANTA
+
+	#else
+		excluded_strings += "Communications Officer"
+	#endif
 	if (string in excluded_strings)
 		return null
 	for (var/datum/job/J in job_controls.staple_jobs)

--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -986,7 +986,7 @@ var/datum/job_controller/job_controls
 	var/list/excluded_strings = list("Special Respawn","Custom Names","Everything Except Assistant",
 	"Engineering Department","Security Department","Heads of Staff", "Pod_Wars", "Syndicate", "Construction Worker")
 	#ifndef MAP_OVERRIDE_MANTA
-		excluded_strings += "Communications Officer"
+	excluded_strings += "Communications Officer"
 	#endif
 	if (string in excluded_strings)
 		return null

--- a/code/datums/controllers/job_controls.dm
+++ b/code/datums/controllers/job_controls.dm
@@ -985,9 +985,7 @@ var/datum/job_controller/job_controls
 		return null
 	var/list/excluded_strings = list("Special Respawn","Custom Names","Everything Except Assistant",
 	"Engineering Department","Security Department","Heads of Staff", "Pod_Wars", "Syndicate", "Construction Worker")
-	#ifdef MAP_OVERRIDE_MANTA
-
-	#else
+	#ifndef MAP_OVERRIDE_MANTA
 		excluded_strings += "Communications Officer"
 	#endif
 	if (string in excluded_strings)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds removed job Construction Worker and non-job Syndicate to excluded strings for job lookup.
Put Communications Officer behind an ifdef check for Manta.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Construction Worker is a removed job but players still have saved preferences for it causing log spam.
Communications Officer's datum is behind an #ifdef for manta.
Syndicate, not sure where this comes from.