### PR TITLE
Fixes HoS access doors on Wrestlemap

### DIFF
--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -18488,7 +18488,8 @@
 "hKP" = (
 /obj/machinery/door/airlock/pyro/glass/command{
 	dir = 4;
-	name = "Head of Security's Room"
+	name = "Head of Security's Room";
+	req_access = null
 	},
 /obj/access_spawn/hos,
 /obj/firedoor_spawn,
@@ -27344,7 +27345,8 @@
 /area/research_outpost/protest)
 "lAZ" = (
 /obj/machinery/door/airlock/pyro/glass/command{
-	name = "Head of Security's Office"
+	name = "Head of Security's Office";
+	req_access = null
 	},
 /obj/access_spawn/hos,
 /obj/firedoor_spawn,
@@ -30510,7 +30512,8 @@
 /area/station/maintenance/inner/the_cage)
 "mXE" = (
 /obj/machinery/door/airlock/pyro/security{
-	name = "Armory"
+	name = "Armory";
+	req_access = null
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/hos,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the armory and HoS office doors using the wrong access on wrestlemap.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7737 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

