### PR TITLE
Fix for minor robogib bug

### DIFF
--- a/code/procs/gibs.dm
+++ b/code/procs/gibs.dm
@@ -91,14 +91,14 @@
 	// NORTH
 	gib = make_cleanable( /obj/decal/cleanable/robot_debris,location)
 	if (prob(25))
-		gib.icon_state = "gibup1"
+		gib.icon_state = "gibup"
 	gib.streak_cleanable(NORTH)
 	gibs.Add(gib)
 
 	// SOUTH
 	gib = make_cleanable( /obj/decal/cleanable/robot_debris,location)
 	if (prob(25))
-		gib.icon_state = "gibdown1"
+		gib.icon_state = "gibdown"
 	gib.streak_cleanable(SOUTH)
 	gibs.Add(gib)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Corrects two cases of invalid icon assignment

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Currently the robogib proc has a chance to produce two invisible robot debris due to using invalid state keys. This will now make them visible. The cleanbots weren't cleaning imaginary messes after all!


