### PR TITLE
Traitors now get 25 TC - Buylist items are scaled to match

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -79,17 +79,17 @@
 	proc/pick_reward_tier(var/val)
 		switch(val)
 			if (1)
-				value_high = 4
+				value_high = 8
 				value_low = 0
 			if (2)
-				value_high = 6
-				value_low = 3
+				value_high = 12
+				value_low = 6
 			if (3)
-				value_high = 8
-				value_low = 5
+				value_high = 16
+				value_low = 10
 			if (4)
 				value_high = 99
-				value_low = 7
+				value_low = 14
 		pick_a_reward()
 
 	proc/pick_a_reward()

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -215,7 +215,7 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/generic/spy_sticker_kit
 	name = "Spy Sticker Kit"
 	item = /obj/item/storage/box/spy_sticker_kit
-	cost = 14
+	cost = 2
 	desc = "This kit contains innocuous stickers that you can use to broadcast audio and observe a video feed wirelessly."
 	blockedmode = list(/datum/game_mode/revolution)
 

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -43,21 +43,21 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/generic/revolver
 	name = "Revolver"
 	item = /obj/item/storage/box/revolver
-	cost = 6
+	cost = 12
 	desc = "The traditional sidearm of a Syndicate field agent. Holds 7 rounds and comes with extra ammo."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/pistol
 	name = "Suppressed .22 Pistol"
 	item = /obj/item/storage/box/pistol
-	cost = 3
+	cost = 6
 	desc = "A fairly weak yet sneaky pistol, it can still be heard but it won't alert anyone about who fired it."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/shotgun
 	name = "Shotgun"
 	item = /obj/item/storage/box/shotgun
-	cost = 8
+	cost = 16
 	desc = "Not exactly stealthy, but it'll certainly make an impression."
 	not_in_crates = 1
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
@@ -65,14 +65,14 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/generic/radbow
 	name = "Rad Poison Crossbow"
 	item = /obj/item/gun/energy/crossbow
-	cost = 3
+	cost = 6
 	desc = "Crossbow Model C - Now with safer Niobium core. This ranged weapon is great for hitting someone in a dark corridor! They'll never know what hit em! Will slowly recharge between shots."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/garrote
 	name = "Fibre Wire"
 	item = /obj/item/garrote
-	cost = 3
+	cost = 6
 	desc = "Commonly used by special forces for silent removal of isolated targets. Ensure you are out of sight, apply to the target's neck from behind with a firm two-hand grip and wait for death to occur."
 	blockedmode = list(/datum/game_mode/revolution)
 
@@ -81,70 +81,70 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/generic/empgrenades
 	name = "EMP Grenades"
 	item = /obj/item/storage/emp_grenade_pouch
-	cost = 1
+	cost = 2
 	desc = "A pouch of EMP grenades, each capable of causing havoc with the electrical and computer systems found aboard the modern space station. Shorts out power systems, causes feedback in electronic vision devices such as thermals, and causes robots to go haywire."
 	blockedmode = list(/datum/game_mode/spy)
 
 /datum/syndicate_buylist/generic/tacticalgrenades
 	name = "Tactical Grenades"
 	item = /obj/item/storage/tactical_grenade_pouch
-	cost = 2
+	cost = 4
 	desc = "A pouch of assorted special-ops grenades."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/voicechanger
 	name = "Voice Changer"
 	item = /obj/item/voice_changer
-	cost = 1
+	cost = 2
 	desc = "This voice-modulation device will dynamically disguise your voice to that of whoever is listed on your identification card, via incredibly complex algorithms. Discretely fits inside most masks, and can be removed with wirecutters."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/chamsuit
 	name = "Chameleon Jumpsuit"
 	item = /obj/item/clothing/under/chameleon
-	cost = 1
+	cost = 2
 	desc = "A jumpsuit made of advanced fibres that can change colour to suit the needs of the wearer. Do not expose to electromagnetic interference."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/syndicard
 	name = "Agent Card"
 	item = /obj/item/card/id/syndicate
-	cost = 1
+	cost = 2
 	desc = "A counterfeit identification card, designed to prevent tracking by the station's AI systems. It features a one-time programmable identification circuit, allowing the entry of a custom false identity. It is also capable of scanning other ID cards and replicating their access credentials."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/emag
 	name = "Electromagnet Card (EMAG)"
 	item = /obj/item/card/emag
-	cost = 6
+	cost = 12
 	desc = "A sophisticated tool of sabotage and infiltration. Capable of shorting out or otherwise bypassing security on door locks, robot friend/foe identification systems, shuttle control consoles, and more!"
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/fimplant
 	name = "Freedom Implant"
 	item = /obj/item/implanter/freedom
-	cost = 1
+	cost = 2
 	desc = "An implant that allows instant escape from handcuffs and shackles. Multiple uses possible but not guaranteed."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/spen
 	name = "Sleepy Pen"
 	item = /obj/item/pen/sleepypen
-	cost = 5
+	cost = 10
 	desc = "A small pen that has a syringe filled with a powerful sleeping agent inside. Capable of injecting a victim discretely. Refillable once initial contents are used up."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/jammer
 	name = "Signal Jammer"
 	item = /obj/item/radiojammer
-	cost = 3
+	cost = 6
 	desc = "Silences radios in an area around you while activated. No one will hear them scream."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/psink
 	name = "Power Sink"
 	item = /obj/item/device/powersink
-	cost = 5
+	cost = 10
 	desc = "Lights too bright? Airlocks too automatic? Alarms too functional? Or maybe just nostalgic about the good ol' days before electricity came along? The XL-100 Power Sink addresses all these ills and more. Simply screw to the nearest exposed wiring and flip the switch, and this little wonder will get to work on draining all of that nasty power."
 	not_in_crates = 1
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
@@ -152,42 +152,42 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/generic/detomatix
 	name = "Detomatix Cartridge"
 	item = /obj/item/disk/data/cartridge/syndicate
-	cost = 1
+	cost = 2
 	desc = "A PDA cartridge allowing remote detonation of other devices. Detonation programs may be accessed through the file manager. Comes complete with readme file."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/trickcigs
 	name = "Trick Cigarettes"
 	item = /obj/item/cigpacket/syndicate
-	cost = 1
+	cost = 2
 	desc = "A pack of Syndicool Lights exploding trick cigarettes. Due to the use of a military-grade explosive, please do not attempt to smoke these after lighting."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/dnascram
 	name = "DNA Scrambler"
 	item = /obj/item/genetics_injector/dna_scrambler
-	cost = 1
+	cost = 2
 	desc = "An injector that gives a new, random identity upon injection."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/derringer
 	name = "Derringer"
 	item = /obj/item/gun/kinetic/derringer
-	cost = 2
+	cost = 4
 	desc = "A small pistol that can be hidden inside worn clothes and retrieved using the wink emote. Comes with two shots and does extreme damage at close range."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/stealthstorage
 	name = "Stealth Storage"
 	item = /obj/item/storage/box/syndibox
-	cost = 1
+	cost = 2
 	desc = "This little wonder is capable of not only safely storing most small goods, but it can also be tapped against other objects in order to emulate their appearance. Note: May not perform optimally upon close inspection."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/esword
 	name = "Cyalume Saber"
 	item = /obj/item/sword
-	cost = 7
+	cost = 14
 	desc = "A powerful melee weapon, crafted using the latest in applied photonics! When inactive, it is small enough to fit in a pocket!"
 	not_in_crates = 1
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
@@ -201,35 +201,35 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/generic/katana
 	name = "Katana"
 	item = /obj/item/katana_sheath
-	cost = 7
+	cost = 14
 	desc = "A Japanese sword created in the fire of a dying star. Comes with a sheath for easier storage"
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/wrestling
 	name = "Wrestling Belt"
 	item = /obj/item/storage/belt/wrestling
-	cost = 7
+	cost = 14
 	desc = "A haunted antique wrestling belt, imbued with the spirits of wrestlers past. Wearing it unlocks a number of wrestling moves, which can be accessed in a separate command tab."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/spy_sticker_kit
 	name = "Spy Sticker Kit"
 	item = /obj/item/storage/box/spy_sticker_kit
-	cost = 1
+	cost = 14
 	desc = "This kit contains innocuous stickers that you can use to broadcast audio and observe a video feed wirelessly."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/omnitool
 	name = "Syndicate Omnitool"
 	item = /obj/item/tool/omnitool/syndicate
-	cost = 2
+	cost = 4
 	desc = "A miniature set of tools that you can hide in your clothing and retrieve with the flex emote. Has knife and weldingtool modes."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/generic/bighat
 	name = "Syndicate Hat"
 	item = /obj/item/clothing/head/bighat/syndicate
-	cost = 12
+	cost = 25
 	desc = "Think you're tough shit buddy?"
 	not_in_crates = 1 //see /datum/syndicate_buylist/surplus/bighat
 	blockedmode = list(/datum/game_mode/spy_theft, /datum/game_mode/revolution)
@@ -244,7 +244,7 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/traitor/cloak
 	name = "Cloaking Device"
 	item = /obj/item/cloaking_device
-	cost = 6
+	cost = 12
 	//not_in_crates = 1
 	desc = "Hides you from normal sight. AI and Cyborgs will still see you and so will any human with thermals so be careful how you use it."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -252,70 +252,70 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/traitor/sponge_capsules
 	name = "Syndicate Sponge Capsules"
 	item = /obj/item/spongecaps/syndicate
-	cost = 3
+	cost = 6
 	desc = "A pack of sponge capsules that react with water and produce nasty critters."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/bomb
 	name = "Syndicates in Pipebomb"
 	item = /obj/item/pipebomb/bomb/miniature_syndicate
-	cost = 3
+	cost = 6
 	desc = "A rather volatile pipe bomb packed with miniature syndicate troops."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/champrojector
 	name = "Chameleon Projector"
 	item = /obj/item/device/chameleon
-	cost = 5
+	cost = 10
 	desc = "Advanced cloaking device that scans an object and, when activated, makes the bearer look like the object. Slows movement while in use."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/holographic_disguiser
 	name = "Holographic Disguiser"
 	item = /obj/item/device/disguiser
-	cost = 2
+	cost = 4
 	desc = "A device capable of disguising your identity temporarily. Beware of flashes and projectiles!"
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/areacloak
 	name = "Cloaking Field Generator"
 	item = /obj/item/cloak_gen
-	cost = 3
+	cost = 6
 	desc = "Remote-controlled device that produces an area of effect cloaking field while active. Don't lose the remote!"
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/floorcloset
 	name = "Floor Closet"
 	item = /obj/storage/closet/syndi
-	cost = 1
+	cost = 2
 	desc = "This closet was produced using the finest in applied optical illusion technology. When closed, it will dynamically assume the appearance of the floor tile underneath."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/snidely
 	name = "Fake Moustache"
 	item = /obj/item/clothing/mask/moustache
-	cost = 1
+	cost = 2
 	desc = "The ultimate in disguise technology. This will perfectly conceal your identity from any onlookers and leave them stunned at your majestic facial hair."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/bowling
 	name = "Bowling Kit"
 	item = /obj/item/storage/bowling
-	cost = 7
+	cost = 14
 	desc = "Comes with several bowling balls and a suit. You won't be able to pluck up the courage to throw them very hard without wearing the suit!"
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/football
 	name = "Space-American Football Kit"
 	item = /obj/item/storage/football
-	cost = 7
+	cost = 14
 	desc = "This kit contains everything you need to become a great football player! Wearing all of the equipment inside will grant you the ability to rush down and tackle foes. You'll also make amazing throws!"
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/mindslave
 	name = "Mind Slave implant"
 	item = /obj/item/implanter/mindslave
-	cost = 3
+	cost = 6
 	vr_allowed = 0
 	desc = "Temporarily place an injected victim under your complete control! Faster and more effective than hypnotism! Warning: Implant effects are NOT indefinite."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution) // Whatever you do, don't allow mindslave implants in spy or rev.
@@ -323,7 +323,7 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/traitor/deluxe_mindslave
 	name = "Deluxe Mind Slave implant"
 	item = /obj/item/implanter/super_mindslave
-	cost = 6
+	cost = 12
 	vr_allowed = 0
 	desc = "Place an injected victim under your complete control! Enhanced neurostimulators make this version last virtually indefinitely!"
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -331,7 +331,7 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/traitor/microbomb
 	name = "Microbomb Implant"
 	item = /obj/item/implanter/uplink_microbomb
-	cost = 1
+	cost = 2
 	vr_allowed = 0
 	desc = "This miniaturized explosive packs a decent punch and will detonate upon the unintentional death of the host. Do not swallow and keep out of reach of children."
 	blockedmode = list(/datum/game_mode/revolution)
@@ -339,7 +339,7 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/traitor/macrobomb
 	name = "Macrobomb Implant"
 	item = /obj/item/implanter/uplink_macrobomb
-	cost = 12
+	cost = 25
 	vr_allowed = 0
 	desc = "Like the microbomb, but much more powerful. Macrobombs for macrofun!"
 	blockedmode = list(/datum/game_mode/revolution)
@@ -347,27 +347,27 @@ proc/build_syndi_buylist_cache()
 /datum/syndicate_buylist/traitor/lightbreaker
 	name = "Light Breaker"
 	item = /obj/item/lightbreaker
-	cost = 4
+	cost = 8
 	desc = "A casette player that breaks all lights near you. It also temporarily deafens and staggers all nearby people. Comes with four charges and has a distinctive sound. Can be rewound with a screwdriver."
 
 /datum/syndicate_buylist/traitor/ringtone
 	name = "SounDreamS PRO cartridge"
 	item = /obj/item/disk/data/cartridge/ringtone_syndie
-	cost = 1
+	cost = 2
 	desc = "A pirated copy of SounDreamS PRO, a PDA cartridge loaded with dozens of realistic, illegal-sounding sound effects that'll play whenever someone sends a message to your PDA."
 	blockedmode = list(/datum/game_mode/spy_theft)
 
 /datum/syndicate_buylist/traitor/sonicgrenades
 	name = "Sonic Grenades"
 	item = /obj/item/storage/sonic_grenade_pouch
-	cost = 2
+	cost = 4
 	desc = "A pouch filled with five sonic grenades, each one packs enough power to shatter reinforced windows and pop eardrums. No more being cornered by an angry mob! Comes with earplugs."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/traitor/surplus
 	name = "Surplus Crate"
 	item = /obj/storage/crate/syndicate_surplus
-	cost = 12
+	cost = 25
 	vr_allowed = 0
 	desc = "A crate containing 18-24 credits worth of whatever junk we had lying around."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
@@ -392,7 +392,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/idtracker
 	name = "Target ID Tracker"
 	item = /obj/item/pinpointer/idtracker
-	cost = 1
+	cost = 2
 	desc = "Allows you to track the IDs of your assassination targets, but only the ID. If they have changed or destroyed it, the pin pointer will not be useful."
 	not_in_crates = 1
 	vr_allowed = 0
@@ -405,7 +405,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/idtracker/spy
 	name = "Target ID Tracker (SPY)"
 	item = /obj/item/pinpointer/idtracker/spy
-	cost = 1
+	cost = 2
 	desc = "Allows you to track the IDs of all other antagonists, but only the ID. If they have changed or destroyed it, the pin pointer will not be useful."
 	vr_allowed = 0
 	not_in_crates = 1
@@ -430,7 +430,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/clowncar
 	name = "Clown Car"
 	item = /obj/vehicle/clowncar/surplus
-	cost = 5
+	cost = 10
 	vr_allowed = 0
 	desc = "A funny-looking car designed for circus events. Seats 30, very roomy! Comes with an extra set of clown clothes."
 	job = list("Clown")
@@ -439,7 +439,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/boomboots
 	name = "Boom Boots"
 	item = /obj/item/clothing/shoes/cowboy/boom
-	cost = 12
+	cost = 25
 	vr_allowed = 0
 	desc = "These big red boots have an explosive step sound. The entire station is sure to want to show you their appreciation."
 	job = list("Clown")
@@ -449,7 +449,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/clown_mask
 	name = "Clown Mask"
 	item = /obj/item/clothing/mask/gas/syndie_clown
-	cost = 5
+	cost = 10
 	vr_allowed = 0
 	desc = "A clown mask haunted by the souls of those who honked before. Only true clowns should attempt to wear this. It also functions like a gas mask."
 	job = list("Clown")
@@ -459,7 +459,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/fake_revolver
 	name = "Funny-looking Revolver"
 	item = /obj/item/storage/box/fakerevolver
-	cost = 1
+	cost = 2
 	desc = "A revolver with a twist. It will always fire backwards! Watch some vigilante try to get you NOW!"
 	job = list("Clown")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -467,7 +467,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/chambomb
 	name = "Chameleon Bomb Case"
 	item = /obj/item/storage/box/chameleonbomb
-	cost = 3
+	cost = 6
 	vr_allowed = 0
 	desc = "2 questionable mixtures of a chameleon projector and a bomb. Scan an object to take on its appearance, arm the bomb, and then explode the face(s) of whoever tries to touch it."
 	job = list("Clown")
@@ -476,7 +476,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/sinjector
 	name = "Speed Injector"
 	item = /obj/item/speed_injector
-	cost = 3
+	cost = 6
 	desc = "Disguised as a screwdriver, this stealthy device can be loaded with dna injectors which will be injected into the target instantly and stealthily. The dna injector will be altered when inserted so that there will be a ten second delay before the gene manifests in the victim."
 	job = list("Geneticist")
 	not_in_crates = 1
@@ -485,7 +485,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/minibible
 	name = "Miniature Bible"
 	item = /obj/item/storage/bible/mini
-	cost = 1
+	cost = 2
 	desc = "We understand it can be difficult to carry out some of our missions. Here is some spiritual counsel in a small package."
 	job = list("Assistant","Technical Assistant","Medical Assistant","Staff Assistant", "Chaplain", "Clown")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -494,7 +494,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/contract
 	name = "Faustian Bargain Kit"
 	item = /obj/item/storage/briefcase/satan
-	cost = 8
+	cost = 16
 	desc = "Comes complete with three soul binding contracts, three extra-pointy pens, and one suit provided by Lucifer himself."
 	job = list("Chaplain")
 	not_in_crates = 1
@@ -510,7 +510,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/mailsuit
 	name = "Mailman Suit"
 	item = /obj/item/clothing/under/misc/mail/syndicate
-	cost = 1
+	cost = 2
 	desc = "A mailman's uniform that allows the wearer to use mail chutes as a means of transportation."
 	job = list("Mailman")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -518,7 +518,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/chargehacker
 	name = "Mining Charge Hacker"
 	item = /obj/item/device/chargehacker
-	cost = 4
+	cost = 8
 	desc = "A tool designed to hack mining charges so that they will attach to any surface, disguised as a geological scanner."
 	not_in_crates = 1
 	job = list("Miner")
@@ -527,7 +527,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/kudzuseed
 	name = "Kudzu Seed"
 	item = /obj/item/kudzuseed
-	cost = 4
+	cost = 8
 	desc = "Syndikudzu. Interesting. Plant on the floor to grow."
 	vr_allowed = 0
 	job = list("Botanist", "Staff Assistant")
@@ -536,7 +536,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/maneater
 	name = "Maneater Seed"
 	item = /obj/item/seed/maneater
-	cost = 1
+	cost = 2
 	desc = "A boon for the green-thumbed agent! Simply plant and nurture to raise your own faithful guard-plant! Feed me, Seymour!"
 	not_in_crates = 1
 	job = list("Botanist")
@@ -545,7 +545,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/saw
 	name = "Chainsaw"
 	item = /obj/item/saw/syndie
-	cost = 7
+	cost = 14
 	desc = "This old earth beauty is made by hand with strict attention to detail. Unlike today's competing botanical chainsaw, it actually cuts things!"
 	not_in_crates = 1
 	job = list("Botanist")
@@ -554,7 +554,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/hotbox_lighter
 	name = "Hotbox Lighter"
 	item = /obj/item/device/light/zippo/syndicate
-	cost = 1
+	cost = 2
 	desc = "The unique fuel mixture gives this lighter a unique flame capable of creating a much denser smoke when burning piles of herbs compared to any normal lighter!"
 	job = list("Botanist")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
@@ -562,7 +562,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/waspgrenade
 	name = "Wasp Grenades"
 	item = /obj/item/storage/box/wasp_grenade_kit
-	cost = 3
+	cost = 6
 	desc = "These wasp grenades contain genetically modified extra double large hornets that will surely inspire awe in all your non-botanical friends."
 	job = list("Botanist", "Apiculturist")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -570,7 +570,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/wasp_crossbow
 	name = "Wasp Crossbow"
 	item = /obj/item/gun/energy/wasp
-	cost = 6
+	cost = 12
 	desc = "Become the member of the Space Cobra Unit you always wanted to be! Spread pain and fear far and wide using this scattershot wasp egg launcher! Through the power of sheer wasp-y fury, this crossbow will slowly recharge between shots and is guaranteed to light up your day with maniacal joy and to bring your enemies no end of sorrow."
 	not_in_crates = 1 //the value of the item goes down significantly for non-botanists since only botanists are treated kindly by wasps
 	job = list("Botanist", "Apiculturist")
@@ -579,7 +579,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/fakegrenade
 	name = "Fake Cleaner Grenades"
 	item = /obj/item/storage/box/f_grenade_kit
-	cost = 2
+	cost = 4
 	desc = "This cleaning grenade features over 500% of the legal level of active agent. Cleans dirt off of floors and flesh off of bone! Also contains space lube to create a dazzling shine!"
 	job = list("Janitor")
 	blockedmode = list(/datum/game_mode/spy)
@@ -587,7 +587,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/compactor
 	name = "Trash Compactor Cart"
 	item = /obj/storage/cart/trash/syndicate
-	cost = 4
+	cost = 8
 	desc = "Identical in appearance to an ordinary trash cart, this beauty is capable of compacting (1) laying person placed inside at a time. It was originally supposed to only compact nonliving things, but a serendipitous design mistake resulted in 1500 units with a reversed safety unit."
 	not_in_crates = 1
 	vr_allowed = 0
@@ -601,7 +601,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/slip_and_sign
 	name = "Slip and Sign"
 	item = /obj/item/caution/traitor
-	cost = 2
+	cost = 4
 	desc = "This Wet Floor Sign spits out organic superlubricant under everyone nearby unless they are wearing galoshes. That'll teach them to ignore the signs. If you are wearing the long janitor gloves you can click with a bucket (or beaker or drinking glass etc.) to replace the payload."
 	job = list("Janitor")
 
@@ -613,14 +613,14 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/overcharged_vacuum
 	name = "Overcharged Vacuum Cleaner"
 	item = /obj/item/handheld_vacuum/overcharged
-	cost = 5
+	cost = 10
 	desc = "This vacuum cleaner's special attack is way more powerful than the regular thing."
 	job = list("Janitor")
 
 /datum/syndicate_buylist/traitor/syndanalyser
 	name = "Syndicate Device Analyzer"
 	item = /obj/item/electronics/scanner/syndicate
-	cost = 4
+	cost = 8
 	vr_allowed = 0
 	desc = "The shell of a standard Nanotrasen mechanic's analyzer with cutting-edge Syndicate internals. This baby can scan almost anything!"
 	job = list("Mechanic")
@@ -629,7 +629,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/stimulants
 	name = "Stimulants"
 	item = /obj/item/storage/box/stimulants
-	cost = 6
+	cost = 12
 	desc = "When top agents need energy, they turn to our new line of X-Cite 500 stimulants. This 3-pack of all-natural* and worry-free** blend accelerates perception, endurance, and reaction time to superhuman levels! Shrug off even the cruelest of blows without a scratch! <br><br><font size=-1>*Contains less than 0.5 grams unnatural material per 0.49 gram serving.<br>**May cause dizziness, blurred vision, heart failure, renal compaction, adenoid calcification, or death. Users are recommended to take only a single dose at a time, and let withdrawl symptoms play out naturally.</font>"
 	job = list("Medical Doctor","Medical Director","Scientist","Geneticist","Pathologist","Research Director")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -637,7 +637,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/syringegun
 	name = "Syringe Gun"
 	item = /obj/item/gun/reagent/syringe
-	cost = 3
+	cost = 6
 	desc = "This stainless-steel, revolving wonder fires needles. Perfect for today's safari-loving Syndicate doctor! Loaded by transferring reagents to the gun's internal reservoir."
 	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Bartender")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -646,7 +646,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/powergloves
 	name = "Power Gloves"
 	item = /obj/item/clothing/gloves/powergloves
-	cost = 6
+	cost = 12
 	desc = "These marvels of modern technology employ nanites and space science to draw energy from nearby cables to zap things. BZZZZT!"
 	not_in_crates = 1
 	job = list("Engineer", "Chief Engineer", "Mechanic")
@@ -655,7 +655,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/pickpocket
 	name = "Pickpocket Gun"
 	item = /obj/item/gun/energy/pickpocket
-	cost = 3
+	cost = 6
 	vr_allowed = 0
 	desc = "A stealthy claw gun capable of stealing and planting items, and severely messing with people."
 	job = list("Engineer", "Chief Engineer", "Mechanic", "Clown", "Staff Assistant")
@@ -664,7 +664,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/poisonbottle
 	name = "Poison Bottle"
 	item = /obj/item/reagent_containers/glass/bottle/poison
-	cost = 1
+	cost = 2
 	desc = "A bottle of poison. Which poison? Who knows."
 	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Bartender")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -672,7 +672,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/poisonbundle
 	name = "Poison Bottle Bundle"
 	item = /obj/item/storage/box/poison
-	cost = 7
+	cost = 14
 	desc = "A box filled with seven random poison bottles."
 	job = list("Medical Doctor", "Medical Director", "Research Director", "Scientist", "Bartender")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -680,7 +680,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/chemicompiler
 	name = "Chemicompiler"
 	item = /obj/item/device/chemicompiler
-	cost = 5
+	cost = 10
 	not_in_crates = 1
 	desc = "A handheld version of the Chemicompiler machine in Chemistry."
 	job = list("Research Director", "Scientist")
@@ -689,7 +689,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/robosuit
 	name = "Syndicate Robot Frame"
 	item = /obj/item/parts/robot_parts/robot_frame/syndicate
-	cost = 2
+	cost = 4
 	desc = "A cyborg shell crafted from the finest recycled steel and reverse-engineered microelectronics. A cyborg crafted from this will see only Syndicate operatives (Such as yourself!) as human. Cyborg also comes preloaded with popular game \"Angry About the Bird\" and is compatible with most headphones."
 	not_in_crates = 1
 	vr_allowed = 0
@@ -699,7 +699,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/conversion_chamber
 	name = "Conversion Chamber"
 	item = /obj/machinery/recharge_station/syndicate
-	cost = 6
+	cost = 12
 	vr_allowed = 0
 	desc = "A modified standard-issue cyborg recharging station that will automatically convert any human placed inside into a cyborg. Be aware that cyborgs will follow the active lawset in place on-station."
 	job = list("Roboticist")
@@ -709,7 +709,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/safari
 	name = "Safari Kit"
 	item = /obj/item/storage/box/costume/safari
-	cost = 7
+	cost = 14
 	desc = "Almost everything you need to hunt the most dangerous game. Tranquilizer rifle not included."
 	job = list("Medical Director")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft, /datum/game_mode/revolution)
@@ -722,7 +722,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/pizza_sharpener
 	name = "Pizza Sharpener"
 	item = /obj/item/kitchen/utensil/knife/pizza_cutter/traitor
-	cost = 5
+	cost = 10
 	desc = "Have you ever been making a pizza and thought \"this pizza would be better if I could fatally injure someone by throwing it at them\"? Well think no longer! Because you're sharpening pizzas now. You weirdo."
 	job = list("Chef")
 	blockedmode = list(/datum/game_mode/revolution)
@@ -731,7 +731,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/syndiesauce
 	name = "Syndicate Sauce"
 	item = /obj/item/reagent_containers/food/snacks/condiment/syndisauce
-	cost = 1
+	cost = 2
 	desc = "Our patented secret blend of herbs and spices! Guaranteed to knock even the harshest food critic right off their feet! And into the grave. Because this is poison."
 	job = list("Chef", "Bartender")
 	blockedmode = list(/datum/game_mode/revolution)
@@ -739,7 +739,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/donkpockets
 	name = "Syndicate Donk Pockets"
 	item = /obj/item/storage/box/donkpocket_w_kit
-	cost = 2
+	cost = 4
 	desc = "Ready to eat, no microwave required! The pocket-sandwich station personnel crave, now with added medical agents to heal you up in a pinch! Zero grams trans-fat per serving*!<br><br><font size=1>*Made with partially-hydrogenated wizard blood.</font>"
 	job = list("Chef")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -747,7 +747,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/butcherknife
 	name = "Butcher's Knife"
 	item = /obj/item/knife/butcher
-	cost = 7
+	cost = 14
 	desc = "An extremely sharp knife with a weighted handle for accurate throwing. Caution: May cause extreme bleeding if the cutting edge comes into contact with human flesh."
 	not_in_crates = 1
 	job = list("Chef")
@@ -756,7 +756,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/moonshine
 	name = "Jug of Moonshine"
 	item = /obj/item/reagent_containers/food/drinks/moonshine
-	cost = 2
+	cost = 4
 	desc = "A jug full of incredibly potent alcohol. Not recommended for human consumption."
 	job = list("Bartender")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -764,7 +764,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/shotglass
 	name = "Extra Large Shot Glasses"
 	item = /obj/item/storage/box/glassbox/syndie
-	cost = 2
+	cost = 4
 	desc = "A box of shot glasses that hold WAAAY more that normal. Cheat at drinking games!"
 	job = list("Bartender")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -772,7 +772,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/vuvuzelagun
 	name = "Vuvuzela Gun"
 	item = /obj/item/gun/energy/vuvuzela_gun
-	cost = 3
+	cost = 6
 	desc = "<b>BZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ</b>"
 	job = list("Assistant","Technical Assistant","Medical Assistant","Staff Assistant", "Clown")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -780,7 +780,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/moustache_grenade
 	name = "Moustache Grenade"
 	item = /obj/item/old_grenade/moustache
-	cost = 1
+	cost = 2
 	desc = "A disturbingly hairy grenade."
 	job = list("Assistant","Technical Assistant","Medical Assistant","Staff Assistant", "Clown")
 	blockedmode = list(/datum/game_mode/revolution)
@@ -788,7 +788,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/hotdog_bomb
 	name = "Hotdog Bomb"
 	item = /obj/item/gimmickbomb/hotdog
-	cost = 1
+	cost = 2
 	desc = "Turn your worst enemies into hotdogs."
 	job = list("Chef", "Sous-Chef", "Waiter", "Clown")
 	blockedmode = list(/datum/game_mode/revolution)
@@ -796,7 +796,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/chemgrenades
 	name = "Chem Grenade Starter Kit"
 	item = /obj/item/storage/box/grenade_starter_kit
-	cost = 2
+	cost = 4
 	desc = "Tired of destroying your own face with acid reactions? Want to make the janitor feel incompetent? This kit gets you started with three grenades. Just add beakers and screw!"
 	job = list("Scientist","Research Director")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -804,7 +804,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/ammo_38AP // 2 TC for 1 speedloader was very poor value compared to other guns and traitor items in general (Convair880).
 	name = ".38 AP ammo box"
 	item = /obj/item/storage/box/ammo38AP
-	cost = 2
+	cost = 4
 	desc = "Armor-piercing ammo for a .38 Special revolver (not included)."
 	job = list("Detective")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution, /datum/game_mode/spy_theft)
@@ -812,7 +812,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/traitorthermalscanner
 	name = "Advanced Optical Thermal Scanner"
 	item = /obj/item/clothing/glasses/thermal/traitor
-	cost = 3
+	cost = 6
 	desc = "An advanced optical thermal scanner capable of seeing living entities through walls and smoke."
 	job = list("Detective")
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
@@ -820,7 +820,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/cargo_transporter
 	name = "Syndicate Cargo Transporter"
 	item = /obj/item/cargotele/traitor
-	cost = 3
+	cost = 6
 	vr_allowed = 0
 	desc = "A modified cargo transporter which teleports containers to a random spot in space and welds them shut."
 	job = list("Quartermaster","Miner","Engineer")
@@ -829,7 +829,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/telegun
 	name = "Teleport Gun"
 	item = /obj/item/gun/energy/teleport
-	cost = 7
+	cost = 14
 	vr_allowed = 0
 	desc = "An experimental hybrid between a hand teleporter and a directed-energy weapon. Probably a very bad idea. Note -- Only works in conjunction with a stationary teleporter."
 	job = list("Research Director")
@@ -838,7 +838,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/portapuke
 	name = "Port-a-Puke"
 	item = /obj/machinery/portapuke
-	cost = 7
+	cost = 14
 	desc = "An experimental torture chamber that will make any human placed inside puke until they die!"
 	job = list("Janitor")
 	blockedmode = list(/datum/game_mode/revolution)
@@ -846,7 +846,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/monkey_barrel
 	name = "Barrel-O-Monkeys"
 	item = /obj/storage/monkey_barrel
-	cost = 6
+	cost = 12
 	vr_allowed = 0
 	desc = "A barrel of bloodthirsty apes. Careful!"
 	job = list("Staff Assistant","Test Subject","Geneticist","Pathologist")
@@ -855,7 +855,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/mindslave_module
 	name = "Mindslave Cloning Module"
 	item = /obj/item/cloneModule/mindslave_module
-	cost = 6
+	cost = 12
 	vr_allowed = 0
 	desc = "An add on to the genetics cloning pod that make anyone cloned loyal to whoever installed it."
 	job = list("Geneticist", "Medical Doctor", "Medical Director")
@@ -864,7 +864,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/deluxe_mindslave_module
 	name = "Deluxe Mindslave Cloning Module Kit"
 	item = /obj/item/storage/box/mindslave_module_kit
-	cost = 10 //  Always leave them 1tc so they can buy the moustache. Style is key.
+	cost = 20
 	vr_allowed = 0
 	desc = "A Deluxe Mindslave Cloning Kit. Contains a mindslave cloning module and a cloning lab in a box!"
 	job = list("Geneticist", "Medical Doctor", "Medical Director")
@@ -873,7 +873,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/buddy_ammofab
 	name = "Guardbuddy Ammo Replicator"
 	item = /obj/item/device/guardbot_module/ammofab
-	cost = 1
+	cost = 2
 	vr_allowed = 0
 	desc = "A device that allows PR-6S Guardbuddy units to use their internal charge to replenish kinetic ammunition."
 	job = list("Research Director")
@@ -882,7 +882,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/wiretap
 	name = "Wiretap Radio Upgrade"
 	item = /obj/item/device/radio_upgrade
-	cost = 3
+	cost = 6
 	desc = "A small device that may be installed in a headset to grant access to all station channels."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 	vr_allowed = 0
@@ -890,7 +890,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/traitor/tape
 	name = "Ducktape"
 	item = /obj/item/handcuffs/tape_roll
-	cost = 1
+	cost = 2
 	desc = "A roll of duct tape for makeshift handcuffs. Lets you restrain someone 10 times before being used up."
 	blockedmode = list(/datum/game_mode/revolution)
 
@@ -904,75 +904,75 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/surplus/dagger
 	name = "Syndicate Dagger"
 	item = /obj/item/dagger/syndicate
-	cost = 2
+	cost = 4
 	desc = "An ornamental dagger for stabbing people with."
 	blockedmode = list(/datum/game_mode/spy)
 
 /datum/syndicate_buylist/surplus/advanced_laser
 	name = "Laser Rifle"
 	item = /obj/item/gun/energy/laser_gun/pred
-	cost = 6
+	cost = 12
 	desc = "An experimental laser design with a self-charging cerenkite battery."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/surplus/breachingT
 	name = "Thermite Breaching Charge"
 	item = /obj/item/breaching_charge/thermite
-	cost = 1
+	cost = 2
 	desc = "A self-contained thermite breaching charge, useful for destroying walls."
 	blockedmode = list(/datum/game_mode/spy)
 
 /datum/syndicate_buylist/surplus/breaching
 	name = "Breaching Charge"
 	item = /obj/item/breaching_charge
-	cost = 1
+	cost = 2
 	desc = "A self-contained explosive breaching charge, useful for destroying walls."
 	blockedmode = list(/datum/game_mode/spy)
 
 /datum/syndicate_buylist/surplus/flaregun
 	name = "Flare Gun"
 	item = /obj/item/storage/box/flaregun // Gave this thing a box of spare ammo. Having only one shot was kinda lackluster (Convair880).
-	cost = 2
+	cost = 4
 	desc = "A signal flaregun for emergency use. Or for setting jerks on fire"
 	blockedmode = list(/datum/game_mode/spy)
 
 /datum/syndicate_buylist/surplus/rifle
 	name = "Old Hunting Rifle"
 	item = /obj/item/gun/kinetic/hunting_rifle
-	cost = 3
+	cost = 6
 	desc = "An old hunting rifle, comes with only four bullets. Use them wisely."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution, /datum/game_mode/spy_theft)
 
 	spy
-		cost = 5
+		cost = 10
 		blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 		not_in_crates = TRUE
 
 /datum/syndicate_buylist/surplus/bananagrenades
 	name = "Banana Grenades"
 	item = /obj/item/storage/banana_grenade_pouch
-	cost = 2
+	cost = 4
 	desc = "Honk."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft)
 
 /datum/syndicate_buylist/surplus/turboflash_box
 	name = "Flash/cell assembly box"
 	item = /obj/item/storage/box/turbo_flash_kit
-	cost = 1
+	cost = 2
 	desc = "A box full of common stun weapons with power cells hastily wired into them. Looks dangerous."
 	blockedmode = list(/datum/game_mode/spy)
 
 /datum/syndicate_buylist/surplus/syndicate_armor
 	name = "Syndicate Command Armor"
 	item = /obj/item/clothing/suit/space/industrial/syndicate
-	cost = 5
+	cost = 10
 	desc = "A set of syndicate command armor. I guess the last owner must have died."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/surplus/egun_upgrade
 	name = "Energy Gun Upgrade Pack"
 	item = /obj/item/ammo/power_cell/self_charging/disruptor
-	cost = 2
+	cost = 4
 	desc = "An advanced self-charging power cell, the ideal upgrade for an energy gun!"
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
@@ -980,7 +980,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/surplus/landmine
 	name = "Land Mine"
 	item = /obj/random_item_spawner/landmine/surplus // RNG picker.
-	cost = 1
+	cost = 2
 	desc = "Some old anti-personnel mine we found in the warehouse."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
@@ -989,21 +989,21 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/surplus/cybereye_kit_sechud
 	name = "Ocular Prosthesis Kit (SecHUD)"
 	item = /obj/item/device/ocular_implanter
-	cost = 1
+	cost = 2
 	desc = "A pair of surplus cybereyes that can access the Security HUD system. Comes with a convenient but terrifying implanter."
 	blockedmode = list(/datum/game_mode/revolution)
 
 /datum/syndicate_buylist/surplus/emaghypo
 	name = "Hacked Hypospray"
 	item = /obj/item/reagent_containers/hypospray/emagged
-	cost = 1
+	cost = 2
 	desc = "A special hacked hypospray, capable of holding any chemical!"
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
 /datum/syndicate_buylist/surplus/sarin_grenade
 	name = "Sarin Grenade"
 	item = /obj/item/chem_grenade/sarin
-	cost = 1
+	cost = 2
 	desc = "A terrifying grenade containing a potent nerve gas. Try not to get caught in the smoke."
 	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/revolution)
 
@@ -1023,6 +1023,23 @@ This is basically useless for anyone but miners.
 		name = "[syndicate_currency]"
 	run_on_spawn(var/obj/item/uplink_telecrystal/tc, mob/living/owner, in_surplus_crate)
 		tc.name = "[syndicate_currency]"
+
+/datum/syndicate_buylist/generic/telecrystal
+	name = "5 Pure Telecrystals"
+	item = /obj/item/uplink_telecrystal
+	cost = 5
+	desc = "A stack of pure Telecrystals, orignating from plasma giants. Used as currency in Syndicate Uplinks."
+	blockedmode = list(/datum/game_mode/spy, /datum/game_mode/spy_theft)
+	telecrystal = TRUE
+	vr_allowed = FALSE
+	not_in_crates = TRUE
+	New()
+		. = ..()
+		name = "[syndicate_currency]"
+
+	run_on_spawn(var/obj/item/uplink_telecrystal/tc, mob/living/owner, in_surplus_crate)
+		tc.amount = 5
+		tc.update_stack_appearance()
 
 /datum/syndicate_buylist/generic/trick_telecrystal
 	name = "Trick Pure Telecrystal"
@@ -1072,7 +1089,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/generic/revflash
 	name = "Revolutionary Flash"
 	item = /obj/item/device/flash/revolution
-	cost = 5
+	cost = 10
 	desc = "This flash never runs out and will convert susceptible crew when a rev head uses it. It will also allow the rev head to break loyalty implants."
 	vr_allowed = 0
 	exclusivemode = list(/datum/game_mode/revolution)
@@ -1081,7 +1098,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/generic/revflashbang
 	name = "Revolutionary Flashbang"
 	item = /obj/item/chem_grenade/flashbang/revolution
-	cost = 2
+	cost = 4
 	desc = "This single-use flashbang will convert all crew within range. It doesn't matter who primes the flash - it will convert all the same."
 	vr_allowed = 0
 	exclusivemode = list(/datum/game_mode/revolution)
@@ -1090,7 +1107,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/generic/revsign
 	name = "Revolutionary Sign"
 	item = /obj/item/revolutionary_sign
-	cost = 4
+	cost = 8
 	desc = "This large revolutionary sign will inspire all nearby revolutionaries and grant them small combat buffs. A rev head needs to be holding this sign for it to have any effect."
 	exclusivemode = list(/datum/game_mode/revolution)
 	not_in_crates = 1
@@ -1098,7 +1115,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/generic/rev_dagger
 	name = "Sacrificial Dagger"
 	item = /obj/item/dagger
-	cost = 2
+	cost = 4
 	desc = "An ornamental dagger for stabbing people with."
 	exclusivemode = list(/datum/game_mode/revolution)
 	not_in_crates = 1
@@ -1106,7 +1123,7 @@ This is basically useless for anyone but miners.
 /datum/syndicate_buylist/generic/rev_normal_flash
 	name = "Flash"
 	item = /obj/item/device/flash
-	cost = 1
+	cost = 2
 	desc = "Just a standard-issue flash. Won't remove implants like the Revolutionary Flash."
 	exclusivemode = list(/datum/game_mode/revolution)
 	not_in_crates = 1

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1142,7 +1142,9 @@ THROWING DARTS
 	sneaky = 1
 	New()
 		var/obj/item/implant/microbomb/macrobomb/newbomb = new/obj/item/implant/microbomb/macrobomb( src )
-		newbomb.explosionPower = rand(22,32)
+		var/datum/syndicate_buylist/traitor/macrobomb/bomb_datum
+		for(var/i in 1 to bomb_datum.cost)
+			newbomb.explosionPower += (prob(90) ? 1 : 2)
 		src.imp = newbomb
 		..()
 		return
@@ -1153,7 +1155,7 @@ THROWING DARTS
 	sneaky = 1
 	New()
 		var/obj/item/implant/microbomb/newbomb = new/obj/item/implant/microbomb( src )
-		newbomb.explosionPower = prob(75) ? 2 : 3
+		newbomb.explosionPower = prob(90) ? 1 : 2
 		src.imp = newbomb
 		..()
 		return

--- a/code/obj/item/traitorcoins.dm
+++ b/code/obj/item/traitorcoins.dm
@@ -29,9 +29,7 @@
 			..(user)
 
 	update_stack_appearance()
-		if(material)
-			name = "[amount] [initial(src.name)][amount > 1 ? "s":""]"
-		return
+		name = "[amount ? "[amount] " : ""][syndicate_currency][amount > 1 ? "s":""]"
 
 /obj/item/explosive_uplink_telecrystal
 	name = "pure telecrystal"

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -17,7 +17,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	stamina_cost = 0
 	stamina_crit_chance = 0
 
-	var/uses = 12 // Amount of telecrystals.
+	var/uses = 25 // Amount of telecrystals.
 	var/list/datum/syndicate_buylist/items_general = list() // See setup().
 	var/list/datum/syndicate_buylist/items_job = list()
 	var/list/datum/syndicate_buylist/items_objective = list()

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -269,6 +269,9 @@
 			gibs(src.loc)
 			return
 
+#define SURPLUS_CRATE_TC_MIN 36
+#define SURPLUS_CRATE_TC_MAX 48
+
 /obj/storage/crate/syndicate_surplus
 	var/nest_amt = 0
 	var/static/list/possible_items = list()
@@ -298,9 +301,9 @@
 					possible_items += S
 
 		if (islist(possible_items) && length(possible_items))
-			while(telecrystals < 18)
+			while(telecrystals < 36)
 				var/datum/syndicate_buylist/item_datum = pick(possible_items)
-				if(telecrystals + item_datum.cost > 24) continue
+				if(telecrystals + item_datum.cost > 48) continue
 				var/obj/item/I = new item_datum.item(src)
 				I.Scale(NESTED_SCALING_FACTOR**nest_amt, NESTED_SCALING_FACTOR**nest_amt) //scale the contents if we're nested
 				if (owner)
@@ -309,6 +312,8 @@
 						owner.mind.traitor_crate_items += item_datum
 				telecrystals += item_datum.cost
 		#undef NESTED_SCALING_FACTOR
+#undef SURPLUS_CRATE_TC_MIN
+#undef SURPLUS_CRATE_TC_MAX
 
 /obj/storage/crate/pizza
 	name = "pizza box"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Balance] [Input Wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR increases the TC count for traitors to 25 from 12, but also scales the cost of all traitor items to be about equivalent to what they were before.

The only mechanical additions/features that have been added are:

- Microbombs now have an average of 1.1 explosion power (`prob(90) ? 1 : 2`), down from 2.25 (`prob(25) ? 3 : 2`), to account for them still sticking at 1 TC
- Macrobombs now roll the microbomb chance a number of times equal to its cost in TC (25), instead of using its own strange math
- You can now buy TC from uplinks in stacks of 5 as well
- Traitors do get the equivalent of 0.5 extra TC (12 -> 25 instead of 12 -> 24)

## Why's this needed?

This change may not do much immediately in this PR, but I fully intend to make a future PR regarding balance and cost of the items, but here's some reasons why this is a good change in the long term:

- Currently, items that cost the same can be hard to stand out. For instance, take the Agent Card (1 TC) and the Chameleon Jumpsuit (1 TC). The agent card is miles better and more worth the TC than the jumpsuit, but you can't make the jumpsuit picked more by making it cheaper, it's already as cheap as can be, and you can't increase the agent card's price _at all_ without knocking it from costing 1/12th your TC to 1/6th, which is a massive jump in terms of TC breakpoints.
- In a future PR, I plan to increase/decrease the price of some items, bringing their cost to what would properly reflect their effectiveness, something that in some cases is undoable with how underinflated our TC are.
- It may lead the way to future content that could potentially give traitors a small amount of extra TC, which giving even _1_ more to traitors currently would upend a lot of balance decisions.


## Why not rebalance the item's costs in this PR?
I'd like to get the go-ahead on the concept first before making actual balance changes, in addition to atomization concerns.

Edit: Here's a document I threw together, which increases/decreases the cost of certain items by 1, [here](https://docs.google.com/document/d/1a_fG0agz3gRAdSM2rxAi8kWzowdr6glghUNWUbnlv9g/edit?usp=sharing).
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(*)Traitors now get 25 TC, but their uplink item costs have been scaled to match this increase.
```
