### PR TITLE
Add missing adventure crates

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -55426,6 +55426,7 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/teleporter)
 "crV" = (
+/obj/item/device/radio/beacon,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/teleporter)
 "crW" = (
@@ -56650,6 +56651,14 @@
 /area/station/science/testchamber)
 "cuM" = (
 /obj/table/reinforced/auto,
+/obj/item/device/light/glowstick{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/device/light/glowstick{
+	pixel_x = 4;
+	pixel_y = 11
+	},
 /obj/machinery/recharger,
 /obj/item/clothing/head/helmet/camera,
 /obj/item/clothing/glasses/sunglasses,
@@ -77709,30 +77718,11 @@
 /turf/simulated/floor/grey/blackgrime,
 /area/station/hangar/science)
 "dHM" = (
-/obj/item/device/radio/headset/multifreq,
-/obj/item/device/radio/headset/multifreq,
-/obj/item/device/radio/headset/multifreq,
-/obj/item/device/radio/headset/multifreq,
-/obj/item/device/audio_log,
-/obj/item/camera,
-/obj/item/device/light/flashlight,
-/obj/item/device/light/flashlight,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/snacks/sandwich/pb,
-/obj/item/paper{
-	desc = "Aw dang, mooom";
-	info = "Good luck on your adventure, sweetie! Love, Mom.<br> <i>Whose mom? Yours? Who knows.</i>";
-	name = "note from mom"
-	},
-/obj/item/device/radio/beacon,
-/obj/item/device/light/glowstick,
-/obj/item/device/light/glowstick,
-/obj/item/paper/book/from_file/critter_compendium,
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/storage/crate,
 /obj/machinery/light,
+/obj/storage/crate/adventure,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/teleporter)
 "dJs" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -36476,6 +36476,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/storage/crate/adventure,
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
 "kxG" = (

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -52506,8 +52506,15 @@
 /area/station/science/testchamber)
 "cDp" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/item/clothing/head/helmet/camera,
-/obj/item/clothing/head/helmet/camera,
+/obj/machinery/computer/security/wooden_tv/small{
+	pixel_y = 7
+	},
+/obj/item/clothing/head/helmet/camera{
+	pixel_y = -2
+	},
+/obj/item/clothing/head/helmet/camera{
+	pixel_y = -2
+	},
 /turf/simulated/floor/purpleblack{
 	dir = 8
 	},
@@ -52672,8 +52679,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/computer/security/wooden_tv/small,
-/obj/table/wood/auto,
+/obj/storage/crate/adventure,
 /turf/simulated/floor/purple,
 /area/station/science/artifact{
 	name = "Artifact Lounge"

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -32592,11 +32592,7 @@
 	},
 /area/station/science/teleporter)
 "bWe" = (
-/obj/table/auto,
-/obj/item/reagent_containers/food/snacks/sandwich/pbh{
-	desc = "A good luck charm from one of Heisenbee's relatives.";
-	name = "nice peanut butter and honey sandwich"
-	},
+/obj/storage/crate/adventure,
 /turf/simulated/floor/purplewhite,
 /area/station/science/teleporter)
 "bWg" = (

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -29001,6 +29001,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/storage/crate/adventure,
 /turf/simulated/floor/orangeblack/side/white{
 	dir = 6
 	},


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Some maps had adventure crates missing from the Science tele-science areas. This PR adds these.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency across maps.