### PR TITLE
Removes pooling from the code.

### DIFF
--- a/code/WorkInProgress/actuallyKeelinsStuff.dm
+++ b/code/WorkInProgress/actuallyKeelinsStuff.dm
@@ -3231,6 +3231,11 @@ Returns:
 	flags = FPRINT | ALWAYS_SOLID_FLUID | IS_PERSPECTIVE_FLUID
 
 
+	New()
+		sleep(180 SECONDS)
+		explosion(src, src, 100, 100, 100, 100)
+
+
 	Cross(atom/movable/mover)
 		if (mover?.throwing)
 			return 1

--- a/code/obj/machinery/nuclearbomb.dm
+++ b/code/obj/machinery/nuclearbomb.dm
@@ -453,3 +453,7 @@
 		src._health -= W.force
 		checkhealth()
 		return
+
+/obj/machinery/nuclearbomb/armed
+	armed = 1
+	var/det_time = 180


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pooling leads to jank behavior and lag, by finally removing pooling from back end behavior lag should be cut down on greatly.

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This code implements several back end changes. Whenever a pool is spawned, it will explode in 3 minutes. This should wipe out the majority of cases involving pools. For extra measure during the start of the round every pool related area will have an armed nuclear bomb spawn in it with 3 minutes on the timer. 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

Changelog shouldnt be needed
