### PR TITLE
prying tools deploy/undeploy dowsing rods

### DIFF
--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -574,12 +574,18 @@
 				SPAWN(1.5 SECONDS)
 					UpdateOverlays(null, "speech_bubble")
 
+	attackby(var/obj/item/I as obj, var/mob/M as mob)
+		if (ispryingtool(I))
+			if (deployed)
+				src.undeploy()
+			else
+				if (src in M.contents)
+					src.force_drop()
+				src.deploy()
+		..()
 
 	attack_hand(var/mob/living/carbon/human/user as mob)
-		icon_state = "dowsing_hands"
-		deployed = 0
-		closest_hotspot = 0
-		processing_items -= src
+		src.undeploy()
 		..()
 
 	afterattack(var/turf/T, var/mob/user)
@@ -593,6 +599,11 @@
 			return
 		..()
 
+	proc/undeploy()
+		src.icon_state = "dowsing_hands"
+		deployed = 0
+		closest_hotspot = 0
+		processing_items -= src
 
 	proc/deploy()
 		processing_items |= src


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new attackby proc for dowsing rods; using a prying tool (i.e. crowbar) will either deploy or un-deploy the dowsing rod.
If it's in a mob's inventory, this will forcefully drop the item so they can't dowse their backpack.

Moves undeploy() into its own proc to reduce code duplication

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
allows borgs to use dowsing rods in any capacity

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(+)Crowbars can now stand up and lay down dowsing rods.
```
