### PR TITLE
Replaces "recall to mainframe" AI shell HUD button with "eject to eyecam"

### DIFF
--- a/code/datums/hud/robot.dm
+++ b/code/datums/hud/robot.dm
@@ -264,7 +264,7 @@
 		pda = create_screen("pda", "Cyborg PDA", 'icons/mob/hud_ai.dmi', "pda", "WEST, NORTH+0.5", HUD_LAYER)
 		pda.underlays += "button"
 
-		eyecam = create_screen("eyecam", "Deploy to eyecam", 'icons/mob/screen1.dmi', "x", "SOUTH,EAST", HUD_LAYER)
+		eyecam = create_screen("eyecam", "Eject to eyecam", 'icons/mob/screen1.dmi', "x", "SOUTH,EAST", HUD_LAYER)
 		eyecam.underlays += "block"
 
 

--- a/code/datums/hud/robot.dm
+++ b/code/datums/hud/robot.dm
@@ -27,7 +27,7 @@
 		temp
 
 		pda
-		mainframe
+		eyecam
 
 	var/list/screen_tools = list()
 
@@ -264,8 +264,8 @@
 		pda = create_screen("pda", "Cyborg PDA", 'icons/mob/hud_ai.dmi', "pda", "WEST, NORTH+0.5", HUD_LAYER)
 		pda.underlays += "button"
 
-		mainframe = create_screen("mainframe", "Return to Mainframe", 'icons/mob/screen1.dmi', "x", "SOUTH,EAST", HUD_LAYER)
-		mainframe.underlays += "block"
+		eyecam = create_screen("eyecam", "Deploy to eyecam", 'icons/mob/screen1.dmi', "x", "SOUTH,EAST", HUD_LAYER)
+		eyecam.underlays += "block"
 
 
 	scrolled(id, dx, dy, user, parms, atom/movable/screen/hud/scr)
@@ -395,8 +395,8 @@
 				last_health = -1
 			if ("pda")
 				master.access_internal_pda()
-			if ("mainframe")
-				master.return_mainframe()
+			if ("eyecam")
+				master.become_eye()
 
 	proc/update_status_effects()
 		for(var/atom/movable/screen/statusEffect/G in src.objects)
@@ -565,8 +565,8 @@
 
 			// I put this here because there's nowhere else for it right now.
 			// @TODO robot hud needs a general update() call imo.
-			if (src.mainframe)
-				mainframe.invisibility = (master.mainframe ? INVIS_NONE : INVIS_ALWAYS)
+			if (src.eyecam)
+				eyecam.invisibility = (master.mainframe ? INVIS_NONE : INVIS_ALWAYS)
 
 
 		update_pulling()

--- a/code/datums/hud/shell.dm
+++ b/code/datums/hud/shell.dm
@@ -30,7 +30,7 @@
 		create_screen("store", "Store", 'icons/mob/hud_robot.dmi', "store", "CENTER+1:16, SOUTH", HUD_LAYER+1)
 		create_screen("tools", "Tools", 'icons/mob/hud_robot.dmi', "tools", "CENTER+2:16, SOUTH", HUD_LAYER+1)
 
-		eyecam = create_screen("eyecam", "Deploy to eyecam", 'icons/mob/screen1.dmi', "x", "SOUTH,EAST", HUD_LAYER)
+		eyecam = create_screen("eyecam", "Eject to eyecam", 'icons/mob/screen1.dmi', "x", "SOUTH,EAST", HUD_LAYER)
 		eyecam.underlays += "block"
 
 		update_active_tool()

--- a/code/datums/hud/shell.dm
+++ b/code/datums/hud/shell.dm
@@ -4,6 +4,7 @@
 		tool2
 		tool3
 		charge
+		eyecam
 
 	var/list/last_tools = list()
 	var/list/atom/movable/screen/hud/tool_selector_bg = list()
@@ -29,6 +30,9 @@
 		create_screen("store", "Store", 'icons/mob/hud_robot.dmi', "store", "CENTER+1:16, SOUTH", HUD_LAYER+1)
 		create_screen("tools", "Tools", 'icons/mob/hud_robot.dmi', "tools", "CENTER+2:16, SOUTH", HUD_LAYER+1)
 
+		eyecam = create_screen("eyecam", "Deploy to eyecam", 'icons/mob/screen1.dmi', "x", "SOUTH,EAST", HUD_LAYER)
+		eyecam.underlays += "block"
+
 		update_active_tool()
 		update_tools()
 		update_tool_selector()
@@ -52,6 +56,8 @@
 				master.uneq_active()
 			if ("tools")
 				set_show_tool_selector(!show_tool_selector)
+			if ("eyecam")
+				master.become_eye()
 
 	proc
 		update_charge()

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -57,6 +57,20 @@
 /mob/living/silicon/proc/show_laws()
 	return
 
+/mob/living/silicon/proc/return_mainframe()
+	if (mainframe)
+		mainframe.return_to(src)
+	else
+		boutput(src, "<span class='alert'>You lack a dedicated mainframe!</span>")
+		return
+
+/mob/living/silicon/proc/become_eye()
+	if (!mainframe)
+		return
+	src.return_mainframe()
+	mainframe.eye_view()
+	mainframe.eyecam.set_loc(src)
+
 // Moves this down from ai.dm so AI shells and AI-controlled cyborgs can use it too.
 // Also made it a little more functional and less buggy (Convair880).
 #define SORT "* Sort alphabetically..."

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -730,6 +730,13 @@ Frequency:
 		boutput(src, "<span class='alert'>You lack a dedicated mainframe!</span>")
 		return
 
+/mob/living/silicon/hivebot/proc/become_eye()
+	if (!mainframe)
+		return
+	return_mainframe()
+	mainframe.eye_view()
+	mainframe.eyecam.set_loc(src)
+
 /mob/living/silicon/hivebot
 	clamp_values()
 		..()

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -722,20 +722,9 @@ Frequency:
 	set name = "Recall to Mainframe"
 	return_mainframe()
 
-/mob/living/silicon/hivebot/proc/return_mainframe()
-	if(mainframe)
-		mainframe.return_to(src)
-		src.UpdateIcon()
-	else
-		boutput(src, "<span class='alert'>You lack a dedicated mainframe!</span>")
-		return
-
-/mob/living/silicon/hivebot/proc/become_eye()
-	if (!mainframe)
-		return
-	return_mainframe()
-	mainframe.eye_view()
-	mainframe.eyecam.set_loc(src)
+/mob/living/silicon/hivebot/return_mainframe()
+	..()
+	src.UpdateIcon()
 
 /mob/living/silicon/hivebot
 	clamp_values()

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2978,20 +2978,9 @@
 	set name = "Recall to Mainframe"
 	return_mainframe()
 
-/mob/living/silicon/robot/proc/return_mainframe()
-	if (mainframe)
-		mainframe.return_to(src)
-		src.update_appearance()
-	else
-		boutput(src, "<span class='alert'>You lack a dedicated mainframe!</span>")
-		return
-
-/mob/living/silicon/robot/proc/become_eye()
-	if (!mainframe)
-		return
-	return_mainframe()
-	mainframe.eye_view()
-	mainframe.eyecam.set_loc(src)
+/mob/living/silicon/robot/return_mainframe()
+	..()
+	src.update_appearance()
 
 /mob/living/silicon/robot/ghostize()
 	if (src.mainframe)

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2986,6 +2986,13 @@
 		boutput(src, "<span class='alert'>You lack a dedicated mainframe!</span>")
 		return
 
+/mob/living/silicon/robot/proc/become_eye()
+	if (!mainframe)
+		return
+	return_mainframe()
+	mainframe.eye_view()
+	mainframe.eyecam.set_loc(src)
+
 /mob/living/silicon/robot/ghostize()
 	if (src.mainframe)
 		src.mainframe.return_to(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the red X button on the AI shell HUD eject you to eyecam (free move) view centered on the shell. Also adds this button to the little eyebot shell's HUD. The recall to mainframe verb still works as normal.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You often want to leave a shell to look at something nearby, just behind a wall etc. Previously you'd have to recall to mainframe, eject to eyecam with the half second of jank that that always entails and then fly/jump back to where your shell is. The recall to mainframe HUD button was somewhat redundant anyway, so now it has a purpose beyond misclicking on it when you meant to stop-pull.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Added a button to AI shells to eject in place, no more scrolling across half the map to find your shell again.
```
