### PR TITLE
Makes weedkiller (atrazine) remove kudzu on contact with it.

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2861,6 +2861,13 @@ datum
 				if (growing.growthmode == "weed")
 					P.HYPdamageplant("poison",2)
 					P.growth -= 3
+
+			reaction_obj(var/obj/O, var/volume)
+				if (istype(O, /obj/spacevine))
+					var/obj/spacevine/kudzu = O
+					if (kudzu.current_stage < 2)
+						qdel(O)
+
 		safrole
 			name = "safrole"
 			id = "safrole"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature][input wanted][balance][wiki]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As the title says. It will only remove the weakest kudzu, thick and dense kudzu tiles will be immune to it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Kudzu is extremely annoying to deal with. It'd be nice to have some decently strong counter against it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TTerc
(*)Weedkiller (atrazine) can now remove non-thick/dense kudzu tiles.
```
