### PR TITLE
Fix blob overmind being able to clear plant trays

### DIFF
--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -821,7 +821,7 @@
 
 	MouseDrop(over_object, src_location, over_location)
 		..()
-		if(!isliving(usr)) return // ghosts killing plants fix
+		if(!isliving(usr) || isintangible(usr)) return // ghosts killing plants fix
 		if(get_dist(src, usr) > 1)
 			boutput(usr, "<span class='alert'>You need to be closer to empty the tray out!</span>")
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Prevents blobs being mean to botanists

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #7175 
