### PR TITLE
Fix chickens not de-agro'ing

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -275,7 +275,7 @@
 		consumer.nutrition += src.heal_amt * 10
 		src.heal(consumer)
 		playsound(consumer.loc,"sound/items/eatfood.ogg", rand(10,50), 1)
-		on_bite(consumer)
+		on_bite(consumer, feeder)
 		if (src.festivity)
 			modify_christmas_cheer(src.festivity)
 		if (!src.amount)
@@ -356,7 +356,7 @@
 
 
 
-	proc/on_bite(mob/eater)
+	proc/on_bite(mob/eater, mob/feeder)
 		//if (reagents?.total_volume)
 		//	reagents.reaction(M, INGEST)
 		//	reagents.trans_to(M, reagents.total_volume/(src.amount ? src.amount : 1))
@@ -386,7 +386,7 @@
 				src.add_filter("bite", 0, alpha_mask_filter(icon=icon('icons/obj/foodNdrink/food.dmi', "eating[desired_mask]")))
 
 		eat_twitch(eater)
-		eater.on_eat(src)
+		eater.on_eat(src, feeder)
 
 	proc/on_finish(mob/eater)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG][SECRET] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Fixes chickens maintaining aggression even after being hand fed
* Replaces a `usr` check with an actual passed mob argument
* has a corresponding secret repo change to make use of the new arg

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* There's no way to appease any of the chickens currently


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(+)Fixed a bug that prevented players from calming down angered and frightened chickens by hand feeding.
```
