### PR TITLE
Silicon-Jobban and not DNR doesnt disintegrate brain

### DIFF
--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -198,12 +198,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/head)
 				boutput(user, "<span class='alert'>This brain doesn't look any good to use.</span>")
 				return
 			else if ( B.owner  &&  (jobban_isbanned(B.owner.current,"Cyborg") || B.owner.dnr) ) //If the borg-to-be is jobbanned or has DNR set
-				boutput(user, "<span class='alert'>The brain disintigrates in your hands!</span>")
-				user.drop_item()
-				qdel(B)
-				var/datum/effects/system/harmless_smoke_spread/smoke = new /datum/effects/system/harmless_smoke_spread()
-				smoke.set_up(1, 0, user.loc)
-				smoke.start()
+				boutput(user, "<span class='alert'>The brain doesn't fit!</span>")
 				return
 			user.drop_item()
 			B.set_loc(src)

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -197,7 +197,15 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/head)
 			if ( !(B.owner && B.owner.key) && !istype(W, /obj/item/organ/brain/latejoin) )
 				boutput(user, "<span class='alert'>This brain doesn't look any good to use.</span>")
 				return
-			else if ( B.owner  &&  (jobban_isbanned(B.owner.current,"Cyborg") || B.owner.dnr) ) //If the borg-to-be is jobbanned or has DNR set
+			else if ( B.owner  &&  (B.owner.dnr || (jobban_isbanned(B.owner.current,"Cyborg") && B.owner.dnr)) ) //If the borg-to-be has DNR set or is Jobbanned and DNR
+				boutput(user, "<span class='alert'>The brain disintigrates in your hands!</span>")
+				user.drop_item()
+				qdel(B)
+				var/datum/effects/system/harmless_smoke_spread/smoke = new /datum/effects/system/harmless_smoke_spread()
+				smoke.set_up(1, 0, user.loc)
+				smoke.start()
+				return
+			else if ( B.owner  &&  (jobban_isbanned(B.owner.current,"Cyborg") && !B.owner.dnr) ) //If the borg-to-be is jobbanned and doesnt have DNR set
 				boutput(user, "<span class='alert'>The brain doesn't fit!</span>")
 				return
 			user.drop_item()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Putting a Jobbanned (but not DNR) brain in a borg doesnt disintegrate it.
Jobbanned + DNR brains still disintegrate, or only DNR brains disintegrate.
Displays a message "The brain doesnt fit!"

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Deleting the brain because someone is set to DNR or job-banned sucks, since then you can only play again if you roll
random event antag, or get monkeycloned (when the roboticist doesnt foolishly disintegrate it), which barely happens.
This PR makes it not delete the brain. Simple.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Jimmyl
(+)Jobbanned and not DNR people dont have their brain deleted if put in a borg head
```
