### PR TITLE
Alaster Blaster Change

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1203,6 +1203,7 @@
 	cell_type = /obj/item/ammo/power_cell/med_power
 	desc = "A gun that produces a harmful laser, causing substantial damage."
 	muzzle_flash = "muzzle_flash_laser"
+	is_syndicate = 1
 
 	New()
 		set_current_projectile(new/datum/projectile/laser/alastor)

--- a/maps/z3_water.dmm
+++ b/maps/z3_water.dmm
@@ -2139,6 +2139,10 @@
 /obj/machinery/handscanner{
 	pixel_y = 32
 	},
+/mob/living/critter/gunbot/syndicate{
+	desc = "Painted in red and black, all indentifying marks have been scraped off. Darn.";
+	name = "Unmarked robot"
+	},
 /turf/unsimulated/floor/black,
 /area/wrecknsspolaris/vault)
 "fH" = (

--- a/maps/z3_water.dmm
+++ b/maps/z3_water.dmm
@@ -1518,7 +1518,17 @@
 /obj/storage/crate/classcrate{
 	name = "secure crate"
 	},
-/obj/item/paper/manufacturer_blueprint/alastor,
+/obj/item/gun/energy/alastor{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/gun/energy/alastor{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/gun/energy/alastor{
+	pixel_y = 6
+	},
 /turf/unsimulated/floor/black,
 /area/wrecknsspolaris/vault)
 "eb" = (

--- a/maps/z3_water.dmm
+++ b/maps/z3_water.dmm
@@ -2139,9 +2139,11 @@
 /obj/machinery/handscanner{
 	pixel_y = 32
 	},
-/mob/living/critter/gunbot/syndicate{
+/mob/living/critter/gunbot{
 	desc = "Painted in red and black, all indentifying marks have been scraped off. Darn.";
-	name = "Unmarked robot"
+	icon_state = "mars_nuke_bot";
+	interesting = "your scanner picks up a faint etching of a name. Even though your being shot at. Seems this one is named Ketchup.";
+	name = "Unmarked Robot"
 	},
 /turf/unsimulated/floor/black,
 /area/wrecknsspolaris/vault)
@@ -2277,6 +2279,12 @@
 	pixel_y = 32
 	},
 /obj/map/light/green,
+/mob/living/critter/gunbot{
+	desc = "Painted in red and black, all indentifying marks have been scraped off. Darn.";
+	icon_state = "mars_nuke_bot";
+	interesting = "your scanner picks up a faint etching of a name. Even though your being shot at. Seems this one is named Mustard.";
+	name = "Unmarked Robot"
+	},
 /turf/unsimulated/floor/black,
 /area/wrecknsspolaris/vault)
 "fZ" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Removes the Alaster Blaster blueprint and replaces it with three examples of the gun. Also makes it harder to get access to the weapons

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's pretty easy to rush and get the blaster blueprints, and once you do you have a really robust ranged weapon with no downsides. And you can print more. This has to led to mining producing a bunch of them on any round where the Azone it is in is rolled. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Eagle
(+) The blueprint for a certain gun has been swapped out with some examples of it. 
```
