### PR TITLE
made appraisal scanners work for artifacts (somewhat)

### DIFF
--- a/code/datums/controllers/artifact_controls.dm
+++ b/code/datums/controllers/artifact_controls.dm
@@ -1,14 +1,26 @@
 var/datum/artifact_controller/artifact_controls
 
 /datum/artifact_controller
+	/// list of all artifacts
 	var/list/artifacts = list()
+	/// list with an instance of each artifact type, sorted by size and alphabetically
 	var/list/datum/artifact/artifact_types = list()
+	/// associative list with the instance from above, with the key being the type name
+	var/list/datum/artifact/artifact_types_from_name = list()
+	/// associative list of lists, with the keys being artifact origin names (and "all") and artifact types
+	/// the value is the rarity of the type.
+	/// This is used with weighted_pick for randomly generated artifacts (sometimes of specific origin)
 	var/list/artifact_rarities = list()
+	/// list with an instance of each artifact origin
 	var/list/artifact_origins = list()
 
+	/// list of artifact origin names, for artifact forms
 	var/list/artifact_origin_names = list()
+	/// list of artifact type names, for artifact forms
 	var/list/artifact_type_names = list()
+	/// list of artifact fault names, for artifact forms
 	var/list/artifact_fault_names = list()
+	/// list of artifact trigger names, for artifact forms (unused)
 	var/list/artifact_trigger_names = list()
 	var/spawner_type = null
 	var/spawner_cine = 0
@@ -24,14 +36,10 @@ var/datum/artifact_controller/artifact_controls
 			artifact_origin_names += AO.type_name
 			artifact_rarities[AO.name] = list()
 
-		// type list
-		// also make one list for each origin of all artifact types
-		// and also one that just holds all types
-		// the type is the index, the value the rarity
-		// for use with weighted_pick
 		for (var/A in concrete_typesof(/datum/artifact))
 			var/datum/artifact/AI = new A
 			artifact_types += AI
+			artifact_types_from_name[AI.type_name] = AI
 
 			artifact_rarities["all"][A] = AI.rarity_weight
 			for (var/origin in artifact_rarities)

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -235,7 +235,7 @@
 			update_shipping_data()
 
 	proc/calculate_artifact_price(var/modifier, var/correctness)
-		return modifier*modifier * 20000 * correctness
+		return ((modifier**2) * 20000 * correctness)
 
 	proc/sell_artifact(obj/sell_art, var/datum/artifact/sell_art_datum)
 		var/price = 0

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -234,15 +234,16 @@
 
 			update_shipping_data()
 
+	proc/calculate_artifact_price(var/modifier, var/correctness)
+		return modifier*modifier * 20000 * correctness
+
 	proc/sell_artifact(obj/sell_art, var/datum/artifact/sell_art_datum)
 		var/price = 0
 		var/modifier = sell_art_datum.get_rarity_modifier()
+		var/obj/item/sticker/postit/artifact_paper/pap = locate(/obj/item/sticker/postit/artifact_paper/) in sell_art.vis_contents
 
 		// calculate price
-		price = modifier*modifier * 20000
-		var/obj/item/sticker/postit/artifact_paper/pap = locate(/obj/item/sticker/postit/artifact_paper/) in sell_art.vis_contents
-		if(pap?.lastAnalysis)
-			price *= pap.lastAnalysis
+		price = calculate_artifact_price(modifier, max(pap?.lastAnalysis, 1))
 		price *= randfloat(0.9, 1.3)
 		price = round(price, 5)
 

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -767,8 +767,8 @@ that cannot be itched
 			return
 
 		var/datum/artifact/art = null
+		var/obj/O = A
 		if (isobj(A))
-			var/obj/O = A
 			art = O.artifact
 		else
 			// objs only
@@ -777,10 +777,18 @@ that cannot be itched
 		var/sell_value = 0
 		var/out_text = ""
 		if (art)
-			// TODO: Artifact valuation
-			// shippingmarket.sell_artifact(AM, art)
-			boutput(user, "<span class='alert'>Artifact appraisal not yet available. Coming Soon&trade;!</span>")
-			return
+			var/obj/item/sticker/postit/artifact_paper/pap = locate(/obj/item/sticker/postit/artifact_paper/) in O.vis_contents
+			if (pap?.artifactType)
+				out_text = "<strong>The following values depend on correct analysis of the artifact<br>Average price for [pap.artifactType] type artifacts</strong><br>"
+				// the unrandomized sell value for an artifact of the type detailed on the form, with perfect analysis
+				sell_value = shippingmarket.calculate_artifact_price(artifact_controls.artifact_types_from_name[pap.artifactType].get_rarity_modifier(), 3)
+				sell_value = round(sell_value, 5)
+			else if (pap)
+				boutput(user, "<span class='alert'>Attached Analysis Form&trade; needs to be filled out!</span>")
+				return
+			else
+				boutput(user, "<span class='alert'>Artifact appraisal is only possible via an attached Analysis Form&trade;!</span>")
+				return
 
 		else if (istype(A, /obj/storage/crate))
 			sell_value = -1
@@ -825,6 +833,8 @@ that cannot be itched
 			var/image/chat_maptext/chat_text = null
 			var/popup_text = "<span class='ol c pixel'[sell_value == 0 ? " style='color: #bbbbbb;'>No value" : ">$[round(sell_value)]"]</span>"
 			chat_text = make_chat_maptext(A, popup_text, alpha = 180, force = 1, time = 1.5 SECONDS)
+			// many of the artifacts are upside down and stuff, it makes text a bit hard to read!
+			chat_text.appearance_flags = RESET_TRANSFORM | RESET_COLOR | RESET_ALPHA
 			if (chat_text)
 				// don't bother bumping up other things
 				chat_text.show_to(user.client)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Appraisers now work on artifacts, assuming the artifact has an analysis form attached.
It will give the base price for an artifact of that type with a fully correct analysis.

I also put some more comments that explain all the different lists we have in artifact controls.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It makes sense that it'd work on things you can sell! Also the appraiser promised this feature was coming soon:tm:.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) Cargo appraisers can now be used on artifacts. They need to have a form attached, and the analysis will only be correct if you've filled out the form correctly. Due to artifacts being unique items, the price may vary quite a bit from what the appraiser says (mostly upwards).
```
