### PR TITLE
Adds and updates descriptions on a ton of things

### DIFF
--- a/code/WorkInProgress/Electronics.dm
+++ b/code/WorkInProgress/Electronics.dm
@@ -838,7 +838,7 @@
 
 /obj/item/deconstructor
 	name = "deconstruction device"
-	desc = "A device meant to facilitate the deconstruction of scannable machines."
+	desc = "A saw-like device capable of taking apart reverse-engineered machines. Or your crewmates."
 	icon = 'icons/obj/items/device.dmi'
 	icon_state = "deconstruction-saw"
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -11,7 +11,7 @@
 
 /obj/machinery/disposal
 	name = "disposal unit"
-	desc = "A pneumatic waste disposal unit."
+	desc = "A pressurized trashcan that flushes things you put into it through pipes, usually to disposals."
 	icon = 'icons/obj/disposal.dmi'
 	icon_state = "disposal"
 	anchored = 1

--- a/code/modules/atmospherics/machinery/unary/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/unary/vent_pump.dm
@@ -2,7 +2,7 @@
 	icon = 'icons/obj/atmospherics/vent_pump.dmi'
 	icon_state = "out"
 	name = "Air Vent"
-	desc = "Has a valve and pump attached to it"
+	desc = "A vent used for repressurization. It's probably hooked up to a canister port, somewhere."
 	level = 1
 	plane = PLANE_FLOOR
 	var/on = 1

--- a/code/modules/chemistry/Chemistry-Dispenser.dm
+++ b/code/modules/chemistry/Chemistry-Dispenser.dm
@@ -1,5 +1,6 @@
 /obj/machinery/chem_dispenser
 	name = "chem dispenser"
+	desc = "A complicated, soda fountain-like machine that allows the user to dispense basic chemicals for use in recipies."
 	density = 1
 	anchored = 1
 	icon = 'icons/obj/chemical.dmi'

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -11,6 +11,7 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /obj/machinery/chem_heater
 	name = "Reagent Heater/Cooler"
+	desc = "A device used for the slow but precise heating and cooling of chemicals. It looks like a cross between an oven and a urinal."
 	density = 1
 	anchored = 1
 	icon = 'icons/obj/chemical.dmi'
@@ -297,6 +298,7 @@
 
 /obj/machinery/chem_master
 	name = "CheMaster 3000"
+	desc = "A computer-like device used in the production of various pharmaceutical items. It has a slot for a beaker on the top."
 	density = 1
 	anchored = 1
 	icon = 'icons/obj/chemical.dmi'

--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -322,7 +322,7 @@
 
 /obj/reagent_dispensers/fueltank
 	name = "fueltank"
-	desc = "A fueltank"
+	desc = "A high-pressure tank full of welding fuel. Keep away from open flames and sparks."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "weldtank"
 	amount_per_transfer_from_this = 25

--- a/code/modules/chemistry/tools/grenades.dm
+++ b/code/modules/chemistry/tools/grenades.dm
@@ -237,7 +237,7 @@
 
 /obj/item/chem_grenade/metalfoam
 	name = "metal foam grenade"
-	desc = "Used for emergency sealing of air breaches."
+	desc = "After activating, creates a mess of foamed metal. Useful for plugging the hull up."
 	icon = 'icons/obj/items/grenade.dmi'
 	icon_state = "metalfoam"
 	icon_state_armed = "metalfoam1"
@@ -258,7 +258,7 @@
 
 /obj/item/chem_grenade/firefighting
 	name = "fire fighting grenade"
-	desc = "Can help to put out dangerous fires from a distance."
+	desc = "Propells firefighting foam in a wide area around it after activation, putting out fires."
 	icon = 'icons/obj/items/grenade.dmi'
 	icon_state = "firefighting"
 	icon_state_armed = "firefighting1"

--- a/code/modules/chemistry/tools/hyposprays.dm
+++ b/code/modules/chemistry/tools/hyposprays.dm
@@ -11,7 +11,7 @@ var/global/list/chem_whitelist = list("antihol", "charcoal", "epinephrine", "ins
 
 /obj/item/reagent_containers/hypospray
 	name = "hypospray"
-	desc = "An automated injector that will dump out any harmful chemicals it finds in itself."
+	desc = "An advanced device capable of injecting various medicines into a patient instantaneously. Dumps any harmful chemicals."
 	icon = 'icons/obj/chemical.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_medical.dmi'
 	initial_volume = 30

--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -6,7 +6,7 @@
 #define S_INJECT 1
 /obj/item/reagent_containers/syringe
 	name = "syringe"
-	desc = "A syringe."
+	desc = "A hollow device with a metal tip. Can be used to put chemicals into containers, and with co-operation, people."
 	icon = 'icons/obj/syringe.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_medical.dmi'
 	item_state = "syringe_0"

--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -6,7 +6,7 @@
 #define S_INJECT 1
 /obj/item/reagent_containers/syringe
 	name = "syringe"
-	desc = "A hollow device with a metal tip. Can be used to put chemicals into containers, and with co-operation, people."
+	desc = "A hollow device with a metal tip. Used to draw or deposit reagents into containers, and with co-operation, people."
 	icon = 'icons/obj/syringe.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_medical.dmi'
 	item_state = "syringe_0"

--- a/code/modules/materials/Mat_Fabrication.dm
+++ b/code/modules/materials/Mat_Fabrication.dm
@@ -66,7 +66,7 @@
 /// Material science fabricator
 /obj/machinery/nanofab
 	name = "Nano-fabricator"
-	desc = "'Nano' means it's high-tech stuff."
+	desc = "A more complicated sibling to the manufacturers, this machine can make things that inherit material properties."// this isnt super good but it's better than what it was
 	icon = 'icons/obj/manufacturer.dmi'
 	icon_state = "fab2-on"
 	anchored = 1

--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -91,7 +91,7 @@ CONTAINS:
 
 /obj/item/circular_saw
 	name = "circular saw"
-	desc = "A saw used to cut bone with precision."
+	desc = "A saw used to slice through bone in surgeries, and attackers in self defense."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "saw1"
 	inhand_image_icon = 'icons/mob/inhand/hand_medical.dmi'
@@ -347,7 +347,7 @@ CONTAINS:
 
 /obj/item/robodefibrillator
 	name = "defibrillator"
-	desc = "Used to resuscitate critical patients."
+	desc = "Uses electrical currents to restart the hearts of critical patients."
 	flags = FPRINT | TABLEPASS | CONDUCT
 	icon = 'icons/obj/surgery.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_medical.dmi'
@@ -385,7 +385,7 @@ CONTAINS:
 		if (user)
 			user.show_text("You reapair the on board medical scanner.", "blue")
 			src.desc = null
-			src.desc = "Used to resuscitate critical patients."
+			src.desc = "Uses electrical currents to restart the hearts of critical patients."
 		src.emagged = 0
 		return 1
 
@@ -589,7 +589,7 @@ CONTAINS:
 
 /obj/item/robodefibrillator/emagged
 	emagged = 1
-	desc = "Used to resuscitate critical patients.  The screen only shows the word KILL flashing over and over."
+	desc = "Uses electrical currents to restart the hearts of critical patients. The screen only shows the word KILL flashing over and over."
 
 /obj/item/robodefibrillator/vr
 	icon = 'icons/effects/VR.dmi'
@@ -630,7 +630,7 @@ CONTAINS:
 /obj/machinery/defib_mount
 	name = "mounted defibrillator"
 	icon = 'icons/obj/compact_machines.dmi'
-	desc = "Used to resuscitate critical patients."
+	desc = "Uses electrical currents to restart the hearts of critical patients."
 	icon_state = "defib1"
 	anchored = 1
 	density = 0

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -49,7 +49,7 @@
 
 /obj/machinery/atmospherics/binary/circulatorTemp
 	name = "hot gas circulator"
-	desc = "It's the gas circulator of a thermoeletric generator."
+	desc = "The gas circulator of a thermoeletric generator. This one is designed to handle hot air."
 	icon = 'icons/obj/atmospherics/pipes.dmi'
 	icon_state = "circ1-off"
 	var/obj/machinery/power/generatorTemp/generator = null
@@ -412,6 +412,7 @@
 /obj/machinery/atmospherics/binary/circulatorTemp/right
 	icon_state = "circ2-off"
 	name = "cold gas circulator"
+	desc = "The gas circulator of a thermoeletric generator. This one is designed to handle cold air."
 
 
 /datum/action/bar/icon/teg_circulator_repair

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -19,6 +19,7 @@ var/zapLimiter = 0
 
 /obj/machinery/power/apc
 	name = "area power controller"
+	desc = "The smaller, more numerous sibling of the SMES. Protects electrical equipment from extreme power fluctuations, and if the generator goes offline, can supply electricity to its room from an internal cell."
 	icon_state = "apc0"
 	anchored = 1
 	plane = PLANE_NOSHADOW_ABOVE

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -14,7 +14,7 @@
 
 /obj/machinery/power/smes
 	name = "power storage unit"
-	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit."
+	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. Acts as a giant capacitor for the station's electricitical grid, soaking up extra power or dishing it out."
 	icon_state = "smes"
 	density = 1
 	anchored = 1

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1125,7 +1125,7 @@
 
 /obj/machinery/vending/medical
 	name = "NanoMed Plus"
-	desc = "Medical drug dispenser."
+	desc = "An ID-selective dispenser for drugs and medical equipment"
 	icon_state = "med"
 	icon_panel = "standard-panel"
 	icon_deny = "med-deny"
@@ -1231,7 +1231,7 @@
 
 /obj/machinery/vending/security
 	name = "SecTech"
-	desc = "A security equipment vendor."
+	desc = "An ID-selective dispenser for security equipment."
 	icon_state = "sec"
 	icon_panel = "standard-panel"
 	icon_deny = "sec-deny"
@@ -1262,7 +1262,7 @@
 
 /obj/machinery/vending/security_ammo //ass jam time yes
 	name = "AmmoTech"
-	desc = "A restricted ammunition vendor."
+	desc = "A restricted vendor stocked with various riot-suppressive ammunitions."
 	icon_state = "sec"
 	icon_panel = "standard-panel"
 	icon_deny = "sec-deny"
@@ -2231,7 +2231,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/staff/crystal, 1)
 
 /obj/machinery/vending/standard
-	desc = "A standard vending machine."
+	desc = "A vending machine full of various useful tools and devices that definitely cannot be used to make bombs"
 	icon_state = "standard"
 	icon_panel = "standard-panel"
 	acceptcard = 0
@@ -2247,6 +2247,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/device/igniter, 8)
 		product_list += new/datum/data/vending_product(/obj/item/device/radio/signaler, 8)
 		product_list += new/datum/data/vending_product(/obj/item/wirecutters, 1)
+		product_list += new/datum/data/vending_product(/obj/item/screwdriver, 1)
 		product_list += new/datum/data/vending_product(/obj/item/device/timer, 8)
 		product_list += new/datum/data/vending_product(/obj/item/device/analyzer/atmosanalyzer_upgrade, 3)
 		product_list += new/datum/data/vending_product(/obj/item/pressure_crystal, 5)

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2247,7 +2247,6 @@
 		product_list += new/datum/data/vending_product(/obj/item/device/igniter, 8)
 		product_list += new/datum/data/vending_product(/obj/item/device/radio/signaler, 8)
 		product_list += new/datum/data/vending_product(/obj/item/wirecutters, 1)
-		product_list += new/datum/data/vending_product(/obj/item/screwdriver, 1)
 		product_list += new/datum/data/vending_product(/obj/item/device/timer, 8)
 		product_list += new/datum/data/vending_product(/obj/item/device/analyzer/atmosanalyzer_upgrade, 3)
 		product_list += new/datum/data/vending_product(/obj/item/pressure_crystal, 5)

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1068,7 +1068,7 @@
 
 /obj/item/clothing/suit/space/emerg
 	name = "emergency suit"
-	desc = "A suit that protects against low pressure environments for a short time."
+	desc = "A suit that protects against low pressure environments for a short time. Amazingly, it's even more bulky and uncomfortable than the engineering suits."
 	icon_state = "emerg"
 	item_state = "emerg"
 	c_flags = SPACEWEAR

--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -1,6 +1,6 @@
 /obj/item/device/flash
 	name = "flash"
-	desc = "A device that emits an extremely bright light when used. Useful for briefly stunning people or starting a dance party."
+	desc = "A device that emits a complicated strobe when used, causing disorientation. Useful for stunning people or starting a dance party."
 	uses_multiple_icon_states = 1
 	icon_state = "flash"
 	force = 1

--- a/code/obj/item/device/gps.dm
+++ b/code/obj/item/device/gps.dm
@@ -1,6 +1,6 @@
 /obj/item/device/gps
 	name = "space GPS"
-	desc = "Tells you your coordinates based on the nearest coordinate beacon."
+	desc = "A navigation device that can tell you your position, and the position of other GPS devices. Uses coordinate beacons."
 	icon_state = "gps-off"
 	item_state = "electronic"
 	var/allowtrack = 1 // defaults to on so people know where you are (sort of!)

--- a/code/obj/item/device/igniter.dm
+++ b/code/obj/item/device/igniter.dm
@@ -1,6 +1,6 @@
 /obj/item/device/igniter
 	name = "igniter"
-	desc = "A small electronic device able to ignite combustable substances."
+	desc = "A small electronic device can be paired with other electronics, or used to heat chemicals directly."
 	icon_state = "igniter"
 	var/status = 1.0
 	flags = FPRINT | TABLEPASS| CONDUCT | ONBELT | USEDELAY

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -124,7 +124,7 @@
 	icon_state = "glowstick-green0"
 	var/base_state = "glowstick-green"
 	name = "emergency glowstick"
-	desc = "A small tube that reacts chemicals in order to produce a larger radius of illumination than PDA lights. A label on it reads, WARNING: USE IN RAVES, DANCING, OR FUN WILL VOID WARRANTY."
+	desc = "A small tube that reacts chemicals in order to produce a larger radius of illumination than PDA lights. A label on it reads, WARNING: USE IN RAVES, DANCING, OR FUN WILL VOID WARRANTY."// I love the idea of a glowstick having a warranty so I'm leaving the description like this
 	w_class = W_CLASS_SMALL
 	flags = ONBELT | TABLEPASS
 	var/heated = 0

--- a/code/obj/item/device/lights.dm
+++ b/code/obj/item/device/lights.dm
@@ -124,7 +124,7 @@
 	icon_state = "glowstick-green0"
 	var/base_state = "glowstick-green"
 	name = "emergency glowstick"
-	desc = "For emergency use only. Not for use in illegal lightswitch raves."
+	desc = "A small tube that reacts chemicals in order to produce a larger radius of illumination than PDA lights. A label on it reads, WARNING: USE IN RAVES, DANCING, OR FUN WILL VOID WARRANTY."
 	w_class = W_CLASS_SMALL
 	flags = ONBELT | TABLEPASS
 	var/heated = 0

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -2,7 +2,7 @@
 
 /obj/item/device/pda2
 	name = "PDA"
-	desc = "A portable microcomputer by Thinktronic Systems, LTD. Functionality determined by an EEPROM cartridge."
+	desc = "A portable microcomputer by Thinktronic Systems, LTD. It has a slot for an ID card, and a hole to put a pen into."
 	icon = 'icons/obj/items/pda.dmi'
 	icon_state = "pda"
 	item_state = "pda"

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1266,7 +1266,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 //1.57
 /obj/item/gun/kinetic/riot40mm
-	desc = "A 40mm riot control launcher."
+	desc = "A 40mm riot control gun. It can accept standard 40mm rounds and hand-thrown grenades."
 	name = "Riot launcher"
 	icon_state = "40mm"
 	item_state = "40mm"

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -382,7 +382,7 @@ proc/find_ghost_by_key(var/find_key)
 
 /obj/machinery/clone_scanner
 	name = "cloning machine scanner"
-	desc = "Some sort of weird machine that you stuff people into to scan their genetic DNA for cloning."
+	desc = "A machine that you stuff living, and freshly not-so-living people into in order to scan them for cloning"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "scanner_0"
 	density = 1

--- a/code/obj/machinery/dispenser.dm
+++ b/code/obj/machinery/dispenser.dm
@@ -2,7 +2,7 @@
 		Oxygen and plasma tank dispenser
 */
 /obj/machinery/dispenser
-	desc = "A simple yet bulky one-way storage device for gas tanks. Holds 10 plasma and 10 oxygen tanks."
+	desc = "A storage device for gas tanks. Holds 10 plasma and 10 oxygen tanks."
 	name = "Tank Storage Unit"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "dispenser-empty"

--- a/code/obj/machinery/igniter.dm
+++ b/code/obj/machinery/igniter.dm
@@ -6,7 +6,7 @@
 	var/id = null
 	var/on = 1.0
 	anchored = 1.0
-	desc = "A device that ignites in order to start fires remotely."
+	desc = "A device can be paired with other electronics, or used to heat chemicals directly."
 
 /obj/machinery/igniter/attack_ai(mob/user as mob)
 	return src.Attackhand(user)

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2526,7 +2526,7 @@
 		/obj/item/material_piece/copper,
 		/obj/item/material_piece/glass,
 		/obj/item/material_piece/cloth/cottonfabric
-		/obj/item/material_piece/bohrum,
+		/obj/item/material_piece/bohrum,// adding these just so it can print everything from the get-go
 		/obj/item/material_piece/uqill
 		/obj/item/material_piece/claretine,)
 	accept_blueprints = 0

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2525,7 +2525,7 @@
 	free_resources = list(/obj/item/material_piece/steel,
 		/obj/item/material_piece/copper,
 		/obj/item/material_piece/glass,
-		/obj/item/material_piece/cloth/cottonfabric
+		/obj/item/material_piece/cloth/cottonfabric,
 		/obj/item/material_piece/bohrum,
 		/obj/item/material_piece/uqill
 		/obj/item/material_piece/claretine,)

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2028,7 +2028,7 @@
 
 /obj/machinery/manufacturer/general
 	name = "General Manufacturer"
-	desc = "A manufacturing unit calibrated to produce tools and general purpose items."
+	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing tools and general purpose items.."
 	free_resource_amt = 5
 	free_resources = list(/obj/item/material_piece/steel,
 		/obj/item/material_piece/copper,
@@ -2089,7 +2089,7 @@
 
 /obj/machinery/manufacturer/robotics
 	name = "Robotics Fabricator"
-	desc = "A manufacturing unit calibrated to produce robot-related equipment."
+	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing robot-related equipment."
 	icon_state = "fab-robotics"
 	icon_base = "robotics"
 	free_resource_amt = 5
@@ -2190,7 +2190,7 @@
 
 /obj/machinery/manufacturer/medical
 	name = "Medical Fabricator"
-	desc = "A manufacturing unit calibrated to produce medical equipment."
+	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing medical equipment."
 	icon_state = "fab-med"
 	icon_base = "med"
 	free_resource_amt = 2
@@ -2256,7 +2256,7 @@
 
 /obj/machinery/manufacturer/mining
 	name = "Mining Fabricator"
-	desc = "A manufacturing unit calibrated to produce mining related equipment."
+	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing mining related equipment."
 	icon_state = "fab-mining"
 	icon_base = "mining"
 	free_resource_amt = 2
@@ -2306,7 +2306,7 @@
 
 /obj/machinery/manufacturer/hangar
 	name = "Ship Component Fabricator"
-	desc = "A manufacturing unit calibrated to produce parts for ships."
+	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing parts for ships."
 	icon_state = "fab-hangar"
 	icon_base = "hangar"
 	free_resource_amt = 2
@@ -2347,7 +2347,7 @@
 
 /obj/machinery/manufacturer/uniform // add more stuff to this as needed, but it should be for regular uniforms the HoP might hand out, not tons of gimmicks. -cogwerks
 	name = "Uniform Manufacturer"
-	desc = "A manufacturing unit calibrated to produce workplace uniforms."
+	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing workplace uniforms."
 	icon_state = "fab-jumpsuit"
 	icon_base = "jumpsuit"
 	free_resource_amt = 5
@@ -2446,7 +2446,7 @@
 //and i hate this, i do, but you're gonna have to update this list whenever you update /personnel or /uniform
 /obj/machinery/manufacturer/hop_and_uniform
 	name = "Personnel Manufacturer"
-	desc = "A manufacturing unit calibrated to produce workplace uniforms and identification equipment."
+	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing workplace uniforms and identification equipment."
 	icon_state = "fab-access"
 	icon_base = "access"
 	free_resource_amt = 5
@@ -2501,7 +2501,7 @@
 
 /obj/machinery/manufacturer/qm // This manufacturer just creates different crated and boxes for the QM. Lets give their boring lives at least something more interesting.
 	name = "Crate Manufacturer"
-	desc = "A manufacturing unit calibrated to produce different crates and boxes."
+	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing different crates and boxes."
 	icon_state = "fab-crates"
 	icon_base = "crates"
 	free_resource_amt = 5
@@ -2518,14 +2518,17 @@
 
 /obj/machinery/manufacturer/zombie_survival
 	name = "Uber-Extreme Survival Manufacturer"
-	desc = "A manufacturing unit calibrated to produce items useful in surviving extreme scenarios."
+	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing items useful in surviving extreme scenarios."
 	icon_state = "fab-crates"
 	icon_base = "crates"
 	free_resource_amt = 50
 	free_resources = list(/obj/item/material_piece/steel,
 		/obj/item/material_piece/copper,
 		/obj/item/material_piece/glass,
-		/obj/item/material_piece/cloth/cottonfabric)
+		/obj/item/material_piece/cloth/cottonfabric
+		/obj/item/material_piece/bohrum,
+		/obj/item/material_piece/uqill
+		/obj/item/material_piece/claretine,)
 	accept_blueprints = 0
 	available = list(
 	/datum/manufacture/engspacesuit,

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2526,7 +2526,7 @@
 		/obj/item/material_piece/copper,
 		/obj/item/material_piece/glass,
 		/obj/item/material_piece/cloth/cottonfabric
-		/obj/item/material_piece/bohrum,// adding these just so it can print everything from the get-go
+		/obj/item/material_piece/bohrum,
 		/obj/item/material_piece/uqill
 		/obj/item/material_piece/claretine,)
 	accept_blueprints = 0

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2525,10 +2525,7 @@
 	free_resources = list(/obj/item/material_piece/steel,
 		/obj/item/material_piece/copper,
 		/obj/item/material_piece/glass,
-		/obj/item/material_piece/cloth/cottonfabric,
-		/obj/item/material_piece/bohrum,
-		/obj/item/material_piece/uqill
-		/obj/item/material_piece/claretine,)
+		/obj/item/material_piece/cloth/cottonfabric)
 	accept_blueprints = 0
 	available = list(
 	/datum/manufacture/engspacesuit,

--- a/code/obj/machinery/sleeper.dm
+++ b/code/obj/machinery/sleeper.dm
@@ -669,7 +669,7 @@
 
 /obj/machinery/sleeper/port_a_medbay
 	name = "Port-A-Medbay"
-	desc = "An emergency transportation device for critically injured patients."
+	desc = "A transportation and stabilization device for critically injured patients."
 	icon = 'icons/obj/porters.dmi'
 	anchored = 0
 	mats = 30
@@ -765,7 +765,7 @@
 
 /obj/machinery/sleeper/compact
 	name = "Compact Sleeper"
-	desc = "Your usual sleeper, but compact this time. Wow!"
+	desc = "Has the same air supply and stabilization capabilites as your usual, but compact this time. Wow!"
 	icon = 'icons/obj/compact_machines.dmi'
 	icon_state = "compact_sleeper"
 	anchored = 1

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -753,7 +753,7 @@
 
 /obj/submachine/chem_extractor/
 	name = "Reagent Extractor"
-	desc = "A machine which can extract reagents from organic matter."
+	desc = "A machine which can extract reagents from matter. Has a slot for a beaker and a chute to put things into."
 	density = 1
 	anchored = 1
 	mats = 6


### PR DESCRIPTION
## About the PR 
This rewords a lot of descriptions, changes a lot more, and adds a few to the more common things that straight up needed them. Notable examples are flashes, manufactureres, the nanofabricator, hyposprays, the chemaster 3k, syringes, reagent extractor, and sec and med vendors

## Why's this needed?
90% of the time, when someone sees something they don't recognize, they'll examine it to try and figure out how it works. Adding clues as how to use something and just better explaining the purpose of things makes it a lot easier to get accustomed to the game.
