### PR TITLE
Adds a define to disable set_area

### DIFF
--- a/_std/__build.dm
+++ b/_std/__build.dm
@@ -34,6 +34,7 @@ o+`        `-` ``..-:yooos-..----------..`
 //#define IM_REALLY_IN_A_FUCKING_HURRY_HERE 1  // Skip setup for atmos, Z5, don't show changelogs, skip pregame lobby
 //#define GOTTA_GO_FAST_BUT_ZLEVELS_TOO_SLOW 1  // Only include the map Atlas, no other zlevels. Boots way faster
 //#define Z_LOG_ENABLE 1  // Enable additional world.log logging
+//#define NO_SET_AREA 1 // Removes all references to set_area so it doesn't generate a gazillion errors on startup
 
 
 //////////// PROFILING OPTIONS

--- a/code/datums/titlecard.dm
+++ b/code/datums/titlecard.dm
@@ -40,7 +40,9 @@
 		last_pregame_html += {"#overlay{display:none;}"}
 	else
 		last_pregame_html += {"#overlay{background-image:url([resource(src.overlay_image_url)]);background-color:transparent;left:0;top:0;right:0;bottom:0;position:fixed;}"}
+#ifndef NO_SET_AREA
 	last_pregame_html += {".area{white-space:pre;color:#fff;text-shadow: -2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000;font:1em 'PxPlus IBM VGA9';-webkit-text-stroke:0.083em black;}a{text-decoration:none;}#leftside{position:fixed;left:0;bottom:0;}#status,#timer{text-align:center;position:fixed;right:0;bottom:0;height:12%;width:40%;}#timer{bottom:15%;}</style></head><body><script>document.onclick=function(){location="byond://winset?id=mapwindow.map&focus=true";};function set_area(id,text){document.getElementById(id).innerHTML=text||"";};onresize=function(){document.body.style.fontSize=Math.min(innerWidth/672,innerHeight/480)*16+"px";};onload=function(){onresize();location="byond://winset?command=.send-lobby-text";};</script><div id="overlay"></div><div id="status" class="area"></div><div id="timer" class="area"></div><div id="leftside" class="area"></div>[src.add_html]</body></html>"}
+#endif
 	for(var/client/C)
 		if(istype(C.mob, /mob/new_player))
 			C << browse(last_pregame_html, "window=pregameBrowser")
@@ -56,10 +58,12 @@
 	if(current_state <= GAME_STATE_PREGAME)
 		return
 #endif
+#ifndef NO_SET_AREA
 	if (last_pregame_html == pregameHTML)
 		for(var/client/C)
 			if(istype(C.mob, /mob/new_player))
 				C << output(list2params(list(id, text)), "pregameBrowser:set_area")
+#endif
 
 /client/verb/send_lobby_text()
 	set name = ".send-lobby-text"
@@ -80,8 +84,10 @@
 	if(current_state <= GAME_STATE_PREGAME)
 		return
 #endif
+#ifndef NO_SET_AREA
 	for (var/id in maptext_areas)
 		C << output(list2params(list(id, maptext_areas[id])), "pregameBrowser:set_area")
+#endif
 
 ///old title card turf
 /obj/titlecard


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Extremely stupid and boneheaded solution to the "set_area is undefined" local server error, just removes all references to set_area. Obviously breaks the pregame HTML but you probably don't care about that if you're just local testing.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I HATE SET_AREA
I HATE SET_AREA
I HATE SET_AREA