### PR TITLE
Made non-intact floors always burn down to space

### DIFF
--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1520,7 +1520,10 @@ DEFINE_FLOORS(grasslush/thin,
 	return ..()
 
 /turf/simulated/floor/burn_down()
-	src.ex_act(2)
+	if (src.intact)
+		src.ex_act(2)
+	else //make sure plating always burns down to space and not... plating
+		src.ex_act(1)
 
 /turf/simulated/floor/ex_act(severity)
 	switch(severity)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes plating and other non-intact floors always burn down to space instead of having a chance to become plating.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
ZWRh3 pointed out in the discord that thermite doesn't break plating consistently, meaning you can burn down a plating floor with thermite only for it to be replaced by plating, making it look like your thermite did nothing.
