### PR TITLE
make mulebots wait for doors

### DIFF
--- a/code/modules/robotics/bot/mulebot.dm
+++ b/code/modules/robotics/bot/mulebot.dm
@@ -576,8 +576,11 @@
 								mode = 2
 
 						else		// failed to move
-
-							//boutput(world, "Unable to move.")
+							// we did not move, so let us see if we are being blocked by a door
+							var/obj/machinery/door/block_door = locate(/obj/machinery/door/) in next
+							if (block_door)
+								// we patiently wait for the door - they only need half their operation time until they are non-dense
+								sleep(block_door.operation_time/2)
 
 							blockcount++
 							mode = 4


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Until now, when a mulebot was blocked in its path, it simply made 4 more attempts before recalculating the path.
However, because this processing speed scales with the speed of the mulebot, a mulebot hacked to the fastest speed would often already do this before an airlock was opened.
This usually happened with external airlocks, because those take longer to open.
In practice, the mulebot would take much longer, because it kept starting a different path.

With my change, when a mulebot is blocked by a door, it will wait for the amount of time it should take for the door to open. 
(Depending on what kind of door it is.)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
In my mulebot-aided travels through the space in the middle of cog2 I often almost suffocated because the mulebot would constantly go back and forth between two airlocks.

fixes #5997
fixes #4057 (the issue was also mentioned there, and I don't think any of the other issues mentioned there exist anymore)
