### PR TITLE
Makes it that voice and emotes go over the both eye + single eye blindness layer

### DIFF
--- a/code/WorkInProgress/OverlayManager.dm
+++ b/code/WorkInProgress/OverlayManager.dm
@@ -349,7 +349,7 @@
 		var/datum/overlayDefinition/dither = new()
 		dither.d_icon = 'icons/effects/overlays/knockout2t.dmi'
 		dither.d_icon_state = "knockout2t"
-		dither.d_blend_mode = 1
+		dither.d_blend_mode = 2
 		dither.d_mouse_opacity = 0 // fuck not being able to click on things, if we want blindness to have disadvantages then find something else
 		dither.d_screen_loc = "CENTER-7,CENTER-7"
 		definitions.Add(dither)
@@ -368,7 +368,7 @@
 		var/datum/overlayDefinition/dither = new()
 		dither.d_icon = 'icons/effects/overlays/Rtrans.dmi'
 		dither.d_icon_state = "Rtrans"
-		dither.d_blend_mode = 1
+		dither.d_blend_mode = 2
 		//dither.d_mouse_opacity = 1
 		//dither.do_wide_fill = 0
 		definitions.Add(dither)
@@ -388,7 +388,7 @@
 		var/datum/overlayDefinition/dither = new()
 		dither.d_icon = 'icons/effects/overlays/Ltrans.dmi'
 		dither.d_icon_state = "Ltrans"
-		dither.d_blend_mode = 1
+		dither.d_blend_mode = 2
 		//dither.d_mouse_opacity = 1
 		//dither.do_wide_fill = 0
 		definitions.Add(dither)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes it that emotes and typed chat go over the blindness layers, making blind players able to locate people by the location of their voice. 

Pros of this PR: 
-Makes it where you do not need to constantly be skimming the chat bar to figure out if someone talked near you
-Makes it where you are able to locate someone by the sound of their voice
-Makes it where you are able to locate someone by a noisy emote

Cons of this PR:
-Makes it that some non-auditory emotes are visible, such as shivering and stretching, which someone with blindness would not be able to perceive 

Fixes #5700

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Having blindness is extremely frustrating when talking in a group of multiple people, as you have to either be very close to them, or constantly reading the chat log in the side

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Yellow/Myco
(*)Voices and Emotes now go over the blindness layers
```
