### PR TITLE
Remove cargo access spawners at mining on Horizon

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -25425,7 +25425,6 @@
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
 	},
-/obj/access_spawn/cargo,
 /obj/access_spawn/mining,
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -26514,7 +26513,6 @@
 /obj/machinery/door/firedoor/pyro{
 	dir = 4
 	},
-/obj/access_spawn/cargo,
 /obj/access_spawn/mining,
 /turf/simulated/floor/yellow/side,
 /area/station/mining/staff_room)


### PR DESCRIPTION
[BUG - MINOR][MAPPING]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR removes two cargo access spawners on the front doors of the mining department on Horizon.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Minor bug fix, it meant that someone with cargo access but not mining access could still access mining (found this when playing as security).
