### PR TITLE
Adds artistic toolboxes to all maps in rotation.

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -19057,6 +19057,9 @@
 /obj/item/clothing/glasses/vr/arcade,
 /obj/item/clothing/glasses/vr/arcade,
 /obj/item/clothing/glasses/vr/arcade,
+/obj/item/storage/toolbox/artistic{
+	pixel_y = 8
+	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fred2"

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -13232,6 +13232,7 @@
 	icon_state = "2-4"
 	},
 /obj/storage/crate/clown,
+/obj/item/storage/toolbox/artistic,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown)
 "azZ" = (

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -7697,7 +7697,7 @@
 /obj/table/auto,
 /obj/item/device/analyzer/atmospheric{
 	pixel_x = 9;
-	pixel_y = 6
+	pixel_y = 12
 	},
 /obj/item/weldingtool{
 	pixel_x = -3;
@@ -7705,6 +7705,9 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/item/storage/toolbox/artistic{
+	pixel_y = -6
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -19197,6 +19197,7 @@
 	pixel_x = -3;
 	pixel_y = 12
 	},
+/obj/item/storage/toolbox/artistic,
 /turf/simulated/floor/carpet,
 /area/station/crew_quarters/quartersA)
 "aSc" = (

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -18133,6 +18133,9 @@
 /area/station/chapel/office)
 "aUc" = (
 /obj/table/wood/auto,
+/obj/item/storage/toolbox/artistic{
+	pixel_y = -6
+	},
 /obj/candle_light{
 	pixel_y = 12
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -28829,6 +28829,10 @@
 /area/station/storage/warehouse)
 "bKD" = (
 /obj/rack,
+/obj/item/storage/toolbox/artistic{
+	pixel_y = -6
+	},
+/obj/item/storage/toolbox/artistic,
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/storage/warehouse)
 "bKE" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -45795,6 +45795,11 @@
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
+"dKK" = (
+/obj/table/glass/reinforced/auto,
+/obj/item/storage/toolbox/artistic,
+/turf/simulated/floor,
+/area/station/crew_quarters/lounge/port)
 "dLb" = (
 /obj/decal/cleanable/paper,
 /obj/machinery/power/apc/autoname_south,
@@ -82244,7 +82249,7 @@ bSu
 bTt
 bUG
 bVE
-bUG
+dKK
 bUp
 bXP
 bXb


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds an artistic toolbox to all maps in rotation and adds an additional toolbox to Oshan.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Jan said it would be nice and I think artistic toolboxes are underused.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Danger Noodle
(+)Added artistic toolboxes to all maps in rotation.
```
