### PR TITLE
Latex Gloves require Insulative Material instead of Fabric

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -827,7 +827,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 
 /datum/manufacture/latex_gloves
 	name = "Latex Gloves"
-	item_paths = list("FAB-1")
+	item_paths = list("INS-1")
 	item_amounts = list(1)
 	item_outputs = list(/obj/item/clothing/gloves/latex)
 	time = 5 SECONDS


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes production of latex gloves in a medical fabricator to use insulative material instead of fabric


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Latex is a type of rubber, so it makes sense


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)CrystalClover
(+)Changed Latex gloves to require insulative material instead of fabric
```
