### PR TITLE
Fix material processor

### DIFF
--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -223,7 +223,7 @@
 			boutput(usr, "<span class='alert'>You can't use that as an output target.</span>")
 		return
 
-	MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+	MouseDrop_T(atom/movable/O as obj, mob/user as mob)
 		if (get_dist(user, src) > 1 || get_dist(user, O) > 1 || is_incapacitated(user) || isAI(user))
 			return
 
@@ -241,8 +241,9 @@
 			else boutput(user, "<span class='alert'>No material loaded!</span>")
 			return
 
+		if (!istype(O, /obj/item))
+			return
 		var/obj/item/W = O
-
 		if(W in user && !W.cant_drop)
 			user.u_equip(W)
 			W.set_loc(src.loc)
@@ -264,7 +265,9 @@
 		if (!user || !O || !istype(O))
 			return
 		user.visible_message("<span class='notice'>[user] begins quickly stuffing [O] into [src]!</span>")
+		user.u_equip(O)
 		O.set_loc(src)
+		O.dropped()
 		var/staystill = user.loc
 		for(var/obj/item/M in view(1,user))
 			if (!M || M.loc == user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[RUNTIME][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Checks the mousedrop is for an item before trying to handle it like one.
Remove material if dragged from hands.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes when mousedrop from mob to material processor. I couldn't find any functionality for mousedropping from the mob.
The material location would get messed up and you'd end up holding a material that was inside the processor.