### PR TITLE
CHEER_UP Program!

### DIFF
--- a/code/datums/controllers/explosion_controls.dm
+++ b/code/datums/controllers/explosion_controls.dm
@@ -24,8 +24,7 @@ var/datum/explosion_controller/explosions
 			return
 		if (epicenter.loc:sanctuary)
 			return//no boom boom in sanctuary
-
-		queued_explosions += new/datum/explosion(source, epicenter, power, brisance, angle, width)
+		queued_explosions += new/datum/explosion(source, epicenter, power, brisance, angle, width, usr)
 
 	proc/queue_damage(var/list/new_turfs)
 		var/c = 0
@@ -145,8 +144,9 @@ var/datum/explosion_controller/explosions
 	var/brisance
 	var/angle
 	var/width
+	var/user
 
-	New(atom/source, turf/epicenter, power, brisance, angle, width)
+	New(atom/source, turf/epicenter, power, brisance, angle, width, user)
 		..()
 		src.source = source
 		src.epicenter = epicenter
@@ -154,12 +154,13 @@ var/datum/explosion_controller/explosions
 		src.brisance = brisance
 		src.angle = angle
 		src.width = width
+		src.user = user
 
 	proc/logMe(var/power)
 		//I do not give a flying FUCK about what goes on in the colosseum. =I
 		if(!istype(get_area(epicenter), /area/colosseum))
 			// Cannot read null.name
-			var/logmsg = "Explosion with power [power] (Source: [source ? "[source.name]" : "*unknown*"])  at [log_loc(epicenter)]. Source last touched by: [source ? "[source.fingerprintslast]" : "*null*"]"
+			var/logmsg = "Explosion with power [power] (Source: [source ? "[source.name]" : "*unknown*"])  at [log_loc(epicenter)]. Source last touched by: [source?.fingerprintslast ? "[source.fingerprintslast]" : "*null*"] (usr: [ismob(user) ? key_name(user) : user])"
 			if(power > 10)
 				message_admins(logmsg)
 			logTheThing("bombing", null, null, logmsg)

--- a/code/modules/networks/computer3/mainframe2/tapes.dm
+++ b/code/modules/networks/computer3/mainframe2/tapes.dm
@@ -148,6 +148,7 @@
 		src.root.add_file( new /datum/computer/file/guardbot_task/bodyguard(src) )
 		src.root.add_file( new /datum/computer/file/guardbot_task/security/area_guard(src) )
 		src.root.add_file( new /datum/computer/file/guardbot_task/bodyguard/heckle(src) )
+		src.root.add_file( new /datum/computer/file/guardbot_task/bodyguard/cheer_up(src) )
 		src.root.add_file( new /datum/computer/file/mainframe_program/guardbot_interface(src))
 		src.root.add_file( new /datum/computer/file/record/pr6_readme(src))
 		src.root.add_file( new /datum/computer/file/record/patrol_script(src))

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -3539,7 +3539,6 @@
 					master.scratchpad["targetname"] = ckey(src.protected_name)
 					src.master.add_task(/datum/computer/file/guardbot_task/security/seek, 1, 0)
 
-			return
 
 		check_buddy()
 			return 0
@@ -3593,7 +3592,6 @@
 					master.scratchpad["targetname"] = ckey(src.protected_name)
 					src.master.add_task(/datum/computer/file/guardbot_task/security/seek, 1, 0)
 
-			return
 
 		check_buddy()
 			return 0

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -3544,6 +3544,57 @@
 		check_buddy()
 			return 0
 
+
+	bodyguard/cheer_up
+		name = "cheer_up"
+		task_id = "CHEER_UP"
+		var/global/list/buddy_cheer_up_phrases = list("A magician was walking down the street, then he turned into a grocery store.","Three guys walked into a bar, you’d think at least one of them would have seen it.","You’re having a heart attack, the dispatcher says that help is going to arrive in a heartbeat.","The past, present and future walked into a bar, things got tense.","I asked my French friend if they like videogames, they said Wii.","RIP boiled water, you will be mist.","A guy’s left side was cut off, don’t worry he’s all right now.","What did the sea say to another sea?","You shouldn’t wear glasses while playing football. Why?","Why shouldn’t you get close to trees?","Why are there gates in graveyards?","What do you call an illegally parked frog?","Two silk worms compete in a race, who won?","Whaddya call a cow with no legs?","How does a tree get into his account?","I can't help set the speakers at concerts anymore.")
+		var/global/list/buddy_cheer_up_answers = list("Nothing, they just waved.","Because it’s a contact sport.","Because they’re pretty shady.","Because everyone is dying to get there.","A toad.","None of them, it ended in a tie.","Ground Beef!","It logs in!","Nobody liked my feedback.")
+		var/tmp/initial_seek_complete = 0
+
+		task_act()
+			if (..())
+				return
+
+			if (src.protected && prob(10))
+				var/buddy_cheer_up_chooser = rand(1,16)
+				var/buddy_cheer_up_answer_chooser = (buddy_cheer_up_chooser - 7) //There are more phrases than answers.
+				master.speak(buddy_cheer_up_phrases[buddy_cheer_up_chooser])
+				master.point(src.protected, 1)
+
+				if (buddy_cheer_up_chooser >= 8) //Does the phrase need an answer?
+					master.point(src.protected, 1)
+					master.speak(buddy_cheer_up_answers[buddy_cheer_up_answer_chooser])
+
+
+		look_for_protected() //Search for a mob in view with the name we are programmed to guard.
+			if(src.protected) return //We have someone to protect!
+			for (var/mob/living/C in view(7,master))
+				if (isdead(C)) //We were too late!
+					continue
+
+				var/check_name = C.name
+				if(ishuman(C) && C:wear_id)
+					check_name = C:wear_id:registered
+
+				if (ckey(check_name) == ckey(src.protected_name))
+					src.protected = C
+					buddy_is_dork = 1
+					//src.desired_emotion = GUARDING_EMOTION
+					master.speak("Level 9F [pick("unhappy person","person in need of cheering-up","coolest person on the station","genius","friend","joke-defiency")] detected!")
+					master.point(C)
+					return
+
+				if (!initial_seek_complete)
+					initial_seek_complete = 1
+					master.scratchpad["targetname"] = ckey(src.protected_name)
+					src.master.add_task(/datum/computer/file/guardbot_task/security/seek, 1, 0)
+
+			return
+
+		check_buddy()
+			return 0
+
 #undef SEARCH_EMOTION
 #undef GUARDING_EMOTION
 #undef GUARDING_DORK_EMOTION

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -3548,8 +3548,9 @@
 	bodyguard/cheer_up
 		name = "cheer_up"
 		task_id = "CHEER_UP"
-		var/global/list/buddy_cheer_up_phrases = list("A magician was walking down the street, then he turned into a grocery store.","Three guys walked into a bar, you’d think at least one of them would have seen it.","You’re having a heart attack, the dispatcher says that help is going to arrive in a heartbeat.","The past, present and future walked into a bar, things got tense.","I asked my French friend if they like videogames, they said Wii.","RIP boiled water, you will be mist.","A guy’s left side was cut off, don’t worry he’s all right now.","What did the sea say to another sea?","You shouldn’t wear glasses while playing football. Why?","Why shouldn’t you get close to trees?","Why are there gates in graveyards?","What do you call an illegally parked frog?","Two silk worms compete in a race, who won?","Whaddya call a cow with no legs?","How does a tree get into his account?","I can't help set the speakers at concerts anymore.")
-		var/global/list/buddy_cheer_up_answers = list("Nothing, they just waved.","Because it’s a contact sport.","Because they’re pretty shady.","Because everyone is dying to get there.","A toad.","None of them, it ended in a tie.","Ground Beef!","It logs in!","Nobody liked my feedback.")
+		var/global/list/buddy_cheer_up_phrases = list("A magician was walking down the street, then he turned into a grocery store.","Three guys walked into a bar, you’d think at least one of them would have seen it.","You’re having a heart attack, the dispatcher says that help is going to arrive in a heartbeat.","The past, present and future walked into a bar, things got tense.","I asked my French friend if they like videogames, they said Wii.","RIP boiled water, you will be mist.","A guy’s left side was cut off, don’t worry, he’s all right now.")
+		var/global/list/buddy_cheer_up_starters = list("What did the sea say to another sea?","You shouldn’t wear glasses while playing football. Why?","Why shouldn’t you get close to trees?","Why are there gates in graveyards?","What do you call an illegally parked frog?","Two silk worms compete in a race, who won?","Whaddya call a cow with no legs?","How does a tree get into his account?","I can't help set the speakers at concerts anymore.","What’re caterpillars scared of?","What has four wheels and is green?","What did one lobster say to the other?",)
+		var/global/list/buddy_cheer_up_answers = list("Nothing, they just waved.","Because it’s a contact sport.","Because they’re pretty shady.","Because everyone is dying to get there.","A toad.","None of them, it ended in a tie.","Ground Beef!","It logs in!","Nobody liked my feedback.","Dog-appilers!","Grass! I lied about the wheels.","Nothing, since they can't talk. If they could, though, probably something about shellfish.")
 		var/tmp/initial_seek_complete = 0
 
 		task_act()
@@ -3557,14 +3558,16 @@
 				return
 
 			if (src.protected && prob(10))
-				var/buddy_cheer_up_chooser = rand(1,16)
-				var/buddy_cheer_up_answer_chooser = (buddy_cheer_up_chooser - 7) //There are more phrases than answers.
-				master.speak(buddy_cheer_up_phrases[buddy_cheer_up_chooser])
-				master.point(src.protected, 1)
-
-				if (buddy_cheer_up_chooser >= 8) //Does the phrase need an answer?
+				if (prob(40))
+					var/buddy_cheer_up_chooser = rand(1, buddy_cheer_up_phrases.len)
+					master.speak(buddy_cheer_up_phrases[buddy_cheer_up_chooser])
 					master.point(src.protected, 1)
-					master.speak(buddy_cheer_up_answers[buddy_cheer_up_answer_chooser])
+				else
+					var/buddy_cheer_up_chooser = rand(1, buddy_cheer_up_starters.len)
+					master.speak(buddy_cheer_up_starters[buddy_cheer_up_chooser])
+					master.point(src.protected, 1)
+					master.speak(buddy_cheer_up_answers[buddy_cheer_up_chooser])
+
 
 
 		look_for_protected() //Search for a mob in view with the name we are programmed to guard.

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -3582,7 +3582,6 @@
 				if (ckey(check_name) == ckey(src.protected_name))
 					src.protected = C
 					buddy_is_dork = 1
-					//src.desired_emotion = GUARDING_EMOTION
 					master.speak("Level 9F [pick("unhappy person","person in need of cheering-up","coolest person on the station","genius","friend","joke-defiency")] detected!")
 					master.point(C)
 					return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] --> [INPUT WANTED] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This adds a new program for the guardbuddies, cheer_up! It is the inverse of "heckle" and it has the buddy follow the person around and tell jokes to make them happy. It uses the same format as heckle (https://wiki.ss13.co/TermOS#GuardBuddies) to assign the buddies to this task. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The buddies are adorable and need more programming options. Sometimes you don't want to insult someone, you want to make them happy and tell corny jokes!


## Sending out the bat signal

Currently there are 16 jokes, and I have more that I can think of, research, and remember, but Rome wasn't built in a day, nor by one-person, so if you have a joke, please submit it here! 

https://forms.gle/KJGhnCdPWzzBJUFCA

Thanks!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)AmazingDragons
(*)Added a new morale-boosting problem to the mainframe for control of your favorite guardbuddies!
```
