### PR TITLE
Changes hakama item name to uwagi and hakama

### DIFF
--- a/code/obj/item/clothing/under/gimmick/hakama.dm
+++ b/code/obj/item/clothing/under/gimmick/hakama.dm
@@ -1,5 +1,5 @@
 /obj/item/clothing/under/gimmick/hakama
-	name = "hakama"
+	name = "uwagi and hakama"
 	desc = "The traditional garb of the samurai. You have no idea what this is doing on a space station."
 	icon_state = "hakama_1"
 	item_state = "hakama_1"

--- a/code/obj/item/kendo.dm
+++ b/code/obj/item/kendo.dm
@@ -247,7 +247,7 @@
 	spawn_contents = list(/obj/item/clothing/head/helmet/men=2,/obj/item/clothing/suit/armor/douandtare=2,/obj/item/clothing/gloves/kote=2,/obj/item/shinai_bag=1)
 
 /obj/item/storage/box/kendo_box/hakama
-	name = "hakama box"
-	desc = "A box full of hakama!"
+	name = "uwagi and hakama box"
+	desc = "A box full of sets of uwagi and hakama!"
 	icon_state = "box"
 	spawn_contents = list(/obj/item/clothing/under/gimmick/hakama/random=7)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Renames the "hakama" item to "uwagi and hakama", as well as the storage boxes they may come in. Nothing else changed on the backend; just how they're described in-game.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Would you see a set of a shirt and pants and call the whole thing "trousers"?
