### PR TITLE
adjusts persistent bookshelf offset on maps

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4658,12 +4658,15 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/bookshelf/persistent,
+/obj/bookshelf/persistent{
+	density = 0;
+	pixel_y = 22
+	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 6;
 	name = "autoname - SS13";
-	pixel_y = 20;
+	pixel_y = 18;
 	tag = ""
 	},
 /turf/simulated/floor,

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -4666,7 +4666,7 @@
 	c_tag = "autotag";
 	dir = 6;
 	name = "autoname - SS13";
-	pixel_y = 18;
+	pixel_y = 20;
 	tag = ""
 	},
 /turf/simulated/floor,

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -43007,7 +43007,10 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/bookshelf/persistent,
+/obj/bookshelf/persistent{
+	density = 0;
+	pixel_y = 19
+	},
 /turf/simulated/floor/black/side{
 	dir = 1
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -17548,7 +17548,10 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "aUr" = (
-/obj/bookshelf/persistent,
+/obj/bookshelf/persistent{
+	density = 0;
+	pixel_y = 19
+	},
 /obj/cable{
 	icon_state = "2-8"
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -68172,7 +68172,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/bookshelf/persistent,
+/obj/bookshelf/persistent{
+	density = 0;
+	pixel_y = 19
+	},
 /turf/simulated/floor/arrival{
 	dir = 9
 	},

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -36729,7 +36729,10 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/lab)
 "lNC" = (
-/obj/bookshelf/persistent,
+/obj/bookshelf/persistent{
+	density = 0;
+	pixel_y = 19
+	},
 /turf/simulated/floor,
 /area/station/crew_quarters/lounge/starboard)
 "lNG" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -11097,7 +11097,9 @@
 /area/station/hallway/primary/south)
 "cYe" = (
 /obj/bookshelf/persistent{
-	layer = 10
+	density = 0;
+	layer = 10;
+	pixel_y = 19
 	},
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/wood/six,

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -40680,7 +40680,10 @@
 	},
 /area/station/security/main)
 "bYE" = (
-/obj/bookshelf/persistent,
+/obj/bookshelf/persistent{
+	density = 0;
+	pixel_y = 19
+	},
 /obj/disposalpipe/segment/cargo{
 	dir = 4
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -12143,7 +12143,10 @@
 /area/station/turret_protected/ai)
 "aHP" = (
 /obj/machinery/power/apc/autoname_west,
-/obj/bookshelf/persistent,
+/obj/bookshelf/persistent{
+	density = 0;
+	pixel_y = 19
+	},
 /obj/cable{
 	icon_state = "0-4"
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -45459,7 +45459,10 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "clV" = (
-/obj/bookshelf/persistent,
+/obj/bookshelf/persistent{
+	density = 0;
+	pixel_y = 19
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "clW" = (

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -37403,7 +37403,9 @@
 	})
 "cfO" = (
 /obj/bookshelf/persistent{
-	file_name = "data/persistent_bookshelf_cairngorm.json"
+	density = 0;
+	file_name = "data/persistent_bookshelf_cairngorm.json";
+	pixel_y = 19
 	},
 /obj/storage/crate/bin{
 	desc = "A large bin, for trash.";


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
when bookshelves were refactored their pixel offsets were removed. this re-adds them so that they dont clutter hallways anymore.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
mistake, restoring the status quo 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->