### PR TITLE
Fix shuttle window connections

### DIFF
--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -727,7 +727,7 @@
 		/turf/simulated/wall/auto/jen, /turf/simulated/wall/auto/reinforced/jen,
 		/turf/unsimulated/wall/auto/supernorn/wood, /turf/unsimulated/wall/auto/adventure/shuttle/dark, /turf/simulated/wall/auto/reinforced/old, /turf/unsimulated/wall/auto/lead/blue, /turf/unsimulated/wall/auto/adventure/old, /turf/unsimulated/wall/auto/adventure/mars/interior, /turf/unsimulated/wall/auto/adventure/shuttle, /turf/unsimulated/wall/auto/reinforced/supernorn)
 
-	var/list/connects_to_exceptions = list(/obj/window/cubicle, /obj/window/reinforced)
+	var/list/connects_to_exceptions = list(/obj/window/cubicle, /obj/window/reinforced, /turf/unsimulated/wall/auto/lead/blue)
 	var/list/connects_with_overlay_exceptions = list(/obj/window, /obj/machinery/door/poddoor )
 	alpha = 160
 	the_tuff_stuff

--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -633,6 +633,7 @@ ABSTRACT_TYPE(turf/unsimulated/wall/auto/lead)
 /turf/unsimulated/wall/auto/lead/blue
 	icon_state = "mapiconb"
 	mod = "leadb-"
+	connects_to_exceptions = list(/obj/window/auto) // fixes shuttle wall alignment
 
 /turf/unsimulated/wall/auto/lead/gray
 	icon_state = "mapicong"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds exceptions for both window/auto and auto/lead/blue walls so they don't auto-connect with each other.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8114

## In game example

https://user-images.githubusercontent.com/91498627/163601166-cc3c16cd-91f3-4913-b367-cd7c1eab2eca.mp4


