### PR TITLE
Changes construction crate contents

### DIFF
--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -440,7 +440,7 @@
 			user.visible_message("<span class='notice'>[user] finishes stuffing materials into [src].</span>")
 
 /obj/item/room_planner
-	name = "\improper Floor and Wall Planner"
+	name = "\improper Floor and Wall Designer"
 	icon = 'icons/obj/construction.dmi'
 	icon_state = "plan"
 	item_state = "gun"

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1316,12 +1316,10 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	name = "Construction Equipment"
 	desc = "The mothballed tools of our former Construction Workers, in a crate, for you!"
 	category = "Engineering Department"
-	contains = list(/obj/item/lamp_manufacturer/organic,/obj/item/material_shaper,/obj/item/room_planner,/obj/item/clothing/under/rank/orangeoveralls)
-	//i was going to add a version of the construction visualliser w/o seeing invisible monsters but FUCK SIGHT CODE WHAT THE FUCK
-	cost = 8000
+	contains = list(/obj/item/lamp_manufacturer/organic,/obj/item/room_planner,/obj/item/clothing/under/rank/orangeoveralls)
+	cost = 7000
 	containertype = /obj/storage/secure/crate
-	containername = "Construction Equipment (Cardlocked \[Engineering])"
-	access = access_engineering
+	containername = "Construction Equipment"
 
 /* ================================================= */
 /* -------------------- Complex -------------------- */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR removes the lock from the construction crate ordered through the QM console, removes the window planner from the crate, renames the "floor planner" to "floor designer" and lowers the price by 1000 to make up for the removal of the window planner.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Locked QM crates usually contain dangerous items, like weapons or tools that threaten station integrity. The crate only contains items that change the station cosmetically, as such i dont think that a crate lock is warranted.

The "floor and wall planner" has been renamed to "floor and wall designer" to be less confusing. The "planner" doesnt plan anything, it only changes flooring and wall appearances. 

The window planner located in the crate is pretty much worthless, only working with glasses which were never included inside the crate. Therefore, i removed it as it currently serves little to no purpose unless the glasses were changed, as they currently detect invisible creatures and people.
To compensate for that loss, the crate is now 1000 credits cheaper!

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
