### PR TITLE
Specialist ammobag fix

### DIFF
--- a/code/obj/item/nuclear_operative/ammo_bag.dm
+++ b/code/obj/item/nuclear_operative/ammo_bag.dm
@@ -91,10 +91,13 @@
 				var/list/ammo_list = W.ammobag_magazines.Copy(2, 0)
 				ammo = pick(ammo_list)
 				ammo_cost = W.ammobag_restock_cost
-			else if(length(W.ammobag_magazines == 1))
+			else if(length(W.ammobag_magazines) == 1)
+				ammo = W.ammobag_magazines[1]
 				if(!W.ammobag_spec_required)
-					ammo = W.ammobag_magazines[1]
 					ammo_cost = W.ammobag_restock_cost - 1
+				else
+					ammo_cost = W.ammobag_restock_cost
+
 		else
 			ammo = W.ammobag_magazines[1]
 			ammo_cost = W.ammobag_restock_cost


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Turns out specialist ammo bags runtimed when they tried to make ammo for a gun that only had one magazine type.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs are bad


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Syndicate Specialist ammobags now work with all nukeop guns again.
```
