### PR TITLE
Skip item selection when eating off a plate with a single item.

### DIFF
--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -668,7 +668,13 @@ TRAYS
 			return
 		if(!W.edible)
 			if(istype(W, /obj/item/kitchen/utensil/fork) || istype(W, /obj/item/kitchen/utensil/spoon))
-				var/obj/item/reagent_containers/food/sel_food = input(user, "Which food do you want to eat?", "[src] Contents") as null|anything in ordered_contents
+				var/obj/item/reagent_containers/food/sel_food = null
+				if(length(ordered_contents) > 1)
+					sel_food = input(user, "Which food do you want to eat?", "[src] Contents") as null|anything in ordered_contents
+				else if(length(ordered_contents) == 1)
+					sel_food = ordered_contents[1]
+				else
+					user.visible_message("<b>[user]</b> stares glumly at the empty plate.","You stare glumly at the empty plate.")
 				if(!sel_food)
 					return
 				sel_food.Eat(user,user)
@@ -699,7 +705,11 @@ TRAYS
 			if(ordered_contents.len == 0)
 				boutput(M, "There's no food to take off of \the [src]!")
 				return
-			var/food_sel = input(M, "Which food do you want to take off of \the [src]?", "[src]'s contents") as null|anything in ordered_contents
+			var/obj/item/food_sel = null
+			if(length(ordered_contents) == 1)
+				food_sel = ordered_contents[1]
+			else
+				food_sel = input(M, "Which food do you want to take off of \the [src]?", "[src]'s contents") as null|anything in ordered_contents
 			if(!food_sel)
 				return
 
@@ -714,7 +724,11 @@ TRAYS
 		if(ordered_contents.len == 0)
 			boutput(user, "There's no food to take off of \the [src]!")
 			return
-		var/food_sel = input(user, "Which food do you want to take off of \the [src]?", "[src]'s contents") as null|anything in ordered_contents
+		var/obj/item/food_sel = null
+		if(length(ordered_contents) == 1)
+			food_sel = ordered_contents[1]
+		else
+			food_sel = input(user, "Which food do you want to take off of \the [src]?", "[src]'s contents") as null|anything in ordered_contents
 		if(!food_sel)
 			return
 		user.put_in_hand_or_drop(food_sel)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The PR skips the item selection dialog when eating from a plate with a single item. It also skips the dialog when taking the only item off of a plate.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
If there is only one item on the plate, there is no need to ask the user which item they want to eat or remove. This will make it faster and easier to eat single items off plates. Having to answer a dialog with every bite is slow and makes eating a pain.


