### PR TITLE
Limit number of atoms a flusher can flush at once

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -42,6 +42,7 @@
 #include "defines\lag.dm"
 #include "defines\landmarks.dm"
 #include "defines\layer.dm"
+#include "defines\logging.dm"
 #include "defines\logic.dm"
 #include "defines\materials.dm"
 #include "defines\medals.dm"

--- a/_std/defines/logging.dm
+++ b/_std/defines/logging.dm
@@ -1,0 +1,2 @@
+// Thresholds for admin logs & other log stuff.
+#define LOG_FLUSHING_THRESHOLD 1000

--- a/_std/defines/logging.dm
+++ b/_std/defines/logging.dm
@@ -1,2 +1,2 @@
-// Thresholds for admin logs & other log stuff.
+/// Thresholds for admin logs & other log stuff.
 #define LOG_FLUSHING_THRESHOLD 1000

--- a/code/WorkInProgress/MechanicMadness.dm
+++ b/code/WorkInProgress/MechanicMadness.dm
@@ -633,6 +633,7 @@
 
 	var/obj/disposalpipe/trunk/trunk = null
 	var/datum/gas_mixture/air_contents
+	var/max_capacity = 100
 
 	New()
 		. = ..()
@@ -663,11 +664,15 @@
 		return 0
 
 	proc/flushp(var/datum/mechanicsMessage/input)
+		var/count = 0
 		if(level == 2) return
 		if(input?.signal && !ON_COOLDOWN(src, SEND_COOLDOWN_ID, src.cooldown_time) && trunk)
 			for(var/atom/movable/M in src.loc)
 				if(M == src || M.anchored || isAI(M)) continue
+				if(count == src.max_capacity)
+					break
 				M.set_loc(src)
+				count++
 			flushit()
 		return
 

--- a/code/WorkInProgress/recycling/disposal.dm
+++ b/code/WorkInProgress/recycling/disposal.dm
@@ -41,6 +41,9 @@
 		else
 			src.set_loc(D)
 
+		if (length(D.contents) > LOG_FLUSHING_THRESHOLD)
+			message_admins("[length(D.contents)] atoms flushed by [D] at [log_loc(D)] last touched by: [key_name(D.fingerprintslast)].")
+
 		// now everything inside the disposal gets put into the holder
 		// note AM since can contain mobs or objs
 		for(var/atom/movable/AM in D)
@@ -48,7 +51,7 @@
 			if(ishuman(AM))
 				var/mob/living/carbon/human/H = AM
 				H.unlock_medal("It'sa me, Mario", 1)
-
+			LAGCHECK(LAG_HIGH)
 
 
 	// start the movement process


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

* Limits flushers to 100 atoms per activation
* Adds admin message for the creation of very large disposalholders
* LAGCHECK for initializing dispoalholder

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Flushers previously could flush an infinite amount of atoms and cause a lot of lag.
This fixes all of that and makes it easier for future diagnosis if anything happens.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Stonepillar
(*)Flusher components now have a limit of 100 things to flush at once.
```
