### PR TITLE
Fixes clickdrag on shinai bag

### DIFF
--- a/code/obj/item/kendo.dm
+++ b/code/obj/item/kendo.dm
@@ -240,6 +240,23 @@
 		else
 			..()
 
+	MouseDrop(atom/over_object, src_location, over_location)
+		..()
+		var/atom/movable/screen/hud/S = over_object
+		if (istype(S))
+			playsound(src.loc, "rustle", 50, 1, -5)
+			if (!usr.restrained() && !usr.stat && src.loc == usr)
+				if (S.id == "rhand")
+					if (!usr.r_hand)
+						usr.u_equip(src)
+						usr.put_in_hand_or_drop(src, 0)
+				else
+					if (S.id == "lhand")
+						if (!usr.l_hand)
+							usr.u_equip(src)
+							usr.put_in_hand_or_drop(src, 1)
+				return
+
 /obj/item/storage/box/kendo_box
 	name = "kendo box"
 	desc = "A box full of kendo gear!"

--- a/code/obj/item/kendo.dm
+++ b/code/obj/item/kendo.dm
@@ -255,7 +255,6 @@
 						if (!usr.l_hand)
 							usr.u_equip(src)
 							usr.put_in_hand_or_drop(src, 1)
-				return
 
 /obj/item/storage/box/kendo_box
 	name = "kendo box"

--- a/code/obj/item/kendo.dm
+++ b/code/obj/item/kendo.dm
@@ -240,7 +240,7 @@
 		else
 			..()
 
-	MouseDrop(atom/over_object, src_location, over_location)
+	mouse_drop(atom/over_object, src_location, over_location)
 		..()
 		var/atom/movable/screen/hud/S = over_object
 		if (istype(S))

--- a/code/obj/item/kendo.dm
+++ b/code/obj/item/kendo.dm
@@ -245,7 +245,7 @@
 		var/atom/movable/screen/hud/S = over_object
 		if (istype(S))
 			playsound(src.loc, "rustle", 50, 1, -5)
-			if (!usr.restrained() && !usr.stat && src.loc == usr)
+			if (can_act(usr) && src.loc == usr)
 				if (S.id == "rhand")
 					if (!usr.r_hand)
 						usr.u_equip(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Shinai bags cannot be taken off by clickdragging to hand because they do not inherit the relevant proc from /obj/item/storage - they are of path /obj/item/shinai_bag. They can still be removed by clickdragging to floor.

This PR adds the relevant override to MouseDrop to enable clickdragging to hand.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #3644