### PR TITLE
Makes Matter Cartridges small items.

### DIFF
--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -860,6 +860,7 @@ Broken RCD + Effects
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	icon_state = "ammo"
 	item_state = "rcdammo"
+	w_class = W_CLASS_NORMAL
 	opacity = 0
 	density = 0
 	anchored = 0.0

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -860,7 +860,7 @@ Broken RCD + Effects
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	icon_state = "ammo"
 	item_state = "rcdammo"
-	w_class = W_CLASS_NORMAL
+	w_class = W_CLASS_SMALL
 	opacity = 0
 	density = 0
 	anchored = 0.0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] [SMALL] [QOL]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes RCD matter cartridges from being considered a normal item into being a small item. Essentially just allowing for cartridges to be stored in boxes instead of one small 10 matter cartridge being the same size as the entire RCD, and taking up entire slots of a backpack. 

Last year this probably would've been too much as the RCD was abused by people looking to break into the armory, or any important areas, and wasn't actually used very much for engineering. Now that the RCD has been smacked with a few nerfs, and certain jobs have been murdered in an alleyway, I'd like to give it some QOL for the actual engineers.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Engineering has a lot of item bloat, and they need storage space the most out of any job by a long shot. This is just a tiny nudge in the right direction, hopefully making things a little less cluttered for them.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Momoberry
(+)Matter Cartridges are now small items, and can fit in boxes.
```
