### PR TITLE
Security PDAs on RP no longer have security alert function.

### DIFF
--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -113,7 +113,11 @@
 		icon_state = "pda-hos"
 		setup_default_pen = /obj/item/pen/fancy
 		setup_default_cartridge = /obj/item/disk/data/cartridge/hos
+		#ifdef RP_MODE
+		setup_default_module = /obj/item/device/pda_module/flashlight
+		#else
 		setup_default_module = /obj/item/device/pda_module/alert
+		#endif
 		setup_drive_size = 32
 		mailgroups = list(MGD_SECURITY,MGD_COMMAND,MGD_PARTY)
 		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CRISIS, MGA_TRACKING)
@@ -122,7 +126,11 @@
 		icon_state = "pda-nt"
 		setup_default_pen = /obj/item/pen/fancy
 		setup_default_cartridge = /obj/item/disk/data/cartridge/hos //hos cart gives access to manifest compared to regular sec cart, useful for NTSO
+		#ifdef RP_MODE
+		setup_default_module = /obj/item/device/pda_module/flashlight
+		#else
 		setup_default_module = /obj/item/device/pda_module/alert
+		#endif
 		setup_drive_size = 32
 		mailgroups = list(MGD_SECURITY,MGD_COMMAND,MGD_PARTY)
 		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CRISIS, MGA_TRACKING)
@@ -191,7 +199,11 @@
 	security
 		icon_state = "pda-s"
 		setup_default_cartridge = /obj/item/disk/data/cartridge/security
+		#ifdef RP_MODE
+		setup_default_module = /obj/item/device/pda_module/flashlight
+		#else
 		setup_default_module = /obj/item/device/pda_module/alert
+		#endif
 		mailgroups = list(MGD_SECURITY,MGD_PARTY)
 		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_CHECKPOINT, MGA_ARREST, MGA_DEATH, MGA_MEDCRIT, MGA_CRISIS, MGA_TRACKING)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR swaps out the PDA alert module for a flashlight for security, the NTSO, and the HoS.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
After a few discussions on discord of how RPSec can feel extremely oppressive against antagonists, and the sec alert seems to be a large part of it. With one press of the button, you send the already __extremely__ communicative security team into a frenzy, causing usually every officer to drop their shit to run over to the alert caller. Keep in mind, this is silent, not like a radio message.

With that in mind, I decided to make this PR to poke the water, see what people think.

And no, "Spend a quarter of your TC on a sig jammer so you can talk with a secoff without risking them silently calling backup" isn't really an argument with how restrictive TC amounts/costs can be.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(*)Following several budget cuts and two lawsuits, all security alert buttons in PDAs have been replaced with flashlights. (RP ONLY)
```
