### PR TITLE
Fixes players dying in the blob tutorial

### DIFF
--- a/code/modules/tutorials/blob_tutorial.dm
+++ b/code/modules/tutorials/blob_tutorial.dm
@@ -415,7 +415,6 @@ var/global/list/blob_tutorial_areas = list(/area/blob/tutorial_zone_1, /area/blo
 		name = "Click moving"
 		instructions = "Moving around with arrow keys or WASD is vastly inefficient when you need to cover large distances at once. You can also move around by right-clicking a tile, however. Right-click the marked tile to move there and proceed."
 		var/turf/target
-		var/list/allowed_to_rclick = list()
 		finished = 0
 
 		SetUp()
@@ -426,12 +425,10 @@ var/global/list/blob_tutorial_areas = list(/area/blob/tutorial_zone_1, /area/blo
 			var/tz = MT.initial_turf.z
 			target = locate(tx + 3, ty + 3, tz)
 			target.UpdateOverlays(marker,"marker")
-			for (var/turf/T in MT.tutorial_area)
-				if(T.name == "steel floor")
-					allowed_to_rclick += T
 
 		PerformAction(var/action, var/context)
-			if (!(context in allowed_to_rclick)) //Stop the player from suicide by cordon
+			var/datum/tutorial_base/blob/MT = tutorial
+			if (!(context in MT.tutorial_area) || !istype(context, /turf/simulated/floor)) //Stop the player from suicide by cordon
 				return 0
 			else if (action == "clickmove" && context == target)
 				finished = 1

--- a/code/modules/tutorials/blob_tutorial.dm
+++ b/code/modules/tutorials/blob_tutorial.dm
@@ -415,6 +415,7 @@ var/global/list/blob_tutorial_areas = list(/area/blob/tutorial_zone_1, /area/blo
 		name = "Click moving"
 		instructions = "Moving around with arrow keys or WASD is vastly inefficient when you need to cover large distances at once. You can also move around by right-clicking a tile, however. Right-click the marked tile to move there and proceed."
 		var/turf/target
+		var/list/allowed_to_rclick = list()
 		finished = 0
 
 		SetUp()
@@ -425,9 +426,14 @@ var/global/list/blob_tutorial_areas = list(/area/blob/tutorial_zone_1, /area/blo
 			var/tz = MT.initial_turf.z
 			target = locate(tx + 3, ty + 3, tz)
 			target.UpdateOverlays(marker,"marker")
+			for (var/turf/T in MT.tutorial_area)
+				if(T.name == "steel floor")
+					allowed_to_rclick += T
 
 		PerformAction(var/action, var/context)
-			if (action == "clickmove" && context == target)
+			if (!(context in allowed_to_rclick)) //Stop the player from suicide by cordon
+				return 0
+			else if (action == "clickmove" && context == target)
 				finished = 1
 				return 1
 			return 1 // bad but prevents chat spam which leads to crashes


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
During the learning to move by right-clicking phase of the blob tutorial, players are currently able to:
- Kill themselves by clicking the cordon or the wall (then walking into the cordon);
or
- Jump to adjacent blob tutorial areas.

Dying in the tutorial bypasses the grace period 2nd respawn and immediately ends your antagonist round. This is unfortunate for players rolling a reasonably rare antagonist for the first time.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #6511.