### PR TITLE
fix emoter artifacts giving borgs the "invalid emote" message

### DIFF
--- a/code/mob/living/carbon/cube.dm
+++ b/code/mob/living/carbon/cube.dm
@@ -141,7 +141,7 @@
 					if(src.emote_check(voluntary, 10))
 						message = "<B>[src]</B> jiggles like only a meat cube can."
 				else
-					src.show_text("Invalid Emote: [act]")
+					if (voluntary) src.show_text("Invalid Emote: [act]")
 		if (message && isalive(src))
 			logTheThing("say", src, null, "EMOTE: [message]")
 			if (m_type & 1)

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1200,7 +1200,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 				SPAWN(1 SECOND)
 					src.emote_allowed = 1
 		else
-			src.show_text("Invalid Emote: [act]")
+			if (voluntary) src.show_text("Invalid Emote: [act]")
 			return
 
 	if ((message && isalive(src)))

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -906,7 +906,7 @@
 					game_stats.Increment("farts")
 #endif
 			else
-				src.show_text("Invalid Emote: [act]")
+				if (voluntary) src.show_text("Invalid Emote: [act]")
 				return
 
 		if (message && isalive(src))

--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -384,7 +384,7 @@
 				SPAWN(1 SECOND)
 					src.emote_allowed = 1
 		else
-			src.show_text("Invalid Emote: [act]")
+			if (voluntary) src.show_text("Invalid Emote: [act]")
 			return
 
 	if ((message && isalive(src)))

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -617,7 +617,7 @@
 					SPAWN(1 SECOND)
 						src.emote_allowed = 1
 			else
-				src.show_text("Invalid Emote: [act]")
+				if (voluntary) src.show_text("Invalid Emote: [act]")
 				return
 		if (!isalive(src))
 			return

--- a/code/obj/artifacts/artifact_machines/emoter.dm
+++ b/code/obj/artifacts/artifact_machines/emoter.dm
@@ -53,6 +53,6 @@
 				if(count++ > 15) break
 				if(picked_emote == "fart")
 					if(!(locate(/obj/item/storage/bible) in get_turf(L))) //bible fart bad
-						L.emote(picked_emote)
+						L.emote(picked_emote, FALSE)
 				else
-					L.emote(picked_emote)
+					L.emote(picked_emote, FALSE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so the emotes from emoter artifacts count as involuntary, and makes it so that involuntary emotes do not trigger that message if they are invalid.

This way valid emotes (like scream) should still work on all applicable lifeforms.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #7740 
