### PR TITLE
Fix players dying in the blob tutorial

### DIFF
--- a/code/modules/tutorials/blob_tutorial.dm
+++ b/code/modules/tutorials/blob_tutorial.dm
@@ -415,6 +415,7 @@ var/global/list/blob_tutorial_areas = list(/area/blob/tutorial_zone_1, /area/blo
 		name = "Click moving"
 		instructions = "Moving around with arrow keys or WASD is vastly inefficient when you need to cover large distances at once. You can also move around by right-clicking a tile, however. Right-click the marked tile to move there and proceed."
 		var/turf/target
+		var/list/allowed_to_rclick = list()
 		finished = 0
 
 		SetUp()
@@ -425,9 +426,14 @@ var/global/list/blob_tutorial_areas = list(/area/blob/tutorial_zone_1, /area/blo
 			var/tz = MT.initial_turf.z
 			target = locate(tx + 3, ty + 3, tz)
 			target.UpdateOverlays(marker,"marker")
+			for (var/turf/T in MT.tutorial_area)
+				if(T.name == "steel floor")
+					allowed_to_rclick += T
 
 		PerformAction(var/action, var/context)
-			if (action == "clickmove" && context == target)
+			if (!(context in allowed_to_rclick)) //Stop the player from suicide by cordon
+				return 0
+			else if (action == "clickmove" && context == target)
 				finished = 1
 				return 1
 			return 1 // bad but prevents chat spam which leads to crashes

--- a/code/obj/critter/big_animals.dm
+++ b/code/obj/critter/big_animals.dm
@@ -204,29 +204,13 @@ obj/critter/bear/care
 				targetLimb.delete()
 				return
 
-		//Old instakill code. Happens when there are no more limbs to chew.
+		//Instakill code. Happens when there are no more limbs to chew.
 		//I want to rework this so the yeti keeps the heads as a trophy and he drops them once dead
 		src.attacking = 1
 		src.visible_message("<span class='combat'><B>[src]</B> devours the rest of [M] in one bite!</span>")
 		logTheThing("combat", M, null, "was devoured by [src] at [log_loc(src)].") // Some logging for instakill critters would be nice (Convair880).
 		playsound(src.loc, "sound/items/eatfood.ogg", 30, 1, -2)
-		M.death(1)
-		var/atom/movable/overlay/animation = null
-		M.transforming = 1
-		M.canmove = 0
-		M.icon = null
-		APPLY_MOB_PROPERTY(M, PROP_INVISIBILITY, "transform", INVIS_ALWAYS)
-		if(ishuman(M))
-			animation = new(src.loc)
-			animation.icon_state = "blank"
-			animation.icon = 'icons/mob/mob.dmi'
-			animation.master = src
-		if (M.client)
-			var/mob/dead/observer/newmob
-			newmob = new/mob/dead/observer(M)
-			M.client.mob = newmob
-			M.mind.transfer_to(newmob)
-		qdel(M)
+		M.remove()
 		src.task = "thinking"
 		src.seek_target()
 		src.attacking = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
During the learning to move by right-clicking phase of the blob tutorial, players are currently able to:
- Kill themselves by clicking the cordon or the wall (then walking into the cordon);
or
- Jump to adjacent blob tutorial areas.

Dying in the tutorial bypasses the grace period 2nd respawn and immediately ends your antagonist round. This is unfortunate for players rolling a reasonably rare antagonist for the first time.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #6511.
