### PR TITLE
Fix nukie weapon crate layering

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -27,6 +27,7 @@
 	opacity = 0
 	anchored = 1
 	flags = TGUI_INTERACTIVE
+	layer = OBJ_LAYER - 0.1	// Match vending machines
 
 	var/sound_token = 'sound/machines/capsulebuy.ogg'
 	var/sound_buy = 'sound/machines/spend.ogg'
@@ -95,8 +96,6 @@
 
 
 	proc/vended(var/atom/A)
-		if(A.layer <= src.layer)
-			A.layer = src.layer + 0.1
 		if(log_purchase)
 			logTheThing("debug", usr, null, "bought [A] from [src] at [log_loc(get_turf(src))]")
 		.= 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Copy layer from vending machines.
Ditch layer adjustment.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Crates are above their contents.
Layer adjustment should never be necessary. I'm not convinced OBJ_LAYER is actually appropriate but this is the code vending machines use.