### PR TITLE
Fix mutant race characters from resetting to default colors on clone

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -202,6 +202,7 @@
 	proc/onAdd(var/mob/owner)
 		if(mutantRace && ishuman(owner))
 			var/mob/living/carbon/human/H = owner
+			H.mutantrace?.origAH.CopyOther(H.bioHolder.mobAppearance)
 			H.set_mutantrace(mutantRace)
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes those with mutant race traits from having their character color set to default values when cloned. Currently, the mutant race traits delete character color preferences when applied. With this change, mutant race characters will keep keep their custom colors when cloned.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7254 and fixes #7168

