### PR TITLE
remove unnecessary message from emoter artifacts

### DIFF
--- a/code/obj/artifacts/artifact_machines/emoter.dm
+++ b/code/obj/artifacts/artifact_machines/emoter.dm
@@ -56,4 +56,3 @@
 						L.emote(picked_emote)
 				else
 					L.emote(picked_emote)
-				boutput(L, "A nearby object forces you to [picked_emote].")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Right now they also give you a message any time they make you emote, this PR removes that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bit annoying to get two messages every time (since you already get one for emoting).

I also think not giving this message would be more fun for purposes like hiding them near departments as a prank, and it doesn't really feel like it makes much sense that you would automatically know that an object nearby is making you emote when it could be through a wall, out of sight.

(Also, these should maybe be made to trigger artifacts faults at some point in some form, but that's for another PR.)