### PR TITLE
fix bugs with dimensional shift and teleport wands

### DIFF
--- a/code/datums/abilities/wizard/phaseshift.dm
+++ b/code/datums/abilities/wizard/phaseshift.dm
@@ -33,7 +33,7 @@
 /proc/spell_invisibility(var/mob/H, var/time, var/check_for_watchers = 0, var/stop_burning = 0, var/dry_run_only = 0)
 	if (!H || !ismob(H))
 		return
-	if (!isturf(H.loc) && !istype(H.loc, /obj/dummy/spell_invis))
+	if (!isturf(H.loc))
 		H.show_text("You can't seem to turn incorporeal here.", "red")
 		return
 	if (H.stat || H.getStatusDuration("paralysis") > 0)

--- a/code/obj/artifacts/artifact_items/teleport_wand.dm
+++ b/code/obj/artifacts/artifact_items/teleport_wand.dm
@@ -72,7 +72,7 @@
 		return
 
 	proc/can_teleport_here(var/turf/T,mob/user)
-		if(!istype(user.loc,/obj/dummy/spell_invis/))
+		if(istype(user.loc,/obj/dummy/spell_invis/))
 			return FALSE
 		if(isrestrictedz(T.z))
 			return FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
#6720 had some incorrect checks, making it so teleport wands could not be used.
The check that was supposed to make phase shift unusable inside dimension shift was wrong as well, and not needed in the first place, since the isturf(H.loc) check already covered this case anyway.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad