### PR TITLE
Adds hemolymph to the game

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1663,8 +1663,12 @@ TYPEINFO(/datum/mutantrace)
 	New(mob/living/carbon/human/M)
 		. = ..()
 		if(ishuman(M))
+			M.blood_id = "hemolymph"
+			H.blood_color = "009E81"
 			M.mob_flags |= SHOULD_HAVE_A_TAIL
 		APPLY_ATOM_PROPERTY(M, PROP_MOB_RADPROT, src, 100)
+
+
 
 	say_verb()
 		return "clicks"

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1664,7 +1664,7 @@ TYPEINFO(/datum/mutantrace)
 		. = ..()
 		if(ishuman(M))
 			M.blood_id = "hemolymph"
-			H.blood_color = "009E81"
+			//H.blood_color = "009E81"
 			M.mob_flags |= SHOULD_HAVE_A_TAIL
 		APPLY_ATOM_PROPERTY(M, PROP_MOB_RADPROT, src, 100)
 

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -1412,6 +1412,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 /mob/living/critter/small_animal/cockroach
 	name = "cockroach"
 	real_name = "cockroach"
+	blood_id = "hemolymph"
 	desc = "An unpleasant insect that lives in filthy places."
 	icon_state = "roach"
 	icon_state_dead = "roach-dead"
@@ -1479,6 +1480,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 /mob/living/critter/small_animal/scorpion
 	name = "scorpion"
 	real_name = "scorpion"
+	blood_id = "hemolymph"
 	desc = "Ack! Get it away! AAAAAAAA."
 	icon_state = "spacescorpion"
 	icon_state_dead = "spacescorpion-dead"
@@ -1527,6 +1529,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 /mob/living/critter/small_animal/cockroach/robo
 	name = "roboroach"
 	real_name = "roboroach"
+	blood_id = "oil"
 	desc = "The vermin of the future!"
 	health_brute = 10
 	health_burn = 10
@@ -2224,6 +2227,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 /mob/living/critter/small_animal/butterfly
 	name = "butterfly"
 	real_name = "butterfly"
+	blood_id = "hemolymph"
 	desc = "It's a beautiful butterfly! How did it get here?"
 	hand_count = 2
 	icon_state = "butterfly1"
@@ -3019,6 +3023,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 /mob/living/critter/small_animal/trilobite
 	name = "trilobite"
 	real_name = "trilobite"
+	blood_id = "hemolymph"
 	desc = "This is an alien trilobite."
 	icon_state = "trilobite"
 	icon_state_dead = "trilobite-dead"

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1927,13 +1927,14 @@ datum
 			name = "Copper"
 			id = "copper"
 			result = "copper"
+			mix_sound = 'sound/misc/drinkfizz.ogg'
 			required_reagents = list("hemolymph" = 3, "cleaner" = 1,  "acetone" = 2)// 6 u total to make
 			required_temperature = T0C + 30 // just a little bit of heat
 			result_amount = 1
-			mix_phrase = "The hemolymph denatures into some basal components."
+			mix_phrase = "The hemolymph bubbles as a black precipitate falls out of the solution, denaturing into basic components."
 			on_reaction(var/datum/reagents/holder, created_volume)
-				holder.add_reagent("meat_slurry", 2*created_volume)// 2 meat slurry, since animal tissue
-				holder.add_reagent("saline", created_volume)// 1 saline-glucose solution, since blood
+				holder.add_reagent("meat_slurry", created_volume)// 2 meat slurry, since animal tissue
+				holder.add_reagent("saline", 2*created_volume)// 1 saline-glucose solution, since blood
 				holder.add_reagent("spaceacillin", created_volume)// 1 spaceacillin, since hemolymph is used for bacterial tests IRL
 				holder.add_reagent("denatured_enzyme", created_volume)// and just some random biological chemicals for good measure
 

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1923,6 +1923,20 @@ datum
 			result_amount = 3
 			mix_phrase = "An iridescent black chemical forms in the container."
 
+		hemodissolve // denaturing hemolymph
+			name = "Copper"
+			id = "copper"
+			result = "copper"
+			required_reagents = list("hemolymph" = 3, "cleaner" = 1,  "acetone" = 2)// 6 u total to make
+			required_temperature = T0C + 30 // just a little bit of heat
+			result_amount = 1
+			mix_phrase = "The hemolymph denatures into some basal components."
+			on_reaction(var/datum/reagents/holder, created_volume)
+				holder.add_reagent("meat_slurry", 2*created_volume)// 2 meat slurry, since animal tissue
+				holder.add_reagent("saline", created_volume)// 1 saline-glucose solution, since blood
+				holder.add_reagent("spaceacillin", created_volume)// 1 spaceacillin, since hemolymph is used for bacterial tests IRL
+				holder.add_reagent("enzymatic_leftovers", created_volume)// and just some random biological chemicals for good measure
+
 		mutagen
 			name = "Unstable mutagen"
 			id = "mutagen"

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1928,14 +1928,14 @@ datum
 			id = "copper"
 			result = "copper"
 			mix_sound = 'sound/misc/drinkfizz.ogg'
-			required_reagents = list("hemolymph" = 3, "cleaner" = 1,  "acetone" = 2)// 6 u total to make
+			required_reagents = list("hemolymph" = 5, "cleaner" = 1,  "acetone" = 1)
 			required_temperature = T0C + 30 // just a little bit of heat
 			result_amount = 1
 			mix_phrase = "The hemolymph bubbles as a black precipitate falls out of the solution, denaturing into basic components."
 			on_reaction(var/datum/reagents/holder, created_volume)
-				holder.add_reagent("meat_slurry", created_volume)// 2 meat slurry, since animal tissue
-				holder.add_reagent("saline", 2*created_volume)// 1 saline-glucose solution, since blood
-				holder.add_reagent("spaceacillin", created_volume)// 1 spaceacillin, since hemolymph is used for bacterial tests IRL
+				holder.add_reagent("meat_slurry", created_volume)// meat slurry, since animal tissue
+				holder.add_reagent("saline", 2*created_volume)//  saline-glucose solution, since blood
+				holder.add_reagent("spaceacillin", created_volume)//  spaceacillin, since hemolymph is used for bacterial tests IRL
 				holder.add_reagent("denatured_enzyme", created_volume)// and just some random biological chemicals for good measure
 
 		mutagen

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -1935,7 +1935,7 @@ datum
 				holder.add_reagent("meat_slurry", 2*created_volume)// 2 meat slurry, since animal tissue
 				holder.add_reagent("saline", created_volume)// 1 saline-glucose solution, since blood
 				holder.add_reagent("spaceacillin", created_volume)// 1 spaceacillin, since hemolymph is used for bacterial tests IRL
-				holder.add_reagent("enzymatic_leftovers", created_volume)// and just some random biological chemicals for good measure
+				holder.add_reagent("denatured_enzyme", created_volume)// and just some random biological chemicals for good measure
 
 		mutagen
 			name = "Unstable mutagen"

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3191,6 +3191,16 @@ datum
 				holder.del_reagent(id)
 				holder.del_reagent("blood")
 
+		blood/hemolymph
+			name = "hemolymph"
+			id = "hemolymph"
+			taste "metallic yet slightly bitter"
+			description = "Hemolymph is a blood-like bodily fluid found in many invertibrates that derives its blue-green color from the presence of copper proteins."
+			reagent_state = LIQUID
+			fluid_r = 0
+			fluid_b = 158
+			fluid_g = 128
+
 
 		vomit
 			name = "vomit"

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3194,7 +3194,7 @@ datum
 		blood/hemolymph
 			name = "hemolymph"
 			id = "hemolymph"
-			taste "metallic yet slightly bitter"
+			//taste = "metallic yet slightly bitter"
 			description = "Hemolymph is a blood-like bodily fluid found in many invertibrates that derives its blue-green color from the presence of copper proteins."
 			reagent_state = LIQUID
 			fluid_r = 0

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3197,9 +3197,9 @@ datum
 			//taste = "metallic yet slightly bitter"
 			description = "Hemolymph is a blood-like bodily fluid found in many invertibrates that derives its blue-green color from the presence of copper proteins."
 			reagent_state = LIQUID
-			fluid_r = 0
-			fluid_b = 158
-			fluid_g = 128
+			fluid_r = 6
+			fluid_b = 161
+			fluid_g = 125
 
 
 		vomit


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[wiki]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adds hemolymph to the game as a blood replacement for roachpeople, cockroaches, butterflies, and scorpions:
![image](https://user-images.githubusercontent.com/96703882/161865188-4807a2ea-da3d-420b-b038-291b1288afc4.png)
This also adds a recipie where, with heat, acetone, and spacecleaner, it can be denatured into copper, meat slurry, saline glucose, spaceacillin, and some leftover enzymes.
![image](https://user-images.githubusercontent.com/96703882/161865326-dbb81bd5-6057-47b4-a8e1-b5108017516b.png)
This is a nod to the fact that IRL hemolymph, most notably that of horseshoe crabs, is used for medical applications in detecting bacteria. It also adds an alternate way to get meat slurry without the use of botany/kitchen, though if this is controversial I can change it


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs don't have the same blood as us, and differing blood colors are pretty cool! I also think more ways to get meat slurry and more uses for the various fluids spacemen seep all over the station is a good thing to add.


## Changelog

```changelog
(u)NightmareChamillian
(*)Roach people (and some bug critters for that matter) now bleed hemolymph instead of normal blood
(+)Hemolymph can be broken down with space cleaner, acetone, and some heat. 
```
