### PR TITLE
Embalming

### DIFF
--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -285,6 +285,7 @@
 	name = "syringe (synaptizine)"
 	desc = "Contains synaptizine, a mild stimulant to increase alertness."
 	initial_reagents = "synaptizine"
+	
 /obj/item/reagent_containers/syringe/formaldehyde
 	name = "syringe (embalming fluid)"
 	desc = "Contains formaldehyde, a chemical that prevents corpses from decaying."

--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -285,6 +285,9 @@
 	name = "syringe (synaptizine)"
 	desc = "Contains synaptizine, a mild stimulant to increase alertness."
 	initial_reagents = "synaptizine"
-
+/obj/item/reagent_containers/syringe/formaldehyde
+	name = "syringe (embalming fluid)"
+	desc = "Contains formaldehyde, a chemical that prevents corpses from decaying."
+	initial_reagents = "formaldehyde"
 #undef S_DRAW
 #undef S_INJECT

--- a/code/obj/machinery/porters.dm
+++ b/code/obj/machinery/porters.dm
@@ -868,6 +868,7 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/emergency_injector/saline, 10)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/emergency_injector/spaceacillin, 4)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/emergency_injector/synaptizine, 4)
+		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/syringe/formaldehyde, 2)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/ampoule/smelling_salts, 4)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/pill/mutadone, 5)
 		product_list += new/datum/data/vending_product(/obj/item/bandage, 6)
@@ -877,6 +878,7 @@ var/global/list/portable_machinery = list() // stop looping through world for th
 
 		//Hidden
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/emergency_injector/random, rand(1, 3), hidden=1)
+
 
 	disposing()
 		if (islist(portable_machinery))


### PR DESCRIPTION
## About the PR:
 Adds two syringes with embalming fluid into the nanomed

## Why's this needed? 
This will make emergency embalming easier for the more experienced and caring Medical Doctors, and will allow for better preservation of corpses in situations where the morgue is gone or inaccessible and the one doesn't have crematorium access. Furthermore, this will allow for saucier traitor MD gameplay. 


## Changelog
```
(u)NightmareChamillian
(+)Added Embalming Syringes to the nanomed
```