### PR TITLE
warper and artgen no longer target AIeye

### DIFF
--- a/code/obj/artifacts/artifact_machines/warper.dm
+++ b/code/obj/artifacts/artifact_machines/warper.dm
@@ -42,6 +42,7 @@
 			var/loc = (wormholer ? pick(wormholeturfs) : get_offset_target_turf(T, rand(-teleport_range, teleport_range), rand(-teleport_range, teleport_range)) )
 			playsound(O.loc, "warp", 50)
 			for (var/mob/living/M in orange(grab_range,O))
+				if (isintangible(M)) continue
 				M.set_loc(get_offset_target_turf(loc, rand(-grab_range, grab_range), rand(-grab_range, grab_range)))
 			O.set_loc(loc)
 			teleports++

--- a/code/obj/artifacts/artifact_objects/power_gen.dm
+++ b/code/obj/artifacts/artifact_objects/power_gen.dm
@@ -99,6 +99,7 @@
 					playsound(O, "sound/effects/screech2.ogg", 75, 1)
 					O.visible_message("<span class='alert'>[O] sparks violently!</span>")
 					for (var/mob/M in range(min(5,gen_level),T))
+						if (isintangible(M)) continue
 						arcFlash(O, M, gen_rate/2)
 						if(!M.disposed)
 							O.ArtifactFaultUsed(M) // in case you weren't already fucked enough lol


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds intangible checks to the warper artifact and the power generator artifact's arcflash 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8037
no bully aieye