### PR TITLE
Adjusts pop divisor for revolution game mode

### DIFF
--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -19,7 +19,7 @@
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 	var/const/min_revheads = 3
 	var/const/max_revheads = 5
-	var/const/pop_divisor = 20
+	var/const/pop_divisor = 15
 	var/win_check_freq = 30 SECONDS //frequency of checks on the win conditions
 	var/round_limit = 40 MINUTES //see post_setup
 	var/endthisshit = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This adjusts the pop divisor that dictates the amount of revheads for a round. It is changed from 20 to 15. This means that now it takes 52 people readied up for 4 revheads, and 67 people readied up for 5.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Only around 70% of people ready up, and then a lot of people join after ready up. I dont think theres ever been more then 3 revheads in a round because its way too high. This should make seeing more then 3 revheads actually a thing you see.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u]Ikea
(*)Revhead scaling has been adjusted to where you should actually see more then 3 revheads on higherpops. Please yell or something if there's you believe theres an imbalance of revheads.
```
