### PR TITLE
Make enzymatic reclaimer delete cloner record implant

### DIFF
--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -1183,9 +1183,12 @@
 				for (var/obj/item/implant/I in target.implant)
 					if (istype(I,/obj/item/implant/projectile))
 						continue
-					var/obj/item/implantcase/newcase = new /obj/item/implantcase(target.loc, usedimplant = I)
 					I.on_remove(target)
 					target.implant.Remove(I)
+					if (istype(I,/obj/item/implant/cloner))
+						qdel(I)
+						continue
+					var/obj/item/implantcase/newcase = new /obj/item/implantcase(target.loc, usedimplant = I)
 					var/image/wadblood = image('icons/obj/surgery.dmi', icon_state = "implantpaper-blood")
 					wadblood.color = target.blood_color
 					newcase.UpdateOverlays(wadblood, "blood")


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just makes it so that the enzymatic reclaimer deletes any cloner record implants in someone when they are grinded.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Just a very minor thing, but if someone's cloning record implant is removed, their health list is given as 0, 0, 0, 0. This means that if there are several people queued up for clone scanning, and their bodies have been grinded, they will be reported misleadingly as having no damage taken. This PR would make it so that it says "No implant detected" instead once grinded (still 0, 0, 0, 0 if cut out of body).

It also makes a bit of sense in that you are given an implant when clone scanned, and it is consumed when you are put into the reclaimer. I'm not sure if there is much antagonist use for a clone scan implant left on the ground too.