### PR TITLE
Toggle view range verb now works with widescreen

### DIFF
--- a/code/modules/admin/toggles.dm
+++ b/code/modules/admin/toggles.dm
@@ -414,7 +414,7 @@ client/proc/toggle_ghost_respawns()
 	set name = "Toggle View Range"
 	set desc = "switches between 1x and custom views"
 
-	if(src.view == world.view)
+	if(src.view == world.view || src.view == "21x15")
 		var/x = input("Enter view width in tiles: (1 - 59, default 15 (normal) / 21 (widescreen))", "Width", 21)
 		var/y = input("Enter view height in tiles: (1 - 30, default 15)", "Height", 15)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[TRIVIAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a check to accept widescreen as a pre-toggle value for Toggle View Range verb. Tested ingame and it works. There is no global widescreen view value so I put the value in manually.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Toggle view range actually working.
