### PR TITLE
Removes Forensics from Security, HoS, NTSO, and Inspector PDA's, adds in new NT-CSI forensics cartridge to PDA vending machines.

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1528,6 +1528,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/disk/data/cartridge/medical, 5, cost=PAY_DOCTORATE/3)
 		product_list += new/datum/data/vending_product(/obj/item/disk/data/cartridge/toxins, 5, cost=PAY_DOCTORATE/3)
 		product_list += new/datum/data/vending_product(/obj/item/disk/data/cartridge/quartermaster, 5, cost=PAY_TRADESMAN/3)
+		product_list += new/datum/data/vending_product(/obj/item/disk/data/cartridge/investigative, 6, cost=PAY_DOCTORATE/3)
 		product_list += new/datum/data/vending_product(/obj/item/disk/data/cartridge/ringtone, 5, cost=PAY_TRADESMAN/6)
 		product_list += new/datum/data/vending_product(/obj/item/disk/data/cartridge/ringtone_basic, 5, cost=PAY_TRADESMAN/3)
 		product_list += new/datum/data/vending_product(/obj/item/disk/data/cartridge/ringtone_chimes, 5, cost=PAY_TRADESMAN/3)

--- a/code/obj/item/device/pda2/cartridges.dm
+++ b/code/obj/item/device/pda2/cartridges.dm
@@ -209,7 +209,20 @@
 			src.root.add_file( new /datum/computer/file/pda_program/records/security(src))
 			src.root.add_file( new /datum/computer/file/pda_program/bot_control/secbot(src))
 			src.root.add_file( new /datum/computer/file/pda_program/security_ticket(src))
-			src.root.add_file( new /datum/computer/file/pda_program/packet_sniffer(src) )
+			src.root.add_file( new /datum/computer/file/pda_program/packet_sniffer(src))
+			src.read_only = 1
+
+	investigative
+		name = "\improper NT-CSI cartridge"
+		desc = "Looking closer, the label reads NanoTrasen Crap Shoot Investigator Cartridge."
+		icon_state = "cart-forensics"
+		file_amount = 64
+
+		New()
+			..()
+			src.root.add_file( new /datum/computer/file/pda_program/scan/forensic_scan(src))
+			src.root.add_file( new /datum/computer/file/pda_program/scan/reagent_scan(src))
+			src.root.add_file( new /datum/computer/file/pda_program/packet_sniffer(src))
 			src.read_only = 1
 
 	hos

--- a/code/obj/item/device/pda2/cartridges.dm
+++ b/code/obj/item/device/pda2/cartridges.dm
@@ -60,7 +60,6 @@
 			src.root.add_file( new /datum/computer/file/pda_program/status_display(src))
 			src.root.add_file( new /datum/computer/file/pda_program/qm_records(src))
 			src.root.add_file( new /datum/computer/file/pda_program/fileshare(src))
-			src.root.add_file( new /datum/computer/file/pda_program/scan/forensic_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/records/security(src))
 			src.root.add_file( new /datum/computer/file/pda_program/security_ticket(src))
 			src.root.add_file( new /datum/computer/file/pda_program/power_checker(src))
@@ -188,7 +187,6 @@
 
 		New()
 			..()
-			src.root.add_file( new /datum/computer/file/pda_program/scan/forensic_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/records/security(src))
 			src.root.add_file( new /datum/computer/file/pda_program/bot_control/secbot(src))
 			src.root.add_file( new /datum/computer/file/pda_program/portable_machinery_control/portabrig(src))
@@ -227,7 +225,6 @@
 			src.root.add_file( new /datum/computer/file/pda_program/portable_machinery_control/portabrig(src))
 			src.root.add_file( new /datum/computer/file/pda_program/qm_records(src))
 			src.root.add_file( new /datum/computer/file/pda_program/fileshare(src))
-			src.root.add_file( new /datum/computer/file/pda_program/scan/forensic_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/scan/health_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/records/security(src))
 			src.root.add_file( new /datum/computer/file/pda_program/security_ticket(src))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [input wanted][balance] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This change removes forensics scanner from:



## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The role of detective is very undefined, from a part of the security team to a lone wolf. When Security can do one of the most important parts of the detectives job all from their roundstart PDA, it can make the role feel useless in helping solve crime. 

This change defines the detective as THE forensics job on the station, being the person you need to call for forensics. A side effect of this change is also making security assistants more important to solving crime, as their token gets them a forensics scanner by default. 

The forensics cart is for security who really want to fill the role of forensics, in which they give up their security cartridge in exchange for the forensics, reagent, and packet scanner. It also allows for non-security private investigators to have a chance at solving crime.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Yellow/Myco
(*)Removes Forensics from Security, HoS, NTSO, and Inspector PDA's.
(*)Adds new NT-CSI forensics cartridge to PDA vending machines
```
