### PR TITLE
Fix flusher lag (again)

### DIFF
--- a/code/obj/machinery/floorflusher.dm
+++ b/code/obj/machinery/floorflusher.dm
@@ -18,6 +18,7 @@
 	var/flush = 0	// true if triggered
 	var/obj/disposalpipe/trunk/trunk = null // the attached pipe trunk, if none reject user
 	var/flushing = 0	// true if flushing in progress
+	var/max_capacity = 100
 
 	// Please keep synchronizied with these lists for easy map changes:
 	// /obj/storage/secure/closet/brig/automatic (secure_closets.dm)
@@ -286,8 +287,12 @@
 		open = 1
 		flick("floorflush_a", src)
 		src.icon_state = "floorflush_o"
+		var/count = 0
 		for(var/atom/movable/AM in src.loc)
 			src.Crossed(AM) // try to flush them
+			if (count >= src.max_capacity)
+				break
+			count++
 
 	proc/closeup()
 		open = 0


### PR DESCRIPTION
[performance]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Floor flushers will only flush 100 atoms at a time when they first
open due to a similar issue to #6898.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This can cause lag in a way similar to flusher components, so
the same fix applies here.

Probably best to at some point write a more in-depth feature for flushers that allows them to get clogged
or something when you stuff too much shit into them. For now let's fix the abusable lag.
