### PR TITLE
Replaces a room on kondaru.

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -39107,10 +39107,10 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/item/clothing/glasses/monocle,
-/obj/item/clothing/head/longtophat,
-/obj/item/clothing/shoes/dress_shoes,
-/obj/item/clothing/under/misc/fancy_vest,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/under/gimmick/maid,
+/obj/item/mop,
+/obj/item/spraybottle,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
 "cre" = (
@@ -41702,12 +41702,28 @@
 /area/station/security/brig)
 "eJX" = (
 /obj/table/wood/auto,
-/obj/item/reagent_containers/food/snacks/crumpet{
-	pixel_x = -6;
-	pixel_y = 4
-	},
 /obj/item/reagent_containers/food/drinks/tea{
-	pixel_x = 5
+	pixel_x = 7
+	},
+/obj/item/plate{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/snacks/burger/heartburger{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/sticker/smile{
+	pixel_x = -9;
+	pixel_y = -5
+	},
+/obj/item/sticker/heart{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/obj/item/sticker/heart{
+	pixel_x = -3;
+	pixel_y = -3
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/crew_quarters/quarters_south)
@@ -54395,6 +54411,10 @@
 	icon_state = "bedsheet-blue"
 	},
 /obj/machinery/light/small,
+/obj/item/toy/plush/small/possum{
+	pixel_x = 4;
+	pixel_y = -1
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
 /area/station/crew_quarters/quarters_south)
 "rMN" = (
@@ -59751,6 +59771,9 @@
 /turf/simulated/floor/grey,
 /area/station/quartermaster/cargobay)
 "xcb" = (
+/obj/decal/poster/wallsign/poster_octocluwne{
+	pixel_y = 28
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
 "xcm" = (
@@ -59876,6 +59899,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "xgt" = (
+/obj/decal/poster/wallsign/poster_borg{
+	pixel_y = 28
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/crew_quarters/quarters_south)
 "xgv" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -41702,12 +41702,13 @@
 /area/station/security/brig)
 "eJX" = (
 /obj/table/wood/auto,
-/obj/item/reagent_containers/food/drinks/tea{
-	pixel_x = 7
-	},
 /obj/item/plate{
 	pixel_x = -3;
 	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/tea{
+	pixel_x = 7;
+	pixel_y = 5
 	},
 /obj/item/reagent_containers/food/snacks/burger/heartburger{
 	pixel_x = -3;

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -39103,16 +39103,14 @@
 /area/shuttle/merchant_shuttle/right_station/cogmap)
 "cqS" = (
 /obj/storage/closet/dresser,
-/obj/item/clothing/under/gimmick/maid,
-/obj/decal/poster/wallsign/poster_rand{
-	pixel_x = 8;
-	pixel_y = 28
-	},
-/obj/item/clothing/head/maid,
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/item/clothing/glasses/monocle,
+/obj/item/clothing/head/longtophat,
+/obj/item/clothing/shoes/dress_shoes,
+/obj/item/clothing/under/misc/fancy_vest,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
 "cre" = (
@@ -41704,24 +41702,12 @@
 /area/station/security/brig)
 "eJX" = (
 /obj/table/wood/auto,
-/obj/item/plate{
-	pixel_y = 7
+/obj/item/reagent_containers/food/snacks/crumpet{
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/obj/item/spraybottle/cleaner,
-/obj/item/sticker/heart{
-	rand_pos = 1
-	},
-/obj/item/sticker/heart{
-	rand_pos = 1
-	},
-/obj/item/sticker/heart{
-	rand_pos = 1
-	},
-/obj/item/sticker/heart{
-	rand_pos = 1
-	},
-/obj/item/sticker/heart{
-	rand_pos = 1
+/obj/item/reagent_containers/food/drinks/tea{
+	pixel_x = 5
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/station/crew_quarters/quarters_south)
@@ -59765,13 +59751,6 @@
 /turf/simulated/floor/grey,
 /area/station/quartermaster/cargobay)
 "xcb" = (
-/obj/decal/poster/wallsign/poster_rand{
-	pixel_y = 28
-	},
-/obj/decal/poster/wallsign/poster_rand{
-	pixel_x = -7;
-	pixel_y = 36
-	},
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
 "xcm" = (
@@ -59897,14 +59876,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "xgt" = (
-/obj/decal/poster/wallsign/poster_rand{
-	pixel_x = -10;
-	pixel_y = 38
-	},
-/obj/decal/poster/wallsign/poster_rand{
-	pixel_x = 9;
-	pixel_y = 31
-	},
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/crew_quarters/quarters_south)
 "xgv" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It replaces one of the crew quarters' contents with something that toes less on breaking rule 4. You can now find a crumpet, some tea and fancy clothes in that location.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Right now this room is very suggestive to say the least and I highly doubt that we need any of that anywhere close to goonstation.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

