### PR TITLE
Missing Horizon escape tile

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -59675,10 +59675,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
-"udC" = (
-/obj/machinery/door/airlock/pyro/external,
-/turf/space,
-/area/station/hallway/secondary/exit)
 "ufA" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/decal/cleanable/dirt,
@@ -134084,7 +134080,7 @@ jje
 jje
 jje
 jje
-udC
+aJE
 ifg
 aLp
 mEz


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a missing tile to the Horizon airbridge to escape

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
holes stinky