### PR TITLE
Pod wars turrets only attack enemies

### DIFF
--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -307,7 +307,7 @@ ABSTRACT_TYPE(/obj/deployable_turret/pod_wars)
 	is_friend(var/mob/living/C)
 		if (!C.ckey || !C.mind)
 			return 1
-		if (C.mind?.special_role == "NanoTrasen")
+		if (C.mind?.special_role != "Syndicate")
 			return 1
 		else
 			return 0
@@ -339,7 +339,7 @@ ABSTRACT_TYPE(/obj/deployable_turret/pod_wars)
 	is_friend(var/mob/living/C)
 		if (!C.ckey || !C.mind)
 			return 1
-		if (C.mind.special_role == "Syndicate")
+		if (C.mind.special_role != "NanoTrasen")
 			return 1
 		else
 			return 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the pod wars turrets to only attack enemies rather than only NOT attacking allies. This allows unaligned players to not be targeted.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7363
