### PR TITLE
Battle royale death effect

### DIFF
--- a/code/datums/components/battleroyale_death.dm
+++ b/code/datums/components/battleroyale_death.dm
@@ -1,0 +1,17 @@
+/datum/component/battleroyale_death
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+
+/datum/component/battleroyale_death/Initialize()
+	if(!ismob(parent))
+		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_MOB_DEATH, .proc/death_effect)
+
+/datum/component/battleroyale_death/proc/death_effect()
+	if (ishuman(parent))
+		var/mob/living/carbon/human/H = parent
+		H.unequip_all()
+		H.elecgib()
+
+/datum/component/battleroyale_death/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_DEATH)
+	. = ..()

--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -124,6 +124,9 @@ var/global/list/datum/mind/battle_pass_holders = list()
 		// Stuff them on the shuttle
 	player.current.set_loc(pick_landmark(LANDMARK_BATTLE_ROYALE_SPAWN))
 	equip_battler(player.current)
+	if (ishuman(player.current))
+		var/mob/living/carbon/human/H = player.current
+		H.AddComponent(/datum/component/battleroyale_death)
 	SPAWN_DBG(MAX_TIME_ON_SHUTTLE)
 		if(istype(get_area(player.current),/area/shuttle/battle) || istype(get_area(player.current),/area/shuttle_transit_space/west) )
 			boutput(player.current,"<span class='alert'>You are thrown out of the shuttle for taking too long!</span>")

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1845,13 +1845,27 @@
 	src.icon = null
 	APPLY_MOB_PROPERTY(src, PROP_INVISIBILITY, "transform", INVIS_ALWAYS)
 
-
+	var/col_r = 0.4
+	var/col_g = 0.8
+	var/col_b = 1.0
+	var/brightness = 0.7
+	var/height = 1
+	var/datum/light/light
+	var/light_type = /datum/light/point
 
 	if (ishuman(src))
 		animation = new(src.loc)
 		animation.master = src
 		flick("elecgibbed", animation)
-
+		if(ispath(light_type))
+			light = new light_type
+			light.set_brightness(brightness)
+			light.set_color(col_r, col_g, col_b)
+			light.set_height(height)
+			light.attach(animation)
+			light.enable()
+			SPAWN_DBG(1 SECOND)
+				qdel(light)
 	if ((src.mind || src.client) && !istype(src, /mob/living/carbon/human/npc))
 		var/mob/dead/observer/newmob = ghostize()
 		newmob.corpse = null

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -255,6 +255,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\components\arable.dm"
 #include "code\datums\components\barber.dm"
 #include "code\datums\components\baseball_bat_reflect.dm"
+#include "code\datums\components\battleroyale_death.dm"
 #include "code\datums\components\biodegradable.dm"
 #include "code\datums\components\cell_holder.dm"
 #include "code\datums\components\clown_disbelief_item.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Players who die in Battle Royale are now elec gibbed and drop all their gear.
Adds a light effect to **human** elecgib() so you can see it in the dark.

https://user-images.githubusercontent.com/70909958/151712796-dce60908-b2b3-4949-83d6-dbf08b3a8c41.mp4

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Simplifies life for everyone. It's easier to loot, no more miasma or radioactive/mutagenic field bodies.
A human being vaporized by electricity would probably be quite bright.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)When you die in Battle Royale you are now vaporized and drop your gear.
```
