### PR TITLE
Add golden crayon to donut2

### DIFF
--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -24754,6 +24754,7 @@
 	pixel_x = -6;
 	pixel_y = 5
 	},
+/obj/item/pen/crayon/golden,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fgreen1"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Puts a golden crayon in the HoPs office. On the bridge. On donut2.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Donut2 sometimes shows up in the map rotation, and currently the traitor objective for stealing the golden crayon
is impossible on Donut2.