### PR TITLE
Add components for common item-related functionality

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -108,6 +108,7 @@
 #include "macros\spawn.dm"
 #include "macros\strings.dm"
 #include "macros\time.dm"
+#include "macros\transfers.dm"
 #include "macros\turf.dm"
 #include "macros\twitch_sbill.dm"
 #include "macros\vehicles.dm"

--- a/_std/defines/component_defines.dm
+++ b/_std/defines/component_defines.dm
@@ -84,6 +84,11 @@
 #define COMSIG_ATOM_POST_UPDATE_ICON "atom_after_update_icon"
 /// When reagents change
 #define COMSIG_ATOM_REAGENT_CHANGE "atm_reag"
+/// When an atom is dragged onto something (over_object, src_location, over_location)
+#define COMSIG_ATOM_MOUSEDROP "atom_mousedrop"
+/// When something is dragged onto an atom (object, usr)
+#define COMSIG_ATOM_MOUSEDROP_T "atom_mousedrop_t"
+
 // ---- atom/movable signals ----
 
 /// when an AM moves (thing, previous_loc, direction)
@@ -324,6 +329,14 @@
 
 
 #define COMSIG_SUSSY_PHRASE "sussy"
+
+// ---- Transfer system ----
+/// When an item is requested to be transfered to the output target (/obj/item/)
+#define COMSIG_INCOMING_TRANSFER "incoming_tx"
+/// When the target wants to send an item to an output (/obj/item/)
+#define COMSIG_OUTGOING_TRANSFER "outgoing_tx"
+/// Return whether the target should allow receiving items from the given atom (/atom)
+#define COMSIG_CAN_LINK "permit_tx"
 
 // ---- ability signals ----
 /// Send item to a mob

--- a/_std/macros/transfers.dm
+++ b/_std/macros/transfers.dm
@@ -1,0 +1,4 @@
+/// Transfer signal helpers
+
+/// Transfer the given movable to the output of the given target or to the loc of the target.
+#define TRANSFER_OR_DROP(T, AM) if (!SEND_SIGNAL(T, COMSIG_OUTGOING_TRANSFER, AM)){AM.set_loc(T.loc)}

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -642,7 +642,8 @@
 		if (!hasPDA)
 			. += "<br>*No PDA detected!*"
 
-/atom/proc/MouseDrop_T()
+/atom/proc/MouseDrop_T(dropped, user)
+	SEND_SIGNAL(src, COMSIG_ATOM_MOUSEDROP_T, dropped, user)
 	return
 
 /atom/proc/Attackhand(mob/user as mob)
@@ -763,7 +764,7 @@
 
 	return null
 
-/atom/MouseDrop(atom/over_object as mob|obj|turf)
+/atom/MouseDrop(atom/over_object as mob|obj|turf, src_location, over_location)
 	SPAWN( 0 )
 		if (istype(over_object, /atom))
 			if (isalive(usr))
@@ -785,6 +786,7 @@
 					var/obj/machinery/M = over_object
 					if (M.allow_stunned_dragndrop == 1)
 						M.MouseDrop_T(src, usr)
+		SEND_SIGNAL(src, COMSIG_ATOM_MOUSEDROP, usr, over_object, src_location, over_location)
 		return
 	..()
 	return

--- a/code/datums/components/transfers.dm
+++ b/code/datums/components/transfers.dm
@@ -1,0 +1,227 @@
+/// Components for common machine item tasks (setting output turf, filtering attackby, etc.)
+
+#define cant_do_shit(nerd) (!isliving(nerd) || isintangible(nerd) || is_incapacitated(nerd))
+
+/// Provides ability to output items directly into item transfer-supporting things.
+/datum/component/transfer_output
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	var/atom/output_target
+
+/datum/component/transfer_output/Initialize()
+	if (!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/transfer_output/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ATOM_MOUSEDROP, .proc/handle_drop)
+	RegisterSignal(parent, COMSIG_OUTGOING_TRANSFER, .proc/handle_outgoing)
+
+/datum/component/transfer_output/proc/handle_outgoing(comsig_target, obj/item/outgoing)
+	if(!output_target)
+		return
+
+	if(!in_interact_range(parent, output_target))
+		src.output_target = null
+		return
+
+	if(isturf(output_target))
+		outgoing.set_loc(output_target)
+		return TRUE
+
+	return SEND_SIGNAL(output_target, COMSIG_INCOMING_TRANSFER, outgoing)
+
+/datum/component/transfer_output/proc/handle_drop(comsig_target, mob/dropper, atom/over_object)
+	if(cant_do_shit(dropper))
+		return
+
+	if(over_object == parent)
+		boutput(dropper, "<span class='notice'>You reset the output location of [parent]!</span>")
+		src.output_target = null
+		return
+
+	if(!in_interact_range(parent, dropper))
+		return
+
+	if(!in_interact_range(over_object, parent))
+		boutput(dropper, "<span class='alert'>[over_object] is too far away!</span>")
+		return
+
+	if (isturf(over_object) || SEND_SIGNAL(over_object, COMSIG_CAN_LINK, parent))
+		boutput(dropper, "<span class='notice'>You set [parent] to output to [over_object].</span>")
+		output_target = over_object
+	else
+		boutput(dropper, "<span class='alert'>\The [over_object] cannot be used as an output for [parent].</span>")
+
+
+/// Provides many common item input features.
+/datum/component/transfer_input
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	/// Optional proc name on parent, for transfer side-effects.
+	var/transfer_proc
+	var/list/filter
+	var/filter_proc
+	var/filter_link_proc
+
+/datum/component/transfer_input/Initialize(list/filter=null, transfer=null, filter_proc=null, filter_link_proc=null)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	src.transfer_proc = transfer
+	src.filter = filter
+	src.filter_proc = filter_proc
+	src.filter_link_proc = filter_link_proc
+
+/datum/component/transfer_input/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_INCOMING_TRANSFER, .proc/handle_incoming)
+	RegisterSignal(parent, COMSIG_CAN_LINK, .proc/handle_incoming_link)
+	RegisterSignal(parent, COMSIG_ATTACKBY, .proc/handle_attackby)
+
+/datum/component/transfer_input/proc/handle_incoming_link(comsig_target, obj/other)
+	return !filter_link_proc || call(parent, filter_link_proc)(other)
+
+/datum/component/transfer_input/proc/handle_incoming(comsig_target, obj/item/incoming)
+	if (!isitem(incoming))
+		return
+
+	if (filter && !(incoming.type in filter))
+		return
+
+	if(!filter_proc || call(parent, filter_proc)(incoming))
+		incoming.set_loc(parent)
+		if (transfer_proc)
+			call(parent, transfer_proc)(incoming)
+		return TRUE
+
+#define CONTAINER_CHOICE_PLACE "Place container inside"
+#define CONTAINER_CHOICE_DUMP  "Dump its contents inside"
+
+/datum/component/transfer_input/proc/handle_attackby(comsig_target, obj/item/incoming, mob/attacker)
+	if(!isitem(incoming))
+		return
+
+	if (istype(incoming, /obj/item/deconstructor) || isgrab(incoming))
+		return
+
+	if(cant_do_shit(attacker))
+		return
+
+	if (istype(incoming, /obj/item/magtractor))
+		var/obj/item/magtractor/M = incoming
+		if (M.holding)
+			incoming = M.holding
+
+	if(incoming.cant_drop)
+		boutput(attacker, "<span class='alert'>You can't put that in [parent] when it's attached to you!</span>")
+		return
+
+	if ((istype(incoming, /obj/item/storage) || istype(incoming, /obj/item/satchel) || istype(incoming, /obj/item/ore_scoop)) && length(incoming.contents))
+		var/action
+		if(!filter_proc || call(parent, filter_proc)(incoming))
+			action = input(attacker, "What do you want to do with [incoming]?") as null|anything in list(CONTAINER_CHOICE_PLACE, CONTAINER_CHOICE_DUMP)
+		else
+			action = CONTAINER_CHOICE_DUMP
+
+		if (!action)
+			return
+
+		if (!in_interact_range(parent, attacker))
+			boutput(attacker, "<span class='alert'>You need to be closer to [parent] to do that.</span>")
+			return
+
+		if (action == CONTAINER_CHOICE_DUMP)
+			if (istype(incoming, /obj/item/ore_scoop))
+				var/obj/item/ore_scoop/scoop = incoming
+				incoming = scoop.satchel
+			for(var/obj/item/I in incoming)
+				if (SEND_SIGNAL(parent, COMSIG_INCOMING_TRANSFER, I))
+					attacker.u_equip(I)
+					I.dropped()
+			attacker.visible_message("<span class='notice'>[attacker] dumps out [incoming] into [parent].</span>")
+			return TRUE
+
+	if (SEND_SIGNAL(parent, COMSIG_INCOMING_TRANSFER, incoming))
+		attacker.visible_message("<span class='notice'>[attacker] places [incoming] into [parent]</span>")
+		attacker.u_equip(incoming)
+		if(isitem(incoming))
+			var/obj/item/I = incoming
+			I.dropped()
+		return TRUE
+
+#undef CONTAINER_CHOICE_DUMP
+#undef CONTAINER_CHOICE_PLACE
+
+
+// transfer_input with quick-loading abilities
+
+/datum/component/transfer_input/quickloading/RegisterWithParent()
+	..()
+	RegisterSignal(parent, COMSIG_ATOM_MOUSEDROP_T, .proc/handle_drop_t)
+
+/datum/component/transfer_input/quickloading/proc/handle_drop_t(comsig_target, atom/dropped, mob/user)
+	if(cant_do_shit(user))
+		return
+
+	if(!in_interact_range(parent, user))
+		return
+
+	if(!in_interact_range(dropped, parent))
+		boutput(user, "<span class='alert'>[dropped] is too far away!</span>")
+		return
+
+	if (istype(dropped, /obj/storage/crate) || istype(dropped, /obj/storage/cart/))
+		var/obj/storage/S = dropped
+		if (S.welded || S.locked)
+			boutput(user, "<span class='alert'>You have to be able to open [dropped] to quick-load from it!")
+			return
+
+		for(var/obj/item/AM in S.contents)
+			SEND_SIGNAL(parent, COMSIG_INCOMING_TRANSFER, AM)
+		user.visible_message("<span class='notice'>[user] quick-loads [S] into [parent]</span>")
+	else if (isitem(dropped))
+		var/obj/item/I = dropped
+		if(SEND_SIGNAL(parent, COMSIG_INCOMING_TRANSFER, I))
+			actions.start(new /datum/action/bar/quickload(parent, I.type), user)
+
+
+/datum/action/bar/quickload
+	duration = 0.1 SECONDS
+	id = "quickloading"
+	var/atom/target // where we are sending the transfers
+	var/load_type // what type we should load
+
+	New(atom/target, load_type)
+		..()
+		src.target = target
+		src.load_type = load_type
+
+	onStart()
+		. = ..()
+		loopStart()
+		owner.visible_message("<span class='notice'>[owner] begins quickly stuffing things into [target]!</span>")
+
+	onUpdate()
+		. = ..()
+		if(get_dist(owner, target) > 1)
+			src.interrupt(INTERRUPT_ALWAYS)
+
+	loopStart()
+		. = ..()
+		if(get_dist(owner, target) > 1)
+			src.interrupt(INTERRUPT_ALWAYS)
+
+	onEnd()
+		. = ..()
+		if (!load_type)
+			return
+		if(get_dist(owner, target) > 1)
+			src.interrupt(INTERRUPT_ALWAYS)
+			return
+		for(var/obj/item/M in view(1, owner))
+			if (!M || M.loc == owner)
+				continue
+			if (M.type != load_type)
+				continue
+			if(SEND_SIGNAL(target, COMSIG_INCOMING_TRANSFER, M))
+				playsound(target, "sound/items/Deconstruct.ogg", 40, 1)
+				onRestart()
+				return
+
+#undef cant_do_shit

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -285,6 +285,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\components\snowballs.dm"
 #include "code\datums\components\toggle_hood.dm"
 #include "code\datums\components\transfer_on_attack.dm"
+#include "code\datums\components\transfers.dm"
 #include "code\datums\components\tripsalot.dm"
 #include "code\datums\components\waddling.dm"
 #include "code\datums\components\itemblock\_itemblock.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds components for handling item inputs from crates, satchels, storage items, crates, magtractors, and other machines
using the output component. The 'quickloading' variant of the input component provides mousedrop handling for crates and loose piles of stuff, the latter now utilizing action bars!

In order to implement the above, there are two new comsigs, `COMSIG_ATOM_MOUSEDROP` and `COMSIG_ATOM_MOUSEDROP_T`.

### Brief Explanation

The input and output components both generically move items to each other using signals.
When an object with an output component wants to output an item to wherever it is currently set,
it emits a `COMSIG_OUTGOING_TRANSFER`, which causes the component to send a `COMSIG_INCOMING_TRANSFER`
to the output target. If that signal returns `TRUE`, then that means the output has consumed the item and moved it.
If it does not, the component instead places the item into the parent's location.

![image](https://user-images.githubusercontent.com/65367576/154190521-07b16bf0-348f-4c7c-9d13-bc7ff1954d09.png)

To set the output target, the output component listens for MouseDrop signals, and sends `COMSIG_CAN_LINK` to
whatever the target is. If it returns `TRUE`, then it becomes the new output.

<details>
<summary>More comprehensive overview of signals.</summary>

![image](https://user-images.githubusercontent.com/65367576/154190242-02435a47-4747-4830-ab5b-cc65881cb21d.png)

</details>

Because there are **many** places where this component could be used to replace old code, and because
replacing the old code may end up changing how certain machines act, this branch does not contain any
actual use of the component.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This was atomized out of the **disposal pipe rework** branch, with the original intention of creating a
frictionless and generic way to funnel items from disposal pipes into machines.

The same segments of decently complicated code are copy+pasted all over the codebase, from fabricators to
compost dispensers. These components allow those to be eliminated, and for all of them to be able to output
to each-other.