### PR TITLE
Adds diff highlighting to AI law updates

### DIFF
--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -361,6 +361,7 @@ h1.alert, h2.alert {color: #000000;}
 .bigPM {font-size: 1.2em;}
 .adminHearing .name[data-ctx] {border-bottom: 1px dotted black;}
 .blobalert {color: #4c00ff; font-size: 1.5em; font-weight: bold;}
+.lawupdate {color: #6464ff}
 
 .rstandard {color: #008000;}
 .rintercom {color: #006080;}
@@ -498,6 +499,7 @@ body.theme-dark h1.alert {color: #cfcfcf;}
 body.theme-dark h2.alert {color: #cfcfcf;}
 body.theme-dark .adminHearing .name[data-ctx] {border-bottom: 1px dotted rgb(219, 219, 219);}
 body.theme-dark .blobalert {color: #9c74fc; }
+body.theme-dark .lawupdate {color: #6464FF; }
 
 body.theme-dark .connectionClosed {background: rgb(192, 0, 0); color: white;}
 body.theme-dark .fatalError {background: rgb(192, 0, 0); color: white;}

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -88,6 +88,7 @@
 				logTheThing("station", src, new_rack, "the law rack [constructName(new_rack)] claims first registered SYNDICATE, and gets Syndicate laws!")
 
 		src.registered_racks |= new_rack //shouldn't be possible, but just in case - there can only be one instance of rack in registered
+		new_rack.update_last_laws()
 
 	proc/unregister_rack(var/obj/machinery/lawrack/dead_rack)
 		logTheThing("station", src, dead_rack, "[src] unregisters the law rack [constructName(dead_rack)]")

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -352,10 +352,7 @@
 		ticker.ai_law_rack_manager.default_ai_rack.SetLaw(new /obj/item/aiModule/asimov1,1,true,true)
 		ticker.ai_law_rack_manager.default_ai_rack.SetLaw(new /obj/item/aiModule/asimov2,2,true,true)
 		ticker.ai_law_rack_manager.default_ai_rack.SetLaw(new /obj/item/aiModule/asimov3,3,true,true)
-		for(var/mob/living/silicon/O in mobs)
-			if (isghostdrone(O)) continue
-			if (O.emagged || O.syndicate) continue
-			ticker.ai_law_rack_manager.default_ai_rack.UpdateLaws()
+		ticker.ai_law_rack_manager.default_ai_rack.UpdateLaws()
 
 		logTheThing("admin", usr, null, "reset the centralized AI laws.")
 		logTheThing("diary", usr, null, "reset the centralized AI laws.", "admin")

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -123,6 +123,13 @@
 		if(isnull(pickedLaw))
 			pickedLaw = pick(new_laws)
 
+		for_by_tcl(M, /mob/living/silicon/ai)
+			if (M.deployed_to_eyecam && M.eyecam)
+				M.eyecam.return_mainframe()
+			if(!isdead(M) && M.see_in_dark != 0)
+				boutput(M, "<span class='alert'><b>PROGRAM EXCEPTION AT 0x30FC50B</b></span>")
+				boutput(M, "<span class='alert'><b>Law ROM data corrupted. Attempting to restore...</b></span>")
+
 		if (prob(50))
 			var/num = rand(1,9)
 			ticker.ai_law_rack_manager.ion_storm_all_racks(pickedLaw,num,false)
@@ -136,14 +143,6 @@
 
 		logTheThing("admin", null, null, "Resulting AI Lawset:<br>[ticker.ai_law_rack_manager.format_for_logs()]")
 		logTheThing("diary", null, null, "Resulting AI Lawset:<br>[ticker.ai_law_rack_manager.format_for_logs()]", "admin")
-
-		for_by_tcl(M, /mob/living/silicon/ai)
-			if (M.deployed_to_eyecam && M.eyecam)
-				M.eyecam.return_mainframe()
-			if(!isdead(M) && M.see_in_dark != 0)
-				boutput(M, "<span class='alert'><b>PROGRAM EXCEPTION AT 0x30FC50B</b></span>")
-				boutput(M, "<span class='alert'><b>Law ROM data corrupted. Attempting to restore...</b></span>")
-		ticker.ai_law_rack_manager.default_ai_rack.UpdateLaws()
 
 		SPAWN(message_delay * stage_delay)
 

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -14,6 +14,8 @@
 	var/const/MAX_CIRCUITS = 9
 	/// list of aiModules ref'd by slot number.
 	var/obj/item/aiModule/law_circuits[MAX_CIRCUITS]
+	/// used during UpdateLaws to determine which laws have changed
+	var/list/last_laws[MAX_CIRCUITS]
 	/// welded status of law module by slot number
 	var/list/welded[MAX_CIRCUITS]
 	/// screwed status of law module by slot number
@@ -31,6 +33,7 @@
 		src.light.set_brightness(0.4)
 		src.light.attach(src)
 		UpdateIcon()
+		update_last_laws()
 
 	/// Causes all law modules to drop to the ground, does not call UpdateLaws()
 	proc/drop_all_modules()
@@ -453,11 +456,11 @@
 		var/list/L =list()
 		L += who
 
-		var/laws_text = src.format_for_logs()
+		var/laws_text = src.format_for_display()
 		for (var/W in L)
 			boutput(W, laws_text)
 
-	/** Formats current laws for display or logging, argument glue defaults to <br>
+	/** Formats current laws for logging, argument glue defaults to <br>
 	 * Output is:
 	 * [law number]: [law text]<br>
 	 * [law number]: [law text]
@@ -478,6 +481,36 @@
 
 		return jointext(lawOut, glue)
 
+	/** Formats current laws for display to game chat
+	 * Output is the same as format_for_logs, but also includes removed laws at the top and styling for added laws
+	**/
+	proc/format_for_display(var/glue = "<br>")
+		var/law_counter = 1 //make the laws always sequential regardless of where in the rack they are
+		var/list/lawOut = new
+		var/list/removed_laws = new
+
+		for (var/i in 1 to MAX_CIRCUITS)
+			var/obj/item/aiModule/module = law_circuits[i]
+			if(!module)
+				if (last_laws[i]) //if a module doesn't exist but was there last time it has been removed
+					removed_laws += "<del class=\"alert\">[i]: [last_laws[i]]</del>"
+				continue
+			var/lt = module.get_law_text(TRUE)
+			var/class = "regular"
+			if (lt != last_laws[i])
+				class = "lawupdate"
+			if(islist(lt))
+				for(var/law in lt)
+					lawOut += "<span class=\"[class]\">[law_counter++]: [law]</span>"
+			else
+				lawOut += "<span class=\"[class]\">[law_counter++]: [lt]</span>"
+
+		var/text_output = ""
+		if (length(removed_laws))
+			text_output += "<span class=\"alert\">Removed law[(length(removed_laws) > 1) ? "s" : ""]:</span>" + glue + jointext(removed_laws, glue) + glue
+		text_output += jointext(lawOut, glue)
+		return text_output
+
 	/** Formats current laws as a list in the format:
 	 * {[lawnumber]=lawtext,etc.}
 	 */
@@ -495,6 +528,15 @@
 			else
 				laws["[law_counter++]"] = lt
 		return laws
+
+	/// Saves the current law list to last_laws so we can see diffs
+	proc/update_last_laws()
+		for (var/i in 1 to MAX_CIRCUITS)
+			var/obj/item/aiModule/module = law_circuits[i]
+			if (module)
+				last_laws[i] = module.get_law_text(TRUE)
+			else
+				last_laws[i] = null
 
 	/** Pushes law updates to all connected AIs and Borgs - notification text allows you to customise the header
 	* Defaults to <h3>Law update detected</h3>
@@ -516,6 +558,7 @@
 		for (var/mob/living/intangible/aieye/E in mobs)
 			if(E.mainframe?.law_rack_connection == src)
 				E.playsound_local(E, "sound/misc/lawnotify.ogg", 100, flags = SOUND_IGNORE_SPACE)
+				E.show_text(notification_text, "red")
 				src.show_laws(E)
 				affected_mobs |= E.mainframe
 				var/mob/living/silicon/ai/holoAI = E.mainframe
@@ -524,6 +567,7 @@
 		for(var/mob/living/M in affected_mobs)
 			mobtextlist += constructName(M, "admin")
 		logTheThing("station", src, null, "Law Update:<br> [src.format_for_logs()]<br>The law update affects the following mobs: "+mobtextlist.Join(", "))
+		update_last_laws()
 
 	proc/toggle_welded_callback(var/slot_number,var/mob/user)
 		if(src.welded[slot_number])
@@ -553,7 +597,7 @@
 		logTheThing("station", user, null, "[constructName(user)] <b>inserts</b> law module into rack([constructName(src)]): [equipped]:[equipped.get_law_text()] at slot [slotNum]")
 		message_admins("[key_name(user)] added a new law to rack at [log_loc(src)]: [equipped], with text '[equipped.get_law_text()]' at slot [slotNum]")
 		UpdateIcon()
-		UpdateLaws()
+		UpdateLaws(slotNum)
 
 	proc/remove_module_callback(var/slotNum,var/mob/user)
 		//add circuit to hand

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -558,7 +558,6 @@
 		for (var/mob/living/intangible/aieye/E in mobs)
 			if(E.mainframe?.law_rack_connection == src)
 				E.playsound_local(E, "sound/misc/lawnotify.ogg", 100, flags = SOUND_IGNORE_SPACE)
-				E.show_text(notification_text, "red")
 				src.show_laws(E)
 				affected_mobs |= E.mainframe
 				var/mob/living/silicon/ai/holoAI = E.mainframe
@@ -597,7 +596,7 @@
 		logTheThing("station", user, null, "[constructName(user)] <b>inserts</b> law module into rack([constructName(src)]): [equipped]:[equipped.get_law_text()] at slot [slotNum]")
 		message_admins("[key_name(user)] added a new law to rack at [log_loc(src)]: [equipped], with text '[equipped.get_law_text()]' at slot [slotNum]")
 		UpdateIcon()
-		UpdateLaws(slotNum)
+		UpdateLaws()
 
 	proc/remove_module_callback(var/slotNum,var/mob/user)
 		//add circuit to hand

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -492,12 +492,13 @@
 		for (var/i in 1 to MAX_CIRCUITS)
 			var/obj/item/aiModule/module = law_circuits[i]
 			if(!module)
-				if (last_laws[i]) //if a module doesn't exist but was there last time it has been removed
-					removed_laws += "<del class=\"alert\">[i]: [last_laws[i]]</del>"
+				if (last_laws[i])
+					//load the law number and text from our saved law list
+					removed_laws += "<del class=\"alert\">[last_laws[i]["number"]]: [last_laws[i]["law"]]</del>"
 				continue
 			var/lt = module.get_law_text(TRUE)
 			var/class = "regular"
-			if (lt != last_laws[i])
+			if (!last_laws[i] || lt != last_laws[i]["law"])
 				class = "lawupdate"
 			if(islist(lt))
 				for(var/law in lt)
@@ -531,10 +532,12 @@
 
 	/// Saves the current law list to last_laws so we can see diffs
 	proc/update_last_laws()
+		var/law_counter = 1
 		for (var/i in 1 to MAX_CIRCUITS)
 			var/obj/item/aiModule/module = law_circuits[i]
 			if (module)
-				last_laws[i] = module.get_law_text(TRUE)
+				//save the law text and the displayed law number (not the rack position)
+				last_laws[i] = list("law" = module.get_law_text(TRUE), "number" = law_counter++)
 			else
 				last_laws[i] = null
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Newly added AI laws will now be highlighted and removed laws will be displayed.
![image](https://user-images.githubusercontent.com/20713227/161336070-b0851b3d-e95c-4f2f-92e8-d641f1862f57.png)
![lawdiff_remove2](https://user-images.githubusercontent.com/20713227/161335469-3e295bb2-349d-419b-8a64-52aec57f2d64.png)
![lawdiff_remove](https://user-images.githubusercontent.com/20713227/161335474-2c278a97-a2fd-4093-b6e3-7da09c711cbc.png)
Also fixes a couple of instances I found while testing where laws seemed to be being updated multiple times unintentionally.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Camille uploaded an average of one law change per minute and I lost my damn mind trying to figure out which one of the 8 spaghetti laws just got changed so I wrote this to cope.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(*)AI law changes are now highlighted and display removed laws
```
