### PR TITLE
changes the recipe of heparin to use blood instead of meat slurry

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -3163,7 +3163,7 @@ datum
 			name = "Heparin"
 			id = "heparin"
 			result = "heparin"
-			required_reagents = list("sugar" = 1, "meat_slurry" = 1, "phenol" = 1, "acid" = 1)
+			required_reagents = list("sugar" = 1, "blood" = 1, "phenol" = 1, "acid" = 1)
 			result_amount = 2
 
 		proconvertin // coagulant


### PR DESCRIPTION
[LABEL][balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes heparin's recipe from needing meat slurry to needing blood, because heparin is barely used and the fact it currently needs such a hard to get chem to manufacture makes it even harder to come by.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I see no reason not to do it, its not a particularly good medicine, its used for conditions that are somewhat rare and mostly a result of doctors messing something up, and it isn't that dangerous as to warrant such a hard precursor.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Colossusqw
(+)Changed the heparin recipe from needing meat slurry to needing blood.
```
