### PR TITLE
allow martians to use translators

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2968,6 +2968,10 @@
 			. = 1
 		else if (langname in mutantrace.understood_languages)
 			. = 1
+		else if (istype(src.wear_mask, /obj/item/clothing/mask/monkey_translator))
+			var/obj/item/clothing/mask/monkey_translator/translator = src.wear_mask
+			if (langname == translator.new_language)
+				. = 1
 		else
 			. = 0
 	else

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -241,6 +241,7 @@
 	mats = 12	// 2x voice changer cost. It's complicated ok
 	w_class = W_CLASS_SMALL
 	c_flags = COVERSMOUTH	// NOT usable for internals.
+	compatible_species = list("human", "cow", "werewolf", "martian")
 	var/new_language = "english"	// idk maybe you can varedit one so that humans speak monkey instead. who knows
 
 /obj/item/clothing/mask/breath


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This buffs the translator to make it so that people wearing them can also understand the language that the translator provides, not just speak it. (This was not necessary until now, because monkeys also speak english by default.)

It also makes the vocal translator mask compatible with the martian mutantrace. (The other 3 races were the default setting of the mask parent, I did not want to disallow translator masks for those, even if they are usually not necessary.)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I heard of a martian diplomat trying to put on and use a vocal translator, and I thought it would be pretty cool if it actually worked!
The martian will still have to navigate the station to get the translator first, so some funny language barrier stuff will still happen until then.
Those people who prefer to be unintelligible the entire round can simply not get a translator!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) Martian diplomats should now be able to use vocal translators.
```
