### PR TITLE
Randomizes the discs contained within the records in the radio station.

### DIFF
--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -407,51 +407,51 @@ ABSTRACT_TYPE(/obj/item/record/random)
 	record_name = "chill track #4"
 	song = "sound/radio_station/music/chill_4.ogg"
 
-/obj/item/record/january
+/obj/item/record/random/january
 	record_name = "january"
 	song = "sound/radio_station/music/january.xm"
 
-/obj/item/record/february
+/obj/item/record/random/february
 	record_name = "february"
 	song = "sound/radio_station/music/february.xm"
 
-/obj/item/record/march
+/obj/item/record/random/march
 	record_name = "march"
 	song = "sound/radio_station/music/march.xm"
 
-/obj/item/record/april
+/obj/item/record/random/april
 	record_name = "april"
 	song = "sound/radio_station/music/april.xm"
 
-/obj/item/record/may
+/obj/item/record/random/may
 	record_name = "may"
 	song = "sound/radio_station/music/may.xm"
 
-/obj/item/record/june
+/obj/item/record/random/june
 	record_name = "june"
 	song = "sound/radio_station/music/june.xm"
 
-/obj/item/record/july
+/obj/item/record/random/july
 	record_name = "july"
 	song = "sound/radio_station/music/july.xm"
 
-/obj/item/record/august
+/obj/item/record/random/august
 	record_name = "august"
 	song = "sound/radio_station/music/august.xm"
 
-/obj/item/record/september
+/obj/item/record/random/september
 	record_name = "september"
 	song = "sound/radio_station/music/september.xm"
 
-/obj/item/record/october
+/obj/item/record/random/october
 	record_name = "october"
 	song = "sound/radio_station/music/october.xm"
 
-/obj/item/record/november
+/obj/item/record/random/november
 	record_name = "november"
 	song = "sound/radio_station/music/november.xm"
 
-/obj/item/record/december
+/obj/item/record/random/december
 	record_name = "december"
 	song = "sound/radio_station/music/december.xm"
 

--- a/code/modules/telescience/radiostation.dm
+++ b/code/modules/telescience/radiostation.dm
@@ -712,20 +712,20 @@ ABSTRACT_TYPE(/obj/item/record/random/notaquario)
 	icon_state = "sleeve_[rand(4,36)]"
 
 /obj/item/storage/box/record/radio/one
-	spawn_contents = list(/obj/item/record/january,
-	/obj/item/record/february,
-	/obj/item/record/march,
-	/obj/item/record/april,
-	/obj/item/record/may,
-	/obj/item/record/june)
+	spawn_contents = list(/obj/item/record/random/january,
+	/obj/item/record/random/february,
+	/obj/item/record/random/march,
+	/obj/item/record/random/april,
+	/obj/item/record/random/may,
+	/obj/item/record/random/june)
 
 /obj/item/storage/box/record/radio/two
-	spawn_contents = list(/obj/item/record/july,
-	/obj/item/record/august,
-	/obj/item/record/september,
-	/obj/item/record/october,
-	/obj/item/record/november,
-	/obj/item/record/december)
+	spawn_contents = list(/obj/item/record/random/july,
+	/obj/item/record/random/august,
+	/obj/item/record/random/september,
+	/obj/item/record/random/october,
+	/obj/item/record/random/november,
+	/obj/item/record/random/december)
 
 /obj/item/storage/box/record/radio/nostalgic
 	name = "\improper Nostalgic Dance record sleeve"

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -38256,11 +38256,11 @@
 	pixel_y = -6
 	},
 /obj/table/wood/auto,
-/obj/item/storage/box/record/radio/two{
+/obj/item/storage/box/record/radio/host{
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/item/storage/box/record/radio/one,
+/obj/item/storage/box/record/radio/host,
 /turf/simulated/floor/darkblue/checker/other,
 /area/station/crew_quarters/radio/lab)
 "bTk" = (

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -4291,6 +4291,8 @@
 	icon_state = "tile1"
 	},
 /obj/storage/crate/bloody,
+/obj/item/storage/box/record/radio/two,
+/obj/item/storage/box/record/radio/one,
 /obj/item/paper/tug/warehouse,
 /obj/item/cigpacket/cigarillo/juicer,
 /obj/item/cigpacket/cigarillo/juicer,

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -1545,11 +1545,11 @@
 /area/mining/comms)
 "aey" = (
 /obj/table/wood/auto,
-/obj/item/storage/box/record/radio/two{
+/obj/item/storage/box/record/radio/host{
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/item/storage/box/record/radio/one,
+/obj/item/storage/box/record/radio/host,
 /turf/simulated/floor/carpet/grime,
 /area/radiostation/studio)
 "aez" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The records inside of the radio station have been replaced with random songs instead of the month ones.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A lot of songs get overplayed, this is due in large part to the selection of songs the talk show host having access to is highly limited. This should increase the variety of songs that are played on the radio. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)The records contained within the radio station are now randomized.
```
