### PR TITLE
Fix busted mechanics connections

### DIFF
--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -257,18 +257,31 @@ TYPEINFO(/datum/component/mechanics_holder)
 		if("Trigger")
 			SEND_SIGNAL(A, _COMSIG_MECHCOMP_LINK, parent, user)
 		if("Receiver")
-			link_devices(null, A, user) //What do you want, an invitation? No signal needed!
+			link_devices(comsig_target, A, user) //What do you want, an invitation? No signal needed!
 		if("*CANCEL*")
 			return
 	return
 
 //We are in the scope of the receiver-component, our argument is the trigger
 //This feels weird/backwards, but it results in fewer SEND_SIGNALS & var/lists
-/datum/component/mechanics_holder/proc/link_devices(var/comsig_target, atom/trigger, mob/user)
+/datum/component/mechanics_holder/proc/link_devices(atom/comsig_target, atom/trigger, mob/user)
 	var/atom/receiver = parent
+	if(trigger == comsig_target)
+		boutput(user, "<span class='alert'>Can not connect a component to itself.</span>")
+		return
 	if(trigger in src.connected_outgoing)
 		boutput(user, "<span class='alert'>Can not create a direct loop between 2 components.</span>")
 		return
+	if(trigger.loc != comsig_target.loc)
+		var/obj/item/storage/mechanics/cabinet = null
+		if(istype(comsig_target.loc, /obj/item/storage/mechanics))
+			cabinet = comsig_target.loc
+		if(istype(trigger.loc, /obj/item/storage/mechanics))
+			cabinet = trigger.loc
+		if(cabinet)
+			if(!cabinet.anchored)
+				boutput(user,"<span class='alert'>Cannot create connection through an unsecured component housing</span>")
+				return
 	if(!IN_RANGE(receiver, trigger, WIDE_TILE_WIDTH))
 		boutput(user, "<span class='alert'>These two components are too far apart to connect.</span>")
 		return
@@ -309,7 +322,7 @@ TYPEINFO(/datum/component/mechanics_holder)
 	// check if the multitool has a connector component - if so, we are connecting components, not configuring!
 	var/datum/component/mechanics_connector/connector = W.GetComponent(/datum/component/mechanics_connector)
 	if(connector)
-		src.link_devices(null, connector.connectee, user)
+		src.link_devices(comsig_target, connector.connectee, user)
 		return TRUE
 	if(istype(comsig_target, /obj/machinery/door))
 		var/obj/machinery/door/hacked_door = comsig_target


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fix being able to connect components to themselves for instant spam and being able to connect
through unsecured housings using connect mode on the multi tool

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

https://user-images.githubusercontent.com/65367576/162251277-b67b4f2b-78e3-49cf-81d0-d1fbb8aa08d9.mp4

Generally, makes mechanics really busted.
