### PR TITLE
Fixed pickpocket gun removing attached items

### DIFF
--- a/code/modules/projectiles/pickpocket.dm
+++ b/code/modules/projectiles/pickpocket.dm
@@ -50,6 +50,9 @@
 				if ("l_leg")
 					stolenItem = M.l_store ? M.l_store : M.r_store ? M.r_store : null
 			if (stolenItem) // Found a thing to steal, hurrah
+				if (stolenItem.cant_other_remove)
+					M.throw_at(linkedGun, 3, 0.5)
+					return
 				logTheThing("combat", linkedGun, null, " successfully steals \a [stolenItem]")
 				M.u_equip(stolenItem)
 				linkedGun.heldItem = stolenItem


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #7181 with @zjdtmkhzt's suggestion of making it pull the player instead. Also prevents the gun from removing cursed items such as cluwne masks, not sure if this was intentional.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previously it would steal the item that would then get stuck to the thief's hand. Bad.