### PR TITLE
Shooting range ammo bag

### DIFF
--- a/code/obj/item/nuclear_operative/ammo_bag.dm
+++ b/code/obj/item/nuclear_operative/ammo_bag.dm
@@ -149,3 +149,6 @@
 				playsound(K, 'sound/weapons/gunload_light.ogg', 50, 1)
 			else
 				playsound(K, reload_sound, 50, 1)
+
+	ex_act(severity)
+		return

--- a/code/obj/item/nuclear_operative/ammo_bag.dm
+++ b/code/obj/item/nuclear_operative/ammo_bag.dm
@@ -126,3 +126,26 @@
 	New()
 		..()
 		desc = "A bag that can fabricate specialist magazines for standard syndicate weapons. Technology! It has [charge] charge left."
+
+//Universal
+/obj/item/ammo/ammobox/shootingrange
+	name = "Shooting Range Ammo Bag"
+	desc = "A universal ammo bag for kinetic ammunition."
+	icon_state = "ammobag-sp-d"
+	anchored = 2
+
+	attackby(obj/item/I as obj, mob/user as mob)
+		if(istype(I, /obj/item/gun/kinetic))
+			var/obj/item/gun/kinetic/K = I
+			if(K.ammo.amount_left>=K.max_ammo_capacity)
+				user.show_text("[K] is full!", "red")
+				return
+			K.ammo.amount_left = K.max_ammo_capacity
+			K.UpdateIcon()
+			user.visible_message("<span class='alert'>[user] refills [K] from [src].</span>", "<span class='alert'>You fully refill [K] with ammo from [src].</span>")
+			var/obj/item/ammo/bullets/magazine = K.default_magazine
+			var/reload_sound = initial(magazine.sound_load)
+			if(isnull(reload_sound))
+				playsound(K, 'sound/weapons/gunload_light.ogg', 50, 1)
+			else
+				playsound(K, reload_sound, 50, 1)

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -76491,6 +76491,11 @@
 	},
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
+"wiy" = (
+/obj/table/auto,
+/obj/item/ammo/ammobox/shootingrange,
+/turf/unsimulated/floor/darkblue,
+/area/syndicate_station/firing_range)
 "wky" = (
 /obj/decal/fakeobjects{
 	anchored = 1;
@@ -107639,7 +107644,7 @@ cIe
 cIe
 cIe
 dep
-dex
+wiy
 deG
 btf
 btf


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an unlimited ammo bag to the Battlecruiser shooting range.
The bag does not give ammunition and instead reloads any kinetic weapon used on it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nuclear operatives would waste ammo if they tested their weapon.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Nuclear operatives now have an ammo bag on their shooting range.
```
