### PR TITLE
Fixes revenant ability icons not updating

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -20,6 +20,7 @@
 	var/tabName = "Spells"
 
 	var/mob/owner = null
+	var/datum/abilityHolder/relay = null
 
 	var/x_occupied = 0
 	var/y_occupied = 0

--- a/code/datums/abilities/revenant.dm
+++ b/code/datums/abilities/revenant.dm
@@ -4,7 +4,6 @@
 	cast_while_dead = 1
 	var/channeling = 0
 
-	var/datum/abilityHolder/wraith/relay = null
 	var/datum/bioEffect/hidden/revenant/revenant = null
 	pointName = "Wraith Points"
 
@@ -39,8 +38,9 @@
 	onAbilityStat()
 		..()
 		.= list()
-		.["Points:"] = round(relay.points)
-		.["Gen. rate:"] = round(relay.regenRate + relay.lastBonus)
+		if (relay) // Avoids a runtime whilst setting up revenant verbs
+			.["Points:"] = round(relay.points)
+			.["Gen. rate:"] = round(relay.regenRate + relay.lastBonus)
 
 /datum/bioEffect/hidden/revenant
 	name = "Revenant"
@@ -244,13 +244,40 @@
 			owner.mind.spells.len = 0
 		return*/
 
+/atom/movable/screen/ability/topBar/revenant
+
+	update_cooldown_cost()
+		var/newcolor = null
+		var/on_cooldown = round((owner.last_cast - world.time) / 10)
+
+		if (owner.pointCost)
+			if (owner.pointCost > owner.holder.relay.points)
+				newcolor = rgb(64, 64, 64)
+				point_overlay.maptext = "<span class='sh vb r ps2p' style='color: #cc2222;'>[owner.pointCost]</span>"
+			else
+				point_overlay.maptext = "<span class='sh vb r ps2p'>[owner.pointCost]</span>"
+		else
+			src.maptext = null
+
+		if (on_cooldown > 0)
+			newcolor = rgb(96, 96, 96)
+			cooldown_overlay.alpha = 255
+			cooldown_overlay.maptext = "<span class='sh vb c ps2p'>[min(999, on_cooldown)]</span>"
+			point_overlay.alpha = 64
+		else
+			cooldown_overlay.alpha = 0
+			point_overlay.alpha = 255
+
+		if (newcolor != src.color)
+			src.color = newcolor
+
 /datum/targetable/revenantAbility
 	icon = 'icons/mob/wraith_ui.dmi'
 	preferred_holder_type = /datum/abilityHolder/revenant
 	theme = "wraith"
 
 	New()
-		var/atom/movable/screen/ability/topBar/B = new /atom/movable/screen/ability/topBar(null)
+		var/atom/movable/screen/ability/topBar/revenant/B = new /atom/movable/screen/ability/topBar/revenant(null)
 		B.icon = src.icon
 		B.icon_state = src.icon_state
 		B.owner = src

--- a/code/datums/abilities/revenant.dm
+++ b/code/datums/abilities/revenant.dm
@@ -245,7 +245,6 @@
 		return*/
 
 /atom/movable/screen/ability/topBar/revenant
-
 	update_cooldown_cost()
 		var/newcolor = null
 		var/on_cooldown = round((owner.last_cast - world.time) / 10)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Revenant's abilities were always shown as darkened and unavailable because proc/update_cooldown_cost() was checking against the revenant's points. As revenants don't generate their own points, they use those generated in their wraith abilityHolder, this meant the icons never updated. 

This PR provides an override to the proc so it checks the wraith abilityHolder's points instead of the revenant's. 

Actually using abilities checked and deducted points from the correct pot, and so did not need fixing.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #1937 - see comment.
Fixes #4935 - most of the bug described was previously fixed in [#6243 Wraith/Revenant UI update + fixes], but this closes it out.