### PR TITLE
Adds a new admin verb to allow for player caps

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -505,6 +505,7 @@ var/global
 	)
 
 	hardRebootFilePath = "data/hard-reboot"
+	living_pop_cap = 0
 
 /proc/addGlobalRenderSource(var/image/I, var/key)
 	if(I && length(key) && !globalRenderSources[key])

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -232,6 +232,21 @@ mob/new_player
 				boutput(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
 				return
 
+			if(living_pop_cap)
+				var/living_people = 0
+				for(var/client/C in clients)
+					LAGCHECK(LAG_LOW)
+					if(!C.mob)
+						continue
+					if(!istype(C.mob, /mob/living))
+						continue
+					living_people++
+					if(living_people >= living_pop_cap)
+						break
+				if(living_people >= living_pop_cap)
+					boutput(usr, "<span class='notice'>There are more people currently alive than is allowed. You may try again later or observe.</span>")
+					return
+
 			if (ticker?.mode)
 				var/mob/living/silicon/S = locate(href_list["SelectedJob"]) in mobs
 				if (S)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -187,7 +187,8 @@ var/list/admin_verbs = list(
 		/client/proc/cmd_lightsout,
 
 		/client/proc/vpn_whitelist_add,
-		/client/proc/vpn_whitelist_remove
+		/client/proc/vpn_whitelist_remove,
+		/client/proc/set_living_pop_cap
 		),
 
 	4 = list(

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -2803,3 +2803,19 @@ var/global/mirrored_physical_zone_created = FALSE //enables secondary code branc
 		logTheThing("admin", usr, AM, "has shipped [AM] to cargo.")
 		logTheThing("diary", usr, AM, "has shipped [AM] to cargo.", "admin")
 		message_admins("[key_name(usr)] has shipped [AM] to cargo.")
+
+/client/proc/set_living_pop_cap()
+	SET_ADMIN_CAT(ADMIN_CAT_SERVER)
+	set desc = "Set the amount of living people allowed at once. Does not affect observers. Only applies to latejoiners."
+	set name = "Set Living Pop Cap"
+	admin_only
+	var/how_much = text2num(input(src, "What do you want the living population cap to be? (Set to 0 for no limit)"))
+
+	if(!isnum(how_much) || (how_much < 0))
+		boutput(src, "That number is invalid.")
+		return
+
+	living_pop_cap = how_much
+	logTheThing("admin", usr, null, "set the living population cap to [how_much == 0 ? "have no pop limit" : how_much].")
+	logTheThing("diary", usr, null, "set the living population cap to [how_much == 0 ? "have no pop limit" : how_much].", "admin")
+	message_admins("[key_name(usr)] set the living population cap to [how_much == 0 ? "have no pop limit" : how_much].")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a new admin verb, "set living player cap", which allows admins to set the maximum amount of people that can be in a round (playing, not in lobby or observing) at once. If there are more people than the set number, nobody new can latejoin until the amount of living people with clients goes below the threshold. Does not affect roundstart, only latejoining.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Population control during events while still allowing observers without config fuckery
