### PR TITLE
disallow text selection highlighting in tooltips

### DIFF
--- a/browserassets/css/tooltip.css
+++ b/browserassets/css/tooltip.css
@@ -26,6 +26,7 @@ html, body {
 	border: 2px solid #222;
 	background: #333;
 	user-select: none;
+	-ms-user-select: none;
 }
 
 .pinned .wrap .title {


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
makes text in tooltips on inventory hover unselectable via mouse

## Why's this needed? 
this usually happens on accident and it is difficult to try and click your cursor in the right spot to get it to go away