### PR TITLE
Fixes Attack Effects Playing When Using Wrench or Tank on Canister

### DIFF
--- a/code/modules/atmospherics/portable/canister.dm
+++ b/code/modules/atmospherics/portable/canister.dm
@@ -48,13 +48,6 @@
 	powered()
 		return 1
 
-	attackby(obj/item/W as obj, mob/user as mob)
-		..()
-		user.lastattacked = src
-		attack_particle(user,src)
-		hit_twitch(src)
-		playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Light_1.ogg', 50, 1)
-
 /obj/machinery/portable_atmospherics/canister/sleeping_agent
 	name = "Canister: \[N2O\]"
 	icon_state = "redws"
@@ -381,6 +374,10 @@
 			elecflash(src)
 	else if(!iswrenchingtool(W) && !istype(W, /obj/item/tank) && !istype(W, /obj/item/device/analyzer/atmospheric) && !istype(W, /obj/item/device/pda2))
 		src.visible_message("<span class='alert'>[user] hits the [src] with a [W]!</span>")
+		user.lastattacked = src
+		attack_particle(user,src)
+		hit_twitch(src)
+		playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Light_1.ogg', 50, 1)
 		logTheThing("combat", user, null, "attacked [src] [log_atmos(src)] with [W] at [log_loc(src)].")
 		src.health -= W.force
 		healthcheck(user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

In #8055 I accidentally coded it in a way that hitting a canister with a wrench or tank would play the attack animation and sound (as well as doing it's normal function and no damage). This is because I put the code in the wrong spot basically, it should've gone with the existing attackby code for canisters but I didn't think of that at the time oops. This fixes the bug and makes it work as intended

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

bug bad !

