### PR TITLE
Convert spacebux and purchases to use bulk api

### DIFF
--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -623,6 +623,8 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 
 	logTheThing("debug", null, null, "Revving up the spacebux loop...")
 
+	/// list of ckeys and keypairs to bulk commit
+	var/list/bulk_commit = list()
 	for(var/mob/player in mobs)
 		if (player?.client && player.mind && !player.mind.joined_observer && !istype(player,/mob/new_player))
 			logTheThing("debug", null, null, "Iterating on [player.client]")
@@ -733,23 +735,30 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 			earnings = round(earnings)
 			//logTheThing("debug", null, null, "Zamujasa: [world.timeofday] spacebux calc finish: [player.mind.ckey]")
 
-			SPAWN_DBG(0)
-				if(player.client)
-					player.client.add_to_bank(earnings)
-					// Fix for persistent_bank-is-NaN bug
-					if (player.client.persistent_bank != player.client.persistent_bank)
-						player.client.set_persistent_bank(50000)
-					if (player_loses_held_item)
-						logTheThing("debug", null, null, "[player.ckey] lost held item")
-						player.client.set_last_purchase(0)
+			if(player.client)
+				if (player_loses_held_item)
+					logTheThing("debug", null, null, "[player.ckey] lost held item")
+					player.client.persistent_bank_item = "none"
 
-					bank_earnings.pilot_bonus = pilot_bonus
-					bank_earnings.final_payout = earnings
-					bank_earnings.held_item = player.client.persistent_bank_item
-					bank_earnings.new_balance = player.client.persistent_bank
-					bank_earnings.Subscribe( player.client )
+				bulk_commit[player.ckey] = list(
+					"persistent_bank" = list(
+						"command" = "add",
+						"value" = earnings
+					),
+					"persistent_bank_item" = list(
+						"command" = "replace",
+						"value" = player.client.persistent_bank_item
+					)
+				)
 
+				bank_earnings.pilot_bonus = pilot_bonus
+				bank_earnings.final_payout = earnings
+				bank_earnings.held_item = player.client.persistent_bank_item
+				bank_earnings.new_balance = player.client.persistent_bank + earnings
+				bank_earnings.Subscribe( player.client )
 
+	//do bulk commit
+	cloud_put_bulk(json_encode(bulk_commit))
 	logTheThing("debug", null, null, "Done with spacebux")
 
 	for_by_tcl(P, /obj/bookshelf/persistent) //make the bookshelf save its contents

--- a/code/player.dm
+++ b/code/player.dm
@@ -173,78 +173,6 @@
 #endif
 		return TRUE // I guess
 
-	/** Bulk cloud save for saving many key value pairs and/or many ckeys in a single api call
-	 * example input (formatted for readability)
-	 *  command add adds a number onto the current value (record must exist in the cloud to update or it won't do anything)
-	 *  command replace overwrites the existing record
-	 * 	{
-	 * 		"some_ckey":{
-	 * 			"persistent_bank":{
-	 * 				"command":"add",
-	 * 				"value":42069
-	 * 			},
-	 * 			"persistent_bank_item":{
-	 * 				"command":"replace",
-	 * 				"value":"none"
-	 * 			}
-	 * 		},
-	 * 		"some_other_ckey":{
-	 * 			"persistent_bank":{
-	 * 				"command":"add",
-	 * 				"value":1337
-	 * 			},
-	 * 			"persistent_bank_item":{
-	 * 				"command":"replace",
-	 * 				"value":"rubber_ducky"
-	 * 			}
-	 * 		}
-	 * 	}
-	**/
-	proc/cloud_put_bulk(json)
-		if (!rustg_json_is_valid(json))
-			stack_trace("cloud_put_bulk received an invalid json object.")
-			return FALSE
-		var/list/decoded_json = json_decode(json)
-		var/list/sanitized = list()
-		for (var/json_ckey in decoded_json)
-			var/clean_ckey = ckey(json_ckey)
-			if (!length(decoded_json[json_ckey]))
-				stack_trace("cloud_put_bulk received ckey \"[clean_ckey]\" without any key pairs to save.")
-				continue
-			sanitized[clean_ckey] = list()
-			for (var/json_key in decoded_json[json_ckey])
-				var/value = decoded_json[json_ckey][json_key]["value"]
-				if (isnull(value))
-					value = "" //api wants empty strings, not nulls
-				sanitized[clean_ckey][json_key] = list ("command" = decoded_json[json_ckey][json_key]["command"], "value" = value)
-#ifdef LIVE_SERVER
-		var/sanitized_json = json_encode(sanitized)
-		// Via rust-g HTTP
-		var/datum/http_request/request = new() //If it fails, oh well...
-		request.prepare(RUSTG_HTTP_METHOD_GET, "[config.spacebee_api_url]/api/cloudsave?dataput_bulk&api_key=[config.spacebee_api_key]&value=[url_encode(sanitized_json)]", "","")
-		request.begin_async()
-#else
-// temp disabled
-/* 		var/save_json
-		var/list/decoded_save
-		if (fexists("data/simulated_cloud.json"))
-			save_json = file2text("data/simulated_cloud.json")
-			decoded_save = json_decode(save_json)
-		else
-			decoded_save = list()
-
-		for (var/sani_ckey in sanitized)
-			if (!decoded_save[sani_ckey])
-				decoded_save[sani_ckey] = list(cdata = list())
-			for (var/data_key in sanitized[sani_ckey])
-				decoded_save[sani_ckey]["cdata"][data_key] = sanitized[sani_ckey][data_key]
-
-		//t2f appends, but need to to replace
-		fdel("data/simulated_cloud.json")
-		text2file(json_encode(decoded_save),"data/simulated_cloud.json") */
-#endif
-		return TRUE
-
 	/// Returns some cloud data on the client
 	proc/cloud_get( var/key )
 		return clouddata ? clouddata[key] : null
@@ -335,3 +263,75 @@
 	if (!player)
 		player = new(key)
 	return player
+
+/** Bulk cloud save for saving many key value pairs and/or many ckeys in a single api call
+ * example input (formatted for readability)
+ *  command add adds a number onto the current value (record must exist in the cloud to update or it won't do anything)
+ *  command replace overwrites the existing record
+ * 	{
+ * 		"some_ckey":{
+ * 			"persistent_bank":{
+ * 				"command":"add",
+ * 				"value":42069
+ * 			},
+ * 			"persistent_bank_item":{
+ * 				"command":"replace",
+ * 				"value":"none"
+ * 			}
+ * 		},
+ * 		"some_other_ckey":{
+ * 			"persistent_bank":{
+ * 				"command":"add",
+ * 				"value":1337
+ * 			},
+ * 			"persistent_bank_item":{
+ * 				"command":"replace",
+ * 				"value":"rubber_ducky"
+ * 			}
+ * 		}
+ * 	}
+**/
+proc/cloud_put_bulk(json)
+	if (!rustg_json_is_valid(json))
+		stack_trace("cloud_put_bulk received an invalid json object.")
+		return FALSE
+	var/list/decoded_json = json_decode(json)
+	var/list/sanitized = list()
+	for (var/json_ckey in decoded_json)
+		var/clean_ckey = ckey(json_ckey)
+		if (!length(decoded_json[json_ckey]))
+			stack_trace("cloud_put_bulk received ckey \"[clean_ckey]\" without any key pairs to save.")
+			continue
+		sanitized[clean_ckey] = list()
+		for (var/json_key in decoded_json[json_ckey])
+			var/value = decoded_json[json_ckey][json_key]["value"]
+			if (isnull(value))
+				value = "" //api wants empty strings, not nulls
+			sanitized[clean_ckey][json_key] = list ("command" = decoded_json[json_ckey][json_key]["command"], "value" = value)
+#ifdef LIVE_SERVER
+	var/sanitized_json = json_encode(sanitized)
+	// Via rust-g HTTP
+	var/datum/http_request/request = new() //If it fails, oh well...
+	request.prepare(RUSTG_HTTP_METHOD_GET, "[config.spacebee_api_url]/api/cloudsave?dataput_bulk&api_key=[config.spacebee_api_key]&value=[url_encode(sanitized_json)]", "","")
+	request.begin_async()
+#else
+// temp disabled
+/* 		var/save_json
+	var/list/decoded_save
+	if (fexists("data/simulated_cloud.json"))
+		save_json = file2text("data/simulated_cloud.json")
+		decoded_save = json_decode(save_json)
+	else
+		decoded_save = list()
+
+	for (var/sani_ckey in sanitized)
+		if (!decoded_save[sani_ckey])
+			decoded_save[sani_ckey] = list(cdata = list())
+		for (var/data_key in sanitized[sani_ckey])
+			decoded_save[sani_ckey]["cdata"][data_key] = sanitized[sani_ckey][data_key]
+
+	//t2f appends, but need to to replace
+	fdel("data/simulated_cloud.json")
+	text2file(json_encode(decoded_save),"data/simulated_cloud.json") */
+#endif
+	return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [PERFOMANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Changes end of round spacebux and purchase saving to use a single bulk api commit instead of a whole bunch at once


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* More performant
