### PR TITLE
Fix donut 2 artlab tape drive spawning empty

### DIFF
--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -1307,7 +1307,7 @@
 	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto,
-/turf/space,
+/turf/simulated/floor/plating,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/research)
 "adv" = (

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -1303,12 +1303,12 @@
 /turf/simulated/floor,
 /area/station/science/lobby)
 "adt" = (
-/obj/wingrille_spawn/auto,
 /obj/cable{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/obj/wingrille_spawn/auto,
 /turf/space,
+/turf/simulated/floor/plating,
 /area/station/security/checkpoint/research)
 "adv" = (
 /obj/overlay{
@@ -4513,7 +4513,7 @@
 /obj/machinery/networked/storage/tape_drive{
 	bank_id = "Artlab";
 	locked = 0;
-	setup_spawn_with_tape = 0
+	setup_drive_type = /obj/item/disk/data/tape/artifact_research
 	},
 /turf/simulated/floor/white/checker2{
 	dir = 8


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
it has been like this for how long and I'm just now noticing??? how were people doing artlab aaaaa
also (hopefully) fix some weird tile on top of the sec checkpoint spawning as space for some reason

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having artlab be functional is good