### PR TITLE
Minor datum gun limb changes

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -269,7 +269,7 @@
 					hit_with_existing_projectile(P, target) // Includes log entry.
 				else
 					P.launch()
-			user.visible_message("<b class='alert'>[user] shoots [user == target ? "[him_or_her(user)]self" : target] point-blank with the [holder.name]!</b>")
+			user.visible_message("<b class='alert'>[user] shoots [target] point-blank with the [holder.name]!</b>")
 			next_shot_at = ticker.round_elapsed_ticks + cooldown
 			if (!current_shots)
 				reloaded_at = ticker.round_elapsed_ticks + reload_time

--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -235,7 +235,22 @@
 		else
 			reloaded_at = ticker.round_elapsed_ticks + reload_time
 
+	attack_hand(atom/target, mob/user, var/reach, params, location, control)
+		return
+
+	help(mob/living/target, mob/living/user)
+		return
+
+	disarm(mob/living/target, mob/living/user)
+		src.point_blank(target, user)
+
+	grab(mob/living/target, mob/living/user)
+		return
+
 	harm(mob/living/target, mob/living/user)
+		src.point_blank(target, user)
+
+	proc/point_blank(mob/living/target, mob/living/user)
 		if (reloaded_at > ticker.round_elapsed_ticks && !current_shots)
 			boutput(user, "<span class='alert'>The [holder.name] is [reloading_str]!</span>")
 			return
@@ -254,7 +269,7 @@
 					hit_with_existing_projectile(P, target) // Includes log entry.
 				else
 					P.launch()
-			user.visible_message("<b class='alert'>[user] fires at [target] with the [holder.name]!</b>")
+			user.visible_message("<b class='alert'>[user] shoots [user == target ? "[him_or_her(user)]self" : target] point-blank with the [holder.name]!</b>")
 			next_shot_at = ticker.round_elapsed_ticks + cooldown
 			if (!current_shots)
 				reloaded_at = ticker.round_elapsed_ticks + reload_time


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just makes some minor changes for the /datum/limb/gun datum.

It allows you to use disarming to point-blank, prevents interacting with stuff, and disables help and grab intents.

It also changes the firing message to show that point-blanking is being used.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Disarming can't be used to point-blank with a gun limb, which you would expect with regular weapons being able to.

Interacting with stuff and using help and grab intents don't make sense since it is a gun limb.

A clarification about the firing being point-blank when point-blanking is used would be nice.