### PR TITLE
Add auto shuttle and final storm to Battle Royale

### DIFF
--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -115,8 +115,19 @@ var/global/list/datum/mind/battle_pass_holders = list()
 	ticker.ai_law_rack_manager.default_ai_rack.DeleteAllLaws()
 	ticker.ai_law_rack_manager.default_ai_rack.SetLawCustom("Battle Royale","BR Protocol in effect. Observe the effects of the BR Mind Control Program, do not interfere.",1,true,true)
 
-
 	emergency_shuttle.disabled = 1
+
+	for(var/x in 1 to world.maxx)
+		var/turf/T = locate(x, 1, Z_LEVEL_STATION)
+		T.ReplaceWith(/turf/cordon, force = TRUE)
+		T = locate(x, world.maxy - 2, Z_LEVEL_STATION)	// Why is the Z change edge not at the actual edge??
+		T.ReplaceWith(/turf/cordon, force = TRUE)
+
+	for(var/y in 1 to world.maxy)
+		var/turf/T = locate(1, y, Z_LEVEL_STATION)
+		T.ReplaceWith(/turf/cordon, force = TRUE)
+		T = locate(world.maxx - 2, y, Z_LEVEL_STATION)	// Why is the Z change edge not at the actual edge??
+		T.ReplaceWith(/turf/cordon, force = TRUE)
 	return 1
 
 
@@ -205,18 +216,14 @@ var/global/list/datum/mind/battle_pass_holders = list()
 					var/turf/T = get_turf(H)
 					if (T.z != Z_LEVEL_STATION)
 						var/area/GA = get_area(T)
-						var/no_tick_damage = FALSE
+						var/safe_area = FALSE
 						for (var/EA in excluded_areas)
 							if(istype(GA, EA))
-								no_tick_damage = TRUE
+								safe_area = TRUE
 								break
-						if (!no_tick_damage)
-							if (src.next_storm == null)
-								boutput(H, "<span class='alert'>You were outside the [station_or_ship()] after the shuttle left!</span>")
-								H.gib()
-							else
-								boutput(H, "<span class='alert'>You are outside the battle area! Return to the station!</span>")
-								random_brute_damage(H, 10, 0)
+						if (!safe_area)
+							boutput(H, "<span class='alert'>You were outside the [station_or_ship()] during a Battle Royale!</span>")
+							H.gib()
 
 	// Is it time for a storm?
 	if (src.next_storm != null)

--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -119,15 +119,15 @@ var/global/list/datum/mind/battle_pass_holders = list()
 
 	for(var/x in 1 to world.maxx)
 		var/turf/T = locate(x, 1, Z_LEVEL_STATION)
-		T.ReplaceWith(/turf/cordon, force = TRUE)
+		T.ReplaceWith(/turf/unsimulated/wall/void, force = TRUE)
 		T = locate(x, world.maxy - 2, Z_LEVEL_STATION)	// Why is the Z change edge not at the actual edge??
-		T.ReplaceWith(/turf/cordon, force = TRUE)
+		T.ReplaceWith(/turf/unsimulated/wall/void, force = TRUE)
 
 	for(var/y in 1 to world.maxy)
 		var/turf/T = locate(1, y, Z_LEVEL_STATION)
-		T.ReplaceWith(/turf/cordon, force = TRUE)
+		T.ReplaceWith(/turf/unsimulated/wall/void, force = TRUE)
 		T = locate(world.maxx - 2, y, Z_LEVEL_STATION)	// Why is the Z change edge not at the actual edge??
-		T.ReplaceWith(/turf/cordon, force = TRUE)
+		T.ReplaceWith(/turf/unsimulated/wall/void, force = TRUE)
 	return 1
 
 

--- a/code/modules/events/battle_storm.dm
+++ b/code/modules/events/battle_storm.dm
@@ -6,7 +6,7 @@
 	var/list/area/safe_areas = list()
 	var/list/safe_area_names = list()
 	var/list/area/safe_locations = list()
-	var/list/area/excluded_areas = list(/area/sim, /area/afterlife, /area/gauntlet/, /area/shuttle/battle, /area/shuttle/escape/transit, /area/shuttle_transit_space)
+	var/list/area/excluded_areas = list(/area/shuttle/battle, /area/shuttle/escape/transit, /area/shuttle_transit_space)
 	var/activations = 0
 
 	New()

--- a/code/modules/events/battle_storm.dm
+++ b/code/modules/events/battle_storm.dm
@@ -13,32 +13,33 @@
 		..()
 		safe_locations = get_accessible_station_areas()
 
-	event_effect()
+	event_effect(var/final = FALSE)
 		// Pick a safe area(s)
 		activations++
 		safe_area_names = list()
 		safe_areas = list()
-		var/num_safe_areas = clamp(6 - activations, 1, 5)
-		var/area/temp = null
-		var/list/locations_copy = list()
-		for(var/A in safe_locations)
-			locations_copy.Add(A)
-		for(var/i = 0, i < num_safe_areas, i++)
-			temp = pick(locations_copy)
-			locations_copy.Remove(temp)
-			safe_area_names.Add(temp)
-			safe_areas.Add(safe_locations[temp])
-			safe_locations[temp].icon_state = "blue"
+		if (!final)
+			var/num_safe_areas = clamp(6 - activations, 1, 5)
+			var/area/temp = null
+			var/list/locations_copy = list()
+			for(var/A in safe_locations)
+				locations_copy.Add(A)
+			for(var/i = 0, i < num_safe_areas, i++)
+				temp = pick(locations_copy)
+				locations_copy.Remove(temp)
+				safe_area_names.Add(temp)
+				safe_areas.Add(safe_locations[temp])
+				safe_locations[temp].icon_state = "blue"
 
 		for (var/mob/M in mobs)
-			if (!inafterlife(M) && !isVRghost(M))
+			if (M.z == Z_LEVEL_STATION)
 				M.flash(3 SECONDS)
 		var/sound/siren = sound('sound/misc/airraid_loop_short.ogg')
 		siren.repeat = TRUE
 		siren.channel = 5
 		siren.volume = 50 // wire note: lets not deafen players with an air raid siren
 		world << siren
-		command_alert("A BATTLE STORM is approaching the [station_or_ship()]! Impact in 60 seconds. You will take large amounts of damage unless you are standing in [get_battle_area_names(safe_area_names)]!", "BATTLE STORM INCOMING")
+		command_alert("A BATTLE STORM is approaching the [station_or_ship()]! Impact in 60 seconds. [final ? "You must make it to the escape shuttle or die" : "You will take large amounts of damage unless you are standing in [get_battle_area_names(safe_area_names)]"]!", "BATTLE STORM INCOMING")
 
 		SPAWN(60 SECONDS)
 
@@ -47,7 +48,7 @@
 			siren.volume = 50
 
 			for (var/mob/M in mobs)
-				if (!inafterlife(M) && !isVRghost(M))
+				if (M.z == Z_LEVEL_STATION)
 					M.flash(3 SECONDS)
 
 	#ifndef UNDERWATER_MAP


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
1. Automatically calls a shuttle when BR reaches 5 players remaining.
2. Adds an infinite deadly storm timed for the shuttles departure.
3. Implements an invisible cordon around Z1.
4. Now kills anyone who gets outside Z1.
5. Limits storm effect to Z1.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
1. Forces a round end situation.
2. Makes players actually get on the shuttle.
3. So we don't have to worry about the potential complications of players sneaking off the Z.
4. Backup if anyone ever sneaks out.
5. Avoids visual bugs and having to worry about Z2 dead players.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Battle Royale now forces a shuttle when five players remain. A deadly storm will hit the entire station, finish everyone else off or escape on the shuttle to survive!
(+)Battle Royale now prevents you leaving the station level edges, be careful spacing players as they may return.
```
