### PR TITLE
Make it/its selectable

### DIFF
--- a/code/datums/pronouns.dm
+++ b/code/datums/pronouns.dm
@@ -85,4 +85,4 @@ ABSTRACT_TYPE(/datum/pronouns)
 	possessive = "its"
 	posessivePronoun = "its"
 	reflexive = "itself"
-	choosable = FALSE
+	choosable = TRUE


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Make it/its selectable in the HoP's console (and, as a side effect, in the character setup screen)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

A few people do use it/its for themselves (including, in certain non-ss13-related-contexts, myself), but more importantly I needed it as HoP while issuing an ID card to a spider. This is clearly the most important reason.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Keiya
(+)Made it/its pronouns selectable in the the identity computer and character setup screen.
```
