### PR TITLE
make option for reenabling the top menu easier to find

### DIFF
--- a/code/interface.dm
+++ b/code/interface.dm
@@ -37,6 +37,25 @@
 				if("Cancel")
 					return
 
+		disable_menu()
+			set category = "Commands"
+			set name = "disable_menu"
+			set desc = "Disables the menu and gives a message about it"
+			set hidden = 1
+			boutput(src, {"
+				<div style="border: 3px solid red; padding: 3px;">
+					You have disabled the menu. To enable the menu again, you can use the Menu button on the top right corner of the screen!
+					<a href='byond://winset?command=enable_menu'>Or just click here!</a>
+				</div>"})
+			winset(src, null, "hide_menu.is-checked=true; mainwindow.menu=''; menub.is-visible = true")
+
+		enable_menu()
+			set category = "Commands"
+			set name = "enable_menu"
+			set desc = "Reenables the menu"
+			set hidden = 1
+			winset(src, null, "mainwindow.menu='menu'; hide_menu.is-checked=false; menub.is-visible = false")
+
 		github()
 			set category = "Commands"
 			set name = "github"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -225,7 +225,7 @@ menu "menu"
 		is-checked = true
 	elem "hide_menu"
 		name = "&Hide menu"
-		command = ".winset \"hide_menu.is-checked=true?mainwindow.menu='';menub.is-visible = true\""
+		command = "disable_menu"
 		category = "&Window"
 		can-check = true
 		saved-params = "is-checked"
@@ -1452,7 +1452,7 @@ window "rpane"
 		is-visible = false
 		saved-params = "is-checked"
 		text = "Menu"
-		command = ".winset \"mainwindow.menu='menu'; hide_menu.is-checked=false; menub.is-visible = false\""
+		command = "enable_menu"
 	elem "mapb"
 		type = BUTTON
 		pos = 315,5

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -223,12 +223,6 @@ menu "menu"
 		can-check = true
 		saved-params = "is-checked"
 		is-checked = true
-	elem "hide_menu"
-		name = "&Hide menu"
-		command = ".winset \"hide_menu.is-checked=true?mainwindow.menu='';menub.is-visible = true\""
-		category = "&Window"
-		can-check = true
-		saved-params = "is-checked"
 	elem
 		name = "&Effects"
 		command = ""
@@ -1443,16 +1437,6 @@ window "rpane"
 		command = ".winset \"rpanewindow.left=infowindow\""
 		group = "rpanemode"
 		button-type = pushbox
-	elem "menub"
-		type = BUTTON
-		pos = 135,5
-		size = 60x20
-		anchor1 = none
-		anchor2 = none
-		is-visible = false
-		saved-params = "is-checked"
-		text = "Menu"
-		command = ".winset \"mainwindow.menu='menu'; hide_menu.is-checked=false; menub.is-visible = false\""
 	elem "mapb"
 		type = BUTTON
 		pos = 315,5

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1445,9 +1445,9 @@ window "rpane"
 		button-type = pushbox
 	elem "menub"
 		type = BUTTON
-		pos = 135,5
+		pos = 250,5
 		size = 60x20
-		anchor1 = none
+		anchor1 = 100,0
 		anchor2 = none
 		is-visible = false
 		saved-params = "is-checked"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -223,6 +223,12 @@ menu "menu"
 		can-check = true
 		saved-params = "is-checked"
 		is-checked = true
+	elem "hide_menu"
+		name = "&Hide menu"
+		command = ".winset \"hide_menu.is-checked=true?mainwindow.menu='';menub.is-visible = true\""
+		category = "&Window"
+		can-check = true
+		saved-params = "is-checked"
 	elem
 		name = "&Effects"
 		command = ""
@@ -1437,6 +1443,16 @@ window "rpane"
 		command = ".winset \"rpanewindow.left=infowindow\""
 		group = "rpanemode"
 		button-type = pushbox
+	elem "menub"
+		type = BUTTON
+		pos = 135,5
+		size = 60x20
+		anchor1 = none
+		anchor2 = none
+		is-visible = false
+		saved-params = "is-checked"
+		text = "Menu"
+		command = ".winset \"mainwindow.menu='menu'; hide_menu.is-checked=false; menub.is-visible = false\""
 	elem "mapb"
 		type = BUTTON
 		pos = 315,5


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://user-images.githubusercontent.com/35579460/149075494-1d635e76-288c-4648-a3c1-064fc138a3c9.png)
^ This one ^

UPDATE:
Apparently people actually use this feature, so I changed things so that disabling the menu now gives an alert in chat that tells you about the existence of the button. The alert also has a link to reenable the menu, in case the disabling was an accident.
I also changed the anchoring on the menu button, so it should be less likely to be hidden behind other stuff.
You can see a video below.
https://user-images.githubusercontent.com/35579460/149184262-46d181dd-e106-4d02-acfb-7bdbd135a903.mp4
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We keep getting mentorhelps about how to bring the menu back, especially since the button to do so is often not visible without moving the screen divider further to the left.

~~I think hardly anyone actually uses this feature? 
But I am going to put INPUT WANTED on this PR so you can yell at me if you do and we can find another solution!~~

