### PR TITLE
fix two tube lights on donut3 pool bean

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -20656,10 +20656,6 @@
 /obj/storage/closet/welding_supply,
 /turf/simulated/floor/yellow,
 /area/station/engine/inner)
-"fHp" = (
-/obj/machinery/light,
-/turf/simulated/floor/white,
-/area/spacehabitat/pool)
 "fHw" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/landmark/random_room/size3x3,
@@ -56646,7 +56642,7 @@
 /obj/submachine/chef_sink/chem_sink{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/white,
 /area/spacehabitat/pool)
 "qle" = (
@@ -103563,7 +103559,7 @@ iCP
 fTA
 fTA
 ifv
-fHp
+irM
 ifv
 fTA
 wnK


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces two lights in the donut3 pool bean bathroom with versions that autoplace.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
One of them was oriented wrong because it didn't autoplace, the other was fine (along a south wall anyway) but every other light in the pool is an incandescent one so I replaced it for consistency.