### PR TITLE
locker and window density fix

### DIFF
--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -442,10 +442,10 @@
 	alter_health()
 		. = get_turf(src)
 
-	Cross(atom/movable/mover)
-		. = open
-		if (src.is_short)
-			return 0
+	//Cross(atom/movable/mover)
+	//	. = open
+	//	if (src.is_short)
+	//		return 0
 
 	ex_act(severity)
 		switch (severity)
@@ -508,6 +508,8 @@
 			src.dump_contents(user)
 		else
 			src.dump_contents()
+		if (!is_short)
+			src.set_density(0)
 		src.open = 1
 		src.UpdateIcon()
 		p_class = initial(p_class)
@@ -528,7 +530,8 @@
 		if(entangled && !entangleLogic && !entangled.can_open())
 			visible_message("<span class='alert'>It won't budge!</span>")
 			return 0
-
+		if (!is_short)
+			src.set_density(1)
 		src.open = 0
 
 		for (var/obj/O in get_turf(src))

--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -442,11 +442,6 @@
 	alter_health()
 		. = get_turf(src)
 
-	//Cross(atom/movable/mover)
-	//	. = open
-	//	if (src.is_short)
-	//		return 0
-
 	ex_act(severity)
 		switch (severity)
 			if (1)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -303,6 +303,7 @@
 		return the_text
 
 	Cross(atom/movable/mover)
+		if(!src.density) return 1
 		if(istype(mover, /obj/projectile))
 			var/obj/projectile/P = mover
 			if(P.proj_data.window_pass)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes lockers and windows ignoring density


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad, makes windows and lockers made out of ectoplasm alloys/hautnium work (the lockers will still be half broken until #8132 gets merged too)
