### PR TITLE
AIEye Fixes - Fixes #7197 and Fixes #7559

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -665,7 +665,7 @@
 /mob/living/silicon/ai/capitalize_speech()
 	if (!client)
 		if (src?.eyecam?.client?.preferences)
-			return src.eyecam.client.preferences
+			return src.eyecam.client.preferences.auto_capitalization
 	. = ..()
 
 /mob/living/say(var/message, ignore_stamina_winded)

--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -282,6 +282,13 @@
 	resist()
 		return 0 //can't actually resist anything because there's nothing to resist, but maybe the hot key could be used for something?
 
+	//death stuff that should be passed to mainframe
+	gib(give_medal, include_ejectables) //this should be admin only, I would hope
+		message_admins("something gibbed the AI - if this wasn't an admin action, something has gone badly wrong")
+		return mainframe.gib(give_medal, include_ejectables)
+
+
+
 	proc/mainframe_check()
 		if (mainframe)
 			if (isdead(mainframe))

--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -284,8 +284,9 @@
 
 	//death stuff that should be passed to mainframe
 	gib(give_medal, include_ejectables) //this should be admin only, I would hope
-		message_admins("something gibbed the AI - if this wasn't an admin action, something has gone badly wrong")
-		return mainframe.gib(give_medal, include_ejectables)
+		message_admins("something tried to gib the AI Eye - if this wasn't an admin action, something has gone badly wrong")
+		return 0
+		//return mainframe.gib(give_medal, include_ejectables) //re-enable this when you are SUPREMELY CONFIDENT that all calls to gib() have intangible checks
 
 
 

--- a/code/modules/materials/Mat_RawMaterials.dm
+++ b/code/modules/materials/Mat_RawMaterials.dm
@@ -73,6 +73,9 @@
 		if (isobserver(usr))
 			boutput(usr, "<span class='alert'>Quit that! You're dead!</span>")
 			return
+		if(isintangible(usr))
+			boutput(usr,"<span class='alert'>You need hands to do that. Do you have hands? No? Then stop it.</span>")
+			return
 
 		if(!istype(over_object, /atom/movable/screen/hud))
 			if (get_dist(usr,src) > 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #7197 and #7559
Blob overminds and AI eyes can't stack ores anymore, and receive a message similar to ghosts when they try.
Fixed a minor code error which meant auto-capitalisation was always on for the AI eye
Adds a logging message for admins when something tries to gib() the AI eye.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugs are bad

