### PR TITLE
Rationalize Donut 3 phones

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -27444,7 +27444,6 @@
 /area/station/hallway/primary/east)
 "hJJ" = (
 /obj/table/round/auto,
-/obj/machinery/phone,
 /obj/machinery/light_switch/auto,
 /obj/noticeboard/persistent{
 	name = "Cargo persistent notice board";
@@ -30578,6 +30577,12 @@
 	dir = 1
 	},
 /area/station/medical/medbay/treatment)
+"iGL" = (
+/obj/machinery/phone/wall{
+	pixel_y = 5
+	},
+/turf/simulated/wall/auto/jen,
+/area/station/ranch)
 "iGT" = (
 /obj/cable{
 	d1 = 4;
@@ -38419,6 +38424,10 @@
 /obj/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/phone/wall{
+	pixel_x = -30;
+	pixel_y = 4
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
@@ -130636,7 +130645,7 @@ mfs
 mfs
 mfs
 mfs
-mfs
+iGL
 sFl
 fBI
 uNZ

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -7569,6 +7569,11 @@
 	},
 /area/station/medical/cdc)
 "bSp" = (
+/obj/item/device/radio/intercom/botany{
+	dir = 4;
+	pixel_x = -22;
+	pixel_y = 18
+	},
 /turf/simulated/floor/green/corner,
 /area/station/hydroponics/bay)
 "bSq" = (
@@ -20755,7 +20760,6 @@
 	},
 /obj/item/bee_egg_carton,
 /obj/item/bee_egg_carton,
-/obj/item/device/radio/intercom/botany,
 /obj/noticeboard/persistent{
 	name = "Botany persistent notice board";
 	persistent_id = "botany"
@@ -35985,9 +35989,9 @@
 /obj/item/paper/ranch_guide,
 /obj/item/fishing_rod,
 /obj/item/chicken_carrier,
-/obj/machinery/light_switch/auto{
-	pixel_x = -24;
-	pixel_y = 5
+/obj/machinery/light_switch/east{
+	dir = 4;
+	pixel_x = -28
 	},
 /obj/machinery/light/incandescent/netural,
 /obj/item/device/camera_viewer/ranch,
@@ -52505,7 +52509,8 @@
 /area/station/hallway/primary/west)
 "plZ" = (
 /obj/machinery/firealarm{
-	pixel_y = 24;
+	pixel_x = -4;
+	pixel_y = 28;
 	text = "NF"
 	},
 /obj/submachine/seed_manipulator{
@@ -64553,6 +64558,7 @@
 	tag = ""
 	},
 /obj/machinery/phone/wall{
+	pixel_x = 4;
 	pixel_y = 36
 	},
 /turf/simulated/floor,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -407,6 +407,7 @@
 	pixel_x = 1;
 	pixel_y = 41
 	},
+/obj/submachine/slot_machine,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
 "aaC" = (
@@ -3322,10 +3323,6 @@
 "aGP" = (
 /obj/machinery/light/incandescent/warm,
 /obj/storage/secure/closet/security/equipment,
-/obj/machinery/phone/wall{
-	pixel_x = 24;
-	pixel_y = 8
-	},
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
@@ -9005,7 +9002,6 @@
 /area/station/science/chemistry)
 "cpD" = (
 /obj/table/wood/auto,
-/obj/machinery/phone,
 /turf/simulated/floor/carpet/purple/fancy/junction/nw_e,
 /area/station/crew_quarters/hor)
 "cpH" = (
@@ -16651,12 +16647,10 @@
 	dir = 1;
 	icon_state = "tile1"
 	},
-/obj/table/auto,
 /obj/decal/tile_edge/line/grey{
 	dir = 1;
 	icon_state = "tile1"
 	},
-/obj/machinery/phone,
 /obj/decal/poster/wallsign/stencil/right/s{
 	pixel_x = 4;
 	pixel_y = 41
@@ -16664,6 +16658,9 @@
 /obj/decal/poster/wallsign/stencil/right/i{
 	pixel_x = 13;
 	pixel_y = 41
+	},
+/obj/machinery/computer/arcade{
+	desc = "The VR representation of a popular computer game."
 	},
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
@@ -38783,10 +38780,6 @@
 	},
 /area/station/maintenance/outer/west)
 "llV" = (
-/obj/machinery/phone/wall{
-	pixel_x = -23;
-	pixel_y = 4
-	},
 /obj/cable{
 	icon_state = "1-2"
 	},
@@ -47941,7 +47934,6 @@
 	},
 /area/station/hallway/primary/west)
 "nUf" = (
-/obj/machinery/phone,
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
@@ -54018,10 +54010,6 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/obj/machinery/phone/wall{
-	pixel_x = -1;
-	pixel_y = -19
-	},
 /turf/simulated/floor/redblack,
 /area/station/security/equipment)
 "pHv" = (
@@ -55371,7 +55359,6 @@
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/medical/medbay/surgery/storage)
 "qbj" = (
-/obj/machinery/phone,
 /obj/table/reinforced/chemistry/auto,
 /obj/item/reagent_containers/emergency_injector/calomel{
 	pixel_y = -14
@@ -56622,7 +56609,6 @@
 /obj/table/reinforced/bar/auto{
 	name = "table"
 	},
-/obj/machinery/phone,
 /turf/simulated/floor/carpet{
 	icon_state = "fred2"
 	},
@@ -65667,10 +65653,6 @@
 /turf/simulated/floor/industrial,
 /area/station/quartermaster/refinery)
 "sXk" = (
-/obj/machinery/phone/wall{
-	pixel_x = -5;
-	pixel_y = 32
-	},
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -67664,6 +67646,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"tBh" = (
+/obj/machinery/phone/wall,
+/turf/simulated/wall/auto/reinforced/jen/blue,
+/area/station/bridge)
 "tBC" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/random_item_spawner/junk/one_or_zero,
@@ -77676,6 +77662,7 @@
 	icon_state = "line1"
 	},
 /obj/table/auto,
+/obj/machinery/phone,
 /turf/simulated/floor/purpleblack{
 	dir = 5
 	},
@@ -78175,16 +78162,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/brig/south_side)
-"wEs" = (
-/obj/disposalpipe/segment/brig{
-	dir = 1
-	},
-/obj/machinery/phone/wall{
-	pixel_x = 23;
-	pixel_y = 24
-	},
-/turf/simulated/floor/red/checker,
-/area/station/security/checkpoint/arrivals)
 "wEy" = (
 /obj/stool/bench/auto,
 /turf/simulated/floor/blue/side{
@@ -114673,7 +114650,7 @@ rdj
 rdj
 mxj
 tGy
-wEs
+mkV
 mkV
 mkV
 dWY
@@ -117122,7 +117099,7 @@ nMc
 nHT
 nMc
 nMc
-prh
+tBh
 bbp
 vlq
 dqf

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -4665,6 +4665,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
 /turf/simulated/floor/stairs/wide{
 	dir = 4
 	},
@@ -18169,6 +18172,14 @@
 	dir = 4
 	},
 /area/station/security/hos)
+"eYO" = (
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood/eight{
+	dir = 1
+	},
+/area/station/crew_quarters/cafeteria)
 "eYU" = (
 /obj/cable{
 	d1 = 2;
@@ -30577,12 +30588,6 @@
 	dir = 1
 	},
 /area/station/medical/medbay/treatment)
-"iGL" = (
-/obj/machinery/phone/wall{
-	pixel_y = 5
-	},
-/turf/simulated/wall/auto/jen,
-/area/station/ranch)
 "iGT" = (
 /obj/cable{
 	d1 = 4;
@@ -38426,7 +38431,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/phone/wall{
-	pixel_x = -30;
+	pixel_x = -28;
 	pixel_y = 4
 	},
 /turf/simulated/floor,
@@ -44037,7 +44042,6 @@
 /area/station/security/equipment)
 "mLe" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/phone,
 /turf/simulated/floor/carpet/green/fancy/innercorner{
 	dir = 8
 	},
@@ -60918,10 +60922,6 @@
 /obj/disposalpipe/junction/left/east,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/east)
-"rzO" = (
-/obj/decal/poster/wallsign/bar,
-/turf/simulated/wall/auto/jen,
-/area/station/crew_quarters/kitchen)
 "rzR" = (
 /obj/machinery/light/incandescent/cool,
 /obj/machinery/camera{
@@ -61096,6 +61096,9 @@
 	},
 /obj/disposalpipe/trunk{
 	dir = 1
+	},
+/obj/decal/poster/wallsign/bar{
+	pixel_y = 32
 	},
 /turf/simulated/floor/wood/eight{
 	dir = 1
@@ -64549,6 +64552,9 @@
 	pixel_y = 20;
 	tag = ""
 	},
+/obj/machinery/phone/wall{
+	pixel_y = 36
+	},
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "sFw" = (
@@ -67655,10 +67661,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"tBh" = (
-/obj/machinery/phone/wall,
-/turf/simulated/wall/auto/reinforced/jen/blue,
-/area/station/bridge)
 "tBC" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/random_item_spawner/junk/one_or_zero,
@@ -117108,7 +117110,7 @@ nMc
 nHT
 nMc
 nMc
-tBh
+prh
 bbp
 vlq
 dqf
@@ -126425,8 +126427,8 @@ hJO
 fsn
 saL
 pQh
-rzO
-rNI
+pQh
+eYO
 qHy
 eEy
 rul
@@ -130645,7 +130647,7 @@ mfs
 mfs
 mfs
 mfs
-iGL
+mfs
 sFl
 fBI
 uNZ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the following phones from Donut 3:
RD Office
Security Equipment Room
Chief Engineer's Office
Brig Long Term Cell - North (Replaced with Robustris/Slot machine to match South when divider is raised)
Pod Bay Security
Arrivals Security
Escape Hallway Security
Chapel Office

Moves the following phones on Donut 3:
Captains Office -> Bridge
Medbay Lobby converted to Wall Phone for visibility.
Chemistry -> Science Lobby

New left, old right
![image](https://user-images.githubusercontent.com/70909958/144845175-f07f2237-1b36-435f-830e-e18c7e17fc6c.png)
Ignore Drug Den - Random prefab

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Excessive number of phones.
Office phones are largely pointless but these might be wanted for RP?

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Changed phones on Donut 3, removed arrivals/office phones. Moved and added some phones.
```
