### PR TITLE
Fix access requirement on a medical locker

### DIFF
--- a/code/obj/storage/closets.dm
+++ b/code/obj/storage/closets.dm
@@ -523,19 +523,6 @@
 					/obj/item/clothing/glasses/meson = 1,
 					/obj/item/reagent_containers/emergency_injector/anti_rad = 1)
 
-/obj/storage/closet/medicalclothes
-	name = "medical clothing locker"
-	icon = 'icons/obj/large_storage.dmi'
-	icon_closed = "medical_clothes"
-	icon_state = "medical_clothes"
-	icon_opened = "secure_white-open"
-	desc = "A handy medical locker for storing your doctoring apparel."
-	spawn_contents = list(/obj/item/clothing/head/nursehat = 3,
-					/obj/item/clothing/suit/nursedress = 3,
-					/obj/item/clothing/suit/wintercoat/medical = 3,
-					/obj/item/clothing/head/headmirror = 3,
-					/obj/item/clothing/suit/labcoat/medical = 3)
-
 /obj/storage/closet/command/ruined //replacements for azones and mining level flavor
 	name = "Dented command locker"
 	desc = "This thing looks ransacked."

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -409,6 +409,16 @@
 	/obj/item/storage/box/lglo_kit/random,
 	/obj/item/clothing/glasses/healthgoggles)
 
+/obj/storage/secure/closet/medical/apparel
+	name = "medical apparel locker"
+	icon_closed = "medical_clothes"
+	icon_state = "medical_clothes"
+	spawn_contents = list(/obj/item/clothing/head/nursehat = 3,
+	/obj/item/clothing/suit/nursedress = 3,
+	/obj/item/clothing/suit/wintercoat/medical = 3,
+	/obj/item/clothing/head/headmirror = 3,
+	/obj/item/clothing/suit/labcoat/medical = 3)
+
 /obj/storage/secure/closet/medical/chemical
 	name = "restricted medical locker"
 	icon_closed = "medical_restricted"

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -12862,7 +12862,7 @@
 	},
 /area/station/medical/medbay)
 "FE" = (
-/obj/storage/closet/medicalclothes,
+/obj/storage/secure/closet/medical/apparel,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -50001,7 +50001,7 @@
 	dir = 8;
 	pixel_x = -10
 	},
-/obj/storage/closet/medicalclothes,
+/obj/storage/secure/closet/medical/apparel,
 /turf/simulated/floor/black,
 /area/station/medical/medbay/surgery)
 "smW" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -55528,7 +55528,7 @@
 /turf/simulated/floor/plating,
 /area/station/routing/sortingRoom)
 "hSq" = (
-/obj/storage/closet/medicalclothes,
+/obj/storage/secure/closet/medical/apparel,
 /turf/simulated/floor/arrival{
 	dir = 6
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -80669,7 +80669,7 @@
 /turf/simulated/floor/airless/caution/northsouth,
 /area/station/hangar/science)
 "vxs" = (
-/obj/storage/closet/medicalclothes,
+/obj/storage/secure/closet/medical/apparel,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "vyj" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -47264,7 +47264,7 @@
 /obj/machinery/light/emergency{
 	dir = 4
 	},
-/obj/storage/closet/medicalclothes,
+/obj/storage/secure/closet/medical/apparel,
 /turf/simulated/floor/bluewhite/corner{
 	dir = 8
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -77848,7 +77848,7 @@
 /obj/disposalpipe/switch_junction/right/east{
 	mail_tag = "morgue"
 	},
-/obj/storage/closet/medicalclothes,
+/obj/storage/secure/closet/medical/apparel,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "wuh" = (

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -59910,7 +59910,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/storage/closet/medicalclothes,
+/obj/storage/secure/closet/medical/apparel,
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -44881,7 +44881,7 @@
 /turf/simulated/floor/greenblack,
 /area/station/turret_protected/Zeta)
 "hRE" = (
-/obj/storage/closet/medicalclothes,
+/obj/storage/secure/closet/medical/apparel,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "hRN" = (

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -5058,7 +5058,7 @@
 	icon_state = "line3"
 	},
 /obj/disposalpipe/segment,
-/obj/storage/closet/medicalclothes,
+/obj/storage/secure/closet/medical/apparel,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -46046,7 +46046,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "fIX" = (
-/obj/storage/closet/medicalclothes,
+/obj/storage/secure/closet/medical/apparel,
 /turf/simulated/floor/red/checker,
 /area/station/medical/medbay/surgery/storage)
 "fJg" = (

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -63941,7 +63941,7 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/captain)
 "coK" = (
-/obj/storage/closet/medicalclothes,
+/obj/storage/secure/closet/medical/apparel,
 /turf/simulated/floor/arrival{
 	dir = 10
 	},


### PR DESCRIPTION
[MINOR][CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes the access requirement on one of the medical lockers to be the same as the rest of the medical lockers, previously having no access requirement. This is done by changing the object path, from /obj/storage/closet/medicalclothes -> /obj/storage/secure/closet/medical/apparel.

Ex. The one on the left in Oshan
![image](https://user-images.githubusercontent.com/53062374/148336305-f76b4d6e-919b-4371-a424-d5a88df3666c.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes access requirement.