### PR TITLE
Fix horizon disposals

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -25425,10 +25425,7 @@
 	layer = 4;
 	name = "Crusher Door"
 	},
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/junction/left/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bkK" = (
@@ -46566,6 +46563,7 @@
 	operating = 1
 	},
 /obj/map/light/dimreddish,
+/obj/disposalpipe/segment/ejection,
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
@@ -46578,7 +46576,6 @@
 	},
 /obj/machinery/crusher,
 /obj/map/light/dimreddish,
-/obj/disposalpipe/segment/ejection,
 /turf/space,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 4
@@ -55780,7 +55777,10 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southwest)
 "kKb" = (
-/obj/disposalpipe/junction/right/north,
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/disposal)
 "kLr" = (
@@ -58383,7 +58383,10 @@
 /turf/space,
 /area/space)
 "rhT" = (
-/obj/disposalpipe/segment/ejection,
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/disposal)
 "rjk" = (
@@ -60817,6 +60820,17 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
+"wUo" = (
+/obj/securearea{
+	desc = "It looks pretty dangerous in there.";
+	name = "HAZARDOUS AREA"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/disposal)
 "wUH" = (
 /obj/item/chair/folded,
 /obj/machinery/light/incandescent/harsh/very,
@@ -121693,7 +121707,7 @@ arE
 aaa
 aaa
 aaa
-bHl
+wUo
 cmR
 bkJ
 pax


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Redirects the horizon disposal pipe to not pass under crusher


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* The crusher crushes disposal pipes