### PR TITLE
Adamantium Skeleton Shows Message When It Works + Slight Math Change to It

### DIFF
--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -187,11 +187,17 @@
 	if(src.bioHolder && src.bioHolder.HasEffect("shoot_limb"))
 		delib_chance += 20
 
-	if (src.traitHolder && src.traitHolder.hasTrait("explolimbs") || src.getStatusDuration("food_explosion_resist"))
+	if (src.getStatusDuration("food_explosion_resist"))
 		delib_chance = round(delib_chance / 2)
 
 	if (prob(delib_chance) && !shielded)
-		src.sever_limb(pick(list("l_arm","r_arm","l_leg","r_leg"))) //max one delimb at once
+		if (src.traitHolder && src.traitHolder.hasTrait("explolimbs"))
+			if(prob(50))
+				boutput(src, "<span class='notice'><b>Your unusually strong bones keep your limbs attatched through the blast!</b></span>")
+			else
+				src.sever_limb(pick(list("l_arm","r_arm","l_leg","r_leg")))
+		else
+			src.sever_limb(pick(list("l_arm","r_arm","l_leg","r_leg"))) //max one delimb at once
 
 	switch (power)
 		if (-INFINITY to 0) //blocked

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -193,7 +193,7 @@
 	if (prob(delib_chance) && !shielded)
 		if (src.traitHolder && src.traitHolder.hasTrait("explolimbs"))
 			if(prob(50))
-				boutput(src, "<span class='notice'><b>Your unusually strong bones keep your limbs attatched through the blast!</b></span>")
+				boutput(src, "<span class='notice'><b>Your unusually strong bones keep your limbs attached through the blast!</b></span>")
 			else
 				src.sever_limb(pick(list("l_arm","r_arm","l_leg","r_leg")))
 		else


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The other trait idea I've had for a while

This PR makes adamantium skeleton output a message in blue whenever it prevents you from losing a limb. Changes the way the math is done slightly to make this possible which has very minimal implications but overall buffs the trait. Basically:

Currently (without this PR) it checks for adamantium skeleton, and if you have it it halves the chance of your limb blowing off. Now, it rolls the normal limb blowing off value, and if you have adamantium skeleton it rolls a 50% chance to ignore it (and output the message) and a 50% chance to blow your limb off. In an instance where you normally would have a 10% chance to lose a limb, both should result in a 5% chance in the end, assuming I have even a basic understanding of how probability works (I sincerely might not). 

However, if you were to have a 120% base chance to lose a limb, you'd previously have a 60% chance with adamantium skeleton. Now it'll be 50%. If you had a 200% chance to lose a limb, it'd be cut down to 100%, this cuts it down to 50%. Basically you have at most a 50/50 chance of losing a limb to any given explosion, but it can be much lower too. This is a slight buff to the trait in situations where you're hit by a very very strong bomb, as far as I can tell. 

Also it stacks with the food buff that previously did not stack with it. This is pretty strong in tandem with the trait, but you have to have the foresight to eat a food ahead of time *and* have the trait, which is complicated enough play that I think it's good and fine. Rewards you for knowing you're gonna be facing explosives that could delimb you if you end up using it.

The chat message: (Yes I know attached is spelt wrong in this screenshot I fixed that but didn't want to boot a private server up again for another pic so just pretend it's spelt right tyia)

![unknown](https://user-images.githubusercontent.com/53125172/161367295-021c1593-44a5-44d2-8fc7-a0a535aa0b4e.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Adamantium Skeleton is an interesting trait, but feels like nothing when you have it since you **don't realize it's helping you when it does.** If we want the trait system to be engaging and interesting to interact with, players should receive feedback when their trait helped them, so they can feel like they used the mechanics wisely and that their trait was worth picking. It makes it less 'set and forget' if you're told unambiguously that adamantium skeleton prevented you from losing a limb. Let's you make a more meaningful choice hopefully.

The niche buff to it's resistance is good also imo, though it wasn't initially 'the plan'. It means that how much it helps you actually scales with explosive power, so you can feel more empowered to take risks around bigger explosions. And anything that big will very likely almost kill you anyways (and still knock off a limb half the time), but you'll still be able to go "oh my trait worked!", and it's satisfying to plan something ahead of time (picking a trait) and then seeing that planning pay off. So I think that the very meager buff has that advantage, but also doesn't really break much or make the trait much too powerful, especially since it's such a niche resistance to begin with.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flaborized
(+)The Adamantium Skeleton trait now outputs a message in the chat when it prevents you from losing a limb.
```
