### PR TITLE
Attack Animation/Sfx/Delays for Hitting Phones and Canisters

### DIFF
--- a/code/modules/atmospherics/portable/canister.dm
+++ b/code/modules/atmospherics/portable/canister.dm
@@ -48,6 +48,13 @@
 	powered()
 		return 1
 
+	attackby(obj/item/W as obj, mob/user as mob)
+		..()
+		user.lastattacked = src
+		attack_particle(user,src)
+		hit_twitch(src)
+		playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Light_1.ogg', 50, 1)
+
 /obj/machinery/portable_atmospherics/canister/sleeping_agent
 	name = "Canister: \[N2O\]"
 	icon_state = "redws"

--- a/code/obj/machinery/phone.dm
+++ b/code/obj/machinery/phone.dm
@@ -7,7 +7,7 @@
 	density = 0
 	mats = 25
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WIRECUTTERS | DECON_MULTITOOL
-	_health = 50
+	_health = 25
 	color = null
 	var/can_talk_across_z_levels = 0
 	var/phone_id = null
@@ -155,6 +155,9 @@
 		..()
 		src._health -= P.force
 		attack_particle(user,src)
+		user.lastattacked = src
+		hit_twitch(src)
+		playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Light_1.ogg', 50, 1)
 		if(src._health <= 0)
 			if(src.linked)
 				hang_up()


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Not an April Fools joke sorry. This PR adds delays, attack animations (the item you're holding animates to hit the thing you're hitting and it wobbles a bit when hit) and generic machine-hit-y noises to smacking canisters and phones with weapons. Also reduces the health of phones to compensate (halves it). Canisters seemed fine with the current health so they're the same.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I wanted to get back into those really old PRs I made to add damage-ability to various machines that should be breakable. In my opinion, every item that's breakable by bashing should have visual effects and sound effects, to cue players into when hitting something does nothing and when hitting something... does damage. Canisters and phones are already breakable objects, so this adds that bit of language to them. Much better than the item being breakable but showing no indication your attacks do anything imo.

This technically makes canisters harder to break, by a lot actually. Since currently with no delay you can break them near instantly with any weapon by spamclicking. I think this is an improvement that makes sense though. I made phones a lot weaker so they don't take forever to break, but canisters 'feel right' with this amount of HP.