### PR TITLE
adds spectro bitflag for fueltanks

### DIFF
--- a/code/modules/chemistry/tools/fuel_tanks.dm
+++ b/code/modules/chemistry/tools/fuel_tanks.dm
@@ -20,6 +20,7 @@
 	can_recycle = FALSE
 	can_chug = 0
 	initial_reagents = "fuel"
+	rc_flags = RC_SPECTRO
 
 /obj/item/reagent_containers/food/drinks/fueltank/empty
 	initial_reagents = null


### PR DESCRIPTION
[bugfix]
## About the PR
fixes #7337
allows analysis of fueltank contents with spectroscopic analyzers

## Why's this needed? 
seems intuitive