### PR TITLE
Keybind fixes for AZERTY (Ghost, intents & targeting)

### DIFF
--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -336,6 +336,17 @@
 	..()
 	C.apply_keybind("human")
 
+	if (!C.preferences.use_wasd)
+		C.apply_keybind("human_arrow")
+
+	if (C.preferences.use_azerty)
+		C.apply_keybind("human_azerty")
+
+	if (C.tg_controls)
+		C.apply_keybind("human_tg")
+		if (C.preferences.use_azerty)
+			C.apply_keybind("human_tg_azerty")
+
 /mob/dead/observer/is_spacefaring()
 	return 1
 

--- a/code/modules/interface/keybind_style.dm
+++ b/code/modules/interface/keybind_style.dm
@@ -194,12 +194,23 @@ var/global/list/datum/keybind_style/keybind_styles = null
 /datum/keybind_style/human/tg/azerty
 	name = "human_tg_azerty"
 	changed_keys = list(
-	"W" = "attackself"
+		"W" = "attackself"
 	)
 
 /datum/keybind_style/human/azerty
 	name = "human_azerty"
 	changed_keys = list(
+		"&" = "help",
+		"é" = "disarm",
+		"\"" = "grab",
+		"'" = "harm",
+		"(" = "head",
+		"-" = "chest",
+		"è" = "l_arm",
+		"_" = "r_arm",
+		"ç" = "l_leg",
+		"à" = "r_leg",
+		")" = "walk",
 		"A" = "drop",
 		"Q" = KEY_LEFT
 	)
@@ -253,6 +264,10 @@ var/global/list/datum/keybind_style/keybind_styles = null
 /datum/keybind_style/robot/azerty
 	name = "robot_azerty"
 	changed_keys = list(
+		"&" = "module1",
+		"é" = "module2",
+		"\"" = "module3",
+		"'" = "module4",
 		"A" = "unequip",
 		"Q" = KEY_LEFT
 	)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds the checks for which layout should be assigned to ghosts, letting them move left using the AZERTY layout.
It also changes the number row (changing intents and targets) to use the french AZERTY layout.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It fixes a bug with the ghosts being unable to move left.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Magma Hunter
(+)Changes the AZERTY number row to use the French layout. Also fixes it for ghosts.
```
