### PR TITLE
Daggers throw stun gets better at range (and awful at pointblank)

### DIFF
--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -470,6 +470,7 @@
 	stamina_cost = 5
 	stamina_crit_chance = 50
 	pickup_sfx = "sound/items/blade_pull.ogg"
+	var/range_to_stun = 3
 
 	New()
 		..()
@@ -481,15 +482,15 @@
 			A:lastattacker = usr
 			A:lastattackertime = world.time
 
-		var/R = thr.get_throw_travelled()
+		var/range_travelled = thr.get_throw_travelled()
 
-		if(R > 3)
-			A.changeStatus("weakened", (R * 1.5) SECONDS)
-			A:force_laydown_standup()
+		if(range_travelled > range_to_stun)
+			A.changeStatus("weakened", (range_travelled * 1.5) SECONDS)
+			A.force_laydown_standup()
 
 		else
 			var/mob/living/carbon/C = A
-			C.do_disorient(stamina_damage = (R * 10), weakened = 0, stunned = 0, disorient = (R * 5), remove_stamina_below_zero = 1)
+			C.do_disorient(stamina_damage = (range_travelled * 15), weakened = 0, stunned = 0, disorient = (range_travelled * 5), remove_stamina_below_zero = 1)
 			C.emote("twitch_v")
 
 		take_bleeding_damage(A, null, 5, DAMAGE_CUT)

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -480,8 +480,18 @@
 		if (ismob(usr))
 			A:lastattacker = usr
 			A:lastattackertime = world.time
-		A.changeStatus("weakened", 6 SECONDS)
-		A:force_laydown_standup()
+
+		var/R = thr.get_throw_travelled()
+
+		if(R > 3)
+			A.changeStatus("weakened", (R * 1.5) SECONDS)
+			A:force_laydown_standup()
+
+		else
+			var/mob/living/carbon/C = A
+			C.do_disorient(stamina_damage = (R * 10), weakened = 0, stunned = 0, disorient = (R * 5), remove_stamina_below_zero = 1)
+			C.emote("twitch_v")
+
 		take_bleeding_damage(A, null, 5, DAMAGE_CUT)
 		playsound(src, 'sound/impact_sounds/Flesh_Stab_3.ogg', 40, 1)
 

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -486,7 +486,7 @@
 
 		if(range_travelled > range_to_stun)
 			A.changeStatus("weakened", (range_travelled * 1.5) SECONDS)
-			A.force_laydown_standup()
+			A:force_laydown_standup()
 
 		else
 			var/mob/living/carbon/C = A


### PR DESCRIPTION
[BALANCE]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Daggers now get better with range, with a stronger disorient and stamina damage the more tiles it travels.
Ranges above 3 directly inflict a stun. Also its crap at pointblank. Still cuts people just fine though.
https://user-images.githubusercontent.com/70376633/149582328-a7a40219-6f72-4cfc-b960-354ddc0361c9.mp4
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some nerd rushing you with a dagger and permastunning you is never funny, especially on rev rounds.
Also, made sec drop their guns and get stunned for 5 seconds, which usually means security ends up getting stunned with their stuff, with little chance to fight back. This PR makes it better the farther it travels, and also makes it crap at pointblank throws.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Jimmyl
(+)Dagger stun is now based on tiles travelled, so you cant pointblank people for free instastuns.
```
