### PR TITLE
Weaken the effect of heating on large hotboxes/puddles

### DIFF
--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -66,7 +66,7 @@
 
 	temperature_reagents(exposed_temperature, exposed_volume = 100, exposed_heat_capacity = 100, change_cap = 15, change_min = 0.0000001, loud = 0)
 		if (my_group)
-			exposed_volume = exposed_volume = my_group.amt_per_tile
+			exposed_volume = my_group.amt_per_tile
 		..()
 		src.update_total()
 

--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -65,7 +65,8 @@
 				.= "very deep"
 
 	temperature_reagents(exposed_temperature, exposed_volume = 100, exposed_heat_capacity = 100, change_cap = 15, change_min = 0.0000001, loud = 0)
-		exposed_volume = my_group.amt_per_tile
+		if (my_group)
+			exposed_volume = exposed_volume = my_group.amt_per_tile
 		..()
 		src.update_total()
 

--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -65,7 +65,7 @@
 				.= "very deep"
 
 	temperature_reagents(exposed_temperature, exposed_volume = 100, exposed_heat_capacity = 100, change_cap = 15, change_min = 0.0000001, loud = 0)
-		exposed_volume = exposed_volume/my_group.members.len
+		exposed_volume = my_group.amt_per_tile
 		..()
 		src.update_total()
 

--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -65,6 +65,7 @@
 				.= "very deep"
 
 	temperature_reagents(exposed_temperature, exposed_volume = 100, exposed_heat_capacity = 100, change_cap = 15, change_min = 0.0000001, loud = 0)
+		exposed_volume = exposed_volume/my_group.members.len
 		..()
 		src.update_total()
 


### PR DESCRIPTION
[BALANCE]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes temperature_reagents only heat 1 tile's worth of chems for liquids/smokes, lowering the overall heating. 

While there's some outstanding code (possibly an issue) that seems to be making the minimum increment 1 degree, it's 5x better than the surprisingly easy to achieve 500C super hotbox achievable with a couple leaves of cannabis and a lighter.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently even a basic hotbox/flood becomes scalding hot in a very short time with just one candle, burning people with no mask. This slows the rate of heating down significantly.

Kinda nerfs lethal hotboxes, but odds are if you aren't wearing a mask you'd be dying to the deathweed in a deathweed cloud rather than 3 hundred degree smoke. 
