### PR TITLE
Prevent pickpocket and pass with itemarms

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1282,10 +1282,28 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 			thing = src.l_hand
 		else if (src.r_hand)
 			thing = src.r_hand
-
 		if (!thing)
 			return
 
+	// Prevent attempting to pass item arms
+	if (thing == src.l_hand)
+		if (ishuman(src))
+			var/mob/living/carbon/human/H = src
+			if (!(H.has_hand(1)))
+				if (!(H.has_hand(0)))
+					return
+				else
+					thing = src.r_hand
+	if (thing == src.r_hand)
+		if (ishuman(src))
+			var/mob/living/carbon/human/H = src
+			if (!(H.has_hand(0)))
+				if (!(H.has_hand(1)))
+					return
+				else
+					thing = src.l_hand
+	if (!thing)
+		return
 	//passing grab theoretically could be a mechanic but needs some annoying fixed - swapping around assailant and item grab handling an stuff probably
 	if(istype(thing,/obj/item/grab))
 		return

--- a/code/mob/living/carbon/human/monkeys.dm
+++ b/code/mob/living/carbon/human/monkeys.dm
@@ -526,6 +526,11 @@
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
+		if (!(source.has_hand(1) || source.has_hand(0)))
+			source.show_text("You can't take something without hands.", "red")
+			interrupt(INTERRUPT_ALWAYS)
+			return
+
 		logTheThing("combat", source, target, "tries to pickpocket \an [I] from [constructTarget(target,"combat")]")
 
 		if(slot == SLOT_L_STORE || slot == SLOT_R_STORE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevent monkeys pickpocketing and passing with item arms.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
They do not have hands.
Pick pocket ability bar will still begin for a moment 