### PR TITLE
Buffed knife choking

### DIFF
--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -604,7 +604,8 @@
 	.= 0
 	if (src.chokehold && src.chokehold.state == GRAB_KILL)
 		if (tool_flags & TOOL_CUTTING && hit_type == DAMAGE_CUT)		//bleed em a bit
-			take_bleeding_damage(src.chokehold.affecting, src.chokehold.assailant, 0.5 * mult, bloodsplatter = 0)
+			src.chokehold.affecting.TakeDamage(zone="All", brute=(1 * mult))  //hurt em a bit
+			take_bleeding_damage(src.chokehold.affecting, src.chokehold.assailant, 1.4 * mult, bloodsplatter = 0)
 
 /obj/item/proc/try_grab(var/mob/living/target, var/mob/living/user)
 	.= 0


### PR DESCRIPTION
[balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the amount of bleed knife grabs do by .9 as well as given them a small amount of brute damage applied while choking somebody in addition to the normal effects of choking. This should make knives much more desirable for murder because knives lower the amount of time to kill somebody with a choke.
With some testing I've determined these stats:
0:52 - 1:00 to crit
1:30 - 1:40 for hypotension
~2:30 to kill with good RNG

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Knife grabs don't even bring the person to hypotension before they die. It's kind sad right now cause they are mostly worthless in the regards of choking somebody out.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(*)Made choking with sharp objects, like knives, deal much more bleed and a small amount of brute damage.
```
