### PR TITLE
Critters can no longer use light switches

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -1296,6 +1296,7 @@ var/list/ghostcritter_blocked = ghostcritter_blocked_objects()
 /proc/ghostcritter_blocked_objects() // Generates an associate list of (type = 1) that can be checked much faster than looping istypes
 	var/blocked_types = list(/obj/item/device/flash,\
 	/obj/item/reagent_containers/glass/beaker,\
+	/obj/machinery/light_switch,\
 	/obj/item/reagent_containers/glass/bottle,\
 	/obj/item/scalpel,\
 	/obj/item/circular_saw,\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As the title says, ghost critters are now not allowed to use switches


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
As was pointed out by Andres Kojima, salty or greifing ghosts can easily spawn as a critter and spam light switches to annoy people or just turn off lights. There's no real reason they need to be able to use them.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)NightmareChamillian
(+)Light switches are now too high for ghost critters
```
