### PR TITLE
Fix the paper scanners in the Cog2 net cafe and research department

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -12324,7 +12324,7 @@
 	},
 /obj/table/auto,
 /obj/machinery/networked/storage/scanner{
-	bank_id = "security";
+	bank_id = "netcafe";
 	pixel_y = 4
 	},
 /turf/simulated/floor/circuit,
@@ -58142,7 +58142,7 @@
 "cyU" = (
 /obj/table/reinforced/auto,
 /obj/machinery/networked/storage/scanner{
-	bank_id = "security";
+	bank_id = "research";
 	pixel_y = 4
 	},
 /obj/cable{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The net cafe and research paper scanners were assigned an already in-use ID, so they did could not be controlled via DWAINE. This gives them the scanners appropriate IDs and allows them to be accessed via the network as expected.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7783
The scanners do not currently work and this will fix that.