### PR TITLE
Minor rod count bug fix

### DIFF
--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -126,7 +126,7 @@
 			var/obj/item/rods/R = new /obj/item/rods
 			R.amount = 1
 			var/obj/item/rods/S = W
-			S.amount = S.amount - 1
+			S.change_stack_amount(-1)
 			if (S.amount == 0)
 				qdel(S)
 			var/obj/item/assembly/weld_rod/F = new /obj/item/assembly/weld_rod( user )


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes rods not updating stack number when used on welders to make flamethrowers by calling proc change_stack_amount rather than directly changing var amount.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Prevents confusion over when the material gets used and how much is left. Stacks shouldn't lie about their amount.