### PR TITLE
Wrap attack_self with AttackSelf

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -138,7 +138,7 @@
 
 	execute_ability()
 		var/obj/item/clothing/suit/W = the_item
-		W.attack_self(the_mob)
+		W.AttackSelf(the_mob)
 		..()
 
 /obj/ability_button/magboot_toggle
@@ -324,7 +324,7 @@
 
 	execute_ability()
 		var/obj/item/saw/S = the_item
-		S.attack_self(usr)
+		S.AttackSelf(usr)
 		..()
 
 ////////////////////////////////////////////////////////////
@@ -368,7 +368,7 @@
 
 	execute_ability()
 		var/obj/item/cable_coil/C = the_item
-		C.attack_self(usr)
+		C.AttackSelf(usr)
 		..()
 
 ////////////////////////////////////////////////////////////
@@ -406,7 +406,7 @@
 
 	execute_ability()
 		var/obj/item/device/t_scanner/J = the_item
-		J.attack_self(the_mob)
+		J.AttackSelf(the_mob)
 		if(J.on) icon_state = "off"
 		else  icon_state = "on"
 		..()
@@ -419,7 +419,7 @@
 
 	execute_ability()
 		var/obj/item/clothing/glasses/meson/J = the_item
-		J.attack_self(the_mob)
+		J.AttackSelf(the_mob)
 		if(J.on) icon_state = "meson1"
 		else  icon_state = "meson0"
 		..()
@@ -432,7 +432,7 @@
 
 	execute_ability()
 		var/obj/item/clothing/head/helmet/space/syndicate/specialist/engineer/J = the_item
-		J.attack_self(the_mob)
+		J.AttackSelf(the_mob)
 		if(J.on) icon_state = "meson1"
 		else  icon_state = "meson0"
 		..()

--- a/code/WorkInProgress/GerhazoStuff.dm
+++ b/code/WorkInProgress/GerhazoStuff.dm
@@ -54,7 +54,7 @@
 
 		if(deflecting_sword)
 			if(deflecting_sword.active == 0)  // turn the sword on if it's off
-				deflecting_sword.attack_self(src)
+				deflecting_sword.AttackSelf(src)
 				src.visible_message("<span class='alert'>[src] instinctively switches his [deflecting_sword] on in response to the incoming [P.name]!</span>")
 			var/datum/abilityHolder/cyalume_knight/my_ability_holder = src.get_ability_holder(/datum/abilityHolder/cyalume_knight)
 			var/force_drain_multiplier = 0.3  // projectile's damage(power) is multiplied by this and then subtracted from ability holder's points

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -499,7 +499,7 @@
 				grace_penalty = time_left
 
 		if (target == equipped)
-			equipped.AttackSelf(src, params, location, control)
+			equipped.AttackSelf(src)
 			if(equipped.flags & ATTACK_SELF_DELAY)
 				src.next_click = world.time + (equipped ? equipped.click_delay : src.click_delay)
 		else if (params["ctrl"])

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -499,7 +499,7 @@
 				grace_penalty = time_left
 
 		if (target == equipped)
-			equipped.attack_self(src, params, location, control)
+			equipped.AttackSelf(src, params, location, control)
 			if(equipped.flags & ATTACK_SELF_DELAY)
 				src.next_click = world.time + (equipped ? equipped.click_delay : src.click_delay)
 		else if (params["ctrl"])

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3116,7 +3116,7 @@
 	if (M && M.zone_sel && M.zone_sel.selecting == "chest" && src.chest_item != null && (src.chest_item in src.contents))
 		logTheThing("combat", M, src, "activates [src.chest_item] embedded in [src]'s chest cavity at [log_loc(src)]")
 		SPAWN(0) //might sleep/input/etc, and we don't want to hold anything up
-			src.chest_item.attack_self(src)
+			src.chest_item.AttackSelf(src)
 	return
 
 /mob/living/carbon/human/proc/chest_item_dump_reagents_on_flip()
@@ -3187,10 +3187,10 @@
 		// Make copy of item on ground
 		var/obj/item/outChestItem = src.chest_item
 		outChestItem.set_loc(get_turf(src))
-		src.chest_item.attack_self(src)
+		src.chest_item.AttackSelf(src)
 		src.chest_item = null
 		return
-	src.chest_item.attack_self(src)
+	src.chest_item.AttackSelf(src)
 
 /mob/living/carbon/human/attackby(obj/item/W, mob/M)
 	if (src.parry_or_dodge(M))

--- a/code/mob/living/carbon/human/npc.dm
+++ b/code/mob/living/carbon/human/npc.dm
@@ -559,11 +559,11 @@
 				if(istype(src.equipped(), /obj/item/device/light/zippo))
 					var/obj/item/device/light/zippo/zippo = src.equipped()
 					if(!zippo.on)
-						zippo.attack_self(src)
+						zippo.AttackSelf(src)
 				if(istype(src.equipped(), /obj/item/weldingtool))
 					var/obj/item/weldingtool/welder = src.equipped()
 					if(!welder.welding)
-						welder.attack_self(src)
+						welder.AttackSelf(src)
 				src.ai_attack_target(cigarette, src.equipped())
 				throw_equipped = 1
 
@@ -598,7 +598,7 @@
 
 	// use
 	if(src.equipped() && prob(ai_state == AI_PASSIVE ? 2 : 7) && ai_useitems)
-		src.equipped().attack_self(src)
+		src.equipped().AttackSelf(src)
 
 	// throw
 	if(throw_equipped)

--- a/code/mob/living/critter/ai/human.dm
+++ b/code/mob/living/critter/ai/human.dm
@@ -274,7 +274,7 @@
 								holder.ownhuman.drop_item()
 
 							if (G.state <= GRAB_PASSIVE)
-								G.attack_self(holder.ownhuman)
+								G.AttackSelf(holder.ownhuman)
 							else
 								holder.ownhuman.emote("flip")
 								holder.move_away(holder.target,1)

--- a/code/mob/living/critter/ai/ocean.dm
+++ b/code/mob/living/critter/ai/ocean.dm
@@ -334,7 +334,7 @@
 							owncritter.drop_item()
 
 						if (G.state <= GRAB_PASSIVE)
-							G.attack_self(owncritter)
+							G.AttackSelf(owncritter)
 						else
 							owncritter.emote("flip")
 							holder.move_away(holder.target,1)

--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -212,7 +212,7 @@
 	click(atom/target, params)
 		if (target == src)
 			if (canattack)
-				src.item.attack_self(src)
+				src.item.AttackSelf(src)
 			else
 				if(!isitem(src.item))
 					src.item.Attackhand(src)

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1864,7 +1864,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 		return
 
 	if (istype(src.internal_pda,/obj/item/device/pda2/))
-		src.internal_pda.attack_self(message_mob)
+		src.internal_pda.AttackSelf(message_mob)
 	else
 		boutput(usr, "<span class='alert'><b>Internal PDA not found!</span>")
 
@@ -1882,7 +1882,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 		return
 
 	if (istype(which,/obj/item/device/radio/))
-		which.attack_self(message_mob)
+		which.AttackSelf(message_mob)
 	else
 		boutput(usr, "<span class='alert'><b>Radio not found!</b></span>")
 

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -368,7 +368,7 @@
 
 		var/obj/item/item = target
 		if (istype(item) && item == src.equipped())
-			item.attack_self(src)
+			item.AttackSelf(src)
 			return
 
 		if (src.client && src.client.check_key(KEY_PULL))

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1570,7 +1570,7 @@
 			var/obj/item/O = locate(href_list["mod"])
 			if (!O || (O.loc != src && O.loc != src.module))
 				return
-			O.attack_self(src)
+			O.AttackSelf(src)
 
 		if (href_list["act"])
 			if(!src.module) return
@@ -1929,7 +1929,7 @@
 		return
 	*/
 		if(istype(src.radio))
-			src.radio.attack_self(src)
+			src.radio.AttackSelf(src)
 
 	proc/toggle_module_pack()
 		if(weapon_lock)
@@ -2169,7 +2169,7 @@
 		set desc = "Access your internal PDA device."
 
 		if (src.internal_pda && istype(src.internal_pda, /obj/item/device/pda2/))
-			src.internal_pda.attack_self(src)
+			src.internal_pda.AttackSelf(src)
 		else
 			boutput(usr, "<span class='alert'><b>Internal PDA not found!</span>")
 

--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -953,7 +953,7 @@
 							target.zone_sel.selecting = old_zone_sel
 
 						if (prob(20))
-							I.attack_self(target)
+							I.AttackSelf(target)
 
 
 				if ("shoved_down" in src.disarm_RNG_result)

--- a/code/modules/atmospherics/portable/canister.dm
+++ b/code/modules/atmospherics/portable/canister.dm
@@ -469,7 +469,7 @@
 			src.det.failsafe_engage()
 			. = TRUE
 		if("trigger")
-			src.det.trigger.attack_self(usr)
+			src.det.trigger.AttackSelf(usr)
 			. = TRUE
 		if("timer")
 			if(!src.det.part_fs.timing)

--- a/code/modules/chemistry/tools/iv_drips.dm
+++ b/code/modules/chemistry/tools/iv_drips.dm
@@ -297,7 +297,7 @@
 				src.IV.attack(over_object, usr)
 				return
 			else if (src.IV && over_object == src)
-				src.IV.attack_self(usr)
+				src.IV.AttackSelf(usr)
 				return
 			else if (istype(over_object, /obj/stool/bed) || istype(over_object, /obj/stool/chair) || istype(over_object, /obj/machinery/optable))
 				if (A == src.paired_obj && src.detach_from())

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -877,7 +877,7 @@
 
 /// Call this proc inplace of attack_self(...)
 /obj/item/proc/AttackSelf(mob/user as mob)
-	SHOULD_NOT_OVERRIDE(1)
+	SHOULD_NOT_OVERRIDE(TRUE)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user))
 		return
 	src.attack_self(user)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -875,7 +875,20 @@
 		STOP_TRACKING_CAT(TR_CAT_BURNING_ITEMS)
 	burning_last_process = src.burning
 
+/// Call this proc inplace of attack_self(...)
+/obj/item/proc/AttackSelf(mob/user as mob)
+	SHOULD_NOT_OVERRIDE(1)
+	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user))
+		return
+	src.attack_self(user)
+
+/**
+ * DO NOT CALL THIS PROC - Call AttackSelf(...) Instead!
+ *
+ * Only override this proc!
+ */
 /obj/item/proc/attack_self(mob/user)
+	PROTECTED_PROC(TRUE)
 	if (src.temp_flags & IS_LIMB_ITEM)
 		if (istype(src.loc,/obj/item/parts/human_parts/arm/left/item))
 			var/obj/item/parts/human_parts/arm/left/item/I = src.loc
@@ -885,8 +898,6 @@
 			var/obj/item/parts/human_parts/arm/right/item/I = src.loc
 			I.remove_from_mob()
 			I.set_item(src)
-
-	SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user)
 
 	chokehold?.attack_self(user)
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -878,9 +878,9 @@
 /// Call this proc inplace of attack_self(...)
 /obj/item/proc/AttackSelf(mob/user as mob)
 	SHOULD_NOT_OVERRIDE(TRUE)
-	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user))
-		return
-	src.attack_self(user)
+	. = SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user)
+	if(!.)
+		. = src.attack_self(user)
 
 /**
  * DO NOT CALL THIS PROC - Call AttackSelf(...) Instead!

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -432,7 +432,7 @@
 	record_prog.active1 = GR
 	record_prog.active2 = MR
 	record_prog.mode = 1
-	pda.attack_self(usr)
+	pda.AttackSelf(usr)
 
 /proc/scan_reagents(var/atom/A as turf|obj|mob, var/show_temp = 1, var/single_line = 0, var/visible = 0, var/medical = 0)
 	if (!A)


### PR DESCRIPTION
[cleanliness]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Creates an `AttackSelf` wrapper for `attack_self`.  Impacts hoodies, component linking (disabling), tool supported items.
Previous implementation made no effort to set a return so this _should_ be no observable changes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allow for Components to override or run alongside the existing item's `attack_self`