### PR TITLE
Lets you dump hypospray contents back into containers

### DIFF
--- a/code/modules/chemistry/tools/hyposprays.dm
+++ b/code/modules/chemistry/tools/hyposprays.dm
@@ -143,3 +143,22 @@ var/global/list/chem_whitelist = list("antihol", "charcoal", "epinephrine", "ins
 		playsound(M, src.sound_inject, 80, 0)
 
 		UpdateIcon()
+
+	afterattack(obj/target, mob/user, flag)
+		if (isobj(target) && target.is_open_container() && target.reagents)
+			if (!src.reagents || !src.reagents.total_volume)
+				boutput(user, "<span class='alert'>[src] is already empty.</span>")
+				return
+
+			if (target.reagents.is_full())
+				boutput(user, "<span class='alert'>[target] is full!</span>")
+				return
+
+			logTheThing("combat", user, null, "dumps the contents of [src] [log_reagents(src)] into [target] at [log_loc(user)].")
+			src.reagents.trans_to(target, src.reagents.total_volume)
+			boutput(user, "<span class='notice'>You dump the contents of [src] into [target].</span>")
+
+			playsound(src.loc, 'sound/misc/pourdrink2.ogg', 50, 1, 0.1)
+			return
+		else
+			return ..()

--- a/code/modules/chemistry/tools/hyposprays.dm
+++ b/code/modules/chemistry/tools/hyposprays.dm
@@ -155,8 +155,8 @@ var/global/list/chem_whitelist = list("antihol", "charcoal", "epinephrine", "ins
 				return
 
 			logTheThing("combat", user, null, "dumps the contents of [src] [log_reagents(src)] into [target] at [log_loc(user)].")
-			src.reagents.trans_to(target, src.reagents.total_volume)
 			boutput(user, "<span class='notice'>You dump the contents of [src] into [target].</span>")
+			src.reagents.trans_to(target, src.reagents.total_volume)
 
 			playsound(src.loc, 'sound/misc/pourdrink2.ogg', 50, 1, 0.1)
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows you to dump all (or as much as possible) of the contents of a hypospray into an open container.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lets you waste less medicine/other chems, by pouring out any excess back into a container to use later; such an advanced medical device should probably be emptiable like this.

So then, e.g., you won't have to just delete all extra meds entirely, or inject all of it into someone who doesn't actually need it, when you need to use the hypospray for a different medicine.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)CodeJester
(+)You can now dump the contents of a hypospray back into a beaker or other reagent container.
```
