### PR TITLE
Fix scanners breaking dwarfism gene

### DIFF
--- a/code/modules/medical/genetics/bioEffects/useless.dm
+++ b/code/modules/medical/genetics/bioEffects/useless.dm
@@ -252,6 +252,8 @@
 		owner.vis_contents += src.distort
 		src.filter = owner.get_filter("dwarfism")
 		animate(src.filter, size=src.size, time=0.7 SECONDS, easing=SINE_EASING, flags=ANIMATION_PARALLEL)
+		owner.remove_filter("dwarfism")
+		owner.add_filter("dwarfism", 1, displacement_map_filter(size=src.size, render_source = src.distort.render_target))
 
 	OnRemove()
 		owner.remove_filter("dwarfism")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Instead of trying to dig into/fight BYOND's `animate`, this hack(-ish) instantly replaces the dwarfism filter with a pre-scaled filter 
at the same size the animation finishes at. Removing the gene still works without further changes because the filter is named the same.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The previous method of applying dwarfism relied on the animation staying in place to keep the player scaled. Since health/gene/forensic/etc scanners also use animations, the resulting conflict caused the dwarfism to "break", since the animation restored the default sprite.

Fixes #7215 
Fixes #6770 
(probably) Fixes #6574 
(probably) Fixes #5517

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(+)Fixed scanners breaking the dwarfism gene effect
```
