### PR TITLE
produce satchels can now carry chicken feathers

### DIFF
--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -188,7 +188,8 @@
 		/obj/item/clothing/head/butt,
 		/obj/item/parts/human_parts/arm,
 		/obj/item/parts/human_parts/leg,
-		/obj/item/raw_material/cotton)
+		/obj/item/raw_material/cotton,
+		/obj/item/feather)
 		itemstring = "items of produce"
 
 		large


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [QOL][FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Lets produce satchels hold feathers


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* makes it easier to clean up dead chickens by butchering them into feathers and nuggets and then scooping it all into the satchel


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(+)Produce satchels may now hold feathers.
```
