### PR TITLE
Suicide command now always opens a suicide method selection window

### DIFF
--- a/code/mob/suicide.dm
+++ b/code/mob/suicide.dm
@@ -124,41 +124,39 @@
 						continue
 				suicides += O
 
-	if (suicides.len)
-		var/obj/selection
-		selection = input(src, "Choose your death:", "Selection") as null|anything in suicides
-		if (isnull(selection))
-			if (src)
+	var/obj/selection
+	selection = input(src, "Choose your death:", "Selection") as null|anything in suicides
+	if (isnull(selection))
+		if (src)
+			src.suiciding = 0
+		return
+
+	src.unlock_medal("Damned", 1) //You don't get the medal if you tried to wuss out!
+
+	if (!isnull(src.on_chair) && selection == src.on_chair)
+		src.visible_message("<span class='alert'><b>[src] jumps off of the chair straight onto [his_or_her(src)] head!</b></span>")
+		src.TakeDamage("head", 200, 0)
+		SPAWN_DBG(50 SECONDS)
+			if (src && !isdead(src))
 				src.suiciding = 0
-			return
-
-		src.unlock_medal("Damned", 1) //You don't get the medal if you tried to wuss out!
-
-		if (!isnull(src.on_chair) && selection == src.on_chair)
-			src.visible_message("<span class='alert'><b>[src] jumps off of the chair straight onto [his_or_her(src)] head!</b></span>")
-			src.TakeDamage("head", 200, 0)
-			SPAWN_DBG(50 SECONDS)
-				if (src && !isdead(src))
-					src.suiciding = 0
-			src.pixel_y = 0
-			reset_anchored(src)
-			src.on_chair = 0
-			src.buckled = null
-			return
-		else if (istype(selection))
-			selection.suicide(src)
-			SPAWN_DBG(50 SECONDS)
-				if (src && !isdead(src))
-					src.suiciding = 0
-		else
-			//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
-			src.visible_message("<span class='alert'><b>[src] is holding [his_or_her(src)] breath. It looks like [hes_or_shes(src)] trying to commit suicide.</b></span>")
-			src.take_oxygen_deprivation(175)
-			SPAWN_DBG(20 SECONDS) //in case they get revived by cryo chamber or something stupid like that, let them suicide again in 20 seconds
-				if (src && !isdead(src))
-					src.suiciding = 0
-			return
-	return
+		src.pixel_y = 0
+		reset_anchored(src)
+		src.on_chair = 0
+		src.buckled = null
+		return
+	else if (istype(selection))
+		selection.suicide(src)
+		SPAWN_DBG(50 SECONDS)
+			if (src && !isdead(src))
+				src.suiciding = 0
+	else
+		//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
+		src.visible_message("<span class='alert'><b>[src] is holding [his_or_her(src)] breath. It looks like [hes_or_shes(src)] trying to commit suicide.</b></span>")
+		src.take_oxygen_deprivation(175)
+		SPAWN_DBG(20 SECONDS) //in case they get revived by cryo chamber or something stupid like that, let them suicide again in 20 seconds
+			if (src && !isdead(src))
+				src.suiciding = 0
+		return
 
 /mob/dead/aieye/do_suicide()
 	src.return_mainframe()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol][input wanted]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Title. In case of no available suicide methods, it'll still open a window that lets you choose holding your breath:

![0](https://user-images.githubusercontent.com/62990808/147408841-a4538da6-ecf3-45df-b27c-b79fb3436d1c.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I saw someone suggest it the other day and I liked the idea, as it encourages players to try out various fancy suicide methods without risking that the command will default to holding your breath.

Buuut I want some input first before merging it

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(+)Suicide command now always opens a suicide method selection window.
```
