### PR TITLE
move normal human initialization to initializeBioholder

### DIFF
--- a/code/mob/living/carbon/human/normal.dm
+++ b/code/mob/living/carbon/human/normal.dm
@@ -1,238 +1,204 @@
 /mob/living/carbon/human/normal
-	New()
-		..()
-		SPAWN_DBG(0)
-			randomize_look(src, 1, 1, 1, 1, 1, 1, src)
-			src.gender = src.bioHolder?.mobAppearance?.gender
-			src.update_colorful_parts()
-
-		SPAWN_DBG(1 SECOND)
-			set_clothing_icon_dirty()
+	initializeBioholder()
+		. = ..()
+		randomize_look(src, 1, 1, 1, 1, 1, 1, src)
+		src.gender = src.bioHolder?.mobAppearance?.gender
+		src.update_colorful_parts()
+		set_clothing_icon_dirty()
 
 /mob/living/carbon/human/normal/assistant
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Staff Assistant")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Staff Assistant")
 
 /mob/living/carbon/human/normal/syndicate
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Syndicate")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Syndicate")
 
 /mob/living/carbon/human/normal/captain
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Captain")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Captain")
 
 /mob/living/carbon/human/normal/headofpersonnel
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Head of Personnel")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Head of Personnel")
 
 /mob/living/carbon/human/normal/chiefengineer
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Chief Engineer")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Chief Engineer")
 
 /mob/living/carbon/human/normal/researchdirector
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Research Director")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Research Director")
 
 /mob/living/carbon/human/normal/headofsecurity
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Head of Security")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Head of Security")
 
 /mob/living/carbon/human/normal/securityofficer
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Security Officer")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Security Officer")
 
 /mob/living/carbon/human/normal/securityassistant
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Security Assistant")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Security Assistant")
 
 /mob/living/carbon/human/normal/detective
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Detective")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Detective")
 
 /mob/living/carbon/human/normal/clown
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Clown")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Clown")
 
 /mob/living/carbon/human/normal/chef
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Chef")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Chef")
 
 /mob/living/carbon/human/normal/chaplain
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Chaplain")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Chaplain")
 
 /mob/living/carbon/human/normal/bartender
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Bartender")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Bartender")
 
 /mob/living/carbon/human/normal/botanist
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Botanist")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Botanist")
 
 /mob/living/carbon/human/normal/rancher
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Rancher")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Rancher")
 
 /mob/living/carbon/human/normal/janitor
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Janitor")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Janitor")
 
 /mob/living/carbon/human/normal/mechanic
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Mechanic")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Mechanic")
 
 /mob/living/carbon/human/normal/engineer
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Engineer")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Engineer")
 
 /mob/living/carbon/human/normal/miner
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Miner")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Miner")
 
 /mob/living/carbon/human/normal/quartermaster
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Quartermaster")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Quartermaster")
 
 /mob/living/carbon/human/normal/medicaldoctor
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Medical Doctor")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Medical Doctor")
 
 /mob/living/carbon/human/normal/geneticist
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Geneticist")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Geneticist")
 
 /mob/living/carbon/human/normal/pathologist
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Pathologist")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Pathologist")
 
 /mob/living/carbon/human/normal/roboticist
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Roboticist")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Roboticist")
 
 /mob/living/carbon/human/normal/chemist
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Chemist")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Chemist")
 
 /mob/living/carbon/human/normal/scientist
-	New()
-		..()
-		SPAWN_DBG(0)
-			JobEquipSpawned("Scientist")
+	initializeBioholder()
+		. = ..()
+		JobEquipSpawned("Scientist")
 
 /mob/living/carbon/human/normal/wizard
-	New()
-		..()
-		SPAWN_DBG(0)
-			if (src.gender && src.gender == "female")
-				src.real_name = pick_string_autokey("names/wizard_female.txt")
-			else
-				src.real_name = pick_string_autokey("names/wizard_male.txt")
+	initializeBioholder()
+		. = ..()
+		if (src.gender && src.gender == "female")
+			src.real_name = pick_string_autokey("names/wizard_female.txt")
+		else
+			src.real_name = pick_string_autokey("names/wizard_male.txt")
 
-			equip_wizard(src, 1)
-		return
+		equip_wizard(src, 1)
 
 /mob/living/carbon/human/normal/rescue
-	New()
-		..()
-		SPAWN_DBG(0)
-			src.equip_new_if_possible(/obj/item/clothing/shoes/red, slot_shoes)
-			src.equip_new_if_possible(/obj/item/clothing/under/color/red, slot_w_uniform)
-			src.equip_new_if_possible(/obj/item/card/id, slot_wear_id)
-			src.equip_new_if_possible(/obj/item/device/radio/headset, slot_ears)
-			src.equip_new_if_possible(/obj/item/storage/belt/utility/prepared, slot_belt)
-			src.equip_new_if_possible(/obj/item/storage/backpack/withO2, slot_back)
-			src.equip_new_if_possible(/obj/item/device/light/flashlight, slot_l_store)
-			src.equip_new_if_possible(/obj/item/clothing/suit/armor/vest, slot_wear_suit)
-			src.equip_new_if_possible(/obj/item/clothing/mask/gas, slot_wear_mask)
-			src.equip_new_if_possible(/obj/item/clothing/gloves/black, slot_gloves)
-			src.equip_new_if_possible(/obj/item/clothing/glasses/nightvision, slot_glasses)
+	initializeBioholder()
+		. = ..()
+		src.equip_new_if_possible(/obj/item/clothing/shoes/red, slot_shoes)
+		src.equip_new_if_possible(/obj/item/clothing/under/color/red, slot_w_uniform)
+		src.equip_new_if_possible(/obj/item/card/id, slot_wear_id)
+		src.equip_new_if_possible(/obj/item/device/radio/headset, slot_ears)
+		src.equip_new_if_possible(/obj/item/storage/belt/utility/prepared, slot_belt)
+		src.equip_new_if_possible(/obj/item/storage/backpack/withO2, slot_back)
+		src.equip_new_if_possible(/obj/item/device/light/flashlight, slot_l_store)
+		src.equip_new_if_possible(/obj/item/clothing/suit/armor/vest, slot_wear_suit)
+		src.equip_new_if_possible(/obj/item/clothing/mask/gas, slot_wear_mask)
+		src.equip_new_if_possible(/obj/item/clothing/gloves/black, slot_gloves)
+		src.equip_new_if_possible(/obj/item/clothing/glasses/nightvision, slot_glasses)
 
-			var/obj/item/card/id/C = src.wear_id
-			if(C)
-				C.registered = src.real_name
-				C.assignment = "NT-SO Rescue Worker"
-				C.name = "[C.registered]'s ID Card ([C.assignment])"
-				C.access = get_all_accesses()
+		var/obj/item/card/id/C = src.wear_id
+		if(C)
+			C.registered = src.real_name
+			C.assignment = "NT-SO Rescue Worker"
+			C.name = "[C.registered]'s ID Card ([C.assignment])"
+			C.access = get_all_accesses()
 
-			update_clothing()
+		update_clothing()
 
 /mob/living/carbon/human/normal/ntso
-	New()
-		..()
-		SPAWN_DBG(0)
-			src.equip_new_if_possible(/obj/item/clothing/shoes/swat, slot_shoes)
-			src.equip_new_if_possible(/obj/item/clothing/under/misc/NT, slot_w_uniform)
-			src.equip_new_if_possible(/obj/item/card/id, slot_wear_id)
-			src.equip_new_if_possible(/obj/item/device/radio/headset/command/captain, slot_ears)
-			src.equip_new_if_possible(/obj/item/storage/belt/security, slot_belt)
-			src.equip_new_if_possible(/obj/item/storage/backpack/NT, slot_back)
-			src.equip_new_if_possible(/obj/item/clothing/glasses/nightvision, slot_l_store)
-			src.equip_new_if_possible(/obj/item/crowbar, slot_r_store)
-			src.equip_new_if_possible(/obj/item/clothing/suit/armor/NT_alt, slot_wear_suit)
-			src.equip_new_if_possible(/obj/item/clothing/mask/gas/swat, slot_wear_mask)
-			src.equip_new_if_possible(/obj/item/clothing/head/NTberet, slot_head)
-			src.equip_new_if_possible(/obj/item/clothing/gloves/black, slot_gloves)
-			src.equip_new_if_possible(/obj/item/clothing/glasses/sunglasses/sechud, slot_glasses)
+	initializeBioholder()
+		. = ..()
+		src.equip_new_if_possible(/obj/item/clothing/shoes/swat, slot_shoes)
+		src.equip_new_if_possible(/obj/item/clothing/under/misc/NT, slot_w_uniform)
+		src.equip_new_if_possible(/obj/item/card/id, slot_wear_id)
+		src.equip_new_if_possible(/obj/item/device/radio/headset/command/captain, slot_ears)
+		src.equip_new_if_possible(/obj/item/storage/belt/security, slot_belt)
+		src.equip_new_if_possible(/obj/item/storage/backpack/NT, slot_back)
+		src.equip_new_if_possible(/obj/item/clothing/glasses/nightvision, slot_l_store)
+		src.equip_new_if_possible(/obj/item/crowbar, slot_r_store)
+		src.equip_new_if_possible(/obj/item/clothing/suit/armor/NT_alt, slot_wear_suit)
+		src.equip_new_if_possible(/obj/item/clothing/mask/gas/swat, slot_wear_mask)
+		src.equip_new_if_possible(/obj/item/clothing/head/NTberet, slot_head)
+		src.equip_new_if_possible(/obj/item/clothing/gloves/black, slot_gloves)
+		src.equip_new_if_possible(/obj/item/clothing/glasses/sunglasses/sechud, slot_glasses)
 
-			var/obj/item/card/id/C = src.wear_id
-			if(C)
-				C.registered = src.real_name
-				C.assignment = "NT-SO Special Operative"
-				C.name = "[C.registered]'s ID Card ([C.assignment])"
-				var/list/ntso_access = get_all_accesses()
-				ntso_access += access_maxsec // This makes sense, right? They're highly trained and trusted.
-				C.access = ntso_access
+		var/obj/item/card/id/C = src.wear_id
+		if(C)
+			C.registered = src.real_name
+			C.assignment = "NT-SO Special Operative"
+			C.name = "[C.registered]'s ID Card ([C.assignment])"
+			var/list/ntso_access = get_all_accesses()
+			ntso_access += access_maxsec // This makes sense, right? They're highly trained and trusted.
+			C.access = ntso_access
 
-			update_clothing()
+		update_clothing()

--- a/code/mob/living/carbon/human/normal.dm
+++ b/code/mob/living/carbon/human/normal.dm
@@ -7,143 +7,143 @@
 		set_clothing_icon_dirty()
 
 /mob/living/carbon/human/normal/assistant
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Staff Assistant")
 
 /mob/living/carbon/human/normal/syndicate
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Syndicate")
 
 /mob/living/carbon/human/normal/captain
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Captain")
 
 /mob/living/carbon/human/normal/headofpersonnel
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Head of Personnel")
 
 /mob/living/carbon/human/normal/chiefengineer
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Chief Engineer")
 
 /mob/living/carbon/human/normal/researchdirector
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Research Director")
 
 /mob/living/carbon/human/normal/headofsecurity
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Head of Security")
 
 /mob/living/carbon/human/normal/securityofficer
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Security Officer")
 
 /mob/living/carbon/human/normal/securityassistant
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Security Assistant")
 
 /mob/living/carbon/human/normal/detective
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Detective")
 
 /mob/living/carbon/human/normal/clown
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Clown")
 
 /mob/living/carbon/human/normal/chef
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Chef")
 
 /mob/living/carbon/human/normal/chaplain
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Chaplain")
 
 /mob/living/carbon/human/normal/bartender
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Bartender")
 
 /mob/living/carbon/human/normal/botanist
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Botanist")
 
 /mob/living/carbon/human/normal/rancher
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Rancher")
 
 /mob/living/carbon/human/normal/janitor
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Janitor")
 
 /mob/living/carbon/human/normal/mechanic
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Mechanic")
 
 /mob/living/carbon/human/normal/engineer
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Engineer")
 
 /mob/living/carbon/human/normal/miner
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Miner")
 
 /mob/living/carbon/human/normal/quartermaster
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Quartermaster")
 
 /mob/living/carbon/human/normal/medicaldoctor
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Medical Doctor")
 
 /mob/living/carbon/human/normal/geneticist
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Geneticist")
 
 /mob/living/carbon/human/normal/pathologist
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Pathologist")
 
 /mob/living/carbon/human/normal/roboticist
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Roboticist")
 
 /mob/living/carbon/human/normal/chemist
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Chemist")
 
 /mob/living/carbon/human/normal/scientist
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		JobEquipSpawned("Scientist")
 
 /mob/living/carbon/human/normal/wizard
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		if (src.gender && src.gender == "female")
 			src.real_name = pick_string_autokey("names/wizard_female.txt")
 		else
@@ -152,8 +152,8 @@
 		equip_wizard(src, 1)
 
 /mob/living/carbon/human/normal/rescue
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		src.equip_new_if_possible(/obj/item/clothing/shoes/red, slot_shoes)
 		src.equip_new_if_possible(/obj/item/clothing/under/color/red, slot_w_uniform)
 		src.equip_new_if_possible(/obj/item/card/id, slot_wear_id)
@@ -176,8 +176,8 @@
 		update_clothing()
 
 /mob/living/carbon/human/normal/ntso
-	initializeBioholder()
-		. = ..()
+	New()
+		..()
 		src.equip_new_if_possible(/obj/item/clothing/shoes/swat, slot_shoes)
 		src.equip_new_if_possible(/obj/item/clothing/under/misc/NT, slot_w_uniform)
 		src.equip_new_if_possible(/obj/item/card/id, slot_wear_id)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fix #6886 
fix #6115

The names were assigned after the ID was made, because they were in a SPAWN_DBG().
I moved them to initializeBioholder, things seem to work now.

Also removed the SPAWN_DBGs from the parts for the job-specific normal humans, it seems to work fine without them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad
