### PR TITLE
Cog1 East External Router Timing Fix

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -64434,7 +64434,7 @@
 /area/station/engine/elect)
 "xVK" = (
 /obj/machinery/launcher_loader/west{
-	door_delay = 4
+	door_delay = 5
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the door_delay var from 4 to 5 on the AMDL leading from the Eastern external router to East maint routing. Fixes a timing issue wherein the door would close JUST before things arrived.
![image](https://user-images.githubusercontent.com/28785926/149690547-6da4e996-37df-41ee-a6e2-8e59ae699058.png)
(this one btw)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I am evidently doomed to just barely miss bugs of my creation and must fix my mistakes. That and it'd be nice if belt hell worked properly, thanks.