### PR TITLE
The Santa suit nukeops have no longer gives slowdown

### DIFF
--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -54,6 +54,11 @@
 	icon_state = "santa"
 	item_state = "santahat"
 
+	noslow
+		setupProperties()
+			..()
+			setProperty("space_movespeed", 0.0)
+
 /obj/item/clothing/suit/space/santa
 	name = "santa suit"
 	desc = "Festive!"
@@ -62,6 +67,11 @@
 	icon = 'icons/obj/clothing/overcoats/item_suit_gimmick.dmi'
 	wear_image_icon = 'icons/mob/overcoats/worn_suit_gimmick.dmi'
 	inhand_image_icon = 'icons/mob/inhand/overcoat/hand_suit_gimmick.dmi'
+
+	noslow
+		setupProperties()
+			..()
+			setProperty("space_movespeed", 0.0)
 
 /obj/item/clothing/mask/owl_mask
 	name = "owl mask"

--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -138,8 +138,8 @@
 #endif
 	/obj/item/clothing/under/misc/syndicate,
 #ifdef XMAS
-	/obj/item/clothing/head/helmet/space/santahat,
-	/obj/item/clothing/suit/space/santa,
+	/obj/item/clothing/head/helmet/space/santahat/noslow,
+	/obj/item/clothing/suit/space/santa/noslow,
 #else
 	/obj/item/clothing/head/helmet/space/syndicate,
 	/obj/item/clothing/suit/space/syndicate,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. This brings santa suits to match red spacesuits in speed.
Note: only affects the suits nukeops have, regular ones are still slow

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Kneecapping nukies in december is lame.
