### PR TITLE
Slipping Hazard trait

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -1083,6 +1083,12 @@ ABSTRACT_TYPE(/obj/trait/job)
 		..()
 		owner.put_in_hand_or_drop(new /obj/item/reagent_containers/food/snacks/cookie/dog)
 
+/obj/trait/super_slips
+	name = "Slipping Hazard (+1)"
+	id = "super_slips"
+	desc = "You never were good at managing yourself slipping."
+	points = 1
+
 //Infernal Contract Traits
 /obj/trait/hair
 	name = "Wickedly Good Hair"

--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -28,8 +28,8 @@
 			var/turf/T = NewLoc
 			if (T.turf_flags & MOB_SLIP)
 				var/wet_adjusted = T.wet
-				if (traitHolder && traitHolder.hasTrait("super_slips") && wet_adjusted == 1)
-					wet_adjusted = 2 //whee
+				if (traitHolder?.hasTrait("super_slips"))
+					wet_adjusted = max(wet_adjusted, 2) //whee
 
 				switch (wet_adjusted)
 					if (1)

--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -27,7 +27,11 @@
 		if (!src.throwing && !src.lying && isturf(NewLoc))
 			var/turf/T = NewLoc
 			if (T.turf_flags & MOB_SLIP)
-				switch (T.wet)
+				var/wet_adjusted = T.wet
+				if (traitHolder && traitHolder.hasTrait("super_slips") && wet_adjusted == 1)
+					wet_adjusted = 2 //whee
+
+				switch (wet_adjusted)
 					if (1)
 						if (locate(/obj/item/clothing/under/towel) in T)
 							src.inertia_dir = 0

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -129,6 +129,8 @@
 
 	if (movedelay < slip_delay)
 		var/intensity = (-0.33)+(6.033763-(-0.33))/(1+(movement_delay_real/(0.4))-1.975308)  //y=d+(6.033763-d)/(1+(x/c)-1.975308)
+		if (traitHolder && traitHolder.hasTrait("super_slips"))
+			intensity = max(intensity, 12) //the 12 is copied from the range of lube slips because that's what I'm trying to emulate
 		var/throw_range = min(round(intensity),50)
 		if (intensity < 1 && intensity > 0 && throw_range <= 0)
 			throw_range = max(throw_range,1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the Slipping Hazard trait, which gives one point and makes all your slips at least as intense as slipping on lube (which I don't think any other slip type except superlube exceeds anyway). It doesn't make you slip more often, but just makes the times you do slip worse.

Slipping on a banana peel carries you and the peel forward before doing the cartoony flip at the end. That's completely unintended but I think it's a good effect.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I thought it'd be funny. Really makes you appreciate how many glass tables cog2 has.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Added the Slipping Hazard trait, for people who'd like to slip worse.
```
