### PR TITLE
Slightly changes the syndicate guitar's description

### DIFF
--- a/code/obj/item/device/studio_monitor.dm
+++ b/code/obj/item/device/studio_monitor.dm
@@ -70,7 +70,7 @@
 
 /obj/item/breaching_hammer/rock_sledge
 	name = "Orpheus electric guitar"
-	desc = "A bolt-on neck flying V electric guitar, finished in blood red. Manufactured by Bonk-Tek."
+	desc = "A bolt-on neck flying V electric guitar, finished in blood red. Manufactured by Funk-Tek."
 	icon = 'icons/obj/large/64x32.dmi'
 	icon_state = "guitar"
 	item_state = "guitar"


### PR DESCRIPTION

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the description of the syndicate guitar to mention Funk-Tek instead of Bonk-Tek

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Funk-Tek is the guys that make music related stuff not the entirety of the Bonk-Tek Consortium
