### PR TITLE
Change wizard teleport and add more TGUI

### DIFF
--- a/code/datums/abilities/santa.dm
+++ b/code/datums/abilities/santa.dm
@@ -217,8 +217,8 @@
 	cooldown = 30 SECONDS
 
 	cast()
-		var/A
-		A = input("Area to jump to", "TELEPORTATION", A) in get_teleareas()
+		var/list/tele_areas = get_teleareas()
+		var/A = tgui_input_list(src, "Area to jump to", "Teleportation", tele_areas)
 		var/area/thearea = get_telearea(A)
 		if(thearea.teleport_blocked)
 			boutput(src, "<span class='alert'>That area is blocked from teleportation.</span>")

--- a/code/datums/abilities/santa.dm
+++ b/code/datums/abilities/santa.dm
@@ -219,6 +219,9 @@
 	cast()
 		var/list/tele_areas = get_teleareas()
 		var/A = tgui_input_list(src, "Area to jump to", "Teleportation", tele_areas)
+		if (isnull(A))
+			boutput(src, "<span class='alert'>Invalid area selected.</span>")
+			return 1
 		var/area/thearea = get_telearea(A)
 		if(thearea.teleport_blocked)
 			boutput(src, "<span class='alert'>That area is blocked from teleportation.</span>")

--- a/code/datums/abilities/wizard/clairvoyance.dm
+++ b/code/datums/abilities/wizard/clairvoyance.dm
@@ -24,7 +24,7 @@
 		if (!length(targets))
 			return
 		targets = sortNames(targets)
-		var/input = input(holder.owner, "Select target", "Clairvoyance") as null|anything in targets
+		var/input = tgui_input_list(holder.owner, "Select target", "Clairvoyance", targets)
 		var/mob/M = targets[input]
 		if (!M || !holder?.owner)
 			return

--- a/code/datums/abilities/wizard/clairvoyance.dm
+++ b/code/datums/abilities/wizard/clairvoyance.dm
@@ -26,12 +26,12 @@
 		targets = sortNames(targets)
 		var/input = tgui_input_list(holder.owner, "Select target", "Clairvoyance", targets)
 		var/mob/M = targets[input]
-		if (!M || !holder?.owner)
+		if (isnull(M) || !holder?.owner)
 			return
 
 		var/turf/T = get_turf(M)
 		var/area/A = get_area(M)
-		if (!T)
+		if (isnull(T))
 			boutput(holder.owner, "<span class='alert'>[M] appears to be trapped in some sort of Schrödinger's cat-like existence neither truly residing in nor completely removed from the universe!</span>")
 			return //oh shit they're in null space
 

--- a/code/datums/abilities/wizard/teleport.dm
+++ b/code/datums/abilities/wizard/teleport.dm
@@ -162,17 +162,15 @@
 	logTheThing("combat", src, null, "teleported from [log_loc(src)] to [log_loc(destination)].")
 	if (effect)
 		animate_teleport_wiz(src)
-		sleep(4 SECONDS) // Animation.
+		sleep(2 SECONDS) // Animation.
 		playsound(src.loc, "sound/effects/mag_teleport.ogg", 25, 1, -1)
+		sleep(2 SECONDS) // Animation.
 		var/datum/effects/system/harmless_smoke_spread/smoke = new /datum/effects/system/harmless_smoke_spread()
 		smoke.set_up(5, 0, src.loc)
 		smoke.attach(src)
 
-		if (perform_check == 3)
-			src.set_loc(destination)
-			smoke.start()
-		else
-			smoke.start()
-			src.set_loc(destination)
+		playsound(destination, "sound/effects/mag_teleport.ogg", 25, 1, -1)
+		src.set_loc(destination)
+		smoke.start()
 
 	return 1

--- a/code/datums/abilities/wizard/teleport.dm
+++ b/code/datums/abilities/wizard/teleport.dm
@@ -7,21 +7,22 @@
 	requires_robes = 1
 	cooldown_staff = 1
 	restricted_area_check = 1
-	voice_grim = "sound/voice/wizard/TeleportGrim.ogg"
-	voice_fem = "sound/voice/wizard/TeleportFem.ogg"
-	voice_other = "sound/voice/wizard/TeleportLoud.ogg"
 
 	cast()
 		if (!holder)
 			return 1
 
-		if (holder.owner && ismob(holder.owner) && holder.owner.teleportscroll(0, 3, spell=src) == 1)
+		if (holder.owner && ismob(holder.owner) && holder.owner.teleportscroll(1, 3, spell=src) == 1)
 			return 0
 
 		return 1
 
 // These two procs were so similar that I combined them (Convair880).
 /mob/proc/teleportscroll(var/effect = 0, var/perform_check = 0, var/obj/item_to_check = null, var/datum/targetable/spell/teleport/spell)
+	var/voice_grim = "sound/voice/wizard/TeleportGrim.ogg"
+	var/voice_fem = "sound/voice/wizard/TeleportFem.ogg"
+	var/voice_other = "sound/voice/wizard/TeleportLoud.ogg"
+
 	if (src.getStatusDuration("paralysis") || !isalive(src))
 		boutput(src, "<span class='alert'>Not when you're incapacitated.</span>")
 		return 0
@@ -50,12 +51,14 @@
 		wiz_shuttle = null
 
 	// Doing it this way to avoid modifying the cached areas
+	var/list/tele_areas = get_teleareas()
 	if (wiz_shuttle)
-		A = input("Area to jump to", "Teleportation", A) in (get_teleareas() | wiz_shuttle.name)
+		tele_areas |= wiz_shuttle.name
+		A = tgui_input_list(src, "Area to jump to", "Teleportation", tele_areas)
 		if(A == wiz_shuttle.name)
 			thearea = wiz_shuttle
 	else
-		A = input("Area to jump to", "Teleportation", A) in get_teleareas()
+		A = tgui_input_list(src, "Area to jump to", "Teleportation", tele_areas)
 
 	if(!thearea)
 		thearea = get_telearea(A)
@@ -121,7 +124,6 @@
 	switch (perform_check)
 		if (1)
 			src.visible_message("<span class='alert'><b>[src] magically disappears!</b></span>")
-
 		if (2)
 			src.visible_message("<span class='alert'><b>[src]</b> presses a button and teleports away.</span>")
 			var/datum/targetable/spell/teleport/tele = src.abilityHolder.getAbility(/datum/targetable/spell/teleport)
@@ -131,17 +133,19 @@
 
 		if (3) // Spell-specific stuff.
 			src.say("SCYAR NILA [uppertext(A)]")
-
+			if(ishuman(src))
+				var/mob/living/carbon/human/O = src
+				if(istype(O.wear_suit, /obj/item/clothing/suit/wizrobe/necro) && istype(O.head, /obj/item/clothing/head/wizard/necro))
+					playsound(O.loc, voice_grim, 50, 0, -1)
+				else if(O.gender == "female")
+					playsound(O.loc, voice_fem, 50, 0, -1)
+				else
+					playsound(O.loc, voice_other, 50, 0, -1)
 			src.visible_message("<span class='alert'><b>[src] begins to fade away!</b></span>")
-			animate_teleport_wiz(src)
-			sleep(4 SECONDS) // Animation.
-
 			var/mob/living/carbon/human/H = src
 			if (istype(H) && H.getStatusDuration("burning"))
-				boutput(H, "<span class='notice'>The flames sputter out as you phase shift.</span>")
+				boutput(H, "<span class='notice'>The flames sputter out as you teleport.</span>")
 				H.set_burning(0)
-
-			playsound(src.loc, "sound/effects/mag_teleport.ogg", 25, 1, -1)
 
 	var/list/L = list()
 	for (var/turf/T3 in get_area_turfs(thearea.type))
@@ -157,14 +161,9 @@
 	var/turf/destination = pick(L)
 	logTheThing("combat", src, null, "teleported from [log_loc(src)] to [log_loc(destination)].")
 	if (effect)
-		if (perform_check == 3)
-			src.set_loc(destination)
-			elecflash(src) // Effect second because we had sound effects etc at the old loc.
-		else
-			elecflash(src)
-			src.set_loc(destination)
-
-	else
+		animate_teleport_wiz(src)
+		sleep(4 SECONDS) // Animation.
+		playsound(src.loc, "sound/effects/mag_teleport.ogg", 25, 1, -1)
 		var/datum/effects/system/harmless_smoke_spread/smoke = new /datum/effects/system/harmless_smoke_spread()
 		smoke.set_up(5, 0, src.loc)
 		smoke.attach(src)

--- a/code/datums/abilities/wizard/teleport.dm
+++ b/code/datums/abilities/wizard/teleport.dm
@@ -61,6 +61,9 @@
 		A = tgui_input_list(src, "Area to jump to", "Teleportation", tele_areas)
 
 	if(!thearea)
+		if (isnull(A))
+			boutput(src, "<span class='alert'>Invalid area selected.</span>")
+			return 1
 		thearea = get_telearea(A)
 
 	if (!thearea || !istype(thearea))

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -50,7 +50,7 @@
 		if (href_list["spell_teleport"])
 			if (!can_act(H))
 				return
-			if (src.uses >= 1 && usr.teleportscroll(0, 1, src) == 1)
+			if (src.uses >= 1 && usr.teleportscroll(1, 1, src) == 1)
 				src.uses -= 1
 		if (ismob(src.loc))
 			attack_self(src.loc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][QOL][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix teleport not using wizard voices.
Changes all wizard teleports to use the teleport effect. Standardize the smoke, make the sounds work on both end.
Adds TGUI to teleport destinations and Clairvoyance.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
1. Bug/oversight. Due to the timing, multiple teleport methods and other checks this works differently to regular spell voice.
2. Inconsistent, makes it clearer a wizard is teleporting in/out.
3. TGUI lists are nice.