### PR TITLE
Infinite lighters fuel bug

### DIFF
--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -1119,8 +1119,9 @@
 
 	New()
 		..()
-		src.create_reagents(20)
-		reagents.add_reagent("fuel", 20)
+		if (!infinite_fuel)
+			src.create_reagents(20)
+			reagents.add_reagent("fuel", 20)
 
 		src.setItemSpecial(/datum/item_special/flame)
 		return
@@ -1128,9 +1129,9 @@
 	attack_self(mob/user)
 		if (user.find_in_hand(src))
 			if (!src.on)
-				if (!reagents)
+				if (!reagents && !infinite_fuel)
 					return
-				if (!reagents.get_reagent_amount("fuel"))
+				if (!reagents.get_reagent_amount("fuel") && !infinite_fuel)
 					user.show_text("Out of fuel.", "red")
 					return
 				src.activate(user)

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -1237,14 +1237,6 @@
 
 	process()
 		if (src.on)
-			if (!reagents)
-				if (ismob(src.loc))
-					src.deactivate(src.loc)
-				else
-					src.deactivate(null)
-				return
-			if (!infinite_fuel && reagents.get_reagent_amount("fuel"))
-				reagents.remove_reagent("fuel", 0.2)
 			var/turf/location = src.loc
 			if (ismob(location))
 				var/mob/M = location
@@ -1253,12 +1245,22 @@
 			var/turf/T = get_turf(src.loc)
 			if (T)
 				T.hotspot_expose(700,5)
-			if (!reagents.get_reagent_amount("fuel"))
+
+			if (infinite_fuel) //skip all fuel checks
+				return
+			if (!reagents)
 				if (ismob(src.loc))
 					src.deactivate(src.loc)
 				else
 					src.deactivate(null)
 				return
+			if (reagents.get_reagent_amount("fuel"))
+				reagents.remove_reagent("fuel", 0.2)
+			if (!reagents.get_reagent_amount("fuel"))
+				if (ismob(src.loc))
+					src.deactivate(src.loc)
+				else
+					src.deactivate(null)
 			//sleep(1 SECOND)
 
 	temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -1129,9 +1129,11 @@
 	attack_self(mob/user)
 		if (user.find_in_hand(src))
 			if (!src.on)
-				if (!reagents && !infinite_fuel)
+				if (infinite_fuel)
+					src.activate(user)
+				if (!reagents)
 					return
-				if (!reagents.get_reagent_amount("fuel") && !infinite_fuel)
+				if (!reagents.get_reagent_amount("fuel"))
 					user.show_text("Out of fuel.", "red")
 					return
 				src.activate(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
Fixes #7239
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes fuel from infinite lighters so they can't explode, lose all their fuel and refuse to accept more.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Infinite should mean infinite.
