### PR TITLE
Replaces sims motive gib with death

### DIFF
--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -399,7 +399,8 @@
 				showOwner("<span class='alert'><b>You can't take being so bored anymore!</b></span>")
 				if (ishuman(holder.owner))
 					var/mob/living/carbon/human/H = holder.owner
-					H.gib()
+					H.death()
+					logTheThing("combat", usr, null, "died from the sims fun motive at [log_loc(owner)].")
 
 		onLife()
 			if (value < 10)

--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -400,7 +400,7 @@
 				if (ishuman(holder.owner))
 					var/mob/living/carbon/human/H = holder.owner
 					H.death()
-					logTheThing("combat", usr, null, "died from the sims fun motive at [log_loc(owner)].")
+					logTheThing("combat", usr, null, "died from the sims fun motive at [log_loc(H)].")
 
 		onLife()
 			if (value < 10)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces fun gib with a regular death.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I know this is a joke but the gibbing just takes players by surprise and usually ends their round.