### PR TITLE
Fixes dumping handheld mechcomps

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -27,7 +27,6 @@
 	var/light_style = "disposal" // for the lights and stuff
 	var/image/handle_image = null
 	var/destination_tag = null
-	var/list/empty_blacklist = list(/obj/item/storage/mechanics/housing_handheld)
 	mats = 20			// whats the point of letting people build trunk pipes if they cant build new disposals?
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_SCREWDRIVER
 	power_usage = 100

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -27,6 +27,7 @@
 	var/light_style = "disposal" // for the lights and stuff
 	var/image/handle_image = null
 	var/destination_tag = null
+	var/list/empty_blacklist = list(/obj/item/storage/mechanics/housing_handheld)
 	mats = 20			// whats the point of letting people build trunk pipes if they cant build new disposals?
 	deconstruct_flags = DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_SCREWDRIVER
 	power_usage = 100
@@ -110,7 +111,11 @@
 				user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
 				return
 		if (istype(I,/obj/item/storage/) && I.contents.len)
-			var/action = input(user, "What do you want to do with [I]?") as null|anything in list("Place it in the Chute","Empty it into the chute","Never Mind")
+			var/action
+			if (istype(I, /obj/item/storage/mechanics/housing_handheld))
+				action = input(user, "What do you want to do with [I]?") as null|anything in list("Place it in the Chute","Never Mind")
+			else
+				action = input(user, "What do you want to do with [I]?") as null|anything in list("Place it in the Chute","Empty it into the chute","Never Mind")
 			if (!action || action == "Never Mind")
 				return
 			if (!in_interact_range(src, user))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR prevents players from dumping handheld mechcomp cabinets into disposal shutes


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#7391


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Conchuckter
(+)Fixes being able to dump handheld MechComp cabinets into chutes
```
