### PR TITLE
Artifact form trays for Ozymandias

### DIFF
--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -78445,11 +78445,18 @@
 /area/station/engine/elect)
 "vrW" = (
 /obj/table/auto,
-/obj/item/storage/box/tapebox,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
 	name = "autoname - SS13"
+	},
+/obj/artifact_paper_dispenser{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/device/matanalyzer{
+	pixel_x = -4;
+	pixel_y = 5
 	},
 /turf/simulated/floor/engine/caution/east,
 /area/station/science/artifact)
@@ -81864,8 +81871,12 @@
 	})
 "wmg" = (
 /obj/table/auto,
-/obj/item/clipboard,
-/obj/item/pen,
+/obj/item/clipboard{
+	pixel_x = -4
+	},
+/obj/artifact_paper_dispenser{
+	pixel_x = 13
+	},
 /turf/simulated/floor/engine/caution/west,
 /area/station/science/artifact)
 "wmn" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds two artifact form trays to Ozymandias' artifact lab.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes artlab work better whenever Ozy happens to roll around.
