### PR TITLE
Fix for null jobs in Sleeperagent.dm

### DIFF
--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -179,9 +179,7 @@
 					boutput(H, "<span class='notice'>A peculiar noise intrudes upon the radio frequency of your [Hs].</span>")
 					if (H.client && !checktraitor(H) && (H.client.preferences.be_traitor || src.override_player_pref))
 						var/datum/job/J = find_job_in_controller_by_string(H?.mind.assigned_role)
-						if(!J)
-							continue
-						if (J.allow_traitors)
+						if (J?.allow_traitors)
 							candidates.Add(H)
 				break
 		for (var/mob/living/silicon/robot/R in mobs)

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -179,6 +179,8 @@
 					boutput(H, "<span class='notice'>A peculiar noise intrudes upon the radio frequency of your [Hs].</span>")
 					if (H.client && !checktraitor(H) && (H.client.preferences.be_traitor || src.override_player_pref))
 						var/datum/job/J = find_job_in_controller_by_string(H?.mind.assigned_role)
+						if(!J)
+							continue
 						if (J.allow_traitors)
 							candidates.Add(H)
 				break


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Checks job isn't null.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
File sleeperagent.dm 
Line 182 
Error Cannot read null.allow_traitors 

Description
proc name: gather listeners (/datum/random_event/major/antag/sleeper_agent/proc/gather_listeners)
  source file: sleeperagent.dm,182