### PR TITLE
Reworks Human Torch Trait

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -952,12 +952,12 @@ ABSTRACT_TYPE(/obj/trait/job)
 		OTHER_STOP_TRACKING_CAT(owner, TR_CAT_NERVOUS_MOBS)
 
 /obj/trait/burning
-	name = "Human Torch (+1)"
+	name = "Human Torch (+2)"
 	cleanName = "Human Torch"
-	desc = "Extends the time that you remain on fire for, when burning."
+	desc = "Fire no longer slowly peters out when you're burning."
 	id = "burning"
 	icon_state = "onfire"
-	points = 1
+	points = 2
 
 /obj/trait/carpenter
 	name = "Carpenter (-1)"

--- a/code/mob/living/life/fire.dm
+++ b/code/mob/living/life/fire.dm
@@ -17,8 +17,3 @@
 			for (var/atom/A in owner.contents)
 				if (A.material)
 					A.material.triggerTemp(A, T0C + 900)
-
-			if(owner.traitHolder && owner.traitHolder.hasTrait("burning"))
-				if(prob(50))
-					owner.update_burning(1)
-		..()

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -659,6 +659,9 @@
 				var/mob/living/carbon/human/H = owner
 				prot = (1 - (H.get_heat_protection() / 100))
 
+			if (H.traitHolder && H.traitHolder.hasTrait("burning")) //trait 'burning' is human torch
+				duration += timePassed										//this makes the fire counter not increment on its own
+
 			if(ismob(owner) && owner:is_heat_resistant())
 				prot = 0
 

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -659,7 +659,7 @@
 				var/mob/living/carbon/human/H = owner
 				prot = (1 - (H.get_heat_protection() / 100))
 
-			if (H.traitHolder && H.traitHolder.hasTrait("burning")) //trait 'burning' is human torch
+			if (H.traitHolder?.hasTrait("burning")) //trait 'burning' is human torch
 				duration += timePassed										//this makes the fire counter not increment on its own
 
 			if(ismob(owner) && owner:is_heat_resistant())


### PR DESCRIPTION
[input wanted][rework]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Human Torch Trait If This PR Is Merged:

- Now prevents your burning counter from decreasing passively. You can still put yourself out with an extinguisher, dropping and rolling, anything that would lower that number normally. It just doesn't count down on its own.
- It's now worth +2 instead of +1 to compensate for it making you weaker.

Here's a video of it doing its thing:

https://user-images.githubusercontent.com/53125172/161360716-6255ad93-fbb9-4f40-8932-60c56f816a3b.mp4



## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Human torch currently doesn't 'feel' like it does anything, since it's such an extremely minor effect that it's basically not noticeable. Traits shouldn't be like that, especially negative traits! You should feel like you're adding to your character's weaknesses, and this aims to make your character more sufficiently vulnerable to fire. It's very deadly specifically when you're knocked out or stunned and on fire, since you could burn... forever. Things that light you on fire for a second or two (welder attack, small amounts of phlog) now light you on fire *until you fix it yourself*. Old trait didn't change the way you had to play, this does! Adds some variety to gameplay, gives people an extra trait point to play around with as incentive to try this out and to make it feel fairer as a pick.

Stopping, dropping and rolling is slightly slower because it's not stacking with the passive drain, too. Any method of putting you out that's not instant is like this actually.

Also, if your corpse is on fire it still burns until someone puts it out. This is hilarious and amazing and I love it and I hope people build museums out of burning human torch corpses. Should also be humorous with the fire resistance gene. 

I mentioned this idea in discord and Aloe casually wrote out the bit of code that makes this work. tyvm aloe for helping my dreams come true

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flaborized
(*)The human torch trait is now worth two points, but totally prevents the burning status counter from decrementing on its own.
```
