### PR TITLE
Nerfs the departure time reduction on emagged shuttles

### DIFF
--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -1,4 +1,5 @@
 /obj/machinery/computer/shuttle
+	var/alreadymagged = FALSE
 	name = "Shuttle"
 	icon_state = "shuttle"
 	var/auth_need = 3.0
@@ -166,21 +167,28 @@
 
 	if (user)
 		var/choice = alert(user, "Would you like to launch the shuttle?","Shuttle control", "Launch", "Cancel")
-		if(get_dist(user, src) > 1 || emergency_shuttle.location != SHUTTLE_LOC_STATION) return
-		switch(choice)
-			if("Launch")
-				if (emergency_shuttle.timeleft() <= 90)
-					boutput(world, "<span class='notice'><B>Alert: Shuttle launch time shortened to 20 seconds!</B></span>")
-					emergency_shuttle.settimeleft( 20 )
-					logTheThing("admin", user, null, "shortens Emergency Shuttle launch time to 20 seconds.")
+		if (get_dist(user, src) > 1 || emergency_shuttle.location != SHUTTLE_LOC_STATION) return
+
+		if (alreadymagged == FALSE)
+			switch(choice)
+				if("Launch")
+					alreadymagged=TRUE
+					if (emergency_shuttle.timeleft() <= 90)
+						boutput(world, "<span class='notice'><B>Alert: Shuttle launch time shortened to 20 seconds!</B></span>")
+						emergency_shuttle.settimeleft( 20 )
+						logTheThing("admin", user, null, "shortens Emergency Shuttle launch time to 20 seconds.")
+						return 1
+					else if(emergency_shuttle.timeleft() <= 30)
+						boutput(world, "<span class='notice'><B>Alert: Shuttle launch time shortened to 10 seconds!</B></span>")
+						emergency_shuttle.settimeleft( 10 )
+						logTheThing("admin", user, null, "shortens Emergency Shuttle launch time to 10 seconds.")
+						return 1
+				if("Cancel")
 					return 1
-				else if(emergency_shuttle.timeleft() <= 30)
-					boutput(world, "<span class='notice'><B>Alert: Shuttle launch time shortened to 10 seconds!</B></span>")
-					emergency_shuttle.settimeleft( 10 )
-					logTheThing("admin", user, null, "shortens Emergency Shuttle launch time to 10 seconds.")
-					return 1
-			if("Cancel")
-				return 1
+		else
+			boutput(user, "<span class='alert'>You have already emagged the shuttle.</span>")
+			return 1
+
 	else
 		boutput(world, "<span class='notice'><B>Alert: Shuttle launch time shortened to 10 seconds!</B></span>")
 		emergency_shuttle.settimeleft( 10 )

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -169,10 +169,16 @@
 		if(get_dist(user, src) > 1 || emergency_shuttle.location != SHUTTLE_LOC_STATION) return
 		switch(choice)
 			if("Launch")
-				boutput(world, "<span class='notice'><B>Alert: Shuttle launch time shortened to 10 seconds!</B></span>")
-				emergency_shuttle.settimeleft( 10 )
-				logTheThing("admin", user, null, "shortens Emergency Shuttle launch time to 10 seconds.")
-				return 1
+				if (emergency_shuttle.timeleft() <= 90)
+					boutput(world, "<span class='notice'><B>Alert: Shuttle launch time shortened to 20 seconds!</B></span>")
+					emergency_shuttle.settimeleft( 20 )
+					logTheThing("admin", user, null, "shortens Emergency Shuttle launch time to 20 seconds.")
+					return 1
+				else if(emergency_shuttle.timeleft() <= 30)
+					boutput(world, "<span class='notice'><B>Alert: Shuttle launch time shortened to 10 seconds!</B></span>")
+					emergency_shuttle.settimeleft( 10 )
+					logTheThing("admin", user, null, "shortens Emergency Shuttle launch time to 10 seconds.")
+					return 1
 			if("Cancel")
 				return 1
 	else


### PR DESCRIPTION
[input][feature][balance]

## about
This PR adds code which only allows a shuttle's console to be emagged once, and a check on how much time is remaining. If there are more than 90 seconds on the clock, it will set the shuttle's timer to 30 seconds, and if there are less than 90 seconds, it will reduce it to 10. I have the logic set up so that, at minimum, a traitor will have to wait 30 seconds between the shuttle's arrival and departure.


## why it's needed
In my opinion, being able to emag the shuttle's console and send it whisking away in ten seconds (a little less, since the shuttle clock seems to be always 3 seconds early for countdowns), is a little over powered. I may change it to be more favorable to the traitor, but in my opinion, giving the crew a little more time to actually get on the shuttle provided the traitor has done nothing to stop them aside from buy an emag is fairer


## changelog
```changelog
```(u)NightmareChamillian
```(*)Emagging the shuttle console has been changed from setting departure to 10 seconds to setting it to 30
```
