### PR TITLE
Consolidate Vamp TEG and Vampires Abilities

### DIFF
--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -219,7 +219,7 @@
 				src.vamp_blood = 0
 				if (haine_blood_debug) logTheThing("debug", owner, null, "<b>HAINE BLOOD DEBUG:</b> [owner]'s vamp_blood dropped below 0 and was reset to 0")
 
-			if (set_null == 1)
+			if (set_null)
 				src.vamp_blood = 0
 			else
 				src.vamp_blood = max(src.vamp_blood + change, 0)
@@ -229,7 +229,7 @@
 				src.points = 0
 				if (haine_blood_debug) logTheThing("debug", owner, null, "<b>HAINE BLOOD DEBUG:</b> [owner]'s vamp_blood_remaining dropped below 0 and was reset to 0")
 
-			if (set_null == 1)
+			if (set_null)
 				src.points = 0
 			else
 				src.points = max(src.points + change, 0)

--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -65,10 +65,7 @@
 
 	var/datum/abilityHolder/vampire/AH = src.get_ability_holder(/datum/abilityHolder/vampire)
 	if (AH && istype(AH))
-		if (total_blood)
-			return AH.vamp_blood
-		else
-			return AH.points
+		return AH.get_vampire_blood(total_blood)
 	else
 		return 0
 
@@ -78,40 +75,11 @@
 
 	var/datum/abilityHolder/vampire/AH = src.get_ability_holder(/datum/abilityHolder/vampire)
 	if (AH && istype(AH))
-		if (total_blood)
-			if (AH.vamp_blood < 0)
-				AH.vamp_blood = 0
-				if (haine_blood_debug) logTheThing("debug", src, null, "<b>HAINE BLOOD DEBUG:</b> [src]'s vamp_blood dropped below 0 and was reset to 0")
-
-			if (set_null == 1)
-				AH.vamp_blood = 0
-			else
-				AH.vamp_blood = max(AH.vamp_blood + change, 0)
-
-		else
-			if (AH.points < 0)
-				AH.points = 0
-				if (haine_blood_debug) logTheThing("debug", src, null, "<b>HAINE BLOOD DEBUG:</b> [src]'s vamp_blood_remaining dropped below 0 and was reset to 0")
-
-			if (set_null == 1)
-				AH.points = 0
-			else
-				AH.points = max(AH.points + change, 0)
+		AH.change_vampire_blood(change, total_blood, set_null)
 	else
 		var/datum/abilityHolder/vampiric_thrall/AHZ = src.get_ability_holder(/datum/abilityHolder/vampiric_thrall)
 		if(AHZ && istype(AHZ) && !total_blood)
-			var/mob/living/carbon/human/M = AHZ.owner
-			if(istype(M) && istype(M.mutantrace, /datum/mutantrace/vampiric_thrall))
-				var/datum/mutantrace/vampiric_thrall/V = M.mutantrace
-				if (V.blood_points < 0)
-					V.blood_points = 0
-					if (haine_blood_debug) logTheThing("debug", src, null, "<b>HAINE BLOOD DEBUG:</b> [src]'s blood_points dropped below 0 and was reset to 0")
-
-				if (set_null == 1)
-					V.blood_points = 0
-				else
-					V.blood_points = max(V.blood_points + change, 0)
-
+			AHZ.change_vampire_blood(change, total_blood, set_null)
 	return
 
 /mob/proc/check_vampire_power(var/which_power = 3) // 1: thermal | 2: xray | 3: full power
@@ -244,6 +212,33 @@
 		if (istype(newloc,/obj/storage/closet/coffin))
 			//var/obj/storage/closet/coffin/C = newloc
 			the_coffin = null
+
+	proc/change_vampire_blood(var/change = 0, var/total_blood = 0, var/set_null = 0)
+		if (total_blood)
+			if (src.vamp_blood < 0)
+				src.vamp_blood = 0
+				if (haine_blood_debug) logTheThing("debug", owner, null, "<b>HAINE BLOOD DEBUG:</b> [owner]'s vamp_blood dropped below 0 and was reset to 0")
+
+			if (set_null == 1)
+				src.vamp_blood = 0
+			else
+				src.vamp_blood = max(src.vamp_blood + change, 0)
+
+		else
+			if (src.points < 0)
+				src.points = 0
+				if (haine_blood_debug) logTheThing("debug", owner, null, "<b>HAINE BLOOD DEBUG:</b> [owner]'s vamp_blood_remaining dropped below 0 and was reset to 0")
+
+			if (set_null == 1)
+				src.points = 0
+			else
+				src.points = max(src.points + change, 0)
+
+	proc/get_vampire_blood(var/total_blood = 0)
+		if (total_blood)
+			return src.vamp_blood
+		else
+			return src.points
 
 	proc/blood_tracking_output(var/deduct = 0)
 		if (!src.owner || !ismob(src.owner))
@@ -385,12 +380,13 @@
 			M.full_heal()
 
 			if (M.bioHolder && M.traitHolder.hasTrait("training_chaplain"))
-				boutput(owner, __red("Wait, this is a chaplain!!! <B>AGDFHSKFGBLDFGLHSFDGHDFGH</B>"))
-				boutput(M, __blue("Your divine protection saves you from enthrallment!"))
-				owner.emote("scream")
-				owner.changeStatus("weakened", 5 SECONDS)
-				owner.TakeDamage("chest", 0, 30)
-				return
+				if(ismob(owner))
+					boutput(owner, __red("Wait, this is a chaplain!!! <B>AGDFHSKFGBLDFGLHSFDGHDFGH</B>"))
+					boutput(M, __blue("Your divine protection saves you from enthrallment!"))
+					owner.emote("scream")
+					owner.changeStatus("weakened", 5 SECONDS)
+					owner.TakeDamage("chest", 0, 30)
+					return
 
 
 			M.real_name = "thrall [M.real_name]"
@@ -505,6 +501,9 @@
 
 		if (!M)
 			return 0
+
+		if(isobj(M)) //Exception for VampTEG and Sentient Objects...
+			return 1
 
 		if (!(iscarbon(M) || ismobcritter(M)))
 			boutput(M, __red("You cannot use any powers in your current form."))

--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -392,7 +392,10 @@
 			M.real_name = "thrall [M.real_name]"
 			if (M.mind)
 				M.mind.special_role = ROLE_VAMPTHRALL
-				M.mind.master = owner.ckey
+				if(ismob(owner))
+					M.mind.master = owner.ckey
+				else
+					M.mind.master = owner
 				if (!(M.mind in ticker.mode.Agimmicks))
 					ticker.mode.Agimmicks += M.mind
 

--- a/code/datums/abilities/vampire/enthrall.dm
+++ b/code/datums/abilities/vampire/enthrall.dm
@@ -102,9 +102,10 @@
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
-		M.visible_message("<span class='alert'><B>[M] stabs [target] with their sharp fingers!</B></span>")
-		boutput(M, __blue("You begin to pump your [pick("polluted","spooky","bad","gross","icky","evil","necrotic")] blood into [target]'s chest."))
-		boutput(target, __red("You feel cold . . ."))
+		if(istype(M))
+			M.visible_message("<span class='alert'><B>[M] stabs [target] with their sharp fingers!</B></span>")
+			boutput(M, __blue("You begin to pump your [pick("polluted","spooky","bad","gross","icky","evil","necrotic")] blood into [target]'s chest."))
+			boutput(target, __red("You feel cold . . ."))
 
 	onUpdate()
 		..()

--- a/code/datums/abilities/vampire/glare.dm
+++ b/code/datums/abilities/vampire/glare.dm
@@ -32,12 +32,16 @@
 			boutput(M, __red("It would be a waste of time to stun the dead."))
 			return 1
 
-		if (!M.sight_check(1))
+		if (istype(M) && !M.sight_check(1))
 			boutput(M, __red("How do you expect this to work? You can't use your eyes right now."))
 			M.visible_message("<span class='alert'>What was that? There's something odd about [M]'s eyes.</span>")
 			return 0 // Cooldown because spam is bad.
 
-		M.visible_message("<span class='alert'><B>[M]'s eyes emit a blinding flash at [target]!</B></span>")
+		if(istype(M))
+			M.visible_message("<span class='alert'><B>[M]'s eyes emit a blinding flash at [target]!</B></span>")
+		else
+			M.visible_message("<span class='alert'><B>[M] emits a blinding flash at [target]!</B></span>")
+
 		var/obj/itemspecialeffect/glare/E = new /obj/itemspecialeffect/glare
 		E.color = "#FFFFFF"
 		E.setup(M.loc)

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -83,8 +83,8 @@
 			boutput(M, __red("The blood of the dead provides little sustenance..."))
 
 		var/bitesize = 5 * mult
-		M.change_vampire_blood(bitesize, 1)
-		M.change_vampire_blood(bitesize, 0)
+		H.change_vampire_blood(bitesize, 1)
+		H.change_vampire_blood(bitesize, 0)
 		H.tally_bite(HH,bitesize)
 		if (HH.blood_volume < 20 * mult)
 			HH.blood_volume = 0
@@ -93,13 +93,14 @@
 		if (istype(H)) H.blood_tracking_output()
 
 	else if (HH.bioHolder && HH.traitHolder.hasTrait("training_chaplain"))
-		M.visible_message("<span class='alert'><b>[M]</b> begins to crisp and burn!</span>", "<span class='alert'>You drank the blood of a holy man! It burns!</span>")
-		M.emote("scream")
-		if (M.get_vampire_blood() >= 20 * mult)
-			M.change_vampire_blood(-20 * mult, 0)
-		else
-			M.change_vampire_blood(0, 0, 1)
-		M.TakeDamage("chest", 0, 30 * mult)
+		if(istype(M))
+			M.visible_message("<span class='alert'><b>[M]</b> begins to crisp and burn!</span>", "<span class='alert'>You drank the blood of a holy man! It burns!</span>")
+			M.emote("scream")
+			if (M.get_vampire_blood() >= 20 * mult)
+				M.change_vampire_blood(-20 * mult, 0)
+			else
+				M.change_vampire_blood(0, 0, 1)
+			M.TakeDamage("chest", 0, 30 * mult)
 
 	else
 		if (isvampire(HH))
@@ -108,8 +109,8 @@
 				HH.change_vampire_blood(-bitesize, 0)
 				HH.change_vampire_blood(-bitesize, 1) // Otherwise, two vampires could perpetually feed off of each other, trading blood endlessly.
 
-				M.change_vampire_blood(bitesize, 0)
-				M.change_vampire_blood(bitesize, 1)
+				H.change_vampire_blood(bitesize, 0)
+				H.change_vampire_blood(bitesize, 1)
 				H.tally_bite(HH,bitesize)
 				if (istype(H))
 					H.blood_tracking_output()
@@ -121,8 +122,8 @@
 				return 0
 		else
 			var/bitesize = 10 * mult
-			M.change_vampire_blood(bitesize, 1)
-			M.change_vampire_blood(bitesize, 0)
+			H.change_vampire_blood(bitesize, 1)
+			H.change_vampire_blood(bitesize, 0)
 			H.tally_bite(HH,bitesize)
 			if (HH.blood_volume < 20 * mult)
 				HH.blood_volume = 0
@@ -130,9 +131,10 @@
 				HH.blood_volume -= 20 * mult
 			//vampires heal, thralls don't
 			if (!thrall)
-				M.HealDamage("All", 3, 3)
-				M.take_toxin_damage(-1)
-				M.take_oxygen_deprivation(-1)
+				if(istype(M))
+					M.HealDamage("All", 3, 3)
+					M.take_toxin_damage(-1)
+					M.take_oxygen_deprivation(-1)
 
 				if (mult >= 1) //mult is only 1 or greater during a pointblank true suck
 					if (HH.blood_volume < 300 && prob(15))
@@ -367,7 +369,6 @@
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
-
 	onStart()
 		..()
 		if(M == null || HH == null)
@@ -397,6 +398,7 @@
 
 		proj.special_data["vamp"] = H
 		proj.special_data["victim"] = HH
+		proj.special_data["returned"] = FALSE
 		proj.targets = list(M)
 
 		proj.launch()

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -409,7 +409,7 @@
 		logTheThing("combat", M, HH, "steals blood from [constructTarget(HH,"combat")] at [log_loc(M)].")
 
 	onEnd()
-		if(get_dist(M, HH) > 7 || M == null || HH == null)
+		if(get_dist(M, HH) > 7 || M == null || HH == null || !H.can_bite(HH, is_pointblank = 0))
 			..()
 			interrupt(INTERRUPT_ALWAYS)
 			src.end()

--- a/code/datums/abilities/vampiric_thrall.dm
+++ b/code/datums/abilities/vampiric_thrall.dm
@@ -92,8 +92,8 @@
 			var/mob/living/carbon/human/H = owner
 			if (istype(H.mutantrace, /datum/mutantrace/vampiric_thrall))
 				var/datum/mutantrace/vampiric_thrall/V = H.mutantrace
-				.["Blood:"] = V.blood_points
-				.["Max HP:"] = H.max_health
+				.["Blood:"] = round(V.blood_points)
+				.["Max HP:"] = round(H.max_health)
 
 	proc/msg_to_master(var/msg)
 		if (master)

--- a/code/datums/abilities/vampiric_thrall.dm
+++ b/code/datums/abilities/vampiric_thrall.dm
@@ -99,6 +99,20 @@
 		if (master)
 			master.transmit_thrall_msg(msg,owner)
 
+	proc/change_vampire_blood(var/change = 0, var/total_blood = 0, var/set_null = 0)
+		if(!total_blood)
+			var/mob/living/carbon/human/M = owner
+			if(istype(M) && istype(M.mutantrace, /datum/mutantrace/vampiric_thrall))
+				var/datum/mutantrace/vampiric_thrall/V = M.mutantrace
+				if (V.blood_points < 0)
+					V.blood_points = 0
+					if (haine_blood_debug) logTheThing("debug", M, null, "<b>HAINE BLOOD DEBUG:</b> [M]'s blood_points dropped below 0 and was reset to 0")
+
+				if (set_null == 1)
+					V.blood_points = 0
+				else
+					V.blood_points = max(V.blood_points + change, 0)
+
 
 /datum/targetable/vampiric_thrall
 	icon = 'icons/mob/spell_buttons.dmi'

--- a/code/datums/abilities/vampiric_thrall.dm
+++ b/code/datums/abilities/vampiric_thrall.dm
@@ -108,7 +108,7 @@
 					V.blood_points = 0
 					if (haine_blood_debug) logTheThing("debug", M, null, "<b>HAINE BLOOD DEBUG:</b> [M]'s blood_points dropped below 0 and was reset to 0")
 
-				if (set_null == 1)
+				if (set_null)
 					V.blood_points = 0
 				else
 					V.blood_points = max(V.blood_points + change, 0)

--- a/code/modules/events/vamp_teg.dm
+++ b/code/modules/events/vamp_teg.dm
@@ -289,22 +289,17 @@ datum/teg_transformation/vampire
 			if(target in abilityHolder.thralls)
 				H = target
 				if( abilityHolder.points > 100 && target.blood_volume < 50 && !ON_COOLDOWN(src.teg,"heal", 120 SECONDS) )
-					//enthrall(H)
 					use_ability(/datum/targetable/vampire/enthrall/teg, target)
 			else
 				if(isalive(target))
 					if( prob(80) && !ON_COOLDOWN(target,"teg_glare", 30 SECONDS) )
 						use_ability(/datum/targetable/vampire/glare, target)
-						//glare(target)
 
 					use_ability(/datum/targetable/vampire/blood_steal, target)
-					// if(!actions.hasAction(src.teg, "vamp_blood_suck_ranged") && !ON_COOLDOWN(src.teg,"vamp_blood_suck_ranged", 10 SECONDS))
-					// 	actions.start(new/datum/action/bar/private/icon/vamp_ranged_blood_suc(src.teg,abilityHolder, target, abilities["Blood Steal"]), src.teg)
 
 			if(ishuman(target))
 				H = target
 				if(isdead(H) && abilityHolder.points > 100 && !ON_COOLDOWN(src.teg,"enthrall",30 SECONDS))
-					//enthrall(H)
 					use_ability(/datum/targetable/vampire/enthrall/teg, target)
 
 		if(probmult(10))
@@ -395,64 +390,6 @@ datum/teg_transformation/vampire
 		var/rendered = "<span class='game thrallsay'><span class='prefix'>Thrall speak:</span> <span class='name vamp'>[name]<span class='text-normal'>[alt_name]</span></span> <span class='message'>[message]</span></span>"
 		for (var/mob/M in src.abilityHolder.thralls)
 			boutput(M, rendered)
-
-	proc/enthrall(mob/living/carbon/human/target)
-		var/datum/abilityHolder/vampire/H = src.abilityHolder
-		if(istype(target))
-			if (!istype(target.mutantrace, /datum/mutantrace/vampiric_thrall))
-				if (!target.mind && !target.client)
-					if (target.ghost && target.ghost.client && !(target.ghost.mind && target.ghost.mind.dnr))
-						var/mob/dead/ghost = target.ghost
-						ghost.show_text("<span class='red'>You feel yourself torn away from the afterlife and back into your body!</span>")
-						if(ghost.mind)
-							ghost.mind.transfer_to(target)
-						else if (ghost.client)
-							target.client = ghost.client
-						else if (ghost.key)
-							target.key = ghost.key
-
-					else if (target.last_client) //if all fails, lets try this
-						for (var/client/C in clients)
-							if (C == target.last_client && C.mob && isobserver(C.mob))
-								if(C.mob && C.mob.mind)
-									C.mob.mind.transfer_to(target)
-								else
-									target.client = C
-								break
-
-				if (!target.client)
-					return
-
-				target.full_heal()
-
-				target.real_name = "zombie [target.real_name]"
-				if (target.mind)
-					target.mind.special_role = ROLE_VAMPTHRALL
-					target.mind.master = src.teg
-					if (!(target.mind in ticker.mode.Agimmicks))
-						ticker.mode.Agimmicks += target.mind
-
-				src.abilityHolder.thralls += target
-
-				target.set_mutantrace(/datum/mutantrace/vampiric_thrall)
-				var/datum/abilityHolder/vampiric_thrall/VZ = target.get_ability_holder(/datum/abilityHolder/vampiric_thrall)
-				if (VZ && istype(VZ))
-					VZ.master = H
-
-				boutput(target, __red("<b>You awaken filled with purpose - you must serve your master \"vampire\", [src.teg]!</B>"))
-				boutput(target, __red("<b>You are bound to the [src.teg]. It hungers for blood! You must protect it and feed it!</B>"))
-				SHOW_MINDSLAVE_TIPS(target)
-			else
-				target.full_heal()
-
-			if (target in H.thralls)
-				//and add blood!
-				var/datum/mutantrace/vampiric_thrall/V = target.mutantrace
-				if (V)
-					V.blood_points += 200
-
-				H.blood_tracking_output(100)
-				H.deductPoints(100)
 
 /datum/targetable/vampire/enthrall/teg
 	max_range = 10

--- a/code/modules/events/vamp_teg.dm
+++ b/code/modules/events/vamp_teg.dm
@@ -48,12 +48,10 @@
 
 		if (!isnum(warning_delay))
 			warning_delay = rand(10, 50)
-			warning_delay = 1 // AZRUN REMOVE THIS YOU MAD LAD
 		warning_delay = warning_delay SECONDS
 
 		if (!isnum(event_duration))
 			event_duration = rand(7, 9)
-			event_duration = 0.01 // AZRUN REMOVE THIS YOU MAD LAD
 		event_duration = event_duration MINUTES
 
 		if (!isnum(grump_to_overcome))
@@ -195,7 +193,6 @@ datum/teg_transformation/vampire
 	var/datum/abilityHolder/vampire/abilityHolder
 	var/list/datum/targetable/vampire/abilities = list()
 	var/health = 150
-	health = 1 // AZRUN REMOVE THIS YOU MAD LAD
 
 	proc/attach_hud()
 		. = FALSE

--- a/code/modules/projectiles/special.dm
+++ b/code/modules/projectiles/special.dm
@@ -591,7 +591,7 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	auto_find_targets = 0
 	silentshot = 1
 	pierces = -1
-
+	max_range = 10
 	shot_sound = "sound/impact_sounds/Flesh_Tear_1.ogg"
 
 	on_launch(var/obj/projectile/P)
@@ -609,13 +609,14 @@ ABSTRACT_TYPE(/datum/projectile/special)
 	on_hit(atom/hit, direction, var/obj/projectile/P)
 		if (("vamp" in P.special_data))
 			var/datum/abilityHolder/vampire/vampire = P.special_data["vamp"]
-			if (vampire.owner == hit && P.max_range == PROJ_INFINITE_RANGE)
+			if (vampire.owner == hit && !P.special_data["returned"])
 				P.travelled = 0
 				P.max_range = 4
+				P.special_data["returned"] = TRUE
 			..()
 
 	on_end(var/obj/projectile/P)
-		if (("vamp" in P.special_data) && ("victim" in P.special_data))
+		if (("vamp" in P.special_data) && ("victim" in P.special_data) && P.special_data["returned"])
 			var/datum/abilityHolder/vampire/vampire = P.special_data["vamp"]
 			var/mob/living/victim = P.special_data["victim"]
 
@@ -623,7 +624,8 @@ ABSTRACT_TYPE(/datum/projectile/special)
 				if (vampire.can_bite(victim,is_pointblank = 0))
 					vampire.do_bite(victim, mult = 0.3333)
 
-				vampire.owner?.add_stamina(20)
+				if(istype(vampire.owner))
+					vampire.owner?.add_stamina(20)
 				victim.remove_stamina(4)
 
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Added rounding to Thrall health and blood totals.

Vampire blood projectiles no longer have infinite range.  There is a chance they may expire if you keep trying to evade them.

Moves helper logic around to be more centralized to related datums.  The blood tracking helpers were mob wide when they were specifically interacting with the ability holder.  Logic moved to ability holder and thin wrapper maintained at mob.

Added support to a number of vampire abilities to be called when the `owner` is not a `mob` to support the Haunted TEG event.  This harmonizes behavior and removes mostly duplicated code.

Blood Suck ability will be canceled when the target is no longer a valid blood donor.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resolves issue where the blood particle would remain after the Haunted TEG reverts back.
Blood Suck will now stop when it is no longer pertinent to blood gain.
Cleanliness. 