### PR TITLE
Alternative SoS changes

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1611,7 +1611,12 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 	if (src.nodamage)
 		return .
 
-	var/health_deficiency = (src.max_health - src.health) + health_deficiency_adjustment // cogwerks // let's treat this like pain
+	var/health_deficiency = 0
+	if (src.max_health > 0)
+		health_deficiency = ((src.max_health-src.health)/src.max_health)*100 + health_deficiency_adjustment // cogwerks // let's treat this like pain
+	else
+		health_deficiency = (src.max_health-src.health) + health_deficiency_adjustment 
+		
 
 	if (health_deficiency >= 30)
 		. += (health_deficiency / 35)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -844,7 +844,9 @@
 
 	if (!antag_removal && src.unkillable) // Doesn't work properly for half the antagonist types anyway (Convair880).
 		newbody.unkillable = 1
-
+		newbody.setStatus("maxhealth-", null, -90)
+		newbody.setStatus("paralysis", 10 SECONDS)
+		
 	if (src.bioHolder)
 		newbody.bioHolder.CopyOther(src.bioHolder)
 		if (!antag_removal && src.spell_soulguard)

--- a/code/z_adventurezones/lavamoon.dm
+++ b/code/z_adventurezones/lavamoon.dm
@@ -772,6 +772,7 @@ var/sound/iomoon_alarm_sound = null
 			elecflash(user,radius = 2, power = 6)
 
 			H.unkillable = 1
+			H.setStatus("maxhealth-", null, -90)
 			H.gib(1)
 			qdel(src)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Soulguard now applies a 90 point max health penalty on pickup, re-applying on further respawns.

Additionally, respawning will paralyse you for 10 seconds, so new spawns can't just pick up their old weapon and continue swinging.


Important note:
As an additional balancing measure, pain is now fixed to be based on max health. Soulguarded nerds in crit could otherwise still zoom and be just as annoying.

I also considered making death rolls scale with max health, but that might be too far (though I am willing to code it if people think the idea of repeatedly beating soulguard vigilantes to death is funnier)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Soulguard's being abused to vigilante, but I think the item's core gimmick can be super fun without being as exploitable.

The existing PR to Soulguard doesn't really address the problem, instead it makes it useless for anyone but supercops who intend to die in the first place.

These changes should keep its gimmicky purpose of never being able to die, but also reduce its' combat effectiveness to laughable levels.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TDHooligan
(+)The gods of the Lava Moon's Shield of Souls demand a toll for their power.
```
