### PR TITLE
PDA Port-A-* Apps now use teleporting animations

### DIFF
--- a/code/obj/item/device/pda2/portable_machinery_control.dm
+++ b/code/obj/item/device/pda2/portable_machinery_control.dm
@@ -235,6 +235,7 @@
 							var/obj/storage/closet/port_a_sci/PS = P4
 							PS.on_teleport()
 
+						flick("[P4.icon_state]-tele", P4)
 						elecflash(P4)
 
 			if ("return")
@@ -281,7 +282,7 @@
 						if (istype(P5, /obj/storage/closet/port_a_sci/))
 							var/obj/storage/closet/port_a_sci/PS2 = P5
 							PS2.on_teleport()
-
+						flick("[P5.icon_state]-tele", P5)
 						elecflash(P5)
 
 		PDA.updateSelfDialog()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the teleport effects already in use for port-a-* remotes to the equivalent PDA apps.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency between porters and PDA apps; use cool animations.