### PR TITLE
Fix large shuttle doors

### DIFF
--- a/assets/maps/shuttles/east/eastbase.dmm
+++ b/assets/maps/shuttles/east/eastbase.dmm
@@ -76,7 +76,6 @@
 /area/shuttle/escape/centcom)
 "cd" = (
 /obj/machinery/door/airlock/pyro/medical/alt{
-	density = 0;
 	dir = 8
 	},
 /turf/unsimulated/floor/shuttle{
@@ -699,8 +698,7 @@
 /area/centcom/outside)
 "CK" = (
 /obj/machinery/door/airlock/pyro/glass/command{
-	dir = 4;
-	req_access = 0
+	dir = 4
 	},
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
@@ -711,7 +709,6 @@
 /area/centcom/outside)
 "DC" = (
 /obj/machinery/door/airlock/pyro/security{
-	density = 0;
 	dir = 4;
 	name = "Secure Transport"
 	},

--- a/assets/maps/shuttles/north/northbase.dmm
+++ b/assets/maps/shuttles/north/northbase.dmm
@@ -228,9 +228,7 @@
 /turf/unsimulated/floor/arrival,
 /area/centcom)
 "gh" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	req_access = null
-	},
+/obj/machinery/door/airlock/pyro/glass/command,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -322,7 +320,6 @@
 /area/shuttle/escape/centcom)
 "iQ" = (
 /obj/machinery/door/airlock/pyro/security{
-	density = 0;
 	name = "Secure Transport"
 	},
 /turf/unsimulated/floor/shuttle,

--- a/assets/maps/shuttles/south/southbase.dmm
+++ b/assets/maps/shuttles/south/southbase.dmm
@@ -144,9 +144,7 @@
 	},
 /area/shuttle/escape/centcom)
 "hY" = (
-/obj/machinery/door/airlock/pyro/glass/command{
-	req_access = null
-	},
+/obj/machinery/door/airlock/pyro/glass/command,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
 	},
@@ -921,7 +919,6 @@
 /area/centcom/outside)
 "Mf" = (
 /obj/machinery/door/airlock/pyro/security{
-	density = 0;
 	name = "Secure Transport"
 	},
 /turf/unsimulated/floor/shuttle{
@@ -1190,9 +1187,7 @@
 /turf/unsimulated/floor/arrival,
 /area/centcom)
 "Xe" = (
-/obj/machinery/door/airlock/pyro/medical/alt{
-	density = 0
-	},
+/obj/machinery/door/airlock/pyro/medical/alt,
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor3"
 	},

--- a/assets/maps/shuttles/west/westbase.dmm
+++ b/assets/maps/shuttles/west/westbase.dmm
@@ -379,8 +379,7 @@
 /area/shuttle/escape/centcom)
 "oM" = (
 /obj/machinery/door/airlock/pyro/glass/command{
-	dir = 4;
-	req_access = 0
+	dir = 4
 	},
 /turf/unsimulated/floor/shuttle{
 	icon_state = "floor2"
@@ -388,7 +387,6 @@
 /area/shuttle/escape/centcom)
 "pj" = (
 /obj/machinery/door/airlock/pyro/security{
-	density = 0;
 	dir = 4;
 	name = "Secure Transport"
 	},
@@ -1027,7 +1025,6 @@
 /area/centcom/outside)
 "NZ" = (
 /obj/machinery/door/airlock/pyro/medical/alt{
-	density = 0;
 	dir = 8
 	},
 /turf/unsimulated/floor/shuttle{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes large shuttle doors have density.
Restores access to shuttle command doors.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Doors should definitely be solid.
Command doors used to require access, inconsistent across shuttles.