### PR TITLE
fixes clarion medbay shuttle door density

### DIFF
--- a/assets/maps/shuttles/north/northbase.dmm
+++ b/assets/maps/shuttles/north/northbase.dmm
@@ -36,7 +36,6 @@
 /area/centcom/outside)
 "aq" = (
 /obj/machinery/door/airlock/pyro/medical/alt{
-	density = 0
 	},
 /turf/unsimulated/floor/shuttle,
 /area/shuttle/escape/centcom)


### PR DESCRIPTION
[bugfix]
## About the PR 
fixes clarion shuttle medbay door density
fixes #7624

## Why's this needed? 
fix good. staffies stay out of cool medbay club.