### PR TITLE
Fix table smoothing

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -75,7 +75,7 @@
 		icon_state = num2text(cardinals)
 		var/ordinals = connectdirs_to_byonddirs(connections)
 
-		if(ordinals & NORTHEAST)
+		if((NORTHEAST & ordinals) == NORTHEAST)
 			if (!src.working_image)
 				src.working_image = image(src.icon, "NE")
 			else
@@ -83,7 +83,7 @@
 			src.UpdateOverlays(working_image, "NEcorner")
 		else
 			src.UpdateOverlays(null, "NEcorner")
-		if(ordinals & SOUTHEAST)
+		if((SOUTHEAST & ordinals) == SOUTHEAST)
 			if (!src.working_image)
 				src.working_image = image(src.icon, "SE")
 			else
@@ -91,7 +91,7 @@
 			src.UpdateOverlays(working_image, "SEcorner")
 		else
 			src.UpdateOverlays(null, "SEcorner")
-		if(ordinals & SOUTHWEST)
+		if((SOUTHWEST & ordinals) == SOUTHWEST)
 			if (!src.working_image)
 				src.working_image = image(src.icon, "SW")
 			else
@@ -100,7 +100,7 @@
 		else
 			src.UpdateOverlays(null, "SWcorner")
 
-		if(ordinals & NORTHWEST)
+		if((NORTHWEST & ordinals) == NORTHWEST)
 			if (!src.working_image)
 				src.working_image = image(src.icon, "NW")
 			else

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -71,11 +71,11 @@
 			return
 
 		var/connections = get_connected_directions_bitflag(list(src.auto_type), connect_diagonal = 1)
-		var/dirs = connections % 16 // get cardinals from match
-		var/connecting_ordinals = connections >> 8
-		icon_state = num2text(dirs)
+		var/cardinals = connections % 16 // first four bits
+		icon_state = num2text(cardinals)
+		var/ordinals = connections >> 4 // last four bits
 
-		if(connecting_ordinals & NORTHEAST)
+		if(ordinals == 1)
 			if (!src.working_image)
 				src.working_image = image(src.icon, "NE")
 			else
@@ -83,7 +83,7 @@
 			src.UpdateOverlays(working_image, "NEcorner")
 		else
 			src.UpdateOverlays(null, "NEcorner")
-		if(connecting_ordinals & SOUTHEAST)
+		if(ordinals == 2)
 			if (!src.working_image)
 				src.working_image = image(src.icon, "SE")
 			else
@@ -91,7 +91,7 @@
 			src.UpdateOverlays(working_image, "SEcorner")
 		else
 			src.UpdateOverlays(null, "SEcorner")
-		if(connecting_ordinals & SOUTHWEST)
+		if(ordinals == 4)
 			if (!src.working_image)
 				src.working_image = image(src.icon, "SW")
 			else
@@ -100,7 +100,7 @@
 		else
 			src.UpdateOverlays(null, "SWcorner")
 
-		if(connecting_ordinals & NORTHWEST)
+		if(ordinals == 8)
 			if (!src.working_image)
 				src.working_image = image(src.icon, "NW")
 			else

--- a/code/procs/gamehelpers.dm
+++ b/code/procs/gamehelpers.dm
@@ -99,7 +99,7 @@ var/list/stinkThingies = list("ass","taint","armpit","excretions","leftovers","a
 /// For interacting with stuff.
 /proc/in_interact_range(atom/source, atom/user)
 	. = FALSE
-	if(bounds_dist(source, user) == 0 || (IN_RANGE(source, user) == 0)) // IN_RANGE is for general stuff, bounds_dist is for large sprites, presumably
+	if(bounds_dist(source, user) == 0 || (IN_RANGE(source, user, 1))) // IN_RANGE is for general stuff, bounds_dist is for large sprites, presumably
 		return TRUE
 	else if (source in bible_contents && locate(/obj/item/storage/bible) in range(1, user)) // whoever added the global bibles, fuck you
 		return TRUE

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2613,3 +2613,13 @@ proc/get_all_character_setup_ringtones()
 			var/datum/ringtone/R_prime = new R
 			selectable_ringtones[R_prime.name] = R_prime
 	return selectable_ringtones
+
+/// converts `get_connected_directions_bitflag()` diagonal bits to byond direction flags
+proc/connectdirs_to_byonddirs(var/connectdir_bitflag)
+	. = 0
+	if (!connectdir_bitflag) return
+	var/B = connectdir_bitflag >> 4
+	if(B == 1) .&= NORTHEAST
+	if(B == 2) .&= SOUTHEAST
+	if(B == 4) .&= SOUTHWEST
+	if(B == 8) .&= NORTHWEST

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2618,8 +2618,7 @@ proc/get_all_character_setup_ringtones()
 proc/connectdirs_to_byonddirs(var/connectdir_bitflag)
 	. = 0
 	if (!connectdir_bitflag) return
-	var/B = connectdir_bitflag >> 4
-	if(B == 1) .&= NORTHEAST
-	if(B == 2) .&= SOUTHEAST
-	if(B == 4) .&= SOUTHWEST
-	if(B == 8) .&= NORTHWEST
+	if(16 & connectdir_bitflag) .|= NORTHEAST
+	if(32 & connectdir_bitflag) .|= SOUTHEAST
+	if(64 & connectdir_bitflag) .|= SOUTHWEST
+	if(128 & connectdir_bitflag) .|= NORTHWEST


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
the combined direction bitflag adds four bits that don't correlate directly to BYOND's ordinal named directions, which are combinations of the cardinal bits. I'm not sure if there's a better way to map these.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Smooth tables are broken