### PR TITLE
Fix random mechcomp housing runtime

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -32,11 +32,11 @@
 	var/can_be_anchored=false
 	custom_suicide=true
 	New()
-		..()
 		src.light = new /datum/light/point
 		src.light.attach(src)
 		src.light.set_color(1,0,1)
 		processing_items |= src
+		..()
 
 	hear_talk(mob/M as mob, msg, real_name, lang_id) // hack to make microphones work
 		for(var/obj/item/mechanics/miccomp/mic in src.contents)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As title. The parent `New` call ends up calling an updating proc somehow, which needs the light to be initialised. I didn't bother to look into why this happens now but it definitely didn't always do so.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes :pensive:﻿