### PR TITLE
Fixes #7665 - Cyborgs can now use missile arrival. So can everyone else.

### DIFF
--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -537,11 +537,12 @@
 							A.announce_arrival(src)
 
 		//Equip_Bank_Purchase AFTER special_setup() call, because they might no longer be a human after that
-		if (possible_new_mob)
-			var/mob/living/newmob = possible_new_mob
-			newmob.Equip_Bank_Purchase(newmob.mind.purchased_bank_item)
-		else
-			src.Equip_Bank_Purchase(src.mind?.purchased_bank_item)
+	//this was previously indented in the ishuman() block, but I don't think it needs to be - Amylizzle
+	if (possible_new_mob)
+		var/mob/living/newmob = possible_new_mob
+		newmob.Equip_Bank_Purchase(newmob.mind.purchased_bank_item)
+	else
+		src.Equip_Bank_Purchase(src.mind?.purchased_bank_item)
 
 	return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- [BUGFIX] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This moves the spacebux purchases check outside the ishuman() block, meaning any non-humans (ie, AI and Cyborgs) can use their spacebux purchases too. AFAIK, those spacebux purchases check that they can work already on the mob so this should be fine.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You buy missile arrival, you should get missile arrival.
Fixes #7665


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Missile Arrival and other Spacebux purchases are now available and working as Cyborg and AI!
```
