### PR TITLE
Item health pass

### DIFF
--- a/code/WorkInProgress/Railgun.dm
+++ b/code/WorkInProgress/Railgun.dm
@@ -21,6 +21,7 @@
 	icon_state = "railgun"
 	item_state = "gun"
 	flags = FPRINT | EXTRADELAY | TABLEPASS | CONDUCT
+	health = 10
 	w_class = W_CLASS_SMALL
 
 	afterattack(atom/target as mob|obj|turf, mob/user as mob)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -10,6 +10,7 @@
 	throwforce = 5.0
 	throw_speed = 3
 	throw_range = 5
+	health = 8
 	w_class = W_CLASS_NORMAL
 	pressure_resistance = 80
 	var/charge = 0	// note %age conveted to actual charge in New

--- a/code/obj/ToSplit/barber_shop.dm
+++ b/code/obj/ToSplit/barber_shop.dm
@@ -33,6 +33,7 @@
 	flags = FPRINT | TABLEPASS | CONDUCT
 	tool_flags = TOOL_SNIPPING
 	force = 8.0
+	health = 6
 	w_class = W_CLASS_TINY
 	hit_type = DAMAGE_STAB
 	hitsound = 'sound/impact_sounds/Flesh_Stab_1.ogg'
@@ -77,6 +78,7 @@
 	flags = FPRINT | TABLEPASS | CONDUCT | ONBELT
 	tool_flags = TOOL_CUTTING
 	force = 7.0
+	health = 6
 	w_class = W_CLASS_TINY
 	hit_type = DAMAGE_CUT
 	hitsound = 'sound/impact_sounds/Flesh_Cut_1.ogg'

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -24,7 +24,8 @@
 	var/burn_possible = 1 //cogwerks fire project - can object catch on fire - let's have all sorts of shit burn at hellish temps
 	//MBC : im shit. change burn_possible to '2' if you want it to pool itself instead of qdeling when burned
 	var/burning = null
-	var/health = 4 //burn faster
+	/// How long an item takes to burn (or be consumed by other means), based on the weight class if no value is set
+	var/health = null
 	var/burn_point = 15000  //this already exists but nothing uses it???
 	var/burn_output = 1500 //how hot should it burn
 	var/burn_type = 0 //0 = ash, 1 = melt
@@ -296,6 +297,12 @@
 		if (src.amount != 1)
 			// this is a gross hack to make things not just show "1" by default
 			src.inventory_counter.update_number(src.amount)
+	if (isnull(src.health))
+		switch (src.w_class)
+			if (W_CLASS_TINY to W_CLASS_NORMAL)
+				src.health = src.w_class + 1
+			else
+				src.health = src.w_class + 2
 	..()
 
 /obj/item/set_loc(var/newloc as turf|mob|obj in world)

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -1010,6 +1010,7 @@ MATERIAL
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	icon_state = "tile_5"
 	item_state = "tile"
+	health = 2
 	w_class = W_CLASS_NORMAL
 	m_amt = 937.5
 	throw_speed = 3

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -507,7 +507,7 @@
 	burn_point = 220
 	burn_output = 900
 	burn_possible = 1
-	health = 10
+	health = 3
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/pen))

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -16,7 +16,7 @@
 	burn_point = 400
 	burn_output = 800
 	burn_possible = 1
-	health = 50
+	health = 10
 	var/team_num
 
 	duration_remove = 6.5 SECONDS

--- a/code/obj/item/device/energy_shield_gen.dm
+++ b/code/obj/item/device/energy_shield_gen.dm
@@ -6,6 +6,7 @@
 	density = 0
 	opacity = 0
 	anchored = 0
+	health = 5
 	w_class = W_CLASS_SMALL
 	pressure_resistance = 2*ONE_ATMOSPHERE
 	var/list/tiles = new/list()
@@ -146,7 +147,7 @@
 	opacity = 0
 	anchored = 1
 	layer=12
-	event_handler_flags = USE_FLUID_ENTER 
+	event_handler_flags = USE_FLUID_ENTER
 	var/health_max = 10
 	var/health = 10
 	var/broken = 0

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -12,6 +12,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	m_amt = 2000
 	force = 10.0
 	throwforce = 5
+	health = 7
 	w_class = W_CLASS_NORMAL
 	throw_speed = 4
 	throw_range = 6

--- a/code/obj/item/metal.dm
+++ b/code/obj/item/metal.dm
@@ -15,6 +15,7 @@ MATERIAL
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	icon_state = "rods"
 	flags = FPRINT | TABLEPASS| CONDUCT
+	health = 3
 	w_class = W_CLASS_NORMAL
 	force = 9.0
 	throwforce = 15.0

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -34,6 +34,7 @@
 	throwforce = 5.0
 	throw_speed = 1
 	throw_range = 5
+	health = 7
 	w_class = W_CLASS_SMALL
 	flags = FPRINT | TABLEPASS | NOSHIELD | USEDELAY
 	tool_flags = TOOL_CUTTING
@@ -1558,6 +1559,7 @@ obj/item/whetstone
 
 	tool_flags = TOOL_CHOPPING //to chop through doors
 	hit_type = DAMAGE_BLUNT
+	health = 10
 	w_class = W_CLASS_NORMAL
 	two_handed = 1
 	click_delay = 30

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -73,6 +73,7 @@
 	throwforce = 5.0
 	throw_speed = 1
 	throw_range = 5
+	health = 8
 	w_class = W_CLASS_SMALL
 	flags = FPRINT | TABLEPASS | NOSHIELD
 	object_flags = NO_ARM_ATTACH

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -840,6 +840,7 @@ WET FLOOR SIGN
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "handvac"
 	mats = list("bamboo"=3, "MET-1"=10)
+	health = 7
 	w_class = W_CLASS_SMALL
 	flags = FPRINT | TABLEPASS | SUPPRESSATTACK
 	item_function_flags = USE_SPECIALS_ON_ALL_INTENTS

--- a/code/obj/item/organs/organ_parent.dm
+++ b/code/obj/item/organs/organ_parent.dm
@@ -15,6 +15,7 @@
 	item_state = "brain"
 	flags = TABLEPASS
 	force = 1.0
+	health = 4
 	w_class = W_CLASS_TINY
 	throwforce = 1.0
 	throw_speed = 3

--- a/code/obj/item/organs/skull.dm
+++ b/code/obj/item/organs/skull.dm
@@ -9,6 +9,7 @@
 	var/preddesc = "A trophy from a less interesting kill." // See assign_gimmick_skull().
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "skull"
+	health = 4
 	w_class = W_CLASS_TINY
 	var/mob/donor = null
 	var/donor_name = null

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -44,7 +44,6 @@
 	burn_point = 220
 	burn_output = 900
 	burn_possible = 2
-	health = 10
 	var/list/form_startpoints
 	var/list/form_endpoints
 	var/font_css_crap = null

--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -21,6 +21,7 @@
 
 /obj/item/plant/herb
 	name = "herb base"
+	health = 4
 	burn_point = 330
 	burn_output = 800
 	burn_possible = 2

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -49,6 +49,7 @@ Broken RCD + Effects
 	throwforce = 10.0
 	throw_speed = 1
 	throw_range = 5
+	health = 7
 	w_class = W_CLASS_NORMAL
 	m_amt = 50000
 
@@ -865,6 +866,7 @@ Broken RCD + Effects
 	anchored = 0.0
 	m_amt = 30000
 	g_amt = 15000
+	health = 6
 	var/matter = 10
 
 	get_desc()

--- a/code/obj/item/satchel.dm
+++ b/code/obj/item/satchel.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "satchel"
 	flags = ONBELT
+	health = 6
 	w_class = W_CLASS_TINY
 	event_handler_flags = USE_FLUID_ENTER | NO_MOUSEDROP_QOL
 	var/maxitems = 50

--- a/code/obj/item/storage/ammo_pouches.dm
+++ b/code/obj/item/storage/ammo_pouches.dm
@@ -7,6 +7,7 @@
 	name = "ammo pouch"
 	icon_state = "ammopouch"
 	desc = "A sturdy fabric pouch designed for carrying ammunition. Can be attatched to the webbing of a uniform to allow for quick access during combat."
+	health = 6
 	w_class = W_CLASS_TINY
 	max_wclass = 1
 	slots = 5
@@ -99,6 +100,7 @@
 	name = "grenade pouch"
 	icon_state = "ammopouch"
 	desc = "A sturdy fabric pouch used to carry several grenades."
+	health = 6
 	w_class = W_CLASS_TINY
 	slots = 6
 	can_hold = list(/obj/item/old_grenade, /obj/item/chem_grenade)
@@ -143,6 +145,7 @@
 /obj/item/storage/medical_pouch
 	name = "trauma field kit"
 	icon_state = "ammopouch-medic"
+	health = 6
 	w_class = W_CLASS_TINY
 	slots = 4
 	does_not_open_in_pocket = 0
@@ -153,6 +156,7 @@
 	name = "security pouch"
 	desc = "A small pouch containing some essential security supplies. Keep out of reach of the clown."
 	icon_state = "ammopouch-sec"
+	health = 6
 	w_class = W_CLASS_SMALL
 	slots = 6
 	does_not_open_in_pocket = 0
@@ -171,6 +175,7 @@
 	name = "tacticool pouch"
 	desc = "A dump pouch for various security accessories, partially-loaded magazines, or maybe even a snack! Attaches to virtually any webbing system through an incredibly complex and very patented Nanotrasen design."
 	icon_state = "ammopouch-large"
+	health = 6
 	w_class = W_CLASS_SMALL
 	slots = 5
 	does_not_open_in_pocket = 0
@@ -183,6 +188,7 @@
 	name = "EMP grenade pouch"
 	desc = "A pouch designed to hold EMP grenades."
 	icon_state = "ammopouch-emp"
+	health = 6
 	w_class = W_CLASS_SMALL
 	slots = 5
 	does_not_open_in_pocket = 0
@@ -192,6 +198,7 @@
 	name = "tactical grenade pouch"
 	desc = "A pouch designed to hold assorted special-ops grenades."
 	icon_state = "ammopouch-grenade"
+	health = 6
 	w_class = W_CLASS_SMALL
 	slots = 7
 	does_not_open_in_pocket = 0
@@ -206,6 +213,7 @@
 	name = "sonic grenade pouch"
 	desc = "A pouch designed to hold sonic grenades, and a pair of earplugs. Wear the earplugs before using the grenades."
 	icon_state = "ammopouch-sonic"
+	health = 6
 	w_class = W_CLASS_SMALL
 	slots = 6
 	does_not_open_in_pocket = 0
@@ -216,6 +224,7 @@
 	name = "banana grenade pouch"
 	desc = "A fun pouch designed to hold banana grenades."
 	icon_state = "ammopouch-banana"
+	health = 6
 	w_class = W_CLASS_SMALL
 	slots = 7 //bonus two slots for the banana grenade kit
 	does_not_open_in_pocket = 0

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -19,6 +19,7 @@
 	flags = FPRINT | ONBELT | TABLEPASS
 	force = 10
 	throwforce = 7
+	health = 7
 	w_class = W_CLASS_NORMAL
 	mats = list("MET-3"=10, "CON-2"=10)
 	contraband = 4

--- a/code/obj/item/table_rack_parts.dm
+++ b/code/obj/item/table_rack_parts.dm
@@ -16,6 +16,7 @@ RACK PARTS
 	stamina_damage = 35
 	stamina_cost = 22
 	stamina_crit_chance = 10
+	health = 8
 	var/furniture_type = /obj/table/auto
 	var/furniture_name = "table"
 	var/reinforced = 0

--- a/code/obj/item/tank.dm
+++ b/code/obj/item/tank.dm
@@ -425,6 +425,7 @@ Contains:
 	name = "emergency oxygentank"
 	icon_state = "em_oxtank"
 	flags = FPRINT | TABLEPASS | ONBELT | CONDUCT
+	health = 5
 	w_class = W_CLASS_SMALL
 	force = 3.0
 	stamina_damage = 30

--- a/code/obj/item/teleportation.dm
+++ b/code/obj/item/teleportation.dm
@@ -118,6 +118,7 @@ Frequency:
 	icon_state = "hand_tele"
 	item_state = "electronic"
 	throwforce = 5
+	health = 5
 	w_class = W_CLASS_SMALL
 	throw_speed = 3
 	throw_range = 5

--- a/code/obj/item/tiles_wires.dm
+++ b/code/obj/item/tiles_wires.dm
@@ -13,6 +13,7 @@ TILES
 	icon = 'icons/obj/metal.dmi'
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	icon_state = "tile"
+	health = 2
 	w_class = W_CLASS_NORMAL
 	m_amt = 937.5
 	throw_speed = 5

--- a/code/obj/item/tool.dm
+++ b/code/obj/item/tool.dm
@@ -6,6 +6,7 @@
 
 	flags = FPRINT | TABLEPASS | CONDUCT | ONBELT
 	w_class = W_CLASS_SMALL
+	health = 5
 
 	// sensible defaults
 	force = 5.0

--- a/code/obj/item/tool/crowbar.dm
+++ b/code/obj/item/tool/crowbar.dm
@@ -9,6 +9,7 @@
 
 	flags = FPRINT | TABLEPASS | CONDUCT | ONBELT
 	tool_flags = TOOL_PRYING
+	health = 5
 	w_class = W_CLASS_SMALL
 
 	force = 7.0

--- a/code/obj/item/tool/screwdriver.dm
+++ b/code/obj/item/tool/screwdriver.dm
@@ -7,6 +7,7 @@
 
 	flags = FPRINT | TABLEPASS | CONDUCT | ONBELT
 	tool_flags = TOOL_SCREWING
+	health = 3
 	w_class = W_CLASS_TINY
 
 	force = 5.0

--- a/code/obj/item/tool/weldingtool.dm
+++ b/code/obj/item/tool/weldingtool.dm
@@ -18,6 +18,7 @@
 	throwforce = 5.0
 	throw_speed = 1
 	throw_range = 5
+	health = 5
 	w_class = W_CLASS_SMALL
 	m_amt = 30
 	g_amt = 30

--- a/code/obj/item/tool/wirecutters.dm
+++ b/code/obj/item/tool/wirecutters.dm
@@ -7,6 +7,7 @@
 
 	flags = FPRINT | TABLEPASS | CONDUCT | ONBELT
 	tool_flags = TOOL_SNIPPING
+	health = 5
 	w_class = W_CLASS_SMALL
 
 	force = 6.0

--- a/code/obj/item/tool/wrench.dm
+++ b/code/obj/item/tool/wrench.dm
@@ -7,6 +7,7 @@
 
 	flags = FPRINT | TABLEPASS | CONDUCT | ONBELT
 	tool_flags = TOOL_WRENCHING
+	health = 5
 	w_class = W_CLASS_SMALL
 
 	force = 5.0

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -1127,6 +1127,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 	var/list/spells = list()
 	flags = FPRINT | ONBELT | TABLEPASS
 	throwforce = 5
+	health = 5
 	w_class = W_CLASS_SMALL
 	throw_speed = 4
 	throw_range = 20

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -16,6 +16,7 @@ ABSTRACT_TYPE(/obj/item/circuitboard)
 /obj/item/circuitboard
 	density = 0
 	anchored = 0
+	health = 6
 	w_class = W_CLASS_SMALL
 	name = "Circuit board"
 	icon = 'icons/obj/module.dmi'

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -72,6 +72,7 @@
 	desc = "A circuit module designed to improve cloning machine scanning capabilities to the point where even the deceased may be scanned."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cloner_upgrade"
+	health = 8
 	w_class = W_CLASS_TINY
 	throwforce = 1
 
@@ -80,6 +81,7 @@
 	desc = "A circuit module designed to improve enzymatic reclaimer capabilities so that the machine will be able to reclaim more matter, faster."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "grinder_upgrade"
+	health = 8
 	w_class = W_CLASS_TINY
 	throwforce = 1
 

--- a/code/obj/machinery/interdictor.dm
+++ b/code/obj/machinery/interdictor.dm
@@ -283,6 +283,7 @@
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "electronic"
 	mats = 6
+	health = 6
 	w_class = W_CLASS_TINY
 	flags = FPRINT | TABLEPASS | CONDUCT
 

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -1524,6 +1524,7 @@
 	icon_state = "pickaxe"
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "pick"
+	health = 8
 	w_class = W_CLASS_NORMAL
 	flags = ONBELT
 	force = 7


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes item health default to being based on item weight and adds specific health values for a lot of items where weight doesn't correlate for inventory reasons.

Weight class health values are as follows:
TINY: 2
SMALL: 3
NORMAL: 4
BULKY: 6
HUGE: 7
GIGANTIC: 8

Notable health changes from this:
Paper 10 -> 2
Jumpsuits 50 -> 10

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Item health is used to determine how fast something burns, is dissolved in acid or is absorbed by a flockdrone. Currently almost all items have the default value of 4, with a couple of weird exceptions such as jumpsuits having 50 (please let me know if there's a good reason for this)
With flock being actively worked on and Nadir (#7730) using acid as a core mechanic it would be nice for item health to make sense.