### PR TITLE
creates new proc for flushing and adds "flushing multiplier"

### DIFF
--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -303,7 +303,6 @@ datum
 				if ((reagent_id != id) && ((reagent_id in flush_specific_reagents) || (!flush_specific_reagents)))//checks if there's a specific reagent list to flush or if it should flush all reagents.
 					amount = amount * mult * M.reagents.reagent_list[reagent_id].flushing_multiplier
 					holder.remove_reagent(reagent_id, amount)
-			return
 
 		// reagent state helper procs
 

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -298,11 +298,11 @@ datum
 				return AD
 			return
 
-		proc/flush(var/mob/M, var/mult = 1, var/amount, var/list/flush_specific_reagents)
+		proc/flush(var/mob/M, var/amount, var/list/flush_specific_reagents)
 			for (var/reagent_id in M.reagents.reagent_list)
 				if ((reagent_id != src.id) && ((reagent_id in flush_specific_reagents) || !flush_specific_reagents))//checks if there's a specific reagent list to flush or if it should flush all reagents.
-					amount = amount * mult * M.reagents.reagent_list[reagent_id].flushing_multiplier
-					holder.remove_reagent(reagent_id, amount)
+					holder.remove_reagent(reagent_id, (amount * M.reagents.reagent_list[reagent_id].flushing_multiplier))
+			return
 
 		// reagent state helper procs
 

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -300,7 +300,7 @@ datum
 
 		proc/flush(var/mob/M, var/mult = 1, var/amount, var/list/flush_specific_reagents)
 			for (var/reagent_id in M.reagents.reagent_list)
-				if ((reagent_id != id) && ((reagent_id in flush_specific_reagents) || (!flush_specific_reagents)))//checks if there's a specific reagent list to flush or if it should flush all reagents.
+				if ((reagent_id != src.id) && ((reagent_id in flush_specific_reagents) || !flush_specific_reagents))//checks if there's a specific reagent list to flush or if it should flush all reagents.
 					amount = amount * mult * M.reagents.reagent_list[reagent_id].flushing_multiplier
 					holder.remove_reagent(reagent_id, amount)
 

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -29,6 +29,7 @@ datum
 		var/reacting = 0 // fuck off chemist spam
 		var/overdose = 0 // if reagents are at or above this in a mob, it's an overdose - if double this, it's a major overdose
 		var/depletion_rate = 0.4 // this much goes away per tick
+		var/flushing_multiplier = 1 // this decides how succeptible it is to other chemical's flushing
 		var/penetrates_skin = 0 //if this reagent can enter the bloodstream through simple touch.
 		var/touch_modifier = 1 //If this does penetrate skin, how much should be transferred by default (assuming naked dude)? 1 = transfer full amount, 0.5 = transfer half, etc.
 		var/taste = null
@@ -295,6 +296,13 @@ datum
 				M.ailments += AD
 				//DEBUG_MESSAGE("became addicted: [AD.name]")
 				return AD
+			return
+
+		proc/flush(var/mob/M, var/mult = 1, var/amount, var/list/flush_specific_reagents)
+			for (var/reagent_id in M.reagents.reagent_list)
+				if ((reagent_id != id) && ((reagent_id in flush_specific_reagents) || (!flush_specific_reagents)))//checks if there's a specific reagent list to flush or if it should flush all reagents.
+					amount = amount * mult * M.reagents.reagent_list[reagent_id].flushing_multiplier
+					holder.remove_reagent(reagent_id, amount)
 			return
 
 		// reagent state helper procs

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -68,7 +68,7 @@ datum
 						M.HealDamage("All", 1 * mult, 1 * mult)
 						if(probmult(15))
 							boutput(H, "<span class='notice'>The milk comforts your [pick("boanes","bones","bonez","boens","bowns","beaunes","brones","bonse")]!</span>")
-				flush(M, mult, 5, flushed_reagents)
+				flush(M,5 * mult, flushed_reagents)
 				..()
 				return
 
@@ -1190,7 +1190,7 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				flush(M, mult, 8)
+				flush(M, 8 * mult)
 				if(M.health > 10)
 					M.take_toxin_damage(2 * mult)
 				if(probmult(20))
@@ -2404,7 +2404,7 @@ datum
 					description = initial(description)
 
 			on_mob_life(var/mob/M, var/mult = 1)
-				flush(M, mult, 1, flushed_reagents)//Tea is good for you!
+				flush(M, 1 * mult, flushed_reagents)//Tea is good for you!
 				..()
 				return
 

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -51,6 +51,7 @@ datum
 			thirst_value = 0.6
 			bladder_value = -0.2
 			viscosity = 0.3
+			var/list/flushed_reagents = list("capsaicin")
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if (!M)
@@ -67,8 +68,7 @@ datum
 						M.HealDamage("All", 1 * mult, 1 * mult)
 						if(probmult(15))
 							boutput(H, "<span class='notice'>The milk comforts your [pick("boanes","bones","bonez","boens","bowns","beaunes","brones","bonse")]!</span>")
-				if (M.reagents.has_reagent("capsaicin"))
-					M.reagents.remove_reagent("capsaicin", 5 * mult)
+				flush(M, mult, 5, flushed_reagents)
 				..()
 				return
 
@@ -1190,9 +1190,7 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				for(var/reagent_id in M.reagents.reagent_list)
-					if(reagent_id != id)
-						M.reagents.remove_reagent(reagent_id, 8 * mult)
+				flush(M, mult, 8)
 				if(M.health > 10)
 					M.take_toxin_damage(2 * mult)
 				if(probmult(20))
@@ -2392,6 +2390,7 @@ datum
 			addiction_prob2 = 1
 			addiction_min = 10
 			minimum_reaction_temperature = -INFINITY
+			var/list/flushed_reagents = list("toxin","toxic_slurry")
 
 			reaction_temperature(exposed_temperature, exposed_volume)
 				if (exposed_temperature <= T0C + 7)
@@ -2405,10 +2404,7 @@ datum
 					description = initial(description)
 
 			on_mob_life(var/mob/M, var/mult = 1)
-				if (holder.has_reagent("toxin")) //Tea is good for you!!
-					holder.remove_reagent("toxin", 1 * mult)
-				if (holder.has_reagent("toxic_slurry"))
-					holder.remove_reagent("toxic_slurry", 1 * mult)
+				flush(M, mult, 1, flushed_reagents)//Tea is good for you!
 				..()
 				return
 

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -1489,7 +1489,7 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				flush(M, mult, 3, flushed_reagents)
+				flush(M, mult, 8, flushed_reagents)
 				if (M.get_toxin_damage() <= 25)
 					M.take_toxin_damage(-2 * mult)
 				..()

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -313,7 +313,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 
-				flush(M, mult, 5)
+				flush(M, 5 * mult)
 				if(M.health > 20)
 					M.take_toxin_damage(5 * mult, 1)	//calomel doesn't damage organs.
 				if(probmult(6))
@@ -638,7 +638,7 @@ datum
 			on_mob_life(var/mob/M, var/method=INGEST, var/mult = 1)
 				if(!M)
 					M = holder.my_atom
-				flush(M, mult, 3, flushed_reagents)
+				flush(M, 3 * mult, flushed_reagents)
 
 				if(method == INGEST)
 					if (M.health < -5 && M.health > -30)
@@ -728,7 +728,7 @@ datum
 				if (M.druggy > 0)
 					M.druggy -= 3
 					M.druggy = max(0, M.druggy)
-				flush(M, mult, 5, flushed_reagents)
+				flush(M, 5 * mult, flushed_reagents)
 				if(M.hasStatus("stimulants"))
 					M.changeStatus("stimulants", -15 SECONDS * mult)
 				if(probmult(5))
@@ -779,7 +779,7 @@ datum
 				M.changeStatus("drowsy", -10 SECONDS)
 				if(M.sleeping && probmult(5)) M.sleeping = 0
 				if(M.get_brain_damage() && prob(5)) M.take_brain_damage(-1 * mult)
-				flush(M, mult, 2, flushed_reagents) //combats symptoms not source //ok combats source a bit more
+				flush(M, 2 * mult, flushed_reagents) //combats symptoms not source //ok combats source a bit more
 				if(M.losebreath > 3)
 					M.losebreath -= (1 * mult)
 				if(M.get_oxygen_deprivation() > 35)
@@ -941,7 +941,7 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				flush(M, mult, 5, flushed_reagents)
+				flush(M, 5 * mult, flushed_reagents)
 				//if(holder.has_reagent("cholesterol")) //probably doesnt actually happen but whatever
 					//holder.remove_reagent("cholesterol", 2)
 				..()
@@ -1115,7 +1115,7 @@ datum
 			target_organs = list("left_kidney", "right_kidney", "liver", "stomach", "intestines")
 
 			on_mob_life(var/mob/M, var/mult = 1)
-				flush(M, mult, 5) //flushes all chemicals but itself
+				flush(M, 5 * mult) //flushes all chemicals but itself
 				M.changeStatus("radiation", -7 SECONDS, 1)
 				if (prob(75))
 					M.HealDamage("All", 0, 0, 4 * mult)
@@ -1158,7 +1158,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 				M.jitteriness = max(M.jitteriness-20,0)
-				flush(M, mult, 3, flushed_reagents)
+				flush(M, 3 * mult, flushed_reagents)
 				if(probmult(7)) M.emote("yawn")
 				if(prob(3))
 					M.setStatusMin("stunned", 3 SECONDS * mult)
@@ -1339,7 +1339,7 @@ datum
 						M.take_brain_damage(-2 * mult)
 				else if (M.health > 15 && M.get_toxin_damage() < 70)
 					M.take_toxin_damage(1 * mult)
-					flush(M, mult, 20, flushed_reagents)
+					flush(M, 20 * mult, flushed_reagents)
 				..()
 				return
 
@@ -1446,7 +1446,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 				if(prob(50))
-					flush(M, mult, 1)
+					flush(M, 1 * mult)
 				M.HealDamage("All", 0, 0, 1.5 * mult)
 
 				if (ishuman(M))
@@ -1489,7 +1489,7 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				flush(M, mult, 8, flushed_reagents)
+				flush(M, 8 * mult, flushed_reagents)
 				if (M.get_toxin_damage() <= 25)
 					M.take_toxin_damage(-2 * mult)
 				..()

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -313,9 +313,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 
-				for(var/reagent_id in M.reagents.reagent_list)
-					if(reagent_id != id)
-						M.reagents.remove_reagent(reagent_id, 5 * mult)
+				flush(M, mult, 5)
 				if(M.health > 20)
 					M.take_toxin_damage(5 * mult, 1)	//calomel doesn't damage organs.
 				if(probmult(6))
@@ -623,6 +621,7 @@ datum
 			transparency = 40
 			value = 3
 			threshold = THRESHOLD_INIT
+			var/list/flushed_reagents = list("neurotoxin","capulettium","sulfonal","ketamine","sodium_thiopental","pancuronium")
 
 			cross_threshold_over()
 				if(ismob(holder?.my_atom))
@@ -639,19 +638,7 @@ datum
 			on_mob_life(var/mob/M, var/method=INGEST, var/mult = 1)
 				if(!M)
 					M = holder.my_atom
-				if(holder.has_reagent("neurotoxin"))
-					holder.remove_reagent("neurotoxin", 3 * mult)
-				if(holder.has_reagent("capulettium"))
-					holder.remove_reagent("capulettium", 3 * mult)
-				if(holder.has_reagent("sulfonal"))
-					holder.remove_reagent("sulfonal", 3 * mult)
-				if(holder.has_reagent("ketamine"))
-					holder.remove_reagent("ketamine", 3 * mult)
-				if(holder.has_reagent("sodium_thiopental"))
-					holder.remove_reagent("sodium_thiopental", 3 * mult)
-				if(holder.has_reagent("pancuronium"))
-					holder.remove_reagent("pancuronium", 3 * mult)
-
+				flush(M, mult, 3, flushed_reagents)
 
 				if(method == INGEST)
 					if (M.health < -5 && M.health > -30)
@@ -721,6 +708,7 @@ datum
 			transparency = 255
 			value = 8 // 2c + 3c + 1c + 1c + 1c
 			threshold = THRESHOLD_INIT
+			var/list/flushed_reagents = list("LSD","lsd_bee","psilocybin","crank","bathsalts","THC","space_drugs","catdrugs","methamphetamine","epinephrine","synaptizine")
 
 			cross_threshold_over()
 				if(ismob(holder?.my_atom))
@@ -740,30 +728,7 @@ datum
 				if (M.druggy > 0)
 					M.druggy -= 3
 					M.druggy = max(0, M.druggy)
-				if(holder.has_reagent("LSD"))
-					holder.remove_reagent("LSD", 5 * mult)
-				if(holder.has_reagent("lsd_bee"))
-					holder.remove_reagent("lsd_bee", 5 * mult)
-				if(holder.has_reagent("psilocybin"))
-					holder.remove_reagent("psilocybin", 5 * mult)
-				if(holder.has_reagent("crank"))
-					holder.remove_reagent("crank", 5 * mult)
-				if(holder.has_reagent("bathsalts"))
-					holder.remove_reagent("bathsalts", 5 * mult)
-				if(holder.has_reagent("THC"))
-					holder.remove_reagent("THC", 5 * mult)
-				if(holder.has_reagent("space_drugs"))
-					holder.remove_reagent("space_drugs", 5 * mult)
-				if(holder.has_reagent("catdrugs"))
-					holder.remove_reagent("catdrugs", 5 * mult)
-				if(holder.has_reagent("methamphetamine"))
-					holder.remove_reagent("methamphetamine", 5 * mult)
-				if(holder.has_reagent("epinephrine"))
-					holder.remove_reagent("epinephrine", 5 * mult)
-				if(holder.has_reagent("ephedrine"))
-					holder.remove_reagent("ephedrine", 5 * mult)
-				if(holder.has_reagent("synaptizine"))
-					holder.remove_reagent("synaptizine", 5 * mult)
+				flush(M, mult, 5, flushed_reagents)
 				if(M.hasStatus("stimulants"))
 					M.changeStatus("stimulants", -15 SECONDS * mult)
 				if(probmult(5))
@@ -789,6 +754,7 @@ datum
 			value = 17 // 5c + 5c + 4c + 1c + 1c + 1c
 			stun_resist = 10
 			threshold = THRESHOLD_INIT
+			var/list/flushed_reagents = list("histamine")
 
 			cross_threshold_over()
 				if(ismob(holder?.my_atom))
@@ -813,8 +779,7 @@ datum
 				M.changeStatus("drowsy", -10 SECONDS)
 				if(M.sleeping && probmult(5)) M.sleeping = 0
 				if(M.get_brain_damage() && prob(5)) M.take_brain_damage(-1 * mult)
-				if(holder.has_reagent("histamine"))
-					holder.remove_reagent("histamine", 2 * mult) //combats symptoms not source //ok combats source a bit more
+				flush(M, mult, 2, flushed_reagents) //combats symptoms not source //ok combats source a bit more
 				if(M.losebreath > 3)
 					M.losebreath -= (1 * mult)
 				if(M.get_oxygen_deprivation() > 35)
@@ -972,11 +937,11 @@ datum
 			fluid_b = 240
 			transparency = 50
 			value = 6
+			var/list/flushed_reagents = list("sugar")
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				if(holder.has_reagent("sugar"))
-					holder.remove_reagent("sugar", 5 * mult)
+				flush(M, mult, 5, flushed_reagents)
 				//if(holder.has_reagent("cholesterol")) //probably doesnt actually happen but whatever
 					//holder.remove_reagent("cholesterol", 2)
 				..()
@@ -1150,10 +1115,7 @@ datum
 			target_organs = list("left_kidney", "right_kidney", "liver", "stomach", "intestines")
 
 			on_mob_life(var/mob/M, var/mult = 1)
-				if (!M) M = holder.my_atom
-				for (var/reagent_id in M.reagents.reagent_list)
-					if (reagent_id != id)
-						M.reagents.remove_reagent(reagent_id, 4 * mult)
+				flush(M, mult, 5) //flushes all chemicals but itself
 				M.changeStatus("radiation", -7 SECONDS, 1)
 				if (prob(75))
 					M.HealDamage("All", 0, 0, 4 * mult)
@@ -1179,6 +1141,7 @@ datum
 			addiction_min = 10
 			value = 10 // 4 3 1 1 1
 			threshold = THRESHOLD_INIT
+			var/list/flushed_reagents = list("histamine","itching")
 
 			cross_threshold_over()
 				if(ismob(holder?.my_atom))
@@ -1195,10 +1158,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
 				M.jitteriness = max(M.jitteriness-20,0)
-				if(holder.has_reagent("histamine"))
-					holder.remove_reagent("histamine", 3 * mult)
-				if(holder.has_reagent("itching"))
-					holder.remove_reagent("itching", 3 * mult)
+				flush(M, mult, 3, flushed_reagents)
 				if(probmult(7)) M.emote("yawn")
 				if(prob(3))
 					M.setStatusMin("stunned", 3 SECONDS * mult)
@@ -1334,6 +1294,7 @@ datum
 			var/total_misstep = 0
 			value = 18 // 5 4 5 3 1
 			threshold = THRESHOLD_INIT
+			var/list/flushed_reagents = list("sarin")
 
 			cross_threshold_over()
 				if(ismob(holder?.my_atom))
@@ -1378,8 +1339,7 @@ datum
 						M.take_brain_damage(-2 * mult)
 				else if (M.health > 15 && M.get_toxin_damage() < 70)
 					M.take_toxin_damage(1 * mult)
-				if(M.reagents.has_reagent("sarin"))
-					M.reagents.remove_reagent("sarin",20 * mult)
+					flush(M, mult, 20, flushed_reagents)
 				..()
 				return
 
@@ -1485,9 +1445,8 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				for(var/reagent_id in M.reagents.reagent_list)
-					if(reagent_id != id && prob(50)) // slow this down a bit
-						M.reagents.remove_reagent(reagent_id, 1 * mult)
+				if(prob(50))
+					flush(M, mult, 1)
 				M.HealDamage("All", 0, 0, 1.5 * mult)
 
 				if (ishuman(M))
@@ -1526,10 +1485,11 @@ datum
 			fluid_g = 200
 			transparency = 220
 			value = 6 // 5c + 1c
+			var/list/flushed_reagents = list("ethanol")
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M) M = holder.my_atom
-				if(holder.has_reagent("ethanol")) holder.remove_reagent("ethanol", 8 * mult)
+				flush(M, mult, 3, flushed_reagents)
 				if (M.get_toxin_damage() <= 25)
 					M.take_toxin_damage(-2 * mult)
 				..()

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2974,7 +2974,7 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1) // cogwerks note. making atrazine toxic
 				if (!M) M = holder.my_atom
 				M.take_toxin_damage(2 * mult)
-				flush(M, mult, 2, flushed_reagents)
+				flush(M, 2 * mult, flushed_reagents)
 				..()
 				return
 

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2969,14 +2969,12 @@ datum
 			transparency = 170
 			hygiene_value = 0.3
 			thirst_value = -0.098
+			var/list/flushed_reagents = list("THC","CBD")
 
 			on_mob_life(var/mob/M, var/mult = 1) // cogwerks note. making atrazine toxic
 				if (!M) M = holder.my_atom
 				M.take_toxin_damage(2 * mult)
-				if(holder.has_reagent("THC"))
-					holder.remove_reagent("THC", 1)
-				if(holder.has_reagent("CBD"))
-					holder.remove_reagent("CBD", 1)
+				flush(M, mult, 2, flushed_reagents)
 				..()
 				return
 

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -340,25 +340,18 @@ datum
 			depletion_rate = 0.025
 			penetrates_skin = 0
 			target_organs = list("left_kidney","right_kidney","liver","stomach","intestines","spleen","pancreas")
+			flushing_multiplier = 0.15
 			var/counter = 1
-			var/flushing = 0.1 //standard efficacy against flushing
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if (!M) M = holder.my_atom
 				if (!counter) counter = 1
-
-				if(holder.has_reagent("charcoal")) //to make it a tad harder to treat
-					holder.remove_reagent("charcoal", flushing * mult)
-				if(holder.has_reagent("penteticacid"))
-					holder.remove_reagent("penteticacid", flushing * mult)
 
 				switch(counter += (1 * mult))
 					if (75 to 125)
 						if (probmult(4))
 							M.emote(pick("sneeze","cough","moan","groan"))
 					if (125 to 175)
-						flushing = 1.5 //it gets a tad harder to cure here
-
 						if (probmult(8))
 							M.emote(pick("sneeze","cough","moan","groan"))
 						else if (probmult(5))
@@ -370,8 +363,6 @@ datum
 							if (H.organHolder)
 								H.organHolder.damage_organs(1*mult, 0, 1*mult, target_organs, 20)
 					if (175 to INFINITY)
-						flushing = 3 // time to ramp up that flusher flushing
-
 						if (probmult(10))
 							M.emote(pick("sneeze","drool","cough","moan","groan"))
 						if (probmult(20))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[LABEL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR creates a new flush proc to make chemical flushing behaviour easier to implement and change, and a variable that dictates how susceptible any chem is to being flushed by others. At the moment there is only one use for the flushing component and it's Ricin, that used to flush flushers, the rest is supposed to be changed as balancing choices are made.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Making the code easier to understand and in general "more elegant".

