### PR TITLE
fixes wrong metal amounts for computers

### DIFF
--- a/code/modules/networks/computer3/buildandrepair.dm
+++ b/code/modules/networks/computer3/buildandrepair.dm
@@ -208,7 +208,7 @@
 			if(user.equipped(P) && isweldingtool(P))
 				boutput(user, "<span class='notice'>You deconstruct the frame.</span>")
 				var/obj/item/sheet/A = new /obj/item/sheet( src.loc )
-				A.amount = 5
+				A.amount = metal_given
 				if (src.material)
 					A.setMaterial(src.material)
 				else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so when computer frames are deconstructed they give an amount of sheets defined by the metal_given variable


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
https://github.com/goonstation/goonstation/issues/7495


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Conchuckter
(+)Fixes computer frames always giving 5 sheets instead of their proper amount
```
