### PR TITLE
Fixes #6072 and fixes #6122 - Disposal chutes acting weird when deconstructed to frames

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -64,6 +64,16 @@
 			air_contents = null
 		..()
 
+	was_deconstructed_to_frame(mob/user)
+		if (trunk)
+			trunk.linked = null
+		else
+			trunk = locate() in src.loc //idk maybe this can happens
+			if (trunk)
+				trunk.linked = null
+		trunk = null
+		return ..()
+
 	onDestroy()
 		if (src.powered())
 			elecflash(src, power = 2)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added an override for was_deconstructed_to_frame() which clears the pipe connection. 
You no longer get stuck in frames when being flushed through it, nor inside other mobs who are holding it. Also you can't teleport anymore by building it somewhere else.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs are bad, this one is potentially exploitable.

