### PR TITLE
Fix overlays disappearing during Radiation Blowout event

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -3721,9 +3721,9 @@ ABSTRACT_TYPE(/area/mining)
   * Updates the icon of the area. Mainly used for flashing it red or blue. See: old party lights
   */
 /area/update_icon()
-	if(irradiated) //Don't update the icon whilst we have a radation blowout overlay
-		return
-	if ((fire || eject) && power_environ)
+	if(irradiated) //From a radiation blowout event
+		icon_state = "blowout"
+	else if ((fire || eject) && power_environ)
 		if(fire && !eject)
 			icon_state = null
 		else if(!fire && eject)

--- a/code/area.dm
+++ b/code/area.dm
@@ -3721,6 +3721,8 @@ ABSTRACT_TYPE(/area/mining)
   * Updates the icon of the area. Mainly used for flashing it red or blue. See: old party lights
   */
 /area/update_icon()
+	if(irradiated) //Don't update the icon whilst we have a radation blowout overlay
+		return
 	if ((fire || eject) && power_environ)
 		if(fire && !eject)
 			icon_state = null

--- a/code/modules/events/blowout.dm
+++ b/code/modules/events/blowout.dm
@@ -40,7 +40,7 @@
 				else
 					if (!A.irradiated)
 						A.irradiated = TRUE
-						A.icon_state = "blowout"
+						A.UpdateIcon()
 					for (var/turf/T in A)
 						if (rand(0,1000) < 5 && istype(T,/turf/simulated/floor))
 							Artifact_Spawn(T)
@@ -86,7 +86,7 @@
 					continue
 				if (!A.permarads)
 					A.irradiated = FALSE
-				A.icon_state = null
+				A.UpdateIcon()
 			blowout = FALSE
 
 			command_alert("All radiation alerts onboard [station_name(1)] have been cleared. You may now leave the tunnels freely. Maintenance doors will regain their normal access requirements shortly.", "All Clear")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug where the overlays (but not the deadly radiation) during a Radiation Blowout event could be cleared prematurely, resulting in player confusion and occasional death.

I believe the issue was primarily caused by area/update_icon() nulling the area icon_state during a fire alarm, area power change or light switch toggle. The PR makes the blowout event use the update_icon() proc instead of updating the icon separately.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I believe this can close (except where they should have already been closed with a merged map fix):
Fixes #7110
Fixes #6615
Fixes #5669
Fixes #4946
Fixes #4125

I also believe it closes the following:
Fixes #5912 - Per my comment on the issue I think this was a case of this bug ​misattributed to a different bug, or already fixed.
