### PR TITLE
Moves the hot loop scrubber on cog1 to a less obnoxious location.

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -29775,6 +29775,7 @@
 	can_rupture = 0;
 	dir = 6
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
 "byC" = (
@@ -57666,7 +57667,6 @@
 	dir = 1;
 	level = 2
 	},
-/obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/black,
 /area/station/engine/hotloop)
 "meU" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. The scrubber has been shunned into the corner where it cannot do any harm but still remains helpful if you need it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mr. Rathen tends to push it onto the valves in the room which can starts being very annoying if you're maintaing a burn or setting the engine up multiple rounds in a row and it doesn't feel intended.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
```
