### PR TITLE
Optimise plant seed vendors a little

### DIFF
--- a/code/datums/controllers/hydro_controls.dm
+++ b/code/datums/controllers/hydro_controls.dm
@@ -14,6 +14,7 @@ var/global/list/hydro_controller_queue = list(
 	var/list/plant_species = list()
 	var/list/mutations = list()
 	var/list/strains = list()
+	var/list/vendable_plants = list()
 
 	var/image/pot_death_display = null
 	var/image/pot_health_display = null
@@ -51,6 +52,9 @@ var/global/list/hydro_controller_queue = list(
 					if (ispath(X))
 						P.commuts += HY_get_strain_from_path(X)
 						P.commuts -= X
+
+				if (P.vending)
+					vendable_plants += P
 
 			src.process_queue()
 

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -380,7 +380,7 @@
 	attack_self(var/mob/user as mob)
 		playsound(src.loc, "sound/machines/click.ogg", 100, 1)
 		var/holder = src.loc
-		var/datum/plant/pick = input(usr, "Which seed do you want?", "Portable Seed Fabricator", null) in hydro_controls.vendable_plants
+		var/datum/plant/pick = tgui_input_list(usr, "Which seed do you want?", "Portable Seed Fabricator", hydro_controls.vendable_plants)
 		if (src.loc != holder)
 			return
 		src.selected = pick

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -379,14 +379,8 @@
 
 	attack_self(var/mob/user as mob)
 		playsound(src.loc, "sound/machines/click.ogg", 100, 1)
-		var/list/usable = list()
-		for(var/datum/plant/A in hydro_controls.plant_species)
-			if (!A.vending)
-				continue
-			usable += A
-
 		var/holder = src.loc
-		var/datum/plant/pick = input(usr, "Which seed do you want?", "Portable Seed Fabricator", null) in usable
+		var/datum/plant/pick = input(usr, "Which seed do you want?", "Portable Seed Fabricator", null) in hydro_controls.vendable_plants
 		if (src.loc != holder)
 			return
 		src.selected = pick

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -1161,16 +1161,8 @@
 		if (!src.can_vend)
 			dat+= "<u>Unit currently out of charge. Please wait.</u><br>"
 		dat += "<br>"
-		for(var/datum/plant/A in hydro_controls.plant_species)
-			if (!A.vending)
-				continue
-			if (A.vending > 1)
-				if (src.hacked)
-					if (!src.category || (src.category == A.category))
-						dat += "<b>[A.name]</b>: <A href='?src=\ref[src];disp=\ref[A]'>(VEND)</A><br>"
-				else
-					continue
-			else
+		for(var/datum/plant/A in hydro_controls.vendable_plants)
+			if (A.vending == 1 || src.hacked)
 				if (!src.category || (src.category == A.category))
 					dat += "<b>[A.name]</b>: <A href='?src=\ref[src];disp=\ref[A]'>(VEND)</A><br>"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a list of vendable plants to the hydro controls, so that (portable) seed fabricators can use that instead of making that list themselves.

For portable seed fabricators this removes having to a list of every vendable seed every time you wanted to change it. The big machine fabricators still need to loop over the list because they need to account for hacking, but at least it's a slightly shorter list since all the strange seeds are excluded.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Less unnecessary looping good.
(I expect the difference in performance to be negligible but it's the principle of the thing, damnit)