### PR TITLE
slightly alters glue's splashing behavior

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -818,11 +818,11 @@ datum
 					. = 0
 
 					if(L.getStatusDuration("slowed")>=10 SECONDS)
-						L.setStatus("staggered", max(M.getStatusDuration("staggered"), (0.3 SECONDS)*volume_passed))
 						if(!ON_COOLDOWN(M, "stuck in glue", 15 SECOND))
+							L.setStatus("stunned", min(7 SECONDS, (0.4 SECONDS)*volume_passed))
 							boutput(M, "<span class='notice'>You get stuck in the glue!</span>")
 					else
-						L.changeStatus("slowed", min((0.4 SECONDS)*volume_passed, 10 SECONDS))
+						L.changeStatus("slowed", min((0.4 SECONDS)*volume_passed, 20 SECONDS))
 				return
 
 			reaction_turf(var/turf/target, var/volume)


### PR DESCRIPTION
[LABEL][balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes glue's touch reaction to stun the mob being splashed if they already have 10 or more seconds of slowed, but has a 15 second delay on it to prevent spamming and a maximum of 7 seconds of stun.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Glue is significantly harder to make than its usefulness would make you asume, and i have received feedback on some aspects of it. At the moment it's better to just splash the floor below someone than directly splash them with glue, this will hopefully solve the issue.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hans
(+)Made direct glue splashing somewhat more powerful.
```
