### PR TITLE
Fix slipping hazard doing slips on everything

### DIFF
--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -28,11 +28,11 @@
 			var/turf/T = NewLoc
 			if (T.turf_flags & MOB_SLIP)
 				var/wet_adjusted = T.wet
-				if (traitHolder?.hasTrait("super_slips"))
+				if (traitHolder?.hasTrait("super_slips") && T.wet) //non-zero wet
 					wet_adjusted = max(wet_adjusted, 2) //whee
 
 				switch (wet_adjusted)
-					if (1)
+					if (1) //ATM only the ancient mop does this
 						if (locate(/obj/item/clothing/under/towel) in T)
 							src.inertia_dir = 0
 							T.wet = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes slipping hazard making every step on a simmed floor act like it's lubed.

Also added a comment to the wet = 1 case for the switch up ahead, since it's not clear otherwise and the others have comments anyway.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lube-slipping on every floor is very funny but also makes the game unplayable.

closes #7900
