### PR TITLE
Increased nukie knight gloves disarm resistance from 25 to 40

### DIFF
--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -362,7 +362,7 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 
 	setupProperties()
 		..()
-		setProperty("deflection", 25)
+		setProperty("deflection", 40)
 
 /obj/item/clothing/gloves/swat/NT
 	desc = "A pair of Nanotrasen tactical gloves that are quite fire and electrically-resistant. They also help you block attacks. They do not specifically help you block against blocking though. Just regular attacks."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. Should make knights lose their sword a bit less.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gannets said the current value seemed lower than it should be. So i increased the amount by 15%. Also a knight losing their sword is essentially game over for them it makes sense to make it harder to lose the sword.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)Increased the disarm resistance of nuke ops knight gloves.
```
