### PR TITLE
fix bug where microscopic amounts of chems could make total volume update wrongly

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -558,7 +558,10 @@ datum
 					del_reagent(current_id)
 					update_total()
 
-		proc/del_reagent(var/reagent)
+		/// deletes a reagent from a container
+		/// the first argument is the reagent id
+		/// the second whether or not the total volume of the container should update, which may be undesirable in the update_total proc
+		proc/del_reagent(var/reagent, var/update_total = TRUE)
 			var/datum/reagent/current_reagent = reagent_list[reagent]
 
 			if (current_reagent)
@@ -570,7 +573,8 @@ datum
 					current_reagent.on_remove()
 					remove_possible_reactions(current_reagent.id) //Experimental structure
 					reagent_list.Remove(reagent)
-					update_total()
+					if(update_total)
+						update_total()
 
 					reagents_changed()
 
@@ -588,8 +592,8 @@ datum
 			for(var/current_id in reagent_list)
 				var/datum/reagent/current_reagent = reagent_list[current_id]
 				if(current_reagent)
-					if(current_reagent.volume <= 0.001)
-						del_reagent(current_id)
+					if(current_reagent.volume <= CHEM_EPSILON)
+						del_reagent(current_id, update_total = FALSE)
 					else
 						current_reagent.volume = max(round(current_reagent.volume, 0.001), 0.001)
 						composite_heat_capacity = total_volume/(total_volume+current_reagent.volume)*composite_heat_capacity + current_reagent.volume/(total_volume+current_reagent.volume)*current_reagent.heat_capacity


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When really small amounts of chems got removed by update_total() the removal would trigger another update_total(), whose sum would partially combine with the initial call, thus resulting in too much volume.

I solve this by adding a new argument to del_reagent to make it not call update_total if desired.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad

