### PR TITLE
ai eyes no longer can empty cabinets

### DIFF
--- a/code/WorkInProgress/cabinet.dm
+++ b/code/WorkInProgress/cabinet.dm
@@ -20,7 +20,7 @@
 
 	RawClick(location,control,params)
 		var/mob/user = usr
-		if (ismobcritter(user) || issilicon(user) || isobserver(user))
+		if (ismobcritter(user) || issilicon(user) || isobserver(user) || isAI(user))
 			return
 		if(can_act(user) && can_reach(user, src))
 			var/list/paramList = params2list(params)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a missing isAI check in the cabinet-specific click handling


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AI Eyes are not silicons, so an additional check is required.
Fixes #7768 
