### PR TITLE
Persist Noir gene effect after showering

### DIFF
--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -238,6 +238,10 @@
 			M.tracked_blood = null
 			M.set_clothing_icon_dirty()
 
+			// Noir effect alters M.color, so reapply
+			if (M.bioHolder.HasEffect("noir"))
+				animate_fade_grayscale(M, 0)
+
 		else
 
 			var/mob/living/L = src // Punching cyborgs does leave fingerprints for instance.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This is a dirty hack, but I'm not sure of a way around it to let noir gene holders clear paint off of them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Fixes #7676
* Fewer excuses to not shower
