### PR TITLE
Fixes milk jugs turning into milk bottles

### DIFF
--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -364,6 +364,8 @@
 
 	update_icon()
 		src.underlays = null
+		if (src.icon_state == "milk_calcium")
+			return
 		if (reagents.total_volume)
 			var/fluid_state = round(clamp((src.reagents.total_volume / src.reagents.maximum_volume * 3 + 1), 1, 3))
 			if (!src.fluid_image)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mootimers calcium drink, which is just a regular milk bottle with a randomly overridden name & sprite, loses its unique icon and turns back into a milk bottle when drunk from. This is because milk bottles have an overriden update_icon() proc that switches out the icon to milk bottle icons with varying liquid levels as you drink from it. 

This PR adds an early return to the milk update_icon() proc so it doesn't update the sprite change if it's the jug. The jug looks like one of those opaque white plastic containers to me so I didn't think it needed different states of fullness.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5379
