### PR TITLE
Cover for some weapons in no damage/spellshield protection

### DIFF
--- a/code/obj/item/hydroponics.dm
+++ b/code/obj/item/hydroponics.dm
@@ -187,12 +187,18 @@
 				else
 					qdel(C)
 				return
-			else
-				C.changeStatus("weakened", 3 SECONDS)
 
 		if (!ishuman(target))
+			target.changeStatus("weakened", 3 SECONDS)
 			return ..()
 
+		if (target.nodamage)
+			return ..()
+
+		if (target.spellshield)
+			return ..()
+
+		target.changeStatus("weakened", 3 SECONDS)
 		var/mob/living/carbon/human/H = target
 		if(prob(35))
 			gibs(target.loc, blood_DNA=H.bioHolder.Uid, blood_type=H.bioHolder.bloodType, headbits=FALSE, source=H)

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -701,6 +701,8 @@
 /obj/item/knife/butcher/throw_impact(atom/A, datum/thrown_thing/thr)
 	if(iscarbon(A))
 		var/mob/living/carbon/C = A
+		if (C.spellshield)
+			return ..()
 		if (ismob(usr))
 			A:lastattacker = usr
 			A:lastattackertime = world.time
@@ -1033,6 +1035,10 @@
 
 /obj/item/katana/attack(mob/target as mob, mob/user as mob, def_zone, is_special = 0)
 	if(!ishuman(target)) //only humans can currently be dismembered
+		return ..()
+	if (target.nodamage)
+		return ..()
+	if (target.spellshield)
 		return ..()
 	var/zoney = user.zone_sel.selecting
 	var/mob/living/carbon/human/H = target


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Protects no damage and spellshield against:
Syndicate saw
Butcher knife and hunter spear throw
Katana delimb

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No damage should protect you from nearly anything.
Wizards can show up among traitors but their spellshield wouldn't work properly against traitor weapons with special on hit/throw attacks. Spellshield is already a bit "eh" and considering the other things it blocks these seem like oversights.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Spellshield now protects wizards from the syndicate saw, butcher knife and katana.
```
