### PR TITLE
Move artifact pinpointers to artlab

### DIFF
--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -184,7 +184,6 @@
 	/obj/item/camera = 2,
 	/obj/item/device/light/flashlight = 2,
 	/obj/item/paper/book/from_file/critter_compendium,
-	/obj/item/pinpointer/category/artifacts/safe,
 	/obj/item/reagent_containers/food/drinks/milk,
 	/obj/item/reagent_containers/food/snacks/sandwich/pb,
 	/obj/item/paper/note_from_mom)

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -30865,6 +30865,10 @@
 /area/station/science/artifact)
 "bnT" = (
 /obj/table/reinforced/auto,
+/obj/item/pinpointer/category/artifacts/safe{
+	pixel_x = 5;
+	pixel_y = 6
+	},
 /obj/item/hand_labeler,
 /obj/item/device/audio_log,
 /obj/item/audio_tape{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -45296,6 +45296,10 @@
 	pixel_x = -12;
 	pixel_y = 7
 	},
+/obj/item/pinpointer/category/artifacts/safe{
+	pixel_x = 5;
+	pixel_y = 8
+	},
 /obj/item/device/audio_log{
 	pixel_x = 3;
 	pixel_y = 2

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -71058,12 +71058,16 @@
 /obj/item/device/matanalyzer,
 /obj/item/device/matanalyzer,
 /obj/machinery/light,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
 /obj/artifact_paper_dispenser{
-	pixel_x = -5;
+	pixel_x = -6;
 	pixel_y = 10
 	},
+/obj/item/pinpointer/category/artifacts/safe{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
 /turf/simulated/floor/purple,
 /area/station/science/artifact)
 "daF" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -49358,6 +49358,10 @@
 /area/station/medical/medbay/pharmacy)
 "sFY" = (
 /obj/table/reinforced/chemistry/auto,
+/obj/item/pinpointer/category/artifacts/safe{
+	pixel_x = 6;
+	pixel_y = -1
+	},
 /obj/item/device/audio_log{
 	pixel_x = -5;
 	pixel_y = 10

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -46685,6 +46685,10 @@
 /area/station/medical/medbay)
 "nyK" = (
 /obj/table/auto,
+/obj/item/pinpointer/category/artifacts/safe{
+	pixel_x = 7;
+	pixel_y = 8
+	},
 /obj/item/item_box/pens{
 	pixel_x = -7;
 	pixel_y = 9

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -52691,6 +52691,10 @@
 	},
 /obj/table/wood/auto,
 /obj/item/clipboard/with_pen,
+/obj/item/pinpointer/category/artifacts/safe{
+	pixel_x = 4;
+	pixel_y = 6
+	},
 /obj/item/storage/box/diskbox,
 /obj/disposalpipe/segment{
 	dir = 4

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -51583,6 +51583,10 @@
 /area/station/security/main)
 "oXc" = (
 /obj/table/auto,
+/obj/item/pinpointer/category/artifacts/safe{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /obj/item/storage/box/tapebox,
 /obj/item/device/audio_log,
 /obj/item/audio_tape,

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -31535,6 +31535,10 @@
 /area/shuttle/escape/station)
 "bKj" = (
 /obj/table/reinforced/auto,
+/obj/item/pinpointer/category/artifacts/safe{
+	pixel_x = 4;
+	pixel_y = 5
+	},
 /obj/item/storage/box/tapebox,
 /obj/disposalpipe/segment/mail{
 	dir = 4

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -9763,6 +9763,10 @@
 /area/station/science/artifact)
 "awS" = (
 /obj/table/reinforced/auto,
+/obj/item/pinpointer/category/artifacts/safe{
+	pixel_x = -6;
+	pixel_y = 5
+	},
 /obj/item/storage/box/tapebox,
 /obj/item/disk/data/tape{
 	layer = 3.5

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -35137,6 +35137,10 @@
 /area/station/mining/refinery)
 "jTq" = (
 /obj/table/reinforced/auto,
+/obj/item/pinpointer/category/artifacts/safe{
+	pixel_x = 3;
+	pixel_y = 5
+	},
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/purple/side,
 /area/station/science/artifact)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR moves artifact pinpointers from the adventure crates found in Science tele-science areas to artlab.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I feel it would make more sense to have artifact pinpointers located in the area that they are more involved with. Also, not every tele-science area has artifacts. This would also hopefully make artifact pinpointers a little more visible.