### PR TITLE
Fixes teleportation & possible soft-lock with third-party chameleon projection

### DIFF
--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -80,8 +80,8 @@
 		off_y = rand(-amplitude/3, amplitude/3)
 
 		if (flips < flips_required)
-			var/shake_hands_adj = pick("frantically","wildly","violently","rapidly","vigorously","furiously")
-			var/shake_hands_syn = pick("wave","flail","shake","swing","flap")
+			shake_hands_adj = pick("frantically","wildly","violently","rapidly","vigorously","furiously")
+			shake_hands_syn = pick("wave","flail","shake","swing","flap")
 			user.show_text("<span class='alert'>You [shake_hands_adj] [shake_hands_syn] your hands at the hologram</span>")
 			playsound(src.loc, "sound/effects/elec_bzzz.ogg", 50, 1)
 			animate(src, pixel_x = off_x, pixel_y = off_y, easing = JUMP_EASING, time = 0.5, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
@@ -189,7 +189,7 @@
 				A.set_loc(get_turf(cham))
 			cham.set_loc(src)
 			boutput(usr, "<span class='notice'>You deactivate the [src].</span>")
-			anim.set_loc(get_turf(src))
+			anim.set_loc(get_turf(usr))
 			flick("emppulse",anim)
 			SPAWN_DBG(0.8 SECONDS)
 				anim.set_loc(src)
@@ -200,13 +200,13 @@
 
 			playsound(src, "sound/effects/pop.ogg", 100, 1, 1)
 			cham.master = src
-			cham.set_loc(get_turf(src))
+			cham.set_loc(get_turf(usr))
 			usr.set_loc(cham)
 			src.active = 1
 			cham.flips = 0
 
 			boutput(usr, "<span class='notice'>You activate the [src].</span>")
-			anim.set_loc(get_turf(src))
+			anim.set_loc(get_turf(usr))
 			flick("emppulse",anim)
 			SPAWN_DBG(0.8 SECONDS)
 				anim.set_loc(src)

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -82,7 +82,7 @@
 		if (flips < flips_required)
 			shake_hands_adj = pick("frantically","wildly","violently","rapidly","vigorously","furiously")
 			shake_hands_syn = pick("wave","flail","shake","swing","flap")
-			user.show_text("<span class='alert'>You [shake_hands_adj] [shake_hands_syn] your hands at the hologram</span>")
+			user.show_text("<span class='alert'>You [shake_hands_adj] [shake_hands_syn] your hands at the hologram.</span>")
 			playsound(src.loc, "sound/effects/elec_bzzz.ogg", 50, 1)
 			animate(src, pixel_x = off_x, pixel_y = off_y, easing = JUMP_EASING, time = 0.5, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
 			animate(pixel_x = off_x*-1, pixel_y = off_y*-1, easing = JUMP_EASING, time = 0.5, flags = ANIMATION_RELATIVE)
@@ -188,7 +188,7 @@
 			for (var/atom/movable/A in cham)
 				A.set_loc(get_turf(cham))
 			cham.set_loc(src)
-			boutput(usr, "<span class='notice'>You deactivate the [src].</span>")
+			boutput(usr, "<span class='notice'>You deactivate [src].</span>")
 			anim.set_loc(get_turf(usr))
 			flick("emppulse",anim)
 			SPAWN_DBG(0.8 SECONDS)
@@ -205,7 +205,7 @@
 			src.active = 1
 			cham.flips = 0
 
-			boutput(usr, "<span class='notice'>You activate the [src].</span>")
+			boutput(usr, "<span class='notice'>You activate [src].</span>")
 			anim.set_loc(get_turf(usr))
 			flick("emppulse",anim)
 			SPAWN_DBG(0.8 SECONDS)

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -76,6 +76,7 @@
 	var/can_use = 0
 	var/obj/overlay/anim = null //The toggle animation overlay will also be retained
 	var/obj/dummy/chameleon/cham = null //No sense creating / destroying this
+	var/obj/item/device/chameleon/holder = null
 	var/active = 0
 	tooltip_flags = REBUILD_DIST
 
@@ -163,6 +164,9 @@
 			if (istype(src.loc, /obj/dummy/chameleon)) //No recursive chameleon projectors!!
 				boutput(usr, "<span class='alert'>As your finger nears the power button, time seems to slow, and a strange silence falls.  You reconsider turning on a second projector.</span>")
 				return
+			if (istype(src.loc, /obj/item/parts/human_parts/arm)) //If it's an item arm, the person who's arm it is gets cloaked
+				var/obj/item/device/chameleon/O = src.loc
+				usr = O.holder
 
 			playsound(src, "sound/effects/pop.ogg", 100, 1, 1)
 			cham.master = src


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Activating someone else's chameleon projectors (eg: through disarming people with chameleon projectors for arms) can trigger the chameleon projector item, but with the attacker registered as the item's user. This results in the attacker getting stuck as a projected item and completely unable to interact with anything (including doors and disposal chutes) until: 
- Someone shoves them;
- They use their own chameleon projector (if they have one), "detaching" the first projection;
- The item arm owner uses their projector again;
- They get hit by an explosion.

This PR preserves the interaction of the wrong person getting cloaked whilst providing a means for the cloaked user to avoid a possible soft-lock. It makes the following changes:
- Enables projection to be disrupted through repeated flipping, similar to how you'd get out of a locker or port-a-brig;
- Stops the third party being teleported to the chameleon projector (per #7482).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7436.
Fixes #7482.

Note: This PR does reinterpret the expected behaviour of the linked bugs - from "should not activate on the wrong person" to "should not trap the wrong person without outside interference".

## Changelog
```changelog
(u)MetricDuck
(+)Players can now flip to escape chameleon projector disguises. 
```
