### PR TITLE
Stun on self cauterization

### DIFF
--- a/code/modules/medical/surgery_procs.dm
+++ b/code/modules/medical/surgery_procs.dm
@@ -1581,8 +1581,8 @@ var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gn
 				if(patient == surgeon)// getting your injuries cauterized with a lit torch shouldn't be pleasant.
 					boutput(patient, "<b><span class='alert'>IT BURNS!</span></b>")
 					patient.emote("scream")
-					patient.changeStatus("stunned", 5 SECONDS)
-					patient.changeStatus("weakened", 6 SECONDS)
+					patient.changeStatus("stunned", 4 SECONDS)
+					patient.changeStatus("weakened", 5 SECONDS)
 
 
 				repair_bleeding_damage(patient, 100, 10)

--- a/code/modules/medical/surgery_procs.dm
+++ b/code/modules/medical/surgery_procs.dm
@@ -1578,12 +1578,20 @@ var/global/list/chestitem_whitelist = list(/obj/item/gnomechompski, /obj/item/gn
 				surgeon, "<span class='notice'>You cauterize [surgeon == patient ? "your" : "[patient]'s"] wounds closed with [src].</span>",\
 				patient, "<span class='notice'>[patient == surgeon ? "You cauterize" : "<b>[surgeon]</b> cauterizes"] your wounds closed with [src].</span>")
 
+				if(patient == surgeon)// getting your injuries cauterized with a lit torch shouldn't be pleasant.
+					boutput(patient, "<b><span class='alert'>IT BURNS!</span></b>")
+					patient.emote("scream")
+					patient.changeStatus("stunned", 5 SECONDS)
+					patient.changeStatus("weakened", 6 SECONDS)
+
+
 				repair_bleeding_damage(patient, 100, 10)
 				return 1
 
 			else
 				surgeon.show_text("<b>You were interrupted!</b>", "red")
 				return 1
+
 
 	else
 		return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Balance][input wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds a short (5s) stun penalty to self cauterization.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Frankly, self cauterization is a little overpowered. Anyone who's smart is more than willing to trade 15 brute damage and holding still for a second for a get-out-of-jail free card with bleeding. Adding a stun to self cautery disincentivies people from using it in combat and makes it more realistic; literally burning your blood vessels closed isn't something you do and then continue with whatever task at hand prior.

In summary, this change makes people think a little bit harder as to whether or not they want to self-cauterize, and makes it more immersive when they do.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)NightmareChamillian
(+)Self cauterization on the fly now causes a short (5 second) stun.
```
