### PR TITLE
Adds a gene power module to horizon

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -13307,6 +13307,7 @@
 /obj/item/robodefibrillator,
 /obj/item/storage/firstaid/brain,
 /obj/item/clothing/glasses/eyepatch,
+/obj/item/cloneModule/genepowermodule,
 /turf/simulated/floor/green,
 /area/station/medical/research{
 	name = "Genetic Research"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
All other maps have one and I don't see a reason why horizon shouldn't have it.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Danger Noodle
(+)Horizon's genetics department has been blessed with a gene power module. Enjoy!
```
