### PR TITLE
fix set-regex on regex find components

### DIFF
--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -1388,6 +1388,7 @@
 	proc/setregex(var/datum/mechanicsMessage/input)
 		if(level == 2) return
 		expression = input.signal
+		expressionpatt = input.signal
 		tooltip_rebuild = 1
 	proc/checkstr(var/datum/mechanicsMessage/input)
 		if(level == 2 || !length(expression)) return

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -1387,8 +1387,8 @@
 
 	proc/setregex(var/datum/mechanicsMessage/input)
 		if(level == 2) return
-		expression = ("[input.signal]/[expressionflag]")
-		expressionpatt = input.signal
+		expressionpatt = ("[input.signal]/[expressionflag]")
+		expression = input.signal
 		tooltip_rebuild = 1
 	proc/checkstr(var/datum/mechanicsMessage/input)
 		if(level == 2 || !length(expression)) return

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -1387,7 +1387,7 @@
 
 	proc/setregex(var/datum/mechanicsMessage/input)
 		if(level == 2) return
-		expression = input.signal
+		expression = ("[input.signal]/[expressionflag]")
 		expressionpatt = input.signal
 		tooltip_rebuild = 1
 	proc/checkstr(var/datum/mechanicsMessage/input)


### PR DESCRIPTION


## About the PR 
allows other components to set the regex pattern on regex find components.


## Why's this needed? 
previously it was only changing the pattern in the examine text.



