### PR TITLE
Fixes MONO rules pamphlet + MONO box name change

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2573,7 +2573,7 @@
 		product_list += new/datum/data/vending_product(/obj/item/card_box/clow, 5, cost=PAY_TRADESMAN/2) // (this is an anime joke)
 		product_list += new/datum/data/vending_product(/obj/item/clow_key, 5, cost=PAY_TRADESMAN/2)      //      (please laugh)
 		product_list += new/datum/data/vending_product(/obj/item/card_box/Mono, 5, cost=PAY_UNTRAINED/4)
-		product_list += new/datum/data/vending_product(/obj/item/paper/from_file/MonoRules, 5, cost=PAY_UNTRAINED/5)
+		product_list += new/datum/data/vending_product(/obj/item/paper/book/from_file/MONOrules, 5, cost=PAY_UNTRAINED/5)
 		product_list += new/datum/data/vending_product(/obj/item/dice/weighted, rand(1,3), cost=PAY_TRADESMAN/2, hidden=1)
 		product_list += new/datum/data/vending_product(/obj/item/dice/d1, rand(0,1), cost=PAY_TRADESMAN/3, hidden=1)
 

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -310,6 +310,12 @@ Custom Books
 	icon_state = "bookcc"
 	file_path = "strings/books/DNDrulebook.txt"
 
+/obj/item/paper/book/from_file/MONOrules
+	name = "MONO card game rules"
+	desc = "A pamphlet describing the rules of MONO, the family-friendly and legally distinct card game for all ages!"
+	icon_state = "paper"
+	file_path = "strings/books/MONOrules.txt"
+
 /******************** OTHER BOOKS ********************/
 /obj/item/diary
 	name = "Beepsky's private journal"

--- a/code/obj/item/mono_card_game.dm
+++ b/code/obj/item/mono_card_game.dm
@@ -24,14 +24,9 @@
 
 		update_group_sprite()
 
-/obj/item/paper/from_file/MonoRules
-	file_path = "strings/MONORules.txt"
-	icon_state = "paper"
-
-
 /obj/item/card_box/Mono
 	box_style = "red"
-	name = "Box of MONO"
+	name = "box of MONO cards"
 
 	New()
 		..()

--- a/strings/books/MONOrules.txt
+++ b/strings/books/MONOrules.txt
@@ -1,6 +1,6 @@
 <body>
-<h1>MONO</h1>
-The family friendly and legally distinct playing card game for all ages! For 2-10 players.
+<center><h1>MONO</h1></center>
+<center>The family friendly and legally distinct playing card game for all ages! For 2-10 players.</center>
 <hr>
 
 <h2>Contents</h2>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #7790, allowing the MONO rules document to be purchased and read without displaying any errors. Slight modifications (literally 2 `<center>` tags) have been made to the document itself for pretty.

Also changed the name of the MONO card box to fit the standard of other card boxes.

This doesn't fix the issues with card icon generation b-but we're... we're working on that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad