### PR TITLE
Revert commit 0655df8 (Prismatic spray can only hit 1 person a burst)

### DIFF
--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -253,6 +253,7 @@ ABSTRACT_TYPE(/datum/artifact/art)
 
 	shot_volume = 66
 	projectile_speed = 54
+	hit_ground_chance = 10
 
 	randomise()
 		. = ..()
@@ -261,11 +262,6 @@ ABSTRACT_TYPE(/datum/artifact/art)
 		src.power = max(10, src.power)
 		if(prob(90))
 			src.ks_ratio = 1
-
-	on_pre_hit(atom/hit, angle, obj/projectile/O)
-		. = ..()
-		if(ismob(hit) && ON_COOLDOWN(hit, "prismaticed", 1.5 SECONDS))
-			. = TRUE
 
 	New()
 		..()

--- a/strings/changelog.txt
+++ b/strings/changelog.txt
@@ -174,8 +174,6 @@
 (p)5645
 (e)🎨|sprites
 (*)Status Displays are back (but as of right now not placed on all maps). But you can order a crate of them from cargo for now.
-(u)tarmunora
-(+)prismatic spray spell now hits targets once/burst, and has full ground-hit-chance
 (t)fri nov 12 21
 (u)Azrun, Gannets & Aquario
 (p)6646


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Feature] [Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR reverts 0655df8, adding back the 10% chance to hit people on the ground, but removing the 1.5 second cooldown between getting hit by a projectile.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prismatic spray is incredibly weak as-is, with the damage being incredibly low, should someone even get hit with a damaging prismatic projectile in the first place. They could also get hit with a stamina one, which does basically nothing when you get hit by 1.

![image](https://user-images.githubusercontent.com/41448081/145133352-21873b72-6bb9-436a-b023-69484cef18db.png)
Damage after **SIX** bursts of prismatic spray.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Reverted commit 0655df8, prismatic spray now can hit one person more than once in a burst.
```
