### PR TITLE
Change parasites from ailment to parasite

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -266,7 +266,7 @@
 			affected_mob.cure_disease(src)
 			return
 
-		if (!ismind(source))
+		if (istype(master, /datum/ailment/parasite/headspider) && !ismind(source))
 			affected_mob.cure_disease(src)
 			return
 
@@ -444,6 +444,21 @@
 		AD.master = A
 		AD.affected_mob = src
 		AD.on_infection()
+		return AD
+
+	else if (istype(A, /datum/ailment/parasite))
+		var/datum/ailment_data/parasite/AD = new /datum/ailment_data/parasite
+		AD.name = A.name
+		AD.stage_prob = A.stage_prob
+		AD.cure = A.cure
+		AD.reagentcure = A.reagentcure
+		AD.recureprob = A.recureprob
+		AD.master = A
+
+		AD.master = A
+		AD.affected_mob = src
+		src.ailments += AD
+
 		return AD
 
 	else

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1739,6 +1739,8 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 			src.cure_disease(M)
 		for(var/datum/ailment_data/addiction/A in src.ailments)
 			src.ailments -= A
+		for (var/datum/ailment_data/parasite/P in src.ailments)
+			src.cure_disease(P)
 
 /mob/living/proc/was_harmed(var/mob/M as mob, var/obj/item/weapon = 0, var/special = 0, var/intent = null)
 	SHOULD_CALL_PARENT(TRUE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes parasites to get added to ailments with type /datum/ailment_data/parasite instead of /datum/ailment_data. Headspiders were already directly added as a parasite type.
Adds type check in parasite datum stage_act() for headspider mind check now that other parasites execute this proc or parasites would be instantly cured.
Includes parasites in admin heal.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Parasites didn't get added as their their proper type.
Parasites would not be using their type specific stage_act().

NOTE: Admins could accidentally heal a headspider parasite now. Extremely unlikely but possible, should they be exluded from the heal?