### PR TITLE
Donut3 Ranch Changes

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -458,9 +458,7 @@
 	},
 /area/station/mining/staff_room)
 "aaO" = (
-/obj/item/device/radio/beacon{
-	anchored = 1
-	},
+/obj/item/device/radio/beacon,
 /obj/decal/mule/beacon,
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 10
@@ -1353,6 +1351,13 @@
 	dir = 1
 	},
 /area/station/crew_quarters/kitchen)
+"adN" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/wall/auto/jen,
+/area/station/maintenance/outer/north)
 "adY" = (
 /obj/cable{
 	d1 = 1;
@@ -3730,6 +3735,12 @@
 /obj/stool/chair,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
+"aPK" = (
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/grasstodirt,
+/area/station/ranch)
 "aQh" = (
 /obj/item/gun/kinetic/antisingularity{
 	pixel_x = -6;
@@ -3918,13 +3929,13 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "aSY" = (
+/obj/disposalpipe/trunk,
 /obj/railing/orange/reinforced{
 	dir = 1
 	},
 /obj/machinery/disposal/small{
 	dir = 8
 	},
-/obj/disposalpipe/trunk,
 /turf/simulated/floor/grasstodirt{
 	dir = 1
 	},
@@ -7840,7 +7851,13 @@
 /turf/space,
 /area/space)
 "bYk" = (
-/obj/machinery/light/small/floor/netural,
+/obj/submachine/chef_sink/chem_sink{
+	layer = 3;
+	pixel_y = 8
+	},
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "bYn" = (
@@ -8546,6 +8563,11 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 1;
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -11723,6 +11745,10 @@
 /obj/cable{
 	icon_state = "4-10"
 	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "dhL" = (
@@ -12251,8 +12277,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/plantpot{
-	anchored = 1
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -12428,6 +12455,17 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"drq" = (
+/obj/grille/catwalk/jen/side{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/ne)
 "drr" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -12764,6 +12802,10 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
@@ -16035,6 +16077,10 @@
 	dir = 4
 	},
 /obj/random_item_spawner/junk/one_or_zero,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
 "evb" = (
@@ -16093,9 +16139,7 @@
 /turf/simulated/wall/auto/reinforced/jen,
 /area/station/hangar/main)
 "ewc" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8
-	},
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "ewf" = (
@@ -17841,6 +17885,17 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"eVb" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/grasstodirt,
+/area/station/ranch)
 "eVg" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -19676,7 +19731,6 @@
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant";
-	name = "shrub";
 	tag = "null"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -20762,6 +20816,16 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/south)
+"fKW" = (
+/obj/table/reinforced/auto,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/wateringcan{
+	pixel_y = 9
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "fLf" = (
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
@@ -22069,6 +22133,9 @@
 /obj/item/reagent_containers/food/snacks/ingredient/egg{
 	rand_pos = 0
 	},
+/obj/machinery/light/incandescent/netural{
+	dir = 1
+	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "ggh" = (
@@ -22445,6 +22512,9 @@
 "gmk" = (
 /obj/grille/catwalk/jen/side,
 /obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
 "gmo" = (
@@ -22759,6 +22829,7 @@
 /area/station/maintenance/outer/sw)
 "grh" = (
 /obj/landmark/gps_waypoint,
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/grasstodirt{
 	dir = 9
 	},
@@ -23638,7 +23709,6 @@
 /obj/machinery/door_timer/genpop_s{
 	id = "solitarycell";
 	name = "Solitary";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/redblack,
@@ -24723,6 +24793,16 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
+"gWz" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment{
+	dir = 8
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "gWF" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -24948,6 +25028,14 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
+"gYV" = (
+/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "gZh" = (
 /obj/table/auto,
 /obj/item/cable_coil,
@@ -25448,10 +25536,7 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
+/obj/disposalpipe/junction/right/east,
 /turf/simulated/floor/white/checker2{
 	dir = 1
 	},
@@ -26106,6 +26191,13 @@
 /obj/cable,
 /turf/simulated/floor/plating/jen,
 /area/station/storage/tech)
+"hqG" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "hqM" = (
 /obj/machinery/camera,
 /obj/machinery/light/small/sticky{
@@ -28060,6 +28152,13 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor,
 /area/station/engine/monitoring)
+"hUj" = (
+/obj/disposalpipe/segment/morgue{
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "hUr" = (
 /obj/cable{
 	d1 = 4;
@@ -29879,15 +29978,18 @@
 	name = "Genetic Research"
 	})
 "ivP" = (
-/obj/shrub{
-	dir = 8
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/grass/leafy,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
+	},
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/turf/simulated/floor/wood/seven,
 /area/station/ranch)
 "ivU" = (
 /obj/machinery/rkit,
@@ -31371,6 +31473,9 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
+"iTt" = (
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "iTy" = (
 /obj/decal/poster/wallsign/medbay_right{
 	pixel_x = 1;
@@ -31992,6 +32097,18 @@
 	},
 /turf/simulated/floor/sand,
 /area/station/engine/engineering/ce)
+"jev" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	tag = "icon-xtra_bigstripe-edge (WEST)"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "jey" = (
 /obj/bookshelf{
 	pixel_y = 28
@@ -33130,6 +33247,16 @@
 /obj/machinery/bathtub,
 /turf/simulated/floor/sanitary/blue,
 /area/station/medical/asylum/bathroom)
+"jwK" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/machinery/camera/ranch{
+	dir = 8
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "jwS" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -34946,6 +35073,10 @@
 /obj/machinery/vending/cola/red,
 /turf/simulated/grimycarpet,
 /area/station/hallway/primary/southeast)
+"jZW" = (
+/obj/submachine/seed_vendor,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "kaf" = (
 /obj/cable{
 	d1 = 4;
@@ -36764,6 +36895,12 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"kCe" = (
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "kCh" = (
 /obj/machinery/light/incandescent/harsh,
 /obj/machinery/camera{
@@ -37846,6 +37983,16 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
+"kUm" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0;
+	dir = 4
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/wall/auto/jen,
+/area/station/crew_quarters/catering)
 "kUo" = (
 /obj/cable{
 	d1 = 4;
@@ -38668,6 +38815,9 @@
 "lhw" = (
 /obj/storage/secure/closet/civilian/kitchen,
 /obj/item/hand_labeler,
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "lhF" = (
@@ -40115,6 +40265,7 @@
 /turf/simulated/floor/grey,
 /area/station/science/artifact)
 "lCU" = (
+/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/grasstodirt{
 	dir = 9
 	},
@@ -40389,11 +40540,27 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "lGJ" = (
-/obj/machinery/camera/ranch{
-	dir = 9
-	},
-/turf/simulated/floor/grass/leafy,
+/obj/reagent_dispensers/watertank/big,
+/turf/simulated/floor/wood/seven,
 /area/station/ranch)
+"lGS" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/grille/catwalk/jen/side{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "lGU" = (
 /obj/indestructible/shuttle_corner{
 	dir = 4
@@ -40475,6 +40642,16 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"lIj" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 4
+	},
+/obj/submachine/ranch_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn{
+	doants = 0
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "lIw" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -41817,13 +41994,13 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "man" = (
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/railing/orange/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/grasstodirt{
 	dir = 1
@@ -43568,6 +43745,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/AIsat)
+"mCj" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
+/area/station/ranch)
 "mCk" = (
 /obj/machinery/plantpot,
 /turf/simulated/floor/plating/jen,
@@ -44258,6 +44441,15 @@
 	dir = 4
 	},
 /area/station/hallway/primary/east)
+"mPc" = (
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
+/area/station/ranch)
 "mPh" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/item/storage/wall/emergency{
@@ -44905,22 +45097,14 @@
 /turf/simulated/grimycarpet,
 /area/station/maintenance/inner/east)
 "mYu" = (
-/obj/railing/orange/reinforced{
-	dir = 1
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = -1
-	},
-/obj/submachine/ranch_feed_grinder,
-/obj/item/reagent_containers/food/snacks/plant/corn{
-	doants = 0
-	},
-/turf/simulated/floor/grasstodirt{
-	dir = 1
-	},
-/area/station/ranch)
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "mYx" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/specialroom/medbay,
@@ -46701,6 +46885,12 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/artifact)
+"nyL" = (
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "nza" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -47522,6 +47712,13 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
+"nNl" = (
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg{
+	rand_pos = 0
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "nNm" = (
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/cafeteria)
@@ -47773,6 +47970,22 @@
 "nQI" = (
 /turf/simulated/floor/stairs/wide,
 /area/listeningpost)
+"nQN" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	tag = "icon-xtra_bigstripe-edge (WEST)"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "nQO" = (
 /obj/machinery/vending/cards,
 /turf/simulated/floor/carpet/arcade/half,
@@ -47906,6 +48119,9 @@
 /obj/storage/crate,
 /obj/machinery/light/small/sticky,
 /obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
 "nTd" = (
@@ -48539,6 +48755,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
+"oab" = (
+/obj/chicken_nesting_box,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "oac" = (
 /obj/cable{
 	d1 = 4;
@@ -52562,10 +52782,16 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
+"plf" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "plk" = (
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
 	},
@@ -53526,6 +53752,22 @@
 	dir = 5
 	},
 /area/station/chapel/sanctuary)
+"pyj" = (
+/obj/machinery/disposal/small/west{
+	name = "Kitchen Freezer Chute"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	icon_state = "xtra_bigstripe-edge2"
+	},
+/obj/disposalpipe/trunk/morgue{
+	dir = 8;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/white/checker2{
+	dir = 1
+	},
+/area/station/ranch)
 "pyq" = (
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/maintenance/solar/west)
@@ -57885,7 +58127,6 @@
 	dir = 1;
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant";
-	name = "shrub";
 	tag = "null"
 	},
 /obj/disposalpipe/segment/transport{
@@ -59310,6 +59551,11 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
+"qZq" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/machinery/hydro_growlamp,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "qZz" = (
 /turf/simulated/floor/black/grime,
 /area/station/mining/staff_room)
@@ -59813,6 +60059,11 @@
 	dir = 10
 	},
 /area/station/engine/inner)
+"rhe" = (
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
+/area/station/ranch)
 "rhm" = (
 /obj/grille/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -60598,7 +60849,6 @@
 /obj/machinery/sleeper/compact,
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
 	},
@@ -61527,6 +61777,19 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/red/fancy/edge,
 /area/station/security/hos)
+"rFz" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/table/reinforced/auto,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/obj/item/toy/plush/small/stress_ball,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "rFB" = (
 /obj/machinery/light/incandescent/warm,
 /obj/reagent_dispensers/heliumtank,
@@ -61952,7 +62215,6 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/machinery/light/incandescent/netural,
 /obj/item/device/camera_viewer/ranch,
 /obj/item/storage/box/syringes,
 /obj/item/satchel/hydro,
@@ -61994,9 +62256,6 @@
 "rLV" = (
 /obj/railing/orange/reinforced{
 	dir = 1
-	},
-/obj/railing/orange/reinforced{
-	dir = 4
 	},
 /turf/simulated/floor/grasstodirt{
 	dir = 4
@@ -64117,7 +64376,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/unsimulated/floor{
 	desc = "";
-	dir = 2;
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
 	},
@@ -66979,6 +67237,15 @@
 /obj/machinery/light_switch/south,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbooth)
+"tos" = (
+/obj/table/reinforced/auto,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/item/kitchen/utensil/knife,
+/obj/item/sponge,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "tou" = (
 /obj/cable,
 /obj/cable{
@@ -68774,6 +69041,13 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/asylum/rec)
+"tOy" = (
+/obj/disposalpipe/segment/morgue{
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "tOD" = (
 /obj/disposalpipe/segment{
 	dir = 8
@@ -69824,10 +70098,10 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "ufw" = (
-/obj/railing/orange/reinforced{
-	dir = 4
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
 	},
-/obj/machinery/light/small/floor/netural,
 /turf/simulated/floor/grasstodirt{
 	dir = 4
 	},
@@ -70249,6 +70523,10 @@
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen/side{
 	dir = 9
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
@@ -71772,6 +72050,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
+"uIQ" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 8
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "uIX" = (
 /obj/cable{
 	icon_state = "2-5"
@@ -77294,6 +77578,10 @@
 	},
 /obj/access_spawn/rancher,
 /obj/decal/mule/dropoff,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
 /turf/simulated/floor/plating,
 /area/station/ranch)
 "wnj" = (
@@ -77573,6 +77861,21 @@
 "wqJ" = (
 /turf/simulated/wall/auto/jen,
 /area/station/hydroponics/bay)
+"wqT" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	tag = "icon-xtra_bigstripe-edge (WEST)"
+	},
+/obj/stool/chair/green{
+	dir = 4
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "wqW" = (
 /obj/cable{
 	d1 = 1;
@@ -78650,6 +78953,14 @@
 	icon_state = "floor"
 	},
 /area/shuttle/arrival/station)
+"wGn" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "wGy" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen/side{
@@ -79857,6 +80168,14 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
+"wWH" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 1;
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "wWM" = (
 /obj/critter/turtle/sylvester/HoS,
 /turf/simulated/floor/carpet/red/fancy/edge{
@@ -82775,6 +83094,12 @@
 	},
 /turf/simulated/floor/dojo/sand/circle,
 /area/station/crew_quarters/captain)
+"xPl" = (
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/wall/auto/jen,
+/area/station/crew_quarters/kitchen)
 "xPF" = (
 /obj/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -128328,13 +128653,13 @@ jMm
 cqV
 cqV
 bwx
-ewH
-eGx
-nXr
+mYu
+gWz
+lGS
 gmk
 nTa
-oad
-uAh
+kUm
+nyL
 cjT
 ijS
 rsa
@@ -128630,14 +128955,14 @@ kyD
 cqV
 cqV
 xjy
-ewH
+wGn
 heU
 qNE
 fuZ
 gHa
 hen
 hHn
-hHn
+gYV
 hHn
 jDX
 ptw
@@ -128939,9 +129264,9 @@ ugD
 oHX
 oad
 xth
-uAh
+hUj
 lhw
-pQh
+xPl
 hgC
 hdF
 xHi
@@ -129234,7 +129559,7 @@ kkV
 kvH
 bRl
 rSV
-oHX
+adN
 cRr
 oHX
 oHX
@@ -129838,7 +130163,7 @@ ybG
 oUM
 ubD
 aRI
-bzi
+drq
 ncG
 qAJ
 iaa
@@ -131046,10 +131371,10 @@ gfX
 jQH
 mBB
 oJP
-vzA
+hqG
 fCj
-mBB
-mBB
+oab
+nNl
 mfs
 mfs
 mfs
@@ -131348,15 +131673,15 @@ mBB
 mBB
 mBB
 oJP
-vzA
+hqG
 wYJ
 mBB
 mBB
+uIQ
 mBB
-ewc
 jQH
-mBB
-mYu
+uIQ
+oJP
 rLk
 sJC
 kea
@@ -131650,7 +131975,7 @@ mBB
 mBB
 mBB
 oJP
-vzA
+hqG
 wYJ
 mBB
 mBB
@@ -131950,11 +132275,11 @@ mfs
 mfs
 gYi
 mBB
-bYk
+mBB
 oJP
-vzA
+hqG
 wYJ
-bYk
+mBB
 mBB
 mBB
 mBB
@@ -132254,12 +132579,12 @@ uIp
 ezH
 ezH
 lCU
-vzA
+hqG
 nBy
+mPc
 ezH
 ezH
-ezH
-ezH
+mPc
 ezH
 ezH
 grh
@@ -132556,11 +132881,11 @@ vzA
 vzA
 vzA
 vzA
-vzA
-vzA
-vzA
-vzA
-vzA
+tOy
+kCe
+kCe
+kCe
+wWH
 vzA
 vzA
 vzA
@@ -132862,7 +133187,7 @@ tGj
 mwv
 vzA
 vzA
-vzA
+hqG
 vzA
 vzA
 vzA
@@ -133159,15 +133484,15 @@ aSU
 mBB
 mBB
 mBB
+ewc
 mBB
-bYk
 rLV
-tGj
-tGj
+mCj
+rhe
 ufw
-tGj
-tGj
-tGj
+mCj
+rhe
+rhe
 mwv
 ksz
 mfs
@@ -133463,12 +133788,12 @@ pKk
 pKk
 pKk
 pKk
-pKk
-pKk
-pKk
-pKk
-pKk
-pKk
+eVb
+rFz
+wqT
+nQN
+jev
+jev
 ivP
 man
 nDB
@@ -133765,13 +134090,13 @@ mBB
 mBB
 mBB
 mBB
-mBB
-mBB
-mBB
-mBB
-mBB
-mBB
-mBB
+aPK
+tos
+iTt
+plf
+iTt
+iTt
+qZq
 oJP
 lUK
 mfs
@@ -134062,18 +134387,18 @@ fsc
 jba
 giC
 mfs
-gYi
+bYk
 mBB
 rmq
 sJW
 mBB
-mBB
-mBB
-mBB
-mBB
-sJW
+aPK
+fKW
+jZW
+pyj
+lIj
 lGJ
-mBB
+jwK
 aSY
 fPD
 mfs

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2059,6 +2059,14 @@
 	},
 /turf/simulated/floor/sanitary/blue,
 /area/station/crew_quarters/bathroom)
+"aoM" = (
+/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "apd" = (
 /obj/table/auto,
 /obj/machinery/light/incandescent/netural{
@@ -2511,6 +2519,21 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/solar/small_backup1)
+"awI" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	tag = "icon-xtra_bigstripe-edge (WEST)"
+	},
+/obj/stool/chair/green{
+	dir = 4
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "awJ" = (
 /obj/wingrille_spawn/auto/tuff,
 /obj/cable,
@@ -2560,16 +2583,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/science/storage)
-"axn" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4
-	},
-/obj/submachine/ranch_feed_grinder,
-/obj/item/reagent_containers/food/snacks/plant/corn{
-	doants = 0
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "axo" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small{
@@ -3755,6 +3768,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
+"aQo" = (
+/obj/disposalpipe/segment/morgue{
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "aQp" = (
 /obj/cable{
 	d1 = 2;
@@ -3859,10 +3879,6 @@
 	dir = 10
 	},
 /area/station/hallway/primary/east)
-"aRO" = (
-/obj/submachine/seed_vendor,
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "aRU" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -5026,6 +5042,22 @@
 /area/station/chapel/sanctuary{
 	name = "Funeral Parlor"
 	})
+"blo" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	tag = "icon-xtra_bigstripe-edge (WEST)"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "blF" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/disposalpipe/segment{
@@ -5038,6 +5070,10 @@
 "blX" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
@@ -5856,13 +5892,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
-"bwQ" = (
-/obj/disposalpipe/segment/morgue{
-	icon_state = "pipe-c";
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "bwT" = (
 /obj/item/ammo/bullets/antisingularity{
 	pixel_x = -7;
@@ -8379,21 +8408,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"cgd" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8;
-	tag = "icon-xtra_bigstripe-edge (WEST)"
-	},
-/obj/stool/chair/green{
-	dir = 4
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "cgw" = (
 /obj/machinery/vending/cola/blue,
 /turf/simulated/floor/red/side{
@@ -8764,6 +8778,16 @@
 	icon_state = "fblue2"
 	},
 /area/station/medical/head)
+"cmX" = (
+/obj/table/reinforced/auto,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/wateringcan{
+	pixel_y = 9
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "cni" = (
 /obj/random_pod_spawner/random_putt_spawner,
 /turf/simulated/floor/shuttlebay,
@@ -9210,13 +9234,6 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
-"cuS" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "cva" = (
 /obj/decal/mule/dropoff,
 /obj/access_spawn/eva,
@@ -9503,6 +9520,10 @@
 "cxF" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
+	},
+/obj/disposalpipe/segment/morgue{
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
@@ -9834,12 +9855,6 @@
 	dir = 8
 	},
 /area/shuttle/arrival/station)
-"cDk" = (
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/wall/auto/jen,
-/area/station/crew_quarters/kitchen)
 "cDl" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner{
 	dir = 5
@@ -11837,6 +11852,15 @@
 "diK" = (
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
+"diU" = (
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
+/area/station/ranch)
 "diY" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 1;
@@ -12562,16 +12586,6 @@
 "dsw" = (
 /turf/simulated/floor/specialroom/freezer,
 /area/station/maintenance/inner/sw)
-"dsC" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment{
-	dir = 8
-	},
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/north)
 "dsW" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -13328,9 +13342,6 @@
 	},
 /turf/space,
 /area/space)
-"dGe" = (
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "dGg" = (
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/hangar/main)
@@ -14920,6 +14931,9 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
+"ebZ" = (
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "ecg" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 4
@@ -20377,15 +20391,6 @@
 	dir = 1
 	},
 /area/station/medical/asylum/kitchen)
-"fDI" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	icon_state = "pipe-c";
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/north)
 "fDP" = (
 /obj/access_spawn/head_of_personnel,
 /obj/cable{
@@ -20823,6 +20828,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"fKp" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/machinery/camera/ranch{
+	dir = 8
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "fKu" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/jen,
@@ -24287,6 +24302,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/main)
+"gOh" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/grasstodirt,
+/area/station/ranch)
 "gOs" = (
 /obj/cable{
 	d2 = 8;
@@ -25540,7 +25566,6 @@
 /obj/machinery/light/incandescent/netural{
 	dir = 1
 	},
-/obj/disposalpipe/junction/right/east,
 /turf/simulated/floor/white/checker2{
 	dir = 1
 	},
@@ -26707,6 +26732,12 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/escape/corner,
 /area/station/hallway/secondary/exit)
+"hxQ" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 8
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "hxY" = (
 /obj/cable{
 	d1 = 1;
@@ -26785,22 +26816,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"hyB" = (
-/obj/machinery/disposal/small/west{
-	name = "Kitchen Freezer Chute"
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8;
-	icon_state = "xtra_bigstripe-edge2"
-	},
-/obj/disposalpipe/trunk/morgue{
-	dir = 8;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/white/checker2{
-	dir = 1
-	},
-/area/station/ranch)
 "hyE" = (
 /obj/wingrille_spawn/auto/tuff,
 /obj/window_blinds/cog2/middle{
@@ -27098,6 +27113,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/singcore)
+"hCx" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 4
+	},
+/obj/submachine/ranch_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn{
+	doants = 0
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "hCH" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -28050,13 +28075,6 @@
 	},
 /turf/simulated/grass,
 /area/station/hallway/secondary/exit)
-"hRX" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/wall/auto/jen,
-/area/station/maintenance/outer/north)
 "hSc" = (
 /obj/machinery/light/incandescent/warm,
 /obj/disposalpipe/segment{
@@ -28186,17 +28204,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
-"hUu" = (
-/obj/grille/catwalk/jen/side{
-	dir = 1
-	},
-/obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/ne)
 "hUy" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
@@ -28629,6 +28636,10 @@
 /obj/storage/closet/radiation,
 /turf/simulated/floor/yellowblack,
 /area/station/engine/engineering)
+"iaZ" = (
+/obj/disposalpipe/junction/left/east,
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "iba" = (
 /obj/disposalpipe/segment{
 	dir = 8
@@ -28999,12 +29010,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/west)
-"ifo" = (
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "ifv" = (
 /obj/machinery/shower{
 	dir = 4
@@ -29198,6 +29203,13 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/grimycarpet,
 /area/station/crew_quarters/stockex)
+"iij" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/wall/auto/jen,
+/area/station/maintenance/outer/north)
 "iik" = (
 /obj/cable{
 	d1 = 4;
@@ -29340,13 +29352,6 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
-"ikS" = (
-/obj/disposalpipe/segment/morgue{
-	icon_state = "pipe-c";
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
 "ikW" = (
 /obj/cable{
 	d1 = 4;
@@ -29979,15 +29984,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
-"ivz" = (
-/obj/railing/orange/reinforced{
-	dir = 8
-	},
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/grasstodirt{
-	dir = 8
-	},
-/area/station/ranch)
 "ivI" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -30823,12 +30819,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"iHf" = (
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
 "iHg" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -33476,12 +33466,6 @@
 	dir = 1
 	},
 /area/station/turret_protected/AIsat)
-"jAh" = (
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/grasstodirt{
-	dir = 4
-	},
-/area/station/ranch)
 "jAj" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -35794,12 +35778,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
-"kkB" = (
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/grasstodirt,
-/area/station/ranch)
 "kkK" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin{
@@ -37210,6 +37188,12 @@
 	},
 /turf/simulated/floor/wood/six,
 /area/station/library)
+"kGB" = (
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "kGJ" = (
 /turf/simulated/floor/greenwhite/other{
 	dir = 8
@@ -38835,6 +38819,8 @@
 /obj/storage/secure/closet/civilian/kitchen,
 /obj/item/hand_labeler,
 /obj/disposalpipe/segment/morgue{
+	dir = 8;
+	icon_state = "pipe-c";
 	name = "kitchen freezer pipe"
 	},
 /turf/simulated/floor/black,
@@ -38851,6 +38837,24 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/science/gen_storage)
+"lhJ" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/grille/catwalk/jen/side{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "lhK" = (
 /obj/table/wood/auto/desk,
 /obj/decal/cleanable/dirt/jen,
@@ -40478,24 +40482,6 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/west)
-"lFS" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/grille/catwalk/jen/side{
-	dir = 1
-	},
-/obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/north)
 "lFZ" = (
 /obj/disposalpipe/segment/food,
 /obj/disposalpipe/segment/morgue{
@@ -41043,11 +41029,6 @@
 /area/station/chapel/sanctuary{
 	name = "Funeral Parlor"
 	})
-"lNi" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/hydro_growlamp,
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "lNp" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
@@ -41469,6 +41450,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
+"lSn" = (
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/grasstodirt,
+/area/station/ranch)
 "lSo" = (
 /obj/cable{
 	d1 = 1;
@@ -41533,14 +41520,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"lSO" = (
-/obj/disposalpipe/segment/transport,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
 "lST" = (
 /turf/simulated/floor/carpet/green/fancy,
 /area/station/engine/engineering/ce)
@@ -43767,18 +43746,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/AIsat)
-"mCi" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8;
-	tag = "icon-xtra_bigstripe-edge (WEST)"
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "mCk" = (
 /obj/machinery/plantpot,
 /turf/simulated/floor/plating/jen,
@@ -44095,6 +44062,10 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/security/brig/north_side)
+"mHS" = (
+/obj/chicken_nesting_box,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "mHU" = (
 /obj/machinery/light/small/sticky/warm/very{
 	dir = 1
@@ -44366,17 +44337,6 @@
 	dir = 1
 	},
 /area/station/engine/inner)
-"mMy" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/grasstodirt,
-/area/station/ranch)
 "mMB" = (
 /obj/decal/cleanable/rust/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -46504,6 +46464,22 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
+"nst" = (
+/obj/machinery/disposal/small/west{
+	name = "Kitchen Freezer Chute"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	icon_state = "xtra_bigstripe-edge2"
+	},
+/obj/disposalpipe/trunk/morgue{
+	dir = 8;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/white/checker2{
+	dir = 1
+	},
+/area/station/ranch)
 "nsG" = (
 /obj/storage/closet/radiation,
 /turf/simulated/floor/yellowblack{
@@ -47712,16 +47688,6 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
-"nMW" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	can_rupture = 0;
-	dir = 4
-	},
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/wall/auto/jen,
-/area/station/crew_quarters/catering)
 "nMZ" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -48846,6 +48812,12 @@
 /obj/machinery/vending/monkey,
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
+"obC" = (
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "ocf" = (
 /obj/cable{
 	d1 = 1;
@@ -48939,16 +48911,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/east)
-"odI" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/plantpot{
-	anchored = 1
-	},
-/obj/machinery/camera/ranch{
-	dir = 8
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "odN" = (
 /obj/machinery/computer/operating{
 	id = "robotics"
@@ -49310,6 +49272,19 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/southeast)
+"oky" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "okM" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
@@ -50017,9 +49992,6 @@
 /area/station/medical/cdc)
 "ost" = (
 /obj/machinery/light/incandescent/cool/very,
-/obj/disposalpipe/trunk/morgue{
-	name = "kitchen freezer pipe"
-	},
 /obj/disposaloutlet{
 	desc = "Listen... sometimes it's just a waste to so heartlessly toss perfectly good meat into the reclaimer...";
 	dir = 1;
@@ -50027,6 +49999,10 @@
 	mailgroup2 = "medbay";
 	message = "Morgue-to-kitchen outlet activated.";
 	name = "Morgue Outlet"
+	},
+/obj/disposalpipe/trunk/morgue{
+	dir = 1;
+	name = "kitchen freezer pipe"
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
@@ -50080,6 +50056,19 @@
 	allows_vehicles = 0
 	},
 /area/station/science/teleporter)
+"otm" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/table/reinforced/auto,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/obj/item/toy/plush/small/stress_ball,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "otu" = (
 /obj/machinery/chem_dispenser,
 /obj/decal/tile_edge/stripe/extra_big,
@@ -52431,6 +52420,11 @@
 /obj/grille/catwalk/jen/side,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/east)
+"pgL" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/machinery/hydro_growlamp,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "pgN" = (
 /obj/access_spawn/maint,
 /obj/decal/mule/dropoff,
@@ -53380,10 +53374,6 @@
 /area/station/crew_quarters/bar)
 "ptw" = (
 /obj/disposalpipe/segment/transport,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
 /obj/surgery_tray/kitchen_island,
 /obj/noticeboard/persistent{
 	name = "Kitchen persistent notice board";
@@ -55186,12 +55176,6 @@
 	dir = 5
 	},
 /area/station/security/quarters)
-"pSF" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "pSH" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -58401,10 +58385,6 @@
 	dir = 1
 	},
 /area/station/engine/engineering)
-"qJW" = (
-/obj/chicken_nesting_box,
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "qKk" = (
 /obj/random_item_spawner/tools/one_or_zero,
 /obj/rack,
@@ -58827,13 +58807,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/crew_quarters/garden)
-"qOQ" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "qOZ" = (
 /obj/grille/catwalk/jen,
 /obj/disposalpipe/segment{
@@ -60794,6 +60767,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -62839,22 +62815,6 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/AIsat)
-"rVK" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8;
-	tag = "icon-xtra_bigstripe-edge (WEST)"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "rVM" = (
 /obj/grille/catwalk/jen/side,
 /obj/decal/cleanable/dirt/jen,
@@ -63122,12 +63082,14 @@
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)
 "sac" = (
+/obj/decal/cleanable/dirt/jen,
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
+	icon_state = "pipe-c";
 	name = "kitchen freezer pipe"
 	},
-/turf/simulated/wall/auto/jen,
-/area/station/crew_quarters/catering)
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "sad" = (
 /obj/cable{
 	d1 = 1;
@@ -63728,6 +63690,11 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
+"siV" = (
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
+/area/station/ranch)
 "sjd" = (
 /obj/disposalpipe/segment,
 /obj/decal/tile_edge/stripe/corner/big2{
@@ -63985,6 +63952,15 @@
 "smZ" = (
 /turf/simulated/floor/wood/five,
 /area/station/hydroponics/bay)
+"snc" = (
+/obj/table/reinforced/auto,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/item/kitchen/utensil/knife,
+/obj/item/sponge,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "snq" = (
 /obj/decal/tile_edge/line/black{
 	dir = 4;
@@ -65036,6 +65012,15 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/inner)
+"sEm" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/specialroom/freezer,
+/area/station/crew_quarters/catering)
 "sEo" = (
 /obj/decal/poster/wallsign/hazard_rad,
 /obj/wingrille_spawn/auto,
@@ -65494,6 +65479,10 @@
 	},
 /obj/access_spawn/kitchen,
 /obj/firedoor_spawn,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "sLc" = (
@@ -65856,12 +65845,13 @@
 /area/station/chapel/sanctuary{
 	name = "Funeral Parlor"
 	})
-"sSa" = (
-/obj/submachine/chicken_incubator,
-/obj/item/reagent_containers/food/snacks/ingredient/egg{
-	rand_pos = 0
+"sSb" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 1;
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
 	},
-/turf/simulated/floor/grass/leafy,
+/turf/simulated/floor/dirt,
 /area/station/ranch)
 "sSd" = (
 /obj/cable{
@@ -66224,6 +66214,18 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
+"sXr" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	tag = "icon-xtra_bigstripe-edge (WEST)"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "sXz" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -67020,6 +67022,13 @@
 	dir = 8
 	},
 /area/mining/magnet)
+"tky" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "tkQ" = (
 /obj/machinery/door/airlock/pyro/glass/engineering{
 	dir = 8;
@@ -67238,6 +67247,12 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
+"tol" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
+/area/station/ranch)
 "toq" = (
 /obj/submachine/chef_oven{
 	dir = 4
@@ -68717,6 +68732,10 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
+"tJz" = (
+/obj/submachine/seed_vendor,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "tJA" = (
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff/maybe_few,
@@ -71259,15 +71278,6 @@
 	icon_state = "fblue2"
 	},
 /area/station/medical/head)
-"uyR" = (
-/obj/table/reinforced/auto,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/obj/item/kitchen/utensil/knife,
-/obj/item/sponge,
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "uyT" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
@@ -72391,14 +72401,6 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
-"uOe" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/north)
 "uOf" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -74336,6 +74338,13 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/white/checker,
 /area/station/medical/medbay/lobby)
+"vra" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "vre" = (
 /turf/simulated/wall/auto/reinforced/jen/purple,
 /area/space)
@@ -74731,14 +74740,6 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/turret_protected/AIsat)
-"vxa" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c";
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "vxj" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -75653,8 +75654,6 @@
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/morgue{
-	dir = 4;
-	icon_state = "pipe-c";
 	name = "kitchen freezer pipe"
 	},
 /turf/simulated/floor/white/checker2{
@@ -76143,11 +76142,6 @@
 	dir = 5
 	},
 /area/space)
-"vPH" = (
-/turf/simulated/floor/grasstodirt{
-	dir = 4
-	},
-/area/station/ranch)
 "vQd" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 4;
@@ -76607,19 +76601,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
-"vXG" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/table/reinforced/auto,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 9
-	},
-/obj/item/toy/plush/small/stress_ball,
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "vXW" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -77786,6 +77767,16 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
+"wpy" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0;
+	dir = 4
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/wall/auto/jen,
+/area/station/crew_quarters/catering)
 "wpE" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass{
@@ -78066,13 +78057,13 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "wsK" = (
+/obj/decal/cleanable/dirt/jen,
 /obj/disposalpipe/segment/morgue{
-	dir = 8;
-	icon_state = "pipe-c";
+	dir = 4;
 	name = "kitchen freezer pipe"
 	},
-/turf/simulated/wall/auto/jen,
-/area/station/crew_quarters/catering)
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "wsM" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /obj/map/light/cyan,
@@ -78112,6 +78103,13 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black,
 /area/station/bridge)
+"wtq" = (
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg{
+	rand_pos = 0
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "wtJ" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small/sticky{
@@ -79794,10 +79792,6 @@
 /area/station/science/artifact)
 "wTd" = (
 /obj/storage/secure/closet/fridge/kitchen,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
 /turf/simulated/floor/white/checker2{
 	dir = 1
 	},
@@ -80850,16 +80844,6 @@
 /obj/access_spawn/engineering_chief,
 /turf/simulated/floor/black/grime,
 /area/station/engine/engineering/ce)
-"xgA" = (
-/obj/table/reinforced/auto,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/wateringcan{
-	pixel_y = 9
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "xgM" = (
 /obj/grille/catwalk/jen/side{
 	dir = 8
@@ -80893,6 +80877,17 @@
 	},
 /turf/simulated/floor/black,
 /area/listeningpost)
+"xhr" = (
+/obj/grille/catwalk/jen/side{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/ne)
 "xhu" = (
 /obj/stool/chair/wooden{
 	dir = 8
@@ -80924,6 +80919,16 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
+"xhZ" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment{
+	dir = 8
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "xie" = (
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
@@ -128661,15 +128666,15 @@ jMm
 cqV
 cqV
 bwx
-fDI
-dsC
-lFS
+sac
+xhZ
+lhJ
 gmk
 nTa
-nMW
-iHf
+wpy
+obC
 cjT
-ijS
+oky
 rsa
 vIw
 tEX
@@ -128963,15 +128968,15 @@ kyD
 cqV
 cqV
 xjy
-uOe
+wsK
 heU
 qNE
 fuZ
 gHa
 hen
 hHn
-lSO
-hHn
+aoM
+aoM
 jDX
 ptw
 jQw
@@ -129272,9 +129277,9 @@ ugD
 oHX
 oad
 xth
-ikS
+iaZ
 lhw
-cDk
+pQh
 hgC
 hdF
 xHi
@@ -129567,7 +129572,7 @@ kkV
 kvH
 bRl
 rSV
-hRX
+iij
 cRr
 oHX
 oHX
@@ -129879,7 +129884,7 @@ avp
 blX
 obw
 gug
-sac
+gug
 gWm
 sjT
 pQh
@@ -130171,7 +130176,7 @@ ybG
 oUM
 ubD
 aRI
-hUu
+xhr
 ncG
 qAJ
 iaa
@@ -130179,9 +130184,9 @@ ygB
 ihv
 ihv
 cxF
-blX
+sEm
 ost
-wsK
+gug
 pQh
 pQh
 pQh
@@ -131379,10 +131384,10 @@ gfX
 jQH
 mBB
 oJP
-qOQ
+vra
 fCj
-qJW
-sSa
+mHS
+wtq
 mfs
 mfs
 mfs
@@ -131681,14 +131686,14 @@ mBB
 mBB
 mBB
 oJP
-qOQ
+vra
 wYJ
 mBB
 mBB
-pSF
+hxQ
 mBB
 jQH
-pSF
+hxQ
 mYu
 rLk
 sJC
@@ -131983,7 +131988,7 @@ mBB
 mBB
 mBB
 oJP
-qOQ
+vra
 wYJ
 mBB
 mBB
@@ -132285,7 +132290,7 @@ gYi
 mBB
 mBB
 oJP
-qOQ
+vra
 wYJ
 mBB
 mBB
@@ -132587,12 +132592,12 @@ uIp
 ezH
 ezH
 lCU
-qOQ
+vra
 nBy
-ivz
+diU
 ezH
 ezH
-ivz
+diU
 ezH
 ezH
 grh
@@ -132889,11 +132894,11 @@ vzA
 vzA
 vzA
 vzA
-bwQ
-ifo
-ifo
-ifo
-vxa
+aQo
+kGB
+kGB
+kGB
+sSb
 vzA
 vzA
 vzA
@@ -133195,7 +133200,7 @@ tGj
 mwv
 vzA
 vzA
-qOQ
+vra
 vzA
 vzA
 vzA
@@ -133495,12 +133500,12 @@ mBB
 ewc
 mBB
 rLV
-jAh
-vPH
+tol
+siV
 ufw
-jAh
-vPH
-vPH
+tol
+siV
+siV
 mwv
 ksz
 mfs
@@ -133796,12 +133801,12 @@ pKk
 pKk
 pKk
 pKk
-mMy
-vXG
-cgd
-rVK
-mCi
-mCi
+gOh
+otm
+awI
+blo
+sXr
+sXr
 ivP
 man
 nDB
@@ -134098,13 +134103,13 @@ mBB
 mBB
 mBB
 mBB
-kkB
-uyR
-dGe
-cuS
-dGe
-dGe
-lNi
+lSn
+snc
+ebZ
+tky
+ebZ
+ebZ
+pgL
 oJP
 lUK
 mfs
@@ -134400,13 +134405,13 @@ mBB
 rmq
 sJW
 mBB
-kkB
-xgA
-aRO
-hyB
-axn
+lSn
+cmX
+tJz
+nst
+hCx
 lGJ
-odI
+fKp
 aSY
 fPD
 mfs

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -1351,13 +1351,6 @@
 	dir = 1
 	},
 /area/station/crew_quarters/kitchen)
-"adN" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/wall/auto/jen,
-/area/station/maintenance/outer/north)
 "adY" = (
 /obj/cable{
 	d1 = 1;
@@ -2567,6 +2560,16 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/science/storage)
+"axn" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 4
+	},
+/obj/submachine/ranch_feed_grinder,
+/obj/item/reagent_containers/food/snacks/plant/corn{
+	doants = 0
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "axo" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/machinery/light/small{
@@ -3735,12 +3738,6 @@
 /obj/stool/chair,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
-"aPK" = (
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/grasstodirt,
-/area/station/ranch)
 "aQh" = (
 /obj/item/gun/kinetic/antisingularity{
 	pixel_x = -6;
@@ -3862,6 +3859,10 @@
 	dir = 10
 	},
 /area/station/hallway/primary/east)
+"aRO" = (
+/obj/submachine/seed_vendor,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "aRU" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -5855,6 +5856,13 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/west)
+"bwQ" = (
+/obj/disposalpipe/segment/morgue{
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "bwT" = (
 /obj/item/ammo/bullets/antisingularity{
 	pixel_x = -7;
@@ -8371,6 +8379,21 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"cgd" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	tag = "icon-xtra_bigstripe-edge (WEST)"
+	},
+/obj/stool/chair/green{
+	dir = 4
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "cgw" = (
 /obj/machinery/vending/cola/blue,
 /turf/simulated/floor/red/side{
@@ -9187,6 +9210,13 @@
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
+"cuS" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "cva" = (
 /obj/decal/mule/dropoff,
 /obj/access_spawn/eva,
@@ -9804,6 +9834,12 @@
 	dir = 8
 	},
 /area/shuttle/arrival/station)
+"cDk" = (
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/wall/auto/jen,
+/area/station/crew_quarters/kitchen)
 "cDl" = (
 /turf/simulated/floor/carpet/blue/fancy/innercorner{
 	dir = 5
@@ -12277,10 +12313,6 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
 "doF" = (
@@ -12455,17 +12487,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"drq" = (
-/obj/grille/catwalk/jen/side{
-	dir = 1
-	},
-/obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/ne)
 "drr" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -12541,6 +12562,16 @@
 "dsw" = (
 /turf/simulated/floor/specialroom/freezer,
 /area/station/maintenance/inner/sw)
+"dsC" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment{
+	dir = 8
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "dsW" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -13297,6 +13328,9 @@
 	},
 /turf/space,
 /area/space)
+"dGe" = (
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "dGg" = (
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/hangar/main)
@@ -17885,17 +17919,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"eVb" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/railing/orange/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/grasstodirt,
-/area/station/ranch)
 "eVg" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -20354,6 +20377,15 @@
 	dir = 1
 	},
 /area/station/medical/asylum/kitchen)
+"fDI" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "fDP" = (
 /obj/access_spawn/head_of_personnel,
 /obj/cable{
@@ -20816,16 +20848,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/south)
-"fKW" = (
-/obj/table/reinforced/auto,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/wateringcan{
-	pixel_y = 9
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "fLf" = (
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
@@ -24793,16 +24815,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
-"gWz" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment{
-	dir = 8
-	},
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/north)
 "gWF" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -25028,14 +25040,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/west)
-"gYV" = (
-/obj/disposalpipe/segment/transport,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
 "gZh" = (
 /obj/table/auto,
 /obj/item/cable_coil,
@@ -26191,13 +26195,6 @@
 /obj/cable,
 /turf/simulated/floor/plating/jen,
 /area/station/storage/tech)
-"hqG" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "hqM" = (
 /obj/machinery/camera,
 /obj/machinery/light/small/sticky{
@@ -26788,6 +26785,22 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"hyB" = (
+/obj/machinery/disposal/small/west{
+	name = "Kitchen Freezer Chute"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	icon_state = "xtra_bigstripe-edge2"
+	},
+/obj/disposalpipe/trunk/morgue{
+	dir = 8;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/white/checker2{
+	dir = 1
+	},
+/area/station/ranch)
 "hyE" = (
 /obj/wingrille_spawn/auto/tuff,
 /obj/window_blinds/cog2/middle{
@@ -28037,6 +28050,13 @@
 	},
 /turf/simulated/grass,
 /area/station/hallway/secondary/exit)
+"hRX" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/wall/auto/jen,
+/area/station/maintenance/outer/north)
 "hSc" = (
 /obj/machinery/light/incandescent/warm,
 /obj/disposalpipe/segment{
@@ -28152,13 +28172,6 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor,
 /area/station/engine/monitoring)
-"hUj" = (
-/obj/disposalpipe/segment/morgue{
-	icon_state = "pipe-c";
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
 "hUr" = (
 /obj/cable{
 	d1 = 4;
@@ -28173,6 +28186,17 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
+"hUu" = (
+/obj/grille/catwalk/jen/side{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/ne)
 "hUy" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
@@ -28975,6 +28999,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/west)
+"ifo" = (
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "ifv" = (
 /obj/machinery/shower{
 	dir = 4
@@ -29310,6 +29340,13 @@
 /obj/machinery/light/emergency,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
+"ikS" = (
+/obj/disposalpipe/segment/morgue{
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "ikW" = (
 /obj/cable{
 	d1 = 4;
@@ -29942,6 +29979,15 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
+"ivz" = (
+/obj/railing/orange/reinforced{
+	dir = 8
+	},
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
+/area/station/ranch)
 "ivI" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -30777,6 +30823,12 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"iHf" = (
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "iHg" = (
 /obj/stool/chair/comfy{
 	dir = 8
@@ -31473,9 +31525,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
-"iTt" = (
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "iTy" = (
 /obj/decal/poster/wallsign/medbay_right{
 	pixel_x = 1;
@@ -32097,18 +32146,6 @@
 	},
 /turf/simulated/floor/sand,
 /area/station/engine/engineering/ce)
-"jev" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8;
-	tag = "icon-xtra_bigstripe-edge (WEST)"
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "jey" = (
 /obj/bookshelf{
 	pixel_y = 28
@@ -33247,16 +33284,6 @@
 /obj/machinery/bathtub,
 /turf/simulated/floor/sanitary/blue,
 /area/station/medical/asylum/bathroom)
-"jwK" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/plantpot{
-	anchored = 1
-	},
-/obj/machinery/camera/ranch{
-	dir = 8
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "jwS" = (
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -33449,6 +33476,12 @@
 	dir = 1
 	},
 /area/station/turret_protected/AIsat)
+"jAh" = (
+/obj/machinery/light/small/floor/netural,
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
+/area/station/ranch)
 "jAj" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -35073,10 +35106,6 @@
 /obj/machinery/vending/cola/red,
 /turf/simulated/grimycarpet,
 /area/station/hallway/primary/southeast)
-"jZW" = (
-/obj/submachine/seed_vendor,
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "kaf" = (
 /obj/cable{
 	d1 = 4;
@@ -35765,6 +35794,12 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
+"kkB" = (
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/grasstodirt,
+/area/station/ranch)
 "kkK" = (
 /obj/table/reinforced/auto,
 /obj/item/paper_bin{
@@ -36895,12 +36930,6 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
-"kCe" = (
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "kCh" = (
 /obj/machinery/light/incandescent/harsh,
 /obj/machinery/camera{
@@ -37983,16 +38012,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
-"kUm" = (
-/obj/machinery/atmospherics/pipe/simple/insulated/cold{
-	can_rupture = 0;
-	dir = 4
-	},
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/wall/auto/jen,
-/area/station/crew_quarters/catering)
 "kUo" = (
 /obj/cable{
 	d1 = 4;
@@ -40459,6 +40478,24 @@
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/west)
+"lFS" = (
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/grille/catwalk/jen/side{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "lFZ" = (
 /obj/disposalpipe/segment/food,
 /obj/disposalpipe/segment/morgue{
@@ -40543,24 +40580,6 @@
 /obj/reagent_dispensers/watertank/big,
 /turf/simulated/floor/wood/seven,
 /area/station/ranch)
-"lGS" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/grille/catwalk/jen/side{
-	dir = 1
-	},
-/obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/north)
 "lGU" = (
 /obj/indestructible/shuttle_corner{
 	dir = 4
@@ -40642,16 +40661,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"lIj" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 4
-	},
-/obj/submachine/ranch_feed_grinder,
-/obj/item/reagent_containers/food/snacks/plant/corn{
-	doants = 0
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "lIw" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -41034,6 +41043,11 @@
 /area/station/chapel/sanctuary{
 	name = "Funeral Parlor"
 	})
+"lNi" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/machinery/hydro_growlamp,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "lNp" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
@@ -41519,6 +41533,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"lSO" = (
+/obj/disposalpipe/segment/transport,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/black,
+/area/station/crew_quarters/catering)
 "lST" = (
 /turf/simulated/floor/carpet/green/fancy,
 /area/station/engine/engineering/ce)
@@ -43745,11 +43767,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/AIsat)
-"mCj" = (
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/grasstodirt{
-	dir = 4
+"mCi" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	tag = "icon-xtra_bigstripe-edge (WEST)"
+	},
+/turf/simulated/floor/wood/seven,
 /area/station/ranch)
 "mCk" = (
 /obj/machinery/plantpot,
@@ -44338,6 +44366,17 @@
 	dir = 1
 	},
 /area/station/engine/inner)
+"mMy" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/railing/orange/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/grasstodirt,
+/area/station/ranch)
 "mMB" = (
 /obj/decal/cleanable/rust/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -44441,15 +44480,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/east)
-"mPc" = (
-/obj/railing/orange/reinforced{
-	dir = 8
-	},
-/obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/grasstodirt{
-	dir = 8
-	},
-/area/station/ranch)
 "mPh" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/item/storage/wall/emergency{
@@ -45097,14 +45127,17 @@
 /turf/simulated/grimycarpet,
 /area/station/maintenance/inner/east)
 "mYu" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	icon_state = "pipe-c";
-	name = "kitchen freezer pipe"
+/obj/railing/orange/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/north)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 1
+	},
+/area/station/ranch)
 "mYx" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/specialroom/medbay,
@@ -46885,12 +46918,6 @@
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/artifact)
-"nyL" = (
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/black,
-/area/station/crew_quarters/catering)
 "nza" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -47685,6 +47712,16 @@
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
+"nMW" = (
+/obj/machinery/atmospherics/pipe/simple/insulated/cold{
+	can_rupture = 0;
+	dir = 4
+	},
+/obj/disposalpipe/segment/morgue{
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/wall/auto/jen,
+/area/station/crew_quarters/catering)
 "nMZ" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -47712,13 +47749,6 @@
 	},
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
-"nNl" = (
-/obj/submachine/chicken_incubator,
-/obj/item/reagent_containers/food/snacks/ingredient/egg{
-	rand_pos = 0
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "nNm" = (
 /turf/simulated/wall/auto/jen,
 /area/station/crew_quarters/cafeteria)
@@ -47970,22 +48000,6 @@
 "nQI" = (
 /turf/simulated/floor/stairs/wide,
 /area/listeningpost)
-"nQN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8;
-	tag = "icon-xtra_bigstripe-edge (WEST)"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "nQO" = (
 /obj/machinery/vending/cards,
 /turf/simulated/floor/carpet/arcade/half,
@@ -48755,10 +48769,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
-"oab" = (
-/obj/chicken_nesting_box,
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "oac" = (
 /obj/cable{
 	d1 = 4;
@@ -48929,6 +48939,16 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/east)
+"odI" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/obj/machinery/plantpot{
+	anchored = 1
+	},
+/obj/machinery/camera/ranch{
+	dir = 8
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "odN" = (
 /obj/machinery/computer/operating{
 	id = "robotics"
@@ -52782,13 +52802,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
-"plf" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "plk" = (
 /turf/unsimulated/floor{
 	desc = "";
@@ -53752,22 +53765,6 @@
 	dir = 5
 	},
 /area/station/chapel/sanctuary)
-"pyj" = (
-/obj/machinery/disposal/small/west{
-	name = "Kitchen Freezer Chute"
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8;
-	icon_state = "xtra_bigstripe-edge2"
-	},
-/obj/disposalpipe/trunk/morgue{
-	dir = 8;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/white/checker2{
-	dir = 1
-	},
-/area/station/ranch)
 "pyq" = (
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/maintenance/solar/west)
@@ -55189,6 +55186,12 @@
 	dir = 5
 	},
 /area/station/security/quarters)
+"pSF" = (
+/obj/machinery/light/incandescent/netural{
+	dir = 8
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "pSH" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -58398,6 +58401,10 @@
 	dir = 1
 	},
 /area/station/engine/engineering)
+"qJW" = (
+/obj/chicken_nesting_box,
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "qKk" = (
 /obj/random_item_spawner/tools/one_or_zero,
 /obj/rack,
@@ -58820,6 +58827,13 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/crew_quarters/garden)
+"qOQ" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "qOZ" = (
 /obj/grille/catwalk/jen,
 /obj/disposalpipe/segment{
@@ -59551,11 +59565,6 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
-"qZq" = (
-/obj/decal/tile_edge/stripe/extra_big,
-/obj/machinery/hydro_growlamp,
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "qZz" = (
 /turf/simulated/floor/black/grime,
 /area/station/mining/staff_room)
@@ -60059,11 +60068,6 @@
 	dir = 10
 	},
 /area/station/engine/inner)
-"rhe" = (
-/turf/simulated/floor/grasstodirt{
-	dir = 4
-	},
-/area/station/ranch)
 "rhm" = (
 /obj/grille/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
@@ -61777,19 +61781,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/red/fancy/edge,
 /area/station/security/hos)
-"rFz" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/table/reinforced/auto,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 9
-	},
-/obj/item/toy/plush/small/stress_ball,
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "rFB" = (
 /obj/machinery/light/incandescent/warm,
 /obj/reagent_dispensers/heliumtank,
@@ -62848,6 +62839,22 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/AIsat)
+"rVK" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8;
+	tag = "icon-xtra_bigstripe-edge (WEST)"
+	},
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "rVM" = (
 /obj/grille/catwalk/jen/side,
 /obj/decal/cleanable/dirt/jen,
@@ -65849,6 +65856,13 @@
 /area/station/chapel/sanctuary{
 	name = "Funeral Parlor"
 	})
+"sSa" = (
+/obj/submachine/chicken_incubator,
+/obj/item/reagent_containers/food/snacks/ingredient/egg{
+	rand_pos = 0
+	},
+/turf/simulated/floor/grass/leafy,
+/area/station/ranch)
 "sSd" = (
 /obj/cable{
 	d1 = 1;
@@ -67237,15 +67251,6 @@
 /obj/machinery/light_switch/south,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbooth)
-"tos" = (
-/obj/table/reinforced/auto,
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 1
-	},
-/obj/item/kitchen/utensil/knife,
-/obj/item/sponge,
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "tou" = (
 /obj/cable,
 /obj/cable{
@@ -69041,13 +69046,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/asylum/rec)
-"tOy" = (
-/obj/disposalpipe/segment/morgue{
-	icon_state = "pipe-c";
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "tOD" = (
 /obj/disposalpipe/segment{
 	dir = 8
@@ -71261,6 +71259,15 @@
 	icon_state = "fblue2"
 	},
 /area/station/medical/head)
+"uyR" = (
+/obj/table/reinforced/auto,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/item/kitchen/utensil/knife,
+/obj/item/sponge,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "uyT" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
@@ -72050,12 +72057,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
-"uIQ" = (
-/obj/machinery/light/incandescent/netural{
-	dir = 8
-	},
-/turf/simulated/floor/grass/leafy,
-/area/station/ranch)
 "uIX" = (
 /obj/cable{
 	icon_state = "2-5"
@@ -72390,6 +72391,14 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
+"uOe" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/north)
 "uOf" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 1;
@@ -74722,6 +74731,14 @@
 	},
 /turf/simulated/floor/blueblack,
 /area/station/turret_protected/AIsat)
+"vxa" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 1;
+	icon_state = "pipe-c";
+	name = "kitchen freezer pipe"
+	},
+/turf/simulated/floor/dirt,
+/area/station/ranch)
 "vxj" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -76126,6 +76143,11 @@
 	dir = 5
 	},
 /area/space)
+"vPH" = (
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
+/area/station/ranch)
 "vQd" = (
 /obj/decal/tile_edge/line/purple{
 	dir = 4;
@@ -76585,6 +76607,19 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
+"vXG" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/table/reinforced/auto,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/obj/item/toy/plush/small/stress_ball,
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "vXW" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -77861,21 +77896,6 @@
 "wqJ" = (
 /turf/simulated/wall/auto/jen,
 /area/station/hydroponics/bay)
-"wqT" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/decal/tile_edge/stripe/extra_big{
-	dir = 8;
-	tag = "icon-xtra_bigstripe-edge (WEST)"
-	},
-/obj/stool/chair/green{
-	dir = 4
-	},
-/turf/simulated/floor/wood/seven,
-/area/station/ranch)
 "wqW" = (
 /obj/cable{
 	d1 = 1;
@@ -78953,14 +78973,6 @@
 	icon_state = "floor"
 	},
 /area/shuttle/arrival/station)
-"wGn" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/north)
 "wGy" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen/side{
@@ -80168,14 +80180,6 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
-"wWH" = (
-/obj/disposalpipe/segment/morgue{
-	dir = 1;
-	icon_state = "pipe-c";
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/floor/dirt,
-/area/station/ranch)
 "wWM" = (
 /obj/critter/turtle/sylvester/HoS,
 /turf/simulated/floor/carpet/red/fancy/edge{
@@ -80846,6 +80850,16 @@
 /obj/access_spawn/engineering_chief,
 /turf/simulated/floor/black/grime,
 /area/station/engine/engineering/ce)
+"xgA" = (
+/obj/table/reinforced/auto,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/wateringcan{
+	pixel_y = 9
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/ranch)
 "xgM" = (
 /obj/grille/catwalk/jen/side{
 	dir = 8
@@ -83094,12 +83108,6 @@
 	},
 /turf/simulated/floor/dojo/sand/circle,
 /area/station/crew_quarters/captain)
-"xPl" = (
-/obj/disposalpipe/segment/morgue{
-	name = "kitchen freezer pipe"
-	},
-/turf/simulated/wall/auto/jen,
-/area/station/crew_quarters/kitchen)
 "xPF" = (
 /obj/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -128653,13 +128661,13 @@ jMm
 cqV
 cqV
 bwx
-mYu
-gWz
-lGS
+fDI
+dsC
+lFS
 gmk
 nTa
-kUm
-nyL
+nMW
+iHf
 cjT
 ijS
 rsa
@@ -128955,14 +128963,14 @@ kyD
 cqV
 cqV
 xjy
-wGn
+uOe
 heU
 qNE
 fuZ
 gHa
 hen
 hHn
-gYV
+lSO
 hHn
 jDX
 ptw
@@ -129264,9 +129272,9 @@ ugD
 oHX
 oad
 xth
-hUj
+ikS
 lhw
-xPl
+cDk
 hgC
 hdF
 xHi
@@ -129559,7 +129567,7 @@ kkV
 kvH
 bRl
 rSV
-adN
+hRX
 cRr
 oHX
 oHX
@@ -130163,7 +130171,7 @@ ybG
 oUM
 ubD
 aRI
-drq
+hUu
 ncG
 qAJ
 iaa
@@ -131371,10 +131379,10 @@ gfX
 jQH
 mBB
 oJP
-hqG
+qOQ
 fCj
-oab
-nNl
+qJW
+sSa
 mfs
 mfs
 mfs
@@ -131673,15 +131681,15 @@ mBB
 mBB
 mBB
 oJP
-hqG
+qOQ
 wYJ
 mBB
 mBB
-uIQ
+pSF
 mBB
 jQH
-uIQ
-oJP
+pSF
+mYu
 rLk
 sJC
 kea
@@ -131975,7 +131983,7 @@ mBB
 mBB
 mBB
 oJP
-hqG
+qOQ
 wYJ
 mBB
 mBB
@@ -132277,7 +132285,7 @@ gYi
 mBB
 mBB
 oJP
-hqG
+qOQ
 wYJ
 mBB
 mBB
@@ -132579,12 +132587,12 @@ uIp
 ezH
 ezH
 lCU
-hqG
+qOQ
 nBy
-mPc
+ivz
 ezH
 ezH
-mPc
+ivz
 ezH
 ezH
 grh
@@ -132881,11 +132889,11 @@ vzA
 vzA
 vzA
 vzA
-tOy
-kCe
-kCe
-kCe
-wWH
+bwQ
+ifo
+ifo
+ifo
+vxa
 vzA
 vzA
 vzA
@@ -133187,7 +133195,7 @@ tGj
 mwv
 vzA
 vzA
-hqG
+qOQ
 vzA
 vzA
 vzA
@@ -133487,12 +133495,12 @@ mBB
 ewc
 mBB
 rLV
-mCj
-rhe
+jAh
+vPH
 ufw
-mCj
-rhe
-rhe
+jAh
+vPH
+vPH
 mwv
 ksz
 mfs
@@ -133788,12 +133796,12 @@ pKk
 pKk
 pKk
 pKk
-eVb
-rFz
-wqT
-nQN
-jev
-jev
+mMy
+vXG
+cgd
+rVK
+mCi
+mCi
 ivP
 man
 nDB
@@ -134090,13 +134098,13 @@ mBB
 mBB
 mBB
 mBB
-aPK
-tos
-iTt
-plf
-iTt
-iTt
-qZq
+kkB
+uyR
+dGe
+cuS
+dGe
+dGe
+lNi
 oJP
 lUK
 mfs
@@ -134392,13 +134400,13 @@ mBB
 rmq
 sJW
 mBB
-aPK
-fKW
-jZW
-pyj
-lIj
+kkB
+xgA
+aRO
+hyB
+axn
 lGJ
-jwK
+odI
 aSY
 fPD
 mfs


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Reworks the donut 3 ranch to add in a grow / work area
* Also adds a freezer chute


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* donut3 ranch pens are pretty huge
* the donut3 ranch had no grow trays so you had to compete with botany
* it looks nice


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(*)The Donut3 Ranch now has space to grow your crops and a kitchen freezer chute.
```
