### PR TITLE
Fixes multiple of the same reagents in reagent groups

### DIFF
--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -340,13 +340,18 @@
 				for (var/reagent in reagentlist)
 					if (lowertext(reagent) in src.dispensable_reagents)
 						G.reagents += lowertext(reagent)
-						//Special amounts!
-						if (istext(reagentlist[reagent])) //Set a dispense amount
-							var/num = text2num_safe(reagentlist[reagent])
-							if(!num) num = 10
-							G.reagents[lowertext(reagent)] = clamp(round(num), 1, 100)
-						else //Default to 10 if no specific amount given
-							G.reagents[lowertext(reagent)] = 10
+						var/reagentAmmount = reagentlist[reagent]
+
+						if (istext(reagentAmmount))
+							var/ammount = text2num_safe(reagentAmmount)
+							G.reagents[lowertext(reagent)] = clamp(round(ammount), 1, 100)
+						// If the input is more than 1 of the same reagent we have a list instead of just text
+						else
+							var/reagentValue = 0
+							for (var/num in reagentAmmount)
+								reagentValue += text2num_safe(num)
+							G.reagents[lowertext(reagent)] = clamp(round(reagentValue), 1, 100)
+
 				if(G.reagents == 0)
 					return
 				G.name = name


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Just makes it account for when the value of the reagent key is a list, by looping trough it and adding all of it's values together.

removes defaulting to 10 when it isn't text because it was never getting called as the input is always either text or a list 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #7056 