### PR TITLE
Kondaru jan22 "bits and bobs" fixbatch

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -1016,6 +1016,11 @@
 /obj/stool/chair/yellow{
 	dir = 8
 	},
+/obj/item/screwdriver{
+	pixel_x = -9;
+	pixel_y = 7;
+	rand_pos = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/routing/eva{
 	name = "Router Cabinet"
@@ -1212,10 +1217,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/item/screwdriver{
-	pixel_x = -11;
-	pixel_y = 7;
-	rand_pos = 0
+/obj/item/toy/gooncode{
+	pixel_x = 6;
+	pixel_y = 9
 	},
 /turf/simulated/floor/plating,
 /area/station/routing/eva{
@@ -7435,13 +7439,16 @@
 /turf/simulated/floor/yellow/side,
 /area/station/hallway/primary/north)
 "ave" = (
-/obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/decal/tile_edge/line/black{
+	dir = 8;
+	icon_state = "line1"
 	},
-/turf/simulated/floor/plating,
-/area/station/engine/elect)
+/obj/noticeboard/persistent{
+	name = "Information Office persistent notice board";
+	persistent_id = "information office"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/radio/news_office)
 "avf" = (
 /obj/machinery/manufacturer/mechanic,
 /turf/simulated/floor/yellow/side,
@@ -7669,10 +7676,6 @@
 	},
 /obj/item/clothing/suit/fire/heavy,
 /obj/item/clothing/head/helmet/welding,
-/obj/noticeboard/persistent{
-	name = "Engineering persistent notice board";
-	persistent_id = "engineering"
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 5
 	},
@@ -7859,6 +7862,10 @@
 /obj/item/cell/supercell/charged,
 /obj/item/cell/supercell/charged,
 /obj/item/cell/supercell/charged,
+/obj/noticeboard/persistent{
+	name = "Mechanics Workshop persistent notice board";
+	persistent_id = "mechanics"
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "aws" = (
@@ -10204,12 +10211,6 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/noticeboard/persistent{
-	name = "Mechanics Workshop persistent notice board";
-	persistent_id = "mechanics";
-	pixel_x = -32;
-	pixel_y = 0
-	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -11520,10 +11521,6 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/noticeboard/persistent{
-	name = "Detective's Office persistent notice board";
-	persistent_id = "detectives office"
-	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aGd" = (
@@ -11539,6 +11536,10 @@
 /obj/machinery/light/lamp/green,
 /obj/deskclutter{
 	pixel_y = -8
+	},
+/obj/noticeboard/persistent{
+	name = "Detective's Office persistent notice board";
+	persistent_id = "detectives office"
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -19122,10 +19123,6 @@
 	pixel_y = 21
 	},
 /obj/disposalpipe/segment/mail/bent/south,
-/obj/noticeboard/persistent{
-	name = "Kitchen persistent notice board";
-	persistent_id = "kitchen"
-	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "bew" = (
@@ -20869,12 +20866,6 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/obj/noticeboard/persistent{
-	name = "Bar persistent notice board";
-	persistent_id = "bar";
-	pixel_x = -32;
-	pixel_y = 0
-	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "bkI" = (
@@ -20992,12 +20983,6 @@
 	dir = 4;
 	layer = 9.1;
 	pixel_x = 10
-	},
-/obj/noticeboard/persistent{
-	name = "Medbay persistent notice board";
-	persistent_id = "medbay";
-	pixel_x = 32;
-	pixel_y = 0
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4
@@ -24298,7 +24283,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/obj/shrub,
+/obj/machinery/hydro_mister,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "bxa" = (
@@ -24822,7 +24807,13 @@
 "byG" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff,
-/obj/item/stamp/cap,
+/obj/item/stamp/cap{
+	pixel_x = -4
+	},
+/obj/item/pinpointer/disk{
+	pixel_x = 2;
+	pixel_y = 17
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/bridge/captain)
 "byH" = (
@@ -25474,9 +25465,9 @@
 /obj/item/clothing/suit/bio_suit/paramedic,
 /obj/item/storage/belt/medical,
 /obj/item/storage/belt/medical,
-/obj/machinery/light/emergency{
-	dir = 1;
-	pixel_y = 16
+/obj/noticeboard/persistent{
+	name = "Medbay persistent notice board";
+	persistent_id = "medbay"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 1
@@ -25752,6 +25743,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "bBZ" = (
@@ -36026,6 +36018,7 @@
 	id = "qmbelthell"
 	},
 /obj/submachine/cargopad/qm2,
+/obj/item/device/radio/intercom/cargo,
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/cargobay)
 "cic" = (
@@ -42269,6 +42262,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/data_terminal,
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "flZ" = (
@@ -44408,7 +44405,10 @@
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
-/obj/machinery/light_switch/north,
+/obj/noticeboard/persistent{
+	name = "Crew Quarters persistent notice board";
+	persistent_id = "crew quarters"
+	},
 /turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/station/crew_quarters/quarters_east)
 "hmG" = (
@@ -45314,6 +45314,10 @@
 	dir = 4;
 	pixel_x = -20
 	},
+/obj/machinery/recharger/wall/sticky{
+	dir = 1;
+	pixel_y = 26
+	},
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -45407,9 +45411,9 @@
 /area/station/maintenance/southeast)
 "iCC" = (
 /obj/vehicle/segway,
-/obj/machinery/recharger/wall/sticky{
-	dir = 1;
-	pixel_y = 26
+/obj/noticeboard/persistent{
+	name = "Security persistent notice board";
+	persistent_id = "security"
 	},
 /turf/simulated/floor/bot,
 /area/station/security/main)
@@ -47879,7 +47883,10 @@
 	icon_state = "chair_couch-blue";
 	name = "ratty blue couch"
 	},
-/obj/machinery/light_switch/north,
+/obj/noticeboard/persistent{
+	name = "Botany persistent notice board";
+	persistent_id = "botany"
+	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -48333,7 +48340,6 @@
 	destinations = list("Catering","Disposal","Engineering","Export","Medbay","Mining","Research","Pod Bay","Security","QM")
 	},
 /obj/machinery/power/data_terminal,
-/obj/item/device/radio/intercom/cargo,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -48585,10 +48591,6 @@
 	pixel_y = 21
 	},
 /obj/submachine/seed_manipulator,
-/obj/noticeboard/persistent{
-	name = "Botany persistent notice board";
-	persistent_id = "botany"
-	},
 /turf/simulated/floor/green/side{
 	dir = 1
 	},
@@ -48809,10 +48811,6 @@
 /area/station/maintenance/northwest)
 "meA" = (
 /obj/wingrille_spawn/auto,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -49838,8 +49836,9 @@
 "njl" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/south,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/noticeboard/persistent{
+	name = "Bar persistent notice board";
+	persistent_id = "bar"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
@@ -51471,6 +51470,10 @@
 	glass_amt = 5;
 	pixel_y = 4
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "oSe" = (
@@ -52058,6 +52061,10 @@
 /turf/space,
 /area/station/ai_monitored/armory)
 "pxy" = (
+/obj/machinery/light/emergency{
+	dir = 1;
+	pixel_y = 16
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 1
 	},
@@ -52490,6 +52497,9 @@
 	},
 /obj/machinery/phone/wall{
 	pixel_y = 32
+	},
+/obj/machinery/light_switch/north{
+	pixel_x = 12
 	},
 /turf/simulated/floor/green/side{
 	dir = 1
@@ -56711,6 +56721,7 @@
 /area/station/hangar/main)
 "ufb" = (
 /obj/machinery/vending/coffee,
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
 "ufA" = (
@@ -57181,8 +57192,10 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/phone/wall{
-	pixel_y = 32
+/obj/machinery/power/data_terminal,
+/obj/noticeboard/persistent{
+	name = "Research persistent notice board";
+	persistent_id = "research"
 	},
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
@@ -57672,6 +57685,10 @@
 	amount = 50
 	},
 /obj/item/storage/box/cablesbox,
+/obj/noticeboard/persistent{
+	name = "Engineering persistent notice board";
+	persistent_id = "engineering"
+	},
 /turf/simulated/floor/black,
 /area/station/engine/storage)
 "uZQ" = (
@@ -96877,7 +96894,7 @@ aRv
 bmi
 aWm
 bue
-aRv
+aPq
 bAV
 bhp
 bUx
@@ -100461,7 +100478,7 @@ afE
 afI
 aho
 ait
-ajr
+ave
 ajr
 ajr
 amh
@@ -118592,7 +118609,7 @@ sys
 bMq
 atm
 aum
-ave
+qrA
 awr
 aFp
 aRV


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT][MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Smallish batch of changes to correct some goofs and add some useful items.

- Repositioned some persistent notice boards that were introduced in locations overlapping with other wall-mounted equipment, and added a few additional ones.
- Added missing data terminals to some of the equipment at the north end of Kondaru's research hall.
- Added a botanical mister to Hydroponics.
- Added an authentication disk pinpointer to the Captain's office.
- Added a gooncode drive.
- Did not add a Space Thing, as one was already present.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Further improves Kondaru's feature set and usability.
