### PR TITLE
Minor change for description of robusted donuts

### DIFF
--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -1441,7 +1441,7 @@
 
 		robusted
 			name = "robusted donut"
-			desc = "A donut for those critical moments."
+			desc = "A donut for those harsh moments. Contains a mix of chemicals for cardiac emergency recovery and any minor trauma that accompanies it."
 			icon_state = "donut5"
 			amount = 6
 			initial_volume = 48


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just makes a minor change to the description of robusted donuts (from the security weapons vendor).

Old:
"A donut for those critical moments."

New:
"A donut for those harsh moments. Contains a mix of chemicals for cardiac emergency recovery and any minor trauma that accompanies it."

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The description right now is a little bit ambiguous. Critical might be hinting at when you are in crit, but it could mean different things and doesn't really give an idea of what's in the donut.