### PR TITLE
Make regular channel prefixes usable for AIs, fix eyebot radio

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -793,12 +793,10 @@
 								secure_headset_mode = lowertext(copytext(message,3,end)) //why did i do this to the players
 							message = copytext(message, end)
 						else // Chances are they're using a regular radio prefix instead of a 2 letter one
-							if (lowertext(copytext(message,3,4) == " ")) // (This makes the :3 prefixes obsolete but fuck em they mess players up)
+							if (!lowertext(copytext(message,2,3) == " ")) // (This makes the :3 prefixes obsolete but fuck em they mess players up)
 								message_mode = "monitor"
 								secure_headset_mode = lowertext(copytext(message,2,3))
-								message = copytext(message, 4)
-							else
-								message = copytext(message, 3)
+							message = copytext(message, 3)
 
 				else
 					if (ishuman(src) || ismobcritter(src) || isrobot(src) || isshell(src)) // this is shit

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -792,12 +792,16 @@
 								end = 4
 								secure_headset_mode = lowertext(copytext(message,3,end)) //why did i do this to the players
 							message = copytext(message, end)
-
-						else
-							message = copytext(message, 3)
+						else // Chances are they're using a regular radio prefix instead of a 2 letter one
+							if (lowertext(copytext(message,3,4) == " ")) // (This makes the :3 prefixes obsolete but fuck em they mess players up)
+								message_mode = "monitor"
+								secure_headset_mode = lowertext(copytext(message,2,3))
+								message = copytext(message, 4)
+							else
+								message = copytext(message, 3)
 
 				else
-					if (ishuman(src) || ismobcritter(src) || isrobot(src)) // this is shit
+					if (ishuman(src) || ismobcritter(src) || isrobot(src) || isshell(src)) // this is shit
 						message_mode = "secure headset"
 						secure_headset_mode = lowertext(copytext(message,2,3))
 					message = copytext(message, 3)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR redirects AIs' messages with a colon prefix to their secure channel radios, so they don't need to add the 3 in there (but doing that still works)

Also fixes eyebots being unable to use their radio's channels

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The :3 prefix thing is one of the least intuitive things AIs have to deal with causing mistakes fairly commonly, and it's not like people otherwise start messages with colons anyway

closes #7253

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(*)AIs can also use normal radio prefixes now (though the :3 prefixes still work too)
```
