### PR TITLE
Fix implant overlay not disappearing upon implant removal

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -72,6 +72,8 @@ THROWING DARTS
 		if (ishuman(src.owner))
 			var/mob/living/carbon/human/H = owner
 			H.implant -= src
+		if (implant_overlay)
+			M.update_clothing()
 		src.owner = null
 		src.implanted = 0
 		return


### PR DESCRIPTION
[BUG - MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a small bug with implant overlays where they would not disappear after removing the implant that added it (ex. arrows).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix.