### PR TITLE
Red Chainsaw weight class to normal when inactive

### DIFF
--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -177,7 +177,7 @@
 	throwforce = 5.0
 	throw_speed = 1
 	throw_range = 5
-	w_class = W_CLASS_BULKY
+	w_class = W_CLASS_NORMAL
 	is_syndicate = 1
 	how_dangerous_is_this_thing = 1 //it gibs differently
 	mats = 14
@@ -193,6 +193,13 @@
 	setupProperties()
 		. = ..()
 		setProperty("deflection", 75)
+
+	attack_self(mob/user as mob)
+		..()
+		if (src.active)
+			w_class = W_CLASS_BULKY
+		else
+			w_class = W_CLASS_NORMAL
 
 /obj/item/saw/syndie/attack(mob/living/carbon/human/target as mob, mob/user as mob)
 	var/mob/living/carbon/human/H = target


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduces the red chainsaw weight class to normal when inactive.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Seems to be a holdover from when this was the only item arm compatible traitor weapon.
It's not like it's subtle in use, both the katana and csaber can be carried at least in a backpack and the surprise attack potential is no worse than a csaber.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Red chainsaw is now normal size when inactive, allowing it to be put in backpacks.
```
