### PR TITLE
Fix mining outpost podbay depressurization

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -22823,7 +22823,6 @@
 /turf/simulated/floor/orangeblack/side{
 	dir = 8
 	},
-/turf/space,
 /area/mining/hangar)
 "tha" = (
 /obj/machinery/door/airlock/pyro/glass/med{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes a stacked turf causing the outpost podbay to stay decompressed

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Need an atmosphere to hold a proper pod naming ceremony