### PR TITLE
Mop Locator now displays correct volume of listed mop buckets.

### DIFF
--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -380,7 +380,7 @@ Code:
 				if (bl.z != cl.z)
 					continue
 
-				ldat += "Bucket - <b>\[[bl.x],[bl.y] ([get_area(bl)])\]</b> - Water level: [B.reagents.total_volume]/400<br>"
+				ldat += "Bucket - <b>\[[bl.x],[bl.y] ([get_area(bl)])\]</b> - Water level: [B.reagents.total_volume]/[B.reagents.maximum_volume]<br>"
 
 			if (!ldat)
 				dat += "None"

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -380,7 +380,7 @@ Code:
 				if (bl.z != cl.z)
 					continue
 
-				ldat += "Bucket - <b>\[[bl.x],[bl.y] ([get_area(bl)])\]</b> - Water level: [B.reagents.total_volume]/50<br>"
+				ldat += "Bucket - <b>\[[bl.x],[bl.y] ([get_area(bl)])\]</b> - Water level: [B.reagents.total_volume]/400<br>"
 
 			if (!ldat)
 				dat += "None"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - TRIVIAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR changes the Mop Locator program found on Janitor PDAs to correctly show the max volume on listed mop buckets. This change also supports buckets with nonstandard volumes, in case anybody considers adding a high-capacity mop bucket for some reason. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #7115. Currently, Mop Locator always displays the maximum volume of mop buckets erroneously as 50 units.
