### PR TITLE
fix a borgifier runtime

### DIFF
--- a/code/obj/artifacts/artifact_objects/borg_maker.dm
+++ b/code/obj/artifacts/artifact_objects/borg_maker.dm
@@ -45,7 +45,8 @@
 			else
 				user.set_loc(get_turf(O.loc))
 			converting = TRUE
-			var/list/obj/item/parts/convertable_limbs = list(humanuser.limbs.l_arm, humanuser.limbs.r_arm, humanuser.limbs.l_leg, humanuser.limbs.r_leg)
+			// keep it truthy to avoid null values due to missing limbs
+			var/list/obj/item/parts/convertable_limbs = keep_truthy(list(humanuser.limbs.l_arm, humanuser.limbs.r_arm, humanuser.limbs.l_leg, humanuser.limbs.r_leg))
 			//figure out which limbs are already robotic and remove them from the list
 			for (var/obj/item/parts/limb in convertable_limbs)
 				if (!limb || (limb.kind_of_limb & LIMB_ROBOT))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug where a borging artifact would get a runtime when borging a person with missing limbs, since the null would not be properly removed from the list of limbs to be replaced.

This was especially bad because this caused the borgifier to stop working, because the "converting" var was not set back to FALSE.

With my change, null values are properly removed from the list.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
To make borgifiers work properly.
