### PR TITLE
Fix cog1 sorting room mail junction

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -56569,7 +56569,7 @@
 /obj/plasticflaps,
 /obj/disposalpipe/switch_junction{
 	dir = 4;
-	mail_tag = "sortingRoom";
+	mail_tag = "sortingroom";
 	name = "sorting room router"
 	},
 /obj/machinery/door/firedoor/pyro{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a mail_tag mismatch between the cog1 sorting room mail junction and chute.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stuff wasn't getting redirected properly.