### PR TITLE
Change reward claim logic for antique Lawbringer

### DIFF
--- a/code/WorkInProgress/JobXPRewards.dm
+++ b/code/WorkInProgress/JobXPRewards.dm
@@ -323,13 +323,22 @@ mob/verb/checkrewards()
 		boutput(C.mob, "<span class='emote'>A pamphlet flutters out.</span>")
 		return
 
-/datum/jobXpReward/head_of_security_LG/old
+/datum/jobXpReward/head_of_security_LG_old
 	name = "The Antique Lawbringer"
 	desc = "Gain access to a voice activated weapon of the past-future-past by sacrificing your gun of the future-past. I.E. The Lawbringer."
-	sacrifice_path = /obj/item/gun/energy/lawbringer
-	reward_path = /obj/item/gun/energy/lawbringer/old
-	sacrifice_name = "Lawbringer"
 	required_levels = list("Head of Security"=5)
+	claimable = 1
+	claimPerRound = 1
+
+	activate(var/client/C)
+		var/obj/item/gun/energy/lawbringer/I = C.mob.find_type_in_hand(/obj/item/gun/energy/lawbringer)
+
+		if (I)
+			I.make_antique()
+			boutput(C.mob, "Your Lawbringer becomes a little more antique!")
+		else
+			boutput(C.mob, "You need to be holding your Lawbringer in order to claim this reward.")
+			src.claimedNumbers[usr.key] --
 
 //Captain
 

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1422,6 +1422,12 @@
 			return 1
 		return 0
 
+	proc/make_antique()
+		name = "antique Lawbringer"
+		icon_state = "old-lawbringer0"
+		old = 1
+		UpdateIcon()
+
 	shoot(var/target,var/start,var/mob/user)
 		if (canshoot())
 			//removing this for now so anyone can shoot it. I PROBABLY will want it back, doing this for some light appeasement to see how it goes.


### PR DESCRIPTION
[BUG - TRIVIAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just changes the logic for the antique Lawbringer reward claim to set the sprite of the Lawbringer to its antique version rather than replace it with a new Lawbringer.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, fixes #7512.