### PR TITLE
Fixed borgs being able to insert their beakers into fabricators

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1013,7 +1013,7 @@
 			src.build_icon()
 
 		else if (istype(W,/obj/item/reagent_containers/glass))
-			if (issilicon(user))
+			if (W.cant_drop)
 				boutput(user, "<span class='alert'>You cannot put the [W] into [src]!</span>")
 				return
 			if (src.beaker)

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -1013,6 +1013,9 @@
 			src.build_icon()
 
 		else if (istype(W,/obj/item/reagent_containers/glass))
+			if (issilicon(user))
+				boutput(user, "<span class='alert'>You cannot put the [W] into [src]!</span>")
+				return
 			if (src.beaker)
 				boutput(user, "<span class='alert'>There's already a receptacle in the machine. You need to remove it first.</span>")
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #7031
Perhaps this should work like chem dispensers, but this at least stops fabricators from desynching borg beakers and making them unusable.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previously the beaker would go into the fabricator, then on ejection would be on the ground and impossible for the borg to pick back up.