### PR TITLE
Makes EMPs eat some of a cloner's records

### DIFF
--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -196,6 +196,14 @@
 		..()
 	return
 
+/obj/machinery/computer/cloning/emp_act()
+	if (length(src.records))
+		for (var/i = 0 ; i <= (min(5,length(src.records))), i += 1) //eat up to 5 records
+			var/RIP = pick(src.records)
+			src.records.Remove(RIP)
+			qdel(RIP)
+	..()
+
 // message = message you want to pass to the noticebox
 // status = warning/success/danger/info which changes the color of the noticebox on the frontend
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat][input wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes EMPs delete up to 5 records from an affected cloning console.

This is on top of the 20% chance for most consoles to just die from EMP, but that's already existing behaviour.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I saw a discussion on cloner sabotage and thought this was a pretty neat idea. Allows for some more traitor fuckery that isn't blowing the entire damn thing up. Plus EMP grenades could use some more things to interact with.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)EMPs now delete some of a cloner's records.
```
