### PR TITLE
refactor strychnine a little so it works properly

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1738,31 +1738,47 @@ datum
 			transparency = 255
 			depletion_rate = 0.2
 			var/ticks = 0
+			var/stage = 0
 
 			on_mob_life(var/mob/M, var/mult = 1)
 
 				var/mob/living/carbon/human/H = M
 				if (!istype(H)) return
 
-				switch(ticks+=(1 * mult))
+				ticks += mult
 
-					if(2) //Just started out. Everything's cool
+				switch (stage)
+					if(0)
+						if(ticks >= 2)
+							stage++
+					if(1)
+						//Just started out. Everything's cool
 						H.add_stam_mod_max(src.id, 75)
-					if(3 to 14)
+						if(ticks >= 3)
+							stage++
+					if(2)
 						if(prob(10)) do_stuff(0, H, mult)
-
-					if(15 to 24) //Ok, now it's getting worrying
+						if(ticks >= 15)
+							stage++
+					if(3)
+						//Ok, now it's getting worrying
 						if(prob(30)) do_stuff(1, H, mult)
-					if(25)
+						if(ticks >= 25)
+							stage++
+					if(4)
 						H.remove_stam_mod_max(src.id)
 						H.add_stam_mod_max(src.id, -50)
 						APPLY_MOB_PROPERTY(H, PROP_STAMINA_REGEN_BONUS, src.id, -2)
-					if(26 to 35)
+						if(ticks >= 26)
+							stage++
+					if(5)
 						if(prob(30)) do_stuff(2, H, mult)
-					if(36 to INFINITY)
-						if(prob(min(ticks, 100))) //Start at 30% chance of bad stuff, increase until death
+						if(ticks >= 36)
+							stage++
+					if(6)
+						//Start at 30% chance of bad stuff, increase until death
+						if(prob(min(ticks, 100)))
 							do_stuff(3, H, mult)
-
 				..()
 
 			on_remove()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I think Strychnine didn't seem to actually do the whole Stamina buff thing, because the ticks var is based on mult, so it is a decimal.
That means it probably won't be exactly 2 or exactly 25 for the switch statement.

I changed it so that it should now be guaranteed to do each stage at least once, so you get to enjoy your 275 stamina for a few seconds before your agonizing 150 stamina death.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's good if chems work as intended.