### PR TITLE
Fixes #4975  by adding a check for anchored components to the small storage parent 

### DIFF
--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -150,7 +150,7 @@
 						return
 				var/obj/item/storage/S = W
 				for (var/obj/item/I in S.get_contents())
-					if(src.check_can_hold(I) > 0)
+					if(src.check_can_hold(I) > 0 && !I.anchored)
 						src.Attackby(I, user, S)
 				return
 			if(!does_not_open_in_pocket)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUGFIX] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Add a check for I.anchored when transferring between storage components


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Prevents anchored components from the device frame being transferred to storage containers.
Fixes #4975



