### PR TITLE
Adds multitool prompt to glitched module description

### DIFF
--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -47,7 +47,11 @@ ABSTRACT_TYPE(/obj/item/aiModule)
 		return
 
 	get_desc()
-		return "It reads, \"<em>[get_law_text()]</em>\""
+		. = ""
+		if(src.glitched)
+			.+= "It isn't working right. You could use a multitool to reset it.<br>"
+		. +=  "It reads, \"<em>[get_law_text()]</em>\""
+
 
 	proc/input_law_info(var/mob/user, var/title = null, var/text = null, var/default = null)
 		if (!user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If an ai module is glitched by an ion storm, adds a prompt to the description telling the user a multitool could fix it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People don't know this works.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Adds a hint to the AI Law Module description telling users they can reset it with a multitool if it's glitchy.
```
