### PR TITLE
Fix runtime on healthscanning silicons

### DIFF
--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -4,7 +4,7 @@
 	if (!M)
 		return "<span class='alert'>ERROR: NO SUBJECT DETECTED</span>"
 
-	if (isghostdrone(M))
+	if (issilicon(M))
 		return "<span class='alert'>ERROR: INVALID DATA FROM SUBJECT</span>"
 
 	if(visible)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[RUNTIME]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Return from health scan proc when scanning silicons.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtime.
Scanner still produces useful health and brute overhead text which maybe it shouldn't but I don't think that harms.