### PR TITLE
Replaces the tables near the medbay cryo pods with reinforced tables

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -49808,7 +49808,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/table/auto,
+/obj/table/reinforced/auto,
 /obj/item/weldingtool{
 	pixel_x = 2;
 	pixel_y = 7
@@ -52129,7 +52129,7 @@
 	layer = 3.5;
 	pixel_y = -24
 	},
-/obj/table/auto,
+/obj/table/reinforced/auto,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = -6;
 	pixel_y = 11

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -70582,7 +70582,7 @@
 	can_rupture = 0;
 	dir = 5
 	},
-/obj/table/auto,
+/obj/table/reinforced/auto,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 4;
 	pixel_y = 5
@@ -70627,10 +70627,10 @@
 	can_rupture = 0;
 	dir = 9
 	},
-/obj/table/auto,
 /obj/item/wrench,
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/remote/porter/port_a_medbay,
+/obj/table/reinforced/auto,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "cZL" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -70627,10 +70627,10 @@
 	can_rupture = 0;
 	dir = 9
 	},
+/obj/table/reinforced/auto,
 /obj/item/wrench,
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/remote/porter/port_a_medbay,
-/obj/table/reinforced/auto,
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "cZL" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -58278,7 +58278,7 @@
 	},
 /area/station/science/lobby)
 "qLV" = (
-/obj/table/auto,
+/obj/table/reinforced/auto,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = -8;
 	pixel_y = 12

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -12962,7 +12962,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/table/auto,
+/obj/table/reinforced/auto,
 /obj/item/wrench,
 /obj/item/wrench,
 /obj/item/bandage,
@@ -60079,7 +60079,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "vrN" = (
-/obj/table/auto,
+/obj/table/reinforced/auto,
 /obj/item/scalpel,
 /obj/item/circular_saw,
 /obj/item/reagent_containers/syringe,

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -21006,7 +21006,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "bla" = (
-/obj/table/auto,
+/obj/table/reinforced/auto,
 /obj/item/paper/cryo,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -9617,7 +9617,7 @@
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "awE" = (
-/obj/table/auto,
+/obj/table/reinforced/auto,
 /obj/item/wrench,
 /obj/item/device/analyzer/healthanalyzer,
 /obj/item/remote/porter/port_a_medbay,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This changes the normal tables in medbay near the cryo tubes to reinforced tables on cogmap, cogmap2, horizon, oshan, kondaru, and donut3. Other available maps already have reinforced tables in those positions. These are the tables that hold wrenches for connecting the oxygen tanks to the cryo tubes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These tables hold wrenches that are there to connect the oxygen tank to the cryo tube pipes. I've always found it annoying that I can't just put the wrench back down after using it for that one purpose with a single click. Instead you have to click drag it from your inventory so it doesn't take apart the table. This change fixes that minor inconvenience.

