### PR TITLE
Fix Assday classic mode not starting

### DIFF
--- a/code/datums/gamemodes/assday_classic.dm
+++ b/code/datums/gamemodes/assday_classic.dm
@@ -15,7 +15,7 @@
 	var/const/traitors_possible = 169
 
 /datum/game_mode/assday/announce()
-	boutput(world, "<B>The current game mode is - ASS DAY!</B>")
+	boutput(world, "<B>The current game mode is - Everyone is a traitor!</B>")
 	boutput(world, "<B>The entire crew of [station_or_ship()] has defected. Beware of dog.</B>")
 
 
@@ -80,23 +80,9 @@
 	return 1
 
 /datum/game_mode/assday/post_setup()
-	var/objective_set_path = null
 	for(var/datum/mind/traitor in traitors)
-		objective_set_path = null // Gotta reset this.
 		switch(traitor.special_role)
 			if(ROLE_TRAITOR)
-			#ifdef RP_MODE
-				objective_set_path = pick(typesof(/datum/objective_set/traitor/rp_friendly))
-			#else
-				objective_set_path = pick(typesof(/datum/objective_set/traitor))
-			#endif
-
-				new objective_set_path(traitor)
-
-				var/obj_count = 1
-				for(var/datum/objective/objective in traitor.objectives)
-					boutput(traitor.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
-					obj_count++
 				SHOW_TRAITOR_HARDMODE_TIPS(traitor.current)
 
 			if (ROLE_WRAITH)

--- a/code/global.dm
+++ b/code/global.dm
@@ -498,7 +498,7 @@ var/global
 	list/valid_modes = list("secret","action","intrigue","random","traitor","meteor","extended","monkey",
 		"nuclear","blob","restructuring","wizard","revolution", "revolution_extended","malfunction",
 		"spy","gang","disaster","changeling","vampire","mixed","mixed_rp", "construction","conspiracy","spy_theft",
-		"battle_royale", "vampire","assday", "football", "flock", "arcfiend"
+		"battle_royale", "vampire","everyone-is-a-traitor", "football", "flock", "arcfiend"
 #if defined(MAP_OVERRIDE_POD_WARS)
 		,"pod_wars"
 #endif

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -831,7 +831,7 @@ var/global/noir = 0
 							<A href='?src=\ref[src];action=[cmd];type=gang'>Gang War (Beta)</A><br>
 							<A href='?src=\ref[src];action=[cmd];type=pod_wars'>Pod Wars (Beta)(only works if current map is pod_wars.dmm)</A><br>
 							<A href='?src=\ref[src];action=[cmd];type=battle_royale'>Battle Royale</A><br>
-							<A href='?src=\ref[src];action=[cmd];type=assday'>Ass Day Classic (For testing only.)</A><br>
+							<A href='?src=\ref[src];action=[cmd];type=everyone-is-a-traitor'>Everyone is a traitor</A><br>
 							<A href='?src=\ref[src];action=[cmd];type=construction'>Construction (For testing only. Don't select this!)</A><br>
 							"})
 #if FOOTBALL_MODE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updated config_tag to match the mode name.
Updated text to match new name.
Removed traitor objective code to stop duplicate objectives.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Assday classic did not function due to a change to config_tag.
Traitor objectives were picked twice.