### PR TITLE
Hunter mask self destruct and mini o2

### DIFF
--- a/code/datums/abilities/hunter.dm
+++ b/code/datums/abilities/hunter.dm
@@ -58,6 +58,7 @@
 		M.equip_if_possible(new /obj/item/clothing/shoes/cowboy/hunter(M), slot_shoes)
 		M.equip_if_possible(new /obj/item/device/radio/headset(M), slot_ears)
 		M.equip_if_possible(new /obj/item/storage/backpack(M), slot_back)
+		M.equip_if_possible(new /obj/item/tank/emergency_oxygen(M), slot_l_store)
 		M.equip_if_possible(new /obj/item/cloaking_device/hunter(M), slot_r_store)
 		M.equip_if_possible(new /obj/item/knife/butcher/hunterspear(M), slot_l_hand)
 		M.equip_if_possible(new /obj/item/gun/energy/plasma_gun/hunter(M), slot_r_hand)

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -25,6 +25,9 @@
 	New()
 		..()
 		src.vchange = new(src) // Built-in voice changer (Convair880).
+		if(istype(src.loc, /mob/living))
+			var/mob/M = src.loc
+			src.AddComponent(/datum/component/self_destruct, M)
 
 	equipped(mob/user)
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the hunter mask also self destruct on death like the spear, gun and cloaking device.
Gives them a mini O2 in their pocket.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a traitor thermal equivalent, acid immune mask.
Helps ensure hunters are ready to go in a potentially depressurised station.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Hunter mask now self destructs on death.
```
