### PR TITLE
Removed maxsec access from beepsky

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -158,6 +158,10 @@
 			our_baton = null
 		target = null
 		..()
+	New()
+		..()
+		SPAWN_DBG(1 SECONDS)
+			src.botcard.access -= access_maxsec
 
 /obj/machinery/bot/secbot/autopatrol
 	auto_patrol = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[input wanted] [Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes the maxsec AKA HoS access from beepsky.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Considering you can pull bots to open up doors, being able to super easily open up the armory with just a bot is a little much. And to be honest, beepsky probably doesn't need maxsec access anyways.


