### PR TITLE
Log spy delivery/rewards

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -116,6 +116,7 @@
 
 		if (reward.item)
 			var/obj/item = new reward.item(pda_turf)
+			logTheThing("debug", user, null, "spy thief reward spawned: [item] at [log_loc(user)]")
 			user.show_text("Your PDA accepts the bounty and spits out [reward] in exchange.", "red")
 			reward.run_on_spawn(item, user, FALSE, hostpda.uplink)
 			user.put_in_hand_or_drop(item)

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -820,6 +820,7 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 							user.show_text("That isn't the right limb!", "red")
 					else
 						M.drop_from_slot(delivery,get_turf(M))
+				logTheThing("debug", user, null, "spy thief claimed delivery of: [delivery] at [log_loc(user)]")
 				qdel(delivery)
 				if (user.mind && user.mind.special_role == ROLE_SPY_THIEF)
 					user.mind.spy_stolen_items += B.name

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -816,11 +816,13 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 							H.changeStatus("weakened", 3 SECONDS)
 							playsound(H.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
 							H.emote("scream")
+							logTheThing("combat", user, null, "spy thief claimed [constructTarget(H)]'s [HP] at [log_loc(user)]")
 						else
 							user.show_text("That isn't the right limb!", "red")
 					else
 						M.drop_from_slot(delivery,get_turf(M))
-				logTheThing("debug", user, null, "spy thief claimed delivery of: [delivery] at [log_loc(user)]")
+				if (!istype(delivery,/obj/item/parts))
+					logTheThing("debug", user, null, "spy thief claimed delivery of: [delivery] at [log_loc(user)]")
 				qdel(delivery)
 				if (user.mind && user.mind.special_role == ROLE_SPY_THIEF)
 					user.mind.spy_stolen_items += B.name


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Logs spy thief claims/rewards.
Limb claims go to the combat log.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So admins know about stolen limbs and missing equipment.