### PR TITLE
Build-A-Vends no longer group products of the same type, but with different names, into the same entry.

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1958,7 +1958,7 @@
 				R.product_amount += 1
 				existed = TRUE
 				break
-			else if (istype(target,R.product_type) && R.real_name == target.real_name)
+			else if (istype(target,R.product_type) && (R.real_name || R.product_name) == (target.real_name || target.name))
 				R.contents += target
 				R.product_amount += 1
 				existed = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Build-A-Vends now use the `name` or `product_name` of products, if the `real_name` does not exist, when it is grouping products into entries.

Previously, products of the same type that had different names, but no `real_name`, would be grouped together (`null == null`).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7365