### PR TITLE
Removes Donut 3 Loafing Blueprint

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -21805,7 +21805,6 @@
 /area/shuttle/arrival/station)
 "gdc" = (
 /obj/machinery/rkit,
-/obj/item/paper/manufacturer_blueprint/loafer,
 /obj/machinery/light/incandescent/warm{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes Donut 3 roundstart loafer blueprint


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not only does no other map have this, but you can only scan a loafer with a traitor scanner for good reason!  It's been getting out of hand and I'm pretty sure it was removed before cause of issues. So this re removes it. No Changelog needed to my knowledge


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

