### PR TITLE
Removes the Obsidian Crown from Petasusaphilic

### DIFF
--- a/code/z_adventurezones/hemera.dm
+++ b/code/z_adventurezones/hemera.dm
@@ -316,7 +316,7 @@ Obsidian Crown
 	name = "obsidian crown"
 	desc = "A crown, apparently made of obsidian, and also apparently very bad news."
 	icon_state = "obcrown"
-
+	blocked_from_petasusaphilic = TRUE
 	magical = 1
 	var/processing = 0
 	var/armor_paired = 0


### PR DESCRIPTION
[Balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds the Obsidian Crown to the petasusaphilic trait blacklist. This should lower the amount of Transposed Particle Fields seen on station as well.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The obsidian crown is an incredible new player trap first of all. It generates a transposed particle field and gibs the player upon reaching crit. Particle fields are then able to gib players that stay still for too long and are ONLY killable with a taser or similar. This isn't good considering only the captain and sec have means to destroy these things. On top of that the crown also warps anyone that attacks or stuns the wearer to a semi distant location thus making it very very good at messing with other players. It's much too game changing to be handed out for free with a trait.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Dimwhat
(+)The obsidian crown is now blacklisted from petasusaphilic
```
