### PR TITLE
Change death check for BR

### DIFF
--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -143,7 +143,7 @@ var/global/list/datum/mind/battle_pass_holders = list()
 /datum/game_mode/battle_royale/check_finished()
 	var/someone_died = 0
 	for(var/datum/mind/M in living_battlers)
-		if(isdead(M.current) || issilicon(M.current) || isobserver(M.current) || inafterlife(M.current) || isVRghost(M.current))
+		if(isdead(M.current) || !ishuman(M.current) || inafterlife(M.current) || isVRghost(M.current))
 			living_battlers.Remove(M)
 			DEBUG_MESSAGE("[M.current.name] died. There are [living_battlers.len] left!")
 			recently_deceased.Add(M)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Simplifies the BR death check to include !ishuman.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Handles players somehow getting borged, transformed into a crittere or being an observer all in one check!