### PR TITLE
Changes borg linker behaviour to be more intuitive

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -327,21 +327,27 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 			return
 
 		if(!src.law_rack_connection)
-			if(!linker.linked_rack)
-				boutput(src,"No stored law rack link to connect to!")
-				return
-			if(linker.linked_rack in ticker.ai_law_rack_manager.registered_racks)
-				src.law_rack_connection = linker.linked_rack
-				logTheThing("station", src, src.law_rack_connection, "[src.name] is connected to the rack at [log_loc(src.law_rack_connection)] with a linker by [user]")
-				boutput(user, "You connect [src.name] to the stored law rack.")
-				src.playsound_local(src, "sound/misc/lawnotify.ogg", 100, flags = SOUND_IGNORE_SPACE)
-				src.show_text("<h3>You have been connected to a law rack</h3>", "red")
-				src.show_laws()
-			else
-				boutput(user,"Linker lost connection to the stored law rack!")
+			boutput(src,"[src.name] is not connected to a law rack")
 		else
 			var/area/A = get_area(src.law_rack_connection)
 			boutput(user, "[src.name] is connected to a law rack at [A.name].")
+
+		if(!linker.linked_rack)
+			return
+
+		if(linker.linked_rack in ticker.ai_law_rack_manager.registered_racks)
+			if(src.law_rack_connection)
+				var/raw = tgui_alert(user,"Do you want to overwrite the linked rack?", "Linker", list("Yes", "No"))
+				if (raw == "Yes")
+					src.law_rack_connection = linker.linked_rack
+					logTheThing("station", src, src.law_rack_connection, "[src.name] is connected to the rack at [log_loc(src.law_rack_connection)] with a linker by [user]")
+					var/area/A = get_area(src.law_rack_connection)
+					boutput(user, "You connect [src.name] to the stored law rack at [A.name].")
+					src.playsound_local(src, "sound/misc/lawnotify.ogg", 100, flags = SOUND_IGNORE_SPACE)
+					src.show_text("<h3>You have been connected to a law rack</h3>", "red")
+					src.show_laws()
+		else
+			boutput(user,"Linker lost connection to the stored law rack!")
 		return
 
 	if (isscrewingtool(W))

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1069,22 +1069,29 @@
 			if(isshell(src) || src.ai_interface)
 				boutput(user,"You need to use this on the AI core directly!")
 				return
+
 			if(!src.law_rack_connection)
-				if(!linker.linked_rack)
-					boutput(user,"No stored law rack link to connect to!")
-					return
-				if(linker.linked_rack in ticker.ai_law_rack_manager.registered_racks)
-					src.law_rack_connection = linker.linked_rack
-					logTheThing("station", src, src.law_rack_connection, "[src.name] is connected to the rack at [log_loc(src.law_rack_connection)] with a linker by [user]")
-					boutput(user, "You connect [src.name] to the stored law rack.")
-					src.playsound_local(src, "sound/misc/lawnotify.ogg", 100, flags = SOUND_IGNORE_SPACE)
-					src.show_text("<h3>You have been connected to a law rack</h3>", "red")
-					src.show_laws()
-				else
-					boutput(user,"Linker lost connection to the stored law rack!")
+				boutput(src,"[src.name] is not connected to a law rack")
 			else
 				var/area/A = get_area(src.law_rack_connection)
 				boutput(user, "[src.name] is connected to a law rack at [A.name].")
+
+			if(!linker.linked_rack)
+				return
+
+			if(linker.linked_rack in ticker.ai_law_rack_manager.registered_racks)
+				if(src.law_rack_connection)
+					var/raw = tgui_alert(user,"Do you want to overwrite the linked rack?", "Linker", list("Yes", "No"))
+					if (raw == "Yes")
+						src.law_rack_connection = linker.linked_rack
+						logTheThing("station", src, src.law_rack_connection, "[src.name] is connected to the rack at [log_loc(src.law_rack_connection)] with a linker by [user]")
+						var/area/A = get_area(src.law_rack_connection)
+						boutput(user, "You connect [src.name] to the stored law rack at [A.name].")
+						src.playsound_local(src, "sound/misc/lawnotify.ogg", 100, flags = SOUND_IGNORE_SPACE)
+						src.show_text("<h3>You have been connected to a law rack</h3>", "red")
+						src.show_laws()
+			else
+				boutput(user,"Linker lost connection to the stored law rack!")
 			return
 
 		if (isweldingtool(W))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BALANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the Linker's behaviour so that it is no longer required to disconnect a borg/AI from a rack before changing it's connection.
You can now overwrite a law rack connection using the linking tool, but you will be prompted before doing so.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People are confused why it doesn't work intuitively. It isn't at all clear that the borg needs to be disconnected first.
It also removes one barrier to changing a borg's laws, because it already requires access to a rack, access to robotics, and a robotics access card.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(*)The Linker tool can now overwrite the connection on a cyborg/AI without needing to be emagged first.
```
