### PR TITLE
Fixes Removable & Reusable Zip-ties #7517

### DIFF
--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -1178,6 +1178,8 @@
 		if (!isdead(target))
 			message_admins("[key_name(owner)] forced [key_name(target, 1)] ([target == 2 ? "dead" : "alive"]) into \an [grinder] at [log_loc(grinder)].")
 		if (grinder.auto_strip && !grinder.emagged)
+			if(target.hasStatus("handcuffed"))
+				target.handcuffs.drop_handcuffs(target) //handcuffs have special handling for zipties and such, remove them properly first
 			target.unequip_all()
 			if (length(target.implant))
 				for (var/obj/item/implant/I in target.implant)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check for the handcuffed status, and calls the special drop_handcuffs() function if so to handle dissolving handcuffs. Does this before calling unequip_all() in the enzymatic reclaimer.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Zip-tie and silver handcuffs should dissolve after one use. The clone grinder let you get around that. Now it doesn't.
