### PR TITLE
Relocate Horizon's Paramedic Suits and Medical Belts

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -7358,7 +7358,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_east,
-/obj/item/storage/belt/medical,
 /turf/simulated/floor/blue/checker{
 	dir = 8
 	},
@@ -9227,7 +9226,6 @@
 "ayw" = (
 /obj/storage/closet/wardrobe/white/genetics,
 /obj/item/storage/box/health_upgrade_kit,
-/obj/item/storage/belt/medical,
 /obj/disposalpipe/segment/morgue{
 	dir = 8
 	},
@@ -9255,7 +9253,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/item/clothing/suit/bio_suit/paramedic,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -9786,8 +9783,6 @@
 "azO" = (
 /obj/storage/closet/biohazard,
 /obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/suit/bio_suit/paramedic,
-/obj/item/storage/belt/medical,
 /obj/item/storage/box/body_bag,
 /obj/item/storage/box/body_bag,
 /obj/item/storage/box/biohazard_bags,
@@ -13839,7 +13834,6 @@
 	pixel_y = 21
 	},
 /obj/item/clothing/glasses/spectro,
-/obj/item/storage/belt/medical,
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},
@@ -14838,6 +14832,7 @@
 	pixel_x = -26;
 	pixel_y = -1
 	},
+/obj/machinery/bot/medbot,
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
 "aMN" = (
@@ -18344,7 +18339,19 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "aUF" = (
-/obj/machinery/bot/medbot,
+/obj/rack,
+/obj/item/clothing/suit/bio_suit/paramedic{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/bio_suit/paramedic{
+	pixel_x = 2
+	},
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical{
+	pixel_x = 3;
+	pixel_y = -2
+	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},

--- a/maps/horizon_xmas.dmm
+++ b/maps/horizon_xmas.dmm
@@ -7880,7 +7880,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_east,
-/obj/item/storage/belt/medical,
 /turf/simulated/floor/blue/checker{
 	dir = 8
 	},
@@ -9922,7 +9921,6 @@
 	},
 /obj/storage/closet/wardrobe/white/genetics,
 /obj/item/storage/box/health_upgrade_kit,
-/obj/item/storage/belt/medical,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/treatment2)
 "ayx" = (
@@ -9948,7 +9946,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/item/clothing/suit/bio_suit/paramedic,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
@@ -10578,8 +10575,6 @@
 /obj/disposalpipe/segment/bent/south,
 /obj/storage/closet/biohazard,
 /obj/item/clothing/mask/gas/emergency,
-/obj/item/clothing/suit/bio_suit/paramedic,
-/obj/item/storage/belt/medical,
 /obj/item/storage/box/body_bag,
 /obj/item/storage/box/body_bag,
 /obj/item/storage/box/biohazard_bags,
@@ -15082,7 +15077,6 @@
 	pixel_y = 21
 	},
 /obj/item/clothing/glasses/spectro,
-/obj/item/storage/belt/medical,
 /turf/simulated/floor/redwhite{
 	dir = 1
 	},
@@ -16169,6 +16163,7 @@
 	pixel_x = -26;
 	pixel_y = -1
 	},
+/obj/machinery/bot/medbot,
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
 "aMN" = (
@@ -19992,7 +19987,19 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbay)
 "aUF" = (
-/obj/machinery/bot/medbot,
+/obj/rack,
+/obj/item/clothing/suit/bio_suit/paramedic{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/bio_suit/paramedic{
+	pixel_x = 2
+	},
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical{
+	pixel_x = 3;
+	pixel_y = -2
+	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},


### PR DESCRIPTION
[MAPPING][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR puts the paramedic suits and medical belts for the medical department on Horizon in an accessible and easy to spot location.

Old:
Paramedic suits (2) and medical belts (3) (deleted) are located in these closets, in the ship behind medical:
![image](https://user-images.githubusercontent.com/53062374/147399294-7b041039-db70-41ef-8c31-583f1befde12.png)

There is also a belt here (deleted):
![image](https://user-images.githubusercontent.com/53062374/147399335-972330d2-1632-47fb-ad4c-251cdfc6212d.png)

New:
2 paramedic suits and belts have been put here on a rack, in line with other maps:
![image](https://user-images.githubusercontent.com/53062374/147399351-63c2833e-0810-4ccd-b11c-45daf5cacf8f.png)

Also a side note, a medibot previously started there, it was moved to just below the cryo-tube.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The current locations of the paramedic suits and medical belts are in an obsure location in closets which is unintuitive when all other maps commonly played use racks to hold the paramedic suits and belts, and the locations are hard to find. I haven't seen anyone use a paramedic suit when playing on Horizon, and had to open up the map to find the paramedic suits.

## Changelog
```
(u)FlameArrow57
(+)Horizon's medical department's paramedic suits and medical belts have been relocated to just below the cryo-tubes.
```