### PR TITLE
You have to be standing next to pods to remove people from them

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -6,6 +6,7 @@
 	flags = FPRINT | USEDELAY
 	anchored = 1.0
 	stops_space_move = 1
+	status = REQ_PHYSICAL_ACCESS
 	var/datum/effects/system/ion_trail_follow/ion_trail = null
 	var/mob/pilot = null //The mob which actually flys the ship
 	var/capacity = 3 //How many passengers the ship can hold


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a physical access requirement to pods, so borgs can't use their magic cybernetic powers to kick people out


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7758 

