### PR TITLE
Reduce damage the nuclear bomb takes from projectiles

### DIFF
--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -291,7 +291,7 @@
 		if (damage <= 0)
 			return
 		if(P.proj_data.damage_type == D_KINETIC || (P.proj_data.damage_type == D_ENERGY && damage))
-			src.take_damage(max(0.1, damage / 3))
+			src.take_damage(damage / 3)
 		else if (P.proj_data.damage_type == D_PIERCING)
 			src.take_damage(damage)
 

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -291,7 +291,7 @@
 		if (damage <= 0)
 			return
 		if(P.proj_data.damage_type == D_KINETIC || (P.proj_data.damage_type == D_ENERGY && damage))
-			src.take_damage(max(1, damage / 3))
+			src.take_damage(max(0.1, damage / 3))
 		else if (P.proj_data.damage_type == D_PIERCING)
 			src.take_damage(damage)
 

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -288,10 +288,10 @@
 
 		if(src.material) src.material.triggerOnBullet(src, src, P)
 
-		if (!damage)
+		if (damage <= 0)
 			return
 		if(P.proj_data.damage_type == D_KINETIC || (P.proj_data.damage_type == D_ENERGY && damage))
-			src.take_damage(damage / 1.7)
+			src.take_damage(max(1, damage / 3))
 		else if (P.proj_data.damage_type == D_PIERCING)
 			src.take_damage(damage)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increase the damage reduction for kinetic and energy projectiles from 1.7 to 3.

> Egun laser
> 4.7 > 2.6
> 
> Assault Rifle
> 4.7 > 2.6
> 
> Pistol
> 2.9 > 1.6
> 
> Spes 6
> 4.7 > 2.6
> 
> SMG
> 1.7 > 1
> 
> Light Machine Gun
> 1.7 > 1
> 
> Sniper
> 12 > 12 (Piercing, no change)
> 
> Revolver
> 5.8 > 3


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The nuke has 150 health. 20 rounds of a stolen assault rifle, egun or laser would do 94 damage, 62% of the nukes total health.
This PR reduces that to 52 damage, 34% of the nukes total health.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)The nuclear bomb has improved armor plating against energy and kinetic projectiles, taking roughly half the damage of the previous model.
```
