### PR TITLE
Fix camera placement on Donut3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -60622,19 +60622,11 @@
 /turf/simulated/floor/greenwhite/other,
 /area/station/crew_quarters/market)
 "rpg" = (
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
 	name = "autoname - SS13";
 	tag = ""
-	},
-/obj/disposalpipe/segment/brig{
-	dir = 4
 	},
 /turf/simulated/floor/wood/two,
 /area/station/hallway/primary/south)
@@ -117049,8 +117041,8 @@ leP
 wCR
 cPd
 tCO
+tsv
 rpg
-cPd
 hBH
 gwJ
 gwJ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[TRIVIAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This fixes the floating camera in the south primary hallway of Donut3. The camera is moved one space south to attach it to the nearest wall.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7824 and fixes #7817
