### PR TITLE
Fixes bible<>storage transfer behaviour

### DIFF
--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -174,6 +174,10 @@
 			checkloc = checkloc.loc
 
 		if (T && istype(T, /obj/item/storage))
+			if (W in bible_contents) //Because we aren't calling attackhand we need to do this manually
+				bible_contents.Remove(W)
+				for_by_tcl(bible, /obj/item/storage/bible)
+					bible.hud?.remove_item(W)
 			src.add_contents(W)
 //			T.hud.remove_item(W)
 		else

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -174,7 +174,7 @@
 			checkloc = checkloc.loc
 
 		if (T && istype(T, /obj/item/storage))
-			if (W in bible_contents) //Because we aren't calling attackhand we need to do this manually
+			if (W in bible_contents)
 				bible_contents.Remove(W)
 				for_by_tcl(bible, /obj/item/storage/bible)
 					bible.hud?.remove_item(W)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Directly transferring items to storage containers from bibles has the following issues:
- Doesn't actually remove the item from the bible_contents global list, meaning the items aren't actually transferred;
- Doesn't properly update the icons in the recipient storage container.

This bug occurs because the bible has unique behavior coded for attackhand(), but there's nothing in /storage for attackby(). The default transfer-between-containers code doesn't work correctly as bibles don't actually store items in themselves, they send objects to loc(null) and keep a global list (so things like Exited() and Entered() aren't called).

This PR copies the necessary code from attackhand() into attackby() so the bible transfer gets handled correctly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7504.