### PR TITLE
Kondaru armory exterior area

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -15802,7 +15802,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/ai_monitored/armory)
+/area/station/security/secwing)
 "aTv" = (
 /obj/item/raw_material/shard/glass,
 /turf/simulated/floor/airless/plating{
@@ -33111,7 +33111,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "bYF" = (
 /obj/disposalpipe/segment/transport,
 /turf/simulated/wall/auto/supernorn,
@@ -34033,7 +34033,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "cbX" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -34047,10 +34047,10 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "cbZ" = (
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "cca" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -39674,7 +39674,7 @@
 	},
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "cRB" = (
 /obj/storage/closet/wardrobe/red/security_gimmick,
 /turf/simulated/floor/red/side,
@@ -39686,7 +39686,7 @@
 /obj/lattice,
 /obj/machinery/light/runway_light/delay4,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "cSO" = (
 /obj/storage/crate,
 /obj/item/clothing/under/gimmick/princess,
@@ -40435,7 +40435,7 @@
 /obj/machinery/light/runway_light/delay5,
 /obj/lattice,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "dCW" = (
 /obj/machinery/manufacturer/hangar,
 /turf/simulated/floor,
@@ -40453,7 +40453,7 @@
 	tag = ""
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "dDe" = (
 /obj/table/auto,
 /obj/item/peripheral/network/radio/locked{
@@ -40692,7 +40692,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/area/station/security/secwing)
 "dOy" = (
 /turf/simulated/floor/redwhite{
 	dir = 8
@@ -40890,7 +40890,7 @@
 	},
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "dXg" = (
 /obj/disposalpipe/segment/vertical,
 /obj/cable{
@@ -41051,7 +41051,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/red,
-/area/station/ai_monitored/armory)
+/area/station/security/secwing)
 "edL" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -41096,7 +41096,7 @@
 	dir = 4
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "eeR" = (
 /obj/storage/crate,
 /turf/simulated/floor/plating,
@@ -41732,7 +41732,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/area/station/security/secwing)
 "eMs" = (
 /obj/disposalpipe/segment/vertical,
 /obj/critter/nicespider,
@@ -42828,7 +42828,7 @@
 	},
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "fNA" = (
 /obj/item/storage/wall/random{
 	dir = 8;
@@ -42890,7 +42890,7 @@
 	},
 /obj/machinery/light/runway_light,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "fQF" = (
 /obj/storage/closet/wardrobe/green,
 /obj/decal/cleanable/dirt,
@@ -43546,7 +43546,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "gvH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -43821,7 +43821,7 @@
 /obj/machinery/turret,
 /obj/lattice,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "gMO" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
@@ -43881,7 +43881,7 @@
 	},
 /obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/area/station/security/secwing)
 "gOo" = (
 /obj/machinery/door_control{
 	id = "imports_door";
@@ -44413,7 +44413,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "hir" = (
 /obj/disposalpipe/switch_junction/left/west{
 	mail_tag = "hydroponics";
@@ -44491,7 +44491,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "hnH" = (
 /obj/machinery/door/airlock/pyro/command{
 	name = "Command Centre"
@@ -44701,7 +44701,7 @@
 	dir = 4
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "hyJ" = (
 /obj/cable{
 	d1 = 1;
@@ -45244,6 +45244,9 @@
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
+"inI" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/turret_protected/armory_outside)
 "iod" = (
 /obj/cable{
 	d1 = 2;
@@ -45335,7 +45338,7 @@
 	},
 /obj/machinery/light/runway_light/delay3,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "iuC" = (
 /obj/grille/catwalk{
 	dir = 4
@@ -45703,7 +45706,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "iLk" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet{
@@ -45875,7 +45878,7 @@
 /obj/machinery/light/runway_light/delay2,
 /obj/lattice,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "iRP" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -46692,7 +46695,7 @@
 	},
 /obj/machinery/light/runway_light/delay5,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "jRa" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -46856,7 +46859,7 @@
 	},
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "kbj" = (
 /obj/machinery/atmospherics/binary/volume_pump{
 	dir = 4;
@@ -47405,7 +47408,7 @@
 	tag = ""
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "kDV" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/black,
@@ -47485,7 +47488,7 @@
 	dir = 4
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "kJD" = (
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
@@ -47910,7 +47913,7 @@
 /obj/machinery/light/runway_light,
 /obj/lattice,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "lgr" = (
 /obj/table/reinforced/auto,
 /obj/machinery/defib_mount{
@@ -48278,7 +48281,7 @@
 	},
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "lvJ" = (
 /obj/rack,
 /obj/item/clothing/suit/space/emerg,
@@ -48830,7 +48833,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "maH" = (
 /obj/item/device/radio/intercom/security,
 /obj/filing_cabinet,
@@ -48869,7 +48872,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "mdB" = (
 /obj/machinery/computer/security/wooden_tv,
 /turf/simulated/floor/plating/damaged1,
@@ -49235,7 +49238,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "mBf" = (
 /obj/disposalpipe/segment/bent/west,
 /obj/cable{
@@ -50367,7 +50370,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "nIU" = (
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/science/research_director)
@@ -50424,7 +50427,7 @@
 	},
 /obj/machinery/light/runway_light/delay2,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "nLw" = (
 /obj/cable{
 	d2 = 8;
@@ -50952,7 +50955,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/red,
-/area/station/ai_monitored/armory)
+/area/station/security/secwing)
 "ojD" = (
 /obj/machinery/disposal/cart_port,
 /obj/disposalpipe/trunk/east,
@@ -51831,7 +51834,7 @@
 	},
 /obj/machinery/light/runway_light/delay5,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "pha" = (
 /obj/table/reinforced/auto,
 /obj/item/decoration/ashtray{
@@ -51893,7 +51896,7 @@
 	},
 /obj/machinery/light/runway_light,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "plQ" = (
 /obj/rack,
 /obj/item/ammo/bullets/smoke,
@@ -52103,7 +52106,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
+/area/station/security/secwing)
 "puJ" = (
 /obj/stool/chair/office/yellow{
 	dir = 4
@@ -52168,7 +52171,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "pxy" = (
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -52777,7 +52780,7 @@
 /obj/lattice,
 /obj/machinery/turret,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "pWA" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/mechanical{
@@ -53583,7 +53586,7 @@
 "qLy" = (
 /obj/lattice,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "qLE" = (
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/cable{
@@ -53636,7 +53639,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "qNt" = (
 /obj/machinery/door/airlock/pyro{
 	name = "Catering Cargo Endpoint"
@@ -53997,7 +54000,7 @@
 	tag = ""
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "rgh" = (
 /obj/machinery/disposal/mail/autoname/mining,
 /obj/disposalpipe/trunk/mail/west,
@@ -54553,7 +54556,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "rSs" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -54907,7 +54910,7 @@
 	},
 /obj/machinery/light/runway_light,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "shm" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/firstaid/fire{
@@ -57513,7 +57516,7 @@
 	dir = 4
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "uGb" = (
 /obj/table/wood/auto,
 /obj/item/paper_bin,
@@ -57659,7 +57662,7 @@
 	req_access_txt = "1"
 	},
 /turf/simulated/floor/engine,
-/area/station/ai_monitored/armory)
+/area/station/security/secwing)
 "uOm" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1
@@ -57833,7 +57836,7 @@
 	},
 /obj/machinery/light/runway_light/delay4,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "uVg" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -58629,7 +58632,7 @@
 	},
 /obj/machinery/light/runway_light/delay5,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "vSu" = (
 /obj/stool/chair/couch{
 	dir = 8;
@@ -59013,7 +59016,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "wmT" = (
 /obj/disposalpipe/segment/food,
 /obj/stool/chair/green{
@@ -59422,7 +59425,7 @@
 	},
 /obj/machinery/light/runway_light,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "wFl" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -59559,7 +59562,7 @@
 	},
 /obj/machinery/light/runway_light/delay4,
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "wMM" = (
 /obj/machinery/hair_dye_dispenser,
 /turf/simulated/floor/specialroom/cafeteria,
@@ -59988,7 +59991,7 @@
 	dir = 4
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "xhg" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -60612,7 +60615,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "xLn" = (
 /turf/simulated/floor/yellow,
 /area/station/engine/storage)
@@ -61012,7 +61015,7 @@
 	icon_state = "lattice-dir"
 	},
 /turf/space,
-/area/station/ai_monitored/armory)
+/area/station/turret_protected/armory_outside)
 "xYT" = (
 /obj/storage/secure/closet/engineering/mining,
 /obj/machinery/power/apc/autoname_east,
@@ -120353,11 +120356,11 @@ kfn
 uEv
 cbZ
 hhI
-cba
-cba
-cba
-cba
-cba
+inI
+inI
+inI
+inI
+inI
 cbW
 cbZ
 cbZ
@@ -120955,7 +120958,7 @@ xJy
 qkd
 vTU
 aTu
-cba
+vTU
 cba
 gjV
 sSD
@@ -120963,7 +120966,7 @@ fIi
 qha
 sVX
 cba
-cba
+inI
 cbZ
 cbZ
 kbb
@@ -121265,7 +121268,7 @@ gYY
 mQH
 rAa
 cba
-cba
+inI
 iKQ
 cbZ
 iuB
@@ -121869,7 +121872,7 @@ mCq
 tho
 eIo
 cba
-cba
+inI
 xLa
 cbZ
 vSl
@@ -122163,7 +122166,7 @@ vTU
 vTU
 vTU
 pur
-cba
+vTU
 cba
 pGO
 hEy
@@ -122171,7 +122174,7 @@ xuw
 vvg
 wQJ
 cba
-cba
+inI
 cbZ
 cbZ
 fPI
@@ -122769,11 +122772,11 @@ fYL
 uEv
 cbZ
 hhI
-cba
-cba
-cba
-cba
-cba
+inI
+inI
+inI
+inI
+inI
 cbW
 cbZ
 cbZ

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -49647,7 +49647,18 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/turret,
+/obj/machinery/turretid{
+	name = "External perimeter turret deactivation control";
+	req_access = null;
+	turretArea = /area/station/turret_protected/armory_outside;
+	pixel_y = -24
+	},
+/obj/access_spawn/hos,
+/obj/deployable_turret/riot{
+	active = 1;
+	anchored = 1;
+	dir = 1
+	},
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "mTQ" = (
@@ -57655,11 +57666,6 @@
 "uNX" = (
 /obj/stool/chair/red{
 	dir = 4
-	},
-/obj/machinery/turretid{
-	pixel_x = -26;
-	req_access = null;
-	req_access_txt = "1"
 	},
 /turf/simulated/floor/engine,
 /area/station/security/secwing)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
1. Gives Kondaru an armory exterior area.
2. Extends the brig to cover the armory entrance.
3. Replaces the interior turret with a NARCS.
4. Moves the turret controls to the interior, below the NARCS with HoS access. This matches Cogmap1 armory.
![image](https://user-images.githubusercontent.com/70909958/159235475-cc14f069-1aee-4001-8430-27c00b64883c.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cogmap 1 and Donut 3 have external room armories that use an exterior area to split the armory into two logical areas.
No other map has the armory area extend past the armory doors. Better reporting ingame and in logs of if someone is actually inside the armory itself.
Turrets protect their area, this change means all the exterior turrets don't waste time trying to shoot an intruder through solid walls.
NARCS are fun, unique to armories and also give clear audio to passing players that someone is inside the armory.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Kondaru armory has changed, it now has a NARCS instead of an interior turret, it has interior/exterior logical areas so the exterior turrets no longer attempt to shoot through the walls and the turret control panel has moved inside and now controls the exterior turrets (HoS access).
```