### PR TITLE
make fabricator speed buttons function as buttons

### DIFF
--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -604,12 +604,13 @@
 							break
 
 			if (href_list["speed"])
+				var/upperbound = src.hacked ? 5 : 3
+				var/given_speed = text2num(href_list["speed"])
 				if (src.mode == "working")
 					boutput(usr, "<span class='alert'>You cannot alter the speed setting while the unit is working.</span>")
+				else if (given_speed >= 1 && given_speed <= upperbound)
+					src.speed = given_speed
 				else
-					var/upperbound = 3
-					if (src.hacked)
-						upperbound = 5
 					var/newset = input(usr,"Enter from 1 to [upperbound]. Higher settings consume more power","Manufacturing Speed") as num
 					newset = clamp(newset, 1, upperbound)
 					src.speed = newset


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes the speed buttons on the fabricator work as buttons, they change the speed to their speed when you push them.
Previously they would all open a window prompting you to input the desired speed.

If the fabricator gets a higher speed than 5 (or higher than 3 when not hacked) the current code adds an extra button to show this while the speed is higher. Pressing this button will open the old input box thing (the same would happen if you were to try to do the href exploit thing with a speed that is too high or too low).

Side-note, I noticed that with the old system you can input decimal values between the different available speeds? This would still be possible here via href and stuff. As far as I can tell it does not cause any issues, the values are still clamped properly and the math seems to work out fine, so I did not fix it in this PR.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's nicer to use, less buttons to push. And why have 3-5 buttons if they all do the same thing anyway?
Requested by: https://forum.ss13.co/showthread.php?tid=18441