### PR TITLE
Add AI Rack interaction with video cards.

### DIFF
--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -641,9 +641,9 @@
 					playsound(src, "sound/machines/bweep.ogg", 50)
 					mined.throw_at(target, 5, 5)
 					src.visible_message("<span class='alert'>[I] energetically expels [mined]!</span>")
-			if (src && !src.GetParticles("rack_spark"))
+			if (src && !src.GetParticles("mine_spark"))
 				playsound(src, "sound/effects/electric_shock_short.ogg", 50)
-				src.UpdateParticles(new/particles/rack_spark,"rack_spark")
+				src.UpdateParticles(new/particles/rack_spark,"mine_spark")
 				src.visible_message("<span class='alert'><b>The [src] starts sparking!</b></span>")
 			sleep(2 SECONDS)
 			if (src && I)
@@ -655,7 +655,7 @@
 						break
 				I.throw_at(target, 5, 5)
 				src.visible_message("<span class='alert'>The [I] is forcefully ejected from the [src]!</span>")
-				src.ClearSpecificParticles("rack_spark")
+				src.ClearSpecificParticles("mine_spark")
 			sleep(0.5 SECONDS)
 			I?.combust()
 

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -620,13 +620,13 @@
 		UpdateLaws()
 
 	proc/insert_videocard_callback(var/mob/user, var/obj/item/peripheral/videocard/I)
-		var/mob/living/target = orange(1,src)[rand(1,8)]
+		var/mob/living/target = null
 		user.u_equip(I)
 		I.set_loc(src)
-		playsound(src, "sound/machines/interdictor_activate.ogg", 50)
+		playsound(src, "sound/machines/interdictor_activate.ogg", 70, extrarange=3)
 		src.visible_message("<span class='alert'>[I] emits a loud whirring noise as it connects into the [src]!</span>")
 		SPAWN(7 SECONDS)
-			playsound(src, "sound/machines/engine_highpower.ogg", 50)
+			playsound(src, "sound/machines/engine_highpower.ogg", 80)
 			src.use_power(500)
 			for (var/i in 1 to 10)
 				sleep(0.3 SECONDS)
@@ -638,8 +638,8 @@
 						if (!isintangible(mob))
 							target = mob
 							break
-					playsound(src, "sound/machines/bweep.ogg", 50)
-					mined.throw_at(target, 5, 5)
+					playsound(src, "sound/machines/bweep.ogg", rand(45,70), 1, pitch = 1.6)
+					mined.throw_at(target, 7, rand(4,6))
 					src.visible_message("<span class='alert'>[I] energetically expels [mined]!</span>")
 			if (src && !src.GetParticles("mine_spark"))
 				playsound(src, "sound/effects/electric_shock_short.ogg", 50)
@@ -649,15 +649,18 @@
 			if (src && I)
 				target = orange(1,src)[rand(1,8)]
 				I.set_loc(src.loc)
-				for (var/mob/living/mob in view(7,src))
+				for (var/mob/living/mob in view(5,src))
 					if (!isintangible(mob))
 						target = mob
 						break
-				I.throw_at(target, 5, 5)
+				I.throw_at(target, 7, rand(6,9))
 				src.visible_message("<span class='alert'>The [I] is forcefully ejected from the [src]!</span>")
 				src.ClearSpecificParticles("mine_spark")
-			sleep(0.5 SECONDS)
-			I?.combust()
+			sleep(0.7 SECONDS) // just enough time to recognize the card
+			if (I)
+				fireflash(I,0,TRUE)
+				I.combust()
+
 
 
 

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -319,8 +319,11 @@
 					M.update_appearance()
 		else if (istype(I, /obj/item/peripheral/videocard))
 			var/obj/item/peripheral/videocard/V = I
-			SETUP_GENERIC_ACTIONBAR(user, src, 5 SECONDS, .proc/insert_videocard_callback, list(user,V), user.equipped().icon, user.equipped().icon_state, \
-					"", INTERRUPT_ACTION | INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ACT)
+			if (GET_COOLDOWN(src, "mine_cooldown") == 0)
+				SETUP_GENERIC_ACTIONBAR(user, src, 5 SECONDS, .proc/insert_videocard_callback, list(user,V), user.equipped().icon, user.equipped().icon_state, \
+						"", INTERRUPT_ACTION | INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ACT)
+			else
+				user.visible_message("<span class='alert'>The [src]'s graphics port isn't ready to accept [I] yet.</span>")
 		else
 			return ..()
 
@@ -621,19 +624,25 @@
 
 	proc/insert_videocard_callback(var/mob/user, var/obj/item/peripheral/videocard/I)
 		var/mob/living/target = null
+		ON_COOLDOWN(src, "mine_cooldown", 30 SECONDS)
 		user.u_equip(I)
 		I.set_loc(src)
-		playsound(src, "sound/machines/interdictor_activate.ogg", 70, extrarange=3)
+		playsound(src, "sound/misc/JetpackMK2on.ogg", 70, extrarange=3)
 		src.visible_message("<span class='alert'>[I] emits a loud whirring noise as it connects into the [src]!</span>")
-		SPAWN(7 SECONDS)
-			playsound(src, "sound/machines/engine_highpower.ogg", 80)
+		SPAWN(6 SECONDS)
+			if (src && !src.GetParticles("mine_spark"))
+				playsound(src, "sound/effects/electric_shock_short.ogg", 50)
+				src.UpdateParticles(new/particles/rack_spark,"mine_spark")
+				src.visible_message("<span class='alert'><b>The [src] starts sparking!</b></span>")
+			sleep(2 SECONDS)
+			if (!src) return
 			src.use_power(500)
 			for (var/i in 1 to 10)
-				sleep(0.3 SECONDS)
+				sleep(0.4 SECONDS)
 				if(src && prob(60))
 					var/obj/mined = new /obj/item/spacecash/buttcoin
 					mined.set_loc(src.loc)
-					target = orange(1,src)[rand(1,8)]
+					target = get_step(src, rand(1,8))
 					for (var/mob/living/mob in view(7,src))
 						if (!isintangible(mob))
 							target = mob
@@ -641,18 +650,15 @@
 					playsound(src, "sound/machines/bweep.ogg", rand(45,70), 1, pitch = 1.6)
 					mined.throw_at(target, 7, rand(4,6))
 					src.visible_message("<span class='alert'>[I] energetically expels [mined]!</span>")
-			if (src && !src.GetParticles("mine_spark"))
-				playsound(src, "sound/effects/electric_shock_short.ogg", 50)
-				src.UpdateParticles(new/particles/rack_spark,"mine_spark")
-				src.visible_message("<span class='alert'><b>The [src] starts sparking!</b></span>")
-			sleep(2 SECONDS)
+			sleep(1 SECOND)
 			if (src && I)
-				target = orange(1,src)[rand(1,8)]
+				target = get_step(src, rand(1,8))
 				I.set_loc(src.loc)
-				for (var/mob/living/mob in view(5,src))
+				for (var/mob/living/mob in view(7,src))
 					if (!isintangible(mob))
 						target = mob
 						break
+				playsound(src, "sound/impact_sounds/Metal_Clang_3.ogg", 90)
 				I.throw_at(target, 7, rand(6,9))
 				src.visible_message("<span class='alert'>The [I] is forcefully ejected from the [src]!</span>")
 				src.ClearSpecificParticles("mine_spark")
@@ -660,9 +666,7 @@
 			if (I)
 				fireflash(I,0,TRUE)
 				I.combust()
-
-
-
+				I.take_damage()
 
 	/// Sets an arbitrary slot to the passed aiModule - will override any module in the slot. Does not call UpdateLaws()
 	proc/SetLaw(var/obj/item/aiModule/mod,var/slot=1,var/screwed_in=false,var/welded_in=false)

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -666,7 +666,6 @@
 			if (I)
 				fireflash(I,0,TRUE)
 				I.combust()
-				I.take_damage()
 
 	/// Sets an arbitrary slot to the passed aiModule - will override any module in the slot. Does not call UpdateLaws()
 	proc/SetLaw(var/obj/item/aiModule/mod,var/slot=1,var/screwed_in=false,var/welded_in=false)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new interaction with the existing video card object and the AI rack
After a short delay, the rack launches several buttcoins at nearby people before finally launching the video card out, setting the card (and presumably the stack of buttcoins on the same tile) ablaze.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Need is a strong word, but i couldn't not make it when the idea came up.

## In game example
as of [6f9f31d](https://github.com/goonstation/goonstation/pull/8110/commits/6f9f31deae86d8bcbe554a1abfb3f546084cf0d3): https://www.youtube.com/watch?v=mKycjl2utlo

as of [6254e20](https://github.com/goonstation/goonstation/pull/8110/commits/6254e20d8d8343863fba85ed32cc4068ff5c669f): https://www.youtube.com/watch?v=X4trIRXASGo

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(+)You can now mine for buttcoin.
```