### PR TITLE
Changes the Staff Assistants general headset to a Civilian Headset

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -988,6 +988,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	map_can_autooverride = 0
 	slot_jump = list(/obj/item/clothing/under/rank)
 	slot_foot = list(/obj/item/clothing/shoes/black)
+	slot_ears = list(/obj/item/device/radio/headset/civilian)
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BALANCE][INPUT WANTED]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

So this was discussed a while ago on rp-server. This changes the Staff Ass's headset to a civilian headset, giving them access to the civilian channel. 

Something to note is that this does not change the headset that is printed within the clothes fabricator, meaning that if they lose their initial headset, they're out of luck.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This allows staff assistants to have more communication options for RP, and be able to be used more as "assistants" for civilian roles. I also believe this could encourage the use of the civilian channel, which is by far the least used channel.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Yellow/Myco
(+)Staff Assistants now spawn with a Civilian Headset, giving them access to the civilian channel
```
