### PR TITLE
Fixes a major issue with nukeop uplink point assignment

### DIFF
--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -971,12 +971,11 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	New()
 		..()
 		var/num_players
-		for(var/client/C)
-			var/mob/new_player/player = C.mob
-			if (!istype(player))
+		for(var/client/C in clients)
+			var/mob/client_mob = C.mob
+			if (!istype(client_mob))
 				continue
-			if (player.ready)
-				num_players++
+			num_players++
 		points = max(2, round(num_players / PLAYERS_PER_UPLINK_POINT))
 		SPAWN_DBG(1 SECOND)
 			if (src && istype(src) && (!length(src.commander_buylist)))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug - major]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I fucked up the uplink code a bit when making it, turns out literally no more than the base 2 points can be assigned, I atomized this out of #7225 so it can be merged ASAP


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs are bad
