### PR TITLE
Replace older brig cell beds with version that allows for buckling

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -13291,7 +13291,7 @@
 	},
 /area/station/janitor/office)
 "GE" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/landmark/start{
 	name = "Janitor"
@@ -19720,7 +19720,7 @@
 /turf/simulated/floor/black,
 /area/station/storage/tech)
 "Xt" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -20539,7 +20539,7 @@
 	},
 /area/station/bridge/customs)
 "ZD" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -20639,7 +20639,7 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/artifact)
 "ZR" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -45720,7 +45720,7 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "gCc" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -50208,7 +50208,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -50219,7 +50219,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -22789,7 +22789,7 @@
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -37669,7 +37669,7 @@
 /turf/space,
 /area/station/hangar/qm)
 "mlY" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -51734,7 +51734,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -55567,7 +55567,7 @@
 	},
 /area/station/solar/east)
 "vLx" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -19075,7 +19075,7 @@
 	},
 /area/station/janitor/office)
 "aWp" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/black,
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -20566,7 +20566,7 @@
 	},
 /area/station/janitor/office)
 "aZH" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/black,
 /turf/simulated/floor,
 /area/station/security/checkpoint/arrivals)
@@ -54309,7 +54309,7 @@
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
 "hai" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/black,
 /obj/machinery/light{
 	dir = 4;

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -3841,7 +3841,7 @@
 /obj/machinery/light/incandescent/warm{
 	dir = 4
 	},
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /turf/simulated/floor,
 /area/listeningpost/syndicateassaultvessel)
 "amJ" = (
@@ -15065,7 +15065,7 @@
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
 "aRj" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -15289,7 +15289,7 @@
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
 "aRQ" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -15648,7 +15648,7 @@
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
 "aTa" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -16054,7 +16054,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/security/brig/cell1)
 "aUh" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/decal/cleanable/dirt/dirt3,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{

--- a/maps/unused/mushroom.dmm
+++ b/maps/unused/mushroom.dmm
@@ -25809,7 +25809,7 @@
 	d1 = 4;
 	d2 = 8
 	},
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/machinery/light/small,
 /turf/simulated/floor,
 /area/station/security/brig)
@@ -26053,7 +26053,7 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "beK" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/machinery/camera{
 	c_tag = "Brig - Solitary 1";
 	dir = 4
@@ -26501,7 +26501,7 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "bfC" = (
-/obj/stool/bed/brig,
+/obj/stool/bed,
 /obj/cable{
 	d1 = 1;
 	d2 = 4;


### PR DESCRIPTION
[MAPPING]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Some brig beds, such as on Horizon, don't allow for buckling. This PR changes these beds to a version that allows for buckling (/obj/stool/bed/brig -> /obj/stool/bed, appears to be the same sprite).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Putting someone in a cell with these types of beds, especially a smaller cell (ex. on Horizon), can be a bit difficult sometimes without stunning them if the person will try to get out of the cell as soon as you stop grabbing them.

This also makes the beds used in line with the other commonly played maps.

On Horizon:

![image](https://user-images.githubusercontent.com/53062374/147899605-4149953b-bdc3-4ead-abe7-dd5b932caf18.png)