### PR TITLE
Fix a null on secbot attacks

### DIFF
--- a/code/modules/robotics/bot/secbot.dm
+++ b/code/modules/robotics/bot/secbot.dm
@@ -579,6 +579,8 @@
 				if (stuncount > 0)
 					sleep(BATON_DELAY_PER_STUN)
 
+			if (isnull(target))
+				return
 			SPAWN_DBG(0.2 SECONDS)
 				src.icon_state = "secbot[src.on][(src.on && src.emagged >= 2) ? "-wild" : null]"
 			if (src.target.getStatusDuration("weakened"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[RUNTIME]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix null on `if (src.target.getStatusDuration("weakened"))`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes bad.