### PR TITLE
Cog1 Chompskey Anti-Invasion Measures

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -53697,7 +53697,6 @@
 /area/station/maintenance/solar/north)
 "eIy" = (
 /obj/storage/closet/emergency,
-/obj/random_item_spawner/chompskey,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "eJd" = (
@@ -57656,7 +57655,6 @@
 	dir = 8
 	},
 /obj/storage/cart,
-/obj/random_item_spawner/chompskey,
 /turf/simulated/floor/grime,
 /area/station/storage/warehouse)
 "mlR" = (
@@ -60711,11 +60709,11 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "rTj" = (
-/obj/random_item_spawner/chompskey,
 /obj/storage/crate/bin{
 	desc = "Theoretically, items that are lost by a person are placed here so that the person may come and find them. This never happens.";
 	name = "\improper Lost and Found bin"
 	},
+/obj/item/gnomechompski,
 /turf/simulated/floor/grey/side,
 /area/station/crew_quarters/courtroom)
 "rTm" = (
@@ -61657,7 +61655,6 @@
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "tse" = (
-/obj/random_item_spawner/chompskey,
 /obj/storage/crate/bin{
 	desc = "Theoretically, items that are lost by a person are placed here so that the person may come and find them. This never happens.";
 	name = "\improper Lost and Found bin"
@@ -62063,7 +62060,6 @@
 /area/station/solar/north)
 "ubf" = (
 /obj/storage/closet/emergency,
-/obj/random_item_spawner/chompskey,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
 "ubA" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Unfucks/fixes #7089 by removing the 5 new `/obj/random_item_spawner/chompskey` spawners which actually spawn chomp's key and not chompski himself. Returns chompski to the Courtroom Lost & Found bin.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I would like to rectify the results of my incompetence thank you very much.
(*Apparently* the key isn't just some random junk item but is actually able to be abused according to some others, whoops)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Nexusuxen
(+)Chomp's Keys should no longer spawn 5 times on Cog1.
```
