### PR TITLE
Change chocolate pie recipe

### DIFF
--- a/code/datums/cookingrecipes.dm
+++ b/code/datums/cookingrecipes.dm
@@ -1186,6 +1186,12 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 	cookbonus = 12
 	output = /obj/item/reagent_containers/food/snacks/pie/pumpkin
 
+/datum/cookingrecipe/pie_chocolate
+	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
+	item2 = /obj/item/reagent_containers/food/snacks/candy/chocolate
+	cookbonus = 10
+	output = /obj/item/reagent_containers/food/snacks/pie/chocolate
+
 /datum/cookingrecipe/pie_cream
 	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
 	item2 = /obj/item/reagent_containers/food/snacks/condiment/cream
@@ -1304,13 +1310,6 @@ ABSTRACT_TYPE(/datum/cookingrecipe)
 	item2 = /obj/item/clothing/head/butt
 	cookbonus = 15
 	output = /obj/item/reagent_containers/food/snacks/pie/ass
-
-/datum/cookingrecipe/pie_chocolate
-	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s
-	item2 = /obj/item/reagent_containers/food/snacks/candy/chocolate
-	item3 = /obj/item/reagent_containers/food/snacks/ingredient/butter
-	cookbonus = 10
-	output = /obj/item/reagent_containers/food/snacks/pie/chocolate
 
 /datum/cookingrecipe/pot_pie
 	item1 = /obj/item/reagent_containers/food/snacks/ingredient/dough_s


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ADD TO WIKI][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This removes the butter ingredient from chocolate pie, so it no longer conflicts with pain au chocolat. I opted to make chocolate pie closer to the other pie variants i.e. sweet dough, $ingredient  -  while keeping all the 'fluffier' pastries with sweet dough, butter, $ingredient.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
pain au choclat is above chocolate pie in the cooing recipes list, so no one can make chocolate pie. People should be able to make chocolate pie :)

Fixes #7891 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(+)Chocolate pie is now made from sweet dough and chocolate.
```
