### PR TITLE
Implement particle control procs

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -163,6 +163,7 @@
 			for(var/datum/statusEffect/effect as anything in src.statusEffects)
 				src.delStatus(effect)
 			src.statusEffects = null
+		ClearAllParticles()
 		..()
 
 	proc/Turn(var/rot)

--- a/code/atom/UpdateParticles.dm
+++ b/code/atom/UpdateParticles.dm
@@ -44,7 +44,3 @@
 		return
 	var/obj/O = particle_refs[key]
 	return O?.particles
-
-/atom/proc/sov()
-	var/particles/P = new/particles/swarm/bees
-	UpdateParticles(P, "bees")

--- a/code/atom/UpdateParticles.dm
+++ b/code/atom/UpdateParticles.dm
@@ -40,7 +40,7 @@
 /atom/proc/GetParticles(key)
 	RETURN_TYPE(/particles)
 	if(!key)
-		CRASH("GetParticle called without a key.")
+		CRASH("GetParticles called without a key.")
 	if (!particle_refs)
 		return
 	var/obj/O = particle_refs[key]

--- a/code/atom/UpdateParticles.dm
+++ b/code/atom/UpdateParticles.dm
@@ -34,6 +34,7 @@
 		var/obj/O = particle_refs[index]
 		if (!O) continue
 		O.vis_locs = null
+		O.particles = null
 		qdel(O)
 
 /atom/proc/GetParticle(key)

--- a/code/atom/UpdateParticles.dm
+++ b/code/atom/UpdateParticles.dm
@@ -37,7 +37,7 @@
 		O.particles = null
 		qdel(O)
 
-/atom/proc/GetParticle(key)
+/atom/proc/GetParticles(key)
 	RETURN_TYPE(/particles)
 	if(!key)
 		CRASH("GetParticle called without a key.")

--- a/code/atom/UpdateParticles.dm
+++ b/code/atom/UpdateParticles.dm
@@ -1,6 +1,6 @@
-/atom/movable/var/list/particle_refs = null
+/atom/var/list/particle_refs = null
 
-/atom/movable/proc/UpdateParticles(particles/P, key, force=0)
+/atom/proc/UpdateParticles(particles/P, key, force=0)
 	if(!key)
 		CRASH("UpdateParticles called without a key.")
 	LAZYLISTINIT(particle_refs)
@@ -17,7 +17,7 @@
 	holder.vis_locs |= src
 	particle_refs[key] = holder
 
-/atom/movable/proc/ClearSpecificParticles(key)
+/atom/proc/ClearSpecificParticles(key)
 	if(!key)
 		CRASH("ClearSpecificParticles called without a key.")
 	if (!particle_refs)
@@ -27,7 +27,7 @@
 	holder?.vis_locs = null
 	qdel(holder)
 
-/atom/movable/proc/ClearAllParticles()
+/atom/proc/ClearAllParticles()
 	if (!particle_refs)
 		return
 	for (var/index as anything in particle_refs)
@@ -36,7 +36,7 @@
 		O.vis_locs = null
 		qdel(O)
 
-/atom/movable/proc/GetParticle(key)
+/atom/proc/GetParticle(key)
 	RETURN_TYPE(/particles)
 	if(!key)
 		CRASH("GetParticle called without a key.")
@@ -44,3 +44,7 @@
 		return
 	var/obj/O = particle_refs[key]
 	return O?.particles
+
+/atom/proc/sov()
+	var/particles/P = new/particles/swarm/bees
+	UpdateParticles(P, "bees")

--- a/code/atom/movable/UpdateParticles.dm
+++ b/code/atom/movable/UpdateParticles.dm
@@ -1,0 +1,46 @@
+/atom/movable/var/list/particle_refs = null
+
+/atom/movable/proc/UpdateParticles(particles/P, key, force=0)
+	if(!key)
+		CRASH("UpdateParticles called without a key.")
+	LAZYLISTINIT(particle_refs)
+	var/obj/effects/holder
+	holder = particle_refs[key]
+	if(!holder && P)
+		holder = new /obj/effects
+	else if(!holder)
+		return
+
+	if(!force && (holder.particles == P)) //If it's the same particle as the other then do not update
+		return
+	holder.particles = P
+	holder.vis_locs |= src
+	particle_refs[key] = holder
+
+/atom/movable/proc/ClearSpecificParticles(key)
+	if(!key)
+		CRASH("ClearSpecificParticles called without a key.")
+	if (!particle_refs)
+		return
+	var/obj/effects/holder
+	holder = particle_refs[key]
+	holder?.vis_locs = null
+	qdel(holder)
+
+/atom/movable/proc/ClearAllParticles()
+	if (!particle_refs)
+		return
+	for (var/index as anything in particle_refs)
+		var/obj/O = particle_refs[index]
+		if (!O) continue
+		O.vis_locs = null
+		qdel(O)
+
+/atom/movable/proc/GetParticle(key)
+	RETURN_TYPE(/particles)
+	if(!key)
+		CRASH("GetParticle called without a key.")
+	if (!particle_refs)
+		return
+	var/obj/O = particle_refs[key]
+	return O?.particles

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -55,7 +55,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\style.dms"
 #include "code\atom\throwing.dm"
 #include "code\atom\UpdateOverlays.dm"
-#include "code\atom\movable\UpdateParticles.dm"
+#include "code\atom\UpdateParticles.dm"
 #include "code\chui\chui.dm"
 #include "code\chui\tab.dm"
 #include "code\chui\template.dm"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -55,6 +55,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\style.dms"
 #include "code\atom\throwing.dm"
 #include "code\atom\UpdateOverlays.dm"
+#include "code\atom\movable\UpdateParticles.dm"
 #include "code\chui\chui.dm"
 #include "code\chui\tab.dm"
 #include "code\chui\template.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements 4 new procs. New particles are attached to `obj/effects` that are added into the targets `vis_contents`

* `UpdateParticles(particles/P, key, force=0)`
* `ClearSpecificParticles(key)`
* `ClearAllParticles()`
* `GetParticles(key)`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Allows for management of particles on atoms, even ones that can't normally enjoy them like turfs