### PR TITLE
Fix fried items becoming small, including mobs.

### DIFF
--- a/code/obj/machinery/deep_fryer.dm
+++ b/code/obj/machinery/deep_fryer.dm
@@ -230,8 +230,11 @@
 		if (isitem(thing))
 			var/obj/item/item = thing
 			fryholder.amount = item.w_class
+			fryholder.w_class = item.w_class
 		else
 			fryholder.amount = 5
+		if (ismob(thing))
+			fryholder.w_class = W_CLASS_BULKY
 		if(thing.reagents)
 			fryholder.reagents.maximum_volume += thing.reagents.total_volume
 			thing.reagents.trans_to(fryholder, thing.reagents.total_volume)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Make deep fried keep their original weight class. Makes deep-fried mobs bulky.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

You can deep fry apes and put them in your pocket. These apes can have TTV backpacks.
You figure the rest out 
