### PR TITLE
Fix cog1 RD office blinds

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -35239,7 +35239,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/science/teleporter)
+/area/station/crew_quarters/hor)
 "bMT" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_albert"
@@ -35926,7 +35926,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/science/teleporter)
+/area/station/crew_quarters/hor)
 "bOs" = (
 /obj/reagent_dispensers/foamtank,
 /obj/item/extinguisher,
@@ -95720,11 +95720,11 @@ aaw
 aaw
 aap
 bIP
-bIP
-bIP
+bJY
+bJY
 bMS
 bOr
-bIP
+bJY
 bJY
 jiw
 bJY


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Assigns the wall/windows between cog1 telescience and RD office to the area of the latter, so the blinds on the window work.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Can't even make pipe bombs in my office without nerds snooping