### PR TITLE
Makes the portapuke syndi mech scannable only.

### DIFF
--- a/code/obj/machinery/portapuke.dm
+++ b/code/obj/machinery/portapuke.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "puke_0"
 	desc = "A weapon of pure terror."
+	is_syndicate = 1
 	density = 1
 	anchored = 0
 	p_class = 1.5


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the is_syndicate var to the portapuke. This makes it only able to be scannable by the syndicate mechanic's scanner.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wow. I really don't need to say why this seems like a bad thing. But uh.... it's incredibly easy to mass produce this thing for all sorts of nefarious purposes.