### PR TITLE
Replace older security computers

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -4990,7 +4990,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/arrivals)
 "aon" = (
-/obj/machinery/computer/secure_data,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/computer3/generic/secure_data,
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
@@ -5003,6 +5007,9 @@
 	icon_state = "1-4"
 	},
 /obj/submachine/weapon_vendor/security,
+/obj/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/red/side,
 /area/station/security/checkpoint/arrivals)
 "aop" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -20920,11 +20920,11 @@
 	dir = 8;
 	pixel_y = 6
 	},
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/computer3/generic/secure_data{
+	dir = 4
 	},
 /turf/simulated/floor/red/checker{
 	dir = 4
@@ -25274,7 +25274,6 @@
 /turf/simulated/floor/black,
 /area/station/ranch)
 "fAh" = (
-/obj/machinery/computer/secure_data,
 /obj/decal/tile_edge/line/white{
 	icon_state = "line1"
 	},
@@ -25285,6 +25284,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer3/generic/secure_data,
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "fAk" = (
@@ -38616,15 +38616,15 @@
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
 	},
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/computer3/generic/secure_data{
+	dir = 8
 	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint{
@@ -47700,7 +47700,6 @@
 	dir = 5;
 	icon_state = "line2"
 	},
-/obj/machinery/computer/secure_data,
 /obj/decal/poster/wallsign/poster_nt{
 	pixel_y = 28
 	},
@@ -47708,6 +47707,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/computer3/generic/secure_data,
 /turf/simulated/floor/red/checker,
 /area/station/security/main)
 "rFS" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -905,11 +905,11 @@
 /area/station/turret_protected/AIsat)
 "abL" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/secure_data,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/computer3/generic/secure_data,
 /turf/simulated/floor/carpet/grime,
 /area/station/security/quarters)
 "abN" = (
@@ -14465,6 +14465,11 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red/checker,
 /area/station/security/checkpoint/arrivals)
 "dXc" = (
@@ -20110,6 +20115,8 @@
 "fCu" = (
 /obj/machinery/computer3/generic/secure_data,
 /obj/machinery/light/incandescent/warm,
+/obj/machinery/power/data_terminal,
+/obj/cable,
 /turf/simulated/floor/redblack{
 	dir = 10
 	},
@@ -36325,9 +36332,6 @@
 /turf/simulated/floor/plating/jen,
 /area/station/ranch)
 "kwK" = (
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
 /obj/decoration/vent{
 	pixel_x = 1;
 	pixel_y = 32
@@ -36340,6 +36344,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/data_terminal,
+/obj/machinery/computer3/generic/secure_data{
+	dir = 8
+	},
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
@@ -37835,6 +37842,11 @@
 "kUt" = (
 /obj/stool/chair/office/red{
 	dir = 8
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/redblack{
 	dir = 8
@@ -39890,6 +39902,17 @@
 	dir = 1
 	},
 /area/station/bridge/customs)
+"lBj" = (
+/obj/disposalpipe/segment/brig{
+	dir = 1
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/red/checker,
+/area/station/security/checkpoint/arrivals)
 "lBr" = (
 /turf/simulated/floor/purpleblack{
 	dir = 5
@@ -64560,10 +64583,10 @@
 	icon_state = "1-10"
 	},
 /obj/cable,
-/obj/machinery/computer/secure_data{
+/obj/machinery/power/data_terminal,
+/obj/machinery/computer3/generic/secure_data{
 	dir = 8
 	},
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
@@ -70947,13 +70970,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "uzE" = (
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/mug/random_color{
-	pixel_x = 9;
-	pixel_y = 2
-	},
 /obj/machinery/light/emergency{
 	dir = 8
 	},
@@ -70963,6 +70979,13 @@
 	icon_state = "0-4"
 	},
 /obj/cable,
+/obj/machinery/computer3/generic/secure_data{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/mug/random_color{
+	pixel_x = 9;
+	pixel_y = 2
+	},
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "red2"
@@ -74146,6 +74169,10 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/brig,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/podbay)
 "vum" = (
@@ -80765,6 +80792,11 @@
 /area/shuttle/arrival/station)
 "xlY" = (
 /obj/machinery/computer3/generic/secure_data,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/red/checker,
 /area/station/security/checkpoint/arrivals)
 "xmb" = (
@@ -114987,7 +115019,7 @@ mxj
 tGy
 mkV
 mkV
-mkV
+lBj
 dWY
 ioP
 pAu

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -25593,6 +25593,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red/checker{
 	dir = 4
 	},
@@ -26088,10 +26093,15 @@
 	},
 /area/station/maintenance/southwest)
 "bmz" = (
-/obj/machinery/computer/secure_data{
+/obj/machinery/recharger/wall/sticky,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/computer3/generic/secure_data{
 	dir = 8
 	},
-/obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/red/checker{
 	dir = 4
 	},
@@ -26256,12 +26266,17 @@
 /area/station/hangar/qm)
 "bmT" = (
 /obj/machinery/light_switch/north,
-/obj/machinery/computer/secure_data,
 /obj/decal/cleanable/dirt,
 /obj/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/computer3/generic/secure_data,
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -32476,11 +32491,19 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
 "bDC" = (
 /obj/disposalpipe/segment/mineral{
 	dir = 4
+	},
+/obj/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
@@ -32494,6 +32517,9 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/transport,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
 "bDE" = (
@@ -54484,6 +54510,11 @@
 /obj/disposalpipe/segment/transport{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red/checker{
 	dir = 4

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -31025,9 +31025,6 @@
 	},
 /area/station/security/secwing)
 "bQK" = (
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -31036,6 +31033,9 @@
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/computer3/generic/secure_data{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/security/hos)


### PR DESCRIPTION
[MAPPING][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There are a few security computers in some of the maps that are outdated, such as in the main security lobby of Donut 3, using the interface used for security cabinets. This PR replaces these security computers with the ones that use the command line interface, along with adding data terminals and power cables for these computers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These security computers are outdated.

## Changelog
```changelog
(u)FlameArrow57
(+)Older security computers have been replaced by their newer versions.
```