### PR TITLE
Battle Royale Loot scaling

### DIFF
--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -46,6 +46,13 @@ var/global/list/datum/mind/battle_pass_holders = list()
 				player.mind.special_role = ROLE_BATTLER
 				living_battlers.Add(player.mind)
 
+	for (var/turf/space/space in world)
+		LAGCHECK(LAG_LOW)
+		if(space.icon_state != "darkvoid")
+			space.icon_state = "darkvoid"
+			space.icon = 'icons/turf/floors.dmi'
+			space.name = "void"
+
 	storm = new /datum/random_event/special/battlestorm()
 	dropper = new/datum/random_event/special/supplydrop()
 
@@ -96,8 +103,12 @@ var/global/list/datum/mind/battle_pass_holders = list()
 				qdel(MAC)
 			if (/obj/machinery/networked/telepad)
 				qdel(MAC)
+			if (/obj/machinery/portable_atmospherics/canister/sleeping_agent)
+				qdel(MAC)
+			if (/obj/machinery/portable_atmospherics/canister/toxins)
+				qdel(MAC)
 
-	hide_weapons_everywhere()
+	hide_weapons_everywhere(length(living_battlers))
 	next_storm = world.time + rand(MIN_TIME_BETWEEN_STORMS,MAX_TIME_BETWEEN_STORMS)
 	next_drop = world.time + rand(MIN_TIME_BETWEEN_SUPPLY_DROPS,MAX_TIME_BETWEEN_SUPPLY_DROPS)
 
@@ -218,7 +229,7 @@ var/global/list/datum/mind/battle_pass_holders = list()
 
 
 // Does what it says on the tin
-proc/hide_weapons_everywhere()
+proc/hide_weapons_everywhere(var/total_battlers = 1)
 	boutput(world, "<span class='notice'>Now hiding a shitton of goodies on the [station_or_ship()]. Please be patient!</span>")
 	// Replace all lockers with generic syndicate to clear out junk items, remove sec lockers so it's not too much of a hot spot
 	// Im stealing the list of items from the surplus crate so this check needs to happen
@@ -323,20 +334,35 @@ proc/hide_weapons_everywhere()
 	chest_supplies.Add(/obj/item/clothing/head/helmet/football)
 	chest_supplies.Add(/obj/item/clothing/head/helmet/batman)
 
+	var/total_storage
+	switch(total_battlers)
+		if(100 to 999)
+			total_storage = 0.1
+		if(70 to 99)
+			total_storage = 0.2
+		if(50 to 69)
+			total_storage = 0.3
+		if(0 to 49)
+			total_storage = 0.4
+
+	var/total_utility
 	for_by_tcl(S, /obj/storage)
 		var/turf/T = get_turf(S)
 		if (T.z != Z_LEVEL_STATION)
 			continue
-		if (istype(S, /obj/storage/secure/closet) || istype(S, /obj/storage/closet) || istype(S, /obj/storage/crate))
+		if (istype(S, /obj/storage/secure/closet) || istype(S, /obj/storage/closet) || istype(S, /obj/storage/crate) || istype(S, /obj/storage/cart))
 			qdel(S)
 			var/rand_storage = rand()
-			if (rand_storage <= 0.4)
-				continue
-			else if (rand_storage <= 0.5)
-				if (prob(50))
-					new /obj/storage/closet/emergency(T)
+			if (rand_storage <= total_storage)
+				if (total_utility < 30)
+					if (prob((100 - ((total_storage + 0.1) * 100))))
+						total_utility++
+						if (prob(50))
+							new /obj/storage/closet/emergency(T)
+						else
+							new /obj/storage/closet/fire(T)
 				else
-					new /obj/storage/closet/fire(T)
+					continue
 			else
 				if (prob(50))
 					var/obj/storage/closet/locker = new /obj/storage/closet/syndicate(T)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
1. Scales up number of BR loot closets/crates based on player count.
2. Caps utility closets at 30.
3. Replace carts with loot.
4. Remove plasma and sleeping agent canisters.
5. Change space to the void.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
1. There was not enough loot for higher player counts,
2. Avoid too many utility closets at lower player counts.
3. Increase loot spawns, carts weren't useful anyway,
4. Gasses were distracting from fighting,
5. Start of void theming for BR.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Battle Royale loot amount scales with player counts.
```
