### PR TITLE
Bank account now counts towards richest escapee

### DIFF
--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -245,8 +245,12 @@ var/datum/score_tracker/score_tracker
 					most_damaged_escapee = M
 
 				var/cash_total = get_cash_in_thing(M)
-				if (richest_total < cash_total)
-					richest_total = cash_total
+				var/bank_account = data_core.bank.find_record("name", M.real_name)
+				var/bank_total = 0
+				if(bank_account)
+					bank_total = bank_account["current_money"]
+				if (richest_total < (cash_total + bank_total))
+					richest_total = cash_total + bank_total
 					richest_escapee = M
 
 		command_pets_escaped = list()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUGFIX] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds bank account balance to the total amount of cash on you for calculating richest escapee


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7943 
And honestly, it always kinda bothered me too.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Bank account balance now counts towards richest escapee.
```
