### PR TITLE
Cleanup /obj/machinery/bot refs on disposing

### DIFF
--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -97,6 +97,8 @@
 	disposing()
 		botcard = null
 		qdel(chat_text)
+		bot_mover.master = null
+		bot_mover = null
 		chat_text = null
 		if(cam)
 			cam.dispose()

--- a/code/modules/robotics/bot/bot_parent.dm
+++ b/code/modules/robotics/bot/bot_parent.dm
@@ -97,7 +97,7 @@
 	disposing()
 		botcard = null
 		qdel(chat_text)
-		bot_mover.master = null
+		bot_mover?.master = null
 		bot_mover = null
 		chat_text = null
 		if(cam)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][TRIVIAL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Cleanup circular references to `bot_mover` when parent robot is disposed


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* When `/obj/machinery/bot` objects are deleted they do not cleanup circular references to and from their `/datum/robot_mover` resulting in garbage collection failure debug alerts