### PR TITLE
Fixes two more instances of AIeye jank

### DIFF
--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -78,6 +78,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 		return
 
 	mouse_drop(atom/over_object as obj)
+		if (isintangible(usr))
+			return
 		if (!can_mousedrop)
 			boutput(usr, "<span class='alert'>Nope.</span>")
 			return

--- a/code/obj/soup_pot.dm
+++ b/code/obj/soup_pot.dm
@@ -119,7 +119,7 @@
 					W.afterattack(pot,user) // ????
 
 	MouseDrop_T(obj/item/W as obj, mob/user as mob)
-		if (istype(W, /obj/item/soup_pot) && in_interact_range(W, user) && in_interact_range(src, user))
+		if (istype(W, /obj/item/soup_pot) && in_interact_range(W, user) && in_interact_range(src, user) && !isintangible(user))
 			return src.Attackby(W, user)
 		return ..()
 
@@ -134,7 +134,8 @@
 			src.pot = null
 
 	attack_ai(mob/user as mob)
-		return src.Attackhand(user)
+		if (!isintangible(user) && in_interact_range(src, user)) //stop AIs teleporting soup
+			return src.Attackhand(user)
 
 	proc/light(var/mob/user, var/message as text)
 		if(pot.my_soup)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #7591 and Fixes #7590
AI can no longer teleport soup, that era is behind us
(also the AI being able to click-drag transfer reagents in eye form is reasonably dangerous)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
jank--