### PR TITLE
Stop chair flipping when you fall off the chair

### DIFF
--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -649,6 +649,7 @@
 				chair_chump.changeStatus("stunned", 2 SECONDS)
 				random_brute_damage(chair_chump, 15)
 				playsound(chair_chump.loc, "swing_hit", 50, 1)
+				chair_chump.end_chair_flip_targeting()
 
 			var/obj/item/chair/folded/C = null
 			if(istype(src, /obj/stool/chair/syndicate))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Explicitly end chair-flip targeting when a chair is folded out from underneath someone.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Should fix #7889
