### PR TITLE
Add a stove to the kitchen in Destiny, also move the intercom

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -44196,7 +44196,6 @@
 	},
 /area/station/science/research_director)
 "pLl" = (
-/obj/item/device/radio/intercom/catering,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
@@ -46296,6 +46295,7 @@
 	name = "Produce Chute"
 	},
 /obj/disposalpipe/trunk/food,
+/obj/item/device/radio/intercom/catering,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "qPI" = (

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -25198,6 +25198,20 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
+"fwW" = (
+/obj/item/reagent_containers/food/snacks/hotdog,
+/obj/item/reagent_containers/food/snacks/hotdog,
+/obj/item/reagent_containers/food/snacks/hotdog,
+/obj/item/reagent_containers/food/snacks/hotdog,
+/obj/storage/cart/hotdog,
+/obj/item/shaker/mustard{
+	pixel_x = -6
+	},
+/obj/item/shaker/ketchup{
+	pixel_x = 6
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "fxq" = (
 /obj/disposalpipe/segment/mail{
 	dir = 2;
@@ -44182,22 +44196,14 @@
 	},
 /area/station/science/research_director)
 "pLl" = (
-/obj/storage/cart/hotdog,
-/obj/item/reagent_containers/food/snacks/hotdog,
-/obj/item/reagent_containers/food/snacks/hotdog,
-/obj/item/reagent_containers/food/snacks/hotdog,
-/obj/item/reagent_containers/food/snacks/hotdog,
-/obj/item/shaker/mustard{
-	pixel_x = -6
-	},
-/obj/item/shaker/ketchup{
-	pixel_x = 6
-	},
 /obj/item/device/radio/intercom/catering,
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/stove,
+/obj/item/soup_pot,
+/obj/item/ladle,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "pLt" = (
@@ -110171,7 +110177,7 @@ wNu
 wNu
 wNu
 fWu
-wNu
+fwW
 cor
 fGo
 auT


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a stove to the kitchen in Destiny on the tile where the hotdog stand used to be, subsequently moved it next to the lockers. The intercom was moved to behind the chute due to it being covered by the APC.

![obraz](https://user-images.githubusercontent.com/93096874/152488120-44a748b5-37da-48c8-bbb5-55a019bc7d86.png)

Also, this is my first PR so if i screwed anything up say so and i'll fix it.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There's a stove on (almost) every active map, there's no reason as to why it should be excluded on this one, especially when making soup is such a major part in the work of a chef.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Josephin23
(+)Added a stove to the kitchen in Destiny, also moved the intercom.
```
