### PR TITLE
Adds 6 random rooms to donut3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -51778,9 +51778,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/grille/catwalk/jen/side{
-	dir = 10
-	},
+/obj/grille/catwalk/jen/inner,
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
@@ -58280,7 +58278,7 @@
 /area/station/maintenance/outer/se)
 "qHs" = (
 /obj/disposalpipe/segment,
-/obj/grille/catwalk/jen,
+/obj/grille/catwalk/jen/side,
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
@@ -59467,13 +59465,11 @@
 /turf/simulated/floor/black/grime,
 /area/station/medical/robotics)
 "qXZ" = (
-/obj/grille/catwalk/jen/side,
 /obj/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/decal/cleanable/dirt/jen,
-/turf/simulated/floor/plating/jen,
+/turf/simulated/wall/auto/jen,
 /area/station/maintenance/outer/sw)
 "qYf" = (
 /obj/railing/orange{
@@ -74633,13 +74629,15 @@
 /turf/simulated/floor/stairs/medical/wide,
 /area/station/medical/cdc)
 "vvF" = (
-/obj/grille/catwalk/jen/twosides{
-	dir = 4
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/grille/catwalk/jen/inner{
+	dir = 4
+	},
 /obj/decal/cleanable/dirt/jen,
+/obj/storage/closet,
+/obj/random_item_spawner/junk/maybe_few,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "vvL" = (
@@ -81561,6 +81559,9 @@
 /obj/machinery/sleeper/compact,
 /turf/simulated/floor/white/checker,
 /area/station/medical/medbay/lobby)
+"xrL" = (
+/turf/simulated/wall/auto/jen,
+/area/station/maintenance/outer/sw)
 "xrP" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
@@ -116139,8 +116140,8 @@ umn
 wlr
 vNB
 xPV
-vSX
 xtf
+xrL
 iZp
 pfO
 iZp

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -3141,9 +3141,10 @@
 /area/station/science/teleporter)
 "aFn" = (
 /obj/decal/cleanable/dirt/jen,
-/obj/decal/cleanable/rust/jen,
+/obj/machinery/fluid_canister,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/nw)
+/area/station/maintenance/outer/ne)
 "aFv" = (
 /turf/simulated/wall/auto/reinforced/jen/purple,
 /area/station/science/chemistry)
@@ -5371,8 +5372,11 @@
 /turf/simulated/floor/white,
 /area/spacehabitat/pool)
 "bqp" = (
+/obj/reagent_dispensers/foamtank,
 /obj/decal/cleanable/dirt/jen,
-/obj/machinery/fluid_canister,
+/obj/machinery/light/small/sticky{
+	dir = 1
+	},
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
@@ -5677,12 +5681,7 @@
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
 "buk" = (
-/obj/reagent_dispensers/foamtank,
-/obj/decal/cleanable/dirt/jen,
-/obj/machinery/light/small/sticky{
-	dir = 1
-	},
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/obj/landmark/random_room/size3x3,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "bul" = (
@@ -14688,9 +14687,6 @@
 	layer = 4
 	},
 /obj/decal/cleanable/dirt/jen,
-/obj/machinery/light/small/sticky{
-	dir = 4
-	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
 "dYt" = (
@@ -15812,12 +15808,11 @@
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
 "epL" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/middle{
-	dir = 10
-	},
-/turf/simulated/floor/airless/plating,
-/area/station/crew_quarters/bathroom)
+/obj/decal/cleanable/dirt/jen,
+/obj/floorpillstatue,
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/ne)
 "epN" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/specialroom/chapel{
@@ -17681,6 +17676,10 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
+"eQB" = (
+/obj/landmark/random_room/size5x3,
+/turf/simulated/floor/plating,
+/area/station/maintenance/outer/sw)
 "eQN" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 8
@@ -19268,11 +19267,11 @@
 	},
 /area/station/bridge)
 "foi" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/decal/cleanable/rust/jen,
-/obj/floorpillstatue,
+/obj/railing/orange{
+	dir = 1
+	},
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/ne)
+/area/station/maintenance/outer/se)
 "foK" = (
 /obj/cable,
 /obj/cable{
@@ -20218,6 +20217,14 @@
 "fCp" = (
 /turf/simulated/floor/red/corner,
 /area/station/hallway/primary/west)
+"fCs" = (
+/obj/disposalpipe/broken{
+	color = "#ff6666";
+	dir = 4;
+	name = "BYE"
+	},
+/turf/space,
+/area/space)
 "fCu" = (
 /obj/machinery/computer3/generic/secure_data,
 /obj/machinery/light/incandescent/warm,
@@ -20654,8 +20661,8 @@
 /turf/simulated/floor/white,
 /area/spacehabitat/pool)
 "fHw" = (
-/obj/machinery/light/small/sticky,
 /obj/decal/cleanable/dirt/jen,
+/obj/landmark/random_room/size3x3,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
 "fHG" = (
@@ -22473,11 +22480,15 @@
 	},
 /area/station/hallway/primary/west)
 "gkS" = (
-/obj/storage/closet,
+/obj/grille/catwalk/jen/side{
+	dir = 5
+	},
+/obj/machinery/light/small/sticky{
+	dir = 1
+	},
 /obj/decal/cleanable/dirt/jen,
-/obj/random_item_spawner/junk/few,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/nw)
+/area/station/maintenance/outer/se)
 "gln" = (
 /obj/disposalpipe/trunk/mail,
 /obj/machinery/disposal/mail/small/autoname/hydroponics/north{
@@ -28264,6 +28275,13 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"hVE" = (
+/obj/disposalpipe/segment/brig{
+	dir = 4
+	},
+/obj/wingrille_spawn/auto/tuff,
+/turf/simulated/floor/plating,
+/area/station/maintenance/outer/sw)
 "hVL" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -28530,9 +28548,6 @@
 	},
 /area/station/crew_quarters/kitchen)
 "iad" = (
-/obj/grille/steel,
-/obj/item/clothing/head/helmet/space/santahat,
-/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
 "iaf" = (
@@ -31825,6 +31840,9 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
+"iZp" = (
+/turf/simulated/floor/plating,
+/area/station/maintenance/outer/sw)
 "iZr" = (
 /obj/grille/catwalk/jen,
 /obj/disposalpipe/segment{
@@ -40627,6 +40645,10 @@
 	dir = 1
 	},
 /area/station/crew_quarters/cafeteria)
+"lHL" = (
+/obj/landmark/random_room/size3x5,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/south)
 "lHM" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass,
@@ -46744,6 +46766,7 @@
 	layer = 4
 	},
 /obj/decal/cleanable/dirt/jen,
+/obj/landmark/random_room/size3x3,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/nw)
 "nxj" = (
@@ -48138,6 +48161,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/bridge)
+"nTf" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/decoration/vent/vent3,
+/turf/simulated/wall/auto/jen/red,
+/area/station/maintenance/outer/sw)
 "nTg" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/cable{
@@ -48402,12 +48432,12 @@
 	},
 /area/station/medical/medbay/treatment)
 "nVK" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/right{
-	dir = 8
+/obj/decal/cleanable/dirt/jen,
+/obj/grille/catwalk/jen/side{
+	dir = 4
 	},
-/turf/simulated/floor/airless/plating,
-/area/station/crew_quarters/bathroom)
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/se)
 "nVN" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor,
@@ -51744,6 +51774,16 @@
 	dir = 4
 	},
 /area/station/bridge)
+"oTo" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/grille/catwalk/jen/side{
+	dir = 10
+	},
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/sw)
 "oTz" = (
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
@@ -52366,13 +52406,11 @@
 	},
 /area/station/hallway/primary/south)
 "pfO" = (
-/obj/disposalpipe/broken{
-	color = "#ff6666";
-	dir = 4;
-	name = "BYE"
+/obj/disposalpipe/segment/brig{
+	dir = 4
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/plating,
+/area/station/maintenance/outer/sw)
 "pfS" = (
 /obj/decal/mule/dropoff,
 /obj/machinery/door/airlock/pyro/glass,
@@ -55385,11 +55423,8 @@
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/customs)
 "pVS" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/obj/machinery/light/small/sticky{
-	dir = 1
-	},
 /obj/decal/cleanable/dirt/jen,
+/obj/grille/catwalk/jen/twosides,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
 "pVT" = (
@@ -55984,12 +56019,9 @@
 /turf/simulated/floor/plating/jen,
 /area/station/storage/tech)
 "qdO" = (
-/obj/wingrille_spawn/auto/crystal,
-/obj/window_blinds/cog2/middle{
-	dir = 8
-	},
-/turf/simulated/floor/airless/plating,
-/area/station/crew_quarters/bathroom)
+/obj/landmark/random_room/size5x3,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/se)
 "qdQ" = (
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/yellowblack{
@@ -58243,15 +58275,15 @@
 /turf/simulated/floor/wood/five,
 /area/station/hydroponics/bay)
 "qHn" = (
-/obj/grille/catwalk/jen/side{
-	dir = 5
-	},
-/obj/machinery/light/small/sticky{
-	dir = 1
-	},
-/obj/decal/cleanable/dirt/jen,
+/obj/railing/orange,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
+"qHs" = (
+/obj/disposalpipe/segment,
+/obj/grille/catwalk/jen,
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/outer/sw)
 "qHy" = (
 /obj/decal/stage_edge{
 	dir = 2;
@@ -62542,6 +62574,12 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
+"rRU" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/auto/jen/red,
+/area/station/maintenance/outer/sw)
 "rSb" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -65180,13 +65218,8 @@
 /turf/simulated/wall/auto/jen,
 /area/station/library)
 "sGC" = (
-/obj/railing/orange{
-	dir = 4
-	},
-/obj/decal/cleanable/dirt/jen,
-/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/se)
+/area/station/maintenance/inner/south)
 "sGW" = (
 /obj/grille/catwalk/jen/side,
 /obj/decal/cleanable/dirt/jen,
@@ -66391,11 +66424,9 @@
 	name = "Tool Storage"
 	})
 "sZM" = (
-/obj/storage/closet,
-/obj/decal/cleanable/dirt/jen,
-/obj/decal/cleanable/rust/jen,
+/obj/wingrille_spawn/auto/tuff,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/se)
+/area/station/maintenance/inner/south)
 "sZR" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -71019,8 +71050,16 @@
 /turf/simulated/floor/black,
 /area/listeningpost)
 "uvh" = (
-/obj/decoration/vent/vent3,
-/turf/simulated/wall/auto/jen/red,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/decal/cleanable/dirt/jen,
+/obj/grille/catwalk/jen/side{
+	dir = 1
+	},
+/turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/sw)
 "uvs" = (
 /turf/simulated/floor/black,
@@ -80463,12 +80502,20 @@
 /turf/simulated/wall/auto/reinforced/jen/red,
 /area/station/turret_protected/AIbaseoutside)
 "xaI" = (
-/obj/rack,
-/obj/random_item_spawner/tools/one,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/grille/catwalk/jen/side{
+	dir = 1
+	},
+/obj/grille/catwalk/jen/side{
+	dir = 1
+	},
 /obj/decal/cleanable/dirt/jen,
-/obj/decal/cleanable/rust/jen,
 /turf/simulated/floor/plating/jen,
-/area/station/maintenance/outer/se)
+/area/station/maintenance/outer/sw)
 "xaM" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -114283,7 +114330,7 @@ xQE
 vNB
 vvF
 pFp
-rdj
+fCs
 rdj
 rdj
 rdj
@@ -114583,11 +114630,11 @@ vNB
 wyM
 xQE
 vNB
-vvF
+rRU
 ieL
-rdj
-rdj
-rdj
+hVE
+pFp
+ieL
 rdj
 rdj
 rdj
@@ -114883,13 +114930,13 @@ umn
 oXO
 vNB
 uHW
-xQE
 uvh
-vvF
+jDb
+nTf
+iZp
+pfO
+eQB
 ieL
-rdj
-rdj
-rdj
 rdj
 rdj
 rdj
@@ -115185,13 +115232,13 @@ hMc
 oXO
 vNB
 rZw
-xQE
-vNB
-vvF
+vVu
+hsj
+rRU
+iZp
+pfO
+iZp
 ieL
-rdj
-rdj
-rdj
 rdj
 rdj
 rdj
@@ -115487,13 +115534,13 @@ wam
 oXO
 vNB
 vNB
-xQE
-vNB
-vvF
-pFp
-rdj
-rdj
-rdj
+xaI
+pBV
+oTo
+iZp
+pfO
+iZp
+ieL
 rdj
 rdj
 rdj
@@ -115790,12 +115837,12 @@ lqZ
 cgw
 vNB
 uew
-kks
+qHs
 qXZ
-pFp
-rdj
-rdj
-rdj
+iZp
+pfO
+iZp
+ieL
 rdj
 rdj
 rdj
@@ -116094,10 +116141,10 @@ vNB
 xPV
 vSX
 xtf
-pFp
+iZp
 pfO
-rdj
-rdj
+iZp
+ieL
 rdj
 rdj
 rdj
@@ -116399,7 +116446,7 @@ wCR
 hBH
 hnk
 hBH
-rdj
+hBH
 rdj
 rdj
 rdj
@@ -116700,8 +116747,8 @@ aaS
 aUJ
 vgo
 uCo
+cPd
 hBH
-rdj
 rdj
 rdj
 rdj
@@ -117002,7 +117049,7 @@ wCR
 cPd
 tCO
 rpg
-hBH
+cPd
 hBH
 gwJ
 gwJ
@@ -121222,11 +121269,11 @@ byn
 ogJ
 jYm
 rdj
-rdj
-epL
-qdO
-qdO
-nVK
+jvq
+oyA
+oyA
+oyA
+oyA
 oyA
 oyA
 sUI
@@ -121524,12 +121571,12 @@ mAu
 ogJ
 jYm
 rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+jvq
+sGC
+sGC
+sGC
+sGC
+lHL
 gwJ
 geb
 kDE
@@ -121826,12 +121873,12 @@ uOj
 ogJ
 jYm
 rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+jvq
+sGC
+sGC
+sGC
+sGC
+sGC
 gwJ
 jBB
 qqy
@@ -122125,15 +122172,15 @@ rdj
 ogJ
 eBP
 sZg
-jpQ
+ogJ
 kuM
 cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-cjG
+jvq
+sGC
+sGC
+sGC
+sGC
+sGC
 gwJ
 jBB
 pyL
@@ -122356,7 +122403,7 @@ vNC
 orp
 fDa
 oBD
-rMd
+qKT
 qKT
 nxh
 baF
@@ -122430,12 +122477,12 @@ jKe
 jpQ
 jvq
 tga
-tga
-tga
-tga
-tga
-tga
-tga
+jvq
+sZM
+sZM
+sGC
+sZM
+sZM
 dpI
 fHL
 pyL
@@ -122658,7 +122705,7 @@ pVy
 gAb
 wmH
 oBD
-aFn
+qKT
 qKT
 qKT
 khV
@@ -122960,7 +123007,7 @@ edQ
 uiq
 dcb
 oBD
-gkS
+qKT
 qKT
 dYm
 lPb
@@ -130475,7 +130522,7 @@ rdj
 aUm
 aNo
 dwQ
-aRI
+epL
 kkV
 ekG
 vpz
@@ -130776,7 +130823,7 @@ rdj
 rdj
 aUm
 aXX
-aRI
+bzZ
 bzZ
 kkV
 gKt
@@ -131074,11 +131121,11 @@ rdj
 rdj
 rdj
 rdj
-rdj
-rdj
 aUm
 aUm
-foi
+aUm
+aUm
+kkV
 kkV
 kkV
 iYv
@@ -131376,12 +131423,12 @@ rdj
 rdj
 rdj
 rdj
-rdj
-rdj
-rdj
 aUm
-kkV
-kkV
+ofw
+ofw
+buk
+ofw
+ofw
 sOX
 qOZ
 aHj
@@ -131678,10 +131725,10 @@ rdj
 rdj
 rdj
 rdj
-rdj
-rdj
-rdj
 aUm
+ofw
+ofw
+ofw
 aRI
 kUF
 btN
@@ -131980,10 +132027,10 @@ rdj
 rdj
 rdj
 rdj
-rdj
-rdj
-rdj
 aUm
+ofw
+ofw
+ofw
 fEX
 lhr
 dyw
@@ -132282,8 +132329,8 @@ rdj
 rdj
 rdj
 rdj
-rdj
-rdj
+aUm
+aUm
 aUm
 aUm
 bzi
@@ -132585,9 +132632,9 @@ rdj
 rdj
 rdj
 rdj
-rdj
 kyD
-bqp
+aFn
+aRI
 bzi
 mkF
 ePf
@@ -132887,9 +132934,9 @@ rdj
 rdj
 rdj
 rdj
-rdj
 kyD
-buk
+bqp
+aRI
 bzi
 oQe
 ePf
@@ -138933,7 +138980,7 @@ rdj
 rdj
 rdj
 rdj
-aUm
+kyD
 rxW
 ofw
 wwj
@@ -141148,7 +141195,7 @@ gLB
 uvJ
 uvJ
 uvJ
-rhm
+nVK
 vfx
 rJj
 iRB
@@ -141450,8 +141497,8 @@ tgB
 dxe
 tUR
 nxQ
+nxQ
 wPF
-rhm
 vco
 vco
 vco
@@ -141751,9 +141798,9 @@ wPF
 hck
 mjX
 wZR
+iad
 nxQ
 fnX
-uvJ
 rhm
 rhm
 uvJ
@@ -142052,8 +142099,8 @@ lVy
 wPF
 dkL
 nxQ
-wZR
 nxQ
+iad
 nxQ
 nxQ
 wPF
@@ -142656,8 +142703,8 @@ lVy
 wPF
 dkL
 nxQ
-kES
-kES
+wZR
+wZR
 vTC
 nxQ
 wPF
@@ -142958,8 +143005,8 @@ lVy
 wPF
 dkL
 nxQ
-iad
-kES
+wZR
+wZR
 vTC
 nxQ
 wPF
@@ -143261,8 +143308,8 @@ wPF
 dkL
 nxQ
 nxQ
+eUW
 nxQ
-sGC
 nxQ
 wPF
 vfx
@@ -145374,10 +145421,10 @@ vqi
 xcV
 vfx
 nxQ
-wPF
-rhm
-vco
-vco
+gkS
+uvJ
+pVS
+pVS
 wvu
 wZR
 tUR
@@ -145676,10 +145723,10 @@ vqi
 aAw
 vfx
 nxQ
-qHn
-uvJ
-uvJ
-rhm
+nxQ
+nxQ
+nxQ
+nxQ
 vfx
 vTC
 vTC
@@ -145978,10 +146025,10 @@ vqi
 aAw
 vfx
 nxQ
+iad
+iad
+qdO
 nxQ
-nxQ
-nxQ
-wPF
 vfx
 vTC
 wZR
@@ -146280,10 +146327,10 @@ vqi
 aAw
 vfx
 nxQ
-vTs
+vTC
 wZR
-izj
-wPF
+wZR
+nxQ
 vfx
 rBB
 tdY
@@ -146581,11 +146628,11 @@ aTe
 vqi
 wxZ
 vfx
-nxQ
-pVS
-kES
-nxQ
-wPF
+foi
+wZR
+wZR
+iad
+qHn
 vfx
 kTi
 paM
@@ -146885,9 +146932,9 @@ wPF
 dhk
 nxQ
 vTC
-xaI
+vTC
+iad
 nxQ
-wPF
 rhm
 vco
 wvu
@@ -147185,11 +147232,11 @@ acm
 vqi
 wPF
 lHP
-ifd
-wZR
-sZM
 nxQ
-wPF
+wZR
+vTC
+iad
+nxQ
 rhm
 uvJ
 iaL
@@ -147491,7 +147538,7 @@ nxQ
 nxQ
 nxQ
 nxQ
-wPF
+nxQ
 vfx
 gQk
 gDk


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 3 3x3 random rooms, 2 random 5x3 rooms and 1 3x5 room for a total of 6 random rooms.
![image](https://user-images.githubusercontent.com/73148980/158278436-7ea7ba61-4385-4bcf-9a07-80d989b937f2.png)
![image](https://user-images.githubusercontent.com/73148980/158278447-68b15fb1-619b-4d07-8163-79f3389e192d.png)
![image](https://user-images.githubusercontent.com/73148980/158278473-d4381492-be5b-4c87-b15b-8dc527393a77.png)
![image](https://user-images.githubusercontent.com/73148980/158278499-e8599bfb-15a8-426b-8953-be044f6369f4.png)
![image](https://user-images.githubusercontent.com/73148980/158278515-2f1120b4-3db2-4220-9b44-86a25ad59167.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
~~I want to be able to explore the new random rooms on highpop~~ Viarety 


