### PR TITLE
Add Hand Labelers to Oshan and Manta's Security Deparments

### DIFF
--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -36270,6 +36270,10 @@
 /area/mantaSpace)
 "ixV" = (
 /obj/table/reinforced/auto,
+/obj/item/hand_labeler{
+	pixel_x = 4;
+	pixel_y = 10
+	},
 /obj/item/storage/box/revimp_kit{
 	pixel_x = 6
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -29804,6 +29804,10 @@
 /obj/item/device/detective_scanner{
 	pixel_x = -6
 	},
+/obj/item/hand_labeler{
+	pixel_x = 8;
+	pixel_y = 10
+	},
 /obj/item/device/detective_scanner{
 	pixel_x = -3
 	},

--- a/maps/oshan_xmas.dmm
+++ b/maps/oshan_xmas.dmm
@@ -31751,6 +31751,10 @@
 /obj/item/device/detective_scanner{
 	pixel_x = -6
 	},
+/obj/item/hand_labeler{
+	pixel_x = 8;
+	pixel_y = 10
+	},
 /obj/item/device/detective_scanner{
 	pixel_x = -3
 	},


### PR DESCRIPTION
[MAPPING][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds hand labelers to the security departments for Oshan and Manta.

Oshan:
![oshan](https://user-images.githubusercontent.com/53062374/147400422-c51c02d0-e4e9-40a4-8260-000207682a14.PNG)

Manta:
![manta](https://user-images.githubusercontent.com/53062374/147400427-77c9487d-5d70-436c-adbd-0e0df421990b.PNG)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The security departments for these maps do not have hand labelers, which is inconvenient for example if you want to label your security weapon pinpointer with your name.

## Changelog
```
(u)FlameArrow57
(+)Oshan and Manta's security departments have been given a hand labeler.
```