### PR TITLE
Added preference for sleeper agent role separately

### DIFF
--- a/code/datums/preferences.dm
+++ b/code/datums/preferences.dm
@@ -24,6 +24,7 @@ datum/preferences
 	var/employment_note
 
 	var/be_traitor = 0
+	var/be_sleeper_agent = 0
 	var/be_syndicate = 0
 	var/be_syndicate_commander = 0
 	var/be_spy = 0
@@ -887,6 +888,7 @@ datum/preferences
 				radio_music_volume = 50
 				use_click_buffer = 0
 				be_traitor = 0
+				be_sleeper_agent = 0
 				be_syndicate = 0
 				be_syndicate_commander = 0
 				be_spy = 0
@@ -1312,6 +1314,7 @@ datum/preferences
 		if (jobban_isbanned(user, "Syndicate"))
 			HTML += "You are banned from playing antagonist roles."
 			src.be_traitor = 0
+			src.be_sleeper_agent = 0
 			src.be_syndicate = 0
 			src.be_syndicate_commander = 0
 			src.be_spy = 0
@@ -1330,6 +1333,7 @@ datum/preferences
 
 			HTML += {"
 			<a href="byond://?src=\ref[src];preferences=1;b_traitor=1" class="[src.be_traitor ? "yup" : "nope"]">[crap_checkbox(src.be_traitor)] Traitor</a>
+			<a href="byond://?src=\ref[src];preferences=1;b_sleeper_agent=1" class="[src.be_sleeper_agent ? "yup" : "nope"]">[crap_checkbox(src.be_sleeper_agent)] Sleeper agent</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_syndicate=1" class="[src.be_syndicate ? "yup" : "nope"]">[crap_checkbox(src.be_syndicate)] Nuclear Operative</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_syndicate_commander=1" class="[src.be_syndicate_commander ? "yup" : "nope"]">[crap_checkbox(src.be_syndicate_commander)] Nuclear Operative Commander</a>
 			<a href="byond://?src=\ref[src];preferences=1;b_spy=1" class="[src.be_spy ? "yup" : "nope"]">[crap_checkbox(src.be_spy)] Spy/Thief</a>
@@ -1537,6 +1541,10 @@ datum/preferences
 
 		if (link_tags["b_traitor"])
 			src.be_traitor = !( src.be_traitor)
+			src.SetChoices(user)
+			return
+		if (link_tags["b_sleeper_agent"])
+			src.be_sleeper_agent = !( src.be_sleeper_agent)
 			src.SetChoices(user)
 			return
 

--- a/code/datums/savefile.dm
+++ b/code/datums/savefile.dm
@@ -84,6 +84,7 @@
 		F["[profileNum]_job_prefs_3"] << src.jobs_low_priority
 		F["[profileNum]_job_prefs_4"] << src.jobs_unwanted
 		F["[profileNum]_be_traitor"] << src.be_traitor
+		F["[profileNum]_be_sleeper_agent"] << src.be_sleeper_agent
 		F["[profileNum]_be_syndicate"] << src.be_syndicate
 		F["[profileNum]_be_syndicate_commander"] << src.be_syndicate_commander
 		F["[profileNum]_be_spy"] << src.be_spy
@@ -269,6 +270,7 @@
 		F["[profileNum]_job_prefs_3"] >> src.jobs_low_priority
 		F["[profileNum]_job_prefs_4"] >> src.jobs_unwanted
 		F["[profileNum]_be_traitor"] >> src.be_traitor
+		F["[profileNum]_be_sleeper_agent"] >> src.be_sleeper_agent
 		F["[profileNum]_be_syndicate"] >> src.be_syndicate
 		F["[profileNum]_be_syndicate_commander"] >> src.be_syndicate_commander
 		F["[profileNum]_be_spy"] >> src.be_spy

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -177,7 +177,7 @@
 				if (Hs.frequency == frequency)
 					listeners += H
 					boutput(H, "<span class='notice'>A peculiar noise intrudes upon the radio frequency of your [Hs].</span>")
-					if (H.client && !checktraitor(H) && (H.client.preferences.be_traitor || src.override_player_pref))
+					if (H.client && !checktraitor(H) && (H.client.preferences.be_sleeper_agent || src.override_player_pref))
 						var/datum/job/J = find_job_in_controller_by_string(H?.mind.assigned_role)
 						if (J.allow_traitors)
 							candidates.Add(H)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an option to select or deselect sleeper agent separately from traitor.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Noticed this wasn't in the game after getting last minute sleeper agent jumpscared several times and wanting a break.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)You can now select or deselect sleeper agent separately from traitor.
```
