### PR TITLE
Allow civilian headsets and staff assistant jumpsuits to be printed from uniform manufacturers

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -697,6 +697,24 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Tool"
 
+/datum/manufacture/civilian_headset
+	name = "Civilian Headset"
+	item_paths = list("MET-1", "CON-1")
+	item_amounts = list(2, 1)
+	item_outputs = list(/obj/item/device/radio/headset)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
+/datum/manufacture/jumpsuit_assistant
+	name = "Staff Assistant Jumpsuit"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/under/rank)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
 /datum/manufacture/jumpsuit
 	name = "Grey Jumpsuit"
 	item_paths = list("FAB-1")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2351,15 +2351,19 @@
 
 /obj/machinery/manufacturer/uniform // add more stuff to this as needed, but it should be for regular uniforms the HoP might hand out, not tons of gimmicks. -cogwerks
 	name = "Uniform Manufacturer"
-	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing workplace uniforms."
+	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing workplace uniforms and headsets."
 	icon_state = "fab-jumpsuit"
 	icon_base = "jumpsuit"
 	free_resource_amt = 5
-	free_resources = list(/obj/item/material_piece/cloth/cottonfabric)
+	free_resources = list(/obj/item/material_piece/cloth/cottonfabric,
+		/obj/item/material_piece/steel,
+		/obj/item/material_piece/copper)
 	accept_blueprints = 0
 	available = list(/datum/manufacture/shoes,	//hey if you update these please remember to add it to /hop_and_uniform's list too
 	/datum/manufacture/shoes_brown,
 	/datum/manufacture/shoes_white,
+	/datum/manufacture/civilian_headset,
+	/datum/manufacture/jumpsuit_assistant,
 	/datum/manufacture/jumpsuit,
 	/datum/manufacture/jumpsuit_white,
 	/datum/manufacture/jumpsuit_red,
@@ -2451,7 +2455,7 @@
 //and i hate this, i do, but you're gonna have to update this list whenever you update /personnel or /uniform
 /obj/machinery/manufacturer/hop_and_uniform
 	name = "Personnel Manufacturer"
-	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing workplace uniforms and identification equipment."
+	desc = "A 3D printer-like machine that can construct a variety of items. This one is for producing workplace uniforms, headsets, and identification equipment."
 	icon_state = "fab-access"
 	icon_base = "access"
 	free_resource_amt = 5
@@ -2466,6 +2470,8 @@
 	/datum/manufacture/shoes,
 	/datum/manufacture/shoes_brown,
 	/datum/manufacture/shoes_white,
+	/datum/manufacture/civilian_headset,
+	/datum/manufacture/jumpsuit_assistant,
 	/datum/manufacture/jumpsuit,
 	/datum/manufacture/jumpsuit_white,
 	/datum/manufacture/jumpsuit_red,


### PR DESCRIPTION
[FEATURE][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows civilian headsets and staff assistant jumpsuits to be printed from the uniform manufacturer and the HoP's uniform manufacturer.

Based on discussion here:
https://forum.ss13.co/showthread.php?tid=17980

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Civilian headsets cannot really be obtained any way if lost, leaving the only option to take a departmental headset from a department in one of its lockers. Staff assistant jumpsuits do not spawn anywhere in the first place.

As security, this also makes it a little easier to replace someone's headset if they are wearing one they shouldn't be wearing and you do not have a replacement on hand, by giving a go to place for getting a new headset, the HoP's office or the uniform manufacturer in crew quarters. Not entirely the same for uniforms since general colors are available, but the staff assistant option would now be available.

It also gives an option for recovering these items if they are taken from your body while being cloned.

I figured putting these in the uniform manufacturer rather than new lockers in crew quarters would be a much better option considering these are clothing items meant for public access and adding new lockers would consider space requirements that could be hard to fit on some maps.

## Changelog
```changelog
(u)FlameArrow57
(+)Civilian headsets and staff assistant jumpsuits can now be printed from uniform manufacturers.
```