### PR TITLE
Smoke Cleans Up After Itself

### DIFF
--- a/code/modules/fluids/air.dm
+++ b/code/modules/fluids/air.dm
@@ -120,6 +120,8 @@ var/list/ban_from_airborne_fluid = list()
 	Crossed(atom/movable/A)
 		..()
 		if (!src.group || !src.group.reagents || src.disposed || istype(A,/obj/fluid))
+			if(src.group?.disposed)
+				qdel(src)
 			return
 		A.EnteredAirborneFluid(src, A.last_turf)
 
@@ -147,6 +149,12 @@ var/list/ban_from_airborne_fluid = list()
 		if(!waterflow_enabled) return
 		for( var/dir in cardinal )
 			LAGCHECK(LAG_LOW)
+			if (!src.group)
+				src.removed()
+
+				for(var/A in .)
+					qdel(A)
+				return
 			blocked_perspective_objects["[dir]"] = 0
 			t = get_step( src, dir )
 			if (!t) //the fuck? how
@@ -233,7 +241,8 @@ var/list/ban_from_airborne_fluid = list()
 						else
 							step_away(push_thing,src)
 
-					F.trigger_fluid_enter()
+					if(F.group.reagents)
+						F.trigger_fluid_enter()
 
 		if (spawned_any && prob(40))
 			playsound( src.loc, 'sound/effects/smoke_tile_spread.ogg', 30,1,7)

--- a/code/modules/fluids/fluid_groups.dm
+++ b/code/modules/fluids/fluid_groups.dm
@@ -485,6 +485,7 @@
 			return 1
 
 		LAGCHECK(LAG_MED)
+		if (src.qdeled) return 1
 
 		var/targetalpha = max(25, (src.average_color.a / 255) * src.max_alpha)
 		var/targetcolor = rgb(src.average_color.r, src.average_color.g, src.average_color.b)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allow lingering groupless smoke to clear itself on mob interaction
Clear created fluid objects when group was disposed as part of creation (if reagents are consumed by Crossed atoms for instance)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I like, just want to work on my cool thing without... runtimes.
