### PR TITLE
Add "SecHUD Flag" entry to security computers

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -164,6 +164,8 @@
 		S["ma_crim"] = "None"
 		S["ma_crim_d"] = "No major crime convictions."
 
+	S["sec_flag"] = "None"
+
 
 	B["job"] = H.job
 	B["current_money"] = 100.0

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -126,7 +126,7 @@
 			if(sec_record)
 				var/sechud_flag = sec_record["sec_flag"]
 				if (lowertext(sechud_flag) != "none")
-					. += "<br><span class='notice'>[src.name] has a Security HUD flag set for them: [sechud_flag]</span>"
+					. += "<br><span class='notice'>[src.name] has a Security HUD flag set:</span> <span class='alert'>[sechud_flag]</span>"
 
 	if (src.is_jittery)
 		switch(src.jitteriness)

--- a/code/mob/living/carbon/human/procs/get_desc.dm
+++ b/code/mob/living/carbon/human/procs/get_desc.dm
@@ -53,9 +53,6 @@
 	if (src.w_uniform)
 		. += "<br><span class='[src.w_uniform.blood_DNA ? "alert" : "notice"]'>[src.name] is wearing [bicon(src.w_uniform)] \an [src.w_uniform.name].</span>"
 
-	if (src.hasStatus("handcuffed"))
-		. +=  "<br><span class='notice'>[src.name] is [bicon(src.handcuffs)] handcuffed!</span>"
-
 	if (src.wear_suit)
 		. += "<br><span class='[src.wear_suit.blood_DNA ? "alert" : "notice"]'>[src.name] has [bicon(src.wear_suit)] \an [src.wear_suit.name] on.</span>"
 
@@ -117,6 +114,19 @@
 				. += "<br><span class='alert'>[src.name] is wearing [bicon(src.wear_id)] [src.wear_id.name] with [bicon(src.wear_id:ID_card)] [src.wear_id:ID_card:name] in it yet doesn't seem to be that person!!!</span>"
 			else
 				. += "<br><span class='notice'>[src.name] is wearing [bicon(src.wear_id)] [src.wear_id.name] with [bicon(src.wear_id:ID_card)] [src.wear_id:ID_card:name] in it.</span>"
+
+	if (src.hasStatus("handcuffed"))
+		. +=  "<br><span class='notice'>[src.name] is [bicon(src.handcuffs)] handcuffed!</span>"
+
+	if (src.arrestIcon?.icon_state && ishuman(usr))
+		var/mob/living/carbon/human/H = usr
+
+		if (istype(H.glasses, /obj/item/clothing/glasses/sunglasses/sechud))
+			var/datum/db_record/sec_record = data_core.security.find_record("name", src.name)
+			if(sec_record)
+				var/sechud_flag = sec_record["sec_flag"]
+				if (lowertext(sechud_flag) != "none")
+					. += "<br><span class='notice'>[src.name] has a Security HUD flag set for them: [sechud_flag]</span>"
 
 	if (src.is_jittery)
 		switch(src.jitteriness)

--- a/code/modules/networks/computer3/sec_rec.dm
+++ b/code/modules/networks/computer3/sec_rec.dm
@@ -710,7 +710,7 @@
 				view_string +={"
 				<br><center><b>Security Data</b></center>
 				<br>\[08]<b>Criminal Status:</b> [src.active_secure["criminal"]]
-				<br>\[09]<b>Sechud Flag:</b> [src.active_secure["sec_flag"]]
+				<br>\[09]<b>SecHUD Flag:</b> [src.active_secure["sec_flag"]]
 				<br>\[10]<b>Minor Crimes:</b> [src.active_secure["mi_crim"]]
 				<br>\[11]<b>Details:</b> [src.active_secure["mi_crim_d"]]
 				<br>\[12]<b><br>Major Crimes:</b> [src.active_secure["ma_crim"]]

--- a/code/modules/networks/computer3/sec_rec.dm
+++ b/code/modules/networks/computer3/sec_rec.dm
@@ -18,11 +18,12 @@
 #define FIELDNUM_PRINT 6
 #define FIELDNUM_PHOTO 7
 #define FIELDNUM_CRIMSTAT 8
-#define FIELDNUM_MINCRIM 9
-#define FIELDNUM_MINDET 10
-#define FIELDNUM_MAJCRIM 11
-#define FIELDNUM_MAJDET 12
-#define FIELDNUM_NOTES 13
+#define FIELDNUM_SECFLAG 9
+#define FIELDNUM_MINCRIM 10
+#define FIELDNUM_MINDET 11
+#define FIELDNUM_MAJCRIM 12
+#define FIELDNUM_MAJDET 13
+#define FIELDNUM_NOTES 14
 
 #define FIELDNUM_DELETE "d"
 #define FIELDNUM_NEWREC "new"
@@ -296,6 +297,7 @@
 						R["full_name"] = src.active_general["full_name"]
 						R["id"] = src.active_general["id"]
 						R["criminal"] = "None"
+						R["sec_flag"] = "None"
 						R["mi_crim"] = "None"
 						R["mi_crim_d"] = "No minor crime convictions."
 						R["ma_crim"] = "None"
@@ -333,6 +335,11 @@
 
 					if (FIELDNUM_CRIMSTAT)
 						src.print_text("Please select: (1) Arrest (2) None (3) Incarcerated<br>(4) Parolled (5) Released (0) Back")
+						src.menu = MENU_FIELD_INPUT
+						return
+
+					if (FIELDNUM_SECFLAG)
+						src.print_text("Please enter new value (10 characters max), or \"None.\"")
 						src.menu = MENU_FIELD_INPUT
 						return
 
@@ -430,6 +437,7 @@
 								src.active_secure["criminal"] = "*Arrest*"
 							if (2)
 								src.active_secure["criminal"] = "None"
+								src.active_secure["sec_flag"] = "None"
 							if (3)
 								src.active_secure["criminal"] = "Incarcerated"
 							if (4)
@@ -441,6 +449,17 @@
 								return
 							else
 								return
+
+					if (FIELDNUM_SECFLAG)
+						if (!src.active_secure)
+							src.print_text("No security record loaded!")
+							src.menu = MENU_IN_RECORD
+							return
+
+						if (ckey(inputText))
+							src.active_secure["sec_flag"] = copytext(inputText, 1, 11) // 10 characters at most
+						else
+							return
 
 					if (FIELDNUM_MINCRIM)
 						if (!src.active_secure)
@@ -691,11 +710,12 @@
 				view_string +={"
 				<br><center><b>Security Data</b></center>
 				<br>\[08]<b>Criminal Status:</b> [src.active_secure["criminal"]]
-				<br>\[09]<b>Minor Crimes:</b> [src.active_secure["mi_crim"]]
-				<br>\[10]<b>Details:</b> [src.active_secure["mi_crim_d"]]
-				<br>\[11]<b><br>Major Crimes:</b> [src.active_secure["ma_crim"]]
-				<br>\[12]<b>Details:</b> [src.active_secure["ma_crim_d"]]
-				<br>\[13]<b>Important Notes:</b> [src.active_secure["notes"]]"}
+				<br>\[09]<b>Sechud Flag:</b> [src.active_secure["sec_flag"]]
+				<br>\[10]<b>Minor Crimes:</b> [src.active_secure["mi_crim"]]
+				<br>\[11]<b>Details:</b> [src.active_secure["mi_crim_d"]]
+				<br>\[12]<b><br>Major Crimes:</b> [src.active_secure["ma_crim"]]
+				<br>\[13]<b>Details:</b> [src.active_secure["ma_crim_d"]]
+				<br>\[14]<b>Important Notes:</b> [src.active_secure["notes"]]"}
 			else
 				view_string += "<br><br><b>Security Record Lost!</b>"
 				view_string += "<br>\[[FIELDNUM_NEWREC]] Create New Security Record.<br>"
@@ -984,6 +1004,7 @@
 #undef FIELDNUM_RANK
 #undef FIELDNUM_PRINT
 #undef FIELDNUM_CRIMSTAT
+#undef FIELDNUM_SECFLAG
 #undef FIELDNUM_MINCRIM
 #undef FIELDNUM_MINDET
 #undef FIELDNUM_MAJCRIM

--- a/code/obj/item/device/pda2/record_progs.dm
+++ b/code/obj/item/device/pda2/record_progs.dm
@@ -50,6 +50,7 @@
 				dat += "<h4>Security Data</h4>"
 				if (istype(src.active2, /datum/db_record) && data_core.security.has_record(src.active2))
 					dat += "Criminal Status: [src.active2["criminal"]]<br>"
+					dat += "Sechud Flag: [src.active2["sec_flag"]]<br>"
 
 					dat += "Minor Crimes: [src.active2["mi_crim"]]<br>"
 					dat += "Details: [src.active2["mi_crim"]]<br><br>"

--- a/code/obj/item/device/pda2/record_progs.dm
+++ b/code/obj/item/device/pda2/record_progs.dm
@@ -50,7 +50,7 @@
 				dat += "<h4>Security Data</h4>"
 				if (istype(src.active2, /datum/db_record) && data_core.security.has_record(src.active2))
 					dat += "Criminal Status: [src.active2["criminal"]]<br>"
-					dat += "Sechud Flag: [src.active2["sec_flag"]]<br>"
+					dat += "SecHUD Flag: [src.active2["sec_flag"]]<br>"
 
 					dat += "Minor Crimes: [src.active2["mi_crim"]]<br>"
 					dat += "Details: [src.active2["mi_crim"]]<br><br>"

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -648,6 +648,7 @@ that cannot be itched
 			src.active2["criminal"] = "Released"
 		else
 			src.active2["criminal"] = "None"
+		src.active2["sec_flag"] = "None"
 		src.active2["mi_crim"] = "None"
 		src.active2["mi_crim_d"] = "No minor crime convictions."
 		src.active2["ma_crim"] = "None"


### PR DESCRIPTION
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a new entry for command line security computers, "SecHUD Flag." When set for someone who has an active arrest status (including paroled, revhead, etc), the SecHUD flag will appear in their examine report for anyone wearing SecHUDs.

![image](https://user-images.githubusercontent.com/53062374/152664751-56e9eda7-c342-461e-b74e-d90d25b80dcb.png)

![image](https://user-images.githubusercontent.com/53062374/152664827-493773dc-5988-495e-a2fb-e513c49f5c58.png)

![image](https://user-images.githubusercontent.com/53062374/152664836-8cace0ce-619f-4999-84e0-b58934e686a9.png)

Its value is initially set as "None," regardless if you are jailbird or not. It has a maximum of 10 characters, meant to be short as anything longer can be put in minor/major crime list and for fast reading. Upon someone's arrest status being set to (2) None, their sechud flag will automatically be set to "None."

Also, a side change, the examine report message about a person being handcuffed was moved to near the bottom of the clothing list, previously it was near the top (would appear just above the SecHUD flag message).

Made based on discussion thread here:
https://forum.ss13.co/showthread.php?tid=17938

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It would help for communication between security officers on arrest reasons, as you could quickly read someone's SecHUD flag to see why they're wanted. 

While it wouldn't remove all required communication for arresting someone if any confusion is there, such as who will be handling the arrest, it could help make some arrests quicker, and still serve as a soft reminder as to why someone is on an arrest status for chaotic games where you might forget or haven't seen the name in a while.

The handcuff message change was done so that security related stuff could be consolidated near the bottom of the examine report rather than the very top, which is in line with where the handcuff message appears when taking items off someone.

## Changelog
```changelog
(u)FlameArrow57
(*)Security computers now provide a SecHUD flag that can be set for someone. If a person has an active arrest status, the flag will appear in their examine report for anyone wearing SecHUDs.
```