### PR TITLE
Adds the firefighter helm chance to wall cabinets

### DIFF
--- a/code/obj/storage/wall_cabinet.dm
+++ b/code/obj/storage/wall_cabinet.dm
@@ -54,6 +54,8 @@
 		..()
 		if (prob(80))
 			new /obj/item/extinguisher(src)
+		if (prob(50))
+			new /obj/item/clothing/head/helmet/firefighter(src)
 		if (prob(30))
 			new /obj/item/clothing/suit/fire(src)
 			new /obj/item/clothing/mask/gas/emergency(src)


### PR DESCRIPTION
[Trivial]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As the title says, should make wall cabinets back to being exactly like their locker counterparts again.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I forgot to add them to here when I added firefighter helms to fire fighting lockers. Woops!