### PR TITLE
Flashlight bugfix: borg edition

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1805,7 +1805,6 @@
 
 	proc/uneq_slot(var/i)
 		if (module_states[i])
-			src.contents -= module_states[i]
 			if (src.module)
 				var/obj/I = module_states[i]
 				if (isitem(I))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes a weird statement removing an unequipped borg tool from the borg's contents.

The item is already removed from contents by set_loc (or presumably the qdel, but AFAIK there is no way to have non-module tools on a borg anyway).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #7414

-Removing the tool from contents set the tool's `loc` to null
-`set_loc` sends a signal with an `oldloc` of null
-The loctargeting component fails to update because null is not an `atom/movable`