### PR TITLE
Geneboth spamming message fix

### DIFF
--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -349,7 +349,6 @@
 	icon = 'icons/ui/context32x32.dmi'
 	var/datum/geneboothproduct/GBP = null
 	var/obj/machinery/genetics_booth/GB = null
-	var/spamt = 0
 
 	disposing()
 		GBP = null
@@ -363,14 +362,9 @@
 
 	checkRequirements(atom/target, mob/user)
 		. = FALSE
-		if (get_dist(target,user) <= 1 && isliving(user))
+		if ((get_dist(target,user) <= 1 && isliving(user)) && !GB?.occupant)
 			. = GBP && GB
-			if (GB?.occupant && world.time > spamt + 5)
-				user.show_text("[target] is currently occupied. Wait until it's done.", "blue")
-				spamt = world.time
-				. = FALSE
-			if(.)
-				GB.show_admin_panel(user)
+			GB.show_admin_panel(user)
 
 	buildBackgroundIcon(atom/target, mob/user)
 		var/image/background = image('icons/ui/context32x32.dmi', src, "[getBackground(target, user)]0")

--- a/code/modules/medical/genetics/geneticsBooth.dm
+++ b/code/modules/medical/genetics/geneticsBooth.dm
@@ -147,10 +147,6 @@
 					if (name_sel == P.name)
 						select_product(P)
 						break
-			if(occupant && occupant != user)
-				user.show_text("There's someone else inside!")
-				return
-
 		else
 			user.show_text("[src] has no products available for purchase right now.", "blue")
 


### PR DESCRIPTION
Removed message inside context_actions.dm, as it's also handled by geneticsBooth.dm itself.
Removed spamt, as it's been overwritten each call by 0, and thereby didn't work (constructor).
Removed unreachable code inside geneticsBooth.dm.

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It removes the message spamming, as described in the bug

fixes #6921 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
