### PR TITLE
Move storage to layer 2.99

### DIFF
--- a/_std/defines/layer.dm
+++ b/_std/defines/layer.dm
@@ -16,7 +16,7 @@
 #define TURF_EFFECTS_LAYER 	(TURF_LAYER+0.8)
 #define GRILLE_LAYER 		(TURF_LAYER+0.9)
 #define COG2_WINDOW_LAYER 	(TURF_LAYER+0.95)
-#define STORAGE_LAYER     (TURF_LAYER+0.99) // Keep lockers etc below items
+#define STORAGE_LAYER		(TURF_LAYER+0.99) // Keep lockers etc below items
 
 // Mob clothing and effect layers
 #define MOB_LAYER_BASE 		4

--- a/_std/defines/layer.dm
+++ b/_std/defines/layer.dm
@@ -16,6 +16,7 @@
 #define TURF_EFFECTS_LAYER 	(TURF_LAYER+0.8)
 #define GRILLE_LAYER 		(TURF_LAYER+0.9)
 #define COG2_WINDOW_LAYER 	(TURF_LAYER+0.95)
+#define STORAGE_LAYER     (TURF_LAYER+0.99) // Keep lockers etc below items
 
 // Mob clothing and effect layers
 #define MOB_LAYER_BASE 		4

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -19,6 +19,7 @@
 	throwforce = 10
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	p_class = 2.5
+	layer = STORAGE_LAYER
 	var/intact_frame = 1 //Variable to create crates and fridges which cannot be closed anymore.
 	var/secure = 0
 	var/personal = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[REWORK]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves /obj/storage to it's own layer, STORAGE_LAYER which is on 2.99.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Experimentation revealed that despite storage appearing to happily share layer 3 with obj/item the ordering of the layer is actually slightly random with rare lockers above their contents.

1. Use Wide Area Spawn to create a bunch of /obj/storage/closet/emergency
2. Go through them one by one, taking out their contents and right click to check they are empty
3. Sooner or later you will discover an item underneath the locker
4. Picking up this item and placing it on the locker will still leave it underneath, yet other items will be on top.
5. If you find another locker you will find that the above/below will persist for certain items.

My hypothesis is that there is a mild randomisation of ordering to all items on layer 3 and it's only due to unknown client behaviour that lockers layered as desired the majority of the time.

I don't know of any side effects as the layers above are atom/movable, mobs, overlays etc that we would want over a locker and it is still above the other layers.