### PR TITLE
Cog2 Armory gets breaching hammers

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -40336,6 +40336,14 @@
 /obj/item/clothing/glasses/thermal,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot,
+/obj/item/breaching_hammer{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/breaching_hammer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "bKE" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Feature] [QoL] [Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds 2 breaching hammers to cog2's armory, which previously lacked them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Inconsistency and missing things bad.

To be honest, at some point there should be a pass of all armories to standardize their equipment

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Cogmap2's armory now has a pair of breaching hammers.
```
