### PR TITLE
Make containment fields explosion immune

### DIFF
--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -805,6 +805,9 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 	..()
 
+/obj/machinery/containment_field/ex_act(severity)
+	return
+
 /obj/machinery/containment_field/attack_hand(mob/user as mob)
 	return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes containment_fields explosion proof.

![image](https://user-images.githubusercontent.com/70909958/159356033-1cd2dd92-bae1-4109-9a42-f27fc7a4c54c.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's an energy beam, why would it get broken? Looks silly.
Does not really change existing behavior too much, field generators are not explosion proof and can be destroyed to remove the beam.