### PR TITLE
Jailbirds now start in brig

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -102,7 +102,7 @@
 		S["notes"] = sec_note
 
 	if(H.traitHolder.hasTrait("jailbird"))
-		S["criminal"] = "*Arrest*"
+		S["criminal"] = "Incarcerated"
 		S["mi_crim"] = pick(\
 								"Public urination.",\
 								"Reading highly confidential private information.",\
@@ -150,7 +150,7 @@
 		else
 			S["notes"] += " [randomNote]"
 
-		boutput(H, "<span class='notice'>You are currently on the run because you've committed the following crimes:</span>")
+		boutput(H, "<span class='notice'>You are currently in the brig because you've committed the following crimes:</span>")
 		boutput(H, "<span class='notice'>- [S["mi_crim"]]</span>")
 		boutput(H, "<span class='notice'>- [S["ma_crim"]]</span>")
 

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -766,12 +766,22 @@
 	points = 1
 	isPositive = 0
 
-obj/trait/pilot
+/obj/trait/pilot
 	name = "Pilot (0) \[Background\]"
 	cleanName = "Pilot"
 	desc = "You spawn in a pod off-station with a Space GPS, Emergency Oxygen Tank, Breath Mask and proper protection, but you have no PDA and your pod cannot open wormholes."
 	id = "pilot"
 	icon_state = "pilot"
+	category = list("background")
+	points = 0
+	isPositive = 0
+
+/obj/trait/jailbird
+	name = "Jailbird (0) \[Background\]"
+	cleanName = "Jailbird"
+	desc = "You have a criminal record and start in the brig!"
+	id = "jailbird"
+	icon_state = "jail"
 	category = list("background")
 	points = 0
 	isPositive = 0
@@ -959,15 +969,6 @@ obj/trait/pilot
 	icon_state = "handshake"
 	points = -1
 	isPositive = 1
-
-/obj/trait/jailbird
-	name = "Jailbird (0)"
-	cleanName = "Jailbird"
-	desc = "You have a criminal record and start in the brig!"
-	id = "jailbird"
-	icon_state = "jail"
-	points = 0
-	isPositive = 0
 
 /obj/trait/clericalerror
 	name = "Clerical Error (0)"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -963,7 +963,7 @@ obj/trait/pilot
 /obj/trait/jailbird
 	name = "Jailbird (0)"
 	cleanName = "Jailbird"
-	desc = "You have a criminal record and are currently on the run!"
+	desc = "You have a criminal record and start in the brig!"
 	id = "jailbird"
 	icon_state = "jail"
 	points = 0

--- a/code/mob/living/life/arrest_icon.dm
+++ b/code/mob/living/life/arrest_icon.dm
@@ -23,8 +23,10 @@
 				var/criminal = record["criminal"]
 				if(criminal == "*Arrest*" || criminal == "Parolled" || criminal == "Incarcerated" || criminal == "Released")
 					arrestState = criminal
-			else if(H.traitHolder.hasTrait("immigrant") && H.traitHolder.hasTrait("jailbird"))
+			else if(H.traitHolder.hasTrait("immigrant"))
 				arrestState = "*Arrest*"
+			else if (H.traitHolder.hasTrait("jailbird"))
+				arrestState = "Incarcerated"
 
 			if (arrestState != "*Arrest*") // Contraband overrides non-arrest statuses, now check for contraband
 				if (locate(/obj/item/implant/antirev) in H.implant)

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -327,6 +327,8 @@ mob/new_player
 				//So the location setting is handled in EquipRank in jobprocs.dm. I assume cause that is run all the time as opposed to this.
 			else if (character.traitHolder && character.traitHolder.hasTrait("pilot"))
 				boutput(character.mind.current,"<h3 class='notice'>You've become lost on your way to the station! Good luck!</h3>")
+			else if (character.traitHolder && character.traitHolder.hasTrait("jailbird"))
+				boutput(character.mind.current,"<h3 class='notice'>You are a criminal and have been locked in the brig for your crimes!</h3>")
 				//As with the Stowaway trait, location setting is handled elsewhere.
 			else if (istype(character.mind.purchased_bank_item, /datum/bank_purchaseable/space_diner) || istype(character.mind.purchased_bank_item, /datum/bank_purchaseable/mail_order))
 				// Location is set in bank_purchaseable Create()

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -494,7 +494,9 @@
 			V.finish_board_pod(src)
 
 		if (src.traitHolder && src.traitHolder.hasTrait("jailbird"))
-			var/turf/jailbirdSpawnLocation = pick(get_area_turfs(/area/station/security/brig))
+			var/turf/jailbirdSpawnLocation
+			while(!isfloor(jailbirdSpawnLocation))
+				jailbirdSpawnLocation = pick(get_area_turfs(/area/station/security/brig))
 			src.set_loc(jailbirdSpawnLocation)
 
 		if (prob(10) && islist(random_pod_codes) && length(random_pod_codes))
@@ -532,15 +534,13 @@
 	return
 
 /mob/living/carbon/human/proc/Equip_Job_Slots(var/datum/job/JOB)
-	message_admins("DOING JOB STUFF")
 	equip_job_items(JOB, src)
 	if (src.traitHolder && src.traitHolder.hasTrait("jailbird"))
-		var/obj/item/clothing/under/US = src.get_slot(SLOT_WEAR_SUIT)
-		US.set_loc(get_turf(src))
+		var/obj/item/clothing/under/US = src.get_slot(SLOT_W_UNIFORM)
 		src.u_equip(US)
 		src.equip_if_possible(US, slot_in_backpack)
 		var/obj/item/clothing/under/color/orange/OJ = new /obj/item/clothing/under/color/orange
-		src.equip_if_possible(OJ, SLOT_WEAR_SUIT)
+		src.equip_if_possible(OJ, SLOT_W_UNIFORM)
 	if (JOB.slot_back)
 		if (istype(src.back, /obj/item/storage))
 			if(JOB.receives_disk)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -493,6 +493,10 @@
 				qdel(snappedDrone)
 			V.finish_board_pod(src)
 
+		if (src.traitHolder && src.traitHolder.hasTrait("jailbird"))
+			var/turf/jailbirdSpawnLocation = pick(get_area_turfs(/area/station/security/brig))
+			src.set_loc(jailbirdSpawnLocation)
+
 		if (prob(10) && islist(random_pod_codes) && length(random_pod_codes))
 			var/obj/machinery/vehicle/V = pick(random_pod_codes)
 			random_pod_codes -= V
@@ -528,7 +532,15 @@
 	return
 
 /mob/living/carbon/human/proc/Equip_Job_Slots(var/datum/job/JOB)
+	message_admins("DOING JOB STUFF")
 	equip_job_items(JOB, src)
+	if (src.traitHolder && src.traitHolder.hasTrait("jailbird"))
+		var/obj/item/clothing/under/US = src.get_slot(SLOT_WEAR_SUIT)
+		US.set_loc(get_turf(src))
+		src.u_equip(US)
+		src.equip_if_possible(US, slot_in_backpack)
+		var/obj/item/clothing/under/color/orange/OJ = new /obj/item/clothing/under/color/orange
+		src.equip_if_possible(OJ, SLOT_WEAR_SUIT)
 	if (JOB.slot_back)
 		if (istype(src.back, /obj/item/storage))
 			if(JOB.receives_disk)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -539,8 +539,8 @@
 		var/obj/item/clothing/under/US = src.get_slot(SLOT_W_UNIFORM)
 		src.u_equip(US)
 		src.equip_if_possible(US, slot_in_backpack)
-		var/obj/item/clothing/under/color/orange/OJ = new /obj/item/clothing/under/color/orange
-		src.equip_if_possible(OJ, SLOT_W_UNIFORM)
+		var/obj/item/clothing/under/misc/PJ = new /obj/item/clothing/under/misc
+		src.equip_if_possible(PJ, SLOT_W_UNIFORM)
 	if (JOB.slot_back)
 		if (istype(src.back, /obj/item/storage))
 			if(JOB.receives_disk)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][INPUT][WIP]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Starts Jailbird's in the brig with a orange jumpsuit and Incarcerated status.
Changed to background trait to not conflict with Stowaway, Pilot.
Tested and does not conflict with Wizard and Nuclear Operative start.

- [ ] Decide what to do about mechanic tools.
- [ ] Decide what to do about captain.
- [ ] Decide how to handle late joins.
- [ ] Decide if any antag spawns would be an issue.
- [ ] Update trait icon to match Background.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Jailbird was often used for trolling sec with Arrest status.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Jailbird trait now starts you in the brig with an orange jumpsuit.
```
