### PR TITLE
Fixes conspirator names showing as Unknown

### DIFF
--- a/code/datums/gamemodes/conspiracy.dm
+++ b/code/datums/gamemodes/conspiracy.dm
@@ -54,7 +54,12 @@
 
 	var/conspiratorList = "The conspiracy consists of: "
 	for (var/datum/mind/conspirator in traitors)
-		conspiratorList = conspiratorList + "<b>" + conspirator.current.name + "</b>, "
+		var/conspirator_name
+		if (conspirator.assigned_role == "Clown")
+			conspirator_name = "a Clown"
+		else
+			conspirator_name = conspirator.current.real_name
+		conspiratorList += "<b>[conspirator_name]</b>, "
 
 	var/pickedObjective = pick(typesof(/datum/objective/conspiracy))
 	for(var/datum/mind/conspirator in traitors)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #7664
Clowns are now listed as "a Clown" since we can't know what name they will pick at the start of the game.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The notes list is the only way to know who is in the conspiracy and so should be as accurate as possible.