### PR TITLE
Allow AI units to change their own name.

### DIFF
--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -490,7 +490,7 @@
 		set category = "AI Commands"
 		mainframe?.open_map()
 
-	verb/change_name()
+	verb/rename_self()
 		set category = "AI Commands"
 		set name = "Change Designation"
 		set desc = "Change your name."

--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -490,6 +490,11 @@
 		set category = "AI Commands"
 		mainframe?.open_map()
 
+	verb/change_name()
+		set category = "AI Commands"
+		set name = "Change Designation"
+		set desc = "Change your name."
+		mainframe?.rename_self()
 
 //---TURF---//
 /turf/var/image/aiImage

--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -107,7 +107,7 @@
 
 		src.closeContextActions()
 		// contextbuttons can also exist on our mainframe and the eye shares the same hud, fun stuff.
-		src.mainframe.closeContextActions()
+		src.mainframe?.closeContextActions()
 
 		if (src.mainframe)
 			src.mainframe.tracker.cease_track()

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1959,11 +1959,9 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 		return
 
 	if (!ON_COOLDOWN(src, "ai_self_rename", src.rename_cooldown))
-		src.show_text("This ability is still on cooldown for [GET_COOLDOWN(src, "ai_self_rename")] seconds!", "red")
-		return
-
-	choose_name(retries=3, default_name=real_name)
-	last_rename = world.time
+		choose_name(retries=3, default_name=real_name)
+	else
+		src.show_text("This ability is still on cooldown for [round(GET_COOLDOWN(src, "ai_self_rename") / 10)] seconds!", "red")
 
 // CALCULATIONS
 

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -2399,7 +2399,7 @@ proc/get_mobs_trackable_by_AI()
 		if(force_instead)
 			newname = default_name
 		else
-			newname = input(src, "You are an AI. Would you like to change your name to something else?", "Name Change", default_name) as null|text
+			newname = input(usr, "You are an AI. Would you like to change your name to something else?", "Name Change", default_name) as null|text
 			if(newname && newname != default_name)
 				phrase_log.log_phrase("name-ai", newname, no_duplicates=TRUE)
 		if (src.brain.owner != brain_owner)

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -116,6 +116,9 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	var/last_vox = -INFINITY
 	var/vox_cooldown = 1200
 
+	var/last_rename = -INFINITY
+	var/rename_cooldown = 9000 // 15 minutes
+
 	var/has_feet = 0
 
 	sound_fart = 'sound/voice/farts/poo2_robot.ogg'
@@ -470,6 +473,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 				src.verbs += /mob/living/silicon/ai/proc/ai_colorchange
 				src.verbs += /mob/living/silicon/ai/proc/ai_station_announcement
 				src.verbs += /mob/living/silicon/ai/proc/view_messageLog
+				src.verbs += /mob/living/silicon/ai/verb/rename_self
 				src.job = "AI"
 				if (src.mind)
 					src.mind.assigned_role = "AI"
@@ -1945,6 +1949,22 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 			message_mob.client.screen += ai_station_map
 		map_ui = new(usr, message_mob, "AIMap")
 		map_ui.open()
+
+/mob/living/silicon/ai/verb/rename_self()
+	set category = "AI Commands"
+	set name = "Change Designation"
+	set desc = "Change your name."
+
+	var/mob/message_mob = src.get_message_mob()
+	if (!src || !message_mob.client || isdead(src))
+		return
+
+	if (last_rename + rename_cooldown > world.time)
+		src.show_text("This ability is still on cooldown for [round((src.rename_cooldown + src.last_rename - world.time) / 10)] seconds!", "red")
+		return
+
+	choose_name(retries=3, default_name=real_name)
+	// last_rename = world.time // REMOVE BEFORE COMITTING
 
 // CALCULATIONS
 

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1964,7 +1964,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 		return
 
 	choose_name(retries=3, default_name=real_name)
-	// last_rename = world.time // REMOVE BEFORE COMITTING
+	last_rename = world.time
 
 // CALCULATIONS
 

--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -116,8 +116,7 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	var/last_vox = -INFINITY
 	var/vox_cooldown = 1200
 
-	var/last_rename = -INFINITY
-	var/rename_cooldown = 9000 // 15 minutes
+	var/rename_cooldown = 10 MINUTES
 
 	var/has_feet = 0
 
@@ -1959,8 +1958,8 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 	if (!src || !message_mob.client || isdead(src))
 		return
 
-	if (last_rename + rename_cooldown > world.time)
-		src.show_text("This ability is still on cooldown for [round((src.rename_cooldown + src.last_rename - world.time) / 10)] seconds!", "red")
+	if (!ON_COOLDOWN(src, "ai_self_rename", src.rename_cooldown))
+		src.show_text("This ability is still on cooldown for [GET_COOLDOWN(src, "ai_self_rename")] seconds!", "red")
 		return
 
 	choose_name(retries=3, default_name=real_name)

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -148,6 +148,7 @@
 	O.verbs += /mob/living/silicon/ai/proc/ai_colorchange
 	O.verbs += /mob/living/silicon/ai/proc/ai_station_announcement
 	O.verbs += /mob/living/silicon/ai/proc/view_messageLog
+	O.verbs += /mob/living/silicon/ai/verb/rename_self
 	O.job = "AI"
 
 	SPAWN(0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new verb "Change Designation" (`change_name()`) to ai core and eye commands.
Fixes a runtime error when forcing someone to respawn as AI via Player Options.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There's no longer an AI Rename module, so there's no way for a player to fix their AI name if it's the default or mistyped.
To prevent spamming, there is a ten minute cooldown between name changes, which does not include the initial name choice.

Fixes #8004 by way of allowing AIs to set names more than once.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(+)AI units can now change their name via a new AI Command: "Change Designation"
```
