### PR TITLE
clicking on a desk with an empty hand opens the storage menu

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -298,12 +298,17 @@
 		else
 			return ..()
 
-	attack_hand(mob/user as mob)
+	attack_hand(mob/user)
 		if (user.is_hulk() && !hulk_immune)
 			user.visible_message("<span class='alert'>[user] destroys the table!</span>")
 			if (prob(40))
 				playsound(src.loc, "sound/impact_sounds/Generic_Hit_Heavy_1.ogg", 50, 1)
 			deconstruct()
+			return
+
+		if (src.has_storage && src.desk_drawer)
+			src.MouseDrop(user, src.loc, user.loc)
+
 		if (ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if (istype(H.w_uniform, /obj/item/clothing/under/misc/lawyer))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

clicking on a desk with an empty hand opens the storage menu for that desk. also removes redundant "as mob"

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

click drag interaction for desks is really unclear and unintuitive imo

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Adhara in Space
(*)Clicking on a desk (or any table with built in storage) with an empty hand opens the storage now.
```
