### PR TITLE
Adjust queueing method of spaced turfs to facilitate atmos calculations

### DIFF
--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -2715,7 +2715,7 @@ Returns:
 			if(T.movable_area_prev_type != null)
 				new T.movable_area_prev_type (T)
 			else
-				new/turf/space(T)
+				T.ReplaceWithSpace()
 
 		for(var/atom/movable/A in objects_to_move)
 			A.animate_movement = 0

--- a/code/modules/atmospherics/FEA_system.dm
+++ b/code/modules/atmospherics/FEA_system.dm
@@ -233,8 +233,8 @@ datum/controller/air_system
 	process()
 		current_cycle++
 
-		process_tiles_to_space()
 		is_busy = TRUE
+		process_tiles_to_space()
 
 		if(!explosions.exploding)
 			if(groups_to_rebuild.len > 0)

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -198,6 +198,9 @@
 		oxygen = MOLES_O2STANDARD
 		nitrogen = MOLES_N2STANDARD
 
+	asteroid
+		icon_state = "aplaceholder"
+
 /turf/space/no_replace
 
 /turf/space/New()
@@ -307,6 +310,11 @@ proc/generate_space_color()
 
 /turf/space/proc/process_cell()
 	return
+
+/turf/proc/delay_space_conversion()
+	if(air_master?.is_busy)
+		air_master.tiles_to_space |= src
+		return TRUE
 
 /turf/cordon
 	name = "CORDON"
@@ -543,8 +551,10 @@ proc/generate_space_color()
 
 	var/new_type = ispath(what) ? what : text2path(what) //what what, what WHAT WHAT WHAAAAAAAAT
 	if (new_type)
+		if(ispath(new_type, /turf/space) && delay_space_conversion()) return
 		new_turf = new new_type(src)
 		if (!isturf(new_turf))
+			if (delay_space_conversion()) return
 			new_turf = new /turf/space(src)
 
 	else switch(what)
@@ -573,6 +583,7 @@ proc/generate_space_color()
 		if ("Unsimulated Floor")
 			new_turf = new /turf/unsimulated/floor(src)
 		else
+			if (delay_space_conversion()) return
 			new_turf = new /turf/space(src)
 
 	if(keep_old_material && oldmat && !istype(new_turf, /turf/space)) new_turf.setMaterial(oldmat)
@@ -708,10 +719,6 @@ proc/generate_space_color()
 	return floor
 
 /turf/proc/ReplaceWithSpace()
-	if( air_master.is_busy )
-		air_master.tiles_to_space |= src
-		return
-
 	var/area/my_area = loc
 	var/turf/floor
 	if (my_area)

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -41831,9 +41831,7 @@
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "bJM" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "bJN" = (
 /obj/lattice{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -7,9 +7,7 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "aae" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aaf" = (
 /obj/lattice{

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -73704,9 +73704,7 @@
 /turf/space,
 /area/space)
 "dhQ" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "dhR" = (
 /obj/cable{

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -15683,9 +15683,7 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "bzl" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "bzn" = (
 /obj/lattice{

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -26645,9 +26645,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "hwr" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/station/turret_protected/AIbaseoutside)
 "hwA" = (
 /obj/machinery/light_switch/north,
@@ -42235,9 +42233,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/breakroom)
 "mdn" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/station/turret_protected/armory_outside)
 "mdw" = (
 /obj/decal/tile_edge/line/blue{
@@ -56871,9 +56867,7 @@
 /obj/machinery/turret{
 	dir = 1
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/station/turret_protected/armory_outside)
 "qny" = (
 /obj/cable{
@@ -69656,9 +69650,7 @@
 	},
 /area/station/medical/cdc)
 "tXv" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "tXG" = (
 /obj/cable{

--- a/maps/donut3_xmas.dmm
+++ b/maps/donut3_xmas.dmm
@@ -26520,9 +26520,7 @@
 	name = "Genetic Research"
 	})
 "hwr" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/station/turret_protected/AIbaseoutside)
 "hwN" = (
 /obj/loudspeaker,
@@ -41784,9 +41782,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/medical/breakroom)
 "mdn" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/station/turret_protected/armory_outside)
 "mdw" = (
 /obj/decal/tile_edge/line/blue{
@@ -56267,9 +56263,7 @@
 /obj/machinery/turret{
 	dir = 1
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/station/turret_protected/armory_outside)
 "qny" = (
 /obj/cable{
@@ -69043,9 +69037,7 @@
 	},
 /area/station/medical/cdc)
 "tXv" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "tXG" = (
 /obj/cable{

--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -17704,9 +17704,7 @@
 /turf/space,
 /area/space)
 "IM" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "IN" = (
 /turf/simulated/wall/asteroid,

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -3192,9 +3192,7 @@
 	name = "Testing Asteroid"
 	})
 "aij" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aik" = (
 /turf/simulated/floor/engine/vacuum{

--- a/maps/horizon_xmas.dmm
+++ b/maps/horizon_xmas.dmm
@@ -3299,9 +3299,7 @@
 	name = "Testing Asteroid"
 	})
 "aij" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aik" = (
 /turf/simulated/floor/engine/vacuum{

--- a/maps/icarus.dmm
+++ b/maps/icarus.dmm
@@ -25190,9 +25190,7 @@
 /turf/simulated/floor/plating/airless,
 /area/listeningpost)
 "bby" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "bbz" = (
 /turf/simulated/wall/asteroid/lighted,

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -3,9 +3,7 @@
 /turf/space,
 /area/space)
 "aab" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aac" = (
 /turf/simulated/wall/asteroid/dark,

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -43439,9 +43439,7 @@
 /turf/simulated/floor,
 /area/station/security/checkpoint/east)
 "mdr" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "mdw" = (
 /obj/table/auto,

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -67185,9 +67185,7 @@
 /turf/space,
 /area/supply/spawn_point)
 "cDf" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "cDn" = (
 /obj/decal/cleanable/dirt,

--- a/maps/setpieces/AIBM_spacejunk.dmm
+++ b/maps/setpieces/AIBM_spacejunk.dmm
@@ -1053,9 +1053,7 @@
 	},
 /area/space)
 "cK" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "cL" = (
 /obj/lattice{

--- a/maps/unused/chiron.dmm
+++ b/maps/unused/chiron.dmm
@@ -147,9 +147,7 @@
 	},
 /area/space)
 "aao" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aap" = (
 /turf/simulated/wall/asteroid,

--- a/maps/unused/concept.dmm
+++ b/maps/unused/concept.dmm
@@ -47448,9 +47448,7 @@
 /turf/simulated/wall/r_wall,
 /area/space)
 "bQk" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "bQl" = (
 /turf/space,
@@ -49706,9 +49704,7 @@
 /area/h7/crew)
 "bVh" = (
 /obj/lattice,
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "bVi" = (
 /turf/simulated/wall,
@@ -56886,9 +56882,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "cif" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	dir = 9;
 	icon_state = "astedge"
@@ -59912,9 +59906,7 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/fuck/main)
 "coC" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	dir = 6;
 	icon_state = "astdetail"
@@ -60621,9 +60613,7 @@
 /turf/space,
 /area/fuck/main)
 "cqc" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	dir = 4;
 	icon_state = "astedge"

--- a/maps/unused/donut2.dmm
+++ b/maps/unused/donut2.dmm
@@ -11,9 +11,7 @@
 /turf/simulated/wall/asteroid,
 /area/space)
 "aad" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aae" = (
 /obj/lattice{

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -11,9 +11,7 @@
 /turf/simulated/wall/asteroid,
 /area/space)
 "aad" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aae" = (
 /obj/lattice{

--- a/maps/unused/donut2_old.dmm
+++ b/maps/unused/donut2_old.dmm
@@ -41274,9 +41274,7 @@
 /turf/simulated/floor/plating,
 /area/space)
 "bIg" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "bIh" = (
 /turf/simulated/wall/asteroid{
@@ -53456,9 +53454,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "cjn" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	dir = 9;
 	icon_state = "astedge"
@@ -56478,9 +56474,7 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/fuck/main)
 "cpI" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	dir = 6;
 	icon_state = "astdetail"
@@ -56488,9 +56482,7 @@
 /area/fuck/main)
 "cpJ" = (
 /obj/lattice,
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "cpK" = (
 /obj/landmark/mining{
@@ -57193,9 +57185,7 @@
 /turf/space,
 /area/fuck/main)
 "crj" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	dir = 4;
 	icon_state = "astedge"

--- a/maps/unused/hainemap.dmm
+++ b/maps/unused/hainemap.dmm
@@ -2414,7 +2414,7 @@
 "gU" = (
 /obj/table/reinforced,
 /obj/item/device/radio/intercom{
-
+	
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/radio,
@@ -4643,9 +4643,7 @@
 	},
 /area/space)
 "nA" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "nB" = (
 /obj/machinery/vending/cola/red,
@@ -7054,7 +7052,7 @@
 /area/space)
 "ui" = (
 /turf/simulated/floor/black/side{
-
+	
 	},
 /area/space)
 "uj" = (

--- a/maps/unused/halloween12.dmm
+++ b/maps/unused/halloween12.dmm
@@ -39337,9 +39337,7 @@
 /turf/simulated/floor/plating,
 /area/space)
 "bCE" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "bCF" = (
 /turf/simulated/wall/asteroid{
@@ -48311,9 +48309,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "bXR" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	dir = 9;
 	icon_state = "astedge"
@@ -49910,9 +49906,7 @@
 /turf/simulated/wall,
 /area/mining/exit_east)
 "cby" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	dir = 6;
 	icon_state = "astdetail"
@@ -49920,9 +49914,7 @@
 /area/space)
 "cbz" = (
 /obj/lattice,
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "cbA" = (
 /turf/space,
@@ -50541,9 +50533,7 @@
 /turf/simulated/wall/asteroid,
 /area/space)
 "ccR" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	dir = 4;
 	icon_state = "astedge"

--- a/maps/unused/halloween14.dmm
+++ b/maps/unused/halloween14.dmm
@@ -658,9 +658,7 @@
 	},
 /area/space)
 "abq" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "abr" = (
 /obj/lattice{

--- a/maps/unused/horizon_2019.dmm
+++ b/maps/unused/horizon_2019.dmm
@@ -9883,9 +9883,7 @@
 /turf/simulated/floor/black/grime,
 /area/station/engine/substation/pylon)
 "axK" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "axL" = (
 /turf/simulated/floor/engine/vacuum{

--- a/maps/unused/linemap.dmm
+++ b/maps/unused/linemap.dmm
@@ -34289,9 +34289,7 @@
 /turf/space,
 /area/space)
 "bAT" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "bAU" = (
 /obj/grille/steel,

--- a/maps/unused/mushroom.dmm
+++ b/maps/unused/mushroom.dmm
@@ -28958,9 +28958,7 @@
 /turf/simulated/wall/asteroid,
 /area/space)
 "blb" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "blc" = (
 /turf/simulated/shuttle/wall{

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -16508,9 +16508,7 @@
 /turf/simulated/wall/asteroid,
 /area/space)
 "blb" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "blc" = (
 /turf/simulated/shuttle/wall{

--- a/maps/unused/mushroom_new_xmas.dmm
+++ b/maps/unused/mushroom_new_xmas.dmm
@@ -30109,9 +30109,7 @@
 /turf/simulated/wall/asteroid,
 /area/space)
 "blb" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "blc" = (
 /turf/simulated/shuttle/wall{

--- a/maps/unused/old_trunkmap.dmm
+++ b/maps/unused/old_trunkmap.dmm
@@ -179,9 +179,7 @@
 /turf/simulated/floor/airless/plating/damaged3,
 /area/space)
 "aaz" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aaA" = (
 /obj/grille/steel,
@@ -280,9 +278,7 @@
 	name = "Mining Outpost"
 	},
 /obj/lattice,
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aaJ" = (
 /obj/landmark/magnet_shield,
@@ -34682,9 +34678,7 @@
 	},
 /area/station/security/hos)
 "bAg" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/syndicate_station)
 "bAh" = (
 /turf/simulated/floor{

--- a/maps/unused/oldmap.dmm
+++ b/maps/unused/oldmap.dmm
@@ -18009,17 +18009,13 @@
 /turf/simulated/floor/plating,
 /area/zeta)
 "Nk" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "Nl" = (
 /turf/space,
 /area/fuck/main)
 "Nm" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	icon_state = "nw1"
 	},
@@ -18043,9 +18039,7 @@
 	},
 /area/fuck/main)
 "Nq" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	icon_state = "north1"
 	},
@@ -19261,9 +19255,7 @@
 /turf/simulated/wall/asteroid,
 /area/space)
 "Qe" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	icon_state = "west1"
 	},
@@ -19567,9 +19559,7 @@
 /turf/simulated/floor/plating,
 /area/engine/miningoutpost)
 "QR" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	icon_state = "ise1"
 	},
@@ -19769,9 +19759,7 @@
 /turf/simulated/floor/plating,
 /area/fuck/main)
 "Rs" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	icon_state = "east1"
 	},

--- a/maps/unused/samedi.dmm
+++ b/maps/unused/samedi.dmm
@@ -6,9 +6,7 @@
 /turf/simulated/wall/asteroid,
 /area/space)
 "aac" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aad" = (
 /obj/grille/steel,

--- a/maps/unused/trunkmap.dmm
+++ b/maps/unused/trunkmap.dmm
@@ -148,9 +148,7 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "aaz" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aaB" = (
 /obj/grille/steel,
@@ -295,9 +293,7 @@
 	name = "Mining Outpost"
 	},
 /obj/lattice,
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aaT" = (
 /obj/landmark/magnet_shield,

--- a/maps/unused/xmas.dmm
+++ b/maps/unused/xmas.dmm
@@ -50847,9 +50847,7 @@
 /turf/simulated/floor/plating,
 /area/AIsattele)
 "bYP" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "bYQ" = (
 /turf/simulated/wall/asteroid{
@@ -50875,9 +50873,7 @@
 	},
 /area/space)
 "bYV" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	icon_state = "nw1"
 	},
@@ -50901,9 +50897,7 @@
 	},
 /area/fuck/main)
 "bYZ" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	icon_state = "north1"
 	},
@@ -52324,9 +52318,7 @@
 /turf/simulated/wall/asteroid,
 /area/space)
 "cbU" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	icon_state = "west1"
 	},
@@ -52739,9 +52731,7 @@
 /turf/simulated/floor/plating,
 /area/engine/miningoutpost)
 "ccO" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	icon_state = "ise1"
 	},
@@ -52950,9 +52940,7 @@
 /turf/simulated/floor/plating,
 /area/fuck/main)
 "cdp" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	icon_state = "east1"
 	},

--- a/maps/warwip/atlas_horizon_xmas_2019.dmm
+++ b/maps/warwip/atlas_horizon_xmas_2019.dmm
@@ -2354,9 +2354,7 @@
 /turf/simulated/floor/industrial,
 /area/space)
 "afY" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "afZ" = (
 /turf/simulated/floor/engine/vacuum{

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -1728,9 +1728,7 @@
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
 "aHg" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aHh" = (
 /obj/tree1,
@@ -3426,9 +3424,7 @@
 /obj/lattice{
 	icon_state = "lattice-dir"
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "btr" = (
 /obj/machinery/turret,
@@ -6698,9 +6694,7 @@
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "cOU" = (
 /obj/table/reinforced/auto,
@@ -13071,9 +13065,7 @@
 /turf/simulated/floor/wood,
 /area/station/chapel/sanctuary)
 "fsQ" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/mining/magnet)
 "fsW" = (
 /obj/storage/cart/trash,
@@ -45008,9 +45000,7 @@
 	dir = 6;
 	icon_state = "lattice-dir"
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "thQ" = (
 /obj/disposalpipe/segment/morgue{

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -9,9 +9,7 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "aad" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aae" = (
 /obj/indestructible/shuttle_corner{
@@ -1231,9 +1229,7 @@
 	dir = 8;
 	icon_state = "lattice-dir"
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "adH" = (
 /obj/lattice{
@@ -2968,9 +2964,7 @@
 /area/mining/refinery)
 "aiG" = (
 /obj/grille/catwalk,
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "aiH" = (
@@ -3165,9 +3159,7 @@
 /area/mining/magnet_control)
 "aji" = (
 /obj/lattice,
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "ajj" = (
 /obj/decal/tile_edge/stripe{
@@ -4909,9 +4901,7 @@
 	dir = 1;
 	layer = 3
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/floor/airless/plating/catwalk,
 /area/space)
 "anH" = (
@@ -5292,9 +5282,7 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/mining/mainasteroid)
 "aoG" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /turf/simulated/wall/asteroid{
 	dir = 6
 	},
@@ -5742,9 +5730,7 @@
 	dir = 6;
 	icon_state = "lattice-dir"
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "apO" = (
 /turf/simulated/floor/caution/south,
@@ -5876,9 +5862,7 @@
 	dir = 4;
 	icon_state = "lattice-dir"
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "aqh" = (
 /obj/cable,
@@ -7895,9 +7879,7 @@
 	dir = 10;
 	icon_state = "lattice-dir"
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "ave" = (
 /obj/table/auto,
@@ -18958,9 +18940,7 @@
 	dir = 1;
 	icon_state = "floattiles4"
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "beg" = (
 /obj/storage/crate/loot,
@@ -21695,9 +21675,7 @@
 	dir = 8;
 	icon_state = "floattiles4"
 	},
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/space)
 "blA" = (
 /obj/decal/fakeobjects/pipe{

--- a/maps/z5.dmm
+++ b/maps/z5.dmm
@@ -1335,9 +1335,7 @@
 	},
 /area/noGenerate)
 "ep" = (
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/noGenerate)
 "eq" = (
 /obj/decal/cleanable/dirt,
@@ -6267,9 +6265,7 @@
 /area/evilreaver/genetics)
 "GJ" = (
 /obj/lattice,
-/turf/space{
-	icon_state = "aplaceholder"
-	},
+/turf/space/asteroid,
 /area/noGenerate)
 "GO" = (
 /turf/unsimulated/wall/auto/adventure/martian,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjust queuing of spacing turfs, removing prefab type of space to allow for proper path checks to new /turf/space/asteroid

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Helping resolve errant space getting into turflists