### PR TITLE
smoke powder no longer consumes all of the reagents without stabilizer (this change was added to stabilized smoke powder a few months back)

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2684,7 +2684,6 @@ datum
 			inhibitors = list("stabiliser")
 			instant = 1
 			special_log_handling = 1
-			consume_all = 1
 			result_amount = 3
 			mix_phrase = "The mixture quickly turns into a pall of smoke!"
 #ifdef CHEM_REACTION_PRIORITY


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
 [BUG] [MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
currently the now useless anti infinismoke behavior of deleting all reagents needed for smoke powder even if they are not supposed to be normally is removed from stabilized smoke powder but not unstabilized smoke powder


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
smoke powder with stabilizer got this change so i assume it not having without it is a bug
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+) minor bug fix related to smoke powder
```
