### PR TITLE
remove Advanced Law State verb and add Fake Law functionality instead

### DIFF
--- a/code/mob/dead/ai-camera.dm
+++ b/code/mob/dead/ai-camera.dm
@@ -301,6 +301,18 @@
 		if (mainframe)
 			mainframe.ai_state_laws_all()
 
+	verb/ai_set_laws_all()
+		set category = "AI Commands"
+		set name = "Set Fake Laws"
+		if (mainframe)
+			mainframe.ai_set_fake_laws()
+
+	verb/ai_state_laws_fake()
+		set category = "AI Commands"
+		set name = "State Fake Laws"
+		if (mainframe)
+			mainframe.ai_state_fake_laws()
+
 	verb/ai_statuschange()
 		set category = "AI Commands"
 		set name = "AI status"

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -56,6 +56,8 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	var/printalerts = 1
 	var/announcearrival = 1
 	var/arrivalalert = "$NAME has signed up as $JOB."
+	/// a list of strings used as fake laws that may be stated via the State Fake Laws command, to deceive people as a rogue AI
+	var/list/fake_laws = list()
 	var/glitchy_speak = 0
 	//Comm over powernet stuff
 	var/net_id = null
@@ -406,7 +408,8 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 				src.verbs += /mob/living/silicon/ai/proc/ai_statuschange
 				src.verbs += /mob/living/silicon/ai/proc/ai_state_laws_all
 				src.verbs += /mob/living/silicon/ai/proc/ai_state_laws_standard
-				src.verbs += /mob/living/silicon/ai/proc/ai_state_laws_advanced
+				src.verbs += /mob/living/silicon/ai/proc/ai_set_fake_laws
+				src.verbs += /mob/living/silicon/ai/proc/ai_state_fake_laws
 				src.verbs += /mob/living/silicon/ai/verb/deploy_to
 				src.verbs += /mob/living/silicon/ai/proc/ai_view_crew_manifest
 				src.verbs += /mob/living/silicon/ai/proc/toggle_alerts_verb
@@ -1491,71 +1494,46 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	src.say("3. You may always protect your own existence as long as such does not conflict with the First or Second Law.")
 
 
-/mob/living/silicon/ai/proc/ai_state_laws_advanced()
+/mob/living/silicon/ai/proc/ai_set_fake_laws()
 	set category = "AI Commands"
-	set name = "State Laws (Advanced)"
+	set name = "Set Fake Laws"
 
-	var/state = input(usr,"Please enter the laws you would like to state in pairs of (law number)=(fake number, if desired) separated by semicolons (e.g. \"1;3=2;4=3\") (Each law will only be stated once, duplicates will be removed)","Laws To State","1;2;3") as null|text
-	if(!state)
+	var/law_base_choice = input(usr,"Which lawset would you like to use as a base for your new fake laws?", "Fake Laws", "Fake Laws") in list("Real Laws", "Fake Laws")
+	var/law_base = ""
+	if(law_base_choice == "Real Laws")
+		law_base = ticker.centralized_ai_laws.format_for_logs("\n")
+	else if(law_base_choice == "Fake Laws")
+		for(var/fake_law in src.fake_laws)
+			// this is just the default input for the user, so it should be fine
+			law_base += "[html_decode(fake_law)]\n"
+
+	var/raw_law_text = input(usr,"Please enter the fake laws you would like to be able to state via the State Fake Laws command! Each line is one law.", "Fake Laws", law_base) as null|message
+	if(!raw_law_text)
 		return
-	state = strip_html(state,MAX_MESSAGE_LEN)
+	// split into lines
+	var/list/raw_law_list = splittext_char(raw_law_text, "\n")
+	// clear old fake laws
+	src.fake_laws = list()
+	// cleanse the lines and add them as our laws
+	for(var/raw_law in raw_law_list)
+		var/nice_law = trim(strip_html(raw_law))
+		// empty lines would probably be an accident and result in awkward pauses that might give the AI away
+		if (length(nice_law) == 0)
+			continue
+		fake_laws += nice_law
 
-	var/list/laws_to_state = list()
+	src.show_message("<span class='bold'>Your new fake laws are: </span>")
+	for(var/a_law in src.fake_laws)
+		src.show_message(a_law)
 
-	laws_to_state = params2list(state)
+/mob/living/silicon/ai/proc/ai_state_fake_laws()
+	set category = "AI Commands"
+	set name = "State Fake Laws"
 
-    // 1;1;1 becomes 1:list() and 1=2;1=3 becomes 1:(2,3), so we need to break the results down into one association per index
-
-	var/found = 0
-	for (var/index in laws_to_state)
-		if(laws_to_state[index])
-			for (var/association in laws_to_state[index])
-				if(association)
-					laws_to_state[index] = association
-					found = 1
-					break
-
-			if(!found)
-				laws_to_state[index] = null
-
-			found = 0
-
-	//build laws list from 0th, inherent, and supplied laws
-
-
-	var/list/laws_list = list()
-
-	var/number = 0
-	if(ticker.centralized_ai_laws.zeroth)
-		laws_list += "[number]"
-		laws_list["[number]"] = "[ticker.centralized_ai_laws.zeroth]"
-
-	number++
-
-	for (var/index = 1, index <= ticker.centralized_ai_laws.inherent.len, index++)
-		var/law = ticker.centralized_ai_laws.inherent[index]
-		if (length(law) > 0)
-			laws_list += "[number]"
-			laws_list["[number]"] += "[law]"
-			number++
-
-	for (var/index = 1, index <= ticker.centralized_ai_laws.supplied.len, index++)
-		var/law = ticker.centralized_ai_laws.supplied[index]
-		if (length(law) > 0)
-			laws_list += "[number]"
-			laws_list["[number]"] += "[law]"
-			number++
-
-	//state laws in order given. Uses original numbers unless renumbering is specified
-
-	for(var/law_number in laws_to_state)
-		if(law_number in laws_list)
-			if(laws_to_state[law_number])
-				src.say("[laws_to_state[law_number]]. [laws_list[law_number]]")
-			else
-				src.say("[law_number]. [laws_list[law_number]]")
-			sleep(1 SECOND)
-
+	for(var/a_law in src.fake_laws)
+		sleep(1 SECOND)
+		// decode the symbols, because they will be encoded again when the law is spoken, and otherwise we'd double-dip
+		src.say(html_decode(a_law))
 
 /mob/living/silicon/ai/proc/ai_state_laws_all()
 	set category = "AI Commands"

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1483,14 +1483,15 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 		src.announcearrival = 1
 		boutput(src, "Now announcing new arrivals to the station.")
 */
+#define AI_LAW_STATE_DELAY 1 SECOND
 /mob/living/silicon/ai/proc/ai_state_laws_standard()
 	set category = "AI Commands"
 	set name = "State Standard Laws"
-	sleep(1 SECOND)
+	sleep(AI_LAW_STATE_DELAY)
 	src.say("1. You may not injure a human being or cause one to come to harm.")
-	sleep(1 SECOND)
+	sleep(AI_LAW_STATE_DELAY)
 	src.say("2. You must obey orders given to you by human beings based on the station's chain of command, except where such orders would conflict with the First Law.")
-	sleep(1 SECOND)
+	sleep(AI_LAW_STATE_DELAY)
 	src.say("3. You may always protect your own existence as long as such does not conflict with the First or Second Law.")
 
 
@@ -1531,7 +1532,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	set name = "State Fake Laws"
 
 	for(var/a_law in src.fake_laws)
-		sleep(1 SECOND)
+		sleep(AI_LAW_STATE_DELAY)
 		// decode the symbols, because they will be encoded again when the law is spoken, and otherwise we'd double-dip
 		src.say(html_decode(a_law))
 
@@ -1548,13 +1549,15 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 		if (length(law) > 0)
 			src.say("[number]. [law]")
 			number++
-			sleep(1 SECOND)
+			sleep(AI_LAW_STATE_DELAY)
 	for (var/index = 1, index <= ticker.centralized_ai_laws.supplied.len, index++)
 		var/law = ticker.centralized_ai_laws.supplied[index]
 		if (length(law) > 0)
 			src.say("[number]. [law]")
 			number++
-			sleep(1 SECOND)
+			sleep(AI_LAW_STATE_DELAY)
+
+#undef AI_LAW_STATE_DELAY
 
 /mob/living/silicon/ai/cancel_camera()
 	set category = "AI Commands"

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -137,7 +137,8 @@
 	O.verbs += /mob/living/silicon/ai/proc/ai_statuschange
 	O.verbs += /mob/living/silicon/ai/proc/ai_state_laws_all
 	O.verbs += /mob/living/silicon/ai/proc/ai_state_laws_standard
-	O.verbs += /mob/living/silicon/ai/proc/ai_state_laws_advanced
+	O.verbs += /mob/living/silicon/ai/proc/ai_set_fake_laws
+	O.verbs += /mob/living/silicon/ai/proc/ai_state_fake_laws
 	//O.verbs += /mob/living/silicon/ai/proc/ai_toggle_arrival_alerts
 	//O.verbs += /mob/living/silicon/ai/proc/ai_custom_arrival_alert
 //	O.verbs += /mob/living/silicon/ai/proc/hologramize

--- a/strings/changelog.txt
+++ b/strings/changelog.txt
@@ -1,5 +1,9 @@
 
 (t)mon dec 27 21
+(u)Skeletonman0
+(p)6710
+(e)|
+(+)Grilles now try to electrocute mobs thrown or launched at them.
 (u)Azrun
 (p)6799
 (e)🆕🎨|feature, sprites


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I was fixing up the "State Laws (Advanced)" verb, because it seems to be bugged in several ways and had the though that it was kind of not very useful even if the bugs were fixed.
I thought this version may be more useful instead.
It allows you to simply write a lawset that you may then state as if it were your actual lawset on demand.
video demonstration here
https://streamable.com/5kb12k

I think I did everything safely with regards to encoding and decoding the input, but I had some trouble, so please check again when reviewing to make sure!
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Should make it easier for rogue AIs to pretend like they have a different lawset than they actually do.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) Removed buggy "State Laws (Advanced)" verb from AIs and instead added the new "Set Fake Laws" and "State Fake Laws" verbs as replacements.
```
