### PR TITLE
Lets paper be stapled into booklets

### DIFF
--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -321,6 +321,17 @@
 		user.put_in_hand_or_drop(M)
 		user.u_equip(src)
 		qdel(src)
+	else if (istype(P, /obj/item/paper))
+		var/obj/item/staple_gun/S = user.find_type_in_hand(/obj/item/staple_gun)
+		if (S?.ammo)
+			var/obj/item/paper_booklet/booklet = new(src.loc)
+			user.drop_item()
+			booklet.pages += src
+			src.set_loc(booklet)
+			booklet.attackby(P, user, params)
+			return
+		else
+			boutput(user, "<span class='alert'>You need a loaded stapler in hand to staple the sheets into a booklet.</span>")
 	else
 		// cut paper?  the sky is the limit!
 		ui_interact(user)	// The other ui will be created with just read mode outside of this

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -328,7 +328,7 @@
 			user.drop_item()
 			booklet.pages += src
 			src.set_loc(booklet)
-			booklet.attackby(P, user, params)
+			booklet.Attackby(P, user, params)
 			return
 		else
 			boutput(user, "<span class='alert'>You need a loaded stapler in hand to staple the sheets into a booklet.</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #7341. Hit one piece of paper with another while holding a stapler in your other hand.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There currently doesn't seem to be a way to make booklets, despite the wiki suggesting you can, so it got reported as a bug and now you can.