### PR TITLE
Added Empty Syringe and IV Drip to Medical Fabricator

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1050,6 +1050,24 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Resource"
 
+/datum/manufacture/syringe
+	name = "Empty Syringe"
+	item_paths = list("CRY-1","MET-1")
+	item_amounts = list(1,1)
+	item_outputs = list(/obj/item/reagent_containers/syringe)
+	time = 5 SECONDS
+	create = 1
+	category = "Tool"
+
+/datum/manufacture/IV_drip
+	name = "Empty IV Drip"
+	item_paths = list("MET-1","INS-1")
+	item_amounts = list(1,2)
+	item_outputs = list(/obj/item/reagent_containers/iv_drip)
+	time = 10 SECONDS
+	create = 1
+	category = "Tool"
+
 /******************** Robotics **************************/
 
 /datum/manufacture/robo_frame

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2214,6 +2214,8 @@
 		/datum/manufacture/glasses,
 		/datum/manufacture/visor,
 		/datum/manufacture/deafhs,
+		/datum/manufacture/syringe,
+		/datum/manufacture/IV_drip,
 		/datum/manufacture/hypospray,
 		/datum/manufacture/patch,
 		/datum/manufacture/mender,
@@ -2252,6 +2254,7 @@
 		/datum/manufacture/rods2,
 		/datum/manufacture/metal,
 		/datum/manufacture/glass
+
 	)
 
 	hidden = list(/datum/manufacture/cyberheart,


### PR DESCRIPTION
## About the PR 
Adds the ability to make Empty Syringes and IV Drips in the medical fabricator
Syringes cost 0.1 metal and 0.1 crystal
IV Drips cost 0.1 metal and 0.2 insulative material

## Why's this needed? 
Feels weird that the medical fabricator cannot fabricate 2 common medical items


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)CrystalClover
(+)Added Syringe and IV Drip to Medical Fabricator
```
