### PR TITLE
Ability Parent & UpdateOverlays 

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -420,36 +420,40 @@
 		..()
 
 	update_icon()
-		src.overlays.Cut()
 		if (owner.waiting_for_hotkey)
-			src.overlays += src.binding
+			UpdateOverlays(src.binding, "binding")
+		else
+			UpdateOverlays(null, "binding")
+
 		if(owner.action_key_number > -1)
-			set_number_overlay(owner.action_key_number)
+			UpdateOverlays(set_number_overlay(owner.action_key_number), "action_key_number")
+		else
+			UpdateOverlays(null, "action_key_number")
 		return
 
 	proc/set_number_overlay(var/num)
+
 		switch(num)
 			if(1)
-				src.overlays += src.one
+				. = src.one
 			if(2)
-				src.overlays += src.two
+				. = src.two
 			if(3)
-				src.overlays += src.three
+				. = src.three
 			if(4)
-				src.overlays += src.four
+				. = src.four
 			if(5)
-				src.overlays += src.five
+				. = src.five
 			if(6)
-				src.overlays += src.six
+				. += src.six
 			if(7)
-				src.overlays += src.seven
+				. = src.seven
 			if(8)
-				src.overlays += src.eight
+				. = src.eight
 			if(9)
-				src.overlays += src.nine
+				. = src.nine
 			if(0)
-				src.overlays += src.zero
-		return
+				. = src.zero
 
 	// Switch to targeted only if multiple mobs are in range. All screen abilities customize their clicked(),
 	// and you have to call this proc there if you want to use it. You also need to set 'target_selection_check = 1'
@@ -601,19 +605,31 @@
 		if (!istype(M) || !M.client)
 			return null
 
-		src.overlays = list()
 		if (owner.holder)
-			if (src == owner.holder.shiftPower)
-				src.overlays += src.shift_highlight
-			if (src == owner.holder.ctrlPower)
-				src.overlays += src.ctrl_highlight
-			if (src == owner.holder.altPower)
-				src.overlays += src.alt_highlight
+			if (src.owner == src.owner.holder.shiftPower)
+				UpdateOverlays(src.shift_highlight, "shift_highlight")
+			else
+				UpdateOverlays(null, "shift_highlight")
+
+			if (src.owner == owner.holder.ctrlPower)
+				UpdateOverlays(src.ctrl_highlight, "ctrl_highlight")
+			else
+				UpdateOverlays(null, "ctrl_highlight")
+
+			if (src.owner == owner.holder.altPower)
+				UpdateOverlays(src.alt_highlight, "alt_highlight")
+			else
+				UpdateOverlays(null, "alt_highlight")
+
 			if (owner.waiting_for_hotkey)
-				src.overlays += src.binding
+				UpdateOverlays(src.binding, "binding")
+			else
+				UpdateOverlays(null, "binding")
 
 		if(owner.action_key_number > -1)
-			set_number_overlay(owner.action_key_number)
+			UpdateOverlays(set_number_overlay(owner.action_key_number), "action_key_number")
+		else
+			UpdateOverlays(null, "action_key_number")
 
 		update_cooldown_cost()
 		return


### PR DESCRIPTION
[bug][feature]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes obliterating overlays in ability_parent.dm.
Fixes references to specific ability to allow for comparisons for Ctrl, Shift, and Alt to generate overlay properly.

![image](https://user-images.githubusercontent.com/1017374/152673344-45197e41-c4c8-47c1-99b6-70339cfc84e9.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Generic Ctrl/Shift/Alt overlays should work now/again.
Abilities can now adjust the overlays not managed by ability_parent.

