### PR TITLE
Russian revolver logging and observer change

### DIFF
--- a/code/obj/item/gun/russian.dm
+++ b/code/obj/item/gun/russian.dm
@@ -45,10 +45,10 @@
 		else if(src.shotsLeft == 1)
 			src.shotsLeft = 0
 			playsound(user, "sound/weapons/Gunshot.ogg", 100, 1)
-			for(var/mob/O in AIviewers(user, null))
-				if (O.client)	O.show_message("<span class='alert'><B>BOOM!</B> [user]'s head explodes.</span>", 1, "<span class='alert'>You hear someone's head explode.</span>", 2)
-				user.TakeDamage("head", 300, 0)
-				take_bleeding_damage(user, null, 500, DAMAGE_STAB)
+			user.tri_message("<span class='alert'><B>BOOM!</B></span>", "<span class='alert'><B>BOOM!</B> [user]'s head explodes.</span>", "<span class='alert'>You hear someone's head explode.</span>", 2)
+			user.TakeDamage("head", 300, 0)
+			take_bleeding_damage(user, null, 500, DAMAGE_STAB)
+			logTheThing("combat", user, null, "shoots themselves with [src] at [log_loc(user)].")
 			inventory_counter.update_number(0)
 			return 1
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add combat logging to Russian revolver and by inheritance the fake 357.
Remove mob loop.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If someone shoots themselves with Russian revolver or fake357 there is nothing in the log, just a sudden crit.
You would take more damage and bleeding damage depending on number of observers.