### PR TITLE
Added check for fuel in zippos

### DIFF
--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -1222,9 +1222,12 @@
 				return
 
 			if (O.reagents.total_volume)
-				O.reagents.trans_to(src, src.reagents.maximum_volume - src.reagents.get_reagent_amount("fuel"))
-				boutput(user, "<span class='notice'>[src] has been refueled.</span>")
-				playsound(src.loc, "sound/effects/zzzt.ogg", 50, 1, -6)
+				if ("fuel" in O.reagents.reagent_list)
+					O.reagents.trans_to(src, src.reagents.maximum_volume - src.reagents.get_reagent_amount("fuel"), 1, 1, O.reagents.reagent_list.Find("fuel"))
+					boutput(user, "<span class='notice'>[src] has been refueled.</span>")
+					playsound(src.loc, "sound/effects/zzzt.ogg", 50, 1, -6)
+				else
+					user.show_text("[src] can only be refilled with fuel.", "red")
 			else
 				user.show_text("[O] is empty.", "red")
 			return

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -1222,7 +1222,7 @@
 				return
 
 			if (O.reagents.total_volume)
-				if ("fuel" in O.reagents.reagent_list)
+				if (O.reagents.has_reagent("fuel"))
 					O.reagents.trans_to(src, src.reagents.maximum_volume - src.reagents.get_reagent_amount("fuel"), 1, 1, O.reagents.reagent_list.Find("fuel"))
 					boutput(user, "<span class='notice'>[src] has been refueled.</span>")
 					playsound(src.loc, "sound/effects/zzzt.ogg", 50, 1, -6)


### PR DESCRIPTION
Added check if container has fuel.
Only tranfer fuel now

## About the PR 
Bugfix for #7286 - Lighter accepts any chemical

## Why's this needed?
fixes #7286
