### PR TITLE
Bulk cloud data saving + Cloud Simulation Refactor

### DIFF
--- a/code/player.dm
+++ b/code/player.dm
@@ -163,11 +163,11 @@
 	 * example input (formatted for readability)
 	 * 	{
 	 * 		"some_ckey":{
-	 * 			"persisten_bank":42069,
+	 * 			"persistent_bank":42069,
 	 * 			"peristent_bank_item":"none"
 	 * 		},
 	 * 		"some_other_ckey":{
-	 * 			"persisten_bank":1337,
+	 * 			"persistent_bank":1337,
 	 * 			"peristent_bank_item":"rubber_ducky"
 	 * 		}
 	 * 	}

--- a/code/player.dm
+++ b/code/player.dm
@@ -164,11 +164,11 @@
 	 * 	{
 	 * 		"some_ckey":{
 	 * 			"persistent_bank":42069,
-	 * 			"peristent_bank_item":"none"
+	 * 			"persistent_bank_item":"none"
 	 * 		},
 	 * 		"some_other_ckey":{
 	 * 			"persistent_bank":1337,
-	 * 			"peristent_bank_item":"rubber_ducky"
+	 * 			"persistent_bank_item":"rubber_ducky"
 	 * 		}
 	 * 	}
 	**/


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Requires API changes (submitted directly to Wire) to work
* Refactors simulated cloud to not use save files, and instead just write to jsons
* Adds a new proc `cloud_put_bulk()` for bulk cloud data saving
* Data is passed to the proc in json format, and can contain multiple ckeys and/or keys
* json data is validated via rust-g prior to processing
* json data is sanitized by dm, ensuring ckey indexes are of valid format, and that they have keypairs to save
* example of a json object (formatted for readability) that you may pass

```json
{
	"some_ckey":{
		"persistent_bank":42069,
		"persistent_bank_item":"none"
	},
	"some_other_ckey":{
		"persistent_bank":1337,
		"persistent_bank_item":"rubber_ducky"
	}
}
```


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Instead of calling the API 100+ times to save player data we can just call it once
