### PR TITLE
Transmute artifact bombs no longer affect intangible things

### DIFF
--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -467,7 +467,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 				if(!smoothEdge && prob(distPercent))
 					continue
 				if(istype(G, /mob))
-					if(!istype(G, /mob/living)) // not stuff like ghosts, please
+					if(!isliving(G) || isintangible(G)) // not stuff like ghosts, please
 						continue
 					var/mob/M = G
 					switch(affects_organic)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an intangible check to the effect of transmute artifacts.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ghost eyeballs aren't made of stuff. They shouldn't be made of leather.
Fixes #7925