### PR TITLE
Replaces The Clarion's Brig-HoS's Office Window With A Plasma Glass One

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -44257,10 +44257,6 @@
 /obj/item/storage/goodybag,
 /obj/item/peripheral/videocard,
 /obj/item/storage/pill_bottle/cyberpunk,
-/obj/item/aiModule/hologram_expansion/clown{
-	pixel_x = -2;
-	pixel_y = 9
-	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown)
 "cUY" = (
@@ -45058,7 +45054,7 @@
 	icon_state = "0-8"
 	},
 /obj/cable,
-/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/left{
 	dir = 4
 	},
@@ -45142,7 +45138,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto/crystal,
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
@@ -49006,7 +49002,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/right{
 	dir = 4
 	},
@@ -50270,10 +50266,6 @@
 /obj/item/disk/data/cartridge/captain,
 /obj/machinery/light,
 /obj/item/spacecash/thousand,
-/obj/item/aiModule/hologram_expansion/syndicate{
-	pixel_x = -2;
-	pixel_y = 10
-	},
 /turf/simulated/floor/yellow/side,
 /area/listeningpost)
 "sVd" = (
@@ -51738,7 +51730,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
+/obj/wingrille_spawn/auto/crystal,
 /obj/window_blinds/cog2/middle{
 	dir = 4
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -44257,6 +44257,10 @@
 /obj/item/storage/goodybag,
 /obj/item/peripheral/videocard,
 /obj/item/storage/pill_bottle/cyberpunk,
+/obj/item/aiModule/hologram_expansion/clown{
+	pixel_x = -2;
+	pixel_y = 9
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown)
 "cUY" = (
@@ -50266,6 +50270,10 @@
 /obj/item/disk/data/cartridge/captain,
 /obj/machinery/light,
 /obj/item/spacecash/thousand,
+/obj/item/aiModule/hologram_expansion/syndicate{
+	pixel_x = -2;
+	pixel_y = 10
+	},
 /turf/simulated/floor/yellow/side,
 /area/listeningpost)
 "sVd" = (


### PR DESCRIPTION
[QoL] [Mapping]


## About the PR:
Replaces the Clarion's Genpop Brig's and the HoS's Office's shared window, orginally a plain glass window, with a plasma glass one.



## Why's this needed? 
See Fig. 1.

Fig. 1:
![AGoodReason](https://user-images.githubusercontent.com/88833499/147689965-945b0d26-0f2f-4e6a-a310-7f8ef097b133.png)
(Yes, I am two months late with this, apologies.)



## Changelog
```changelog
(u)Mr. Moriarty
(+)The NSS Clarion has invested in sturdier windows for the HoS's Office, in order for them to survive the relentless onslaught of StirStir's forehead.
```