### PR TITLE
Fix spawned nukie headsets

### DIFF
--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -322,9 +322,17 @@
 	chat_class = RADIOCL_SYNDICATE
 	secure_frequencies = list("z" = R_FREQ_SYNDICATE)
 	secure_classes = list(RADIOCL_SYNDICATE)
-	protected_radio = 1
+	protected_radio = 1 // Ops can spawn with the deaf trait.
 	icon_override = "syndie"
 	icon_tooltip = "Syndicate Operative"
+
+	New()
+		..()
+		var/the_frequency = R_FREQ_SYNDICATE
+		if (ticker?.mode && istype(ticker.mode, /datum/game_mode/nuclear))
+			var/datum/game_mode/nuclear/N = ticker.mode
+			the_frequency = N.agent_radiofreq
+		src.frequency = the_frequency // let's see if this stops rounds from being ruined every fucking time
 
 	leader
 		icon_override = "syndieboss"

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -328,11 +328,13 @@
 
 	New()
 		..()
-		var/the_frequency = R_FREQ_SYNDICATE
-		if (ticker?.mode && istype(ticker.mode, /datum/game_mode/nuclear))
-			var/datum/game_mode/nuclear/N = ticker.mode
-			the_frequency = N.agent_radiofreq
-		src.frequency = the_frequency // let's see if this stops rounds from being ruined every fucking time
+		SPAWN_DBG(1 SECOND)
+			var/the_frequency = R_FREQ_SYNDICATE
+			if (ticker?.mode && istype(ticker.mode, /datum/game_mode/nuclear))
+				var/datum/game_mode/nuclear/N = ticker.mode
+				the_frequency = N.agent_radiofreq
+			src.frequency = the_frequency // let's see if this stops rounds from being ruined every fucking time
+			message_admins("setting headset to [the_frequency]")
 
 	leader
 		icon_override = "syndieboss"

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -334,7 +334,6 @@
 				var/datum/game_mode/nuclear/N = ticker.mode
 				the_frequency = N.agent_radiofreq
 			src.frequency = the_frequency // let's see if this stops rounds from being ruined every fucking time
-			message_admins("setting headset to [the_frequency]")
 
 	leader
 		icon_override = "syndieboss"

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -298,20 +298,6 @@
 	synd_mob.implant.Add(M)
 	M.implanted(synd_mob)
 
-	var/the_frequency = R_FREQ_SYNDICATE
-	if (ticker?.mode && istype(ticker.mode, /datum/game_mode/nuclear))
-		var/datum/game_mode/nuclear/N = ticker.mode
-		the_frequency = N.agent_radiofreq
-
-	for (var/obj/item/device/radio/headset/R in synd_mob.contents)
-		R.set_secure_frequency("h", the_frequency)
-
-		R.secure_classes = list(RADIOCL_SYNDICATE)
-		R.protected_radio = 1 // Ops can spawn with the deaf trait.
-		R.frequency = the_frequency // let's see if this stops rounds from being ruined every fucking time
-
-	return
-
 /// returns a decimal representing the percentage of alive crew that are also antags
 /proc/get_alive_antags_percentage()
 	var/alive = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Syndicate headsets not created through antagonist procs start with the general channel.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nukie bards and military headset purchases start talking on general and reveal the game mode.