### PR TITLE
Adds Manta command uniforms to respective offices.

### DIFF
--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -23,6 +23,7 @@
 	/obj/item/clothing/under/suit/hos,
 	/obj/item/clothing/under/suit/hos/dress,
 	/obj/item/clothing/under/rank/head_of_security/fancy,
+	/obj/item/clothing/under/rank/head_of_security/fancy_alt,
 	/obj/item/clothing/suit/wintercoat/command)
 
 /obj/item/storage/box/clothing/hop

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -89,6 +89,7 @@
 	/obj/item/clothing/suit/armor/vest,
 	/obj/item/stamp/hop,
 	/obj/item/device/radio/headset/command/hop,
+	/obj/item/clothing/suit/armor/hopcoat,
 	/obj/item/device/accessgun)
 
 /obj/storage/secure/closet/command/research_director


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds the HoS uniform and HoP coat that were present on Manta to the HoS's uniform box and HoP's Locker respectively.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Since Manta was removed from map rotation, I have myself wanted, and heard from a few others who also wished so, to be able to wear the special command clothes that were only present on Manta. This makes them available in the HoS uniform box and the HoP locker (due to space limitations in the uniform box).
It has also been suggested that this change could also be limited to just Oshan due to it's nautical theme.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Munien
(+)Manta station HoS and HoP command attire can now be found in the respective lockers.
```
