### PR TITLE
Flip-emoting while on a skateboard now does a flip.

### DIFF
--- a/code/modules/transport/skateboard.dm
+++ b/code/modules/transport/skateboard.dm
@@ -75,6 +75,8 @@
 	var/atom/last_bumped_atom = null
 	var/list/bumped_queue = list()
 	density = 0
+	mob_flip_inside(var/mob/user)
+		animate_spin(src, prob(50) ? "L" : "R", 1, 0)
 
 /obj/vehicle/skateboard/New()
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Overrides `mob_flip_inside` for the skateboard vehicle

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bonking your head while on a skateboard doesn't make sense - just doing a 'regular' flip doesn't seem to hurt anything?