### PR TITLE
Cleanup circular ref on inventory counters

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1421,6 +1421,7 @@
 	disposing_abilities()
 	setItemSpecial(null)
 	if (src.inventory_counter)
+		src.inventory_counter.vis_locs = null
 		qdel(src.inventory_counter)
 		src.inventory_counter = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* When items are deleted they delete their var ref to any existing inventory counters, but do not clear the `vis_loc` `vis_contents` circular reference


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Prevents clean deletion of any item possessing an inventory counter