### PR TITLE
Macrobombs no longer can be bought on RP

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -339,7 +339,11 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/traitor/macrobomb
 	name = "Macrobomb Implant"
 	item = /obj/item/implanter/uplink_macrobomb
+	#ifdef RP_MODE
+	cost = 0
+	#else
 	cost = 12
+	#endif
 	vr_allowed = 0
 	desc = "Like the microbomb, but much more powerful. Macrobombs for macrofun!"
 	blockedmode = list(/datum/game_mode/revolution)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL] [Input Wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. Goon1/2 are unchanged.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Macrobombs do not lend themselves well to RP for a few reasons:

- You are forgoing any kind of gimmick you could use your TC on
- You are encouraging yourself to die (not inherently bad on its own) with as many people near you as possible
- You're pretty much guaranteeing anyone whose within a few tiles of you to get round removed (provided no clone data)

While you can do the same with 12 microbombs, it makes it much harder to do on a split-second decision, since you have to manually buy and inject 12 micros into yourself, versus one click to buy and one to inject.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Macrobombs can no longer be bought on the RP servers.
```
