### PR TITLE
Spatial Interdictors slightly reduce hotspot impact

### DIFF
--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -254,6 +254,9 @@
 #define PH_EX_WEAK 16
 #define PH_EX 32
 
+// Finding individual hotspots in-game:
+// View global variable -> hotspot_controller
+// hotspot_controller -> hotspot_groups
 /datum/sea_hotspot
 	var/static/heat_dropoff_per_dist_unit = 0.1 // possible todo : a quad curve
 	var/static/base_heat = 1000
@@ -355,10 +358,10 @@
 
 		// interdictors aren't cures, just stopgaps, you still have to pin spots
 		for (var/obj/machinery/interdictor/IX in by_type[/obj/machinery/interdictor])
-			if (IN_RANGE(IX,src,IX.interdict_range) && IX.expend_interdict(400))
+			if (IN_RANGE(IX,C,IX.interdict_range) && IX.expend_interdict(heat+2000)) // even small ones eat power, chomp chomp
+				IX.visible_message("<span class='alert'><b>[IX] warbles as it struggles to mitigate the hotspot!</b></span>")
 				interdicted = TRUE
-				playsound(phenomena_point, 'sound/impact_sounds/Energy_Hit_1.ogg', 30, 1)
-				return
+				playsound(IX.loc, 'sound/effects/screech2.ogg', 30, 1)
 
 		var/found = 0
 		for (var/mob/living/M in range(6, C))
@@ -378,7 +381,7 @@
 		else if (found)
 			playsound(phenomena_point, 'sound/misc/ground_rumble.ogg', 70, 1, 0.1, 1)
 
-		// interdiction should only impact world effects, not sound/text cues
+		// interdiction should only heat/pressure effects, not sound/text cues
 		if (interdicted)
 			phenomena_flags = phenomena_flags / 2  // lower severity by one (1)
 
@@ -389,9 +392,9 @@
 			fireflash(phenomena_point,1)
 
 		if (phenomena_flags & PH_EX_WEAK)
-			explosion(src, phenomena_point, -1, -1, 0, 2)
+			explosion(src, phenomena_point, -1, -1, 1, 2)
 
-		if (phenomena_flags & PH_EX && heat < 8000)
+		if (phenomena_flags & PH_EX)
 			explosion(src, phenomena_point, -1, -1, 2, 3)
 
 		//hey recurse at this arbitrary heat value, thanks

--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -358,7 +358,7 @@
 
 		// interdictors aren't cures, just stopgaps, you still have to pin spots
 		for (var/obj/machinery/interdictor/IX in by_type[/obj/machinery/interdictor])
-			if (IN_RANGE(IX,C,IX.interdict_range) && IX.expend_interdict(heat+2000)) // even small ones eat power, chomp chomp
+			if (IN_RANGE(IX,phenomena_point,IX.interdict_range) && IX.expend_interdict(heat+2000)) // even small ones eat power, chomp chomp
 				IX.visible_message("<span class='alert'><b>[IX] warbles as it struggles to mitigate the hotspot!</b></span>")
 				interdicted = TRUE
 				playsound(IX.loc, 'sound/effects/screech2.ogg', 30, 1)

--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -357,10 +357,7 @@
 		for (var/obj/machinery/interdictor/IX in by_type[/obj/machinery/interdictor])
 			if (IN_RANGE(IX,src,IX.interdict_range) && IX.expend_interdict(400))
 				interdicted = TRUE
-				icon = 'icons/effects/effects.dmi'
-				icon_state = "sparks_attack"
 				playsound(phenomena_point, 'sound/impact_sounds/Energy_Hit_1.ogg', 30, 1)
-				density = 0
 				return
 
 		var/found = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature] [input wanted]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check for spatial interdictors that reduces the impact of hotspot fires and explosions by one 'severity'
Defines an effect for an unused hotspot explosion level `PH_EX_WEAK`

This does not change the audio cues or ground shaking effects, so a strong hotspot will still knock people over, shake your camera, and tell you the ground is violently rumbling.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Engineering has few ways to be proactive about hotpsots on Oshan, and this gives them a tool to help reduce impact to the station until it is pinned. This also gives engineers a safer way to move a spicy hotspot, if they're prepared.

Balance-wise, I settled on:
* A high power draw per interdiction, with scaling power draw based on the heat of the hotspot
* Each hotspot shift is an interdiction event, so multiple hotspots in interdictor range use power very quickly
* Limited-mitigation, to ensure engineers still have to interact with the map mechanics 
* Gives some benefit to lambda rods for clever engineers, as the size of the field may now be a drawback, not a feature
  * On Oshan, it's better to rely on more basic mining materials given the trench, anyway

These mechanics all lean into the theme of the interdictor not reaaally being designed for this, but engineering is deploying everything they have to keep the station together for just a moment longer.

## In-game example
Couple of sections sped up between ground shakes, and a bit messy overlay-wise, but a test run showing mitigation in action
https://www.youtube.com/watch?v=EjLdWL-jhKU

Interested in feedback and suggestions :)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(*) Oshan's Engineering team can now apply spatial interdictors to reduce the explosive impact of hotspots.
```
