### PR TITLE
Fixes solar panel rotation

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -413,7 +413,6 @@
 			return
 
 		var/sgen = SOLARGENRATE * sunfrac
-		sgen *= PROCESSING_TIER_MULTI(src)
 		add_avail(sgen)
 		if(powernet && control)
 			if(control.get_direct_powernet() == powernet) //this line right here...

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -172,7 +172,7 @@
 	if(adir != ndir)
 		var/old_adir = adir
 		var/max_move = rand(8, 12)
-		adir = (360 + adir + clamp((180 - (540 - ndir + adir) % 360 ), -max_move, max_move)) % 360
+		adir = (360 + adir + clamp((180 - (540 - ndir + adir) % 360), -max_move, max_move)) % 360
 		if(adir != old_adir)
 			use_power(power_usage)
 			UpdateIcon()
@@ -423,7 +423,7 @@
 			SPAWN(10+rand(0,15))
 				var/old_adir = adir
 				var/max_move = rand(8, 12)
-				adir = (360 + adir + clamp((180 - (540 - ndir + adir) % 360 ), -max_move, max_move)) % 360
+				adir = (360 + adir + clamp((180 - (540 - ndir + adir) % 360), -max_move, max_move)) % 360
 				if(adir != old_adir)
 					use_power(power_usage)
 					UpdateIcon()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -172,7 +172,7 @@
 	if(adir != ndir)
 		var/old_adir = adir
 		var/max_move = rand(8, 12)
-		adir = (360 + adir + clamp(ndir - adir, -max_move, max_move)) % 360
+		adir = (360 + adir + clamp((180 - (540 - ndir + adir) % 360 ), -max_move, max_move)) % 360
 		if(adir != old_adir)
 			use_power(power_usage)
 			UpdateIcon()
@@ -413,6 +413,7 @@
 			return
 
 		var/sgen = SOLARGENRATE * sunfrac
+		sgen *= PROCESSING_TIER_MULTI(src)
 		add_avail(sgen)
 		if(powernet && control)
 			if(control.get_direct_powernet() == powernet) //this line right here...
@@ -420,6 +421,11 @@
 
 		if(adir != ndir)
 			SPAWN(10+rand(0,15))
-				adir = (360+adir+clamp(ndir-adir,-10,10))%360
-				UpdateIcon()
+				var/old_adir = adir
+				var/max_move = rand(8, 12)
+				adir = (360 + adir + clamp((180 - (540 - ndir + adir) % 360 ), -max_move, max_move)) % 360
+				if(adir != old_adir)
+					use_power(power_usage)
+					UpdateIcon()
+
 				update_solar_exposure()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -424,7 +424,6 @@
 				var/max_move = rand(8, 12)
 				adir = (360 + adir + clamp((180 - (540 - ndir + adir) % 360), -max_move, max_move)) % 360
 				if(adir != old_adir)
-					use_power(power_usage)
 					UpdateIcon()
 
 				update_solar_exposure()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Solar panel rotation currently uses the function:
`adir = (360 + adir + clamp(ndir - adir, -max_move, max_move)) % 360`
When ie: adir is 5 degrees & ndir is 350 degrees, this function evaluates to ~15 degrees, causing the solar panels to slowly increment towards the sun the long way round.

Accordingly, this PR changes the function to:
`adir = (360 + adir + clamp((180 - (540 - ndir + adir) % 360 ), -max_move, max_move)) % 360`
So when ie: adir is 5 degrees & ndir is 350 degrees, the function now evaluates to ~355 degrees, allowing the solar panels to take the short way round instead.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes solar panels rotate in a more expected manner, will have a side-effect of increasing uptime.