### PR TITLE
Adds Pixel Shifting

### DIFF
--- a/_std/defines/input.dm
+++ b/_std/defines/input.dm
@@ -1,5 +1,5 @@
 // haha hope you never need more than 16 of these
-// this used to use hexadecimal, now we can have 32, fun
+// this used to use hexadecimal, now we can have 24, fun
 #define KEY_FORWARD   (1<<0)
 #define KEY_BACKWARD  (1<<1)
 #define KEY_LEFT      (1<<2)

--- a/_std/defines/input.dm
+++ b/_std/defines/input.dm
@@ -1,19 +1,21 @@
 // haha hope you never need more than 16 of these
-#define KEY_FORWARD   0x0001
-#define KEY_BACKWARD  0x0002
-#define KEY_LEFT      0x0004
-#define KEY_RIGHT     0x0008
-#define KEY_RUN       0x0010
-#define KEY_THROW     0x0020
-#define KEY_POINT     0x0040
-#define KEY_EXAMINE   0x0080
-#define KEY_PULL      0x0100
-#define KEY_OPEN      0x0200
-#define KEY_BOLT      0x0400
-#define KEY_SHOCK     0x0800
+// this used to use hexadecimal, now we can have 32, fun
+#define KEY_FORWARD   (1<<0)
+#define KEY_BACKWARD  (1<<1)
+#define KEY_LEFT      (1<<2)
+#define KEY_RIGHT     (1<<3)
+#define KEY_RUN       (1<<4)
+#define KEY_THROW     (1<<5)
+#define KEY_POINT     (1<<6)
+#define KEY_EXAMINE   (1<<7)
+#define KEY_PULL      (1<<8)
+#define KEY_OPEN      (1<<9)
+#define KEY_BOLT      (1<<10)
+#define KEY_SHOCK     (1<<11)
+#define KEY_PIXEL_SHIFT (1<<12)
 
 //input keystates
-#define MODIFIER_NONE   0x0000
-#define MODIFIER_SHIFT  0x0001
-#define MODIFIER_ALT    0x0002
-#define MODIFIER_CTRL   0x0004
+#define MODIFIER_NONE   (1<<0)
+#define MODIFIER_SHIFT  (1<<1)
+#define MODIFIER_ALT    (1<<2)
+#define MODIFIER_CTRL   (1<<3)

--- a/code/WorkInProgress/ItemSpecials.dm
+++ b/code/WorkInProgress/ItemSpecials.dm
@@ -146,6 +146,21 @@
 
 //This needs to happen in process_move(), not Move() so we can change the delay modifier before it is put to use
 /mob/living/process_move(keys)
+	if(keys & KEY_PIXEL_SHIFT)
+		if(keys & KEY_FORWARD)
+			pixel_shift(NORTH)
+			return
+		else if(keys & KEY_BACKWARD)
+			pixel_shift(SOUTH)
+			return
+		else if(keys & KEY_LEFT)
+			pixel_shift(WEST)
+			return
+		else if(keys & KEY_RIGHT)
+			pixel_shift(EAST)
+			return
+	else if(pixel_shifted && (keys & KEY_FORWARD || keys & KEY_BACKWARD || keys & KEY_LEFT || keys & KEY_RIGHT))
+		pixel_shift_reset()
 	if (apply_movement_delay_until != -1)
 		if (apply_movement_delay_until >= world.time)
 			//Don't pick a delay modifier that will exceed the bounds of our delay apply window
@@ -1918,7 +1933,7 @@
 		density = 1
 		del_self = 0
 		clash_time = -1
-	
+
 
 		//mouse_opacity = 1
 		var/bump_count = 0

--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -47,7 +47,8 @@
 			src.move_dir = 0
 
 		if(!src.dir_locked) //in order to not turn around and good fuckin ruin the emote animation
-			src.set_dir(src.move_dir)
+			if(!(keys & KEY_PIXEL_SHIFT))
+				src.set_dir(src.move_dir)
 	if (changed & (KEY_THROW|KEY_PULL|KEY_POINT|KEY_EXAMINE|KEY_BOLT|KEY_OPEN|KEY_SHOCK)) // bleh
 		src.update_cursor()
 

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -127,6 +127,9 @@
 
 	var/const/singing_prefix = "%"
 
+	/// Is the `mob` currently pixel shifted?
+	var/pixel_shifted = FALSE
+
 /mob/living/New(loc, datum/appearanceHolder/AH_passthru, datum/preferences/init_preferences, ignore_randomizer=FALSE)
 	..()
 	init_preferences?.copy_to(src, usr, ignore_randomizer, skip_post_new_stuff=TRUE)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -130,6 +130,9 @@
 	/// Is the `mob/living` currently pixel shifted?
 	var/pixel_shifted = FALSE
 
+	/// Assoc list of pre-pixel shift offsets on X and Y
+	var/list/pre_pixel_shift_offsets = list()
+
 /mob/living/New(loc, datum/appearanceHolder/AH_passthru, datum/preferences/init_preferences, ignore_randomizer=FALSE)
 	..()
 	init_preferences?.copy_to(src, usr, ignore_randomizer, skip_post_new_stuff=TRUE)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -127,7 +127,7 @@
 
 	var/const/singing_prefix = "%"
 
-	/// Is the `mob` currently pixel shifted?
+	/// Is the `mob/living` currently pixel shifted?
 	var/pixel_shifted = FALSE
 
 /mob/living/New(loc, datum/appearanceHolder/AH_passthru, datum/preferences/init_preferences, ignore_randomizer=FALSE)

--- a/code/modules/interface/keybind_style.dm
+++ b/code/modules/interface/keybind_style.dm
@@ -80,6 +80,7 @@ var/global/list/datum/keybind_style/keybind_styles = null
 	"WEST" = KEY_LEFT,
 	"EAST" = KEY_RIGHT,
 	"B" = KEY_POINT,
+	"U" = KEY_PIXEL_SHIFT,
 	"T" = "say",
 	";" = "say_main_radio",
 	"Y" = "say_radio",

--- a/code/modules/mob/living/pixel_shifting.dm
+++ b/code/modules/mob/living/pixel_shifting.dm
@@ -1,0 +1,28 @@
+/mob/living/proc/pixel_shift(dir)
+	if(ON_COOLDOWN(src, "pixel_shift_cooldown", 0.4 DECI SECONDS))
+		return
+
+	switch(dir)
+		if(NORTH)
+			if(pixel_y <= 16)
+				pixel_y++
+				pixel_shifted = TRUE
+		if(EAST)
+			if(pixel_x <= 16)
+				pixel_x++
+				pixel_shifted = TRUE
+		if(SOUTH)
+			if(pixel_y >= -16)
+				pixel_y--
+				pixel_shifted = TRUE
+		if(WEST)
+			if(pixel_x >= -16)
+				pixel_x--
+				pixel_shifted = TRUE
+
+/mob/living/proc/pixel_shift_reset()
+	if(!pixel_shifted)
+		return
+	pixel_shifted = FALSE
+	pixel_x = 0
+	pixel_y = 0

--- a/code/modules/mob/living/pixel_shifting.dm
+++ b/code/modules/mob/living/pixel_shifting.dm
@@ -1,22 +1,25 @@
+#define PIXEL_TOTAL_MAX 22
+#define PIXEL_ONEDIR_MAX 14
+
 /mob/living/proc/pixel_shift(dir)
 	if(ON_COOLDOWN(src, "pixel_shift_cooldown", 0.4 DECI SECONDS))
 		return
 
 	switch(dir)
 		if(NORTH)
-			if(pixel_y <= 16)
+			if(pixel_y <= PIXEL_ONEDIR_MAX && (abs(pixel_x) + abs(pixel_y + 1) <= PIXEL_TOTAL_MAX))
 				pixel_y++
 				pixel_shifted = TRUE
 		if(EAST)
-			if(pixel_x <= 16)
+			if(pixel_x <= PIXEL_ONEDIR_MAX && (abs(pixel_x + 1) + abs(pixel_y) <= PIXEL_TOTAL_MAX))
 				pixel_x++
 				pixel_shifted = TRUE
 		if(SOUTH)
-			if(pixel_y >= -16)
+			if(pixel_y >= -PIXEL_ONEDIR_MAX && (abs(pixel_x) + abs(pixel_y - 1) <= PIXEL_TOTAL_MAX))
 				pixel_y--
 				pixel_shifted = TRUE
 		if(WEST)
-			if(pixel_x >= -16)
+			if(pixel_x >= -PIXEL_ONEDIR_MAX && (abs(pixel_x - 1) + abs(pixel_y) <= PIXEL_TOTAL_MAX))
 				pixel_x--
 				pixel_shifted = TRUE
 
@@ -26,3 +29,6 @@
 	pixel_shifted = FALSE
 	pixel_x = 0
 	pixel_y = 0
+
+#undef PIXEL_TOTAL_MAX
+#undef PIXEL_ONEDIR_MAX

--- a/code/modules/mob/living/pixel_shifting.dm
+++ b/code/modules/mob/living/pixel_shifting.dm
@@ -9,6 +9,8 @@
 		return
 
 	if(!pixel_shifted)
+		pre_pixel_shift_offsets["X"] = pixel_x
+		pre_pixel_shift_offsets["Y"] = pixel_y
 		RegisterSignal(src, COMSIG_MOVABLE_MOVED, .proc/pixel_shift_reset)
 
 	switch(dir)
@@ -33,8 +35,8 @@
 	if(!pixel_shifted)
 		return
 	pixel_shifted = FALSE
-	pixel_x = 0
-	pixel_y = 0
+	pixel_x = pre_pixel_shift_offsets["X"]
+	pixel_y = pre_pixel_shift_offsets["Y"]
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 
 #undef PIXEL_TOTAL_MAX

--- a/code/modules/mob/living/pixel_shifting.dm
+++ b/code/modules/mob/living/pixel_shifting.dm
@@ -2,8 +2,14 @@
 #define PIXEL_ONEDIR_MAX 14
 
 /mob/living/proc/pixel_shift(dir)
+	if(getStatusDuration("paralysis") || getStatusDuration("stunned") || getStatusDuration("weakened") || getStatusDuration("handcuffed") || buckled || anchored || length(grabbed_by))
+		return
+
 	if(ON_COOLDOWN(src, "pixel_shift_cooldown", 0.4 DECI SECONDS))
 		return
+
+	if(!pixel_shifted)
+		RegisterSignal(src, COMSIG_MOVABLE_MOVED, .proc/pixel_shift_reset)
 
 	switch(dir)
 		if(NORTH)
@@ -29,6 +35,7 @@
 	pixel_shifted = FALSE
 	pixel_x = 0
 	pixel_y = 0
+	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
 
 #undef PIXEL_TOTAL_MAX
 #undef PIXEL_ONEDIR_MAX

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1001,6 +1001,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\mining\mining_encounters.dm"
 #include "code\modules\mining\ore.dm"
 #include "code\modules\mining\tile_events.dm"
+#include "code\modules\mob\living\pixel_shifting.dm"
 #include "code\modules\networks\computer3\base_os.dm"
 #include "code\modules\networks\computer3\base_program.dm"
 #include "code\modules\networks\computer3\buildandrepair.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Feature] [Input Wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds pixel shifting to the game! Pixel shifting is a thing that allows you to change the position of your character on the tile you're on, which is a purely visual change that doesn't affect your _actual_ position.

The default setup is holding U and moving via WASD to pixel shift.

Edit: I've changed it to a maximum of 14 pixels in any one direction, and a max of 22 pixels shifted from your original position (no total limit prior)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More ways to express yourself in RP!

[Video Example](https://imgur.com/a/1Z5K13w)

![image](https://user-images.githubusercontent.com/41448081/147379160-5f40fe1a-5496-427f-837d-3909ab2294b7.png)

![image](https://user-images.githubusercontent.com/41448081/147379161-4d897162-14a9-4d4f-8d51-e9f93c7f102e.png)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(*)Added Pixel Shifting, to use, hold U and hold W/A/S/D.
```
