### PR TITLE
visual accessibility tweak for hints on tooltips

### DIFF
--- a/browserassets/css/tooltip.css
+++ b/browserassets/css/tooltip.css
@@ -180,6 +180,6 @@ p {
 
 /* for item description colors */
 .success {color: green;}
-.hint {color: #0000ff;}
-.notice {color: #0000ff;}
+.hint {color: ##9999FF;}
+.notice {color: ##9999FF;}
 .alert {color: #ff0000;}


### PR DESCRIPTION
[cleanliness]
## About the PR 
visual accessibility changes for hints/scans on tooltips from things in player inventories
![textcolorsample](https://user-images.githubusercontent.com/72267018/157046868-207a2908-71be-47f6-a537-b77aa3723e88.png)

top is current; center is proposed revision; bottom is the color of basic descriptor text in tooltips for differentiation comparisons

## Why's this needed? 
very hard as of current to read further info for reagent scans, multitool scans, etc. on the tooltips that you get from hovering over inventory items