### PR TITLE
Stop blowout 'halo' on maps with shield generators

### DIFF
--- a/code/obj/machinery/shield_generators/shield_generator.dm
+++ b/code/obj/machinery/shield_generators/shield_generator.dm
@@ -4,6 +4,7 @@
 /area/station/shield_zone
 	icon_state = "shield_zone"
 	expandable = 0
+	do_not_irradiate = 1
 
 /* ==================== Generator ==================== */
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets the station shield zone area to not be irradiated


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
there's a strip of irradiated tiles where the shield would be on maps that have a station/ship-wide shield generator (e.g. clarion)
