### PR TITLE
Remove extra/stacked sliding door from donut3 security booth

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -8676,7 +8676,6 @@
 	pixel_x = -7;
 	pixel_y = 3
 	},
-/obj/machinery/door/window/southleft,
 /obj/access_spawn/security,
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass/windoor,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug] [mapping]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes a stacked sliding door from the security booth, making the whole booth three sliding windows.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Window consistency at the booth. Stacked windoors very confusing.
