### PR TITLE
Allows frogs to croak

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -1646,6 +1646,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	health_brute = 15
 	health_burn = 15
 	pet_text = list("gently baps", "pets", "cuddles")
+	var/frog_sound = list("sound/voice/screams/frogscream1.ogg","sound/voice/screams/frogscream3.ogg", "sound/voice/screams/frogscream4.ogg")
 
 	New()
 		if (prob(80))
@@ -1674,6 +1675,16 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		HH.limb_name = "mouth"
 		HH.can_hold_items = 0
 
+	specific_emotes(var/act, var/param = null, var/voluntary = 0)
+		switch (act)
+			if ("scream","croak")
+				if (src.emote_check(voluntary, 50))
+					if(rand(1,1000) == 1000)
+						playsound(src, frog_sound, 80, 1, channel=VOLUME_CHANNEL_EMOTE)
+						return "<span class='emote'><b>[src]</b> makes a horrifying noise!</span>"
+					else
+						playsound(src, "sound/misc/croak.ogg", 80, 1, channel=VOLUME_CHANNEL_EMOTE)
+						return "<span class='emote'><b>[src]</b> croaks!</span>"
 
 	weak
 		health_brute = 10

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -1679,7 +1679,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		switch (act)
 			if ("scream","croak")
 				if (src.emote_check(voluntary, 50))
-					if (prob(0.1))
+					if (prob(1))
 						playsound(src, frog_sound, 80, 1, channel=VOLUME_CHANNEL_EMOTE)
 						return "<span class='emote'><b>[src]</b> makes a horrifying noise!</span>"
 					else

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -1679,7 +1679,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 		switch (act)
 			if ("scream","croak")
 				if (src.emote_check(voluntary, 50))
-					if(rand(1,1000) == 1000)
+					if (prob(0.1))
 						playsound(src, frog_sound, 80, 1, channel=VOLUME_CHANNEL_EMOTE)
 						return "<span class='emote'><b>[src]</b> makes a horrifying noise!</span>"
 					else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows frogs to croak with a tiny (1/1000) chance for a shelterfrog croak instead.

Common croak is: 

https://user-images.githubusercontent.com/36884328/163876800-46b758d5-671b-4926-a504-b008d7a8fd63.mp4

Rare croaks are:

https://user-images.githubusercontent.com/36884328/163876832-93233318-1e9c-438f-b607-24fbb7118d07.mp4

https://user-images.githubusercontent.com/36884328/163876840-1ace836f-114a-407d-a33d-66898d6f4864.mp4

https://user-images.githubusercontent.com/36884328/163876845-9b183413-9417-46c5-b86e-88de6a92ce93.mp4

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cats meow, dogs bark, roaches chitter, birds caw but frogs cant croak. This fixes that and comes along with a small chance for a shelterfrog screech for fun!