### PR TITLE
allow directly adding su access at the access computer

### DIFF
--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -16,13 +16,13 @@
 	var/list/supply_access_list = list(access_hangar, access_cargo, access_supply_console, access_mining, access_mining_shuttle, access_mining_outpost)
 	var/list/research_access_list = list(access_medical, access_tox, access_tox_storage, access_medlab, access_medical_lockers, access_research, access_robotics, access_chemistry, access_pathology)
 	var/list/security_access_list = list(access_security, access_brig, access_forensics_lockers, access_maxsec, access_securitylockers, access_carrypermit, access_contrabandpermit)
-	var/list/command_access_list = list(access_research_director, access_emergency_storage, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_heads, access_captain, access_engineering_chief, access_medical_director, access_head_of_personnel, access_ghostdrone)
+	var/list/command_access_list = list(access_research_director, access_emergency_storage, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_heads, access_captain, access_engineering_chief, access_medical_director, access_head_of_personnel, access_dwaine_superuser)
 	var/list/allowed_access_list
 	req_access = list(access_change_ids)
 	desc = "A computer that allows an authorized user to change the identification of other ID cards."
 
 	deconstruct_flags = DECON_MULTITOOL
-	light_r =0.7
+	light_r = 0.7
 	light_g = 1
 	light_b = 0.1
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an option you can click for SU access.

I also remove the ghostdrone access from this list, I don't think it did anything, since it's not in access_name_lookup.
And it has no business being there anyway.

(I also added a space in the code, because it was bugging me and it's RIGHT THERE!)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Not a balance change, since you can already do this via setting the job to Captain or RD or whatever and then modifying it, just some convenience and it is nicer to see who already has su access when editing cards.

This is more convenient and it didn't really make much sense to not be able to add SU access directly, especially when you can add stuff like weapons or contraband permits directly.
