### PR TITLE
secbot summon text uses area instead of turf

### DIFF
--- a/code/obj/item/device/pda2/bot_control.dm
+++ b/code/obj/item/device/pda2/bot_control.dm
@@ -201,7 +201,7 @@
 			if("summon")
 				post_status("bot_control", "command", "summon", "active", active, "target", summon_turf )
 				post_status("bot_control", "command", "bot_status", "active", active)
-				self_text("[active] summoned to [summon_turf]")
+				self_text("[active] summoned to [summon_turf.loc].")
 
 			if("proc")
 				post_status("bot_control", "command", "proc", "active", active)
@@ -223,7 +223,7 @@
 							self_text("Summon failed.")
 							break
 					if(length(bots) >= 1)
-						self_text("[english_list(bots)] summoned to [summon_turf].")
+						self_text("[english_list(bots)] summoned to [summon_turf.loc].")
 		src.lockdown = 0
 		src.all_guard = 0
 		PDA.updateSelfDialog()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As title, but also I added a missing period.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the secbot summon program will say something like "securitron summoned to steel floor", which could be just about anywhere.