### PR TITLE
Fix loaves overflowing with gravy, so the high tier loaves have the intended reagents

### DIFF
--- a/code/WorkInProgress/recycling/disposal.dm
+++ b/code/WorkInProgress/recycling/disposal.dm
@@ -888,11 +888,6 @@
 
 				LAGCHECK(LAG_MED)
 
-
-
-				if (newIngredient.reagents)
-					newIngredient.reagents.trans_to(newLoaf, 1000)
-
 				if (istype(newIngredient, /obj/item/reagent_containers/food/snacks/prison_loaf))
 					var/obj/item/reagent_containers/food/snacks/prison_loaf/otherLoaf = newIngredient
 					newLoaf.loaf_factor += otherLoaf.loaf_factor * 1.2
@@ -976,7 +971,7 @@
 	icon_state = "eloaf"
 	force = 0
 	throwforce = 0
-	initial_volume = 1000
+	initial_volume = 400
 
 	New()
 		..()
@@ -990,7 +985,7 @@
 	icon_state = "ploaf0"
 	force = 0
 	throwforce = 0
-	initial_volume = 1000
+	initial_volume = 400
 	var/loaf_factor = 1
 	var/processing = 0
 


### PR DESCRIPTION
[BUG]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Loaves no longer transfer reagents from reagent containers that are put inside of the loafer.
Lowers maximum capacity of loaves to 400 units.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This behavior was unintended (according to cog), loaves currently overflow with gravy, fake cheese, etc, and quickly
fill up past their current maximum capacity of 1000 units.
Removing the transfer of reagents ensures loaves only contain the intended quantities of reagent for each, and
lets higher-level loaves to actually contain their intended chemicals (uranium, plutonium, george melonium)
