### PR TITLE
improvements for Heavy Nukie Sword

### DIFF
--- a/code/datums/components/itemblock/saberblock.dm
+++ b/code/datums/components/itemblock/saberblock.dm
@@ -1,23 +1,27 @@
 //adds object properties to the sword while blocking with it.
 datum/component/itemblock/saberblock
 	bonus = 1 //bonus is a flag that determines whether or not the item tooltip will include "⛨ Block+: RESIST with this item for more info" when not blocking
+	var/can_block
+
+datum/component/itemblock/saberblock/Initialize(var/can_block_proc)
+	. = ..()
+	can_block = can_block_proc
 
 //proc that is called when the base item is used to block. The parent itemblock component has already registered this proc for the "COMSIG_ITEM_BLOCK_BEGIN" signal
 datum/component/itemblock/saberblock/on_block_begin(obj/item/I, var/obj/item/grab/block/B)
 	. = ..()//Always call your parents
-	var/obj/item/sword/S = I
-	if(istype(S) && S.active && S.off_w_class == W_CLASS_SMALL) //this is gross but it makes it so only active, extendable, swords (not d-saber) get defensive bonuses
+	if(!can_block || (call(I, can_block)()))
 		B.setProperty("reflection", 1)
 		B.setProperty("disorient_resist", 75)
 
 		var/blockplus = DEFAULT_BLOCK_PROTECTION_BONUS + 3
-		if(S.c_flags & BLOCK_CUT)
+		if(I.c_flags & BLOCK_CUT)
 			B.setProperty("I_block_cut", blockplus)
-		if(S.c_flags & BLOCK_STAB)
+		if(I.c_flags & BLOCK_STAB)
 			B.setProperty("I_block_stab", blockplus)
-		if(S.c_flags & BLOCK_BURN)
+		if(I.c_flags & BLOCK_BURN)
 			B.setProperty("I_block_burn", blockplus)
-		if(S.c_flags & BLOCK_BLUNT)
+		if(I.c_flags & BLOCK_BLUNT)
 			B.setProperty("I_block_blunt", blockplus)
 
 //proc that is called when the block is ended. The parent itemblock component has already registered this proc for the "COMSIG_ITEM_BLOCK_END" signal

--- a/code/datums/components/itemblock/saberblock.dm
+++ b/code/datums/components/itemblock/saberblock.dm
@@ -1,16 +1,16 @@
 //adds object properties to the sword while blocking with it.
 datum/component/itemblock/saberblock
 	bonus = 1 //bonus is a flag that determines whether or not the item tooltip will include "⛨ Block+: RESIST with this item for more info" when not blocking
-	var/can_block
+	var/can_block_check
 
 datum/component/itemblock/saberblock/Initialize(var/can_block_proc)
 	. = ..()
-	can_block = can_block_proc
+	can_block_check = can_block_proc
 
 //proc that is called when the base item is used to block. The parent itemblock component has already registered this proc for the "COMSIG_ITEM_BLOCK_BEGIN" signal
 datum/component/itemblock/saberblock/on_block_begin(obj/item/I, var/obj/item/grab/block/B)
 	. = ..()//Always call your parents
-	if(!can_block || (call(I, can_block)()))
+	if(!can_block_check || (call(I, can_block_check)()))
 		B.setProperty("reflection", 1)
 		B.setProperty("disorient_resist", 75)
 

--- a/code/modules/items/specials/ItemSpecials.dm
+++ b/code/modules/items/specials/ItemSpecials.dm
@@ -217,13 +217,14 @@
 			return (E.can_clash && world.time != E.create_time && E.clash_time > 0 && world.time <= E.create_time + E.clash_time)
 		.= ((istype(A, /obj/critter) || (isliving(A) && !isintangible(A)) || istype(A, /obj/machinery/bot)) && A != usr && A != user)
 
-	proc/showEffect(var/name = null, var/direction = NORTH, var/mob/user, alpha=255)
+	proc/showEffect(var/name = null, var/direction = NORTH, var/mob/user, color="#FFFFFF", alpha=255)
 		if(name == null || master == null) return
 		if(!user) user = usr
 		var/obj/itemspecialeffect/E = new /obj/itemspecialeffect
 		if(src.animation_color)
 			E.color = src.animation_color
 		E.alpha = alpha
+		E.color = color
 		E.setup(get_turf(user))
 		E.set_dir(direction)
 		E.icon_state = name
@@ -484,6 +485,8 @@
 	name = "Stab"
 	desc = "Attack with a 2 tile range."
 
+	var/stab_color = "#FFFFFF"
+
 	onAdd()
 		if(master)
 			//cooldown = master.click_delay
@@ -501,7 +504,7 @@
 			var/turf/one = get_step(master, direction)
 			var/turf/two = get_step(one, direction)
 
-			showEffect("spear", direction)
+			showEffect("spear", direction, color=src.stab_color)
 
 			var/hit = 0
 			for(var/turf/T in list(one, two))

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -1498,17 +1498,28 @@ obj/item/whetstone
 
 	var/mode = 1
 	var/maximum_force = 100
+	var/swipe_color = "#0081DF"
+	var/stab_color = "#FF0000"
 
 	New()
 		..()
 		START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
 		src.setItemSpecial(/datum/item_special/swipe)
+		src.update_special_color()
 		AddComponent(/datum/component/itemblock/saberblock)
 		BLOCK_SETUP(BLOCK_SWORD)
 
 	disposing()
 		STOP_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
 		..()
+
+/obj/item/heavy_power_sword/proc/update_special_color()
+	var/datum/item_special/swipe/swipe = src.special
+	var/datum/item_special/rangestab/stab = src.special
+	if (istype(swipe))
+		swipe.swipe_color = src.swipe_color
+	else if (istype(stab))
+		stab.stab_color = src.stab_color
 
 /obj/item/heavy_power_sword/attack(mob/M as mob, mob/user as mob, def_zone)
 
@@ -1540,17 +1551,16 @@ obj/item/whetstone
 			icon_state = "hadar_sword1"
 			item_state = "hadar_sword1"
 			src.mode = 2
-			user.update_inhands()
 			src.setItemSpecial(/datum/item_special/rangestab)
-			tooltip_rebuild = TRUE
 		if(2)
 			boutput(user, "<span class='alert'>[src] transforms in order to swing wide!</span>")
 			icon_state = "hadar_sword2"
 			item_state = "hadar_sword2"
 			src.mode = 1
-			user.update_inhands()
 			src.setItemSpecial(/datum/item_special/swipe)
-			tooltip_rebuild = TRUE
+	user.update_inhands()
+	tooltip_rebuild = TRUE
+	src.update_special_color()
 	..()
 
 // Battering ram - a door breeching melee tool for the armory

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -103,8 +103,11 @@
 		light_c = src.AddComponent(/datum/component/loctargeting/simple_light, r, g, b, 150)
 		light_c.update(0)
 		src.setItemSpecial(/datum/item_special/swipe/csaber)
-		AddComponent(/datum/component/itemblock/saberblock)
+		AddComponent(/datum/component/itemblock/saberblock, .proc/can_reflect)
 		BLOCK_SETUP(BLOCK_SWORD)
+
+/obj/item/sword/proc/can_reflect()
+	return src.active
 
 /obj/item/sword/attack(mob/target, mob/user, def_zone, is_special = 0)
 	if(active)
@@ -432,6 +435,9 @@
 	active_stamina_dmg = 65
 	inactive_stamina_dmg = 30
 	hit_type = DAMAGE_BLUNT
+
+	can_reflect()
+		return FALSE
 
 	get_desc()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The reflect component (like for csabers) was added to the power sword, but it never actually worked because the component required the item to actually be a csaber.
I changed the component to instead work with a proc on the item that returns whether or not it can currently reflect projectiles. If no proc is given (such as on the hadar itself) then the reflection is always on. (While blocking, of course.)

I also made the special attacks on the heavy sword (swipe and stab) have the colors of the corresponding stance on the sword.


https://user-images.githubusercontent.com/35579460/160827517-dbf856d7-338b-4d2b-abd6-9e142ce85562.mp4


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It is good if features actually work. If this proves too strong, it can always be removed later.
This also allows adding of the reflect component to things that are not csabers, if desired.

It looks nicer if the special attacks have the correct color, as they already do on some other weapons like this.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) The nukeops heavy energy sword can now reflect projectiles like a csaber can. (This was always there, it just didn't work because it was bugged until now.)
```
