### PR TITLE
Adds Embalming fluid to Donut 3's morgue

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -34426,6 +34426,10 @@
 	pixel_y = 5
 	},
 /obj/item/storage/box/body_bag,
+/obj/item/reagent_containers/glass/bottle/formaldehyde{
+	pixel_x = 7;
+	pixel_y = 7
+	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/medical/morgue)
 "jPm" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a bottle of embalming fluid to Donut 3's medical morgue.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)Donut 3's medical morgue now comes with a bottle of embalming fluid.
```
