### PR TITLE
Fix chainsaw item arm not updating

### DIFF
--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -32,7 +32,7 @@
 	tool_flags = TOOL_SAWING
 	mats = 12
 	var/sawnoise = "sound/machines/chainsaw_green.ogg"
-	arm_icon = "chainsaw-A"
+	arm_icon = "chainsaw-D"
 	var/base_arm = "chainsaw"
 	over_clothes = 1
 	override_attack_hand = 1
@@ -46,6 +46,7 @@
 	active
 		active = 1
 		force = 12
+		arm_icon = "chainsaw-A"
 
 		New()
 			..()
@@ -151,7 +152,7 @@
 	desc = "A gas powered antique. This one is the real deal. Time for a space chainsaw massacre."
 	contraband = 10 //scary
 	sawnoise = "sound/machines/chainsaw_red.ogg"
-	arm_icon = "chainsaw_s-A"
+	arm_icon = "chainsaw_s-D"
 	base_arm = "chainsaw_s"
 	stamina_damage = 100
 	stamina_cost = 30
@@ -361,6 +362,7 @@
 	sawnoise = "sound/machines/chainsaw_red.ogg"
 	hitsound = "sound/machines/chainsaw_red.ogg"
 	arm_icon = "chainsaw_s-A"
+	base_arm = "chainsaw_s"
 	stamina_damage = 40
 	stamina_cost = 40
 	stamina_crit_chance = 50

--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -64,6 +64,13 @@
 		set_icon_state("[src.base_state][src.active ? null : "_off"]")
 		src.item_state = "[src.base_state][src.active ? "-A" : "-D"]"
 		src.arm_icon = "[src.base_arm][src.active ? "-A" : "-D"]"
+		if (src.temp_flags & IS_LIMB_ITEM)
+			if (istype(src.loc,/obj/item/parts/human_parts/arm/left/item))
+				var/obj/item/parts/human_parts/arm/left/item/I = src.loc
+				I.handlistPart = "l_arm_[src.arm_icon]"
+			else
+				var/obj/item/parts/human_parts/arm/right/item/I = src.loc
+				I.handlistPart = "r_arm_[src.arm_icon]"
 		return
 
 	// Fixed a couple of bugs and cleaned code up a little bit (Convair880).


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes chainsaw item arms icon go between inactive and animated active.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Visual feedback if the saw arm is on or off.