### PR TITLE
wall-phone/normal-phone hang-up fix

### DIFF
--- a/code/obj/machinery/phone.dm
+++ b/code/obj/machinery/phone.dm
@@ -192,7 +192,7 @@
 		src.answered = 0
 		if(src.linked) // Other phone needs updating
 			if(!src.linked.answered) // nobody picked up. Go back to not-ringing state
-				src.linked.icon_state = "[phoneicon]"
+				src.linked.icon_state = "[src.linked.phoneicon]"
 			else if(src.linked.handset && src.linked.handset.holder)
 				src.linked.handset.holder.playsound_local(src.linked.handset.holder,"sound/machines/phones/remote_hangup.ogg",50,0)
 			src.linked.ringing = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Calling a wall-phone from a normal phone (or vice-versa) now sets the right icon on hang-up.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #6919 and possibly fixes #3741

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
