### PR TITLE
Add complex signals

### DIFF
--- a/_std/defines/component_defines.dm
+++ b/_std/defines/component_defines.dm
@@ -101,6 +101,8 @@
 #define COMSIG_MOVABLE_RECEIVE_PACKET "mov_receive_packet"
 /// send this signal to send a radio packet (datum/signal/signal, receive_param / range, frequency), if frequency is null all registered frequencies are used
 #define COMSIG_MOVABLE_POST_RADIO_PACKET "mov_post_radio_packet"
+/// when the outermost movable in the .loc chain changes (thing, old_outermost_movable, new_outermost_movable)
+#define COMSIG_OUTERMOST_MOVABLE_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_outermost_changed")
 
 // ---- item signals ----
 

--- a/_std/defines/component_defines.dm
+++ b/_std/defines/component_defines.dm
@@ -102,9 +102,9 @@
 /// send this signal to send a radio packet (datum/signal/signal, receive_param / range, frequency), if frequency is null all registered frequencies are used
 #define COMSIG_MOVABLE_POST_RADIO_PACKET "mov_post_radio_packet"
 /// when the outermost movable in the .loc chain changes (thing, old_outermost_movable, new_outermost_movable)
-#define COMSIG_OUTERMOST_MOVABLE_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_outermost_changed")
+#define XSIG_OUTERMOST_MOVABLE_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_outermost_changed")
 /// when the z-level of a movable changes (works in nested contents) (thing, old_z_level, new_z_level)
-#define COMSIG_MOVABLE_Z_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_z-level_changed")
+#define XSIG_MOVABLE_Z_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_z-level_changed")
 
 // ---- item signals ----
 

--- a/_std/defines/component_defines.dm
+++ b/_std/defines/component_defines.dm
@@ -4,6 +4,8 @@
 /// Arguments given here are packaged in a list and given to _SendSignal
 #define SEND_SIGNAL(target, sigtype, arguments...) ( !target?.comp_lookup || !target.comp_lookup[sigtype] ? 0 : target._SendSignal(sigtype, list(target, ##arguments)) )
 
+#define SEND_COMPLEX_SIGNAL(target, sigtype, arguments...) SEND_SIGNAL(target, sigtype[2], ##arguments)
+
 #define GLOBAL_SIGNAL preMapLoad // guaranteed to exist and that's all that matters
 
 /**
@@ -19,6 +21,9 @@
 
 /// A wrapper for _LoadComponent that allows us to pretend we're using normal named arguments
 #define LoadComponent(arguments...) _LoadComponent(list(##arguments))
+
+/// Checks if a signal is "complex", i.e. it is handled by adding a special component and registering may have side effects and overhead
+#define IS_COMPLEX_SIGNAL(x) (length(x) == 2 && ispath(x[1], /datum/component/complexsignal))
 
 /**
 	* Return this from `/datum/component/Initialize` or `datum/component/OnTransfer` to have the component be deleted if it's applied to an incorrect type.

--- a/_std/defines/component_defines.dm
+++ b/_std/defines/component_defines.dm
@@ -103,6 +103,8 @@
 #define COMSIG_MOVABLE_POST_RADIO_PACKET "mov_post_radio_packet"
 /// when the outermost movable in the .loc chain changes (thing, old_outermost_movable, new_outermost_movable)
 #define COMSIG_OUTERMOST_MOVABLE_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_outermost_changed")
+/// when the z-level of a movable changes (works in nested contents) (thing, old_z_level, new_z_level)
+#define COMSIG_MOVABLE_Z_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_z-level_changed")
 
 // ---- item signals ----
 

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -195,8 +195,9 @@ TYPEINFO(/datum/component)
   * * sig_type_or_types Either a string signal name, or a list of signal names (strings)
   * * proctype The proc to call back when the signal is emitted
   * * override If a previous registration exists you must explicitly set this
+	* * other arguments get passed to complexsignal/register in the case of a complex signal
   */
-/datum/proc/RegisterSignal(datum/target, sig_type_or_types, proctype, override = FALSE)
+/datum/proc/RegisterSignal(datum/target, sig_type_or_types, proctype, override = FALSE, ...)
 	if(QDELETED(src) || QDELETED(target))
 		return
 
@@ -209,8 +210,17 @@ TYPEINFO(/datum/component)
 	if(!lookup)
 		target.comp_lookup = lookup = list()
 
-	var/list/sig_types = islist(sig_type_or_types) ? sig_type_or_types : list(sig_type_or_types)
+	var/list/sig_types = (islist(sig_type_or_types) && !IS_COMPLEX_SIGNAL(sig_type_or_types)) ? sig_type_or_types : list(sig_type_or_types)
 	for(var/sig_type in sig_types)
+		if(IS_COMPLEX_SIGNAL(sig_type))
+			var/complexsignal_component_type = sig_type[1]
+			var/datum/component/complexsignal/comp = target.LoadComponent(complexsignal_component_type)
+			var/list/register_args = args.Copy()
+			register_args[2] = sig_type[2] // replacing sig_type_or_types
+			register_args[1] = src // comp.register's first argument is the LISTENER not the target
+			comp.register(arglist(register_args))
+			continue
+
 		if(!override && procs[target][sig_type])
 			stack_trace("[sig_type] overridden. Use override = TRUE to suppress this warning")
 
@@ -245,9 +255,16 @@ TYPEINFO(/datum/component)
 	var/list/lookup = target.comp_lookup
 	if(!signal_procs || !signal_procs[target] || !lookup)
 		return
-	if(!islist(sig_type_or_types))
+	if(!islist(sig_type_or_types) || IS_COMPLEX_SIGNAL(sig_type_or_types))
 		sig_type_or_types = list(sig_type_or_types)
 	for(var/sig in sig_type_or_types)
+		if(IS_COMPLEX_SIGNAL(sig))
+			var/complexsignal_component_type = sig[1]
+			var/datum/component/complexsignal/comp = target.GetComponent(complexsignal_component_type)
+			if(isnull(comp))
+				CRASH("Unregistering a complex signal [json_encode(sig)] without its component existing.")
+			comp.unregister(src, sig[2])
+			continue
 		if(!signal_procs[target][sig])
 			if(!istext(sig))
 				stack_trace("We're unregistering with something that isn't a valid signal \[[sig]\], you fucked up")

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -192,7 +192,8 @@ TYPEINFO(/datum/component)
   *
   * Arguments:
   * * datum/target The target to listen for signals from
-  * * sig_type_or_types Either a string signal name, or a list of signal names (strings)
+  * * sig_type_or_types Either a string signal name, or a list of signal names (strings).
+	* 		Complex signals (of the form list(component_type, string) can also be used.)
   * * proctype The proc to call back when the signal is emitted
   * * override If a previous registration exists you must explicitly set this
 	* * other arguments get passed to complexsignal/register in the case of a complex signal

--- a/code/datums/components/complexsignal/complexsignal.dm
+++ b/code/datums/components/complexsignal/complexsignal.dm
@@ -1,0 +1,22 @@
+/datum/component/complexsignal
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	var/registered_count = 0
+	var/qdel_when_unneeded = TRUE
+
+/datum/component/complexsignal/proc/register(datum/listener, sig_type, proctype, override = FALSE, ...)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	registered_count++
+	. = src._register(arglist(args))
+
+/datum/component/complexsignal/proc/_register(datum/listener, sig_type, proctype, override = FALSE, ...)
+	listener.RegisterSignal(src, sig_type, proctype, override)
+
+/datum/component/complexsignal/proc/unregister(datum/listener, sig_type)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	. = src._unregister(listener, sig_type)
+	registered_count--
+	if(registered_count <= 0 && qdel_when_unneeded)
+		qdel(src)
+
+/datum/component/complexsignal/proc/_unregister(datum/listener, sig_type)
+	listener.UnregisterSignal(src, sig_type)

--- a/code/datums/components/complexsignal/complexsignal.dm
+++ b/code/datums/components/complexsignal/complexsignal.dm
@@ -1,6 +1,22 @@
+/**
+ * Handler for a complex singal, that is a signal that requires some additional handling.
+ * You define such signal for example as:
+ * `#define XSIG_OUTERMOST_MOVABLE_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_outermost_changed")`
+ * When this signal gets registered at least once once to a datum the appropriate complex signal component will get registered to it.
+ * When all instances of this signal get unregistered then the component will qdel itself unless [qdel_when_unneeded] is unset.
+ * The intended use is for this component to keep some more complex and resource intensive handling (possibly using other signals) and then send the
+ * actual complex signal when some conditions are met. That signal should be set to `src` like this:
+ * `SEND_COMPLEX_SIGNAL(src, X_OUTERMOST_MOVABLE_CHANGED, old_outermost, new_outermost)`
+ *
+ * A single component type can be used for handling of multiple signals.
+ *
+ * Check [/datum/component/complexsignal/outermost_movable] for an example.
+ */
 /datum/component/complexsignal
 	dupe_mode = COMPONENT_DUPE_UNIQUE
+	/// The number of complex signals registered to this datum
 	var/registered_count = 0
+	/// Whether the component should qdel itself when the number of registered signals drops to zero
 	var/qdel_when_unneeded = TRUE
 
 /datum/component/complexsignal/proc/register(datum/listener, sig_type, proctype, override = FALSE, ...)
@@ -8,6 +24,12 @@
 	registered_count++
 	. = src._register(arglist(args))
 
+/**
+ * Override this to add code which happens when a complex signal is registered. If RegisterSignal is passed additional arguments those get passed
+ * after `override`. Other arguments are the same as for .RegisterSignal.
+ * Complex signal definitions are of the form list(component_path, string_id). The `sig_type` var will in this case contain only the `string_id` and
+ * not the full two-element list.
+ */
 /datum/component/complexsignal/proc/_register(datum/listener, sig_type, proctype, override = FALSE, ...)
 	listener.RegisterSignal(src, sig_type, proctype, override)
 
@@ -18,5 +40,8 @@
 	if(registered_count <= 0 && qdel_when_unneeded)
 		qdel(src)
 
+/**
+ * Override to add code which happens on unregistering a signal.
+ */
 /datum/component/complexsignal/proc/_unregister(datum/listener, sig_type)
 	listener.UnregisterSignal(src, sig_type)

--- a/code/datums/components/complexsignal/outermost_movable.dm
+++ b/code/datums/components/complexsignal/outermost_movable.dm
@@ -51,7 +51,6 @@
 /datum/component/complexsignal/outermost_movable/UnregisterFromParent()
 	var/atom/movable/outermost = src.get_outermost_movable()
 	for(var/atom/movable/AM as anything in loc_chain)
-		if(AM != outermost)
-			AM.UnregisterSignal(src, COMSIG_MOVABLE_SET_LOC)
+		AM.UnregisterSignal(src, COMSIG_MOVABLE_SET_LOC)
 	src.loc_chain.len = 0
 	. = ..()

--- a/code/datums/components/complexsignal/outermost_movable.dm
+++ b/code/datums/components/complexsignal/outermost_movable.dm
@@ -49,7 +49,6 @@
 	. = ..()
 
 /datum/component/complexsignal/outermost_movable/UnregisterFromParent()
-	var/atom/movable/outermost = src.get_outermost_movable()
 	for(var/atom/movable/AM as anything in loc_chain)
 		AM.UnregisterSignal(src, COMSIG_MOVABLE_SET_LOC)
 	src.loc_chain.len = 0

--- a/code/datums/components/complexsignal/outermost_movable.dm
+++ b/code/datums/components/complexsignal/outermost_movable.dm
@@ -36,9 +36,9 @@
 	var/new_z = isnull(new_turf) ? 0 : new_turf.z
 
 	if(new_outermost != old_outermost)
-		SEND_COMPLEX_SIGNAL(src, X_OUTERMOST_MOVABLE_CHANGED, old_outermost, new_outermost)
+		SEND_COMPLEX_SIGNAL(src, XSIG_OUTERMOST_MOVABLE_CHANGED, old_outermost, new_outermost)
 	if(new_z != old_z)
-		SEND_COMPLEX_SIGNAL(src, X_MOVABLE_Z_CHANGED, old_z, new_z)
+		SEND_COMPLEX_SIGNAL(src, XSIG_MOVABLE_Z_CHANGED, old_z, new_z)
 
 /datum/component/complexsignal/outermost_movable/Initialize()
 	if(!ismovable(parent))

--- a/code/datums/components/complexsignal/outermost_movable.dm
+++ b/code/datums/components/complexsignal/outermost_movable.dm
@@ -5,8 +5,11 @@
 	RETURN_TYPE(/atom/movable)
 	return loc_chain[length(loc_chain)]
 
-/datum/component/complexsignal/outermost_movable/proc/on_loc_change()
+/datum/component/complexsignal/outermost_movable/proc/on_loc_change(atom/movable/thing, atom/previous_loc)
 	var/atom/movable/old_outermost = src.get_outermost_movable()
+	var/turf/old_turf = get_turf(previous_loc)
+	var/old_z = isnull(old_turf) ? 0 : old_turf.z
+
 	var/atom/movable/loc_crawl = parent
 	var/break_index = 0
 	var/current_index = 1
@@ -28,7 +31,14 @@
 		src.RegisterSignal(loc_crawl, COMSIG_MOVABLE_SET_LOC, .proc/on_loc_change)
 		loc_crawl = loc_crawl.loc
 
-	SEND_COMPLEX_SIGNAL(src, COMSIG_OUTERMOST_MOVABLE_CHANGED, old_outermost, src.get_outermost_movable())
+	var/atom/movable/new_outermost = src.get_outermost_movable()
+	var/turf/new_turf = get_turf(parent)
+	var/new_z = isnull(new_turf) ? 0 : new_turf.z
+
+	if(new_outermost != old_outermost)
+		SEND_COMPLEX_SIGNAL(src, COMSIG_OUTERMOST_MOVABLE_CHANGED, old_outermost, new_outermost)
+	if(new_z != old_z)
+		SEND_COMPLEX_SIGNAL(src, COMSIG_MOVABLE_Z_CHANGED, old_z, new_z)
 
 /datum/component/complexsignal/outermost_movable/Initialize()
 	if(!ismovable(parent))

--- a/code/datums/components/complexsignal/outermost_movable.dm
+++ b/code/datums/components/complexsignal/outermost_movable.dm
@@ -1,0 +1,47 @@
+/datum/component/complexsignal/outermost_movable
+	var/list/atom/movable/loc_chain
+
+/datum/component/complexsignal/outermost_movable/proc/get_outermost_movable()
+	RETURN_TYPE(/atom/movable)
+	return loc_chain[length(loc_chain)]
+
+/datum/component/complexsignal/outermost_movable/proc/on_loc_change()
+	var/atom/movable/old_outermost = src.get_outermost_movable()
+	var/atom/movable/loc_crawl = parent
+	var/break_index = 0
+	var/current_index = 1
+	for(var/atom/movable/AM as anything in loc_chain)
+		if(!break_index && loc_crawl != AM)
+			break_index = current_index
+		if(break_index) // chain broken
+			src.UnregisterSignal(AM, COMSIG_MOVABLE_SET_LOC)
+		if(!break_index)
+			loc_crawl = loc_crawl.loc
+		current_index++
+
+	if(break_index)
+		loc_chain.len = break_index - 1 // cut away the incorrect locs
+
+	loc_crawl = loc_chain[length(loc_chain)].loc
+	while(ismovable(loc_crawl))
+		loc_chain += loc_crawl
+		src.RegisterSignal(loc_crawl, COMSIG_MOVABLE_SET_LOC, .proc/on_loc_change)
+		loc_crawl = loc_crawl.loc
+
+	SEND_COMPLEX_SIGNAL(src, COMSIG_OUTERMOST_MOVABLE_CHANGED, old_outermost, src.get_outermost_movable())
+
+/datum/component/complexsignal/outermost_movable/Initialize()
+	if(!ismovable(parent))
+		return COMPONENT_INCOMPATIBLE
+	src.RegisterSignal(parent, COMSIG_MOVABLE_SET_LOC, .proc/on_loc_change)
+	src.loc_chain = list(parent)
+	src.on_loc_change()
+	. = ..()
+
+/datum/component/complexsignal/outermost_movable/UnregisterFromParent()
+	var/atom/movable/outermost = src.get_outermost_movable()
+	for(var/atom/movable/AM as anything in loc_chain)
+		if(AM != outermost)
+			AM.UnregisterSignal(src, COMSIG_MOVABLE_SET_LOC)
+	src.loc_chain.len = 0
+	. = ..()

--- a/code/datums/components/complexsignal/outermost_movable.dm
+++ b/code/datums/components/complexsignal/outermost_movable.dm
@@ -36,9 +36,9 @@
 	var/new_z = isnull(new_turf) ? 0 : new_turf.z
 
 	if(new_outermost != old_outermost)
-		SEND_COMPLEX_SIGNAL(src, COMSIG_OUTERMOST_MOVABLE_CHANGED, old_outermost, new_outermost)
+		SEND_COMPLEX_SIGNAL(src, X_OUTERMOST_MOVABLE_CHANGED, old_outermost, new_outermost)
 	if(new_z != old_z)
-		SEND_COMPLEX_SIGNAL(src, COMSIG_MOVABLE_Z_CHANGED, old_z, new_z)
+		SEND_COMPLEX_SIGNAL(src, X_MOVABLE_Z_CHANGED, old_z, new_z)
 
 /datum/component/complexsignal/outermost_movable/Initialize()
 	if(!ismovable(parent))

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -287,6 +287,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\components\transfer_on_attack.dm"
 #include "code\datums\components\tripsalot.dm"
 #include "code\datums\components\waddling.dm"
+#include "code\datums\components\complexsignal\complexsignal.dm"
 #include "code\datums\components\itemblock\_itemblock.dm"
 #include "code\datums\components\itemblock\_unarmedblock.dm"
 #include "code\datums\components\itemblock\backpackblock.dm"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -288,6 +288,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\components\tripsalot.dm"
 #include "code\datums\components\waddling.dm"
 #include "code\datums\components\complexsignal\complexsignal.dm"
+#include "code\datums\components\complexsignal\outermost_movable.dm"
 #include "code\datums\components\itemblock\_itemblock.dm"
 #include "code\datums\components\itemblock\_unarmedblock.dm"
 #include "code\datums\components\itemblock\backpackblock.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR modifies the component + signal system to add "complex signals". Complex signals are for the purposes of this PR basically signals that need to do some additional handling (done via a component) to work properly. This is often more costly than a regular signal but there are cases where implementing a regular signal would either be impossible or would add a huge performance cost. The system of complex signals lets you limit the cost so it only gets applied when the signal is actually in use.

As both an example and a tool for future use two complex signals are provided:

* `COMSIG_OUTERMOST_MOVABLE_CHANGED` which gets sent when the outermost atom/movable in the .loc chain changes
* `COMSIG_MOVABLE_Z_CHANGED` which gets sent when the z-level of the relevant object changes no matter how deeply nested in contents it is

These are both provided by a single component which registers and unregisters signals to all movables in the loc chain to achieve the desired effect.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Tracking changes in an object z-level and keeping track of the outermost movable in the loc chain are both problems which have prevented me and others from implementing some features properly. The signals provided here should hopefully help with those issues. Moreover, the general system of complex signals has potential to get expanded to achieve similar results elsewhere.