### PR TITLE
fix it/its objective pronoun

### DIFF
--- a/code/datums/pronouns.dm
+++ b/code/datums/pronouns.dm
@@ -81,7 +81,7 @@ ABSTRACT_TYPE(/datum/pronouns)
 	name = "it/its"
 	preferredGender = "neuter"
 	subjective = "it"
-	objective = "its"
+	objective = "it"
 	possessive = "its"
 	posessivePronoun = "its"
 	reflexive = "itself"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Just a small grammar tweak in the pronouns records. Shouldn't affect much of anything, unless it's looking at constructed strings for equality or something. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The it/its pronoun record was slightly incorrect - it/its/its/its/itself instead of it/it/its/its/itself. This was probably just due to human language being fluid and confusing, it/its is not the same parts as he/him. Easy fix!
