### PR TITLE
Increases macrobomb average explosion power 25 -> 27

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1142,7 +1142,7 @@ THROWING DARTS
 	sneaky = 1
 	New()
 		var/obj/item/implant/microbomb/macrobomb/newbomb = new/obj/item/implant/microbomb/macrobomb( src )
-		newbomb.explosionPower = rand(20,30)
+		newbomb.explosionPower = rand(22,32)
 		src.imp = newbomb
 		..()
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR increases the average macrobomb explosion power to 27 from 25.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a better idea to buy 12 micros over 1 macro because:
1 micro has an average explosion size of 2.25
1 macro has an average explosion of 25
12 (micros) * 2.25 = 27
It will generally be a better idea to buy 12 micros over a macro, which this PR corrects.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Macrobomb explosion power average increased to 27 from 25.
```
