### PR TITLE
Pod Piercing Projectiles

### DIFF
--- a/code/modules/projectiles/laser.dm
+++ b/code/modules/projectiles/laser.dm
@@ -255,6 +255,7 @@ toxic - poisons
 	color_blue = 1
 	icon_turf_hit = "burn2"
 	projectile_speed = 42
+	damage_type = D_PIERCING
 
 /datum/projectile/laser/precursor // for precursor traps
 	name = "energy bolt"

--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -441,8 +441,14 @@
 				src.health -= damage/1.7
 				hitsound = 'sound/impact_sounds/Metal_Hit_Lowfi_1.ogg'
 			if(D_PIERCING)
-				src.health -= damage/1
+				src.health -= damage/.8
 				hitsound = 'sound/impact_sounds/Generic_Hit_Heavy_1.ogg'
+				if (prob(15))//seems reasonable
+				var/list/mobs = list()
+				for (var/mob/M in src)
+						mobs+=M
+				var/mob/M = pick(mobs)
+
 			if(D_ENERGY)
 				src.health -= damage/1.5
 				hitsound = 'sound/impact_sounds/Energy_Hit_3.ogg'


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] --> [DRAFT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes piercing damage type do less damage to pods but have a chance to damage and possibly kill people in them. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Would add another cool angle to podfighting, and allow for pods to be better at fighting other pods. In draft as I want input from others while I work on this to make sure i'm not fucking something up and I want to be able to show what I have done even when I'm not on my computer so I can still make notes and stuff

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Eagle
(+) Some pod weapons (mostly kinetics) can now pierce into other pods, damaging the people inside at the cost of hull damage.
```
