### PR TITLE
Removes santa's teleport ability

### DIFF
--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -694,7 +694,7 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 		HS.addAbility(/datum/targetable/santa/gifts)
 		HS.addAbility(/datum/targetable/santa/food)
 		HS.addAbility(/datum/targetable/santa/warmth)
-		HS.addAbility(/datum/targetable/santa/teleport)
+		//HS.addAbility(/datum/targetable/santa/teleport)
 		HS.addAbility(/datum/targetable/santa/banish)
 
 	initializeBioholder()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
[input wanted] [removal]
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes santa's teleport ability (still in the code, so an admin could give it)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There has been a massive self-antag problem with santa's abusing their AA and teleport ability, removing their teleport ability should make it much easier and fun for sec to actually catch santa, as on RP as sec santa usually just teleports away before you even get a chance to talk, which means the best option is to just shoot them on sight. I'm sure the same applies to main as well, but I could be wrong.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Merlin1230
(*)Santa has been too naughty this year, so they've lost their ability to teleport.
```
