### PR TITLE
Fix single maintenance-inner-central tile designation

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -44473,7 +44473,7 @@
 /area/station/crew_quarters/radio/lab)
 "ciK" = (
 /turf/simulated/floor/plating/random,
-/area/station/storage/eeva)
+/area/station/maintenance/inner)
 "ciM" = (
 /obj/cable/reinforced{
 	icon_state = "1-2-thick"
@@ -103011,7 +103011,7 @@ aLW
 cfS
 wFP
 ckK
-aDr
+ciK
 ciK
 aks
 aks

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -103012,7 +103012,7 @@ cfS
 wFP
 ckK
 ciK
-ciK
+aDr
 aks
 aks
 bgD

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -44473,7 +44473,7 @@
 /area/station/crew_quarters/radio/lab)
 "ciK" = (
 /turf/simulated/floor/plating/random,
-/area/station/maintenance/inner)
+/area/station/maintenance/inner/central)
 "ciM" = (
 /obj/cable/reinforced{
 	icon_state = "1-2-thick"

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -46680,9 +46680,6 @@
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/radio/lab)
-"ciK" = (
-/turf/simulated/floor/plating/random,
-/area/station/storage/eeva)
 "ciL" = (
 /obj/cable/reinforced{
 	icon_state = "1-2-thick"
@@ -103292,7 +103289,7 @@ cfS
 cfS
 ckK
 aDr
-ciK
+aDr
 aks
 aks
 bgD


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces one EVA tile with an inner-maintenance tile on oshan and oshan-xmas

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Founds by radstorms affect the EVA tile, but not maintenance tiles.
Fixes https://github.com/goonstation/goonstation/issues/6922

## Notes
* I don't know why the changes to each map resulted in different diffs (???)
* First PR here, please double-check my work <3