### PR TITLE
Emergency suits on cairngorn

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -58823,6 +58823,7 @@
 /area/syndicate_station/battlecruiser)
 "dgR" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/storage/crate/packing,
 /turf/unsimulated/floor/black,
 /area/syndicate_station/battlecruiser)
 "dgS" = (
@@ -58862,6 +58863,14 @@
 "dgY" = (
 /obj/storage/crate/wooden,
 /obj/random_item_spawner/junk/some,
+/obj/item/clothing/suit/space/emerg{
+	pixel_x = -2;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/space/emerg{
+	pixel_x = 7;
+	pixel_y = 5
+	},
 /turf/unsimulated/floor/black,
 /area/syndicate_station/battlecruiser)
 "dgZ" = (

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -58823,7 +58823,6 @@
 /area/syndicate_station/battlecruiser)
 "dgR" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/storage/crate/packing,
 /turf/unsimulated/floor/black,
 /area/syndicate_station/battlecruiser)
 "dgS" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds two emergency suits that spawn in the storage closet area of the cairngorn.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've found it's really hard to infiltrate when you don't have any spacesuits that don't yell "HEY THIS GUY'S A TERRORIST" when you wear them, and approaching the station through space is an incredibly risky thing to do, especially since you're giving the station early warning that there's a threat without the main force present. By not giving them any associated helmets, it doesn't give nukies an instantly perfect disguise, but should help enough for somewhat risk-free entries.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)NightmareChamillian
(+)After a raid, two NT-brand emergency spacesuits are now available to nuclear operatives onboard the Cairngorn. The syndicate lost the matching helmets, though.
```
