### PR TITLE
Giving swirlies will extinguish people on fire!

### DIFF
--- a/code/obj/item/toilets.dm
+++ b/code/obj/item/toilets.dm
@@ -33,10 +33,14 @@ TOILET
 	if (istype(W, /obj/item/storage))
 		return
 	if (istype(W, /obj/item/grab))
-		playsound(src, "sound/effects/toilet_flush.ogg", 50, 1)
-		user.visible_message("<span class='notice'>[user] gives [W:affecting] a swirlie!</span>", "<span class='notice'>You give [W:affecting] a swirlie. It's like Middle School all over again!</span>")
+		var/obj/item/grab/G = W
+		playsound(src, 'sound/effects/toilet_flush.ogg', 50, 1)
+		user.visible_message("<span class='notice'>[user] gives [G] a swirlie!</span>", "<span class='notice'>You give [G] a swirlie. It's like Middle School all over again!</span>")
+		if (G.affecting.hasStatus("burning"))
+			G.affecting.changeStatus("burning", -2 SECONDS)
+			playsound(src, 'sound/impact_sounds/burn_sizzle.ogg', 70, 1)
+			return
 		return
-
 	return ..()
 
 /obj/item/storage/toilet/mouse_drop(atom/over_object, src_location, over_location)

--- a/code/obj/item/toilets.dm
+++ b/code/obj/item/toilets.dm
@@ -35,7 +35,7 @@ TOILET
 	if (istype(W, /obj/item/grab))
 		var/obj/item/grab/G = W
 		playsound(src, 'sound/effects/toilet_flush.ogg', 50, 1)
-		user.visible_message("<span class='notice'>[user] gives [G] a swirlie!</span>", "<span class='notice'>You give [G] a swirlie. It's like Middle School all over again!</span>")
+		user.visible_message("<span class='notice'>[user] gives [G.affecting] a swirlie!</span>", "<span class='notice'>You give [G.affecting] a swirlie. It's like Middle School all over again!</span>")
 		if (G.affecting.hasStatus("burning"))
 			G.affecting.changeStatus("burning", -2 SECONDS)
 			playsound(src, 'sound/impact_sounds/burn_sizzle.ogg', 70, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When giving someone a swirlie, it will extinguish part of their flames, at the cost of their dignity!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When being given a swirlie by the HoS for firebombing medbay, my flames should be extinguished, no? I think it would be pretty funny.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

(u)Jakson27
(+)Giving swirlies to people will now extinguish their flames

