### PR TITLE
Fixes rev & head icons appearing under secHud icons

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -195,13 +195,13 @@
 		sims = new /datum/simsHolder/human(src)
 #endif
 
-	health_mon = image('icons/effects/healthgoggles.dmi',src,"100",10)
+	health_mon = image('icons/effects/healthgoggles.dmi',src,"100",EFFECTS_LAYER_UNDER_4)
 	get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).add_image(health_mon)
 
-	health_implant = image('icons/effects/healthgoggles.dmi',src,"100",10)
+	health_implant = image('icons/effects/healthgoggles.dmi',src,"100",EFFECTS_LAYER_UNDER_4)
 	get_image_group(CLIENT_IMAGE_GROUP_HEALTH_MON_ICONS).add_image(health_implant)
 
-	arrestIcon = image('icons/effects/sechud.dmi',src,null,10)
+	arrestIcon = image('icons/effects/sechud.dmi',src,null,EFFECTS_LAYER_UNDER_4)
 	get_image_group(CLIENT_IMAGE_GROUP_ARREST_ICONS).add_image(arrestIcon)
 
 	src.organHolder = new(src)

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -924,18 +924,18 @@
 			for (var/datum/mind/M in HR)
 				if (M.current)
 					if (!see_everything && isobserver(M.current)) continue
-					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = 11) //secHuds are on layer 10.
+					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = EFFECTS_LAYER_UNDER_3) //secHuds are on EFFECTS_LAYER_UNDER_4
 					can_see.Add(I)
 			for (var/datum/mind/M in RR)
 				if (M.current)
 					if (!see_everything && isobserver(M.current)) continue
-					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = 11)
+					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = EFFECTS_LAYER_UNDER_3)
 					can_see.Add(I)
 
 		if (see_heads || see_everything)
 			for (var/datum/mind/M in heads)
 				if (M.current)
-					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = 11)
+					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = EFFECTS_LAYER_UNDER_3)
 					can_see.Add(I)
 
 	else if (istype(ticker.mode, /datum/game_mode/nuclear))

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -929,13 +929,13 @@
 			for (var/datum/mind/M in RR)
 				if (M.current)
 					if (!see_everything && isobserver(M.current)) continue
-					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
+					var/I = image(antag_rev, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
 					can_see.Add(I)
 
 		if (see_heads || see_everything)
 			for (var/datum/mind/M in heads)
 				if (M.current)
-					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
+					var/I = image(antag_head, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
 					can_see.Add(I)
 
 	else if (istype(ticker.mode, /datum/game_mode/nuclear))

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -924,18 +924,18 @@
 			for (var/datum/mind/M in HR)
 				if (M.current)
 					if (!see_everything && isobserver(M.current)) continue
-					var/I = image(antag_revhead, loc = M.current, null, 11) //secHuds are on layer 10.
+					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = 11) //secHuds are on layer 10.
 					can_see.Add(I)
 			for (var/datum/mind/M in RR)
 				if (M.current)
 					if (!see_everything && isobserver(M.current)) continue
-					var/I = image(antag_rev, loc = M.current, null, 11)
+					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = 11)
 					can_see.Add(I)
 
 		if (see_heads || see_everything)
 			for (var/datum/mind/M in heads)
 				if (M.current)
-					var/I = image(antag_head, loc = M.current, null, 11)
+					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = 11)
 					can_see.Add(I)
 
 	else if (istype(ticker.mode, /datum/game_mode/nuclear))

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -924,18 +924,18 @@
 			for (var/datum/mind/M in HR)
 				if (M.current)
 					if (!see_everything && isobserver(M.current)) continue
-					var/I = image(antag_revhead, loc = M.current)
+					var/I = image(antag_revhead, loc = M.current, null, 11) //secHuds are on layer 10.
 					can_see.Add(I)
 			for (var/datum/mind/M in RR)
 				if (M.current)
 					if (!see_everything && isobserver(M.current)) continue
-					var/I = image(antag_rev, loc = M.current)
+					var/I = image(antag_rev, loc = M.current, null, 11)
 					can_see.Add(I)
 
 		if (see_heads || see_everything)
 			for (var/datum/mind/M in heads)
 				if (M.current)
-					var/I = image(antag_head, loc = M.current)
+					var/I = image(antag_head, loc = M.current, null, 11)
 					can_see.Add(I)
 
 	else if (istype(ticker.mode, /datum/game_mode/nuclear))

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -924,18 +924,18 @@
 			for (var/datum/mind/M in HR)
 				if (M.current)
 					if (!see_everything && isobserver(M.current)) continue
-					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = EFFECTS_LAYER_UNDER_3) //secHuds are on EFFECTS_LAYER_UNDER_4
+					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1)) //secHuds are on EFFECTS_LAYER_UNDER_4
 					can_see.Add(I)
 			for (var/datum/mind/M in RR)
 				if (M.current)
 					if (!see_everything && isobserver(M.current)) continue
-					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = EFFECTS_LAYER_UNDER_3)
+					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
 					can_see.Add(I)
 
 		if (see_heads || see_everything)
 			for (var/datum/mind/M in heads)
 				if (M.current)
-					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = EFFECTS_LAYER_UNDER_3)
+					var/I = image(antag_revhead, loc = M.current, icon_state = null, layer = (EFFECTS_LAYER_UNDER_4 + 0.1))
 					can_see.Add(I)
 
 	else if (istype(ticker.mode, /datum/game_mode/nuclear))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Arrest and Rev/Head icons are both generated on layer 10. Either because arrest icons get updated much more often, or because of some secondary reason (testing was inconclusive) arrest icons nearly always obscure rev icons.

This PR bumps revolution antag icons up to layer 11, so they appear on top. Note that loyal/rev icons generated by the secHuds criminal records are still overriden by arrest per secHuds own logic. This change only affects antags who can see revs/heads and who happen to be wearing secHuds.

This PR doesn't touch any other antag icons, which all sit on layer 10 still.

No balance/discussion tag because I don't believe this affects the balance of the game mode - but happy to add the relevant tags if it does.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5708.