### PR TITLE
Fixed borgs and AI shells opening doors while inactive

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1312,7 +1312,7 @@ About the new airlock wires panel:
 			return
 
 		if (issilicon(AM))
-			if (aiControlDisabled == 1 || cant_emag)
+			if (aiControlDisabled || cant_emag)
 				return
 			var/mob/silicon = AM
 			if (!silicon.mind)

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1315,7 +1315,7 @@ About the new airlock wires panel:
 			if (aiControlDisabled == 1 || cant_emag)
 				return
 			var/mob/silicon = AM
-			if (isnull(silicon.mind))
+			if (!silicon.mind)
 				return
 
 		src.last_bump = world.time

--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -1311,8 +1311,12 @@ About the new airlock wires panel:
 		if(world.time - src.last_bump <= 30)
 			return
 
-		if (issilicon(AM) && (aiControlDisabled == 1 || cant_emag))
-			return
+		if (issilicon(AM))
+			if (aiControlDisabled == 1 || cant_emag)
+				return
+			var/mob/silicon = AM
+			if (isnull(silicon.mind))
+				return
 
 		src.last_bump = world.time
 		if (src.isElectrified())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #6868
Just checks if a silicon mob has a mind before letting it bump open a door. Not sure if this would break NPC silicons, I don't know enough about NPC code. Also not sure if this is a bugfix or a balance change, so feel free to re-flair it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AI shells being left around important areas while inactive is extremely common and they shouldn't act as a draggable AA ID.