### PR TITLE
add connect option to mechcomp, for easier connecting

### DIFF
--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -266,6 +266,9 @@
 	if(trigger in src.connected_outgoing)
 		boutput(user, "<span class='alert'>Can not create a direct loop between 2 components.</span>")
 		return
+	if(!IN_RANGE(receiver, trigger, WIDE_TILE_WIDTH))
+		boutput(user, "<span class='alert'>These two components are too far apart to connect.</span>")
+		return
 	if(!src.inputs.len)
 		boutput(user, "<span class='alert'>[receiver.name] has no input slots. Can not connect [trigger.name] as Trigger.</span>")
 		return

--- a/code/obj/item/tool/omnitool.dm
+++ b/code/obj/item/tool/omnitool.dm
@@ -18,6 +18,7 @@
 		src.change_mode(omni_mode)
 
 	attack_self(var/mob/user as mob)
+		..()
 		// cycle between modes
 		var/new_mode = null
 		switch (src.omni_mode)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds a new option to the popup that opens up when you use a pulsing tool on a mechcomp part.
Selecting this option will cause the used pulsing tool to link the first part to any other mechcomp parts you click, until you use the tool in hand to make it stop linking.


https://user-images.githubusercontent.com/35579460/149549227-a2de7964-c152-4ee6-a698-f8e5538584e5.mp4


(This video is a little out of date, you now no longer smack the components with the multitool when using this functionality, and it now only does the message when it stops linking once.)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The main objective for this is to make it possible to link components that are covered by other things, like fluids on the floor, or other mechcomponents, which was previously not really possible with click-drag.
It may also be useful for people who dislike doing stuff via click-drag in general, or when you want to link one component to a lot of other components more quickly.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) Added a new option for mechcomponents to connect them without clickdrag.
```
