### PR TITLE
Fixes several Donut3 pipe mistakes

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -11859,7 +11859,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/disposalpipe/switch_junction/right/north,
+/obj/disposalpipe/junction/right/north,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "dko" = (
@@ -18261,7 +18261,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/disposalpipe/switch_junction/left/south,
+/obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
 "fax" = (
@@ -23135,7 +23135,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/switch_junction/left/south,
+/obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/grime,
 /area/station/security/brig/south_side)
 "gwO" = (
@@ -39662,7 +39662,7 @@
 /obj/shrub{
 	dir = 8
 	},
-/obj/disposalpipe/switch_junction/right/east,
+/obj/disposalpipe/junction/right/east,
 /turf/simulated/floor/circuit/red,
 /area/station/security/main)
 "lwz" = (
@@ -42320,7 +42320,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/disposalpipe/switch_junction/left/north,
+/obj/disposalpipe/junction/left/north,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -52392,14 +52392,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/switch_junction/left/west{
-	dir = 2
-	},
 /obj/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/junction/left/south,
 /turf/simulated/floor/white,
 /area/station/security/quarters)
 "pjy" = (
@@ -82560,7 +82558,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/disposalpipe/switch_junction/left/north,
+/obj/disposalpipe/junction/left/north,
 /turf/simulated/floor/black{
 	icon_state = "respect6"
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2143,12 +2143,12 @@
 	},
 /area/station/science/lobby)
 "aqf" = (
-/obj/disposalpipe/switch_junction/right/south,
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/junction/right,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aqi" = (
@@ -5188,7 +5188,6 @@
 /area/station/ranch)
 "boW" = (
 /obj/cable,
-/obj/disposalpipe/switch_junction/right/south,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -5197,6 +5196,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/disposalpipe/junction/right,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "blue2"
@@ -10241,7 +10241,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/disposalpipe/switch_junction/right/east,
+/obj/disposalpipe/junction/right{
+	dir = 4
+	},
 /turf/simulated/floor/red/checker,
 /area/station/security/checkpoint/west)
 "cMy" = (
@@ -25154,8 +25156,7 @@
 /area/shuttle/arrival/station)
 "hch" = (
 /obj/disposalpipe/trunk{
-	dir = 8;
-	layer = -1
+	dir = 8
 	},
 /obj/machinery/disposal/small{
 	dir = 1;
@@ -37358,10 +37359,7 @@
 	dir = 1
 	},
 /obj/table/reinforced/auto,
-/obj/disposalpipe/segment/brig{
-	dir = 4
-	},
-/obj/disposalpipe/segment/brig,
+/obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
 "kMv" = (
@@ -74226,10 +74224,6 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/grey/side,
 /area/listeningpost)
-"vur" = (
-/obj/disposalpipe/junction/right/west,
-/turf/simulated/wall/auto/jen/blue,
-/area/station/crew_quarters/courtroom)
 "vux" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
@@ -78849,10 +78843,6 @@
 /obj/decal/cleanable/rust/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
-"wJH" = (
-/obj/disposalpipe/segment/brig,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/courtroom)
 "wJP" = (
 /turf/simulated/floor/carpet/green/fancy/innercorner{
 	dir = 4
@@ -79161,15 +79151,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
-"wOu" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/brig,
-/turf/simulated/floor/black,
-/area/station/crew_quarters/courtroom)
 "wOz" = (
 /obj/machinery/light_switch/north,
 /obj/blind_switch/area{
@@ -117548,10 +117529,10 @@ qab
 wfe
 lxV
 gLe
-vur
-wJH
-wOu
-jTG
+uwa
+spN
+sqY
+mWf
 kMo
 ceG
 kXn


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR does the following things to Donut3's piping network:
-Replaces three (presumably) mistaken mail junctions in the disposal network around the bridge area, and one more that connects the interrogation room
-Replaces a lot of mail junctions from the brig entry and exit networks
-Resets the layer on a trunk in the engineering foyer-like room. IDK what it was there for (seems fine on local) but it rendered under the floor in strongdmm
-Fixes a wrong connection in the courtroom, so that the pod bay checkpoint chute connects to the brig outlet instead of sec's trail chute.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #7279

Although I'm not aware of the donut3 courtroom ever being used, the pipes were set up in a way that it was impossible to send anyone to the courtroom's cell. Can't imagine that sending perps directly into security's main room was intended either.

The brig junctions are a similar issue, when I tried brigging myself on local I could end up in various checkpoints but not where I was meant to go.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Donut3's brig piping has been fixed.
```

I don't normally do changelogs for bugfixing but in this case I suspect that a lot of sec players already have gotten used to these things not working properly. Feel free to remove though.