### PR TITLE
Protect last.ckey mobs from football mode deletion

### DIFF
--- a/code/datums/gamemodes/football.dm
+++ b/code/datums/gamemodes/football.dm
@@ -317,9 +317,12 @@ var/global/list/list/datum/mind/football_players = list("blue" = list(), "red" =
 				qdel(C)
 				LAGCHECK(LAG_REALTIME)
 			for(var/mob/living/M in field)
+				if(M.last_ckey)
+					continue
 				qdel(M)
 				LAGCHECK(LAG_REALTIME)
 		for(var/area/football/football in world)
 			for(var/obj/decal/cleanable/D in football)
 				qdel(D)
 				LAGCHECK(LAG_REALTIME)
+		message_admins("Field cleaning complete.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Checks if a mob has last.ckey and skips deleting them.
Adds a message to let admins know the pitch cleaning has finished.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some players got deleted in last football test. Protects admins if they ever run around as a mob.