### PR TITLE
Make sub-unit dumping of reagents possible

### DIFF
--- a/code/modules/chemistry/chemicompiler_core.dm
+++ b/code/modules/chemistry/chemicompiler_core.dm
@@ -805,7 +805,7 @@
 		else
 			showMessage("[src.holder] doesn't have enough reagents to make a vial.")
 	if (target == 13)
-		if(RS.total_volume >= 1)
+		if(RS.total_volume > 0)
 			RS.trans_to(src.ejection_reservoir, amount, index = index)
 			RS = src.ejection_reservoir.reagents
 			RS.reaction(get_turf(src.holder), TOUCH, min(amount, RS.total_volume))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the chemicompiler to dump sub-1 units, when told to. This was changed in 8b45c8cf3124dd93c915ab233a3e26a71e8d3f88 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows the chemicompiler to get rid of sub-unit reaction results again (IE: 0.6666u nitrogen remains after creating ammonia)
This can't be exploited to create more vials or pills, there is also no means to actually reference a sub-unit of chemicals in Chemfuck. This just allows the compiler to dump it when it does show up.