### PR TITLE
Adds the stress ball to the medical fabricator

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1050,6 +1050,15 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Resource"
 
+/datum/manufacture/stress_ball
+	name = "Stress Ball"
+	item_paths = list("FAB-1")
+	item_amounts = list(1)
+	item_outputs = list(/obj/item/toy/plush/small/stress_ball)
+	time = 5 SECONDS
+	create = 1
+	category = "Tool"
+
 /******************** Robotics **************************/
 
 /datum/manufacture/robo_frame

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2233,6 +2233,7 @@
 		/datum/manufacture/eyepatch,
 		/datum/manufacture/blindfold,
 		/datum/manufacture/muzzle,
+		/datum/manufacture/stress_ball,
 		/datum/manufacture/body_bag,
 		/datum/manufacture/implanter,
 		/datum/manufacture/implant_health,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the stress ball from the therapist's office on Oshan and Destiny to the medical fabricator. 

The stress ball itself is made with one fabric, so that it can be printed off round-start, and it's description doesn't really mention anything about what it's made out of.

Unintentionally it causes the implanter to be beside the implants now -- which is nice!

![image](https://user-images.githubusercontent.com/92401911/152725269-6a3e8e54-0a8e-436a-a799-1ddd3b56d8a9.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Small addition to the fabricator that can bring more RP variety to a doctor or therapist's treatment plans for their patients.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)avimour
(+)Medical fabricators can now create stress balls.
```
