### PR TITLE
Fix item arms with arm_icon always displaying right arm image

### DIFF
--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -491,7 +491,7 @@
 		if (istype(I))
 			//if(I.over_clothes) handlistPart += "l_arm_[I.arm_icon]"
 			//else partlistPart += "l_arm_[I.arm_icon]"
-			handlistPart += "r_arm_[I.arm_icon]"
+			handlistPart += "l_arm_[I.arm_icon]"
 			override_attack_hand = I.override_attack_hand
 			can_hold_items = I.can_hold_items
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a typo/copy paste error.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Any item with an arm_icon (pretty much just chainsaws) would show on the right arm when attached to the left.