### PR TITLE
Fixes #1041 - Stock borrow deals now refund deposit if you give shares back on time

### DIFF
--- a/code/modules/economy/stocks/stock_tickers.dm
+++ b/code/modules/economy/stocks/stock_tickers.dm
@@ -224,13 +224,15 @@
 			else if (ticker.round_elapsed_ticks > borrow.lease_expires)
 				if (borrow.borrower in shareholders)
 					var/amt = shareholders[borrow.borrower]
-					if (amt > borrow.share_debt)
+					if (amt >= borrow.share_debt)
 						shareholders[borrow.borrower] -= borrow.share_debt
 						borrows -= borrow
 						if (borrow.borrower in FrozenAccounts)
 							FrozenAccounts[borrow.borrower] -= borrow
 						if (length(FrozenAccounts[borrow.borrower]) == 0)
 							FrozenAccounts -= borrow.borrower
+						//return deposit
+						modifyAccount(borrow.borrower,borrow.deposit)
 						qdel(borrow)
 					else
 						shareholders -= borrow.borrower


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUGFIX] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This basically just fixes a check and does a refund when the lease time is up on a borrowed stock.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You ought to get your deposit back if you give shares back on time.
Fixes #1041

