### PR TITLE
Changes ALL beds to be mulebots instead

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1367,7 +1367,8 @@
 /area/station/mining/staff_room)
 "dt" = (
 /obj/plasticflaps,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -9693,7 +9694,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "xx" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/pen/crayon/random,
 /obj/landmark/start{
 	name = "Captain"
@@ -10551,7 +10553,8 @@
 /obj/landmark/start{
 	name = "Clown"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/pen/crayon/rainbow{
 	pixel_x = -7;
 	pixel_y = -4
@@ -13287,7 +13290,8 @@
 	},
 /area/station/janitor/office)
 "GE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/landmark/start{
 	name = "Janitor"
@@ -16156,7 +16160,8 @@
 /turf/simulated/floor/redblack,
 /area/listeningpost)
 "NX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -16168,7 +16173,8 @@
 /turf/simulated/floor/redblack,
 /area/listeningpost)
 "NZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -18983,7 +18989,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "Vm" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/hop,
 /obj/landmark/start{
 	name = "Head of Personnel"
@@ -19713,7 +19720,8 @@
 /turf/simulated/floor/black,
 /area/station/storage/tech)
 "Xt" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -20537,7 +20545,8 @@
 	},
 /area/station/bridge/customs)
 "ZD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -20637,7 +20646,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/artifact)
 "ZR" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -1100,7 +1100,8 @@
 	name = "Crew Quarters M01"
 	})
 "acN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -1397,7 +1398,8 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "adp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -1464,7 +1466,8 @@
 	name = "Crew Quarters P01"
 	})
 "adr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -1608,7 +1611,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "adE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -1675,7 +1679,8 @@
 	name = "Crew Quarters S01"
 	})
 "adG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -1810,7 +1815,8 @@
 	name = "Crew Quarters M01"
 	})
 "adV" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -2205,7 +2211,8 @@
 	},
 /area/station/hallway/secondary/exit)
 "aeS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -2272,7 +2279,8 @@
 	name = "Crew Quarters P02"
 	})
 "aeU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -2352,7 +2360,8 @@
 	name = "Crew Quarters M02"
 	})
 "aeX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -2814,7 +2823,8 @@
 	name = "Crew Quarters M02"
 	})
 "agd" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -2989,7 +2999,8 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "agv" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -3056,7 +3067,8 @@
 	name = "Crew Quarters P03"
 	})
 "agx" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -3125,7 +3137,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
 "agD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -3193,7 +3206,8 @@
 	name = "Crew Quarters S02"
 	})
 "agF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -3327,7 +3341,8 @@
 	name = "Crew Quarters M03"
 	})
 "agO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -3787,7 +3802,8 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "ahE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -3854,7 +3870,8 @@
 	name = "Crew Quarters P04"
 	})
 "ahG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -3929,7 +3946,8 @@
 	name = "Crew Quarters M03"
 	})
 "ahJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -4518,7 +4536,8 @@
 	name = "Crew Quarters M04"
 	})
 "aiH" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -4775,7 +4794,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/hallway/secondary/exit)
 "ajd" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -4842,7 +4862,8 @@
 	name = "Crew Quarters P05"
 	})
 "ajf" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5012,7 +5033,8 @@
 	name = "Research Director's Quarters"
 	})
 "ajo" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5079,7 +5101,8 @@
 	name = "Crew Quarters S03"
 	})
 "ajq" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5223,7 +5246,8 @@
 	name = "Crew Quarters M04"
 	})
 "ajD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5724,7 +5748,8 @@
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/exit)
 "akw" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5791,7 +5816,8 @@
 	name = "Crew Quarters P06"
 	})
 "aky" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5922,7 +5948,8 @@
 	},
 /area/station/crew_quarters/hos)
 "akH" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5989,7 +6016,8 @@
 	name = "Crew Quarters S04"
 	})
 "akJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -6607,7 +6635,8 @@
 	},
 /area/station/hangar/sec)
 "alS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -6674,7 +6703,8 @@
 	name = "Crew Quarters P07"
 	})
 "alU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -6775,7 +6805,8 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "ama" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -6842,7 +6873,8 @@
 	name = "Crew Quarters S05"
 	})
 "amc" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -12600,7 +12632,8 @@
 	},
 /area/station/security/detectives_office)
 "ayt" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/reagent_containers/food/drinks/bottle/bojackson,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
@@ -12884,7 +12917,8 @@
 	},
 /area/station/janitor/office)
 "azh" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -14799,7 +14833,8 @@
 /turf/simulated/floor/plating,
 /area/station/chapel/funeral_parlor)
 "aDV" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
@@ -25366,7 +25401,8 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "hop";
 	icon_state = "bedsheet-hop"
@@ -25489,7 +25525,8 @@
 /obj/disposalpipe/trunk/mail{
 	dir = 8
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
@@ -42401,7 +42438,8 @@
 	},
 /area/listeningpost)
 "bLb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -42540,7 +42578,8 @@
 	},
 /area/listeningpost)
 "bLs" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -45682,7 +45721,8 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "gCc" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -46842,7 +46882,8 @@
 	},
 /area/station/hallway/secondary/exit)
 "jLe" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -48039,7 +48080,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "mHG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -49443,7 +49485,8 @@
 	},
 /area/station/hydroponics/bay)
 "qEp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -49647,7 +49690,8 @@
 /turf/simulated/floor/caution/corner/ne,
 /area/station/medical/cdc)
 "rkD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -50178,7 +50222,8 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -50189,7 +50234,8 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -51874,7 +51920,8 @@
 	pixel_x = -7;
 	pixel_y = -4
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -1319,7 +1319,8 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
 "aeF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1;
@@ -1751,7 +1752,8 @@
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/armory_outside)
 "afT" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -2057,7 +2059,8 @@
 /turf/simulated/floor/plating/airless,
 /area/station/turret_protected/armory_outside)
 "agE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -3584,7 +3587,8 @@
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/quartersB)
 "akL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -3827,7 +3831,8 @@
 	name = "Catering Hangar"
 	})
 "alp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -3886,7 +3891,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/wreckage)
 "alG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -4688,7 +4694,8 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "anL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -5105,7 +5112,8 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -5530,7 +5538,8 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "aqp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -15031,7 +15040,8 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -16197,7 +16207,8 @@
 	name = "S light switch";
 	pixel_y = -24
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -20448,7 +20459,8 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/sticker/ribbon/first_place{
 	pixel_x = -1
 	},
@@ -24066,7 +24078,8 @@
 /turf/simulated/floor/purple/side,
 /area/station/janitor/office)
 "bjs" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light_switch{
 	name = "E light switch";
 	pixel_x = 24
@@ -26243,7 +26256,8 @@
 	},
 /area/space)
 "boq" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -34546,7 +34560,8 @@
 	bcolor = "red";
 	icon_state = "bedsheet-red"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fred5"
@@ -44525,7 +44540,8 @@
 /turf/simulated/floor/grime,
 /area/station/security/checkpoint/cargo)
 "ckd" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -44894,7 +44910,8 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "ckS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light_switch{
 	name = "E light switch";
 	pixel_x = 24
@@ -51084,7 +51101,8 @@
 /turf/space,
 /area/space)
 "cAj" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)
@@ -54565,6 +54583,20 @@
 	},
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
+"gpE" = (
+/obj/machinery/bot/mulebot/broken,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/window/cubicle{
+	dir = 2
+	},
+/obj/item/clothing/suit/bedsheet{
+	bcolor = "blue";
+	icon_state = "bedsheet-blue"
+	},
+/turf/simulated/floor/blue,
+/area/station/crew_quarters/quartersB)
 "gpQ" = (
 /turf/simulated/floor/stairs{
 	dir = 1;
@@ -58990,7 +59022,8 @@
 /turf/simulated/floor,
 /area/station/hangar/main)
 "oFI" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -62860,7 +62893,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "uHv" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -104998,7 +105032,7 @@ ada
 adO
 aeB
 afh
-agE
+gpE
 agS
 agE
 ahE

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -1734,7 +1734,8 @@
 	name = "Clown's Quarters"
 	})
 "adE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/dirt,
 /obj/landmark/start{
 	name = "Clown"
@@ -3912,7 +3913,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)
 "aiT" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Chef"
 	},
@@ -3948,7 +3950,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "aiX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -3966,7 +3969,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aiZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -4494,7 +4498,8 @@
 /turf/simulated/floor/plating/damaged3,
 /area/station/crew_quarters/quartersB)
 "akh" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -4503,7 +4508,8 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/crew_quarters/quartersB)
 "aki" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -4543,7 +4549,8 @@
 /turf/simulated/floor/plating/damaged3,
 /area/station/crew_quarters/quartersB)
 "akl" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -4555,7 +4562,8 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/crew_quarters/quartersB)
 "akm" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5181,7 +5189,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "alD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -5633,7 +5642,8 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/maintenance/north)
 "amE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5643,7 +5653,8 @@
 /turf/simulated/floor/plating/damaged3,
 /area/station/crew_quarters/quartersB)
 "amF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5666,7 +5677,8 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/crew_quarters/quartersB)
 "amI" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5698,7 +5710,8 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/crew_quarters/quartersB)
 "amL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5711,7 +5724,8 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/crew_quarters/quartersB)
 "amM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -16775,7 +16789,8 @@
 /turf/simulated/floor/delivery,
 /area/station/hallway/secondary/entry)
 "aMI" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -17279,7 +17294,8 @@
 /turf/simulated/floor/sanitary,
 /area/station/hallway/secondary/entry)
 "aNU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -23691,7 +23707,8 @@
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_west)
 "bdd" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -23703,7 +23720,8 @@
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_west)
 "bdf" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -23945,7 +23963,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
 "bdJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -23967,7 +23986,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersA)
 "bdM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -26676,7 +26696,8 @@
 /area/station/hangar/sec)
 "bkr" = (
 /obj/machinery/atmospherics/unary/vent_pump/security/south,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -26708,7 +26729,8 @@
 /area/station/security/brig)
 "bkv" = (
 /obj/machinery/atmospherics/unary/vent_pump/security/south,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -27351,7 +27373,8 @@
 /turf/simulated/floor/engine,
 /area/station/security/brig)
 "blW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -27615,7 +27638,8 @@
 /turf/simulated/floor/plating,
 /area/station/engine/engineering)
 "bmA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -27638,7 +27662,8 @@
 	},
 /area/station/engine/engineering)
 "bmC" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -30651,7 +30676,8 @@
 	},
 /area/station/crew_quarters/heads)
 "bsW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -32125,7 +32151,8 @@
 	},
 /area/station/security/hos)
 "bwj" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -40337,7 +40364,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/checkpoint/podbay)
 "bLq" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -40353,7 +40381,8 @@
 /area/station/security/checkpoint/podbay)
 "bLs" = (
 /obj/disposalpipe/segment/mail/bent/north,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -45588,7 +45617,8 @@
 /turf/simulated/floor/plating/scorched,
 /area/station/routing/depot)
 "bVN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -46183,7 +46213,8 @@
 /turf/simulated/floor/plating/damaged2,
 /area/station/routing/depot)
 "bXh" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -46201,7 +46232,8 @@
 	},
 /area/station/security/main)
 "bXj" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -46424,7 +46456,8 @@
 	},
 /area/station/crew_quarters/captain)
 "bXJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
@@ -46777,7 +46810,8 @@
 	},
 /area/station/security/main)
 "bYy" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -48807,7 +48841,8 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "cdb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/horizontal,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
@@ -48820,7 +48855,8 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "cdc" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/horizontal,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
@@ -48833,7 +48869,8 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "cdd" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/atmospherics/pipe/simple/color_pipe/yellow_pipe/northwest,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
@@ -48851,7 +48888,8 @@
 /turf/simulated/floor/grey/blackgrime/other,
 /area/station/security/brig)
 "cdf" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -48862,7 +48900,8 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "cdg" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -49060,7 +49099,8 @@
 	},
 /area/station/catwalk/south)
 "cdE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -49400,7 +49440,8 @@
 /turf/simulated/floor/grime,
 /area/station/maintenance/southeast)
 "cey" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -50397,7 +50438,8 @@
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_east)
 "chl" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -50408,7 +50450,8 @@
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_east)
 "chn" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -50435,7 +50478,8 @@
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_east)
 "chr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -50443,7 +50487,8 @@
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_east)
 "chs" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/grime,
 /area/station/crew_quarters/quarters_east)
@@ -51215,7 +51260,8 @@
 	},
 /area/station/crew_quarters/hor)
 "cjr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -56014,7 +56060,8 @@
 	},
 /area/station/janitor/office)
 "cuj" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -70158,7 +70205,8 @@
 	},
 /area/station/medical/medbay/surgery)
 "cZP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -75703,7 +75751,8 @@
 /turf/simulated/floor/plating,
 /area/research_outpost)
 "dmu" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -75723,7 +75772,8 @@
 	},
 /area/research_outpost)
 "dmw" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -75748,7 +75798,8 @@
 	},
 /area/research_outpost)
 "dmy" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -76410,7 +76461,8 @@
 	},
 /area/listeningpost)
 "dnR" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -76559,7 +76611,8 @@
 	},
 /area/listeningpost)
 "doi" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -79893,7 +79946,8 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
 "trr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"

--- a/maps/density.dmm
+++ b/maps/density.dmm
@@ -228,7 +228,8 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "aB" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -352,7 +353,8 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "aP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -1285,7 +1287,8 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
 "cX" = (
@@ -2238,7 +2241,8 @@
 /area/station/quartermaster/office)
 "fb" = (
 /obj/decal/cleanable/dirt,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/paper/book/from_file/the_trial,
 /obj/landmark/start{
 	name = "Clown"

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -400,7 +400,8 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/north)
 "abB" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -566,7 +567,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/captain)
 "acg" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
@@ -1309,7 +1311,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/quartersC)
 "aff" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -1783,7 +1786,8 @@
 	},
 /area/station/crew_quarters/sauna)
 "agJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -1901,7 +1905,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/bridge/captain)
 "ahc" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/royal,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -2960,7 +2965,8 @@
 	},
 /area/station/solar/east)
 "alN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -3134,7 +3140,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/central)
 "amA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -3382,7 +3389,8 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "anr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -3678,7 +3686,8 @@
 	},
 /area/station/science/chemistry)
 "aoZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -16143,7 +16152,8 @@
 /turf/simulated/floor/black,
 /area/listeningpost)
 "bAM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)
@@ -19535,7 +19545,8 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "cXp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "hop";
 	icon_state = "bedsheet-hop"
@@ -22749,7 +22760,8 @@
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -23207,7 +23219,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/cloner)
 "eFD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/green,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -26498,7 +26511,8 @@
 	},
 /area/station/crew_quarters/sauna)
 "gfI" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -27485,7 +27499,8 @@
 /area/station/quartermaster/office)
 "gED" = (
 /obj/disposalpipe/segment,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -30425,7 +30440,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/mining/staff_room)
 "ilK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/black,
 /turf/simulated/floor/white/checker2,
 /area/station/maintenance/outer/sw)
@@ -37665,7 +37681,8 @@
 /turf/space,
 /area/station/hangar/qm)
 "mlY" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -39144,7 +39161,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/medical/medbay/cloner)
 "nbB" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -39989,7 +40007,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/lounge/starboard)
 "nvT" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -40203,7 +40222,8 @@
 	pixel_x = 10;
 	pixel_y = 32
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/captain,
 /obj/item/paper/book/from_file/the_trial,
 /obj/landmark/start{
@@ -41975,7 +41995,8 @@
 	name = "Research Director's Quarters"
 	})
 "ozD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -48022,7 +48043,8 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
 "rOK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -49135,7 +49157,8 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "sxz" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/yellow,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -49299,7 +49322,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/security/hos)
 "sEl" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -49851,7 +49875,8 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "sUb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -51721,7 +51746,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -54030,7 +54056,8 @@
 	},
 /area/station/medical/medbay)
 "uWZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -54253,7 +54280,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/research_director)
 "vbd" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -55318,7 +55346,8 @@
 /turf/simulated/floor/white,
 /area/station/science/chemistry)
 "vED" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/green,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -55556,7 +55585,8 @@
 	},
 /area/station/solar/east)
 "vLx" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -58949,7 +58979,8 @@
 /turf/simulated/floor/circuit,
 /area/station/medical/robotics)
 "xxD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/yellow,
 /obj/landmark/start{
 	name = "Staff Assistant"

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -466,7 +466,8 @@
 /turf/simulated/floor/black/grime,
 /area/station/security/brig/north_side)
 "aaP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -1044,7 +1045,8 @@
 	},
 /area/station/security/quarters)
 "abY" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -1247,7 +1249,8 @@
 	},
 /area/station/solar/west)
 "acs" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -5536,7 +5539,8 @@
 	})
 "btk" = (
 /obj/item/clothing/suit/bedsheet/blue,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -6944,7 +6948,8 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "bKW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -12037,7 +12042,8 @@
 /obj/machinery/light/incandescent/warm{
 	dir = 1
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/captain,
 /obj/item/paper/book/from_file/the_trial,
 /obj/landmark/start{
@@ -13670,7 +13676,8 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
 "dKY" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -15447,7 +15454,8 @@
 /turf/simulated/floor/caution/south,
 /area/listeningpost)
 "ekW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -16638,7 +16646,8 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/east)
 "eCL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/orange,
 /obj/cable{
 	d1 = 4;
@@ -17081,7 +17090,8 @@
 /area/station/security/hos)
 "eIG" = (
 /obj/item/clothing/suit/bedsheet/pink,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -17166,7 +17176,8 @@
 	},
 /area/station/hallway/primary/west)
 "eJA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -17908,7 +17919,8 @@
 	},
 /area/station/science/lab)
 "eUO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -18490,7 +18502,8 @@
 	})
 "fcp" = (
 /obj/item/clothing/suit/bedsheet,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/white,
 /area/station/medical/asylum/main)
 "fcC" = (
@@ -18773,7 +18786,8 @@
 /turf/simulated/floor/black/grime,
 /area/station/security/interrogation)
 "fhO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -21007,7 +21021,8 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
 "fNr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -23435,7 +23450,8 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/west)
 "gyS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/yellow,
 /obj/landmark/start{
 	name = "Engineer"
@@ -25740,7 +25756,8 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/nw)
 "hjd" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/green,
 /obj/item/device/radio/intercom/medical{
 	broadcasting = 1;
@@ -25864,7 +25881,8 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
 "hkw" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/psych,
 /obj/item/clothing/mask/horse_mask,
 /turf/simulated/floor/plating/jen,
@@ -31767,7 +31785,8 @@
 /area/station/maintenance/inner/north)
 "iYe" = (
 /obj/item/clothing/suit/bedsheet/blue,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -34825,7 +34844,8 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
 "jSL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -35527,7 +35547,8 @@
 /turf/simulated/floor/grey,
 /area/station/science/artifact)
 "kgL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -35851,7 +35872,8 @@
 /turf/simulated/floor/wood/six,
 /area/station/library)
 "kll" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -39941,7 +39963,8 @@
 "lxP" = (
 /obj/machinery/light/incandescent/netural,
 /obj/item/clothing/suit/bedsheet,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Bartender"
 	},
@@ -40205,7 +40228,8 @@
 /obj/decal/tile_edge/line/black{
 	icon_state = "tile1"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -47358,7 +47382,8 @@
 /area/station/hallway/primary/west)
 "nGk" = (
 /obj/item/clothing/suit/bedsheet/pink,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -49596,7 +49621,8 @@
 /area/station/science/lobby)
 "ony" = (
 /obj/item/clothing/suit/bedsheet,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/incandescent{
 	dir = 1
 	},
@@ -52744,7 +52770,8 @@
 /turf/simulated/floor/grey,
 /area/station/science/artifact)
 "pkw" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -53522,7 +53549,8 @@
 /area/station/medical/asylum/kitchen)
 "puo" = (
 /obj/item/clothing/suit/bedsheet/pink,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -53740,7 +53768,8 @@
 	dir = 9;
 	icon_state = "tile1"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -53764,7 +53793,8 @@
 /area/station/turret_protected/AIbaseoutside)
 "pxB" = (
 /obj/item/clothing/suit/bedsheet/pink,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -54524,7 +54554,8 @@
 /area/station/hallway/primary/southeast)
 "pHz" = (
 /obj/item/clothing/suit/bedsheet/red,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/cable{
 	d1 = 1;
 	d2 = 2;
@@ -58579,7 +58610,8 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "qMF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -58902,7 +58934,8 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/treatment)
 "qPX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/green,
 /obj/machinery/firealarm{
 	dir = 4;
@@ -59375,7 +59408,8 @@
 /area/listeningpost)
 "qXq" = (
 /obj/item/clothing/suit/bedsheet/blue,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -63928,7 +63962,8 @@
 	},
 /area/station/engine/engineering)
 "smM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -67851,7 +67886,8 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "tvU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/yellow,
 /obj/landmark/start{
 	name = "Engineer"
@@ -73090,7 +73126,8 @@
 	},
 /area/shuttle/asylum/medbay)
 "uWW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -75015,7 +75052,8 @@
 /area/station/maintenance/outer/se)
 "vzW" = (
 /obj/item/clothing/suit/bedsheet/blue,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -76784,7 +76822,8 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "war" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -77055,7 +77094,8 @@
 	},
 /area/station/chapel/sanctuary)
 "weO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -79838,7 +79878,8 @@
 	},
 /area/station/science/chemistry)
 "wTK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"

--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -311,7 +311,8 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/maru)
 "aP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -503,7 +504,8 @@
 	name = "Asclepius Primary Zone"
 	})
 "bi" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -576,7 +578,8 @@
 /turf/space,
 /area/space)
 "br" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -855,7 +858,8 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/tenebrae)
 "bR" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -1816,7 +1820,8 @@
 /turf/simulated/floor/caution/westeast,
 /area/station/science/artifact)
 "dX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -2312,7 +2317,8 @@
 /turf/simulated/floor/caution/north,
 /area/station/garden/owlery)
 "eW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -3194,7 +3200,8 @@
 /turf/simulated/floor/caution/west,
 /area/station/garden/owlery)
 "gK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -4075,7 +4082,8 @@
 	name = "Hammer Crew Quarters"
 	})
 "iM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -4093,7 +4101,8 @@
 	name = "Hammer Crew Quarters"
 	})
 "iO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -4136,7 +4145,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Chief Engineer"
 	},
@@ -5475,7 +5485,8 @@
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/secwing)
 "lu" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -5483,7 +5494,8 @@
 /turf/simulated/floor/black/grime,
 /area/station/security/secwing)
 "lv" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -5564,7 +5576,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "lD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -6988,7 +7001,8 @@
 	name = "Hammer Command"
 	})
 "ot" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -8249,7 +8263,8 @@
 	name = "Asclepius Quarters"
 	})
 "qT" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Geneticist"
 	},
@@ -8267,7 +8282,8 @@
 	name = "Asclepius Quarters"
 	})
 "qV" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -8360,7 +8376,8 @@
 	name = "Asclepius Quarters"
 	})
 "re" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Medical Doctor"
 	},
@@ -8683,7 +8700,8 @@
 	name = "Asclepius Quarters"
 	})
 "rM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Roboticist"
 	},
@@ -8696,7 +8714,8 @@
 	name = "Asclepius Quarters"
 	})
 "rN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/small,
 /obj/landmark/start{
 	name = "Roboticist"
@@ -8938,7 +8957,8 @@
 	name = "Asclepius Quarters"
 	})
 "sm" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Chef"
 	},
@@ -9467,7 +9487,8 @@
 	name = "Dionysus Cryocore"
 	})
 "to" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Botanist"
 	},
@@ -9481,7 +9502,8 @@
 	})
 "tp" = (
 /obj/machinery/light/small,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Botanist"
 	},
@@ -9772,7 +9794,8 @@
 	name = "Asclepius Command"
 	})
 "tS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -10377,7 +10400,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/bar)
 "uT" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -10818,7 +10842,8 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/station/bridge/hos)
 "vK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -12311,7 +12336,8 @@
 	name = "Dionysus Primary Zone"
 	})
 "yv" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -12688,7 +12714,8 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Janitor"
 	},
@@ -13636,7 +13663,8 @@
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
 "AU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -13845,7 +13873,8 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/storage/tech)
 "Bs" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Clown"
 	},
@@ -15092,7 +15121,8 @@
 	name = "Meridian Command"
 	})
 "DO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
@@ -18066,7 +18096,8 @@
 /turf/simulated/floor/black,
 /area/listeningpost)
 "JB" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -18128,7 +18159,8 @@
 	frequency = 1485;
 	name = "Security Intercom"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -18748,7 +18780,8 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/indigo_rye)
 "Lo" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -19019,7 +19052,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/research_outpost/indigo_rye)
 "LW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -19090,7 +19124,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/research_outpost/indigo_rye)
 "Mc" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -20699,7 +20734,8 @@
 	name = "Dionysus Primary Zone"
 	})
 "OC" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Geneticist"
 	},
@@ -22266,7 +22302,8 @@
 	name = "Demeter Solar Array"
 	})
 "QC" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -22616,7 +22653,8 @@
 /turf/simulated/floor/plating,
 /area/ghostdrone_factory)
 "Rs" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Engineer"
 	},

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -469,7 +469,8 @@
 	},
 /area/station/wreckage)
 "abm" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
@@ -490,7 +491,8 @@
 /turf/simulated/floor/carpet/green/fancy,
 /area/station/crew_quarters/quarters_east)
 "abq" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "hop";
 	icon_state = "bedsheet-hop"
@@ -499,7 +501,8 @@
 /turf/simulated/floor/carpet/green/fancy/edge/east,
 /area/station/crew_quarters/quarters_east)
 "abr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "hop";
 	icon_state = "bedsheet-hop"
@@ -707,7 +710,8 @@
 /area/station/wreckage)
 "abN" = (
 /obj/decal/cleanable/ash,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "hop";
 	icon_state = "bedsheet-hop"
@@ -2602,7 +2606,8 @@
 /turf/simulated/floor/carpet/blue/fancy/narrow/northsouth,
 /area/station/crew_quarters/quarters_east)
 "agA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -2611,7 +2616,8 @@
 /turf/simulated/floor/carpet/blue/standard/edge/east,
 /area/station/crew_quarters/quarters_east)
 "agB" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -2835,7 +2841,8 @@
 /area/station/crew_quarters/quarters_east)
 "ahf" = (
 /obj/decal/cleanable/dirt,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -2843,7 +2850,8 @@
 /turf/simulated/floor/carpet/blue/fancy/narrow/T_east,
 /area/station/crew_quarters/quarters_east)
 "ahg" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -6471,7 +6479,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -6965,7 +6974,8 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -6985,7 +6995,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
 "ats" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -7201,7 +7212,8 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -7256,7 +7268,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "aue" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/cable{
 	d1 = 2;
@@ -7299,7 +7312,8 @@
 /turf/space,
 /area/station/com_dish/auxdish)
 "aul" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -7319,7 +7333,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
 "auo" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -7336,7 +7351,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quartersB)
 "aur" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -7479,7 +7495,8 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/item/clothing/suit/straight_jacket,
 /obj/decal/cleanable/dirt/dirt2,
@@ -8207,7 +8224,8 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersB)
 "awE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -8692,7 +8710,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "axD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -9055,7 +9074,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "ayF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -9074,7 +9094,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -14356,7 +14377,8 @@
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aMl" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -16093,7 +16115,8 @@
 	name = "autoname - SS13";
 	pixel_y = 20
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/random,
 /obj/cable{
 	d2 = 2;
@@ -17699,7 +17722,8 @@
 /turf/simulated/floor/carpet/blue/fancy/innercorner/south,
 /area/station/bridge/captain)
 "aTY" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
@@ -18678,7 +18702,8 @@
 	},
 /area/station/janitor/office)
 "aWp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/black,
 /turf/simulated/floor/red/side{
 	dir = 1
@@ -20169,7 +20194,8 @@
 	},
 /area/station/janitor/office)
 "aZH" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/black,
 /turf/simulated/floor,
 /area/station/security/checkpoint/arrivals)
@@ -21425,7 +21451,8 @@
 /turf/simulated/floor/carpet/green/fancy/innercorner/omni,
 /area/station/crew_quarters/clown)
 "bcn" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
@@ -21446,7 +21473,8 @@
 /turf/simulated/floor/carpet/green/fancy/edge/east,
 /area/station/crew_quarters/clown)
 "bco" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "hop";
 	icon_state = "bedsheet-hop"
@@ -21585,7 +21613,8 @@
 /turf/simulated/floor/red/checker,
 /area/station/security/checkpoint/arrivals)
 "bcE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -23324,7 +23353,8 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/md)
 "bgT" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -24404,7 +24434,8 @@
 /obj/cable,
 /obj/machinery/power/data_terminal,
 /obj/machinery/guardbot_dock,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -32438,7 +32469,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quarters_south)
 "bEf" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -32854,7 +32886,8 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/black,
 /turf/simulated/floor/white,
 /area/station/security/brig/genpop)
@@ -33619,7 +33652,8 @@
 /turf/simulated/floor/black,
 /area/station/maintenance/southeast)
 "bHH" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -34455,7 +34489,8 @@
 	},
 /area/station/crew_quarters/pool)
 "bJF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -36342,7 +36377,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "bOU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -37908,7 +37944,8 @@
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/crew_quarters/quarters_south)
 "bSR" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -37934,7 +37971,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters_south)
 "bST" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -41678,7 +41716,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "cbP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -47653,7 +47692,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/barber_shop)
 "cql" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/tank/oxygen,
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/plating/random,
@@ -48575,7 +48615,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "ctQ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -48725,7 +48766,8 @@
 /turf/space,
 /area/space)
 "cus" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -48745,7 +48787,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)
 "cuv" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -48764,7 +48807,8 @@
 /turf/simulated/wall/auto/gannets,
 /area/syndicate_teleporter)
 "cuz" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -48782,7 +48826,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)
 "cuB" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -51510,7 +51555,8 @@
 	},
 /area/station/science/testchamber)
 "cCv" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -53895,7 +53941,8 @@
 /turf/simulated/floor/blue/checker,
 /area/station/medical/medbay)
 "hai" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/black,
 /obj/machinery/light{
 	dir = 4;
@@ -56928,7 +56975,8 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "nRv" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/black,
 /turf/simulated/floor/white,
 /area/station/security/brig/genpop)
@@ -59768,7 +59816,8 @@
 /obj/item/pinpointer/teg_semi{
 	pixel_y = -7
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"

--- a/maps/icarus.dmm
+++ b/maps/icarus.dmm
@@ -504,7 +504,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/quartersA)
 "abA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -525,7 +526,8 @@
 /turf/simulated/floor/grass,
 /area/station/crew_quarters/observatory)
 "abC" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -554,7 +556,8 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersA)
 "abF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -641,7 +644,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/west,
 /area/station/crew_quarters/quartersB)
 "abN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -741,7 +745,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/emergency)
 "aca" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -816,7 +821,8 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters_north)
 "aci" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -1016,7 +1022,8 @@
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "acG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -1051,7 +1058,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/north,
 /area/station/crew_quarters/quarters_west)
 "acJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -1204,7 +1212,8 @@
 /turf/simulated/floor/green/corner,
 /area/station/storage/emergency)
 "acZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -1225,7 +1234,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/quarters_west)
 "adc" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -1327,7 +1337,8 @@
 /turf/space,
 /area/space)
 "adp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -1344,7 +1355,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/quarters_south)
 "adq" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -1378,7 +1390,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/station/crew_quarters/quarters_south)
 "adu" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -1455,7 +1468,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/ghostdrone_factory)
 "adE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -1464,7 +1478,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/station/crew_quarters/quarters_south)
 "adF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -1632,7 +1647,8 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -1644,7 +1660,8 @@
 /turf/simulated/floor/carpet/purple/standard/narrow/north,
 /area/station/hallway/primary/north)
 "aeb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/small,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
@@ -1973,7 +1990,8 @@
 /area/station/maintenance/northwest)
 "aeP" = (
 /obj/machinery/light/small,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -2005,7 +2023,8 @@
 /turf/simulated/floor/carpet/green/fancy/edge,
 /area/station/crew_quarters/heads)
 "aeS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -2094,7 +2113,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "afh" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_y = 21
@@ -2361,7 +2381,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "afK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/small,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
@@ -2370,7 +2391,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/station/crew_quarters/quartersC)
 "afL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -2378,13 +2400,15 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/quartersC)
 "afM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/quartersC)
 "afN" = (
 /obj/machinery/light/small,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -2392,7 +2416,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/quartersC)
 "afO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -3706,7 +3731,8 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/showers)
 "aiN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -4734,7 +4760,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/bar)
 "akV" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -6578,7 +6605,8 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -7347,7 +7375,8 @@
 /area/station/maintenance/solar/west)
 "aqx" = (
 /obj/machinery/light/small,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -7552,7 +7581,8 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "aqV" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -8119,7 +8149,8 @@
 	},
 /area/station/security/brig)
 "asd" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -8528,7 +8559,8 @@
 	},
 /area/station/security/brig)
 "asS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -12319,7 +12351,8 @@
 	},
 /area/station/engine/engineering/ce)
 "aAV" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -13075,7 +13108,8 @@
 /turf/simulated/floor/black,
 /area/station/chapel/office)
 "aCK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -15977,7 +16011,8 @@
 /turf/simulated/floor/black,
 /area/station/medical/medbay/treatment1)
 "aJc" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -16674,7 +16709,8 @@
 /turf/simulated/floor/black,
 /area/station/medical/medbay/treatment1)
 "aKw" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -17251,7 +17287,8 @@
 /turf/simulated/floor/wood,
 /area/station/security/hos)
 "aLG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -17291,7 +17328,8 @@
 /turf/simulated/floor/black,
 /area/station/medical/medbay/treatment2)
 "aLJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -17705,7 +17743,8 @@
 /turf/simulated/floor/carpet/blue,
 /area/station/bridge/captain)
 "aMr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
@@ -18114,7 +18153,8 @@
 /turf/simulated/floor/black,
 /area/station/medical/medbay/treatment2)
 "aNi" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -19817,7 +19857,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
 /area/station/medical/head)
 "aQY" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -20290,7 +20331,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/medical/head)
 "aRP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -20308,7 +20350,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/se,
 /area/station/medical/head)
 "aRR" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -20320,7 +20363,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/maintenance/southeast)
 "aRS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -20719,7 +20763,8 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Clown"
 	},
@@ -21858,7 +21903,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/southeast)
 "aUI" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -22528,7 +22574,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/hor)
 "aVZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -24113,7 +24160,8 @@
 /turf/simulated/floor/white/grime,
 /area/station/crew_quarters/toilets)
 "aZy" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -24128,7 +24176,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/maintenance/south)
 "aZA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -24466,7 +24515,8 @@
 /turf/simulated/floor/white/grime,
 /area/station/crew_quarters/toilets)
 "bae" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -24487,7 +24537,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/maintenance/south)
 "baf" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -25541,7 +25592,8 @@
 /turf/simulated/floor/black,
 /area/listeningpost)
 "bcn" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -25607,7 +25659,8 @@
 	pixel_x = 26;
 	pixel_y = 0
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -26443,7 +26496,8 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -26580,7 +26634,8 @@
 /turf/simulated/floor/grey,
 /area/station/hangar/escape)
 "hhA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -26853,7 +26908,8 @@
 	},
 /area/research_outpost/indigo_rye)
 "kne" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -27539,7 +27595,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "sPS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -27749,7 +27806,8 @@
 /turf/simulated/floor/specialroom/chapel,
 /area/station/chapel/sanctuary)
 "vKo" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -27848,7 +27906,8 @@
 /turf/simulated/floor/caution/east,
 /area/research_outpost/indigo_rye)
 "wrb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -715,7 +715,8 @@
 /turf/simulated/floor/plating,
 /area/station/engine/ptl)
 "acd" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -2742,7 +2743,8 @@
 	},
 /area/station/hallway/primary/west)
 "ahG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -3064,7 +3066,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest)
 "aiy" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -3289,7 +3292,8 @@
 	name = "Clowntainment"
 	})
 "aji" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/dirt,
 /obj/item/paper/book/from_file/the_trial,
 /obj/landmark/start{
@@ -4164,7 +4168,8 @@
 	},
 /area/station/hallway/primary/west)
 "als" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -4375,7 +4380,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "alS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -11522,7 +11528,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aGb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -16461,7 +16468,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/east)
 "aVC" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -17616,7 +17624,8 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters_south)
 "aZf" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -17963,7 +17972,8 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -19704,7 +19714,8 @@
 /turf/simulated/floor/carpet/red/fancy/edge/west,
 /area/station/crew_quarters/quarters_north)
 "bhe" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -21043,7 +21054,8 @@
 /turf/space,
 /area/station/mining/refinery)
 "blp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -21545,7 +21557,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "bne" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -23641,7 +23654,8 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/treatment1)
 "but" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -23684,7 +23698,8 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/treatment2)
 "buw" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -24233,7 +24248,8 @@
 /turf/simulated/floor/darkblue,
 /area/station/janitor/office)
 "bwD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -30082,7 +30098,8 @@
 /turf/simulated/floor/carpet/red/fancy/edge/north,
 /area/station/security/hos)
 "bNP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -33992,7 +34009,8 @@
 /turf/simulated/floor/delivery,
 /area/station/routing/security)
 "cbS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -35667,7 +35685,8 @@
 /turf/simulated/floor,
 /area/station/security/checkpoint/customs)
 "cgC" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -36850,7 +36869,8 @@
 /turf/simulated/floor/plating,
 /area/research_outpost/indigo_rye)
 "ckn" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -37191,7 +37211,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/research_outpost/indigo_rye)
 "cld" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -37292,7 +37313,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/research_outpost/indigo_rye)
 "clq" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -37575,7 +37597,8 @@
 /turf/simulated/floor/airless/plating,
 /area/research_outpost/indigo_rye)
 "cmb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -39448,7 +39471,8 @@
 /turf/simulated/floor/black,
 /area/station/bridge)
 "cGD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -42412,7 +42436,8 @@
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
 "frk" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -42985,7 +43010,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "fWx" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/disposalpipe/segment/brig{
 	dir = 2;
@@ -45659,7 +45685,8 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "iJR" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -45705,7 +45732,8 @@
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/armory)
 "iLk" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -46716,7 +46744,8 @@
 /turf/simulated/floor/airless/grey,
 /area/space)
 "jRX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -47571,7 +47600,8 @@
 	name = "Secure Atmospherics"
 	})
 "kNO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_x = -28
 	},
@@ -47898,7 +47928,8 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/nw,
 /area/station/crew_quarters/quarters_north)
 "lgl" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -50058,7 +50089,8 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
@@ -52828,7 +52860,8 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "pXL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/grey/side{
 	dir = 4
@@ -54093,7 +54126,8 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/quarters_east)
 "rlK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -54462,7 +54496,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "rMk" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -54975,7 +55010,8 @@
 /turf/simulated/floor/carpet/green/standard/narrow/northsouth,
 /area/station/crew_quarters/cafeteria)
 "smE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -55197,7 +55233,8 @@
 	},
 /area/station/ranch)
 "syK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -56701,7 +56738,8 @@
 /turf/simulated/floor/plating,
 /area/station/mining/magnet)
 "tRW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/machinery/light_switch{
 	name = "E light switch";
@@ -56780,7 +56818,8 @@
 	},
 /area/station/hallway/secondary/exit)
 "tXo" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -58118,7 +58157,8 @@
 /turf/simulated/floor/caution/northsouth,
 /area/station/hangar/engine)
 "vmX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -58973,7 +59013,8 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "wiQ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -59888,7 +59929,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "xdA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -60644,7 +60686,8 @@
 /turf/simulated/floor/orangeblack,
 /area/station/hallway/primary/south)
 "xLG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -1470,7 +1470,8 @@
 /turf/simulated/floor/grime,
 /area/abandonedmedicalship/robot_trader)
 "aeR" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/under/gimmick/snazza,
 /obj/item/clothing/head/helmet/space/blackstronaut,
 /obj/item/clothing/suit/bedsheet,
@@ -2658,7 +2659,8 @@
 /turf/simulated/floor/specialroom/clown,
 /area/station/crew_quarters/clown)
 "ajB" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/captain,
 /obj/landmark/start{
 	name = "Clown"
@@ -3833,7 +3835,8 @@
 /obj/machinery/light/incandescent/warm{
 	dir = 4
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor,
 /area/listeningpost/syndicateassaultvessel)
 "amJ" = (
@@ -4124,7 +4127,8 @@
 /turf/simulated/floor/sanitary,
 /area/listeningpost/syndicateassaultvessel)
 "anz" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/shuttle{
 	icon_state = "floor3"
 	},
@@ -6608,7 +6612,8 @@
 /turf/simulated/floor/wood,
 /area/station/hos)
 "atM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -7912,7 +7917,8 @@
 	},
 /area/station/engine/inner)
 "axl" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/tile_edge/line/black{
 	dir = 8;
 	icon_state = "line1"
@@ -8299,7 +8305,8 @@
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/breakroom)
 "ayj" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/tile_edge/line/black{
 	dir = 6;
 	icon_state = "line2"
@@ -8545,7 +8552,8 @@
 /turf/simulated/floor/damaged2,
 /area/station/engine/inner)
 "ayQ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/tile_edge/line/black{
 	dir = 4;
 	icon_state = "line1"
@@ -8863,7 +8871,8 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
 "azM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/tile_edge/line/black{
 	dir = 10;
 	icon_state = "line2"
@@ -8963,7 +8972,8 @@
 /turf/simulated/floor/plating,
 /area/station/engine/power)
 "azZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -9997,7 +10007,8 @@
 	},
 /area/station/mining/refinery)
 "aCP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_y = 28
 	},
@@ -10215,7 +10226,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/starboardupperhallway)
 "aDA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
@@ -10261,7 +10273,8 @@
 /turf/simulated/floor,
 /area/station/security/visitation)
 "aDF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
@@ -11220,7 +11233,8 @@
 	},
 /area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aGi" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -11937,7 +11951,8 @@
 /turf/simulated/floor,
 /area/station/hallway/starboardupperhallway)
 "aHV" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
@@ -12037,7 +12052,8 @@
 /turf/simulated/floor,
 /area/station/security/visitation)
 "aIf" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
@@ -12178,7 +12194,8 @@
 	},
 /area/station/crew_quarters/quartersC)
 "aIv" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
@@ -12619,7 +12636,8 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/fitness)
 "aJK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
@@ -13826,7 +13844,8 @@
 	dir = 4;
 	icon_state = "line1"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -14071,7 +14090,8 @@
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "aOh" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
@@ -15050,7 +15070,8 @@
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
 "aRj" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -15274,7 +15295,8 @@
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
 "aRQ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -15633,7 +15655,8 @@
 /turf/simulated/floor,
 /area/station/security/brig/genpop)
 "aTa" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -15932,7 +15955,8 @@
 /turf/simulated/floor/wood,
 /area/station/hos/quarter)
 "aTP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_y = 28
 	},
@@ -16039,7 +16063,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/security/brig/cell1)
 "aUh" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/dirt/dirt3,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -16438,7 +16463,8 @@
 /turf/simulated/floor/red,
 /area/station/security/beepsky)
 "aVd" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -17625,7 +17651,8 @@
 /turf/simulated/floor/carpet/arcade/half,
 /area/station/crew_quarters/quarters)
 "aYm" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
@@ -17879,7 +17906,8 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/quartersA)
 "aYY" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
@@ -18121,7 +18149,8 @@
 	},
 /area/station/crew_quarters/quartersA)
 "aZD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/secure/ssafe{
 	pixel_x = 26
 	},
@@ -26817,7 +26846,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/hor/horprivate)
 "bvX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/machinery/light_switch/auto{
 	pixel_x = -24
@@ -32118,7 +32148,8 @@
 /turf/simulated/floor,
 /area/station/hallway/portlowerhallway)
 "bLM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -38677,7 +38708,8 @@
 /turf/simulated/floor/carpet/red/fancy/edge/nw,
 /area/station/security/hos)
 "oMG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -41200,7 +41232,8 @@
 /turf/simulated/floor/orange,
 /area/station/mining/staff_room)
 "vrU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/machinery/camera{
 	c_tag = "autotag";

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -838,7 +838,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/quartersA)
 "abT" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -850,7 +851,8 @@
 /turf/simulated/floor/red,
 /area/station/crew_quarters/quartersA)
 "abU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -862,7 +864,8 @@
 /turf/simulated/floor/yellow,
 /area/station/crew_quarters/quartersA)
 "abV" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/item_box/assorted/stickers/stickers_limited,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -875,7 +878,8 @@
 /turf/simulated/floor/green,
 /area/station/crew_quarters/quartersA)
 "abW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/storage/box/cookie_tin/sugar,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -888,7 +892,8 @@
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/quartersA)
 "abX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -900,7 +905,8 @@
 /turf/simulated/floor/purple,
 /area/station/crew_quarters/quartersA)
 "abY" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/sticker/ribbon/first_place{
 	pixel_x = -1
 	},
@@ -15186,7 +15192,8 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "aJT" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -17342,7 +17349,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/inner/central)
 "aPN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -17639,7 +17647,8 @@
 /turf/simulated/floor/carpet/red/standard/edge/south,
 /area/listeningpost)
 "aQx" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /turf/simulated/floor/carpet/red/standard/edge/se,
 /area/listeningpost)
@@ -19073,11 +19082,13 @@
 /turf/space/fluid,
 /area/space)
 "aUi" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/space/fluid,
 /area/space)
 "aUj" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/fakeobjects/skeleton,
 /turf/space/fluid,
 /area/space)
@@ -19383,7 +19394,8 @@
 /turf/simulated/floor/grass,
 /area/space)
 "aVm" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/blood/splatter,
 /obj/item/storage/secure/ssafe/loot{
 	pixel_x = 6;
@@ -19663,7 +19675,8 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/oshan_arrivals)
 "aWg" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/device/radio/electropack,
 /turf/simulated/floor/grime,
 /area/iss)
@@ -23015,7 +23028,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "bhc" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Botanist"
 	},
@@ -23159,7 +23173,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "bhz" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Botanist"
 	},
@@ -24329,7 +24344,8 @@
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
 "bkI" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Chef"
 	},
@@ -24604,7 +24620,8 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "blp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Bartender"
 	},
@@ -24784,7 +24801,8 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "blP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Botanist"
 	},
@@ -28907,7 +28925,8 @@
 /turf/simulated/floor/carpet/purple/standard/narrow/nw,
 /area/station/crew_quarters/captain)
 "bwh" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/incandescent/warm,
 /obj/item/clothing/suit/bedsheet/royal,
 /turf/simulated/floor/carpet/purple/standard/narrow/T_north,
@@ -35274,7 +35293,8 @@
 /turf/simulated/floor/carpet/purple/fancy/narrow/ne,
 /area/station/crew_quarters/radio/lab)
 "bLH" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /obj/machinery/light/incandescent/warm,
 /turf/simulated/floor/wood/two,
@@ -35836,7 +35856,8 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "bNp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/orange,
 /obj/item/instrument/harmonica,
 /obj/item/clothing/glasses/vr/arcade,
@@ -36201,7 +36222,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/brig)
 "bOr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/orange,
 /obj/item/clothing/glasses/vr/arcade,
 /turf/simulated/floor/scorched2,
@@ -37525,7 +37547,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/beepsky)
 "bRz" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -37715,7 +37738,8 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bRO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
@@ -39568,7 +39592,8 @@
 	},
 /area/station/maintenance/disposal)
 "bWA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/orange,
 /obj/cable{
 	icon_state = "1-2"
@@ -39594,7 +39619,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "bWD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/orange,
 /obj/cable{
 	icon_state = "1-2"
@@ -40020,7 +40046,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "bXA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/machinery/turretid{
@@ -41806,7 +41833,8 @@
 /turf/simulated/floor/carpet/red/standard/edge/sw,
 /area/tech_outpost)
 "cdB" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/yellow,
 /turf/simulated/floor/carpet/red/standard/edge/se,
 /area/tech_outpost)
@@ -43482,7 +43510,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "cis" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -106,7 +106,8 @@
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
 "abU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -1792,7 +1793,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aAB" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "captain";
 	desc = "This colorful and somewhat childish bedsheet helps the captain sleep at night.";
@@ -1968,7 +1970,8 @@
 	name = "Router Cabinet"
 	})
 "aEr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -3187,7 +3190,8 @@
 	},
 /area/station/hallway/secondary/exit)
 "aUJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /turf/simulated/floor/grey/side{
 	dir = 8
@@ -5250,7 +5254,8 @@
 /turf/simulated/floor,
 /area/station/hydroponics/bay)
 "bzg" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -5270,7 +5275,8 @@
 	},
 /area/station/medical/staff)
 "bzr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -7398,7 +7404,8 @@
 	},
 /area/station/medical/medbay)
 "cgQ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -7931,7 +7938,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "cnt" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -9703,7 +9711,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "cPr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/machinery/light/small{
 	dir = 4;
@@ -11461,7 +11470,8 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "dmN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/landmark/start{
 	name = "Medical Director"
@@ -13034,7 +13044,8 @@
 /turf/simulated/floor/carpet/red/fancy/edge/north,
 /area/station/crew_quarters/jazz)
 "dJy" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -13708,7 +13719,8 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
 "dSh" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -16504,7 +16516,8 @@
 	},
 /area/station/turret_protected/Zeta)
 "eHs" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -17301,7 +17314,8 @@
 /turf/simulated/floor/grey,
 /area/station/crewquarters/cryotron)
 "eTz" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/green,
 /obj/machinery/light/small{
 	dir = 8;
@@ -17440,7 +17454,8 @@
 	name = "Chapel Reception"
 	})
 "eUW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -17457,7 +17472,8 @@
 	},
 /area/station/hallway/primary/north)
 "eVe" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -17822,7 +17838,8 @@
 /area/station/hallway/secondary/west)
 "fay" = (
 /obj/decal/cleanable/dirt,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -18914,7 +18931,8 @@
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/west)
 "ftb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -19786,7 +19804,8 @@
 	},
 /area/station/science/lobby)
 "fFA" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -25709,7 +25728,8 @@
 /turf/simulated/floor/white/grime,
 /area/station/medical/medbay/surgery/storage)
 "hiE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -27963,7 +27983,8 @@
 	},
 /area/station/engine/hotloop)
 "hPG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -29476,7 +29497,8 @@
 	},
 /area/station/engine/engineering)
 "ioQ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/landmark/start{
 	name = "Medical Doctor"
@@ -30169,7 +30191,8 @@
 	})
 "iyT" = (
 /obj/machinery/atmospherics/pipe/simple/overfloor/southwest,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Atmospheric Technician"
 	},
@@ -30865,7 +30888,8 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/robotics)
 "iHN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "iHQ" = (
@@ -33877,7 +33901,8 @@
 /turf/simulated/floor,
 /area/station/science/teleporter)
 "jAd" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -38323,7 +38348,8 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "kKK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -41787,7 +41813,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment2)
 "lHb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Botanist"
 	},
@@ -43956,7 +43983,8 @@
 	name = "Vessel Dock Router"
 	})
 "mjC" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -44226,7 +44254,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbooth)
 "mnh" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/clown{
@@ -45236,7 +45265,8 @@
 /turf/simulated/floor/sanitary/blue,
 /area/station/crewquarters/cryotron)
 "mAB" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -45409,7 +45439,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/north)
 "mDf" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -45901,7 +45932,8 @@
 /turf/simulated/floor,
 /area/station/hangar/main)
 "mKZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -47649,7 +47681,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/ne)
 "nlO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -47904,7 +47937,8 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "nqF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/random,
 /turf/simulated/floor/grime,
 /area/station/hallway/secondary/construction{
@@ -48372,7 +48406,8 @@
 /turf/simulated/floor/grey,
 /area/station/security/hos)
 "nyR" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -48467,7 +48502,8 @@
 /obj/item/storage/secure/ssafe{
 	pixel_x = 28
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -52502,7 +52538,8 @@
 	},
 /area/station/engine/engineering)
 "oCc" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/orange,
 /obj/landmark/start{
 	name = "Rancher"
@@ -53035,7 +53072,8 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/pink,
 /turf/simulated/floor/carpet/purple/fancy/edge/se,
 /area/station/crew_quarters/quarters_west)
@@ -53241,7 +53279,8 @@
 	},
 /area/station/mining/staff_room)
 "oMv" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -57840,7 +57879,8 @@
 	name = "Med-Sci Security Checkpoint"
 	})
 "qcW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -58218,7 +58258,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/ne)
 "qjG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -59108,7 +59149,8 @@
 /turf/simulated/floor,
 /area/station/engine/gas)
 "qwy" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -62884,7 +62926,8 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "rwG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -63108,7 +63151,8 @@
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
 "rAk" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -67278,7 +67322,8 @@
 	},
 /area/station/security/brig/south_side)
 "sDi" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -67453,7 +67498,8 @@
 	name = "Warrens Hall"
 	})
 "sFn" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -68330,7 +68376,8 @@
 /turf/simulated/floor/sanitary/white,
 /area/station/engine/gas)
 "sQD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "black";
 	icon_state = "bedsheet-black"
@@ -68582,7 +68629,8 @@
 	},
 /area/station/engine/power)
 "sTE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -71713,7 +71761,8 @@
 	},
 /area/station/science/lobby)
 "tIV" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -74780,7 +74829,8 @@
 	},
 /area/station/maintenance/solar/south)
 "uyx" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -75667,7 +75717,8 @@
 /turf/simulated/floor/grey,
 /area/station/medical/breakroom)
 "uJn" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -78198,7 +78249,8 @@
 /turf/simulated/floor,
 /area/station/engine/engineering)
 "vpp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -78580,7 +78632,8 @@
 	dir = 4;
 	pixel_x = 12
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/pink,
 /turf/simulated/floor/carpet/purple/fancy/edge/ne,
 /area/station/crew_quarters/quarters_west)
@@ -79850,7 +79903,8 @@
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "vJj" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -79978,7 +80032,8 @@
 /turf/simulated/floor/sanitary,
 /area/station/science/restroom)
 "vKH" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/green,
 /obj/landmark/start{
 	name = "Botanist"
@@ -83334,7 +83389,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "wDw" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -84385,7 +84441,8 @@
 /obj/item/storage/secure/ssafe{
 	pixel_x = 28
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -86001,7 +86058,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/arcade/dungeon)
 "xkj" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -88309,7 +88367,8 @@
 /turf/simulated/floor/neutral/side,
 /area/station/hallway/primary/west)
 "xMJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/landmark/start{
 	name = "Staff Assistant"

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -8589,7 +8589,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -11952,7 +11953,8 @@
 	bcolor = "red";
 	icon_state = "bedsheet-red"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fred5"
@@ -23433,7 +23435,8 @@
 	name = "S light switch";
 	pixel_y = -24
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -35768,7 +35771,8 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/sticker/ribbon/first_place{
 	pixel_x = 1
 	},
@@ -35871,7 +35875,8 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -54105,7 +54110,8 @@
 	},
 /area/station/crew_quarters/cafeteria)
 "bZJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
@@ -54126,7 +54132,8 @@
 	},
 /area/station/crew_quarters/captain)
 "bZL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -54138,7 +54145,8 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bZM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -54148,26 +54156,30 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bZN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bZO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/checkpoint/cargo)
 "bZP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/carpet/grime,
 /area/listeningpost)
 "bZQ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -54180,7 +54192,8 @@
 	},
 /area/station/engine/engineering/ce)
 "bZR" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -54191,7 +54204,8 @@
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/quartersB)
 "bZS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -54202,7 +54216,8 @@
 /turf/simulated/floor/purple,
 /area/station/crew_quarters/quartersA)
 "bZT" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -54216,7 +54231,8 @@
 /turf/simulated/floor/blue,
 /area/station/crew_quarters/quartersB)
 "bZU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
@@ -54230,7 +54246,8 @@
 /turf/simulated/floor/purple,
 /area/station/crew_quarters/quartersA)
 "bZV" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light_switch{
 	name = "E light switch";
 	pixel_x = -24
@@ -54242,7 +54259,8 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/head)
 "bZW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light_switch{
 	name = "E light switch";
 	pixel_x = -24
@@ -68577,7 +68595,8 @@
 /turf/space,
 /area/station/turret_protected/armory_outside)
 "kEM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -70295,7 +70314,8 @@
 	},
 /area/station/hydroponics/bay)
 "wen" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1;

--- a/maps/pod_wars.dmm
+++ b/maps/pod_wars.dmm
@@ -1452,7 +1452,8 @@
 /turf/simulated/floor,
 /area/pod_wars/spacejunk/fstation)
 "fy" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/cubicle{
 	dir = 1
 	},
@@ -2068,7 +2069,8 @@
 	},
 /area/pod_wars/spacejunk/fstation/maintdock)
 "hJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/cubicle{
 	dir = 1
 	},
@@ -2599,7 +2601,8 @@
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
 "jR" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/cubicle{
 	dir = 4
 	},
@@ -3969,7 +3972,8 @@
 /turf/simulated/wall/asteroid/pod_wars,
 /area/pod_wars/asteroid/major/maj_3)
 "pb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/orange,
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
@@ -4879,7 +4883,8 @@
 /obj/window/cubicle{
 	dir = 1
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/yellow,
 /turf/simulated/floor/purple/side{
 	dir = 6
@@ -5680,7 +5685,8 @@
 	},
 /area/pod_wars/spacejunk/fstation)
 "vl" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/cubicle{
 	dir = 1
 	},
@@ -6212,7 +6218,8 @@
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/uvb67/power)
 "wZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/black,
@@ -7567,7 +7574,8 @@
 	},
 /area/pod_wars/spacejunk/fstation)
 "Cb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/red/side{
 	dir = 5
 	},
@@ -10856,7 +10864,8 @@
 	},
 /area/pod_wars/team1/bridge)
 "Pa" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/cubicle{
 	dir = 1
 	},
@@ -12977,7 +12986,8 @@
 /turf/simulated/floor/black,
 /area/pod_wars/spacejunk/reliant)
 "Xh" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/cubicle{
 	dir = 1
 	},
@@ -13714,7 +13724,8 @@
 /turf/simulated/floor/white,
 /area/pod_wars/spacejunk/fstation/medbay)
 "ZQ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/cubicle{
 	dir = 4
 	},

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -3122,7 +3122,8 @@
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
 /area/station/quartermaster/office)
 "bph" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/plating,
 /area/station/maintenance/northwest{
 	name = "Corpse Tunnel"
@@ -7344,7 +7345,8 @@
 /turf/simulated/floor,
 /area/station/science/lab)
 "dbK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/decal/tile_edge/stripe{
 	dir = 8;
@@ -11141,7 +11143,8 @@
 	},
 /area/station/chapel/sanctuary)
 "ezi" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/pink,
 /obj/machinery/power/apc/autoname_west,
 /obj/cable{
@@ -13898,7 +13901,8 @@
 /turf/space,
 /area/space)
 "fKY" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/orange,
 /obj/decal/cleanable/blood,
 /turf/simulated/floor/carpet/green/fancy/edge/se,
@@ -14381,7 +14385,8 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/northwest)
 "fWu" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/black,
 /obj/machinery/light/small/warm,
 /obj/landmark/start{
@@ -16052,7 +16057,8 @@
 	name = "Ringside Hallway"
 	})
 "gKu" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/hop,
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/blue/fancy/edge/se,
@@ -17011,7 +17017,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "hev" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/black,
 /obj/item/clothing/under/gimmick/macho,
 /turf/simulated/floor/wood,
@@ -18072,7 +18079,8 @@
 	name = "Laundry Room"
 	})
 "hCV" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -21852,7 +21860,8 @@
 	name = "The Ring Entrance"
 	})
 "jgF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /turf/simulated/floor/carpet/purple/fancy/edge/sw,
 /area/listeningpost)
@@ -22735,7 +22744,8 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
 "jzU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -25659,7 +25669,8 @@
 	name = "Laundry Room"
 	})
 "kOK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor,
 /area/station/medical/cdc)
@@ -25788,7 +25799,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/west)
 "kRT" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/decal/cleanable/cobweb,
 /obj/decal/cleanable/cobwebFloor,
@@ -28983,7 +28995,8 @@
 /turf/simulated/floor/caution/east,
 /area/station/hangar/sec)
 "mkJ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/toy/plush/small/bunny,
 /obj/decal/cleanable/paper,
 /turf/simulated/floor/plating,
@@ -33320,7 +33333,8 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/arcade)
 "ohs" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
@@ -34529,7 +34543,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "oLf" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/disposalpipe/segment/mail/vertical,
 /obj/item/toy/plush/small/monkey/assistant,
@@ -35139,7 +35154,8 @@
 /turf/simulated/floor,
 /area/station/crew_quarters/data)
 "oYv" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/decoration/clock{
 	pixel_y = 30
@@ -36006,7 +36022,8 @@
 	name = "Crashed Limo"
 	})
 "pvP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
 	},
@@ -38138,7 +38155,8 @@
 /turf/simulated/floor/delivery/caution,
 /area/station/quartermaster/office)
 "qqi" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/captain,
 /obj/decal/tile_edge/stripe{
 	dir = 4
@@ -46227,7 +46245,8 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/science/teleporter)
 "tKt" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/pink,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/quarters_north)
@@ -46807,7 +46826,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/the_cage)
 "uav" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/yellow,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/quarters_north)
@@ -47807,7 +47827,8 @@
 /turf/simulated/floor/black,
 /area/station/janitor/office)
 "uwX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/royal,
 /obj/decal/cleanable/ketchup,
 /obj/item/toy/plush/small/bunny,
@@ -50285,7 +50306,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "vyr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/quarters_south)
@@ -56775,7 +56797,8 @@
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
 "ylE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /turf/simulated/floor/wood/six,
 /area/station/crew_quarters/hos)

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -1354,7 +1354,8 @@
 /turf/unsimulated/floor/white,
 /area/hospital)
 "acQ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/straight_jacket,
 /turf/unsimulated/floor/white,
 /area/hospital)
@@ -1665,7 +1666,8 @@
 /turf/unsimulated/wall/setpieces/hospital/window,
 /area/hospital)
 "adH" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/south,
 /obj/item/clothing/suit/straight_jacket,
 /turf/unsimulated/floor/white,
@@ -3082,7 +3084,8 @@
 /turf/unsimulated/floor/engine/caution/north,
 /area/hospital/samostrel)
 "agR" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/unsimulated/floor/white/grime,
 /area/hospital)
@@ -4117,7 +4120,8 @@
 	},
 /area/hospital/samostrel)
 "akk" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -4367,7 +4371,8 @@
 /turf/unsimulated/floor/carpet/office,
 /area/hospital/samostrel)
 "alL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/unsimulated/floor{
 	icon = 'icons/turf/shuttle.dmi';
@@ -4957,7 +4962,8 @@
 /turf/unsimulated/floor/carpet/office,
 /area/hospital/samostrel)
 "anS" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/unsimulated/floor{
 	icon = 'icons/turf/shuttle.dmi';
 	icon_state = "floor3"
@@ -11279,7 +11285,8 @@
 	},
 /area/marsoutpost)
 "aIX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -12060,7 +12067,8 @@
 /turf/unsimulated/floor/cave,
 /area/crater/cave)
 "aLD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/unsimulated/floor/grime,
 /area/marsoutpost)
 "aLE" = (
@@ -12367,7 +12375,8 @@
 /turf/unsimulated/floor/white/grime,
 /area/marsoutpost)
 "aMr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/unsimulated/floor/white/grime,
 /area/marsoutpost)
@@ -12620,7 +12629,8 @@
 /turf/unsimulated/floor/carpet/grime,
 /area/upper_arctic/pod2)
 "aNe" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/cubicle,
 /obj/item/clothing/suit/bedsheet,
 /obj/decal/cleanable/cobweb2,
@@ -12771,7 +12781,8 @@
 /turf/unsimulated/floor/carpet/grime,
 /area/upper_arctic/pod2)
 "aNE" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/cubicle,
 /obj/item/clothing/suit/bedsheet,
 /obj/decal/fakeobjects/skeleton,
@@ -13638,7 +13649,8 @@
 /turf/unsimulated/floor/carpet/grime,
 /area/upper_arctic/pod2)
 "aQb" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/cubicle{
 	dir = 1
 	},
@@ -14217,7 +14229,8 @@
 /turf/unsimulated/floor/arctic/plating,
 /area/lower_arctic/mining)
 "aRW" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/unsimulated/floor/carpet{
 	dir = 9;
@@ -14245,7 +14258,8 @@
 	},
 /area/crater/biodome/crew)
 "aRZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/unsimulated/floor/carpet{
 	dir = 5;
@@ -14515,7 +14529,8 @@
 	},
 /area/lower_arctic/lower)
 "aSU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/unsimulated/floor/carpet{
 	dir = 10;
@@ -14537,7 +14552,8 @@
 	},
 /area/crater/biodome/crew)
 "aSX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/under/misc/chaplain/rasta,
 /obj/item/clothing/head/rastacap,
 /obj/item/clothing/suit/bedsheet,
@@ -19613,7 +19629,8 @@
 /turf/unsimulated/floor/arctic/snow,
 /area/upper_arctic/exterior/surface)
 "bgD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -19670,7 +19687,8 @@
 /turf/unsimulated/floor/wood,
 /area/marsoutpost)
 "bgL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/dirt,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
@@ -19694,7 +19712,8 @@
 /turf/unsimulated/floor/purple/corner,
 /area/marsoutpost)
 "bgP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -19858,7 +19877,8 @@
 /turf/unsimulated/floor/wood,
 /area/marsoutpost)
 "bhp" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/urine,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
@@ -20146,7 +20166,8 @@
 /turf/unsimulated/floor/wood,
 /area/marsoutpost)
 "bic" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -20154,7 +20175,8 @@
 /turf/unsimulated/floor/wood,
 /area/marsoutpost)
 "bid" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/dirt,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
@@ -20542,7 +20564,8 @@
 	},
 /area/precursor/pit)
 "biZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/unsimulated/floor/carpet/grime,
 /area/drone/crew_quarters)
@@ -20867,7 +20890,8 @@
 	},
 /area/precursor/pit)
 "bjM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/item/gun/kinetic/gyrojet,
 /turf/unsimulated/floor/carpet/grime,
@@ -21204,7 +21228,8 @@
 /turf/unsimulated/floor/purple/side,
 /area/marsoutpost)
 "bkC" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -28815,7 +28840,8 @@
 	},
 /area/iomoon)
 "bFh" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -28857,7 +28883,8 @@
 	},
 /area/iomoon)
 "bFx" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/yellow,
 /turf/unsimulated/floor/carpet/grime,
 /area/owlery/staffhall)
@@ -29110,7 +29137,8 @@
 /turf/unsimulated/floor/setpieces/rootfloor,
 /area/catacombs)
 "bGi" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "pink";
 	icon_state = "bedsheet-pink"
@@ -29869,7 +29897,8 @@
 /turf/unsimulated/wall/setpieces/leadwindow,
 /area/solarium)
 "bIn" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/hop,
 /turf/unsimulated/floor/wood/two,
 /area/owlery/staffhall)
@@ -29889,7 +29918,8 @@
 	},
 /area/solarium)
 "bIq" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/unsimulated/floor/carpet{
 	dir = 5;
@@ -29968,7 +29998,8 @@
 /turf/space/no_replace,
 /area/space)
 "bID" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/item/clothing/under/gimmick/snazza,
 /turf/unsimulated/floor/carpet{
@@ -29982,7 +30013,8 @@
 	},
 /area/solarium)
 "bIF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/unsimulated/floor/carpet{
 	dir = 6;
@@ -32509,7 +32541,8 @@
 /turf/unsimulated/floor/carpet/grime,
 /area/crypt/sigma/crew)
 "bQr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -32892,7 +32925,8 @@
 /turf/unsimulated/floor,
 /area/crunch)
 "bRx" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -34661,7 +34695,8 @@
 	},
 /area/sim/racing_track)
 "bXF" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/device/audio_log/meatland_03,
 /turf/unsimulated/floor/white,
 /area/meat_derelict/main)
@@ -36406,7 +36441,8 @@
 	},
 /area/meat_derelict/guts)
 "cde" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -40344,7 +40380,8 @@
 /turf/unsimulated/floor/black,
 /area/owlery/staffhall)
 "cnv" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /obj/item/paper/ACNote,
 /turf/unsimulated/floor/carpet{
@@ -40967,7 +41004,8 @@
 /turf/unsimulated/floor/tatami/east,
 /area/dojo)
 "cpM" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/unsimulated/floor/wood/two,
 /area/dojo)
@@ -42328,7 +42366,8 @@
 /turf/unsimulated/floor/shuttlebay,
 /area/diner/tug)
 "ctP" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -42781,7 +42820,8 @@
 	},
 /area/sim/racing_entry)
 "cve" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/window/cubicle{
 	dir = 1
 	},
@@ -43131,7 +43171,8 @@
 /turf/unsimulated/floor/caution/north,
 /area/drone/office)
 "cvU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/royal,
 /obj/critter/crow{
 	generic = 0;
@@ -43594,7 +43635,8 @@
 /area/owlery/staffhall)
 "cxg" = (
 /obj/item/clothing/suit/bedsheet/random,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/unsimulated/floor/carpet/grime,
 /area/owlery/staffhall)
 "cxh" = (
@@ -43750,7 +43792,8 @@
 /turf/unsimulated/floor/black,
 /area/owlery/staffhall)
 "cxB" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/blue,
 /turf/unsimulated/floor/wood/two,
 /area/owlery/staffhall)
@@ -50296,7 +50339,8 @@
 /turf/unsimulated/wall/auto/reinforced/supernorn,
 /area/owlery/owleryhall)
 "cNQ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/hop,
 /turf/unsimulated/floor/carpet/grime,
 /area/owlery/office)
@@ -59021,7 +59065,8 @@
 	},
 /area/syndicate_station/battlecruiser)
 "dhw" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -59048,7 +59093,8 @@
 	},
 /area/syndicate_station/battlecruiser)
 "dhy" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -59333,7 +59379,8 @@
 	},
 /area/syndicate_station/battlecruiser)
 "dip" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -59352,7 +59399,8 @@
 /turf/unsimulated/floor/redblack,
 /area/syndicate_station/battlecruiser)
 "dir" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red";
@@ -70584,7 +70632,8 @@
 /turf/unsimulated/floor/carpet/grime,
 /area/crypt/sigma/rd)
 "dUl" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -74123,7 +74172,8 @@
 /turf/unsimulated/floor/wood/two,
 /area/centcom/offices/studenterhue)
 "oYg" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/item/toy/plush/small/kitten/wizard,
 /turf/unsimulated/floor/wood/two{
@@ -75622,7 +75672,8 @@
 	icon_state = "blue"
 	})
 "sMO" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/pink,
 /turf/unsimulated/floor/wood/two{
 	desc = " It is made of wood.";

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -688,7 +688,8 @@
 /turf/unsimulated/floor,
 /area/space_hive)
 "acf" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
@@ -1910,14 +1911,16 @@
 /turf/simulated/floor/caution/west,
 /area/mining/quarters)
 "afG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor,
 /area/mining/quarters)
 "afH" = (
 /turf/simulated/floor/grime,
 /area/mining/quarters)
 "afI" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/grime,
 /area/mining/quarters)
@@ -2039,7 +2042,8 @@
 	},
 /area/mining/mainasteroid)
 "agf" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor,
 /area/mining/quarters)
@@ -8011,7 +8015,8 @@
 	},
 /area/tech_outpost)
 "avu" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor{
 	dir = 4;
@@ -8975,7 +8980,8 @@
 /turf/simulated/floor/plating/damaged3,
 /area/spyshack)
 "azL" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/plating/damaged3,
 /area/spyshack)
@@ -9320,7 +9326,8 @@
 /turf/unsimulated/floor/black,
 /area/timewarp/ship)
 "aEn" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/unsimulated/floor/white/grime,
 /area/timewarp/ship)
@@ -9664,7 +9671,8 @@
 	},
 /area/timewarp/ship)
 "aGm" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "fred2"
@@ -14191,7 +14199,8 @@
 /area/derelict_ai_sat)
 "aSa" = (
 /obj/item/storage/wall/random,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /obj/decal/cleanable/cobweb2,
 /turf/simulated/floor/carpet,
@@ -14571,7 +14580,8 @@
 /area/derelict_ai_sat)
 "aSU" = (
 /obj/item/storage/wall/random,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /obj/item/storage/bible/mini,
 /turf/simulated/floor/carpet,
@@ -14672,7 +14682,8 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/fermid_hive)
 "aTj" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/cobweb,
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
@@ -14686,7 +14697,8 @@
 /turf/simulated/floor/airless/grime,
 /area/abandonedship)
 "aTl" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/under/gimmick/dawson{
 	name = "hipster clothes"
 	},
@@ -14713,7 +14725,8 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /obj/item/seed/cannabis,
 /turf/simulated/floor/carpet,
@@ -14805,7 +14818,8 @@
 /turf/simulated/floor/white/grime,
 /area/derelict_ai_sat)
 "aTD" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/fakeobjects/skeleton{
 	desc = "Eugh, the stench is horrible!";
 	icon = 'icons/misc/hstation.dmi';
@@ -14839,7 +14853,8 @@
 /turf/simulated/floor/airless/grime,
 /area/abandonedship)
 "aTG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/overlay{
 	desc = "Oh.  So THAT'S where he went off to.";
 	icon = 'icons/misc/hstation.dmi';
@@ -15382,7 +15397,8 @@
 /turf/simulated/floor/grime,
 /area/iss)
 "aVl" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -15595,7 +15611,8 @@
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
 "aVN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -15607,7 +15624,8 @@
 /area/abandonedoutpostthing)
 "aVO" = (
 /obj/machinery/light/worn,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -17729,7 +17747,8 @@
 /turf/simulated/floor/grime,
 /area/iss)
 "baH" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/grime,
 /area/iss)
 "baI" = (
@@ -18069,12 +18088,14 @@
 /turf/simulated/floor/airless/damaged5,
 /area/abandonedship)
 "bby" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/machinery/light/small,
 /turf/simulated/floor/grime,
 /area/iss)
 "bbz" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/cleanable/blood/splatter,
 /obj/item/storage/secure/ssafe/loot{
 	pixel_x = 6;
@@ -18114,7 +18135,8 @@
 /turf/simulated/floor/plating,
 /area/iss)
 "bbG" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/critter/zombie/scientist,
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
@@ -18139,7 +18161,8 @@
 	},
 /area/abandonedoutpostthing)
 "bbK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/fakeobjects/skeleton{
 	desc = "Eugh, the stench is horrible!";
 	icon = 'icons/misc/hstation.dmi';
@@ -18351,7 +18374,8 @@
 	},
 /area/abandonedoutpostthing)
 "bcr" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fpurple2"
@@ -18383,7 +18407,8 @@
 	},
 /area/h7/crew)
 "bcw" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "fpurple2"
@@ -18452,7 +18477,8 @@
 	},
 /area/abandonedoutpostthing)
 "bcH" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/fakeobjects/skeleton,
 /obj/item/clothing/suit/bedsheet,
 /obj/decal/cleanable/blood/splatter{
@@ -18477,7 +18503,8 @@
 	},
 /area/h7/crew)
 "bcK" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "fpurple2"
@@ -18545,7 +18572,8 @@
 	},
 /area/abandonedoutpostthing)
 "bcU" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fpurple2"
@@ -18568,7 +18596,8 @@
 	},
 /area/h7/crew)
 "bcX" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/carpet{
 	dir = 4;
@@ -18643,7 +18672,8 @@
 	},
 /area/abandonedoutpostthing)
 "bdi" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -18663,7 +18693,8 @@
 	},
 /area/h7/crew)
 "bdl" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bio_suit,
 /turf/simulated/floor/carpet{
 	dir = 6;
@@ -20443,7 +20474,8 @@
 	icon_state = "hvent";
 	name = "air vent"
 	},
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/decal/fakeobjects/skeleton,
 /obj/item/reagent_containers/pill/tox{
 	pixel_x = -8;
@@ -20967,7 +20999,8 @@
 /turf/simulated/floor/plating/damaged3,
 /area/spyshack)
 "biZ" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/red,
 /turf/simulated/floor{
 	icon_state = "carpetSE"

--- a/maps/z3_water.dmm
+++ b/maps/z3_water.dmm
@@ -702,7 +702,8 @@
 /turf/unsimulated/floor/black,
 /area/wrecknsspolaris)
 "cm" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/captain,
 /obj/machinery/light_switch/auto{
 	last_throw_y = 0;
@@ -2914,7 +2915,8 @@
 "hH" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/decal/cleanable/dirt/jen,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/black,
 /obj/machinery/light_switch/west,
 /turf/unsimulated/floor/grime,
@@ -2958,7 +2960,8 @@
 /turf/unsimulated/floor/plating,
 /area/dank_trench)
 "hN" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet/black,
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/machinery/light/small{

--- a/maps/z5.dmm
+++ b/maps/z5.dmm
@@ -505,7 +505,8 @@
 /area/diner/arcade)
 "bR" = (
 /obj/decal/cleanable/dirt,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "green";
 	icon_state = "bedsheet-green"
@@ -533,7 +534,8 @@
 /turf/simulated/wall/auto/reinforced/old,
 /area/diner/motel)
 "ca" = (
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"
@@ -1072,7 +1074,8 @@
 /area/diner/motel)
 "dB" = (
 /obj/decal/cleanable/dirt,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "red";
 	icon_state = "bedsheet-red"
@@ -1341,7 +1344,8 @@
 /area/noGenerate)
 "eq" = (
 /obj/decal/cleanable/dirt,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "yellow";
 	icon_state = "bedsheet-yellow"
@@ -1358,7 +1362,8 @@
 /area/diner/motel)
 "et" = (
 /obj/decal/cleanable/dirt,
-/obj/stool/bed,
+/obj/machinery/bot/mulebot/broken,
+
 /obj/item/clothing/suit/bedsheet{
 	bcolor = "blue";
 	icon_state = "bedsheet-blue"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr aims to replace all stationary beds with mulebots instead!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mulebots have been shown to increase crew productivity by 5000%! As such, Replacing all those rickety and old beds with comfy and mobile Mulebots will result in a near infinite productivity increase! IWILLNOTRESTTILLTHEGAMEISONLYMULEBOTS


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Replaces all those lame and smelly bed frames with fancy new Mulebots! (Batteries not included)
```
