### PR TITLE
very small guardbuddy bugfixes

### DIFF
--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -1246,7 +1246,7 @@
 		var/burst = shotcount	// TODO: Make rapidfire exist, then work.
 		while(burst > 0 && target)
 			if(IN_RANGE(target_turf, my_turf, 1))
-				budgun.shoot_point_blank(target, my_turf)
+				budgun.shoot_point_blank(target, src)
 			else
 				budgun.shoot(target_turf, my_turf, src)
 			burst--
@@ -1907,7 +1907,7 @@
 
 			src.add_task(src.model_task.copy_file(),1)
 
-		if(src.task?.disposed || src.task.master != src)
+		if(src.task?.disposed || src.task?.master != src)
 			src.task = null
 		if(istype(src.task))
 			src.task.task_act()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pointblanking by buddies gave their turf as user, instead of themselves, which mainly just resulted in missing muzzle flashes and messages like this:
![image](https://user-images.githubusercontent.com/35579460/151422455-81f26904-9a20-4c9f-a964-d1143ccfcf30.png)

There was also a small runtime-causing issue for buddies without tasks, such as those that were just built and then woken without assigning a task.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad
