### PR TITLE
Football mode tweaks (RIP John Madden)

### DIFF
--- a/code/datums/gamemodes/football.dm
+++ b/code/datums/gamemodes/football.dm
@@ -42,7 +42,7 @@ var/global/list/list/datum/mind/football_players = list("blue" = list(), "red" =
 					src.init_player(player, 0, 1)
 
 		time_left = 15 MINUTES
-		time_next_state = 15 SECONDS
+		time_next_state = 30 SECONDS
 
 		clock_num = list(locate("football_clock1000"), locate("football_clock100"), locate("football_clock10"), locate("football_clock1"))
 		red_num = list(locate("football_red100"), locate("football_red10"), locate("football_red1"))
@@ -65,7 +65,7 @@ var/global/list/list/datum/mind/football_players = list("blue" = list(), "red" =
 			var/delta = 0
 			last_tick = ticker.round_elapsed_ticks
 			src.update_game_clock()
-			boutput(world, "Game starts in 15 seconds.")
+			boutput(world, "Game starts in 30 seconds.")
 			while (true)
 				delta = ticker.round_elapsed_ticks - last_tick
 				last_tick = ticker.round_elapsed_ticks
@@ -83,6 +83,10 @@ var/global/list/list/datum/mind/football_players = list("blue" = list(), "red" =
 								the_football = new /obj/item/football/the_big_one()
 							the_football.set_loc(pick(football_spawns["football"]))
 							the_football.invisibility = INVIS_NONE
+							SPAWN_DBG(1 SECOND)
+								playsound_global(world, 'sound/items/police_whistle2.ogg', 50)
+						else
+							src.wave_timer.update_timer(time_next_state / 10)
 
 					if (FOOTBALL_INGAME)
 						time_left -= delta
@@ -105,9 +109,10 @@ var/global/list/list/datum/mind/football_players = list("blue" = list(), "red" =
 					if (FOOTBALL_POSTSCORE)
 						if (time_next_state < 0)
 							src.reset_players(0)
-							src.time_next_state = 10 SECONDS
+							src.clean_field()
+							src.time_next_state = 15 SECONDS
 							src.game_state = FOOTBALL_PREGAME
-							boutput(world, "Next possession in 10 seconds...")
+							boutput(world, "Next possession in 15 seconds...")
 					if (FOOTBALL_POSTGAME)
 						// we just dont do anything
 						return
@@ -301,3 +306,20 @@ var/global/list/list/datum/mind/football_players = list("blue" = list(), "red" =
 		newbody.set_loc(pick_landmark(LANDMARK_ASS_ARENA_SPAWN))
 		return
 		*/
+
+	proc/clean_field()
+		for(var/area/football/field/field in world)
+			for (var/obj/item/I in field)
+				if (!istype(I, /obj/item/football/the_big_one))
+					qdel(I)
+					LAGCHECK(LAG_REALTIME)
+			for(var/obj/critter/C in field)
+				qdel(C)
+				LAGCHECK(LAG_REALTIME)
+			for(var/mob/living/M in field)
+				qdel(M)
+				LAGCHECK(LAG_REALTIME)
+		for(var/area/football/football in world)
+			for(var/obj/decal/cleanable/D in football)
+				qdel(D)
+				LAGCHECK(LAG_REALTIME)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added an automated pitch clear up between rounds.
Increased between round timer by 5 seconds for a slightly bigger window for admins to mess around spawning weaponry
Increase round start by 10 seconds.
Show the spawn countdown timer for each round.
Add whistle sound at the start of each... possession? IDK anything about American Football.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pitch clearing to reduce client lag from the inevitable mess of admin spawned weaponry.
Longer between round timer gives admins a slightly bigger window to spawn things.
Longer start time to give first time players a better chance to read the instructions.
Countdown timer should give players less whiplash into when they get chucked back into the field.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Football pitch gets cleaned between rounds, slightly longer delaybefore rounds.
```
