### PR TITLE
Fix AI brain removal not being logged

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -579,7 +579,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 		var/action_taken = input("What do you want to do?","AI Unit") in actions
 		switch (action_taken)
 			if ("Remove CPU Unit")
-				src.eject_brain()
+				src.eject_brain(user)
 
 			if ("Restart AI")
 				src.try_rebooting_it(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the user argument to the eject_brain procedure call.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Everything that was meant to happen when a brain was removed by a player would instead fail the check.