### PR TITLE
Makes Med, Tech, and Research Assistant jobs more viable for learning

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1226,11 +1226,13 @@ ABSTRACT_TYPE(/datum/job/civilian)
 /datum/job/special/research_assistant
 	name = "Research Assistant"
 	linkcolor = "#9900FF"
-	limit = 1
+	limit = 2
 	wages = PAY_UNTRAINED
 	low_priority_job = 1
-	slot_jump = list(/obj/item/clothing/under/color/white)
-	slot_foot = list(/obj/item/clothing/shoes/white)
+	slot_jump = list(/obj/item/clothing/under/color/lightpurple)
+	slot_foot = list(/obj/item/clothing/shoes/black)
+	slot_belt = list(/obj/item/device/pda2/toxins)
+	slot_ears = list(/obj/item/device/radio/headset/research)
 
 	New()
 		..()
@@ -1240,11 +1242,13 @@ ABSTRACT_TYPE(/datum/job/civilian)
 /datum/job/special/medical_assistant
 	name = "Medical Assistant"
 	linkcolor = "#9900FF"
-	limit = 1
+	limit = 2
 	wages = PAY_UNTRAINED
 	low_priority_job = 1
-	slot_jump = list(/obj/item/clothing/under/color/white)
+	slot_jump = list(/obj/item/clothing/under/scrub,/obj/item/clothing/under/scrub/teal,/obj/item/clothing/under/scrub/blue,/obj/item/clothing/under/scrub/purple,/obj/item/clothing/under/scrub/orange,/obj/item/clothing/under/scrub/pink)
 	slot_foot = list(/obj/item/clothing/shoes/white)
+	slot_ears = list(/obj/item/device/radio/headset/medical)
+	slot_belt = list(/obj/item/device/pda2/medical) //a special PDA since medical gets a lot of overwhelming alerts
 
 	New()
 		..()
@@ -1272,11 +1276,13 @@ ABSTRACT_TYPE(/datum/job/civilian)
 /datum/job/special/tech_assistant
 	name = "Technical Assistant"
 	linkcolor = "#FF9900"
-	limit = 1
+	limit = 2
 	wages = PAY_UNTRAINED
 	low_priority_job = 1
 	slot_jump = list(/obj/item/clothing/under/color/yellow)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
+	slot_ears = list(/obj/item/device/radio/headset/engineer)
+	slot_belt = list(/obj/item/device/pda2/technical_assistant)
 
 	New()
 		..()
@@ -1307,6 +1313,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_foot = list(/obj/item/clothing/shoes/black)
 	slot_poc1 = list(/obj/item/scissors)
 	slot_poc2 = list(/obj/item/razor_blade)
+	slot_ears = list(/obj/item/device/radio/headset/civilian)
 
 	New()
 		..()
@@ -1410,6 +1417,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	slot_jump = list(/obj/item/clothing/under/suit/pinstripe)
 	slot_head = list(/obj/item/clothing/head/flatcap)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
+	slot_ears = list(/obj/item/device/radio/headset/civilian)
 	items_in_backpack = list(/obj/item/instrument/saxophone,/obj/item/instrument/guitar,/obj/item/instrument/bagpipe,/obj/item/instrument/fiddle)
 
 // randomizd gimmick jobs
@@ -2605,6 +2613,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	slot_foot = list(/obj/item/clothing/shoes/black)
 	slot_poc1 = list(/obj/item/scissors)
 	slot_poc2 = list(/obj/item/razor_blade)
+	slot_ears = list(/obj/item/device/radio/headset/civilian)
 
 	New()
 		..()
@@ -2675,6 +2684,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	slot_jump = list(/obj/item/clothing/under/suit/pinstripe)
 	slot_head = list(/obj/item/clothing/head/flatcap)
 	slot_foot = list(/obj/item/clothing/shoes/brown)
+	slot_ears = list(/obj/item/device/radio/headset/civilian)
 	items_in_backpack = list(/obj/item/instrument/saxophone,/obj/item/instrument/guitar,/obj/item/instrument/bagpipe,/obj/item/instrument/fiddle)
 
 /datum/job/battler

--- a/code/obj/item/device/pda2/pda2.dm
+++ b/code/obj/item/device/pda2/pda2.dm
@@ -262,6 +262,11 @@
 		mailgroups = list(MGO_ENGINEER,MGD_STATIONREPAIR,MGD_PARTY)
 		alertgroups = list(MGA_MAIL, MGA_RADIO, MGA_ENGINE, MGA_CRISIS)
 
+	technical_assistant
+		icon_state = "pda-e" //tech ass is too broad to have a set cartridge but should get alerts
+		mailgroups = list(MGD_STATIONREPAIR,MGD_PARTY)
+		alertgroups = list(MGA_MAIL,MGA_RADIO)
+
 	mining
 		icon_state = "pda-e"
 		mailgroups = list(MGD_MINING,MGD_PARTY)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [input wanted][balance] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Note, this will cause a merge conflict with #7545 (if that one is merged)

Changes:
+Research Assistant is given:
	-a light purple jumpsuit
	-black shoes
	-A Science PDA 
	-A research headset
	-2 job slots (up from one)
+Medical Assistant is given:
	-A random chance of nearly every scrub color (except maroon and flowers)
	-A medical headset
	-A Medical PDA 
	-2 job slots (up from one)
+Technical Assistant is Given
	-An engineering headset
	-A special Tech Ass PDA (which gets station repair alerts)
	-2 job slots (up from one)
+Barber is given
	-A civilian headset
+Musician is given
	-A civilian headset


## Why's this needed? <!-- Describe why you think this should be added to the game. -->



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Yellow
(*)Changes up Research Assistant, Medical Assistant, and Technical Assistant to make them more applicable for those who want to learn
(+)Gives both Barbers and Musicians civilian headsets
```
