### PR TITLE
Removes the random command_name'ing, adds in specific locations to random events that occur along with seperating the origin by type (General, Station, Anomaly, Weather)

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -16,6 +16,7 @@
 #include "defines\admin.dm"
 #include "defines\ai.dm"
 #include "defines\antagonists.dm"
+#include "defines\announcement_origins.dm"
 #include "defines\artifacts.dm"
 #include "defines\atom.dm"
 #include "defines\bioeffect.dm"

--- a/_std/defines/announcement_origins.dm
+++ b/_std/defines/announcement_origins.dm
@@ -1,0 +1,9 @@
+#ifdef UNDERWATER_MAP
+	#define ALERT_ANOMALY "Ersetu Trench Anomaly Detection"
+	#define ALERT_WEATHER "Abzu Treaty Weather Station Alert"
+#else
+	#define ALERT_ANOMALY "LRAD Anomaly Detector Alert"
+	#define ALERT_WEATHER "Watchful-Eye Sensor Array Update"
+#endif
+#define ALERT_GENERAL "Frontier Authority Update"
+#define ALERT_STATION "Automated Mainframe Alert"

--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -100,7 +100,7 @@ var/obj/manta_speed_lever/mantaLever = null
 				user.show_text("<span class='notice'><b>You turn off the propellers.</b></span>")
 				on = 0
 				UpdateIcon()
-				command_alert("Attention, NSS Manta is slowing down to a halt. Shutting down propellers.", "NSS Manta Movement Computer", ALERT_STATION)
+				command_alert("Attention, NSS Manta is slowing down to a halt. Shutting down propellers.", "NSS Manta Movement Computer", alert_origin = ALERT_STATION)
 				mantaSetMove(on)
 			else
 				user.show_text("<span class='notice'><b>You turn on the propellers.</b></span>")
@@ -108,7 +108,7 @@ var/obj/manta_speed_lever/mantaLever = null
 				playsound_global(world, "sound/effects/mantamoving.ogg", 90)
 				sleep(7 SECONDS)
 				UpdateIcon()
-				command_alert("Attention, firing up propellers.  NSS Manta will be on the move shortly.", "NSS Manta Movement Computer", ALERT_STATION)
+				command_alert("Attention, firing up propellers.  NSS Manta will be on the move shortly.", "NSS Manta Movement Computer", alert_origin = ALERT_STATION)
 				mantaSetMove(on)
 			return
 		else

--- a/code/WorkInProgress/mantaObjects.dm
+++ b/code/WorkInProgress/mantaObjects.dm
@@ -100,7 +100,7 @@ var/obj/manta_speed_lever/mantaLever = null
 				user.show_text("<span class='notice'><b>You turn off the propellers.</b></span>")
 				on = 0
 				UpdateIcon()
-				command_alert("Attention, NSS Manta is slowing down to a halt. Shutting down propellers.", "NSS Manta Movement Computer")
+				command_alert("Attention, NSS Manta is slowing down to a halt. Shutting down propellers.", "NSS Manta Movement Computer", ALERT_STATION)
 				mantaSetMove(on)
 			else
 				user.show_text("<span class='notice'><b>You turn on the propellers.</b></span>")
@@ -108,7 +108,7 @@ var/obj/manta_speed_lever/mantaLever = null
 				playsound_global(world, "sound/effects/mantamoving.ogg", 90)
 				sleep(7 SECONDS)
 				UpdateIcon()
-				command_alert("Attention, firing up propellers.  NSS Manta will be on the move shortly.", "NSS Manta Movement Computer")
+				command_alert("Attention, firing up propellers.  NSS Manta will be on the move shortly.", "NSS Manta Movement Computer", ALERT_STATION)
 				mantaSetMove(on)
 			return
 		else
@@ -610,7 +610,7 @@ var/obj/manta_speed_lever/mantaLever = null
 			MagneticTether = 0
 			src.desc = "You should start by removing the outer screws from the casing. Be sure to wear some insulated gloves!"
 			playsound_global(world, "sound/effects/manta_alarm.ogg", 90)
-			command_alert("The Magnetic tether has suffered critical damage aboard NSS Manta. Jetpacks equipped with magnetic attachments are now offline, please do not venture out into the ocean until the tether has been repaired.", "Magnetic Tether Damaged")
+			command_alert("The Magnetic tether has suffered critical damage aboard NSS Manta. Jetpacks equipped with magnetic attachments are now offline, please do not venture out into the ocean until the tether has been repaired.", "Magnetic Tether Damaged",ALERT_STATION)
 
 /obj/miningteleporter
 	name = "Experimental long-range mining teleporter"
@@ -1220,7 +1220,7 @@ var/obj/manta_speed_lever/mantaLever = null
 			MagneticTether = 1
 			magnet.health = 100
 			magnet.desc = "A rather delicate magnetic tether array. It allows people to safely explore the ocean around NSS Manta while carrying a magnetic attachment point."
-			command_alert("The Magnetic tether has been successfully repaired. Magnetic attachment points are online once again.", "Magnetic Tether Repaired")
+			command_alert("The Magnetic tether has been successfully repaired. Magnetic attachment points are online once again.", "Magnetic Tether Repaired", alert_origin = ALERT_STATION)
 			return
 
 #ifdef MOVING_SUB_MAP //Defined in the map-specific .dm configuration file.
@@ -1230,7 +1230,7 @@ var/obj/manta_speed_lever/mantaLever = null
 	event_effect(var/source)
 		..()
 		if (random_events.announce_events)
-			command_alert("Communication tower has been severely damaged aboard NSS Manta. Ships automated communication system will now attempt to re-establish signal through backup channel. We estimate this will take eight to ten minutes.", "Communications Malfunction")
+			command_alert("Communication tower has been severely damaged aboard NSS Manta. Ships automated communication system will now attempt to re-establish signal through backup channel. We estimate this will take eight to ten minutes.", "Communications Malfunction", alert_origin = ALERT_STATION)
 			playsound_global(world, "sound/effects/commsdown.ogg", 100)
 			sleep(rand(80,100))
 			signal_loss += 100
@@ -1238,7 +1238,7 @@ var/obj/manta_speed_lever/mantaLever = null
 			signal_loss -= 100
 
 			if (random_events.announce_events)
-				command_alert("Communication link has been established with Oshan Laboratory through backkup channel. Communications should be restored to normal aboard NSS Manta.", "Communications Restored")
+				command_alert("Communication link has been established with Oshan Laboratory through backkup channel. Communications should be restored to normal aboard NSS Manta.", "Communications Restored", alert_origin = ALERT_STATION)
 			else
 				message_admins("<span class='internal'>Manta Comms event ceasing.</span>")
 
@@ -1252,7 +1252,7 @@ var/obj/manta_speed_lever/mantaLever = null
 		if (J.broken)
 			return
 		J.Breakdown()
-		command_alert("Certain junction boxes are malfunctioning around NSS Manta. Please seek out and repair the malfunctioning junction boxes before they lead to power outages.", "Electrical Malfunction")
+		command_alert("Certain junction boxes are malfunctioning around NSS Manta. Please seek out and repair the malfunctioning junction boxes before they lead to power outages.", "Electrical Malfunction", alert_origin = ALERT_STATION)
 
 /datum/random_event/special/namepending
 	name = "Name Pending"

--- a/code/datums/banking.dm
+++ b/code/datums/banking.dm
@@ -165,7 +165,7 @@
 				t["current_money"] += t["wage"]
 				station_budget -= t["wage"]
 			else
-				command_alert("The station budget appears to have run dry. We regret to inform you that no further wage payments are possible until this situation is rectified.","Payroll Announcement")
+				command_alert("The station budget appears to have run dry. We regret to inform you that no further wage payments are possible until this situation is rectified.","Payroll Announcement", ALERT_STATION)
 				wagesystem.pay_active = 0
 				break
 
@@ -677,11 +677,11 @@
 					if (wagesystem.pay_active)
 						wagesystem.pay_active = 0
 						logTheThing("station", usr, null, "suspends the station payroll.")
-						command_alert("The payroll has been suspended until further notice. No further wages will be paid until the payroll is resumed.","Payroll Announcement")
+						command_alert("The payroll has been suspended until further notice. No further wages will be paid until the payroll is resumed.","Payroll Announcement", ALERT_STATION)
 					else
 						wagesystem.pay_active = 1
 						logTheThing("station", usr, null, "resumes the station payroll.")
-						command_alert("The payroll has been resumed. Wages will now be paid into employee accounts normally.","Payroll Announcement")
+						command_alert("The payroll has been resumed. Wages will now be paid into employee accounts normally.","Payroll Announcement", ALERT_STATION)
 				else if(href_list["transfer"])
 					var/transfrom = input("Transfer from which?", "Budgeting", null, null) in list("Payroll", "Shipping", "Research")
 					if (!transfrom)

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -253,7 +253,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 			LAGCHECK(LAG_LOW)
 			var/datum/powernet/PN = E.get_direct_powernet()
 			if(PN?.avail <= 0)
-				command_alert("Reports indicate that the engine on-board [station_name()] has not yet been started. Setting up the engine is strongly recommended, or else stationwide power failures may occur.", "Power Grid Warning")
+				command_alert("Reports indicate that the engine on-board [station_name()] has not yet been started. Setting up the engine is strongly recommended, or else stationwide power failures may occur.", "Power Grid Warning", alert_origin = ALERT_STATION)
 			break
 
 	for(var/turf/T in job_start_locations["AI"])

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -3819,7 +3819,7 @@ var/global/noir = 0
 			if (src.level >= LEVEL_MOD)
 				var/newName = href_list["newName"]
 				if (set_station_name(usr, newName))
-					command_alert("The new station name is [station_name]", "Station Naming Ceremony Completion Detection Algorithm")
+					command_alert("The new station name is [station_name]", "Station Naming Ceremony Completion Detection Algorithm", alert_origin = ALERT_STATION)
 
 				usr.Browse(null, "window=stationnamechanger")
 				src.Game()

--- a/code/modules/cross_server/cross_server_messages/announce.dm
+++ b/code/modules/cross_server/cross_server_messages/announce.dm
@@ -2,7 +2,7 @@
 	name = "announce"
 
 	receive(list/data, datum/game_server/server)
-		command_alert(data["body"], data["title"], override_big_title="Communication from [data["station_name"]]")
+		command_alert(data["body"], data["title"], alert_origin = "Communication from [data["station_name"]]")
 		global.cooldowns["transmit_station"] = 0 // reset cooldown for reply
 		return TRUE
 

--- a/code/modules/events/antagonist_critter_ghost_respawn.dm
+++ b/code/modules/events/antagonist_critter_ghost_respawn.dm
@@ -202,7 +202,7 @@
 					antagify(M.current, null, 1)
 				candidates -= M
 
-			command_alert("Our sensors have detected a hostile nonhuman lifeform in the vicinity of the station.", "Hostile Critter")
+			command_alert("Our sensors have detected a hostile nonhuman lifeform in the vicinity of the station.", "Hostile Critter", alert_origin = ALERT_GENERAL)
 		cleanup_event()
 
 	proc/cleanup_event()

--- a/code/modules/events/black_hole.dm
+++ b/code/modules/events/black_hole.dm
@@ -56,7 +56,7 @@
 			playsound(src,'sound/machines/engine_alert3.ogg',100,0,5,0.5)
 			animate(src, transform = matrix(4, MATRIX_SCALE), time = 300, loop = 0, easing = LINEAR_EASING)
 		if (random_events.announce_events)
-			command_alert("A severe gravitational anomaly has been detected on the [station_or_ship()] in [get_area(src)]. It may collapse into a black hole if not stabilized. All personnel should feed mass to the anomaly until it stabilizes.", "Gravitational Anomaly")
+			command_alert("A severe gravitational anomaly has been detected on the [station_or_ship()] in [get_area(src)]. It may collapse into a black hole if not stabilized. All personnel should feed mass to the anomaly until it stabilizes.", "Gravitational Anomaly", alert_origin = ALERT_ANOMALY)
 
 		sleep(lifespan)
 		if (!stable)

--- a/code/modules/events/blowout.dm
+++ b/code/modules/events/blowout.dm
@@ -16,7 +16,7 @@
 		siren.channel = 5
 		siren.volume = 50 // wire note: lets not deafen players with an air raid siren
 		world << siren
-		command_alert("Extreme levels of radiation detected approaching the [station_or_ship()]. All personnel have [timetoreach].[timetoreachsec] seconds to enter a maintenance tunnel or radiation safezone. Maintenance doors have temporarily had their access requirements removed. This is not a test.", "Anomaly Alert")
+		command_alert("Extreme levels of radiation detected approaching the [station_or_ship()]. All personnel have [timetoreach].[timetoreachsec] seconds to enter a maintenance tunnel or radiation safezone. Maintenance doors have temporarily had their access requirements removed. This is not a test.", "Anomaly Alert", alert_origin = ALERT_WEATHER)
 
 		SPAWN(0)
 			for_by_tcl(A, /obj/machinery/door/airlock)
@@ -76,7 +76,7 @@
 					shake_camera(M, 400, 16)
 
 			sleep(rand(1.5 MINUTES,2 MINUTES)) // drsingh lowered these by popular request.
-			command_alert("Radiation levels lowering [station_or_ship()]wide. ETA 60 seconds until all areas are safe.", "Anomaly Alert")
+			command_alert("Radiation levels lowering [station_or_ship()]wide. ETA 60 seconds until all areas are safe.", "Anomaly Alert", alert_origin = ALERT_WEATHER)
 
 			sleep(rand(25 SECONDS,50 SECONDS)) // drsingh lowered these by popular request
 
@@ -89,7 +89,7 @@
 				A.UpdateIcon()
 			blowout = FALSE
 
-			command_alert("All radiation alerts onboard [station_name(1)] have been cleared. You may now leave the tunnels freely. Maintenance doors will regain their normal access requirements shortly.", "All Clear")
+			command_alert("All radiation alerts onboard [station_name(1)] have been cleared. You may now leave the tunnels freely. Maintenance doors will regain their normal access requirements shortly.", "All Clear", alert_origin = ALERT_WEATHER)
 
 	#ifndef UNDERWATER_MAP
 			for (var/turf/space/S in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))

--- a/code/modules/events/gimmick/bigfart.dm
+++ b/code/modules/events/gimmick/bigfart.dm
@@ -30,7 +30,7 @@
 			var/pickuptext = pick("picked up", "detected", "found", "sighted", "reported", 20; "drunkenly spotted")
 			var/anomlytext = pick("strange anomaly", "wave of cosmic energy", "spectral emission", 20; "shuttle of phantom George Melons clones")
 			var/ohshittext = pick("en route for collision with", "rapidly approaching", "heading towards", 20; "about to seriously fuck up")
-			command_alert("Our [sensortext] have [pickuptext] \a [anomlytext] [ohshittext] the station. Duck and Cover immediately.", "Anomaly Alert")
+			command_alert("Our [sensortext] have [pickuptext] \a [anomlytext] [ohshittext] the station. Duck and Cover immediately.", "Anomaly Alert", alert_origin = ALERT_ANOMALY)
 		var/loops = rand(20, 100)
 		var/freebie = 1
 		for (var/i=0, i<loops, i++)

--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -39,6 +39,7 @@
 	name = "Kudzu Outbreak"
 	centcom_headline = "Plant Outbreak"
 	centcom_message = "Rapidly expanding plant organism detected aboard the station. All personnel must contain the outbreak."
+	centcom_origin = ALERT_STATION
 	message_delay = 2 MINUTES
 	wont_occur_past_this_time = 40 MINUTES
 	customization_available = 1

--- a/code/modules/events/gimmick/power.dm
+++ b/code/modules/events/gimmick/power.dm
@@ -2,6 +2,7 @@
 	name = "Power Outage"
 	centcom_headline = "Critical Power Failure"
 	centcom_message = "Abnormal activity has been detected in the station power grid. As a precautionary measure, the station's power will be shut off for an indeterminate duration."
+	centcom_origin = ALERT_STATION
 
 	event_effect()
 		..()
@@ -21,6 +22,7 @@
 	name = "Power Grid Recharge"
 	centcom_headline = "Power Systems Nominal"
 	centcom_message = "Power has been restored to the station's power grid. We apologize for the inconvenience."
+	centcom_origin = ALERT_STATION
 
 	event_effect()
 		..()

--- a/code/modules/events/gimmick/skeletons.dm
+++ b/code/modules/events/gimmick/skeletons.dm
@@ -39,7 +39,7 @@
 		var/pickuptext = pick("picked up", "detected", "found", "sighted", "reported")
 		var/anomlytext = pick("spooky infestation", "loud clacking noise","rattling of bones")
 		var/ohshittext = pick("en route for collision with", "rapidly approaching", "heading towards")
-		command_alert("Our [sensortext] have [pickuptext] \a [anomlytext] [ohshittext] the station. Be wary of closets.", "Anomaly Alert")
+		command_alert("Our [sensortext] have [pickuptext] \a [anomlytext] [ohshittext] the station. Be wary of closets.", "Anomaly Alert", alert_origin = ALERT_ANOMALY)
 
 		SPAWN(1 DECI SECOND)
 			for(var/i = 0, i<spawn_amount, i++)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -2,6 +2,7 @@
 	name = "Ion Storm"
 	centcom_headline = "Equipment Malfunction"
 	centcom_message = "An electromagnetic storm recently passed by the station. Sensitive electrical equipment may require maintenance."
+	centcom_origin = ALERT_WEATHER
 	message_delay = 5 MINUTES
 	/// The fraction of message_delay taken up by each stage of the ion storm
 	var/stage_delay

--- a/code/modules/events/locker_entanglement.dm
+++ b/code/modules/events/locker_entanglement.dm
@@ -2,6 +2,7 @@
 	name = "Locker Entanglement"
 	centcom_headline = "Quantum Anomaly"
 	centcom_message = {"A quantum anomaly has been detected on station. Locker dimensional subspaces might have become unstable. Enter lockers at your own risk."}
+	centcom_origin = ALERT_ANOMALY
 	weight = 20
 	var/time = null
 

--- a/code/modules/events/magnetic.dm
+++ b/code/modules/events/magnetic.dm
@@ -2,6 +2,7 @@
 	name = "Bio-Magnetic Field"
 	centcom_headline = "Bio-Magnetic Field"
 	centcom_message = {"Strong bio-magnetic fields have been detected manifesting on the station. Personnel are advised to avoid anybody charged with the opposite magnetic charge. The fields should dissipate within a few minutes."}
+	centcom_origin = ALERT_ANOMALY
 	var/list/positive_mobs = list()
 	var/list/negative_mobs = list()
 	var/list/eligible_mobs = list()

--- a/code/modules/events/meteor_shower.dm
+++ b/code/modules/events/meteor_shower.dm
@@ -62,7 +62,7 @@ var/global/meteor_shower_active = 0
 		var/commins = round((ticker.round_elapsed_ticks + warning_delay - ticker.round_elapsed_ticks)/10 ,1)
 		commins = max(0,commins)
 		if (random_events.announce_events)
-			command_alert("[comsev] [shower_name] approaching [comdir]. Impact in [commins] seconds.", "Meteor Alert")
+			command_alert("[comsev] [shower_name] approaching [comdir]. Impact in [commins] seconds.", "Meteor Alert", alert_origin = ALERT_WEATHER)
 			playsound_global(world, 'sound/machines/engine_alert2.ogg', 40)
 			meteor_shower_active = direction
 			for (var/obj/machinery/shield_generator/S as anything in machine_registry[MACHINES_SHIELDGENERATORS])
@@ -70,7 +70,7 @@ var/global/meteor_shower_active = 0
 
 		SPAWN(warning_delay)
 			if (random_events.announce_events)
-				command_alert("The [shower_name] has reached the [station_or_ship()]. Brace for impact.", "Meteor Alert")
+				command_alert("The [shower_name] has reached the [station_or_ship()]. Brace for impact.", "Meteor Alert", alert_origin = ALERT_WEATHER)
 				playsound_global(world, 'sound/machines/engine_alert1.ogg', 30)
 
 			var/start_x

--- a/code/modules/events/playable_pests.dm
+++ b/code/modules/events/playable_pests.dm
@@ -104,7 +104,7 @@
 			pestlandmark.visible_message("A group of pests emerge from their hidey-hole!")
 
 			if (src.num_pests >= 5)
-				command_alert("A large number of pests have been detected onboard.", "Pest invasion")
+				command_alert("A large number of pests have been detected onboard.", "Pest invasion", alert_origin = ALERT_STATION)
 		cleanup_event()
 
 	proc/cleanup_event()

--- a/code/modules/events/radiation.dm
+++ b/code/modules/events/radiation.dm
@@ -2,6 +2,7 @@
 	name = "Radiation Storm"
 	centcom_headline = "Radioactive Anomaly"
 	centcom_message = {"Radioactive anomalies have been detected on the station. Evacuate any areas containing abnormal green or blue energy fields. Medical personnel are advised to prepare potassium iodide and anti-toxin treatments, and remain on standby to treat cases of irradiation."}
+	centcom_origin = ALERT_WEATHER
 	var/min_pulses_per_event = 30
 	var/max_pulses_per_event = 100
 	var/min_delay_between_pulses = 2
@@ -138,6 +139,7 @@
 	name = "Radiation Wave"
 	centcom_headline = "Radiation Wave"
 	centcom_message = "A large wave of radiation is approaching the station. Personnel should use caution when traversing the station and seek medical attention if they experience any side effects from the wave."
+	centcom_origin = ALERT_WEATHER
 
 	event_effect(var/source)
 		..()

--- a/code/modules/events/random_event.dm
+++ b/code/modules/events/random_event.dm
@@ -2,6 +2,7 @@
 	var/name = null                      // What is this event called?
 	var/centcom_headline = null          // The title of the displayed message.
 	var/centcom_message = null           // A message displayed to the crew.
+	var/centcom_origin = null			 // The origin of the message
 	var/message_delay = 0 SECONDS        // How long it takes after the event's effect for the message to arrive.
 	var/required_elapsed_round_time = 0  // Round elapsed ticks must be this or higher for the event to trigger naturally.
 	var/wont_occur_past_this_time = -1   // Event will no longer occur naturally after this many ticks have elapsed.
@@ -19,7 +20,7 @@
 
 		if (centcom_headline && centcom_message && random_events.announce_events)
 			SPAWN(message_delay)
-				command_alert("[centcom_message]", "[centcom_headline]")
+				command_alert("[centcom_message]", "[centcom_headline]", alert_origin = "[centcom_origin]")
 
 	proc/admin_call(var/source)
 		if (!istext(source))

--- a/code/modules/events/solar_flare.dm
+++ b/code/modules/events/solar_flare.dm
@@ -21,7 +21,7 @@
 						//break omitted, multiple interdictors can stack
 
 		if (random_events.announce_events)
-			command_alert("A solar flare has been detected near the [station_or_ship()]. We estimate a signal interference rate of [headline_estimate]% lasting anywhere between three to five minutes.", "Solar Flare")
+			command_alert("A solar flare has been detected near the [station_or_ship()]. We estimate a signal interference rate of [headline_estimate]% lasting anywhere between three to five minutes.", "Solar Flare", alert_origin = ALERT_WEATHER)
 		SPAWN(flare_start_time)
 			signal_loss += signal_loss_current
 
@@ -46,6 +46,6 @@
 	#endif
 
 			if (random_events.announce_events)
-				command_alert("The solar flare has safely passed [station_name(1)]. Communications should be restored to normal.", "All Clear")
+				command_alert("The solar flare has safely passed [station_name(1)]. Communications should be restored to normal.", "All Clear", alert_origin = ALERT_WEATHER)
 			else
 				message_admins("<span class='internal'>Random Radio/Flare Event ceasing.</span>")

--- a/code/modules/events/spatial_tear.dm
+++ b/code/modules/events/spatial_tear.dm
@@ -2,6 +2,7 @@
 	name = "Spatial Tear"
 	centcom_headline = "Spatial Anomaly"
 	centcom_message = "A severe spatial anomaly has been detected near the station. Personnel are advised to avoid any unusual phenomenae."
+	centcom_origin = ALERT_ANOMALY
 	required_elapsed_round_time = 10 MINUTES
 
 	event_effect(var/source)

--- a/code/modules/events/vamp_teg.dm
+++ b/code/modules/events/vamp_teg.dm
@@ -82,14 +82,14 @@
 		// Delayed Warning and Instruction
 		SPAWN(warning_delay)
 			if(event_active)
-				command_alert("Reports indicate that the engine on-board [station_name()] is behaving unusually. Stationwide power failures may occur or worse.", "Engine Warning")
+				command_alert("Reports indicate that the engine on-board [station_name()] is behaving unusually. Stationwide power failures may occur or worse.", "Engine Warning", alert_origin = ALERT_STATION)
 				sleep(30 SECONDS)
 			if(event_active)
 				command_alert("Onsite Engineers inform us a sympathetic connection exists between the furnaces and the engine. Considering burning something it might enjoy: food, people, weed. We're grasping at straws here. ", "Engine Suggestion")
 				sleep(rand(1 MINUTE, 2.5 MINUTES))
 
 			if(event_active)
-				pda_msg("Unknown substance detected in Themo-Electric Generator Circulators. Please drain and replace lubricants.")
+				pda_msg("Unknown substance detected in Themo-Electric Generator Circulators. Please drain and replace lubricants.", alert_origin = ALERT_STATION)
 
 		// FAILURE EVENT
 		SPAWN(event_duration)

--- a/code/modules/events/vamp_teg.dm
+++ b/code/modules/events/vamp_teg.dm
@@ -89,7 +89,7 @@
 				sleep(rand(1 MINUTE, 2.5 MINUTES))
 
 			if(event_active)
-				pda_msg("Unknown substance detected in Themo-Electric Generator Circulators. Please drain and replace lubricants.", alert_origin = ALERT_STATION)
+				pda_msg("Unknown substance detected in Themo-Electric Generator Circulators. Please drain and replace lubricants."
 
 		// FAILURE EVENT
 		SPAWN(event_duration)

--- a/code/modules/events/vamp_teg.dm
+++ b/code/modules/events/vamp_teg.dm
@@ -89,7 +89,7 @@
 				sleep(rand(1 MINUTE, 2.5 MINUTES))
 
 			if(event_active)
-				pda_msg("Unknown substance detected in Themo-Electric Generator Circulators. Please drain and replace lubricants."
+				pda_msg("Unknown substance detected in Themo-Electric Generator Circulators. Please drain and replace lubricants.")
 
 		// FAILURE EVENT
 		SPAWN(event_duration)

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -2,6 +2,7 @@
 	name = "Wormholes"
 	centcom_headline = "Spatial Anomalies"
 	centcom_message = "Multiple localized spatial anomalies detected on the station. Personnel are advised to avoid any spatial distortions."
+	centcom_origin = ALERT_ANOMALY
 	required_elapsed_round_time = 20 MINUTES
 
 	event_effect(var/source)

--- a/code/modules/networks/computer3/comm_dish.dm
+++ b/code/modules/networks/computer3/comm_dish.dm
@@ -75,7 +75,7 @@
 
 		transmit_to_centcom(var/title, var/message, var/user)
 			var/sound_to_play = "sound/misc/announcement_1.ogg"
-			command_alert(message, title, sound_to_play, override_big_title="Transmission to Central Command")
+			command_alert(message, title, sound_to_play, alert_origin = "Transmission to Central Command")
 			message_admins("[user ? user : "Someone"] sent a message to Central Command:<br>[title]<br><br>[message]")
 			var/ircmsg[] = new()
 			ircmsg["msg"] = "[user ? user : "Unknown"] sent a message to Central Command:\n**[title]**\n[message]"
@@ -83,7 +83,7 @@
 
 		transmit_to_partner_station(var/title, var/message, var/user)
 			var/sound_to_play = "sound/misc/announcement_1.ogg"
-			command_alert(message, title, sound_to_play, override_big_title="Transmission to Partner Station")
+			command_alert(message, title, sound_to_play, alert_origin = "Transmission to Partner Station")
 			var/ircmsg[] = new()
 			ircmsg["msg"] = "[user ? user : "Unknown"] sent a message to __[game_servers.get_buddy().name]__:\n**[title]**\n[message]"
 			ircbot.export_async("admin", ircmsg)

--- a/code/modules/networks/computer3/mainframe2/misc_terms.dm
+++ b/code/modules/networks/computer3/mainframe2/misc_terms.dm
@@ -1277,11 +1277,11 @@
 						message_admins(admessage)
 						//World announcement.
 						if(station_or_ship() == "ship")
-							command_alert("The ship's self-destruct sequence has been activated, please evacuate the ship or abort the sequence as soon as possible. Detonation in T-[src.time] seconds", "Self-Destruct Activated")
+							command_alert("The ship's self-destruct sequence has been activated, please evacuate the ship or abort the sequence as soon as possible. Detonation in T-[src.time] seconds", "Self-Destruct Activated", alert_origin = ALERT_STATION)
 							playsound_global(world, "sound/machines/engine_alert2.ogg", 40)
 							return
 						if(station_or_ship() == "station")
-							command_alert("The station's self-destruct sequence has been activated, please evacuate the station or abort the sequence as soon as possible. Detonation in T-[src.time] seconds", "Self-Destruct Activated")
+							command_alert("The station's self-destruct sequence has been activated, please evacuate the station or abort the sequence as soon as possible. Detonation in T-[src.time] seconds", "Self-Destruct Activated", alert_origin = ALERT_STATION)
 							playsound_global(world, "sound/machines/engine_alert2.ogg", 40)
 							return
 					if("deact")

--- a/code/obj/artifacts/artifact_objects/bombs.dm
+++ b/code/obj/artifacts/artifact_objects/bombs.dm
@@ -58,7 +58,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 			playsound(T, alarm_initial, 100, 1, doAlert?200:-1)
 		if (doAlert)
 			var/area/A = get_area(O)
-			command_alert("An extremely unstable object of [artitype.type_name] origin has been detected in [A]. The crew is advised to dispose of it immediately.", "Station Threat Detected")
+			command_alert("An extremely unstable object of [artitype.type_name] origin has been detected in [A]. The crew is advised to dispose of it immediately.", "Station Threat Detected", alert_origin = ALERT_ANOMALY)
 		O.add_simple_light("artbomb", lightColor)
 		animate(O, pixel_y = rand(-3,3), pixel_y = rand(-3,3),time = 1,loop = src.explode_delay + 10 SECONDS, easing = ELASTIC_EASING, flags=ANIMATION_PARALLEL)
 		animate(O.simple_light, flags=ANIMATION_PARALLEL, time = src.explode_delay + 10 SECONDS, transform = matrix() * animationScale)
@@ -105,7 +105,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 		var/turf/T = get_turf(O)
 		T.visible_message("<b><span class='notice'>[O] [text_disarmed]</b></span>")
 		if(src.doAlert && !src.blewUp && !ON_COOLDOWN(O, "alertDisarm", 10 MINUTES)) // lol, don't give the message if it was destroyed by exploding itself
-			command_alert("The object of [src.artitype.type_name] origin has been neutralized. All personnel should return to their duties.", "Station Threat Neutralized")
+			command_alert("The object of [src.artitype.type_name] origin has been neutralized. All personnel should return to their duties.", "Station Threat Neutralized", alert_origin = ALERT_ANOMALY)
 
 	proc/deploy_payload(var/obj/O)
 		if (!O)
@@ -114,7 +114,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 			var/turf/T = get_turf(O)
 			T.visible_message("<b>[O] [text_dud]")
 			if(src.doAlert && !ON_COOLDOWN(O, "alertDud", 10 MINUTES))
-				command_alert("The object of [src.artitype.type_name] origin appears to be nonfunctional. All personnel should return to their duties.", "Station Threat Neutralized")
+				command_alert("The object of [src.artitype.type_name] origin appears to be nonfunctional. All personnel should return to their duties.", "Station Threat Neutralized", alert_origin = ALERT_ANOMALY)
 			O.ArtifactDeactivated()
 			return 1
 
@@ -134,7 +134,7 @@ ABSTRACT_TYPE(/datum/artifact/bomb)
 		if(src.artifact && istype(src.artifact, /datum/artifact/bomb))
 			var/datum/artifact/bomb/B = src.artifact
 			if(B.doAlert && B.activated && !B.blewUp) // lol, don't give the message if it was destroyed by exploding itself
-				command_alert("The object of [B.artitype.type_name] origin has been neutralized. All personnel should return to their duties.", "Station Threat Neutralized")
+				command_alert("The object of [B.artitype.type_name] origin has been neutralized. All personnel should return to their duties.", "Station Threat Neutralized", alert_origin = ALERT_ANOMALY)
 
 
 

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -1267,7 +1267,7 @@ Using electronic "Detomatix" BOMB program is perhaps less simple!<br>
 				var/newName = href_list["newName"]
 
 				if (set_station_name(usr, newName))
-					command_alert("The new station name is [station_name]", "Station Naming Ceremony Completion Detection Algorithm")
+					command_alert("The new station name is [station_name]", "Station Naming Ceremony Completion Detection Algorithm", alert_origin = ALERT_STATION)
 
 			usr.Browse(null, "window=stationnamechanger")
 			src.master.updateSelfDialog()

--- a/code/obj/submachine/slots.dm
+++ b/code/obj/submachine/slots.dm
@@ -174,12 +174,12 @@
 		win_sound = "sound/misc/airraid_loop_short.ogg"
 		exclamation = "JACKPOT! "
 		amount = 300 * wager
-		command_alert("Congratulations to [src.scan.registered] on winning a Jackpot of [amount] credits!", "Jackpot Winner")
+		command_alert("Congratulations to [src.scan.registered] on winning a Jackpot of [amount] credits!", "Jackpot Winner", alert_origin = ALERT_STATION)
 	else if (roll <= 5) //4 - 400
 		win_sound =  "sound/misc/klaxon.ogg"
 		exclamation = "Big Winner! "
 		amount = 100 * wager
-		command_alert("Congratulations to [src.scan.registered] on winning [amount] credits!", "Big Winner")
+		command_alert("Congratulations to [src.scan.registered] on winning [amount] credits!", "Big Winner", alert_origin = ALERT_STATION)
 	else if (roll <= 15) //10 - 500    (Plus additional 5 - 250 if wager <= 250)
 		win_sound =  "sound/musical_instruments/Bell_Huge_1.ogg"
 		exclamation = "Big Winner! "

--- a/code/procs/basketball.dm
+++ b/code/procs/basketball.dm
@@ -345,7 +345,7 @@
 	siren.repeat = 1
 	siren.channel = 5
 	world << siren
-	command_alert("A massive influx of negative b-ball protons has been detected in [get_area(M)]. A Chaos Dunk is imminent. All personnel currently on [station_name(1)] have 15 seconds to reach minimum safe distance. This is not a test.")
+	command_alert("A massive influx of negative b-ball protons has been detected in [get_area(M)]. A Chaos Dunk is imminent. All personnel currently on [station_name(1)] have 15 seconds to reach minimum safe distance. This is not a test.", alert_origin = ALERT_ANOMALY)
 	for(var/area/A in world)
 		A.eject = 1
 		A.UpdateIcon()

--- a/code/procs/command_alert.dm
+++ b/code/procs/command_alert.dm
@@ -1,5 +1,5 @@
-/proc/command_alert(var/text, var/title = "", var/sound_to_play = "", var/do_sanitize = 1, var/override_big_title=null)
-	var/big_title = override_big_title ? override_big_title : "[command_name()] Update"
+/proc/command_alert(var/text, var/title = "", var/sound_to_play = "", var/do_sanitize = 1, var/alert_origin=null)
+	var/big_title = alert_origin ? alert_origin : "[ALERT_GENERAL]"
 	boutput(world, "<h1 class='alert'>[big_title]</h1>")
 
 	if (title && length(title) > 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds two primary functionalities, it adds variety to the location of the messages through four defines that will send alerts

Two common defines:
-The general alert/alert if nothing is specified: **Frontier Authority Update**

-The Station side alert: **Automated Mainframe Alert**

If the map takes place not on Abzu: 
-The anomaly related alerts: **LRAD Anomaly Detector Alert**
       *this stands for Long Range Anomaly Detector Anomaly Detector

-Spatial weather related alerts: **Watchful-Eye Sensor Array Update**
        *the first step to getting newer cogwerks lore in game, they can tell you more about this location on the discord.

If the map takes place on Abzu:
-The anomaly related alerts: **Ersetu Trench Anomaly Detection**
         *the name matches Abzu lore and opens up future abzu deep trench development

-Abzu Weather related alerts: **Abzu Treaty Weather Station Alert**
         *the name opens up more historic Abzu lore

I went through (what should be) every announcement and hand chose whether they were Anomaly Related, Weather related, General/Externally related, or Internally/Station related. 

General Based:
-Antag critters
-Sleeper agent
-Trader arriving/leaving
-Appendicitus
-Lottery
-Almost everything else that isnt mentioned below

Weather Related
-Meteor/shark Shower
-Radiation 
-Radiation blowout
-Solar Flare
-Ion Storm
-Bio-magnetic storm

Anomaly Related
-Wormholes
-Spatial Tear
-Locker entanglement 
-Skeletons (admin only)
-black holes
-Artifact bombs

Station Related:
-Money running out
-Budget things
-Engine not being started
-power outage (admin only as of now)
-Haunted TEG
-Tether and elec box and other manta stuff
-Station name changes

(I probably missed a few)

-----

Things this does not change:

-Any events in any way
-Any event titles or descriptions in the announcements (will happen eventually tho >:P)
-The frequency or weighting of events

This PR is strictly adding the new names to the events, for fluff, worldbuilding clearing up confusion, and further development in the future (possibly more customizable announcements + better event names/more lore accurate descriptions)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

With the old system giving us a random name every round of "System System" or "Elite Space Imperium" or "Galactic Empire", it got people very very confused for who they were working for and where they were as this stuff isn't outwardly told to them when they start playing. Especially with the strange themes of imperialism, it could very easily get new players confused on what type of job it is, and what the energy of goonstation is. I know when I was newer, I read all of the alert names but was always so confused at what this imperial body was that was giving it to us.

This change, while getting some more recently world-building into the game, allows for new players to learn the words such as "Abzu" and "Frontier", two important locations to understanding where one is in SS13. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Yellow/Myco
(*)Adds names to where the announcements for anomalies/weather events/command updates are coming from.
```
