### PR TITLE
Fixes poltergeists retreating to nullspace

### DIFF
--- a/code/mob/wraith.dm
+++ b/code/mob/wraith.dm
@@ -118,7 +118,8 @@
 				plane.alpha = 255
 
 	disposing()
-		poltergeists = null
+		for (var/mob/wraith/poltergeist/P in src.poltergeists)
+			P.master = null
 		..()
 
 	Stat()

--- a/code/mob/wraith.dm
+++ b/code/mob/wraith.dm
@@ -120,6 +120,7 @@
 	disposing()
 		for (var/mob/wraith/poltergeist/P in src.poltergeists)
 			P.master = null
+		poltergeists = null
 		..()
 
 	Stat()

--- a/code/mob/wraith/poltergeist.dm
+++ b/code/mob/wraith/poltergeist.dm
@@ -68,7 +68,7 @@
 			death()
 			boutput(src, "Your portal and master have been destroyed, you return to the nether.")
 
-		update_well_dist(TRUE, TRUE)
+		update_well_dist(master, marker)
 
 		if (loc == master && src.health < src.max_health)
 			HealDamage("chest", 5, 0)
@@ -139,7 +139,7 @@
 
 	Move(var/turf/NewLoc, direct)
 		..()
-		update_well_dist(TRUE, TRUE)
+		update_well_dist(master, marker)
 
 	click(atom/target)
 		. = ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If poltergeists retreat to master after their wraith master is dead they get sent to nullspace.

This bug occurs because wraiths don't properly clear their poltergeists master on death.

This PR fixes this by modifying wraith's disposing() code to null poltergeist.master for each poltergeist when the wraith is banished.

Additionally, this PR also tweaks the update_well_dist() proc to actually account for the fact that the master may be dead (and so not grant unlimited range from the marker if master is null).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7370.
Fixes #5433.