### PR TITLE
Enables pointmode hot key for ghost drones

### DIFF
--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -352,9 +352,10 @@
 			src.examine_verb(target) // in theory, usr should be us, this is shit though
 			return
 
-		if (src.in_point_mode)
+		if ((src.in_point_mode) || (src.client && src.client.check_key(KEY_POINT)))
 			src.point(target)
-			src.toggle_point_mode()
+			if (src.in_point_mode)
+				src.toggle_point_mode()
 			return
 
 		if (get_dist(src, target) > 0) // temporary fix for cyborgs turning by clicking

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -352,7 +352,7 @@
 			src.examine_verb(target) // in theory, usr should be us, this is shit though
 			return
 
-		if ((src.in_point_mode) || (src.client && src.client.check_key(KEY_POINT)))
+		if (src.in_point_mode || src.client?.check_key(KEY_POINT))
 			src.point(target)
 			if (src.in_point_mode)
 				src.toggle_point_mode()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ghost drone pointing is currently implemented slightly oddly: 
- Rclick > point works;
- Ctrl+P does not allow you to enter point mode;
- Holding the point hotkey (b for me) changes the icon to the point icon, but clicking does nothing.

I couldn't tell whether this implementation was deliberate or not (slowing down pointing to prevent spam?), so I've PR'd reimplementation of the b hotkey to ghost drones. If the current implementation was deliberate, please could someone close #6383.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #6383.