### PR TITLE
Add new admin command, View Ref Variables

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -63,24 +63,24 @@
 		boutput(usr, "<span class='alert'>Could not find [S] in the Global Variables list!!</span>" )
 		return
 
-/client/proc/debug_ref_variables()
+/client/proc/debug_ref_variables(ref as text)
 	SET_ADMIN_CAT(ADMIN_CAT_DEBUG)
 	set name = "View Ref Variables"
+	set desc = "(reference) Enter a ref to view the variables of"
 
-	if (src.holder.level < LEVEL_ADMIN)
-		alert("You must be at least an Administrator to use this command.")
+	if (src.holder?.level < LEVEL_ADMIN)
 		src.audit(AUDIT_ACCESS_DENIED, "tried to call debug_ref_variables while being below Administrator rank.")
+		tgui_alert(src.mob, "You must be at least an Administrator to use this command.", "Access Denied")
 		return
 
-	var/ref = input(src, "Enter a ref to view the variables of", "Debug Ref Variables")
 	if(ref)
-		var/thing = locate(ref)
-		if(!thing)
-			thing = locate("\[[ref]\]")
-		if(!thing)
+		var/datum/D = locate(ref)
+		if(!D)
+			D = locate("\[[ref]\]")
+		if(!D)
 			boutput(src, "<span class='alert'>Bad ref or couldn't find that thing. Drats.</span>")
 			return
-		debug_variables(thing)
+		debug_variables(D)
 
 /client/proc/debug_variables(datum/D in world) // causes GC to lock up for a few minutes, the other option is to use atom/D but that doesn't autocomplete in the command bar
 	SET_ADMIN_CAT(ADMIN_CAT_NONE)

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -67,7 +67,7 @@
 	SET_ADMIN_CAT(ADMIN_CAT_DEBUG)
 	set name = "View Ref Variables"
 
-	if (usr.client.holder.level < LEVEL_ADMIN)
+	if (src.holder.level < LEVEL_ADMIN)
 		alert("You must be at least an Administrator to use this command.")
 		src.audit(AUDIT_ACCESS_DENIED, "tried to call debug_ref_variables while being below Administrator rank.")
 		return

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -66,7 +66,7 @@
 /client/proc/debug_ref_variables(ref as text)
 	SET_ADMIN_CAT(ADMIN_CAT_DEBUG)
 	set name = "View Ref Variables"
-	set desc = "(reference) Enter a ref to view the variables of"
+	set desc = "(reference) Enter a ref to view its variables"
 
 	if (src.holder?.level < LEVEL_ADMIN)
 		src.audit(AUDIT_ACCESS_DENIED, "tried to call debug_ref_variables while being below Administrator rank.")

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -63,6 +63,25 @@
 		boutput(usr, "<span class='alert'>Could not find [S] in the Global Variables list!!</span>" )
 		return
 
+/client/proc/debug_ref_variables()
+	SET_ADMIN_CAT(ADMIN_CAT_DEBUG)
+	set name = "View Ref Variables"
+
+	if (usr.client.holder.level < LEVEL_ADMIN)
+		alert("You must be at least an Administrator to use this command.")
+		src.audit(AUDIT_ACCESS_DENIED, "tried to call debug_ref_variables while being below Administrator rank.")
+		return
+
+	var/ref = input(src, "Enter a ref to view the variables of", "Debug Ref Variables")
+	if(ref)
+		var/thing = locate(ref)
+		if(!thing)
+			thing = locate("\[[ref]\]")
+		if(!thing)
+			boutput(src, "<span class='alert'>Bad ref or couldn't find that thing. Drats.</span>")
+			return
+		debug_variables(thing)
+
 /client/proc/debug_variables(datum/D in world) // causes GC to lock up for a few minutes, the other option is to use atom/D but that doesn't autocomplete in the command bar
 	SET_ADMIN_CAT(ADMIN_CAT_NONE)
 	set name = "View Variables"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -368,6 +368,7 @@ var/list/admin_verbs = list(
 		/client/proc/call_proc,
 		/client/proc/call_proc_all,
 		/client/proc/debug_global_variable,
+		/client/proc/debug_ref_variables,
 
 		// /client/proc/admin_airborne_fluid,
 		// /client/proc/replace_space,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds `client/proc/debug_ref_variables`
* Adds proc under the debug tab listed as View Ref Variables

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* It can be annoying to try to view vars on an arbitrary ref, this just makes it easier