### PR TITLE
Antique Lawbringer Name Fix

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1388,7 +1388,11 @@
 	//all gun modes use the same base sprite icon "lawbringer0" depending on the current projectile/current mode, we apply a coloured overlay to it.
 	update_icon()
 		..()
-		src.icon_state = "[old ? "old-" : ""]lawbringer0"
+		var/prefix = ""
+		if(old)
+			prefix = "old-"
+
+		src.icon_state = "[prefix]lawbringer0"
 		src.overlays = null
 
 		var/list/ret = list()
@@ -1398,7 +1402,7 @@
 			//if we're showing zero charge, don't do any overlay, since the main image shows an empty gun anyway
 			if (ratio == 0)
 				return
-			indicator_display.icon_state = "[old ? "old-" : ""]lawbringer-d[ratio]"
+			indicator_display.icon_state = "[prefix]lawbringer-d[ratio]"
 
 			if(current_projectile.type == /datum/projectile/energy_bolt/aoe)			//detain - yellow
 				indicator_display.color = "#FFFF00"

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1444,7 +1444,6 @@
 		return 0
 
 	proc/make_antique()
-		name = "antique Lawbringer"
 		icon_state = "old-lawbringer0"
 		old = 1
 		UpdateIcon()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bugfix]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently, when you claim the Antique Lawbringer reward, the name of the Lawbringer changes to "antique Lawbringer" from "HoS [name]'s Lawbringer". This is a fix for that issue (#7512). 
![image](https://user-images.githubusercontent.com/74819096/156893570-721dda8e-4c56-4ab5-8a1b-0ab02270ad10.png)
![image](https://user-images.githubusercontent.com/74819096/156893575-17390b89-33ad-43f4-a447-bd7dea206141.png)

It also changes the way iconstates are called so that any future additions/modifications do not cause issues.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So the level 5 HoS players can use their Antique Lawbringer without losing their name tags!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Juggernaut2442
(*)Fixes some antique lawbringer bug and cleans up how iconstates are called.
```
