### PR TITLE
Block santa/krampus on no antag spawn modes

### DIFF
--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -49,7 +49,7 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 
 // Might as well tweak Santa/Krampus respawn to make it use the universal player selection proc I wrote (Convair880).
 /proc/santa_krampus_spawn(var/which_one = 0, var/confirmation_delay = 1200)
-	if ((xmas_respawn_lock != 0) && (ticker?.mode?.do_antag_random_spawns))
+	if ((xmas_respawn_lock != 0) || (!ticker?.mode?.do_antag_random_spawns))
 		return
 	if (!isnum(confirmation_delay) || confirmation_delay < 0)
 		message_admins("Couldn't set up [which_one == 0 ? "Santa Claus" : "Krampus"] respawn (setup failed).")

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -49,7 +49,7 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 
 // Might as well tweak Santa/Krampus respawn to make it use the universal player selection proc I wrote (Convair880).
 /proc/santa_krampus_spawn(var/which_one = 0, var/confirmation_delay = 1200)
-	if (xmas_respawn_lock != 0)
+	if ((xmas_respawn_lock != 0) && do_antag_random_spawns)
 		return
 	if (!isnum(confirmation_delay) || confirmation_delay < 0)
 		message_admins("Couldn't set up [which_one == 0 ? "Santa Claus" : "Krampus"] respawn (setup failed).")

--- a/code/modules/holiday/spacemas.dm
+++ b/code/modules/holiday/spacemas.dm
@@ -49,7 +49,7 @@ var/static/list/santa_snacks = list(/obj/item/reagent_containers/food/drinks/egg
 
 // Might as well tweak Santa/Krampus respawn to make it use the universal player selection proc I wrote (Convair880).
 /proc/santa_krampus_spawn(var/which_one = 0, var/confirmation_delay = 1200)
-	if ((xmas_respawn_lock != 0) && do_antag_random_spawns)
+	if ((xmas_respawn_lock != 0) && (ticker?.mode?.do_antag_random_spawns))
 		return
 	if (!isnum(confirmation_delay) || confirmation_delay < 0)
 		message_admins("Couldn't set up [which_one == 0 ? "Santa Claus" : "Krampus"] respawn (setup failed).")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes santa/krampus follow the var do_antag_random_spawns.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Santa is a balance problem on nuclear/revs. God knows what happens on pod wars.

Note that extended uses this var, blocking Santa for extended may be undesirable? This is a bit uncertain as extended is usually used due to misbehavior on RP so it may actually be appropriate to prevent these special roles.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Santa and Krampus no longer spawn in modes that prevent antag spawns.
```
