### PR TITLE
Adds the light switches debug overlay

### DIFF
--- a/code/modules/admin/diagnostics.dm
+++ b/code/modules/admin/diagnostics.dm
@@ -1125,7 +1125,7 @@ proc/debug_map_apc_count(delim,zlim)
 			var/color_factor = 4
 
 			if(!(area in processed_areas))
-				for (var/obj/machinery/light_switch/someswitch in area.contents)
+				for (var/obj/machinery/light_switch/someswitch in area.machines)
 					switchcount += 1
 					switch_turfs += someswitch.loc
 				img.app.overlays = list(src.makeText(switchcount, align_left=TRUE))

--- a/code/modules/admin/diagnostics.dm
+++ b/code/modules/admin/diagnostics.dm
@@ -1111,6 +1111,48 @@ proc/debug_map_apc_count(delim,zlim)
 			else
 				processed_areas.len = 0
 
+	lightswitches //This overlay is a kitbash of areas and active areas, code might be odd as a result
+		name = "light switches"
+		help = {"Shows amount of light switches for non-space areas.<br>
+		Red is none, green is at least one, white turfs have a light switch located on them.<br>
+		This overlay looks only at physical location and does <b>not</b> account for light switches that have otherarea set up."}
+		var/list/area/processed_areas
+		var/list/turf/switch_turfs = list() //Turfs with a light switch on them, to be coloured separately
+		GetInfo(var/turf/theTurf, var/image/debugoverlay/img)
+			var/area/area = theTurf.loc
+			var/switchcount = 0
+			var/list/lcolor = hex_to_rgb_list(debug_color_of(area))
+			var/color_factor = 4
+
+			if(!(area in processed_areas))
+				for (var/obj/machinery/light_switch/someswitch in area.contents)
+					switchcount += 1
+					switch_turfs += someswitch.loc
+				img.app.overlays = list(src.makeText(switchcount, align_left=TRUE))
+				processed_areas += area
+				processed_areas[area] = switchcount //Store this for later turfs in the same area
+
+			if(processed_areas[area]) //this reads the area's stored switch count
+				if (theTurf in switch_turfs) //This turf has a switch on it
+					img.app.color = "#ffffff"
+					img.app.alpha = 100
+				else //Area has switch(es) - This code is directly lifted BTW but it somehow makes the area's debug colour a lot greener
+					lcolor[1] /= color_factor
+					lcolor[3] /= color_factor
+					lcolor[2] = 255 - (255 - lcolor[2]) / color_factor
+					img.app.color = rgb(lcolor[1], lcolor[2], lcolor[3])
+			else //Area has none - this time it's tinted redder
+				lcolor[2] /= color_factor
+				lcolor[3] /= color_factor
+				lcolor[1] = 255 - (255 - lcolor[2]) / color_factor
+				img.app.color = rgb(lcolor[1], lcolor[2], lcolor[3])
+
+			img.app.desc = "Area: [area.name]<br/>Number of switches: [processed_areas[area]]" //update tooltip only after the area is processed
+
+
+		OnStartRendering(client/C)
+			processed_areas = list()
+
 /client/var/list/infoOverlayImages
 /client/var/datum/infooverlay/activeOverlay
 

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)tue jan 15 21
+(u)BatElite
+(*)Added the light switches debug overlay, which shows how many switches are physically present in an area and where to find them.
 (t)tue jan 4 21
 (u)aloe
 (*) Object spawning build modes now default to the currently selected path when changing the path, rather than always defaulting to '/obj/closet'. Yell at me if you don't like this.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds the light switches overlay, which shows the : Red areas have none, green areas have at least one, white turfs have a light switch present on them. For simplicity's sake it only looks at physical location and so switches that use `otherarea` will get miscategorised.
Did you know that cog1's barbershop has 3 light switches? That's probably more than it needs! How about the main medbay area having 4, while neither the operating theatre nor lobby have any! You should see the state of light switches on Horizon, it's rather dire in places.
![image](https://user-images.githubusercontent.com/31984217/149624818-519c2ad5-ec60-484c-91e1-422691904c5a.png)

Codewise this is a kitbash from a few other debug overlays (mainly areas and active areas), so while I have tested the overlay and tried to make it all clean I can't promise the code makes 100% sense.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is mostly intended as a mapping aid, since light switches are easy to miss and can be hard to spot. The overlay makes it easy to find weirdly placed switches or areas that happen to have none.

## Changelog
N/A, but admin changelog entry is included.
