### PR TITLE
Color Codes Medical Ailment States

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -120,7 +120,10 @@
 	proc/scan_info()
 		var/text = "<span class='alert'><b>"
 		if (istype(src.master,/datum/ailment/disease) || istype(src.master,/datum/ailment/malady))
-			text += "[src.state] "
+			if (src.state == "Active" || src.state == "Acute")
+				text += "[src.state] "
+			else
+				text += "<span class='notice'>[src.state] </span>"
 		text += "[src.scantype ? src.scantype : src.master.scantype]:"
 
 		text += " [src.name ? src.name : src.master.name]</b> <small>(Stage [src.stage]/[src.master.max_stages])<br>"


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When you scan someone with a health analyzer, if they have an ailment like cardiac arrest or nanomachines or food poisoning etc. if it's "active" or "acute" that text will be red like normal. If it's anything else, it will be blue instead.

![unknown](https://user-images.githubusercontent.com/53125172/154272514-4c44c5d6-8129-4ef5-8b64-380afe681949.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

When someone has a lot of ailments the chat gets pretty clogged. So you might treat someone, scan them, and then not realize that an active malady turned remissive because everything the chat outputted was a solid brick of red. With an added color change, it should be easier to identify which ailments are treated and which need treatment.

If there are other states that should be red lmk tyia
