### PR TITLE
Chem smoke can no longer produce smoke-banned reagents in-cloud

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -1084,8 +1084,7 @@ datum
 
 		//there were two different implementations, one of which didn't work, so i moved the working one here and both call it now - IM
 		proc/smoke_start(var/volume, var/classic = 0)
-			for(var/reagent_id in reagent_list)
-				purge_smoke_blacklist(reagent_id)
+			purge_smoke_blacklist(reagent_list)
 
 			var/list/covered = covered_turf()
 

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -1084,13 +1084,8 @@ datum
 
 		//there were two different implementations, one of which didn't work, so i moved the working one here and both call it now - IM
 		proc/smoke_start(var/volume, var/classic = 0)
-			del_reagent("thalmerite")
-			del_reagent("big_bang") //remove later if we can get a better fix
-			del_reagent("big_bang_precursor")
-			del_reagent("poor_concrete")
-			del_reagent("okay_concrete")
-			del_reagent("good_concrete")
-			del_reagent("perfect_concrete")
+			for(var/reagent_id in reagent_list)
+				purge_smoke_blacklist(reagent_id)
 
 			var/list/covered = covered_turf()
 

--- a/code/modules/chemistry/Chemistry-Reactions.dm
+++ b/code/modules/chemistry/Chemistry-Reactions.dm
@@ -215,6 +215,7 @@
 
 		M.apply_flash(anim_dur, stunned, stunned, 0, eye_blurry, eye_damage, stamina_damage = stam_damage)
 
+/// Deletes any reagents that are banned in smoke clouds.
 /proc/purge_smoke_blacklist(datum/reagents/FG)
 	FG.del_reagent("thalmerite")
 	FG.del_reagent("big_bang")

--- a/code/modules/chemistry/Chemistry-Reactions.dm
+++ b/code/modules/chemistry/Chemistry-Reactions.dm
@@ -101,6 +101,8 @@
 		if (!source)
 			continue
 
+		purge_smoke_blacklist(holder)
+
 		if (do_sfx)
 			if (narrator_mode || vox_smoke)
 				playsound(location, 'sound/vox/smoke.ogg', 50, 1, -3)
@@ -116,6 +118,7 @@
 		if (source.active_airborne_liquid && source.active_airborne_liquid.group)
 			prev_group_exists = 1
 			var/datum/fluid_group/FG = source.active_airborne_liquid.group
+			purge_smoke_blacklist(FG.reagents)
 
 			if (FG.contained_amt > diminishing_returns_thingymabob)
 				react_amount = react_amount / (1 + ((FG.contained_amt - diminishing_returns_thingymabob) * 0.1))//MBC MAGIC NUMBERS :)
@@ -211,3 +214,12 @@
 		var/stam_damage = 26 * min(amount, 5)
 
 		M.apply_flash(anim_dur, stunned, stunned, 0, eye_blurry, eye_damage, stamina_damage = stam_damage)
+
+/proc/purge_smoke_blacklist(datum/reagents/FG)
+	FG.del_reagent("thalmerite")
+	FG.del_reagent("big_bang")
+	FG.del_reagent("big_bang_precursor")
+	FG.del_reagent("poor_concrete")
+	FG.del_reagent("okay_concrete")
+	FG.del_reagent("good_concrete")
+	FG.del_reagent("perfect_concrete")

--- a/code/modules/fluids/air.dm
+++ b/code/modules/fluids/air.dm
@@ -132,6 +132,7 @@ var/list/ban_from_airborne_fluid = list()
 		src.touched_channel = 0
 		blocked_dirs = 0
 		spawned_any = 0
+		purge_smoke_blacklist(src.group.reagents)
 
 		var/turf/t
 		if(!waterflow_enabled) return

--- a/code/modules/fluids/fluid_procs.dm
+++ b/code/modules/fluids/fluid_procs.dm
@@ -60,6 +60,7 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 		if (airborne)
 			for(var/reagent_id in R.reagent_list)
 				if (reagent_id in ban_from_airborne_fluid) return
+			purge_smoke_blacklist(R.reagent_list)
 		else
 			for(var/reagent_id in R.reagent_list)
 				if (reagent_id in ban_from_fluid) return
@@ -69,6 +70,7 @@ turf/simulated/floor/plating/airless/ocean_canpass()
 			for(var/reagent_id in R.reagent_list)
 				if ( CI++ == index )
 					if (reagent_id in ban_from_airborne_fluid) return
+			purge_smoke_blacklist(R.reagent_list)
 		else
 			for(var/reagent_id in R.reagent_list)
 				if ( CI++ == index )


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title, this purges any chem smoke banned reagents on-synthesis in the air. In addition, it turns the purging of reagents into a proc, to reduce code repetition.
Fixes #6885.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs/Exploits bad.
