### PR TITLE
Fix failed-to-summon secbots halting

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -629,7 +629,7 @@
 				src.doing_something = 1
 				if(!src.path)
 					src.speak("ERROR 99-28: COULD NOT FIND PATH TO SUMMON TARGET. ABORTING.")
-					src.KillPathAndGiveUp(KPAGU_CLEAR_PATH)	// switch back to what we should be
+					src.KillPathAndGiveUp(KPAGU_RETURN_TO_PATROL)	// switch back to what we should be
 
 			/// On guard duty, returning from distraction
 			if(SECBOT_GUARD_IDLE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes a flag for when a secbot doesn't generate a path towards a summon location to one that actually clears the summon mode.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently a secbot failing to path towards a summon will just repeatedly yell the error code and it's both useless and annoying.