### PR TITLE
Fix capitalisation stuff for most guns

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -350,7 +350,7 @@
 //////////////////////// nanotrasen gun
 //Azungar's Nanotrasen inspired Laser Assault Rifle for RP gimmicks
 /obj/item/gun/energy/ntgun
-	name = "Laser Assault Rifle"
+	name = "laser assault rifle"
 	icon_state = "ntneutral100"
 	desc = "Rather futuristic assault rifle with two firing modes."
 	item_state = "ntgun"
@@ -385,7 +385,7 @@
 //////////////////////// Taser Shotgun
 //Azungar's Improved, more beefy weapon for security that can only be acquired via QM.
 /obj/item/gun/energy/tasershotgun
-	name = "Taser Shotgun"
+	name = "taser shotgun"
 	icon_state = "tasers100"
 	desc = "A weapon that produces an cohesive electrical charge that stuns its target. Now in a shotgun format."
 	item_state = "tasers"
@@ -477,7 +477,7 @@
 
 ////////////////////////////////////Wave Gun
 /obj/item/gun/energy/wavegun
-	name = "Wave Gun"
+	name = "wave gun"
 	icon = 'icons/obj/items/gun.dmi'
 	icon_state = "wavegun100"
 	item_state = "wave"
@@ -521,7 +521,7 @@
 
 ////////////////////////////////////BFG
 /obj/item/gun/energy/bfg
-	name = "BFG 9000"
+	name = "\improper BFG 9000"
 	icon = 'icons/obj/items/gun.dmi'
 	icon_state = "bfg"
 	m_amt = 4000
@@ -875,7 +875,7 @@
 
 ///////////////////////////////////////Owl Gun
 /obj/item/gun/energy/owl
-	name = "Owl gun"
+	name = "owl gun"
 	desc = "Its a gun that has two modes, Owl and Owler"
 	item_state = "gun"
 	force = 5.0
@@ -897,7 +897,7 @@
 			src.icon_state = "ghost[ratio]"
 
 /obj/item/gun/energy/owl_safe
-	name = "Owl gun"
+	name = "owl gun"
 	desc = "Hoot!"
 	item_state = "gun"
 	force = 5.0
@@ -920,7 +920,7 @@
 
 ///////////////////////////////////////Frog Gun (Shoots :getin: and :getout:)
 /obj/item/gun/energy/frog
-	name = "Frog Gun"
+	name = "frog gun"
 	item_state = "gun"
 	m_amt = 1000
 	force = 0.0
@@ -936,7 +936,7 @@
 
 ///////////////////////////////////////Shrink Ray
 /obj/item/gun/energy/shrinkray
-	name = "Shrink ray"
+	name = "shrink ray"
 	item_state = "gun"
 	force = 5.0
 	icon_state = "ghost"
@@ -956,7 +956,7 @@
 			src.icon_state = "ghost[ratio]"
 
 /obj/item/gun/energy/shrinkray/growray
-	name = "Grow ray"
+	name = "grow ray"
 	New()
 		..()
 		set_current_projectile(new/datum/projectile/shrink_beam/grow)
@@ -965,7 +965,7 @@
 
 ///////////////////////////////////////Glitch Gun
 /obj/item/gun/energy/glitch_gun
-	name = "Glitch Gun"
+	name = "glitch gun"
 	icon = 'icons/obj/items/gun.dmi'
 	icon_state = "airzooka"
 	m_amt = 4000
@@ -1125,7 +1125,7 @@
 	cell_type = /obj/item/ammo/power_cell/self_charging/big
 
 /obj/item/gun/energy/alastor
-	name = "Alastor pattern laser rifle"
+	name = "\improper Alastor pattern laser rifle"
 	inhand_image_icon = 'icons/mob/inhand/hand_weapons.dmi'
 	icon_state = "alastor100"
 	item_state = "alastor"
@@ -1154,13 +1154,13 @@
 
 ///////////////////////////////////////////////////
 /obj/item/gun/energy/lawbringer/old
-	name = "Antique Lawbringer"
+	name = "antique lawbringer"
 	icon = 'icons/obj/items/gun.dmi'
 	icon_state = "old-lawbringer0"
 	old = 1
 
 /obj/item/gun/energy/lawbringer
-	name = "Lawbringer"
+	name = "lawbringer"
 	icon = 'icons/obj/items/gun.dmi'
 	item_state = "lawg-detain"
 	icon_state = "lawbringer0"
@@ -1491,7 +1491,7 @@
 		projectiles = list(new/datum/projectile/special/howitzer )
 
 /obj/item/gun/energy/signifer2
-	name = "Signifer II"
+	name = "\improper Signifer II"
 	desc = "It's a handgun? Or an smg? You can't tell."
 	icon_state = "signifer2"
 	w_class = W_CLASS_NORMAL		//for clarity
@@ -1554,7 +1554,7 @@
 		. = ..()
 
 /obj/item/gun/energy/tasersmg
-	name = "Taser SMG"
+	name = "taser SMG"
 	icon_state = "tsmg_burst100"
 	desc = "A weapon that produces an cohesive electrical charge that stuns its target, capable of firing in two shot burst or full auto configurations."
 	item_state = "tsmg"
@@ -1593,7 +1593,7 @@
 
 ///////////////////////////////////////Ray Gun
 /obj/item/gun/energy/raygun
-	name = "Experimental Ray Gun"
+	name = "experimental ray gun"
 	icon_state = "raygun"
 	desc = "A weapon that looks vaguely like a cheap toy and is definitely unsafe."
 	item_state = "raygun"

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1154,13 +1154,13 @@
 
 ///////////////////////////////////////////////////
 /obj/item/gun/energy/lawbringer/old
-	name = "antique lawbringer"
+	name = "antique Lawbringer"
 	icon = 'icons/obj/items/gun.dmi'
 	icon_state = "old-lawbringer0"
 	old = 1
 
 /obj/item/gun/energy/lawbringer
-	name = "lawbringer"
+	name = "\improper Lawbringer"
 	icon = 'icons/obj/items/gun.dmi'
 	item_state = "lawg-detain"
 	icon_state = "lawbringer0"

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -350,7 +350,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 //no caliber and ALL
 /obj/item/gun/kinetic/vgun
-	name = "Virtual Pistol"
+	name = "virtual pistol"
 	desc = "This thing would be better if it wasn't such a piece of shit."
 	icon_state = "railgun"
 	force = MELEE_DMG_PISTOL
@@ -373,7 +373,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 			..()
 
 /obj/item/gun/kinetic/zipgun
-	name = "Zip Gun"
+	name = "zip gun"
 	desc = "An improvised and unreliable gun."
 	icon_state = "zipgun"
 	force = MELEE_DMG_PISTOL
@@ -434,7 +434,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 		..()
 
 /obj/item/gun/kinetic/silenced_22
-	name = "Orion silenced pistol"
+	name = "\improper Orion silenced pistol"
 	desc = "A small pistol with an integrated flash and noise suppressor, developed by Specter Tactical Laboratory. Uses .22 rounds."
 	icon_state = "silenced"
 	w_class = W_CLASS_SMALL
@@ -458,7 +458,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 //0.308
 /obj/item/gun/kinetic/minigun
-	name = "Minigun"
+	name = "minigun"
 	desc = "The M134 Minigun is a 7.62×51mm NATO, six-barrel rotary machine gun with a high rate of fire."
 	icon_state = "minigun"
 	item_state = "heavy"
@@ -489,7 +489,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 		setProperty("movespeed", 0.4)
 
 /obj/item/gun/kinetic/ak47
-	name = "AK-744 Rifle"
+	name = "\improper AK-744 Rifle"
 	desc = "Based on an old Cold War relic, often used by paramilitary organizations and space terrorists."
 	icon = 'icons/obj/large/48x32.dmi' // big guns get big icons
 	icon_state = "ak47"
@@ -511,7 +511,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 		..()
 
 /obj/item/gun/kinetic/hunting_rifle
-	name = "Old Hunting Rifle"
+	name = "old hunting rifle"
 	desc = "A powerful antique hunting rifle."
 	icon = 'icons/obj/large/48x32.dmi'
 	icon_state = "ohr"
@@ -534,7 +534,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 		..()
 
 /obj/item/gun/kinetic/dart_rifle
-	name = "Tranquilizer Rifle"
+	name = "tranquilizer rifle"
 	desc = "A veterinary tranquilizer rifle chambered in .308 caliber."
 	icon = 'icons/obj/large/48x32.dmi'
 	icon_state = "tranq"
@@ -558,7 +558,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 //9mm/0.355
 /obj/item/gun/kinetic/clock_188
 	desc = "A reliable weapon used the world over... 50 years ago. Uses 9mm NATO rounds."
-	name = "Clock 188"
+	name = "\improper Clock 188"
 	icon_state = "glock"
 	item_state = "glock"
 	shoot_delay = 2
@@ -601,7 +601,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 /obj/item/gun/kinetic/clock_188/boomerang
 	desc = "Jokingly called a \"Gunarang\" in some circles. Uses 9mm NATO rounds."
-	name = "Clock 180"
+	name = "\improper Clock 180"
 	force = MELEE_DMG_PISTOL
 	throw_range = 10
 	throwforce = 1
@@ -725,7 +725,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 //0.357
 /obj/item/gun/kinetic/revolver
-	name = "Predator revolver"
+	name = "\improper Predator revolver"
 	desc = "A hefty combat revolver developed by Cormorant Precision Arms. Uses .357 caliber rounds."
 	icon_state = "revolver"
 	item_state = "revolver"
@@ -742,7 +742,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 //0.38
 /obj/item/gun/kinetic/detectiverevolver
-	name = "Detective Special revolver"
+	name = "\improper Detective Special revolver"
 	desc = "A snubnosed police-issue revolver developed by Cormorant Precision Arms. Uses .38-Special rounds."
 	icon_state = "detective"
 	item_state = "detective"
@@ -761,7 +761,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 //0.393
 /obj/item/gun/kinetic/foamdartgun
-	name = "Foam Dart Gun"
+	name = "foam dart gun"
 	icon_state = "foamdartgun"
 	desc = "A toy gun that fires foam darts. Keep out of reach of clowns, staff assistants and scientists."
 	w_class = W_CLASS_SMALL
@@ -821,7 +821,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 
 /obj/item/gun/kinetic/foamdartrevolver
-	name = "Foam Dart Revolver"
+	name = "foam dart revolver"
 	icon_state = "foamdartrevolver"
 	desc = "An advanced dart gun for experienced pros. Just holding it imbues you with a sense of great power."
 	w_class = W_CLASS_SMALL
@@ -841,7 +841,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 //0.40
 /obj/item/gun/kinetic/blowgun
-	name = "Flute"
+	name = "flute"
 	desc = "Wait, this isn't a flute. It's a blowgun!"
 	icon_state = "blowgun"
 	item_state = "cane-f"
@@ -910,7 +910,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 	var/hammer_cocked = 0
 
 	detective
-		name = "Peacemaker"
+		name = "\improper Peacemaker"
 		desc = "A barely adequate replica of a nearly ancient single action revolver. Used by war reenactors for the last hundred years or so. Its caliber is obviously the wrong size, though."
 		w_class = W_CLASS_SMALL
 		force = MELEE_DMG_REVOLVER
@@ -1027,7 +1027,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 			set_current_projectile(new/datum/projectile/bullet/a12/weak)
 
 /obj/item/gun/kinetic/riotgun
-	name = "Riot Shotgun"
+	name = "riot shotgun"
 	desc = "A police-issue shotgun meant for suppressing riots."
 	icon = 'icons/obj/large/48x32.dmi'
 	icon_state = "shotty-empty"
@@ -1111,7 +1111,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 /obj/item/gun/kinetic/flaregun
 	desc = "A 12-gauge flaregun."
-	name = "Flare Gun"
+	name = "flare gun"
 	icon_state = "flare"
 	item_state = "flaregun"
 	force = MELEE_DMG_PISTOL
@@ -1274,7 +1274,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 //1.57
 /obj/item/gun/kinetic/riot40mm
 	desc = "A 40mm riot control gun. It can accept standard 40mm rounds and hand-thrown grenades."
-	name = "Riot launcher"
+	name = "riot launcher"
 	icon_state = "40mm"
 	item_state = "40mm"
 	force = MELEE_DMG_SMG
@@ -1311,7 +1311,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 // Ported from old, non-gun RPG-7 object class (Convair880).
 /obj/item/gun/kinetic/rpg7
 	desc = "A rocket-propelled grenade launcher licensed by the Space Irish Republican Army."
-	name = "MPRT-7"
+	name = "\improper MPRT-7"
 	icon = 'icons/obj/large/64x32.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_weapons.dmi'
 	icon_state = "rpg7"
@@ -1362,7 +1362,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 /obj/item/gun/kinetic/antisingularity
 	desc = "An experimental rocket launcher designed to deliver various payloads in rocket format."
-	name = "Singularity Buster rocket launcher"
+	name = "\improper Singularity Buster rocket launcher"
 	icon = 'icons/obj/large/64x32.dmi'
 	icon_state = "ntlauncher"
 	item_state = "ntlauncher"
@@ -1391,7 +1391,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 //3.0
 /obj/item/gun/kinetic/gungun //meesa jarjar binks
-	name = "Gun"
+	name = "\improper Gun"
 	desc = "A gun that shoots... something. It looks like a modified grenade launcher."
 	icon_state = "gungun"
 	item_state = "gungun"
@@ -1409,7 +1409,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 //4.6
 /obj/item/gun/kinetic/airzooka //This is technically kinetic? I guess?
-	name = "Airzooka"
+	name = "airzooka"
 	desc = "The new double action air projection device from Donk Co!"
 	icon_state = "airzooka"
 	force = MELEE_DMG_PISTOL
@@ -1471,7 +1471,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 // agent
 /obj/item/gun/kinetic/pistol
-	name = "Branwen pistol"
+	name = "\improper Branwen pistol"
 	desc = "A semi-automatic, 9mm caliber service pistol, developed by Mabinogi Firearms Company."
 	icon_state = "9mm_pistol"
 	w_class = W_CLASS_NORMAL
@@ -1515,7 +1515,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 	return ..() && !istype(M.get_id(), /obj/item/card/id/syndicate)
 
 /obj/item/gun/kinetic/smg
-	name = "Bellatrix submachine gun"
+	name = "\improper Bellatrix submachine gun"
 	desc = "A semi-automatic, 9mm submachine gun, developed by Almagest Weapons Fabrication."
 	icon = 'icons/obj/large/48x32.dmi'
 	icon_state = "mp52"
@@ -1547,7 +1547,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 		UpdateIcon()
 
 /obj/item/gun/kinetic/tranq_pistol
-	name = "Gwydion tranquilizer pistol"
+	name = "\improper Gwydion tranquilizer pistol"
 	desc = "A silenced 9mm tranquilizer pistol, developed by Mabinogi Firearms Company."
 	icon_state = "tranq_pistol"
 	item_state = "tranq_pistol"
@@ -1589,7 +1589,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 // assault
 /obj/item/gun/kinetic/assault_rifle
-	name = "Sirius assault rifle"
+	name = "\improper Sirius assault rifle"
 	desc = "A bullpup assault rifle capable of semi-automatic and burst fire modes, developed by Almagest Weapons Fabrication."
 	icon = 'icons/obj/large/64x32.dmi'
 	icon_state = "assault_rifle"
@@ -1649,7 +1649,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 // heavy
 /obj/item/gun/kinetic/light_machine_gun
-	name = "Antares light machine gun"
+	name = "\improper Antares light machine gun"
 	desc = "A 100 round light machine gun, developed by Almagest Weapons Fabrication."
 	icon = 'icons/obj/large/64x32.dmi'
 	icon_state = "lmg"
@@ -1683,7 +1683,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 
 /obj/item/gun/kinetic/cannon
-	name = "M20-CV tactical cannon"
+	name = "\improper M20-CV tactical cannon"
 	desc = "A shortened conversion of a 20mm military cannon. Slow but enormously powerful."
 	icon = 'icons/obj/large/64x32.dmi'
 	icon_state = "cannon"
@@ -1721,7 +1721,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 // demo
 /obj/item/gun/kinetic/grenade_launcher
-	name = "Rigil grenade launcher"
+	name = "\improper Rigil grenade launcher"
 	desc = "A 40mm hand-held grenade launcher, developed by Almagest Weapons Fabrication."
 	icon = 'icons/obj/large/64x32.dmi'
 	icon_state = "grenade_launcher"
@@ -1769,7 +1769,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 // sniper
 /obj/item/gun/kinetic/sniper
-	name = "Betelgeuse sniper rifle"
+	name = "\improper Betelgeuse sniper rifle"
 	desc = "A semi-automatic bullpup sniper rifle, developed by Almagest Weapons Fabrication."
 	icon = 'icons/obj/large/64x32.dmi' // big guns get big icons
 	icon_state = "sniper"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR decapitalises or `\improper`s a lot of gun names as I judged most fitting.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I kept getting vaguely annoyed by the grammatical errors caused by the game thinking the nukie guns have proper nouns.

(This sort of thing has to happen at some point I guess)