### PR TITLE
More logging of players turning into critters

### DIFF
--- a/code/modules/medical/diseases/avian_flu.dm
+++ b/code/modules/medical/diseases/avian_flu.dm
@@ -27,4 +27,5 @@
 			boutput(affected_mob, "<span class='alert'>You feel your physical form condensing into something light and airy... What?</span>")
 			affected_mob.visible_message("<span class='alert'><b>[affected_mob] transforms!</b></span>")
 			affected_mob.unequip_all()
+			logTheThing("combat", affected_mob, null, "is transformed into a critter bird by the [name] reagent at [log_loc(affected_mob)].")
 			affected_mob.make_critter(/mob/living/critter/small_animal/bird/random)

--- a/code/modules/medical/diseases/frog_flu.dm
+++ b/code/modules/medical/diseases/frog_flu.dm
@@ -32,4 +32,5 @@
 			boutput(affected_mob, "<span class='alert'>You feel your physical form condensing into something small and green... What?</span>")
 			affected_mob.visible_message("<span class='alert'><b>[affected_mob] transforms!</b></span>")
 			affected_mob.unequip_all()
+			logTheThing("combat", affected_mob, null, "is transformed into a critter frog by the [name] reagent at [log_loc(affected_mob)].")
 			affected_mob.make_critter(/mob/living/critter/small_animal/frog, affected_mob)

--- a/code/modules/medical/diseases/going_catty.dm
+++ b/code/modules/medical/diseases/going_catty.dm
@@ -27,4 +27,5 @@
 			boutput(affected_mob, "<span class='alert'>You feel your physical form condensing into something hairy and small... Uh oh...</span>")
 			affected_mob.visible_message("<span class='alert'><b>[affected_mob] transforms!</b></span>")
 			affected_mob.unequip_all()
+			logTheThing("combat", affected_mob, null, "is transformed into a critter cat by the [name] reagent at [log_loc(affected_mob)].")
 			affected_mob.make_critter(/mob/living/critter/small_animal/cat)

--- a/code/modules/projectiles/crabber.dm
+++ b/code/modules/projectiles/crabber.dm
@@ -52,6 +52,7 @@
 				flick("implode", animation)
 
 				H.unequip_all()
+				logTheThing("combat", H, null, "is transformed into a crab by the crab gun at [log_loc(H)].")
 				var/mob/living/critter/C = H.make_critter(/mob/living/critter/small_animal/crab)
 				if (istype(C))
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Logs when reagents (and crab gun because I was there) turns someone into a critter.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Better than having to look up what reagents got added to them.