### PR TITLE
KICK 2,THE STRENGHTENING

### DIFF
--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -609,7 +609,7 @@
 				setProperty("coldprot", 0)
 				setProperty("heatprot", 0)
 			if(src.material.hasProperty("hard") && src.material.hasProperty("density"))
-				kick_bonus = round((src.material.getProperty("hard") * src.material.getProperty("density")) / 2500)
+				kick_bonus = round((src.material.getProperty("hard") * src.material.getProperty("density")) / 1500)
 			else
 				kick_bonus = 0
 		return

--- a/code/obj/item/football.dm
+++ b/code/obj/item/football.dm
@@ -47,7 +47,7 @@
 	desc = "Sharp cleats made for playing football at a professional level. They must be expensive!"
 	icon_state = "cleats"
 	item_state = "bl_shoes"
-	kick_bonus = 4
+	kick_bonus = 6
 	step_sound = "step_plating"
 	step_priority = STEP_PRIORITY_LOW
 	item_function_flags = IMMUNE_TO_ACID


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Buffs the matsci shoe kick bonus for toed shoes by dividing by 1500 instead of 2500. resulting in an average kick bonus around 5 at MAX  since you would need to use starstone for the toe tip to get close to that bonus , one would usually not get there that easily,  tested it using both uqill and starstone and I was comfortable enough with it.
also buffs cleats kick bonus to 6

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
matsci shoes were lackluster to some people this gives them a more useful stuff to them while not outright being the best 
cows have a kick bonus of 4 naturally and cleats have a current bonus of 4. this can not stand, FOR FOOTBALL IS STRONGER .


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)RSG250
(+)Buffed Matsci shoes and Cleats Kick bonus. Cleats are now stronger than cow feet. FOOTBALL.
```
