### PR TITLE
Make Destiny's boxing ring possible to exit

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -11102,9 +11102,12 @@
 /obj/decal/stage_edge{
 	layer = 2.8
 	},
-/obj/fireworksbox,
 /obj/decal/tile_edge/line/blue{
 	icon_state = "line1"
+	},
+/obj/stool/chair/red{
+	anchored = 0;
+	dir = 4
 	},
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
@@ -11112,26 +11115,26 @@
 /obj/decal/stage_edge{
 	layer = 2.8
 	},
-/obj/table/wood/auto,
-/obj/item/wrestlingbell,
-/obj/item/device/microphone,
 /obj/decal/tile_edge/line/grey{
 	icon_state = "line1"
 	},
 /obj/machinery/light/small/floor,
+/obj/stool/chair/blue{
+	anchored = 0;
+	dir = 8
+	},
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "aVM" = (
 /obj/decal/stage_edge{
 	layer = 2.8
 	},
-/obj/stool/chair/red{
-	anchored = 0;
-	dir = 4
-	},
 /obj/decal/tile_edge/line/blue{
 	icon_state = "line1"
 	},
+/obj/table/wood/auto,
+/obj/item/wrestlingbell,
+/obj/item/device/microphone,
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "aVN" = (
@@ -36912,6 +36915,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
+"lSq" = (
+/obj/decal/boxingropeenter,
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "lSP" = (
 /obj/machinery/chem_master{
 	dir = 8
@@ -39373,19 +39380,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/south)
-"nhj" = (
-/obj/decal/stage_edge{
-	layer = 2.8
-	},
-/obj/stool/chair/blue{
-	anchored = 0;
-	dir = 8
-	},
-/obj/decal/tile_edge/line/red{
-	icon_state = "line1"
-	},
-/turf/simulated/floor/wood/three,
-/area/station/crew_quarters/fitness)
 "nhz" = (
 /turf/simulated/floor/carpet/red/fancy/edge{
 	dir = 10
@@ -57059,6 +57053,16 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southeast)
+"wyt" = (
+/obj/decal/tile_edge/line/red{
+	icon_state = "line1"
+	},
+/obj/decal/stage_edge{
+	layer = 2.8
+	},
+/obj/fireworksbox,
+/turf/simulated/floor/wood/three,
+/area/station/crew_quarters/fitness)
 "wyB" = (
 /obj/stool/chair/moveable{
 	dir = 8
@@ -106561,8 +106565,8 @@ wjM
 aPl
 aPl
 aPl
-xLx
-nhj
+lSq
+aIH
 xSc
 wzM
 jFR
@@ -106864,7 +106868,7 @@ aCb
 aFE
 aFE
 mBC
-aIH
+wyt
 xSc
 wzM
 qJb


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[major]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Shuffles a few things around the bottom of Destiny's boxing ring and gives it a working entrance (as there's not corner exit pieces to my knowledge).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Aside from it being nice to be able to use the ring, there are a few staffie spawns in there who'd be stuck at roundstart. To my knowledge there's no way short of explosives for crew to remove the ropes either.