### PR TITLE
SoS now gives one respawn

### DIFF
--- a/code/WorkInProgress/Azungarstuff.dm
+++ b/code/WorkInProgress/Azungarstuff.dm
@@ -84,6 +84,7 @@
 				var/mob/living/carbon/human/H = M
 				if (istype(H))
 					H.unkillable = 0
+					H.extra_lives = 0
 				if(!M.stat) M.emote("scream")
 				src.visible_message("<span class='alert'><B>[M]</B> falls into the [src] and melts away!</span>")
 				M.firegib() // thanks ISN!

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2077,6 +2077,7 @@
 			// As much as I detest istype(src) checks, this is the simplest way to make sure the anticheat cluwne gets unkillable dudes too.
 			if(istype(src, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = src
+				H.extra_lives = 0
 				H.unkillable = 0
 		else
 			floorcluwne = new /mob/living/carbon/human/cluwne/floor

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -102,6 +102,8 @@
 
 	//The spooky UNKILLABLE MAN
 	var/unkillable = 0
+	//The less spooky killable eventually man
+	var/extra_lives = 0
 
 	var/mob/living/carbon/target = null
 	var/ai_aggressive = 0
@@ -611,7 +613,7 @@
 #endif
 
 	//The unkillable man just respawns nearby! Oh no!
-	if (src.unkillable || src.spell_soulguard)
+	if (src.unkillable || src.spell_soulguard || src.extra_lives)
 		if (src.unkillable && src.mind.dnr) //Unless they have dnr set in which case rip for good
 			logTheThing("combat", src, null, "was about to be respawned (Unkillable) but had DNR set.")
 			if (!gibbed)
@@ -620,7 +622,11 @@
 			var/obj/item/unkill_shield/U = new /obj/item/unkill_shield
 			U.set_loc(src.loc)
 		else
-			logTheThing("combat", src, null, "respawns ([src.spell_soulguard ? "Soul Guard" : "Unkillable"])")
+			if (src.extra_lives)
+				src.extra_lives--
+				logTheThing("combat", src, null, "respawns due to an extra life. Remaining lives: [src.extra_lives])")
+			else
+				logTheThing("combat", src, null, "respawns ([src.spell_soulguard ? "Soul Guard" : "Unkillable"])")
 			src.unkillable_respawn()
 
 	if(src.traitHolder && src.traitHolder.hasTrait("soggy"))
@@ -843,7 +849,8 @@
 	src.abilityHolder = null
 
 	if (!antag_removal && src.unkillable) // Doesn't work properly for half the antagonist types anyway (Convair880).
-		newbody.unkillable = 1
+		if (src.extra_lives)
+			newbody.unkillable = 1
 
 	if (src.bioHolder)
 		newbody.bioHolder.CopyOther(src.bioHolder)
@@ -879,6 +886,7 @@
 		animation.icon_state = "ungibbed"
 		src.unkillable = 0 //Don't want this lying around to repeatedly die or whatever.
 		src.spell_soulguard = 0 // clear this as well
+		src.extra_lives = 0
 		src = null //Detach this, what if we get deleted before the animation ends??
 		SPAWN_DBG(0.7 SECONDS) //Length of animation.
 			newbody.set_loc(animation.loc)
@@ -886,6 +894,7 @@
 	else
 		src.unkillable = 0
 		src.spell_soulguard = 0
+		src.extra_lives = 0
 		APPLY_MOB_PROPERTY(src, PROP_INVISIBILITY, "transform", INVIS_ALWAYS)
 		SPAWN_DBG(2.2 SECONDS) // Has to at least match the organ/limb replacement stuff (Convair880).
 			if (src) qdel(src)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -849,8 +849,9 @@
 	src.abilityHolder = null
 
 	if (!antag_removal && src.unkillable) // Doesn't work properly for half the antagonist types anyway (Convair880).
-		if (src.extra_lives)
-			newbody.unkillable = 1
+		newbody.unkillable = 1
+	if (!antag_removal && src.extra_lives)
+		newbody.extra_lives = src.extra_lives
 
 	if (src.bioHolder)
 		newbody.bioHolder.CopyOther(src.bioHolder)

--- a/code/mob/suicide.dm
+++ b/code/mob/suicide.dm
@@ -93,6 +93,7 @@
 	force_suicide() // something else in the codebase calls this without going through the suicide checks, so shrug
 
 /mob/living/carbon/human/proc/force_suicide()
+	src.extra_lives = 0
 	src.unkillable = 0 //Get owned, nerd!
 
 	var/list/suicides = list("hold your breath")

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2432,7 +2432,7 @@
 		if((istype(weapon, /obj/item/zolscroll)) && istype(user,/mob/living/carbon/human) && (src.z == 1))
 			var/obj/item/zolscroll/scroll = weapon
 			var/mob/living/carbon/human/h = user
-			if(h.unkillable)
+			if(h.unkillable || h.extra_lives)
 				boutput(user,"<span class='alert'><b>Your soul is shielded and cannot be sold!</b></span>")
 				return
 			if(scroll.icon_state != "signed")

--- a/code/obj/item/storage/bible.dm
+++ b/code/obj/item/storage/bible.dm
@@ -171,7 +171,7 @@ var/global/list/bible_contents = list()
 		if (user.traitHolder?.hasTrait("atheist"))
 			user.visible_message("<span class='alert'>[user] farts on the bible with particular vindication.<br><b>Against all odds, [user] remains unharmed!</b></span>")
 			return FALSE
-		else if (ishuman(user) && user:unkillable)
+		else if (ishuman(user) && (user:unkillable || user:extra_lives))
 			user.visible_message("<span class='alert'>[user] farts on the bible.</span>")
 			user:unkillable = 0
 			user.UpdateOverlays(image('icons/misc/32x64.dmi',"halo"), "halo")

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -249,8 +249,9 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 		if (ishuman(L))
 			var/mob/living/carbon/human/H = A
 			//Special halloween-time Unkillable gibspam protection!
-			if (H.unkillable)
+			if (H.unkillable || H.extra_lives)
 				H.unkillable = 0
+				H.extra_lives = 0
 			if (H.mind && H.mind.assigned_role)
 				switch (H.mind.assigned_role)
 					if ("Clown")

--- a/code/obj/zoldorf.dm
+++ b/code/obj/zoldorf.dm
@@ -401,7 +401,7 @@ var/global/list/datum/zoldorfitem/zoldorf_items = list()
 		else if(istype(weapon, /obj/item/zolscroll)) //handling handing of contracts to begin the usurping process
 			var/obj/item/zolscroll/scroll = weapon
 			var/mob/living/carbon/human/h = user
-			if(h.unkillable)
+			if(h.unkillable || h.extra_lives)
 				boutput(h,"<span class='alert'><b>Your soul is shielded and cannot be sold!</b></span>")
 				return
 			if(scroll.icon_state != "signed")
@@ -494,7 +494,7 @@ var/global/list/datum/zoldorfitem/zoldorf_items = list()
 					var/cost = item.soul_cost()
 					if(istype(usr, /mob/living/carbon/human))
 						var/mob/living/carbon/human/user = usr
-						if(user.unkillable) //*giggles in scientist language*
+						if(user.unkillable || user.extra_lives) //*giggles in scientist language*
 							boutput(user,"<span class='alert'><b>Your soul is shielded and cannot be sold!</b></span>")
 							return
 					var/confirm = alert("Are you sure you want to sell [item.cost] of your soul?", "Confirm Transaction", "Yes", "No")

--- a/code/z_adventurezones/biodome.dm
+++ b/code/z_adventurezones/biodome.dm
@@ -418,6 +418,7 @@ SYNDICATE DRONE FACTORY AREAS
 				var/mob/living/carbon/human/H = M
 				if (istype(H))
 					H.unkillable = 0
+					H.extra_lives = 0
 				if(!M.stat) M.emote("scream")
 				src.visible_message("<span class='alert'><B>[M]</B> falls into the [src] and melts away!</span>")
 				M.firegib() // thanks ISN!

--- a/code/z_adventurezones/lavamoon.dm
+++ b/code/z_adventurezones/lavamoon.dm
@@ -771,9 +771,12 @@ var/sound/iomoon_alarm_sound = null
 			//EI NATH!!
 			elecflash(user,radius = 2, power = 6)
 
-			H.extra_lives++
-			H.gib(1)
-			qdel(src)
+			// You instantly die on pick up so we have to give you two lives...
+			logTheThing("combat", src, null, "collects the soul of shields and is gibbed.")
+			H.extra_lives += 2
+			SPAWN_DBG(0.2 SECONDS)
+				H.gib(1)
+				qdel(src)
 
 //Clothing & Associated Equipment
 /obj/item/clothing/suit/rad/iomoon

--- a/code/z_adventurezones/lavamoon.dm
+++ b/code/z_adventurezones/lavamoon.dm
@@ -754,7 +754,7 @@ var/sound/iomoon_alarm_sound = null
 
 
 /*
- *	UNKILLABLE shield. It makes dudes unkillable, it is not unkillable itself.
+ *	UNKILLABLE shield. Gives you one extra life.
  */
 
 /obj/item/unkill_shield
@@ -771,7 +771,7 @@ var/sound/iomoon_alarm_sound = null
 			//EI NATH!!
 			elecflash(user,radius = 2, power = 6)
 
-			H.unkillable = 1
+			H.extra_lives++
 			H.gib(1)
 			qdel(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an extra life variable, changes shield of souls to give you one life.
Added a delay to the gib and qdel to fix nulls.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Infinite respawns are proving to be a problem.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Shield of Souls (azone loot) now gives a single respawn.
```
