### PR TITLE
Anchor tracking beacons

### DIFF
--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -664,21 +664,18 @@ var/list/headset_channel_lookup
 		if (isscrewingtool(I))
 			if (src.anchored)
 				playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
-				user.show_text("You start unscrewing [src] from the floor.", "blue")
-				if (do_after(user, 3 SECONDS))
-					user.show_text("You unscrew [src] from the floor.", "blue")
-					src.anchored = 0
-					return
+				user.visible_message("[user] unscrews [src] from the floor.", "You unscrew [src] from the floor.", "You hear a screwdriver.")
+				src.anchored = 0
+				return
 			else
-				var/turf/T = get_turf(src)
-				if (istype(T, /turf/space))
-					user.show_text("What exactly are you gonna secure [src] to?", "red")
-					return
-				else
-					playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
-					user.show_text("You start securing [src] to [T].", "blue")
-					if (do_after(user, 3 SECONDS))
-						user.show_text("You secure [src] to [T].", "blue")
+				if (isturf(src.loc))
+					var/turf/T = get_turf(src)
+					if (istype(T, /turf/space))
+						user.show_text("What exactly are you gonna secure [src] to?", "red")
+						return
+					else
+						playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
+						user.visible_message("[user] screws [src] to the floor, anchoring it in place.", "You screw [src] to the floor, anchoring it in place.", "You hear a screwdriver.")
 						src.anchored = 1
 						return
 		..()

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -658,6 +658,30 @@ var/list/headset_channel_lookup
 	item_state = "signaler"
 	desc = "A small beacon that is tracked by the Teleporter Computer, allowing things to be sent to its general location."
 	burn_possible = 0
+	anchored = 1
+
+	attackby(obj/item/I as obj, mob/user as mob)
+		if (isscrewingtool(I))
+			if (src.anchored)
+				playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
+				user.show_text("You start unscrewing [src] from the floor.", "blue")
+				if (do_after(user, 3 SECONDS))
+					user.show_text("You unscrew [src] from the floor.", "blue")
+					src.anchored = 0
+					return
+			else
+				var/turf/T = get_turf(src)
+				if (istype(T, /turf/space))
+					user.show_text("What exactly are you gonna secure [src] to?", "red")
+					return
+				else
+					playsound(src.loc, "sound/items/Screwdriver.ogg", 50, 1)
+					user.show_text("You start securing [src] to [T].", "blue")
+					if (do_after(user, 3 SECONDS))
+						user.show_text("You secure [src] to [T].", "blue")
+						src.anchored = 1
+						return
+		..()
 
 /obj/item/device/radio/beacon/New()
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Tracking beacons start anchored.
Tracking beacons can be anchored/unanchored with screwing tools.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Accidentally picking up and moving tracking beacons is too easy.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Tracking beacons start anchored. You can unanchor them with a screwdriver.
```
