### PR TITLE
Up arrow now works for Tetris controls

### DIFF
--- a/browserassets/html/tetris.html
+++ b/browserassets/html/tetris.html
@@ -1002,7 +1002,7 @@
     if (GM.IsAlive){
       switch(keyDown){
 
-        //case 38:
+        case 38:
         case 87:
         case 69:
         case 88: // x


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The up arrow will now rotate the piece clockwise, as it used to.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I accidentally removed the up arrow's functionality for the Tetris arcade, but now it will work properly.
