### PR TITLE
allow changeling victims to vocalize during horror form

### DIFF
--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -297,10 +297,14 @@
 	//show to hivemind
 	for (var/client/C in clients)
 		try_render_chat_to_admin(C, rendered)
-	for (var/mob/M in (hivemind_owner.hivemind + hivemind_owner.owner))
-		if (M.client?.holder && M.client.deadchat && !M.client.player_mode) continue
-		if (isdead(M) || istype(M,/mob/living/critter/changeling) || (M == hivemind_owner.owner))
-			boutput(M, rendered)
+	if (isabomination(hivemind_owner.owner))
+		var/abomination_rendered = "<span class='game'><span class='prefix'></span> <span class='name' data-ctx='\ref[src.mind]'>Congealed [name]</span> <span class='message'>[message]</span></span>"
+		src.audible_message(abomination_rendered)
+	else
+		for (var/mob/M in (hivemind_owner.hivemind + hivemind_owner.owner))
+			if (M.client?.holder && M.client.deadchat && !M.client.player_mode) continue
+			if (isdead(M) || istype(M,/mob/living/critter/changeling) || (M == hivemind_owner.owner))
+				boutput(M, rendered)
 
 //vampire thrall say
 /mob/proc/say_thrall(var/message, var/datum/abilityHolder/vampire/owner)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check into the changling hivemind chat that enables audible says from victims when changeling horror form is enabled. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's very cool to RP being half-absorbed into a horrific monstrosity! 
Also, suggested on forums: https://forum.ss13.co/showthread.php?tid=18155

## Changelog

```changelog
(u)glowbold
(*)As a changeling victim, your pleas for help/mercy/death/JOIN US are now audible when your master goes into horror form!
```
