### PR TITLE
gokarts now set glide size on self when they start to move

### DIFF
--- a/code/WorkInProgress/racing.dm
+++ b/code/WorkInProgress/racing.dm
@@ -462,6 +462,8 @@
 	proc/drive(var/direction, var/speed)
 		set_dir(direction)
 		driving = 1
+		src.glide_size = (32 / speed) * world.tick_lag
+		driver.glide_size = (32 / speed) * world.tick_lag
 		walk(src, dir, speed)
 
 	proc/stop()

--- a/code/WorkInProgress/racing.dm
+++ b/code/WorkInProgress/racing.dm
@@ -463,7 +463,6 @@
 		set_dir(direction)
 		driving = 1
 		src.glide_size = (32 / speed) * world.tick_lag
-		driver.glide_size = (32 / speed) * world.tick_lag
 		walk(src, dir, speed)
 
 	proc/stop()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Gokarts set `glide_size` for themselves


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Hopefully fixes the screen jerk when riding in a gokart