### PR TITLE
Minor Mineral Magnet Mfixes

### DIFF
--- a/code/datums/controllers/mining_controls.dm
+++ b/code/datums/controllers/mining_controls.dm
@@ -171,7 +171,7 @@ var/list/asteroid_blocked_turfs = list()
 		for (var/mob/living/L in src.contents)
 			if(!isintangible(L)) //neither blob overmind or AI eye should block this
 				return 1
-		for (var/obj/machinery/vehicle in src.contents)
+		for (var/obj/machinery/vehicle/V in src.contents)
 			return 1
 		return 0
 

--- a/code/datums/controllers/mining_controls.dm
+++ b/code/datums/controllers/mining_controls.dm
@@ -173,6 +173,13 @@ var/list/asteroid_blocked_turfs = list()
 				return 1
 		for (var/obj/machinery/vehicle/V in src.contents)
 			return 1
+		for (var/obj/artifact/A in src.contents) // check if an artifact has someone inside
+			if (istype(A, /obj/artifact/prison))
+				var/datum/artifact/prison/P = A.artifact
+				if(istype(P.prisoner)) return 1
+			else if (istype(A, /obj/artifact/cloner))
+				var/datum/artifact/cloner/C = A.artifact
+				if(istype(C.clone)) return 1
 		return 0
 
 /obj/forcefield/mining

--- a/code/datums/controllers/mining_controls.dm
+++ b/code/datums/controllers/mining_controls.dm
@@ -166,6 +166,7 @@ var/list/asteroid_blocked_turfs = list()
 	force_fullbright = 1
 	requires_power = 0
 	luminosity = 1
+	expandable = 0
 
 	proc/check_for_unacceptable_content()
 		for (var/mob/living/L in src.contents)

--- a/code/obj/machinery/shield_generators/shield_generator.dm
+++ b/code/obj/machinery/shield_generators/shield_generator.dm
@@ -3,6 +3,7 @@
 
 /area/station/shield_zone
 	icon_state = "shield_zone"
+	expandable = 0
 
 /* ==================== Generator ==================== */
 

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -181,15 +181,7 @@
 		return walls
 
 	proc/check_for_unacceptable_content()
-		var/turf/origin = get_turf(src)
-		for (var/turf/T in block(locate(origin.x - 1, origin.y - 1, origin.z), locate(origin.x + width, origin.y + height, origin.z)))
-			var/mob/M = locate() in T //living
-			if (M)
-				return 1
-			var/obj/machinery/vehicle/V = locate() in T
-			if (V)
-				return 1
-		return 0
+		mining_controls.magnet_area.check_for_unacceptable_content()
 
 	proc/UL()
 		var/turf/origin = get_turf(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Fixes a check for vehicles that was going through all /obj/machinery (including `/obj/machinery/light_area_manager/`, which caused the bug report)
* Adds checks for artifacts-with-people-inside when pulling a new asteroid (previous behavior: artifact deleted, occupant dropped inside active magnet area)
* Reuses the controller magnet safety check instead of copied code
* Makes the mining magnet and static shield generator areas (i.e. NSS Destiny shield generator) non-expandable

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7670, Fixes #3953