### PR TITLE
Remove confusing duplicate armory area

### DIFF
--- a/code/area.dm
+++ b/code/area.dm
@@ -2725,11 +2725,6 @@ ABSTRACT_TYPE(/area/station/security)
 /area/station/security/checkpoint/research
 		name = "Research Security Checkpoint"
 
-/area/station/security/armory //what the fuck this is not the real armory???
-	name = "Armory" //ai_monitored/armory is, shitty ass code
-	icon_state = "armory"
-	sound_environment = 2
-
 /area/station/security/prison
 	name = "Prison Station"
 	icon_state = "brig"

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -20,8 +20,6 @@
 
 	initialize()
 		armory_area = get_area_by_type(/area/station/ai_monitored/armory)
-		if (!armory_area || armory_area.contents.len <= 1)
-			armory_area = get_area_by_type(/area/station/security/armory)
 
 		src.net_id = generate_net_id(src)
 		MAKE_DEFAULT_RADIO_PACKET_COMPONENT(null, control_frequency)

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -203,7 +203,7 @@
 	},
 /obj/machinery/computer/riotgear,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "av" = (
 /obj/machinery/light/runway_light,
 /obj/lattice{
@@ -1805,7 +1805,7 @@
 /area/station/maintenance/northwest)
 "ez" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "eA" = (
 /turf/simulated/floor/bot,
 /area/station/mining/staff_room)
@@ -2130,7 +2130,7 @@
 	},
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
 /turf/simulated/floor/caution/south,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "fy" = (
 /obj/machinery/gibber,
 /turf/simulated/floor/specialroom/freezer,
@@ -2147,7 +2147,7 @@
 /obj/item/chem_grenade/pepper,
 /obj/item/chem_grenade/pepper,
 /turf/simulated/floor/caution/south,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "fA" = (
 /obj/reagent_dispensers/beerkeg,
 /turf/simulated/floor/black,
@@ -2179,7 +2179,7 @@
 	},
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor/caution/south,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "fF" = (
 /obj/lattice{
 	dir = 6;
@@ -2407,10 +2407,10 @@
 /obj/item/clothing/glasses/nightvision,
 /obj/item/clothing/glasses/nightvision,
 /turf/simulated/floor/caution/east,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gr" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gs" = (
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
@@ -2507,7 +2507,7 @@
 "gM" = (
 /obj/decal/poster/wallsign/cdnp,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gN" = (
 /obj/machinery/power/data_terminal,
 /obj/cable,
@@ -2569,7 +2569,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gX" = (
 /turf/simulated/floor/yellow/side{
 	dir = 9
@@ -6741,7 +6741,7 @@
 "qU" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qV" = (
 /obj/stool/chair/office/yellow{
 	dir = 8
@@ -10005,7 +10005,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "yl" = (
 /obj/machinery/nanofab/mining,
 /turf/simulated/floor/yellow/side{
@@ -17771,7 +17771,7 @@
 	pixel_y = 20
 	},
 /turf/simulated/floor/caution/south,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "RP" = (
 /obj/rack,
 /obj/item/device/radio,
@@ -18014,7 +18014,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "Sy" = (
 /obj/machinery/networked/test_apparatus/xraymachine,
 /obj/decal/tile_edge/stripe/big{
@@ -18773,7 +18773,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/caution/south,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "UM" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -18864,7 +18864,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/caution/east,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "Vb" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -27767,17 +27767,17 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgy" = (
 /obj/disposalpipe/segment/food{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgz" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgB" = (
 /obj/cable{
 	d1 = 4;
@@ -28639,7 +28639,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "biR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -29729,7 +29729,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "blm" = (
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -30733,7 +30733,7 @@
 "bnE" = (
 /obj/disposalpipe/segment/food,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bnG" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/Zeta)
@@ -44030,7 +44030,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "csQ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
@@ -44062,7 +44062,7 @@
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cye" = (
 /obj/cable{
 	d1 = 4;
@@ -44267,7 +44267,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cVf" = (
 /obj/machinery/light,
 /turf/simulated/floor/red/side,
@@ -45186,7 +45186,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "foU" = (
 /obj/landmark/gps_waypoint,
 /obj/cable{
@@ -45505,7 +45505,7 @@
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "fZZ" = (
 /obj/machinery/shuttle/engine/heater{
 	icon_state = "alt_heater-R"
@@ -45587,7 +45587,7 @@
 /area/station/turret_protected/ai)
 "glL" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gnD" = (
 /obj/stool/chair/red{
 	anchored = 0;
@@ -45968,7 +45968,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hpd" = (
 /obj/cable{
 	d1 = 2;
@@ -46534,7 +46534,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "iMu" = (
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
@@ -46661,7 +46661,7 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "jhR" = (
 /obj/cable{
 	d1 = 2;
@@ -46904,7 +46904,7 @@
 	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "jUC" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -47001,7 +47001,7 @@
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "kcx" = (
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -47063,7 +47063,7 @@
 	pixel_y = -19
 	},
 /turf/simulated/floor/redblack,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "khz" = (
 /obj/pool/perspective{
 	dir = 4;
@@ -47537,7 +47537,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/redblack,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "lfI" = (
 /obj/window/auto/reinforced,
 /obj/grille/steel{
@@ -48999,7 +48999,7 @@
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "pox" = (
 /obj/disposalpipe/segment/food{
 	dir = 2;
@@ -49406,14 +49406,14 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qAY" = (
 /obj/disposalpipe/segment/food,
 /obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qBc" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -49614,7 +49614,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "rgv" = (
 /obj/table/wood/auto,
 /obj/item/storage/secure/ssafe{
@@ -49845,7 +49845,7 @@
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "rUq" = (
 /obj/disposalpipe/segment/mail,
 /obj/table/reinforced/auto,
@@ -50454,7 +50454,7 @@
 /turf/simulated/floor/redblack{
 	dir = 10
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "tAi" = (
 /turf/simulated/floor/red/side{
 	dir = 10
@@ -50893,7 +50893,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "uDI" = (
 /obj/disposalpipe/segment/mail,
 /obj/disposalpipe/segment{
@@ -51515,7 +51515,7 @@
 /turf/simulated/floor/redblack/corner{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wlE" = (
 /obj/cable{
 	icon_state = "2-8"

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -494,7 +494,7 @@
 "acn" = (
 /obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aco" = (
 /obj/deployable_turret/riot{
 	active = 1;
@@ -508,7 +508,7 @@
 	},
 /obj/access_spawn/hos,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "acp" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -677,7 +677,7 @@
 /area/station/turret_protected/armory_outside)
 "acV" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "acW" = (
 /obj/lattice{
 	dir = 5;
@@ -993,7 +993,7 @@
 /area/space)
 "adE" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "adF" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -1095,7 +1095,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "adW" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/clown)
@@ -1185,7 +1185,7 @@
 	name = "peststart"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aes" = (
 /obj/decal/poster/wallsign/stencil/right/s{
 	pixel_x = 10
@@ -1416,7 +1416,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aeY" = (
 /obj/storage/crate,
 /obj/item/clothing/under/gimmick/princess,
@@ -1720,7 +1720,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "afP" = (
 /obj/table/auto,
 /obj/machinery/light/small{
@@ -1738,7 +1738,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "afS" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -1889,7 +1889,7 @@
 	pixel_y = 11
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "age" = (
 /obj/decal/cleanable/dirt,
 /obj/item/bananapeel,
@@ -2260,7 +2260,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ahs" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/routing/security)
@@ -2685,7 +2685,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aip" = (
 /obj/machinery/conveyor{
 	name = "cargo belt - south";
@@ -3035,7 +3035,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ajj" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -3044,7 +3044,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ajk" = (
 /obj/machinery/door_control{
 	id = "hangar_north";
@@ -3102,7 +3102,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aju" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -3953,7 +3953,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "alQ" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/disposalpipe/segment,
@@ -52477,7 +52477,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "diH" = (
 /obj/machinery/atmospherics/valve{
 	name = "gas mix supply valve"
@@ -53908,7 +53908,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "fpy" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4;
@@ -54037,7 +54037,7 @@
 	},
 /obj/machinery/power/apc/autoname_north/noaicontrol,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "fBp" = (
 /obj/grille/catwalk,
 /obj/cable/yellow{
@@ -54166,7 +54166,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "fGO" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -54332,7 +54332,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "fXj" = (
 /obj/stool/chair{
 	dir = 4
@@ -56924,7 +56924,7 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "kwa" = (
 /obj/disposalpipe/segment/ejection,
 /obj/cable{
@@ -57418,7 +57418,7 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "lCB" = (
 /obj/landmark/gps_waypoint,
 /obj/cable/brown{
@@ -58204,7 +58204,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nje" = (
 /obj/cable/yellow{
 	icon_state = "4-8"
@@ -62018,7 +62018,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "tAc" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -63513,7 +63513,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "vOp" = (
 /obj/shrub{
 	dir = 4;

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -11304,7 +11304,7 @@
 	pixel_x = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aEw" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/hor)
@@ -11355,7 +11355,7 @@
 	pixel_y = 11
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aEE" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/storage/tools)
@@ -22299,7 +22299,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "beu" = (
 /obj/machinery/manufacturer/hangar,
 /turf/simulated/floor,
@@ -27111,7 +27111,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bqd" = (
 /obj/item/storage/toolbox/emergency,
 /obj/disposalpipe/segment/transport{
@@ -32711,7 +32711,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bES" = (
 /obj/machinery/weapon_stand/shotgun_rack,
 /obj/machinery/light/emergency{
@@ -32719,7 +32719,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bET" = (
 /obj/machinery/vending/security_ammo,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/vertical,
@@ -32736,7 +32736,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bEX" = (
 /obj/storage/secure/closet/security/equipment,
 /obj/item_dispenser/handcuffs{
@@ -34684,7 +34684,7 @@
 	name = "Riot Control - Main Hall"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bKu" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/northwest,
 /obj/storage/secure/closet/security/armory,
@@ -34693,7 +34693,7 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bKv" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -34704,7 +34704,7 @@
 	},
 /obj/access_spawn/hos,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bKy" = (
 /obj/cable{
 	d1 = 2;
@@ -35938,18 +35938,18 @@
 "bNE" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/horizontal,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bNF" = (
 /obj/machinery/atmospherics/valve/notify_admins/horizontal{
 	name = "Riot Control - Maintenance"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bNG" = (
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/southwest,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bNH" = (
 /obj/grille/steel,
 /obj/window/auto/reinforced,
@@ -36949,7 +36949,7 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bQw" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/horizontal,
 /obj/disposalpipe/segment/food{
@@ -38157,7 +38157,7 @@
 "bTw" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bTx" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -38196,7 +38196,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bTC" = (
 /obj/item/storage/box/biohazard_bags,
 /obj/machinery/disposal/small/north{
@@ -52245,7 +52245,7 @@
 /area/station/security/main)
 "cKw" = (
 /turf/simulated/wall/auto/reinforced/supernorn/the_tuff_stuff,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cLc" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/wall/auto/supernorn,
@@ -52300,7 +52300,7 @@
 "cQU" = (
 /obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cRB" = (
 /obj/barber_pole,
 /turf/unsimulated/wall/auto/adventure/shuttle/dark,
@@ -52950,7 +52950,7 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "enM" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -53293,7 +53293,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "flX" = (
 /obj/table/wood/auto,
 /obj/item/dice/coin,
@@ -57167,7 +57167,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "owV" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -58116,7 +58116,7 @@
 /area/station/maintenance/northwest)
 "qNy" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qOH" = (
 /obj/decal/poster/wallsign/stencil/right/e,
 /obj/decal/poster/wallsign/stencil/left/r{
@@ -58233,7 +58233,7 @@
 /obj/item/old_grenade/spawner/banana,
 /obj/machinery/light,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "rhI" = (
 /obj/lattice{
 	dir = 4;
@@ -60065,7 +60065,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "vtN" = (
 /obj/cable{
 	d1 = 4;

--- a/maps/horizon_xmas.dmm
+++ b/maps/horizon_xmas.dmm
@@ -16092,7 +16092,7 @@
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aME" = (
 /obj/machinery/light{
 	dir = 1;
@@ -17074,7 +17074,7 @@
 /obj/item/old_grenade/spawner/banana,
 /obj/item/old_grenade/spawner/banana,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aOL" = (
 /turf/simulated/shuttle/wall{
 	dir = 8;
@@ -23250,7 +23250,7 @@
 	},
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bbs" = (
 /obj/decal/poster/wallsign/stencil/right/e,
 /obj/decal/poster/wallsign/stencil/left/s,
@@ -24527,7 +24527,7 @@
 /obj/access_spawn/hos,
 /obj/decal/garland,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bek" = (
 /obj/disposalpipe/trunk{
 	dir = 8;
@@ -28365,7 +28365,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bme" = (
 /obj/disposalpipe/trunk,
 /obj/machinery/floorflusher/industrial{
@@ -35889,11 +35889,11 @@
 /area/station/security/checkpoint/sec_foyer)
 "bCj" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bCk" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bCl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
@@ -38447,7 +38447,7 @@
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bHO" = (
 /obj/machinery/vending/security_ammo,
 /obj/cable{
@@ -38456,7 +38456,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bHP" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/vertical,
 /obj/machinery/computer3/generic/communications,
@@ -38466,7 +38466,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bHQ" = (
 /obj/grille/catwalk{
 	dir = 6;
@@ -39850,7 +39850,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bKN" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -39863,21 +39863,21 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bKO" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/southwest,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bKP" = (
 /obj/disposalpipe/segment/bent/east,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/vertical,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bKQ" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -39889,7 +39889,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bKR" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -41443,7 +41443,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bOb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -41456,7 +41456,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bOc" = (
 /obj/cable{
 	d2 = 8;
@@ -41477,7 +41477,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bOd" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -42726,7 +42726,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bQO" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/machinery/atmospherics/pipe/manifold/overfloor/south,
@@ -42735,7 +42735,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bQP" = (
 /obj/disposalpipe/segment/brig,
 /obj/disposalpipe/segment/food{
@@ -42745,7 +42745,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bQQ" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -42760,7 +42760,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bQR" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -44114,7 +44114,7 @@
 /turf/simulated/floor/redblack{
 	dir = 10
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bTM" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
@@ -44132,7 +44132,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bTO" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -44146,7 +44146,7 @@
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bTP" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -60213,7 +60213,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "sVX" = (
 /obj/item/paper/book/from_file/pocketguide/quartermaster,
 /turf/simulated/floor/plating/random,

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -5739,7 +5739,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bGE" = (
 /obj/table/auto,
 /obj/machinery/computer3/generic/personal,
@@ -7896,7 +7896,7 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cni" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -8425,7 +8425,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cvq" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/grey,
@@ -9948,7 +9948,7 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cTf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -10761,7 +10761,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/caution/corner/se,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ddC" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -10822,7 +10822,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "der" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -18077,7 +18077,7 @@
 "fgu" = (
 /obj/machinery/atmospherics/pipe/simple/overfloor/southeast,
 /turf/simulated/floor/caution/north,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "fgw" = (
 /obj/rack,
 /obj/item/reagent_containers/glass/bottle/acetone/janitors{
@@ -18429,7 +18429,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "flo" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -26810,7 +26810,7 @@
 /turf/simulated/floor/caution/corner/misc{
 	dir = 10
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hwp" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -27511,7 +27511,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/northsouth,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hIh" = (
 /obj/machinery/atmospherics/pipe/simple,
 /turf/simulated/floor/blueblack/corner{
@@ -28620,7 +28620,7 @@
 /obj/item/clothing/glasses/nightvision,
 /obj/item/clothing/glasses/nightvision,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hZD" = (
 /obj/table/auto,
 /obj/machinery/computer3/generic/personal,
@@ -29590,7 +29590,7 @@
 	pixel_x = 23
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "irk" = (
 /obj/cable{
 	d1 = 4;
@@ -31501,7 +31501,7 @@
 "iSS" = (
 /obj/machinery/vending/security_ammo,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "iTc" = (
 /obj/cable{
 	d1 = 2;
@@ -34352,7 +34352,7 @@
 /area/station/quartermaster/office)
 "jGP" = (
 /turf/simulated/floor/caution/corner/nw,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "jGW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -35018,7 +35018,7 @@
 "jQO" = (
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "jQQ" = (
 /turf/simulated/floor{
 	desc = "";
@@ -36479,7 +36479,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "kkd" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -36957,7 +36957,7 @@
 	},
 /obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "krb" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -39383,7 +39383,7 @@
 /obj/item/clothing/glasses/thermal,
 /obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "laJ" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/cable{
@@ -42366,7 +42366,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/east,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "lOc" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
@@ -44841,7 +44841,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/caution/corner/ne,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "muX" = (
 /obj/machinery/rkit,
 /turf/simulated/floor/yellow/side{
@@ -44872,7 +44872,7 @@
 /turf/simulated/floor/caution/corner/misc{
 	dir = 9
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "mvD" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -48020,7 +48020,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/stairs/wide/other,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nta" = (
 /obj/machinery/door/airlock/pyro/glass,
 /obj/cable{
@@ -48118,7 +48118,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nuh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -48852,7 +48852,7 @@
 "nEE" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nEG" = (
 /obj/table/auto,
 /obj/machinery/light,
@@ -50832,7 +50832,7 @@
 /obj/machinery/weapon_stand/shotgun_rack,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/horizontal,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ofE" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -52348,7 +52348,7 @@
 /area/station/security/brig)
 "oAw" = (
 /turf/simulated/floor/caution/corner/sw,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "oAx" = (
 /obj/stool/chair,
 /turf/simulated/floor/carpet/red/fancy/edge/ne,
@@ -52696,7 +52696,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/caution/northsouth,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "oEN" = (
 /obj/table/auto,
 /obj/item/paper_bin,
@@ -53005,7 +53005,7 @@
 /obj/item/reagent_containers/emergency_injector/atropine,
 /obj/item/reagent_containers/emergency_injector/atropine,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "oJx" = (
 /obj/table/auto,
 /obj/machinery/phone,
@@ -59315,7 +59315,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qzN" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/machinery/power/apc/autoname_north,
@@ -59817,7 +59817,7 @@
 "qGy" = (
 /obj/machinery/atmospherics/pipe/tank/sleeping_agent/north,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qGA" = (
 /obj/storage/closet/janitor,
 /obj/machinery/light/small{
@@ -60842,7 +60842,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qUf" = (
 /obj/stool/chair/boxingrope_corner{
 	dir = 6;
@@ -62566,7 +62566,7 @@
 /obj/item/clothing/glasses/thermal,
 /obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "rsu" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -63561,7 +63561,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "rEV" = (
 /obj/machinery/light,
 /obj/machinery/door_control{
@@ -65498,7 +65498,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "sfi" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -70940,7 +70940,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/northsouth,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "twS" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -71621,7 +71621,7 @@
 /area/station/medical/medbay/lobby)
 "tHt" = (
 /turf/simulated/floor/stairs/wide,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "tHA" = (
 /turf/simulated/floor/black,
 /area/station/storage/warehouse)
@@ -80735,7 +80735,7 @@
 /area/station/engine/engineering)
 "vWl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "vWp" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -82723,7 +82723,7 @@
 /area/space)
 "wwj" = (
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wwx" = (
 /obj/stool/chair/red,
 /obj/cable{
@@ -83064,7 +83064,7 @@
 "wzX" = (
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wAh" = (
 /obj/wingrille_spawn/auto/crystal,
 /obj/cable{
@@ -83705,7 +83705,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wGQ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "tour;next_tour=tour3;desc=Janitor's office is on the left here. You make a mess, swing by, it'll get cleaned up. Probably. Door on your right's the backstage.";
@@ -84346,7 +84346,7 @@
 /obj/machinery/atmospherics/pipe/tank/air_repressurization/north,
 /obj/machinery/light,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wPU" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -85033,7 +85033,7 @@
 "wYK" = (
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/caution/south,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wYS" = (
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/station/crew_quarters/quartersA)
@@ -85578,7 +85578,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/caution/east,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "xeV" = (
 /obj/machinery/disposal/cart_port,
 /obj/disposalpipe/trunk/west,
@@ -86134,7 +86134,7 @@
 "xmj" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "xml" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -88072,7 +88072,7 @@
 "xJQ" = (
 /obj/storage/secure/crate/gear/armory/grenades,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "xJT" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/green/checker,
@@ -90279,7 +90279,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/caution/northsouth,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ymf" = (
 /obj/grille/catwalk{
 	dir = 6

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -3729,7 +3729,7 @@
 	name = "peststart"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "afL" = (
 /obj/cable{
 	d1 = 1;
@@ -5149,7 +5149,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aic" = (
 /obj/cable{
 	d1 = 1;
@@ -12504,7 +12504,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "atE" = (
 /obj/cable{
 	d1 = 4;
@@ -13330,7 +13330,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "auN" = (
 /obj/cable{
 	d1 = 4;
@@ -13935,7 +13935,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "avL" = (
 /obj/cable{
 	d1 = 4;
@@ -15029,7 +15029,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "axY" = (
 /obj/cable{
 	d1 = 6;
@@ -18204,7 +18204,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aFH" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4;
@@ -40264,7 +40264,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bzr" = (
 /obj/machinery/door/airlock/pyro/security{
 	aiControlDisabled = 1;
@@ -40277,7 +40277,7 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bzs" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Arrivals Desk";
@@ -49350,7 +49350,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bQy" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -50432,7 +50432,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bSh" = (
 /obj/rack,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -51198,11 +51198,11 @@
 	},
 /obj/machinery/power/apc/autoname_north/noaicontrol,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bUp" = (
 /obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bUq" = (
 /obj/machinery/weapon_stand/taser_rack/recharger/empty,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -51561,7 +51561,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bVe" = (
 /obj/rack,
 /obj/item/caution{
@@ -51767,7 +51767,7 @@
 	pixel_y = 11
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bVl" = (
 /obj/rack,
 /obj/item/clothing/mask/gas/emergency{
@@ -57233,7 +57233,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cfT" = (
 /obj/storage/secure/crate/plasma/armory/anti_biological{
 	req_access = null
@@ -61071,7 +61071,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ckJ" = (
 /obj/table/auto,
 /obj/machinery/recharger{
@@ -64693,7 +64693,7 @@
 /area/station/medical/robotics)
 "crq" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "crr" = (
 /turf/simulated/floor/black,
 /area/station/security/checkpoint)
@@ -66805,7 +66805,7 @@
 /area/station/science/teleporter)
 "cAL" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cAM" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
@@ -67380,7 +67380,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "dcm" = (
 /obj/storage/crate/adventure,
 /obj/decal/tile_edge/stripe/extra_big{
@@ -67480,7 +67480,7 @@
 	},
 /obj/access_spawn/hos,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "dOS" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
@@ -67713,7 +67713,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "fsm" = (
 /obj/machinery/vending/cola/red,
 /turf/simulated/floor,
@@ -68101,7 +68101,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hHs" = (
 /obj/cable/brown{
 	d1 = 4;
@@ -68653,7 +68653,7 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "laJ" = (
 /obj/storage/crate/robotparts,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -68991,7 +68991,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nwg" = (
 /obj/cable{
 	d1 = 4;
@@ -69327,7 +69327,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "pqJ" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/light,

--- a/maps/unused/atlas_old.dmm
+++ b/maps/unused/atlas_old.dmm
@@ -1114,7 +1114,7 @@
 "ds" = (
 /obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "dt" = (
 /turf/simulated/floor/red,
 /area/station/security/brig)
@@ -1265,7 +1265,7 @@
 "dS" = (
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "dT" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -1351,7 +1351,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "eg" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -1376,7 +1376,7 @@
 /area/station/quartermaster/office)
 "ei" = (
 /turf/simulated/wall/auto/reinforced/supernorn/the_tuff_stuff,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ej" = (
 /turf/simulated/floor/specialroom/chapel{
 	dir = 1
@@ -1558,7 +1558,7 @@
 /obj/item/chem_grenade/pepper,
 /obj/item/chem_grenade/pepper,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "eI" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -2592,7 +2592,7 @@
 "hl" = (
 /obj/storage/secure/crate/plasma/armory,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hm" = (
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -2944,7 +2944,7 @@
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hV" = (
 /turf/simulated/wall/auto/supernorn/the_tuff_stuff,
 /area/station/hallway/primary/west)
@@ -9126,7 +9126,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wl" = (
 /obj/machinery/vehicle/miniputt/indyputt,
 /obj/machinery/light,
@@ -16671,7 +16671,7 @@
 "Zz" = (
 /obj/decal/poster/wallsign/framed_award/hos_medal,
 /turf/simulated/wall/auto/reinforced/supernorn/the_tuff_stuff,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 
 (1,1,1) = {"
 aa

--- a/maps/unused/chiron.dmm
+++ b/maps/unused/chiron.dmm
@@ -18766,7 +18766,7 @@
 	},
 /obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aLL" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -26666,7 +26666,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "baI" = (
 /obj/stool/chair{
 	dir = 4
@@ -27074,7 +27074,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bbA" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -27093,7 +27093,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bbB" = (
 /obj/table/auto,
 /obj/item/device/radio/electropack,
@@ -27111,7 +27111,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bbC" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -27550,7 +27550,7 @@
 /area/station/security/brig)
 "bcp" = (
 /turf/simulated/wall/auto/reinforced/gannets,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bcq" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light_switch{
@@ -27569,10 +27569,10 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bcs" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bct" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Outpost Airlock";
@@ -28474,7 +28474,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ben" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -29820,7 +29820,7 @@
 	name = "brig pipe"
 	},
 /turf/simulated/wall/auto/reinforced/gannets,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgR" = (
 /obj/cable{
 	icon_state = "2-8";
@@ -29836,13 +29836,13 @@
 	},
 /obj/machinery/vending/security_ammo,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgT" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/gannets,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgU" = (
 /obj/cable{
 	icon_state = "4-8";
@@ -30590,7 +30590,7 @@
 "bis" = (
 /obj/disposalpipe/segment/brig,
 /turf/simulated/wall/auto/reinforced/gannets,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bit" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/cable{
@@ -33839,7 +33839,7 @@
 /obj/item/ammo/bullets/tranq_darts,
 /obj/item/ammo/bullets/tranq_darts,
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bpB" = (
 /turf/simulated/wall/auto/reinforced/gannets,
 /area/station/maintenance/south)
@@ -33915,7 +33915,7 @@
 /obj/item/ammo/bullets/flare,
 /obj/item/gun/kinetic/flaregun,
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bpO" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/engine/vacuum,

--- a/maps/unused/devship.dmm
+++ b/maps/unused/devship.dmm
@@ -1127,11 +1127,11 @@
 /area/station/crew_quarters/kitchen)
 "dr" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ds" = (
 /obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "dt" = (
 /turf/simulated/floor/red,
 /area/station/security/brig)
@@ -1299,7 +1299,7 @@
 "dS" = (
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "dT" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -1386,7 +1386,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "eg" = (
 /obj/machinery/door/airlock/pyro/alt{
 	name = "Catering Storage"
@@ -1587,7 +1587,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "eI" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -2585,7 +2585,7 @@
 "hl" = (
 /obj/storage/secure/crate/plasma/armory,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hm" = (
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -2959,7 +2959,7 @@
 	},
 /obj/firedoor_spawn,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hV" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/engineering)
@@ -9098,7 +9098,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wl" = (
 /obj/machinery/vehicle/miniputt/indyputt,
 /obj/machinery/light,

--- a/maps/unused/donut2.dmm
+++ b/maps/unused/donut2.dmm
@@ -30456,7 +30456,7 @@
 	},
 /obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "biw" = (
 /obj/grille/steel,
 /obj/window/reinforced{
@@ -30819,7 +30819,7 @@
 /area/station/security/hos)
 "bjs" = (
 /turf/simulated/wall/r_wall,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bjt" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -31328,7 +31328,7 @@
 	},
 /obj/machinery/vending/security_ammo,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bkn" = (
 /obj/window/reinforced{
 	icon_state = "rwindow";
@@ -31342,7 +31342,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bko" = (
 /obj/table/reinforced/auto,
 /obj/item/clothing/suit/straight_jacket,
@@ -31360,7 +31360,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bkp" = (
 /obj/storage/closet/wardrobe/white/genetics,
 /turf/simulated/floor/greenwhite{
@@ -31570,10 +31570,10 @@
 	d2 = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bkP" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bkQ" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -31583,7 +31583,7 @@
 /obj/cable,
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bkR" = (
 /obj/grille/steel,
 /obj/window/reinforced{
@@ -31883,11 +31883,11 @@
 /obj/item/ammo/bullets/autocannon/seeker,
 /obj/item/ammo/bullets/autocannon/seeker,
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "blz" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "blA" = (
 /obj/grille/catwalk/cross{
 	dir = 10

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -25496,7 +25496,7 @@
 /area/station/crew_quarters/fitness)
 "bgP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgQ" = (
 /obj/machinery/light{
 	dir = 8;
@@ -25670,7 +25670,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bhb" = (
 /obj/cable{
 	d1 = 4;
@@ -26476,11 +26476,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "biX" = (
 /obj/machinery/weapon_stand/rifle_rack/recharger,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "biY" = (
 /obj/cable{
 	d1 = 2;
@@ -26596,7 +26596,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bjo" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/bar)
@@ -26703,7 +26703,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bjE" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/main)
@@ -26743,7 +26743,7 @@
 "bjI" = (
 /obj/storage/secure/crate/gear/armory/grenades,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bjJ" = (
 /obj/machinery/door/airlock/pyro/security/alt,
 /obj/access_spawn/brig,
@@ -27204,7 +27204,7 @@
 	pixel_y = 11
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bkP" = (
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -27643,7 +27643,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "blV" = (
 /obj/cable{
 	d1 = 2;
@@ -27729,7 +27729,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bme" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -29225,7 +29225,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bpu" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light{
@@ -29295,7 +29295,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bpE" = (
 /obj/table/auto,
 /obj/item/game_kit,
@@ -29467,7 +29467,7 @@
 "bqc" = (
 /obj/storage/secure/crate/weapon/armory/tranquilizer,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bqd" = (
 /obj/cable{
 	d2 = 4;
@@ -29548,7 +29548,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bql" = (
 /obj/cable{
 	d1 = 4;
@@ -29637,7 +29637,7 @@
 "bqt" = (
 /obj/storage/secure/crate/weapon/armory/phaser,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bqu" = (
 /obj/cable{
 	d1 = 4;
@@ -30089,7 +30089,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "brz" = (
 /obj/table,
 /obj/machinery/microwave,
@@ -33561,7 +33561,7 @@
 /area/station/security/brig)
 "bzC" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bzD" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass/icing,
@@ -38210,7 +38210,7 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "csb" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/shuttlebay{
@@ -38955,7 +38955,7 @@
 	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/airless,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ere" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -39178,7 +39178,7 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "eJS" = (
 /obj/machinery/recharge_station,
 /obj/machinery/camera{
@@ -40196,7 +40196,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gZd" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -40339,7 +40339,7 @@
 "hus" = (
 /obj/machinery/vending/security_ammo,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "huK" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -40809,7 +40809,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ioB" = (
 /obj/machinery/emitter{
 	dir = 4
@@ -42677,7 +42677,7 @@
 "mHk" = (
 /obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "mHm" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/carpet{
@@ -42990,7 +42990,7 @@
 	},
 /obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nwq" = (
 /obj/lattice{
 	dir = 2;
@@ -43621,7 +43621,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "oWl" = (
 /obj/machinery/vehicle/pod_smooth/industrial{
 	dir = 4
@@ -44294,7 +44294,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating/airless,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qmQ" = (
 /obj/machinery/conveyor{
 	id = "cargo"
@@ -44477,7 +44477,7 @@
 /obj/cable,
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/airless,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qKG" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
@@ -44926,7 +44926,7 @@
 	},
 /obj/access_spawn/hos,
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "rWe" = (
 /obj/disposalpipe/segment/mail,
 /obj/decal/tile_edge/floorguide/command{
@@ -45017,7 +45017,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "sdc" = (
 /obj/landmark{
 	name = "SR Welder"
@@ -45167,7 +45167,7 @@
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/security/alt,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "smw" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/redblack{
@@ -45189,7 +45189,7 @@
 	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/airless,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "snf" = (
 /obj/storage/crate,
 /turf/simulated/floor/plating,
@@ -45232,7 +45232,7 @@
 	pixel_y = -20
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "sqV" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/engine,
@@ -45417,7 +45417,7 @@
 	dir = 2
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "sGD" = (
 /obj/table/reinforced/chemistry/auto,
 /obj/item/reagent_containers/iv_drip/saline{
@@ -46296,7 +46296,7 @@
 	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/airless,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "uwR" = (
 /obj/lattice{
 	dir = 5;
@@ -46419,7 +46419,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "uMP" = (
 /obj/tree1,
 /turf/simulated/wall{
@@ -46789,7 +46789,7 @@
 	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/airless,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "vEk" = (
 /obj/stool/bench/green/auto,
 /turf/simulated/floor/greenwhite/other{
@@ -46835,7 +46835,7 @@
 "vIK" = (
 /obj/machinery/light,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "vLf" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -47073,7 +47073,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wqj" = (
 /obj/machinery/camera{
 	c_tag = "Science Hangar";
@@ -47312,7 +47312,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wOn" = (
 /turf/simulated/floor/yellow/side{
 	dir = 6
@@ -47582,7 +47582,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "xwe" = (
 /obj/machinery/shieldgenerator/meteorshield,
 /turf/simulated/floor/plating,

--- a/maps/unused/halloween12.dmm
+++ b/maps/unused/halloween12.dmm
@@ -21134,7 +21134,7 @@
 /area/station/security/hos)
 "aPj" = (
 /turf/simulated/wall/r_wall,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aPk" = (
 /obj/closet/l3closet,
 /turf/simulated/floor/white,
@@ -21447,14 +21447,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aPX" = (
 /obj/machinery/camera/motion{
 	c_tag = "Armory";
 	dir = 2
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aPY" = (
 /obj/window/reinforced{
 	tag = "icon-rwindow (EAST)";
@@ -21470,7 +21470,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aPZ" = (
 /obj/secure_closet/animal,
 /turf/simulated/floor/white,
@@ -21667,7 +21667,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aQw" = (
 /obj/cable{
 	icon_state = "2-8";
@@ -21675,10 +21675,10 @@
 	d2 = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aQx" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aQy" = (
 /obj/window/reinforced{
 	tag = "icon-rwindow (EAST)";
@@ -21689,7 +21689,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aQz" = (
 /obj/grille/steel,
 /obj/window/reinforced{
@@ -21949,7 +21949,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aRf" = (
 /obj/window/reinforced{
 	tag = "icon-rwindow (EAST)";
@@ -21965,7 +21965,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aRg" = (
 /obj/window/reinforced{
 	tag = "icon-rwindow (EAST)";

--- a/maps/unused/halloween14.dmm
+++ b/maps/unused/halloween14.dmm
@@ -27846,7 +27846,7 @@
 /area/station/security/hos)
 "bde" = (
 /turf/simulated/wall/r_wall,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bdf" = (
 /obj/closet/l3closet,
 /turf/simulated/floor/white/grime{
@@ -28210,14 +28210,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bdY" = (
 /obj/machinery/camera/motion{
 	c_tag = "Armory";
 	dir = 2
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bdZ" = (
 /obj/window/reinforced{
 	tag = "icon-rwindow (EAST)";
@@ -28233,7 +28233,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bea" = (
 /obj/secure_closet/animal,
 /turf/simulated/floor/white,
@@ -28434,7 +28434,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bey" = (
 /obj/cable{
 	icon_state = "2-8";
@@ -28442,10 +28442,10 @@
 	d2 = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bez" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "beA" = (
 /obj/window/reinforced{
 	tag = "icon-rwindow (EAST)";
@@ -28456,7 +28456,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "beB" = (
 /obj/grille/steel,
 /obj/window/reinforced{
@@ -28731,7 +28731,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bfj" = (
 /obj/window/reinforced{
 	tag = "icon-rwindow (EAST)";
@@ -28747,7 +28747,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bfk" = (
 /obj/window/reinforced{
 	tag = "icon-rwindow (EAST)";

--- a/maps/unused/horizon_2019.dmm
+++ b/maps/unused/horizon_2019.dmm
@@ -35277,11 +35277,11 @@
 /area/station/security/checkpoint/sec_foyer)
 "bBg" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bBh" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bBi" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
@@ -37745,7 +37745,7 @@
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bGE" = (
 /obj/stool/bed/brig,
 /obj/item/clothing/glasses/vr{
@@ -38992,7 +38992,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bJv" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor/shuttle,
@@ -39003,14 +39003,14 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bJx" = (
 /obj/disposalpipe/segment/bent/east,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/vertical,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bJy" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -39022,7 +39022,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bJz" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -40571,7 +40571,7 @@
 /obj/access_spawn/hos,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bMH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -40586,7 +40586,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bMI" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -40599,7 +40599,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bMJ" = (
 /obj/cable{
 	d2 = 8;
@@ -40620,7 +40620,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bMK" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -41052,7 +41052,7 @@
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bNP" = (
 /obj/landmark{
 	icon_state = "x3";
@@ -41438,7 +41438,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bOG" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -41554,7 +41554,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bOQ" = (
 /obj/landmark{
 	name = "JoinLate"
@@ -41798,14 +41798,14 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bPs" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/machinery/atmospherics/pipe/manifold/overfloor/south,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bPt" = (
 /obj/disposalpipe/segment/brig,
 /obj/disposalpipe/segment/food{
@@ -41815,7 +41815,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bPu" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -41830,7 +41830,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bPv" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -42725,7 +42725,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bRs" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -43116,14 +43116,14 @@
 /turf/simulated/floor/redblack{
 	dir = 10
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bSj" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /obj/storage/secure/crate/weapon/armory/shotgun,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bSk" = (
 /obj/disposalpipe/segment/brig,
 /obj/table/auto,
@@ -43145,7 +43145,7 @@
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bSm" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -43959,7 +43959,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bUa" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/cable{
@@ -44210,7 +44210,7 @@
 "bUH" = (
 /obj/disposalpipe/segment/brig,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bUI" = (
 /obj/disposalpipe/segment/transport,
 /obj/stool/chair/red{
@@ -47215,7 +47215,7 @@
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
 /obj/item/shipcomponent/mainweapon/disruptor,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cax" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -57559,7 +57559,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "iuM" = (
 /obj/table/wood/round/auto,
 /obj/item/paper/book/from_file/critter_compendium,

--- a/maps/unused/linemap.dmm
+++ b/maps/unused/linemap.dmm
@@ -13858,7 +13858,7 @@
 	explosion_resistance = 20;
 	name = "very reinforced wall"
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aGi" = (
 /obj/decal/boxingrope{
 	icon_state = "ringrope";
@@ -14126,16 +14126,16 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aGN" = (
 /obj/item/storage/box/patchbox,
 /obj/iv_stand,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aGO" = (
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aGP" = (
 /obj/decal/boxingrope{
 	density = 1;
@@ -14492,11 +14492,11 @@
 /area/station/security/hos)
 "aHA" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aHB" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aHC" = (
 /obj/item/screwdriver,
 /turf/simulated/floor/plating,
@@ -14717,7 +14717,7 @@
 	},
 /obj/machinery/power/apc/autoname_west,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aIh" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -14728,7 +14728,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aIi" = (
 /obj/machinery/computer3/generic/communications{
 	tag = "icon-comm (WEST)";
@@ -14741,7 +14741,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aIj" = (
 /obj/disposalpipe/segment/mail/vertical,
 /turf/simulated/floor/wood,
@@ -14941,13 +14941,13 @@
 /obj/item/ammo/bullets/tranq_darts,
 /obj/item/ammo/bullets/tranq_darts,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aIJ" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aIK" = (
 /obj/rack,
 /obj/item/clothing/mask/gas,
@@ -14960,7 +14960,7 @@
 /obj/item/chem_grenade/pepper,
 /obj/item/chem_grenade/pepper,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aIL" = (
 /obj/fitness/speedbag/captain,
 /turf/simulated/floor/wood,
@@ -15213,7 +15213,7 @@
 /obj/item/reagent_containers/syringe/haloperidol,
 /obj/item/reagent_containers/syringe/haloperidol,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aJs" = (
 /obj/table/reinforced/auto,
 /obj/machinery/recharger,
@@ -15226,7 +15226,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aJt" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/machinery/light,
@@ -15448,7 +15448,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aJW" = (
 /turf/simulated/wall/auto/gannets,
 /area/station/crew_quarters/bathroom)

--- a/maps/unused/mushroom.dmm
+++ b/maps/unused/mushroom.dmm
@@ -26614,7 +26614,7 @@
 	name = "very r wall";
 	explosion_resistance = 15
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bga" = (
 /turf/space,
 /area/station/turret_protected/ai)
@@ -26713,16 +26713,16 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgn" = (
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgo" = (
 /obj/storage/secure/closet/security/armory{
 	req_access_txt = "37"
 	},
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgp" = (
 /obj/lattice,
 /turf/space,
@@ -26819,7 +26819,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgz" = (
 /obj/machinery/light,
 /turf/space,
@@ -27067,7 +27067,7 @@
 	explosion_resistance = 15;
 	name = "very r wall"
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bhb" = (
 /obj/window/reinforced{
 	tag = "icon-rwindow (EAST)";

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -11480,7 +11480,7 @@
 /area/station/chapel/sanctuary)
 "aTO" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aTP" = (
 /obj/firedoor_spawn,
 /obj/machinery/door/window/southright,
@@ -12520,7 +12520,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aWZ" = (
 /turf/simulated/floor/purple/side{
 	dir = 4
@@ -19805,7 +19805,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bZu" = (
 /obj/stool/chair/comfy/yellow,
 /turf/simulated/floor/carpet{
@@ -19854,7 +19854,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cdX" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/courtroom)
@@ -20427,7 +20427,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cOC" = (
 /obj/table/reinforced/bar,
 /obj/machinery/glass_recycler,
@@ -21867,7 +21867,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "eSw" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -23047,7 +23047,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gmN" = (
 /obj/machinery/atmospherics/pipe/simple{
 	level = 2
@@ -23122,7 +23122,7 @@
 	icon_state = "xtra_bigstripe-corner2"
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gpm" = (
 /obj/machinery/door_control{
 	id = "viparea";
@@ -23182,7 +23182,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gvN" = (
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/kitchen/freezer)
@@ -23831,7 +23831,7 @@
 "hro" = (
 /obj/machinery/weapon_stand/rifle_rack/recharger,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hrr" = (
 /obj/machinery/light/small/floor/cool,
 /obj/decal/tile_edge/line/white{
@@ -24219,7 +24219,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hQk" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -24706,7 +24706,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ioU" = (
 /obj/machinery/light{
 	dir = 4
@@ -26070,7 +26070,7 @@
 	},
 /obj/cable,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "kao" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -26280,7 +26280,7 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "kny" = (
 /obj/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -27174,7 +27174,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "lvP" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -27297,7 +27297,7 @@
 /area/station/engine/engineering/breakroom)
 "lIE" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "lJw" = (
 /obj/lattice,
 /turf/space,
@@ -27490,7 +27490,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "lWh" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -27583,7 +27583,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "meg" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -28112,7 +28112,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "mNS" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -28680,7 +28680,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nzi" = (
 /obj/wingrille_spawn/auto,
 /obj/cable{
@@ -28712,7 +28712,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nAh" = (
 /obj/machinery/networked/artifact_console,
 /obj/machinery/power/data_terminal,
@@ -28991,7 +28991,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nSY" = (
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
@@ -29128,7 +29128,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nZJ" = (
 /obj/shrub,
 /turf/simulated/floor/red/side{
@@ -29315,7 +29315,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "olQ" = (
 /obj/grille/steel,
 /turf/simulated/floor/plating/airless,
@@ -29341,7 +29341,7 @@
 	},
 /obj/machinery/light/incandescent/warm/very,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "onw" = (
 /obj/random_item_spawner/desk_stuff,
 /obj/table/glass/auto,
@@ -30242,7 +30242,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "pmm" = (
 /obj/storage/secure/closet/engineering/mechanic,
 /turf/simulated/floor/yellow/side{
@@ -31380,7 +31380,7 @@
 /turf/simulated/floor/stairs/dark{
 	dir = 1
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qzV" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -32525,7 +32525,7 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "rIi" = (
 /obj/cable,
 /obj/cable{
@@ -32775,7 +32775,7 @@
 /obj/cable,
 /obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "rXg" = (
 /turf/simulated/floor/caution/west,
 /area/station/science/artifact)
@@ -32980,7 +32980,7 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "sni" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -33750,7 +33750,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "tdM" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -34494,7 +34494,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "tLi" = (
 /turf/simulated/floor/white,
 /area/station/turret_protected/AIsat)
@@ -35290,7 +35290,7 @@
 	},
 /obj/machinery/vending/security_ammo,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "uEg" = (
 /obj/machinery/light/small/floor/cool,
 /obj/cable{
@@ -36238,7 +36238,7 @@
 	},
 /obj/machinery/light/incandescent/warm/very,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "vJu" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/security/detectives_office)
@@ -36538,7 +36538,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wcF" = (
 /obj/disposalpipe/segment/ejection{
 	dir = 4
@@ -37639,7 +37639,7 @@
 "xuE" = (
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "xuF" = (
 /obj/machinery/light,
 /obj/cable{
@@ -37758,7 +37758,7 @@
 "xyI" = (
 /obj/machinery/weapon_stand/shotgun_rack,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "xyJ" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/disposalpipe/segment/mail{

--- a/maps/unused/mushroom_new_xmas.dmm
+++ b/maps/unused/mushroom_new_xmas.dmm
@@ -27275,7 +27275,7 @@
 /area/station/security/brig)
 "bfw" = (
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bfx" = (
 /obj/machinery/bot/secbot/beepsky,
 /obj/item/clothing/suit/bedsheet,
@@ -27534,7 +27534,7 @@
 /area/station/security/brig)
 "bfZ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bga" = (
 /turf/space,
 /area/station/turret_protected/ai)
@@ -27627,7 +27627,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgn" = (
 /turf/simulated/floor/red/side{
 	dir = 9
@@ -27635,7 +27635,7 @@
 /area/station/security/brig)
 "bgo" = (
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgp" = (
 /obj/lattice,
 /turf/space,
@@ -27717,7 +27717,7 @@
 	},
 /obj/storage/secure/crate/plasma/armory/anti_biological,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgy" = (
 /obj/cable{
 	icon_state = "4-8";
@@ -27732,7 +27732,7 @@
 /obj/storage/secure/crate/weapon/armory/shotgun,
 /obj/machinery/light,
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bgA" = (
 /obj/cable{
 	icon_state = "0-4";
@@ -31309,7 +31309,7 @@
 "bnN" = (
 /obj/storage/secure/crate/gear/armory/grenades,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bnO" = (
 /obj/storage/secure/closet/security/armory{
 	req_access_txt = "37"
@@ -31317,7 +31317,7 @@
 /obj/item/gun/kinetic/flaregun,
 /obj/item/ammo/bullets/flare,
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bnP" = (
 /obj/machinery/drainage,
 /turf/simulated/floor/sanitary,

--- a/maps/unused/old_trunkmap.dmm
+++ b/maps/unused/old_trunkmap.dmm
@@ -31644,25 +31644,25 @@
 /area/station/engine/engineering)
 "btT" = (
 /turf/simulated/wall/r_wall,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "btU" = (
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "btV" = (
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "btW" = (
 /obj/rack,
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "btX" = (
 /obj/machinery/light{
 	dir = 1;
 	name = "light fixture"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "btY" = (
 /turf/simulated/wall/asteroid{
 	icon_state = "ast1"
@@ -31675,7 +31675,7 @@
 	name = "Sorry"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bua" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/prison)
@@ -31735,19 +31735,19 @@
 	name = "Fire Range Robot"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bui" = (
 /obj/table/reinforced/auto,
 /obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buj" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buk" = (
 /turf/simulated/wall,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bul" = (
 /obj/storage/closet/emergency,
 /turf/simulated/floor,
@@ -31858,7 +31858,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buu" = (
 /obj/cable{
 	icon_state = "2-4";
@@ -31871,7 +31871,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buv" = (
 /obj/cable{
 	icon_state = "4-8";
@@ -31879,7 +31879,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buw" = (
 /obj/cable{
 	icon_state = "4-8";
@@ -31891,7 +31891,7 @@
 	d2 = 2
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bux" = (
 /obj/cable{
 	icon_state = "4-8";
@@ -31899,7 +31899,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor/caution/east,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buy" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -31916,7 +31916,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -31927,7 +31927,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buA" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -31949,7 +31949,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buB" = (
 /obj/cable{
 	icon_state = "2-8";
@@ -32101,18 +32101,18 @@
 /obj/machinery/recharger,
 /obj/cable,
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buR" = (
 /obj/table/auto,
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buS" = (
 /obj/table/auto,
 /obj/machinery/recharger,
 /obj/machinery/light,
 /obj/cable,
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buT" = (
 /obj/cable{
 	d1 = 1;
@@ -32124,7 +32124,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buU" = (
 /obj/cable{
 	icon_state = "4-8";
@@ -32136,7 +32136,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/caution/east,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buV" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -32157,7 +32157,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buW" = (
 /obj/cable{
 	icon_state = "4-8";
@@ -32169,7 +32169,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buX" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -32195,7 +32195,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "buY" = (
 /obj/cable{
 	icon_state = "1-2";

--- a/maps/unused/samedi.dmm
+++ b/maps/unused/samedi.dmm
@@ -13595,7 +13595,7 @@
 /area/station/security/main)
 "aDW" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aDX" = (
 /obj/machinery/power/smes{
 	charge = 2e+007;
@@ -14150,7 +14150,7 @@
 	d2 = 8
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aFi" = (
 /obj/cable{
 	icon_state = "2-8";
@@ -14839,7 +14839,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aGG" = (
 /obj/storage/secure/crate/weapon/armory/phaser,
 /obj/cable{
@@ -14848,7 +14848,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aGH" = (
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
 /obj/machinery/light{
@@ -14859,7 +14859,7 @@
 	},
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aGI" = (
 /obj/table/auto,
 /obj/machinery/light{
@@ -15415,7 +15415,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/plant/lemon,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aHX" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 6;
@@ -15423,7 +15423,7 @@
 	level = 2
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aHY" = (
 /obj/storage/secure/crate/weapon/armory/shotgun,
 /obj/machinery/camera{
@@ -15440,7 +15440,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aHZ" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4;
@@ -15453,7 +15453,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aIa" = (
 /obj/machinery/door/airlock/pyro/command{
 	aiControlDisabled = 1;
@@ -15469,7 +15469,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/delivery,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aIb" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -16049,22 +16049,22 @@
 /obj/item/clothing/glasses/thermal,
 /obj/item/clothing/glasses/thermal,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aJo" = (
 /obj/machinery/atmospherics/valve{
 	name = "Brig Suppression System"
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aJp" = (
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aJq" = (
 /obj/storage/secure/crate/gear/armory/grenades,
 /obj/machinery/power/apc/autoname_east/noaicontrol,
 /obj/cable,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aJr" = (
 /obj/stool/chair/comfy,
 /obj/landmark/start{
@@ -16577,14 +16577,14 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aKz" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aKA" = (
 /obj/table/reinforced/auto,
 /obj/item/gun/kinetic/riot40mm{
@@ -16594,7 +16594,7 @@
 /obj/item/ammo/bullets/smoke,
 /obj/item/gun/kinetic/riot40mm,
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aKB" = (
 /obj/table/reinforced/auto,
 /obj/item/chem_grenade/flashbang,
@@ -16610,7 +16610,7 @@
 	pixel_x = 10
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aKC" = (
 /obj/table/wood/round/auto,
 /obj/cable{
@@ -17718,7 +17718,7 @@
 	d2 = 8
 	},
 /turf/simulated/floor/engine,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "aMU" = (
 /obj/machinery/atmospherics/valve{
 	name = "Chapel Repressurization"

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -27624,7 +27624,7 @@
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cAW" = (
 /obj/table/reinforced/auto,
 /obj/machinery/light/small{
@@ -28174,7 +28174,7 @@
 /turf/simulated/floor/red/side{
 	dir = 5
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "eqo" = (
 /turf/simulated/floor{
 	icon_state = "carpetS"
@@ -28362,7 +28362,7 @@
 	},
 /obj/machinery/vending/security_ammo,
 /turf/simulated/floor/caution/west,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "eVc" = (
 /obj/machinery/door/window/northleft,
 /turf/simulated/floor/carpet/grime,
@@ -28515,7 +28515,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "foT" = (
 /obj/table/auto,
 /obj/disposalpipe/segment,
@@ -28700,7 +28700,7 @@
 	name = "Sorry"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "fXy" = (
 /obj/table/auto,
 /obj/disposalpipe/segment,
@@ -28798,7 +28798,7 @@
 /obj/table/reinforced/auto,
 /obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gnZ" = (
 /obj/machinery/power/smes,
 /obj/cable{
@@ -29037,11 +29037,11 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gRU" = (
 /obj/rack,
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gVo" = (
 /obj/item/device/radio/intercom{
 	frequency = 1357;
@@ -29110,7 +29110,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hqW" = (
 /obj/table/auto,
 /obj/item/assembly/time_ignite,
@@ -29214,7 +29214,7 @@
 	name = "Fire Range Robot"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "hGL" = (
 /obj/grille/steel,
 /obj/window/reinforced{
@@ -29371,7 +29371,7 @@
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ifu" = (
 /obj/machinery/door/poddoor/blast{
 	autoclose = 1;
@@ -29566,7 +29566,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "iHg" = (
 /obj/grille/steel,
 /obj/window/reinforced/south,
@@ -29597,7 +29597,7 @@
 /area/station/security/hos)
 "iJI" = (
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "iKX" = (
 /obj/grille/steel,
 /obj/window/reinforced{
@@ -30131,7 +30131,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "khc" = (
 /turf/simulated/shuttle/wall{
 	dir = 6;
@@ -30194,7 +30194,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/red/side,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ksA" = (
 /turf/simulated/floor/darkpurple,
 /area/station/teleporter)
@@ -30725,7 +30725,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "loK" = (
 /obj/cable{
 	d1 = 2;
@@ -30750,7 +30750,7 @@
 /area/station/maintenance/southwest)
 "luc" = (
 /turf/simulated/wall/r_wall,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "lxz" = (
 /obj/cable{
 	d2 = 2;
@@ -30859,7 +30859,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "lVv" = (
 /turf/simulated/shuttle/wall{
 	dir = 0;
@@ -30974,7 +30974,7 @@
 /obj/machinery/light,
 /obj/cable,
 /turf/simulated/floor/red/side,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "mdm" = (
 /obj/machinery/vending/cards,
 /turf/simulated/floor,
@@ -31112,11 +31112,11 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "mzR" = (
 /obj/storage/secure/closet/security/armory,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "mBg" = (
 /obj/cable{
 	d1 = 1;
@@ -31809,7 +31809,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "oYc" = (
 /obj/cable{
 	d1 = 1;
@@ -31989,7 +31989,7 @@
 /turf/simulated/floor/red/side{
 	dir = 6
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "pDU" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -32050,7 +32050,7 @@
 /turf/simulated/floor/red/side{
 	dir = 9
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "pPx" = (
 /obj/grille/steel,
 /obj/window/reinforced/west,
@@ -32218,7 +32218,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qqf" = (
 /obj/grille/steel,
 /obj/window/reinforced/south,
@@ -32918,7 +32918,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "rXN" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Southeast";
@@ -33210,10 +33210,10 @@
 /turf/simulated/floor/red/side{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "sUS" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "sWl" = (
 /obj/cable{
 	d1 = 1;
@@ -33233,7 +33233,7 @@
 /obj/machinery/recharger,
 /obj/cable,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "sYn" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -33434,13 +33434,13 @@
 /area/station/teleporter)
 "twS" = (
 /turf/simulated/wall,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "txG" = (
 /obj/table/auto,
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "txY" = (
 /obj/machinery/camera{
 	c_tag = "Test Chamber West";
@@ -33522,7 +33522,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "tFL" = (
 /turf/simulated/shuttle/wall{
 	dir = 8;
@@ -33553,7 +33553,7 @@
 /turf/simulated/floor/red/side{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "tJk" = (
 /obj/machinery/door/poddoor{
 	id = "sciencedriver";
@@ -33616,7 +33616,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "tRv" = (
 /obj/grille/steel,
 /obj/window/reinforced{
@@ -34008,7 +34008,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "uza" = (
 /obj/table/reinforced/auto,
 /obj/item/reagent_containers/food/drinks/bottle/wine,
@@ -34028,7 +34028,7 @@
 "uCj" = (
 /obj/table/auto,
 /turf/simulated/floor/red/side,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "uDx" = (
 /obj/grille/steel,
 /obj/window/reinforced/south,
@@ -34143,7 +34143,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "uWM" = (
 /obj/grille/steel,
 /obj/window/reinforced{
@@ -34165,7 +34165,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/caution/east,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "uYx" = (
 /obj/cable{
 	d1 = 4;
@@ -34787,7 +34787,7 @@
 "wVf" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wWu" = (
 /obj/stool,
 /obj/cable{
@@ -34882,7 +34882,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "xxA" = (
 /obj/cable{
 	d1 = 4;
@@ -35065,7 +35065,7 @@
 /turf/simulated/floor/red/side{
 	dir = 1
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "xYh" = (
 /turf/simulated/floor/red/side{
 	dir = 4
@@ -35185,7 +35185,7 @@
 	req_access_txt = "37"
 	},
 /turf/simulated/floor,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ylN" = (
 /obj/cable{
 	d1 = 4;

--- a/maps/warwip/atlas_horizon_xmas_2019.dmm
+++ b/maps/warwip/atlas_horizon_xmas_2019.dmm
@@ -45476,11 +45476,11 @@
 /area/station/security/checkpoint/sec_foyer)
 "bWK" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bWL" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/vertical,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bWM" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
@@ -48030,7 +48030,7 @@
 /turf/simulated/floor/redblack{
 	dir = 9
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ccr" = (
 /obj/machinery/vending/security_ammo,
 /obj/cable{
@@ -48039,7 +48039,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ccs" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/vertical,
 /obj/machinery/computer3/generic/communications,
@@ -48049,7 +48049,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cct" = (
 /obj/machinery/light{
 	dir = 4;
@@ -48064,7 +48064,7 @@
 /turf/simulated/floor/redblack{
 	dir = 5
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ccu" = (
 /obj/stool/bed/brig,
 /obj/item/clothing/glasses/vr{
@@ -49345,7 +49345,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cfr" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -49358,21 +49358,21 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cfs" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/southwest,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cft" = (
 /obj/disposalpipe/segment/bent/east,
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/overfloor/vertical,
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cfu" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -49384,7 +49384,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cfv" = (
 /obj/disposalpipe/segment/brig{
 	dir = 4
@@ -50891,7 +50891,7 @@
 /obj/access_spawn/hos,
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/red,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ciD" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50905,7 +50905,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ciE" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50920,7 +50920,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ciF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -50933,7 +50933,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ciG" = (
 /obj/cable{
 	d2 = 8;
@@ -50954,7 +50954,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ciH" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -52202,14 +52202,14 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "clt" = (
 /obj/disposalpipe/segment/bent/north,
 /obj/machinery/atmospherics/pipe/manifold/overfloor/south,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "clu" = (
 /obj/disposalpipe/segment/brig,
 /obj/disposalpipe/segment/food{
@@ -52219,7 +52219,7 @@
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "clv" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -52234,7 +52234,7 @@
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "clw" = (
 /obj/disposalpipe/segment/food{
 	dir = 4
@@ -53600,14 +53600,14 @@
 /turf/simulated/floor/redblack{
 	dir = 10
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cor" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /obj/storage/secure/crate/weapon/armory/shotgun,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cos" = (
 /obj/disposalpipe/segment/brig,
 /obj/disposalpipe/segment/transport{
@@ -53616,7 +53616,7 @@
 /obj/storage/secure/crate/weapon/armory/pod_weapons,
 /obj/item/shipcomponent/mainweapon/disruptor,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cot" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -53630,7 +53630,7 @@
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cou" = (
 /obj/disposalpipe/segment/transport{
 	dir = 4
@@ -54715,7 +54715,7 @@
 "cqS" = (
 /obj/disposalpipe/segment/brig,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cqT" = (
 /obj/disposalpipe/segment/transport,
 /obj/stool/chair/red{
@@ -75368,7 +75368,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nXe" = (
 /obj/table/reinforced/auto,
 /obj/shrub{

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -609,7 +609,7 @@
 /area/station/maintenance/inner/the_cage)
 "agq" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "agA" = (
 /obj/table/glass/auto,
 /obj/item/storage/pill_bottle/catdrugs,
@@ -3594,7 +3594,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bxz" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "West Solar Panels"
@@ -4162,7 +4162,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "bLh" = (
 /obj/decal/fakeobjects/lighttube_broken,
 /obj/critter/mouse,
@@ -6721,7 +6721,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "cPj" = (
 /obj/dialogueobj/engineerscorpse,
 /obj/storage/closet/wrestling,
@@ -7988,7 +7988,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "doM" = (
 /obj/cable{
 	d1 = 4;
@@ -8120,7 +8120,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "drg" = (
 /obj/cable{
 	d1 = 1;
@@ -9436,7 +9436,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "dQN" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/shuttlebay,
@@ -10250,7 +10250,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "efE" = (
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -16428,7 +16428,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "gRT" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -20568,7 +20568,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "iFW" = (
 /obj/table/auto,
 /obj/machinery/light{
@@ -24035,7 +24035,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "kbF" = (
 /obj/machinery/atmospherics/unary/outlet_injector,
 /turf/simulated/floor,
@@ -24742,7 +24742,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "ktd" = (
 /obj/reagent_dispensers/watertank/big,
 /turf/simulated/floor/caution,
@@ -25447,7 +25447,7 @@
 /obj/machinery/light/emergency,
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "kJM" = (
 /obj/machinery/optable,
 /obj/landmark/gps_waypoint,
@@ -25545,7 +25545,7 @@
 	},
 /obj/item/breaching_hammer,
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "kMt" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
@@ -27803,7 +27803,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "lKH" = (
 /obj/machinery/door/poddoor/blast/pyro{
 	autoclose = 1;
@@ -28482,7 +28482,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "lYJ" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor,
@@ -30530,7 +30530,7 @@
 	icon_state = "delivery2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "mXZ" = (
 /obj/pool/perspective{
 	dir = 1;
@@ -31100,7 +31100,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nmd" = (
 /obj/decal/tile_edge/stripe{
 	dir = 6;
@@ -32025,7 +32025,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "nFV" = (
 /obj/stool/bench/auto,
 /obj/machinery/light_switch{
@@ -33426,7 +33426,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "oiP" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -34070,7 +34070,7 @@
 /area/station/crew_quarters/data)
 "owR" = (
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "oxB" = (
 /obj/machinery/atmospherics/pipe/simple/southwest,
 /turf/simulated/floor,
@@ -35361,7 +35361,7 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "pdF" = (
 /obj/machinery/light{
 	dir = 1;
@@ -39583,7 +39583,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "qRu" = (
 /obj/rack,
 /obj/item/device/light/flashlight,
@@ -40568,7 +40568,7 @@
 /area/ghostdrone_factory)
 "rpC" = (
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "rpF" = (
 /turf/simulated/floor/wood/two,
 /area/research_outpost/protest)
@@ -40782,7 +40782,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "rvr" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -48555,7 +48555,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "uOj" = (
 /obj/disposalpipe/segment/food,
 /turf/simulated/wall/auto/supernorn,
@@ -49185,7 +49185,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "var" = (
 /obj/decal/cleanable/dirt/dirt2,
 /obj/machinery/door/firedoor/pyro,
@@ -51526,7 +51526,7 @@
 "wce" = (
 /obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wcf" = (
 /obj/stool/bench/auto,
 /obj/landmark/start{
@@ -53401,7 +53401,7 @@
 	icon_state = "delivery2"
 	},
 /turf/simulated/floor/black,
-/area/station/security/armory)
+/area/station/ai_monitored/armory)
 "wOu" = (
 /obj/machinery/light,
 /obj/cable{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Kills off /area/station/security/armory
Replaces with /area/station/ai_monitored/armory

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We already have armory at home.