### PR TITLE
Removes redundant check in weldingtool

### DIFF
--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -127,8 +127,6 @@
 			R.amount = 1
 			var/obj/item/rods/S = W
 			S.change_stack_amount(-1)
-			if (S.amount == 0)
-				qdel(S)
 			var/obj/item/assembly/weld_rod/F = new /obj/item/assembly/weld_rod( user )
 			src.set_loc(F)
 			F.welder = src


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes redundant check for stack amount when change_stack_amount already handles that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Meant to include this in https://github.com/goonstation/goonstation/pull/7303#issue-1114383563

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
