### PR TITLE
adds health variable to firelocks

### DIFF
--- a/code/obj/machinery/door/firedoor.dm
+++ b/code/obj/machinery/door/firedoor.dm
@@ -37,7 +37,8 @@
 	cant_emag = 1
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_DESTRUCT
 	mats = 30 // maybe a bit high??
-
+	health = 200
+	health_max = 200
 	xmasify()
 		return
 


### PR DESCRIPTION
## About the PR 
adds a health variable to firelocks so people can now smash them until they break

## Why's this needed? 
i think people being infinitely trapped by firelocks if they don't have a crowbar or are dealing with packetry is bad

```changelog
(u)nefarious6th
(+)you can now break firelocks down by hitting them repeatedly, just like airlocks
```