### PR TITLE
Fix #7654 (PDA Packet Sender Delete not working)

### DIFF
--- a/code/obj/item/device/pda2/diagnostics.dm
+++ b/code/obj/item/device/pda2/diagnostics.dm
@@ -410,6 +410,10 @@
 			keyval.Remove(codekey)
 			keyval[newkey] = newval
 
+		else if(href_list["delete"]) // i accidentally deleted this woops haha
+			var/codekey = href_list["code"]
+
+			keyval.Remove(codekey)
 
 		else if(href_list["prog_delete"])
 			var/codekey = href_list["code"]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix #7654, the Delete button on the Packet Sender PDA Program not working.
Caused by me being a dumbass and somehow not noticing i probably deleted 3 lines too long while coding
The "delete"  function was gone haha oops
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7654


## Changelog
```changelog
(u)Jimmyl
(+)Fixed the bug of the PDA Packet senders Delete button not working
```
