### PR TITLE
Gemstones Windows made see thru again

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -603,6 +603,7 @@
 	name = "quartz"
 	desc = "Quartz is somewhat valuable but not paticularly useful."
 	color = "#BBBBBB"
+	alpha = 220
 	quality = 50
 	var/gem_tier = 3
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
gives the gemstones an alpha of 220


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
they currently dont make good windows and thats a shame.
fixes #6761


```changelog
(u)RSG250
(+)Gemstones make good windows again.
```
