### PR TITLE
Fix ReplaceWith breaking lights before RL_Started

### DIFF
--- a/code/RobustLight2.dm
+++ b/code/RobustLight2.dm
@@ -777,6 +777,8 @@ turf
 		RL_Init()
 			if (!fullbright && !loc:force_fullbright)
 				if(!src.RL_MulOverlay)
+					if (!RL_Started && (locate(/obj/overlay/tile_effect/lighting/mul) in src))
+						return // ReplaceWith is being used before RL has started running
 					src.RL_MulOverlay = new /obj/overlay/tile_effect/lighting/mul
 					src.RL_MulOverlay.set_loc(src)
 					src.RL_MulOverlay.icon_state = src.RL_OverlayState


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Fix ReplaceWith breaking lights before RL_Started


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Mining Z level was changed to generate before the robust lighting system starts up
* Changes to the start order caused an issue where `/turf/New()` creates multiple `/obj/overlay/tile_effect/lighting/mul` objects on any turf touched by a `ReplaceWith` call, breaking lighting