### PR TITLE
Quick-and-dirty fix for janky cleanbot pathing

### DIFF
--- a/code/modules/robotics/bot/cleanbot.dm
+++ b/code/modules/robotics/bot/cleanbot.dm
@@ -394,8 +394,7 @@
 			return
 
 	onInterrupt(flag)
-		master.cleanbottargets -= master.turf2coordinates(get_turf(master.target))
-		master.KillPathAndGiveUp(1)
+		master.KillPathAndGiveUp(0)
 		. = ..()
 
 	onEnd()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This is a simple modification to the interruption code on cleanbot to not remove it's target on interrupt (and not mark it as invalid). 

**HOWEVER**, this pull doesn't fix the issue of the bot interrupting itself by moving while cleaning. If you want to take a crack at that issue, go ahead. This modification is merely to fix the bug that causes cleanbot to "forget" messes in a quick-and-dirty method.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This, in effect, allows a cleanbot that interrupts itself to not "forget" an existing mess prematurely. This resolves #6959

This has an added benefit that if a drone is interrupted by emag-ing it, or attacking it, it will not forget the tile it was trying to clean either. This bug is much rarer, but would lead to the same effect as the previous bug.
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)antrobot
(+)fixed cleanbot's action script. It should no longer "forget" a mess if it is interrupted while cleaning.
```
