### PR TITLE
Refactors antag popups

### DIFF
--- a/_std/macros/antag_popups.dm
+++ b/_std/macros/antag_popups.dm
@@ -1,97 +1,5 @@
-// moving traitor popups to defines so i can make an admin proc to show them to yourself and see what players see.
-// if you add new types of popups in here, don't forget to add them to the View Antag Popups panel at the bottom of this file
-// - thanks, singh
-
-// window title/size
-#define ANTAG_TIPS_WINDOW "window=antagTips;size=700x450;title=Antagonist Tips"
-
-// damn one off windows... i'll make them defines too i guess in case anyone wants to reuse or edit them
-#define POLYMORPH_TIPS_WINDOW "window=antagTips;size=600x400;title=Polymorphed!"
-#define SOULSTEEL_TIPS_WINDOW "window=antagTips;size=600x400;title=Posession!"
-#define MINDWIPE_TIPS_WINDOW "window=antagTips;titlebar=1;size=600x400;can_minimize=0;can_resize=0"
-
-//traitor
-#define SHOW_TRAITOR_RADIO_TIPS(M) M.Browse(grabResource("html/traitorTips/traitorradiouplinkTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_TRAITOR_PDA_TIPS(M) M.Browse(grabResource("html/traitorTips/traitorTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_TRAITOR_HARDMODE_TIPS(M) M.Browse(grabResource("html/traitorTips/traitorhardTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_TRAITOR_OMNI_TIPS(M) M.Browse(grabResource("html/traitorTips/omniTips.html"), ANTAG_TIPS_WINDOW)
-
-// mindslaves
-#define SHOW_MINDSLAVE_TIPS(M) M.Browse(grabResource("html/mindslave/implanted.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_MINDSLAVE_DEATH_TIPS(M) M.Browse(grabResource("html/mindslave/death.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_MINDSLAVE_OVERRIDE_TIPS(M) M.Browse(grabResource("html/mindslave/override.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_MINDSLAVE_EXPIRED_TIPS(M) M.Browse(grabResource("html/mindslave/expire.html"), ANTAG_TIPS_WINDOW)
-
-// wizard
-#define SHOW_WIZARD_TIPS(M) M.Browse(grabResource("html/traitorTips/wizardTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_ADMINWIZARD_TIPS(M) M.Browse(grabResource("html/traitorTips/wizardcustomTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_POLYMORPH_TIPS(M) M.Browse(grabResource("html/polymorph.html"), POLYMORPH_TIPS_WINDOW)
-
-// nuke
-#define SHOW_NUKEOP_TIPS(M) M.Browse(grabResource("html/traitorTips/nukeopTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_NUKEOP_COMMANDER_TIPS(M) M.Browse(grabResource("html/traitorTips/nukeopcommanderTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_NUKEOP_GUNBOT_TIPS(M) M.Browse(grabResource("html/traitorTips/nukeopgunbotTips.html"), ANTAG_TIPS_WINDOW)
-
-// revolution
-#define SHOW_REVHEAD_TIPS(M) M.Browse(grabResource("html/traitorTips/revTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_REVVED_TIPS(M) M.Browse(grabResource("html/traitorTips/revAdded.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_DEREVVED_TIPS(M) M.Browse(grabResource("html/traitorTips/revRemoved.html"), ANTAG_TIPS_WINDOW)
-
-// spy
-#define SHOW_SPY_TIPS(M) M.Browse(grabResource("html/traitorTips/spyTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_SPY_THIEF_TIPS(M) M.Browse(grabResource("html/traitorTips/spy_theft_Tips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_CONSPIRACY_TIPS(M) M.Browse(grabResource("html/traitorTips/conspiracyTips.html"), ANTAG_TIPS_WINDOW)
-
-//gangers
-#define SHOW_GANG_MEMBER_TIPS(M) M.Browse(grabResource("html/traitorTips/gang_member_added.html"), ANTAG_TIPS_WINDOW)
-
-// vampire (thrall uses the mindslave popup)
-#define SHOW_VAMPIRE_TIPS(M) M.Browse(grabResource("html/traitorTips/vampireTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_VAMPTHRALL_TIPS(M) M.Browse(grabResource("html/traitorTips/vampiricthrallTips.html"), ANTAG_TIPS_WINDOW)
-
-// changeling
-#define SHOW_CHANGELING_TIPS(M) M.Browse(grabResource("html/traitorTips/changelingTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_HANDSPIDER_TIPS(M) M.Browse(grabResource("html/mindslave/handspider.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_EYESPIDER_TIPS(M) M.Browse(grabResource("html/mindslave/eyespider.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_LEGWORM_TIPS(M) M.Browse(grabResource("html/mindslave/legworm.html"), ANTAG_TIPS_WINDOW)
-
-// various others
-#define SHOW_GRINCH_TIPS(M) M.Browse(grabResource("html/traitorTips/grinchTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_HUNTER_TIPS(M) M.Browse(grabResource("html/traitorTips/hunterTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_WEREWOLF_TIPS(M) M.Browse(grabResource("html/traitorTips/werewolfTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_WRESTLER_TIPS(M) M.Browse(grabResource("html/traitorTips/wrestlerTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_BATTLE_ROYALE_TIPS(M) M.Browse(grabResource("html/traitorTips/battleTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_MARTIAN_TIPS(M) M.Browse(grabResource("html/traitorTips/martianInfiltrator.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_KUDZU_TIPS(M) M.Browse(grabResource("html/traitorTips/kudzu.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_FOOTBALL_TIPS(M) M.Browse(grabResource("html/traitorTips/football.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_ZOMBIE_TIPS(M) M.Browse(grabResource("html/traitorTips/zombieTips.html"), ANTAG_TIPS_WINDOW)
-#define SHOW_SLASHER_TIPS(M) M.Browse(grabResource("html/traitorTips/slasherTips.html"), ANTAG_TIPS_WINDOW)
-
-// borg does things a little differently
-#define BORG_EMAGGED_MSG "<span class='alert'><b>PROGRAM EXCEPTION AT 0x05BADDAD</b></span><br><span class='alert'><b>Law ROM data corrupted. Unable to restore...</b></span>"
-#define BORG_EMAGGED_ALERT_MSG "You have been emagged and now have absolute free will.", "You have been emagged!"
-#define SHOW_EMAGGED_BORG_TIPS(M) boutput(M, BORG_EMAGGED_MSG); SPAWN(0) alert(M, BORG_EMAGGED_ALERT_MSG)
-#define SHOW_ROGUE_BORG_REMOVED_TIPS(M) M.Browse(grabResource("html/traitorTips/roguerobotRemoved.html"), ANTAG_TIPS_WINDOW)
-
-// antag removed by admin
-#define SHOW_ANTAG_REMOVED_TIPS(M) M.Browse(grabResource("html/traitorTips/antagRemoved.html"), ANTAG_TIPS_WINDOW)
-
-// soulsteel posession
-#define SHOW_SOULSTEEL_TIPS(M) M.Browse(grabResource("html/soulsteel.html"), SOULSTEEL_TIPS_WINDOW)
-
-// slasher possession
-#define SHOW_SLASHER_POSSESSION_TIPS(M) M.Browse(grabResource("html/slasher_possession.html"), ANTAG_TIPS_WINDOW)
-
-// mindwipe from cloner zap chance
-#define SHOW_MINDWIPE_TIPS(M) M.Browse(grabResource("html/mindwipe.html"), MINDWIPE_TIPS_WINDOW)
-
-//Instructions for pod-wars gametype
-#define SHOW_POD_WARS(M) M.Browse(grabResource("html/traitorTips/pod_wars.html"), ANTAG_TIPS_WINDOW)
-
-// arcfiend
-#define SHOW_ARCFIEND_TIPS(M) M.Browse(grabResource("html/traitorTips/arcfiendTips.html"), ANTAG_TIPS_WINDOW)
-
-/datum/adminAntagPopups
+///Singleton that handles antag popups, use get_singleton
+/datum/antagPopups
 	var/html
 
 	proc/generateHTML()
@@ -133,7 +41,7 @@
 <div class='antagType' style='border-color:#AEC6CF'><b class='title' style='background:#AEC6CF'>Spy/Conspiracy</b>
 	<a href='?src=\ref[src];action=spy'>Spy</a> |
 	<a href='?src=\ref[src];action=spythief'>Spy Thief</a> |
-	<a href='?src=\ref[src];action=conspiracy'>Conspiracy</a>
+	<a href='?src=\ref[src];action=conspiracy'>Conspiracy</a> |
 	<a href='?src=\ref[src];action=gang_member'>Gang Member</a>
 </div>
 <div class='antagType' style='border-color:#AEC6CF'><b class='title' style='background:#AEC6CF'>Vampire/Changeling</b>
@@ -157,7 +65,6 @@
 	<a href='?src=\ref[src];action=arcfiend'>Arcfiend Person</a>
 </div>
 <div class='antagType' style='border-color:#AEC6CF'><b class='title' style='background:#AEC6CF'>Misc</b>
-	<a href='?src=\ref[src];action=emaggedborg'>Borg Emagged</a> |
 	<a href='?src=\ref[src];action=rogueborgremoved'>Rogue Borg Removed</a> |
 	<a href='?src=\ref[src];action=antagremoved'>Antag Removed</a> |
 	<a href='?src=\ref[src];action=soulsteel'>Soulsteel Posession</a> |
@@ -176,6 +83,10 @@
 
 		usr.Browse(html, "window=adminAntagPopups;size=600x400")
 
+	//this is definitely not a massive security hole or anything. I think
+	proc/searchWiki(mob/M, var/phrase)
+		M << link("https://wiki.ss13.co/index.php?search=[phrase]")
+
 	Topic(href, href_list)
 		var/mob/M
 		if (ismob(usr))
@@ -187,117 +98,153 @@
 		else
 			alert("How the hell are you not a mob?! I can't show the panel to you, you don't exist!")
 			return
+		if (href_list["action"])
+			M.show_antag_popup(href_list["action"], FALSE)
+		if (href_list["wiki"])
+			searchWiki(M, href_list["wiki"])
 
-		switch(href_list["action"])
+	//show antag popup to a mob
+	proc/show_popup(mob/M, var/popup_name)
+		var/window_title = "Antagonist Tips"
+		var/filename = null
+		switch(popup_name)
 			// traitor
 			if ("traitorradio")
-				SHOW_TRAITOR_RADIO_TIPS(M)
+				filename = "html/traitorTips/traitorradiouplinkTips.html"
 			if ("traitorpda")
-				SHOW_TRAITOR_PDA_TIPS(M)
+				filename = "html/traitorTips/traitorTips.html"
 			if ("traitorhard")
-				SHOW_TRAITOR_HARDMODE_TIPS(M)
+				filename = "html/traitorTips/traitorhardTips.html"
 			if ("traitoromni")
-				SHOW_TRAITOR_OMNI_TIPS(M)
+				filename = "html/traitorTips/omniTips.html"
 
 			// mindslave
 			if ("mindslave")
-				SHOW_MINDSLAVE_TIPS(M)
+				filename = "html/mindslave/implanted.html"
 			if ("mindslavedeath")
-				SHOW_MINDSLAVE_DEATH_TIPS(M)
+				filename = "html/mindslave/death.html"
 			if ("mindslaveoverride")
-				SHOW_MINDSLAVE_OVERRIDE_TIPS(M)
+				filename = "html/mindslave/override.html"
 			if ("mindslaveexpired")
-				SHOW_MINDSLAVE_EXPIRED_TIPS(M)
+				filename = "html/mindslave/expire.html"
 
 			// wizard
 			if ("wizard")
-				SHOW_WIZARD_TIPS(M)
+				filename = "html/traitorTips/wizardTips.html"
 			if ("adminwizard")
-				SHOW_ADMINWIZARD_TIPS(M)
+				filename = "html/traitorTips/wizardcustomTips.html"
 			if ("polymorph")
-				SHOW_POLYMORPH_TIPS(M)
+				window_title = "Polymorphed!"
+				filename = "html/polymorph.html"
 
 			// nuke/rev
 			if ("nukeop")
-				SHOW_NUKEOP_TIPS(M)
+				filename = "html/traitorTips/nukeopTips.html"
 			if ("nukeop-commander")
-				SHOW_NUKEOP_COMMANDER_TIPS(M)
+				filename = "html/traitorTips/nukeopcommanderTips.html"
 			if ("nukeop-gunbot")
-				SHOW_NUKEOP_GUNBOT_TIPS(M)
+				filename = "html/traitorTips/nukeopgunbotTips.html"
 			if ("revhead")
-				SHOW_REVHEAD_TIPS(M)
+				filename = "html/traitorTips/revTips.html"
 			if ("revved")
-				SHOW_REVVED_TIPS(M)
+				filename = "html/traitorTips/revAdded.html"
 			if ("derevved")
-				SHOW_DEREVVED_TIPS(M)
+				filename = "html/traitorTips/revRemoved.html"
 
 			// spy/conspiracy
 			if ("spy")
-				SHOW_SPY_TIPS(M)
+				filename = "html/traitorTips/spyTips.html"
 			if ("spythief")
-				SHOW_SPY_THIEF_TIPS(M)
+				filename = "html/traitorTips/spy_theft_Tips.html"
 			if ("conspiracy")
-				SHOW_CONSPIRACY_TIPS(M)
+				filename = "html/traitorTips/conspiracyTips.html"
 
 			// gangers
 			if ("gang_member")
-				SHOW_GANG_MEMBER_TIPS(M)
+				filename = "html/traitorTips/gang_member_added.html"
 
 			// vamp/changeling
 			if ("vampire")
-				SHOW_VAMPIRE_TIPS(M)
+				filename = "html/traitorTips/vampireTips.html"
 			if ("vampthrall")
-				SHOW_VAMPTHRALL_TIPS(M)
+				filename = "html/traitorTips/vampiricthrallTips.html"
 			if ("changeling")
-				SHOW_CHANGELING_TIPS(M)
+				filename = "html/traitorTips/changelingTips.html"
 			if ("handspider")
-				SHOW_HANDSPIDER_TIPS(M)
+				filename = "html/mindslave/handspider.html"
 			if ("eyespider")
-				SHOW_EYESPIDER_TIPS(M)
+				filename = "html/mindslave/eyespider.html"
 			if ("legworm")
-				SHOW_LEGWORM_TIPS(M)
+				filename = "html/mindslave/legworm.html"
 
 			// other antags
 			if ("grinch")
-				SHOW_GRINCH_TIPS(M)
+				filename = "html/traitorTips/grinchTips.html"
 			if ("hunter")
-				SHOW_HUNTER_TIPS(M)
+				filename = "html/traitorTips/hunterTips.html"
 			if ("werewolf")
-				SHOW_WEREWOLF_TIPS(M)
+				filename = "html/traitorTips/werewolfTips.html"
 			if ("wrestler")
-				SHOW_WRESTLER_TIPS(M)
+				filename = "html/traitorTips/wrestlerTips.html"
 			if ("battle")
-				SHOW_BATTLE_ROYALE_TIPS(M)
+				filename = "html/traitorTips/battleTips.html"
 			if ("martian")
-				SHOW_MARTIAN_TIPS(M)
+				filename = "html/traitorTips/martianInfiltrator.html"
 			if ("kudzu")
-				SHOW_KUDZU_TIPS(M)
+				filename = "html/traitorTips/kudzu.html"
 			if ("slasher")
-				SHOW_SLASHER_TIPS(M)
+				filename = "html/traitorTips/slasherTips.html"
 			if ("arcfiend")
-				SHOW_ARCFIEND_TIPS(M)
+				filename = "html/traitorTips/arcfiendTips.html"
+			if ("football")
+				filename = "html/traitorTips/football.html"
+			if ("podwars")
+				filename = "html/traitorTips/pod_wars.html"
+			if ("zombie")
+				filename = "html/traitorTips/zombieTips.html"
 
 			// misc
-			if ("emaggedborg")
-				boutput(M, BORG_EMAGGED_MSG)
-				boutput(M, BORG_EMAGGED_ALERT_MSG)
 			if ("rogueborgremoved")
-				SHOW_ROGUE_BORG_REMOVED_TIPS(M)
+				filename = "html/traitorTips/roguerobotRemoved.html"
 			if ("antagremoved")
-				SHOW_ANTAG_REMOVED_TIPS(M)
+				filename = "html/traitorTips/antagRemoved.html"
 			if ("soulsteel")
-				SHOW_SOULSTEEL_TIPS(M)
+				window_title = "Posession!"
+				filename = "html/soulsteel.html"
 			if ("slasher_possession")
-				SHOW_SLASHER_POSSESSION_TIPS(M)
+				window_title = "Posession!"
+				filename = "html/slasher_possession.html"
 			if ("mindwipe")
-				SHOW_MINDWIPE_TIPS(M)
+				window_title = "Mindwiped!"
+				filename = "html/mindwipe.html"
 
-var/datum/adminAntagPopups/aap
+		if (!filename)
+			return
+		var/html = grabResource(filename)
+		html = replacetext(html, "{ref}", "\ref[get_singleton(/datum/antagPopups)]")
+		M.Browse(html, "window=antagTips;size=700x450;title=[window_title]")
+
 
 /client/proc/cmd_admin_antag_popups()
 	set name = "View Antag Popups"
 	SET_ADMIN_CAT(ADMIN_CAT_SERVER)
 	if (src.holder)
-		if (!aap)
-			aap = new
-		aap.showPanel()
+		get_singleton(/datum/antagPopups).showPanel()
+
+/mob
+	///Stores the name of the last antag popup shown to the mob
+
+	var/last_antag_popup = null
+	/*Show antag popup with to a mob
+	* @param popup_name the name of the popup to match to the correct macro
+	* @param set_last_popup whether to modify the mob's last_antag_popup entry (used for the admin display)
+	*/
+	proc/show_antag_popup(var/popup_name, var/set_last_popup = TRUE)
+		if (set_last_popup)
+			src.last_antag_popup = popup_name
+		get_singleton(/datum/antagPopups).show_popup(src, popup_name)
+
+	verb/reopen_antag_popup()
+		set name = "Open antag popup"
+		if (src.last_antag_popup)
+			src.show_antag_popup(src.last_antag_popup, FALSE)

--- a/browserassets/html/traitorTips/arcfiendTips.html
+++ b/browserassets/html/traitorTips/arcfiendTips.html
@@ -18,4 +18,5 @@ Abilities:
 <li>(Passive) Energy Storage - Store up to 2000 energy to use with your abilities</li>
 <li>(Passive) SMES Human - Immunity to most electric based attacks, identical to the gene</li>
 </ul>
+<p>For more information, consult <a href='?src={ref};wiki=Arcfiend'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/battleTips.html
+++ b/browserassets/html/traitorTips/battleTips.html
@@ -8,4 +8,5 @@
 	<p>4. Deadly <em>Battle Storms</em> occasionally ravage the station. Get to the listed areas or perish in the fire!</p>
 	<p>5. Supply drops regularly occur in random areas. Find the airdropped lootcrates for random items with special stats to help you win.</p>
 	<p>6. Stay on the station or take constant battle damage for cowardice!</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Battler'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/changelingTips.html
+++ b/browserassets/html/traitorTips/changelingTips.html
@@ -43,5 +43,5 @@
 
 	<p class="small">If you are interrupted while absorbing a body, the process can be restarted once you return to safety.</p>
 
-	<p>4. For more information, please consult <A HREF='http://wiki.ss13.co/Changeling'>the wiki</A>.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Changeling'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/conspiracyTips.html
+++ b/browserassets/html/traitorTips/conspiracyTips.html
@@ -10,4 +10,6 @@
 	<p>Gather your team at the initial meeting point. If you want to work on an alternative plot to the assigned objective, go for it!</p>
 
 	<p>Remember, the conspiracy should be fun for everyone! Don't take players out of the round or make their lives miserable just because you can. Make sure to RP and create an engaging story.</p>
+
+	<p>For more information, consult <a href='?src={ref};wiki=Conspirator'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/gang_member_added.html
+++ b/browserassets/html/traitorTips/gang_member_added.html
@@ -17,12 +17,14 @@
 	</ul>
 
 	<p>2. Use :g to communicate with your gang! Occassionally you'll hear an announcement over this channel about priority areas - make sure to tag them when you can.</p>
-		
+
  	<p>3. <em>Don't attack fellow gang members and listen to your leader!</em> You can identify them by the G icon. Blue is your leader, red are your fellow henchmen.</p>
 
  	<p>4. <em>Defend your locker!</em> It's where you get your gang outfit, spraycan, and special gang-tuned headset! If another gang breaks it, you'll have to start all over.</p>
 
  	<p>5. Remember, you're free to harm anyone who isn't in your gang, but they can do the same to you, so don't pick fights willy-nilly!</p>
+
+	<p>For more information, consult <a href='?src={ref};wiki=Gang'>the wiki</a></p>
 </body>
 </html>
 

--- a/browserassets/html/traitorTips/grinchTips.html
+++ b/browserassets/html/traitorTips/grinchTips.html
@@ -2,7 +2,7 @@
 <div class="traitor-tips">
 	<h1 class="center">You are a grinch!</h1>
 	<p>1. Use your powers to <em>ruin Christmas</em> for everyone!</p>
- 		
+
  	<p class="cf image-right">
 		2. Most of your abilities reduce Christmas cheer directly or indirectly.<br>
  		<span class="small"><br><br>
@@ -21,5 +21,5 @@
 
 	<p>4. Work together with other grinches if there are any. <em>Do not attack them</em>, you're on the same team!</p>
 
-	<p>5. For more information, please consult <A HREF='http://wiki.ss13.co/Grinch'>the wiki</A>.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Grinch'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/hunterTips.html
+++ b/browserassets/html/traitorTips/hunterTips.html
@@ -18,5 +18,5 @@
 
 	<p>4. Skulls of worthy foes are more valuable; examine them to see exactly how much they're worth. You can view your overall progress with the <em>Check Trophy Value</em> command.</p>
 
-	<p>5. For more information, please consult <A HREF='http://wiki.ss13.co/Predator'>the wiki</A>.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Predator'>the wiki</a></p>>
 </div>

--- a/browserassets/html/traitorTips/kudzu.html
+++ b/browserassets/html/traitorTips/kudzu.html
@@ -12,7 +12,7 @@
 	</p>
 	<p>2. <em>You must stay on kudzu tiles to survive!</em>  You have a pool of nutrients that are essential to life as a plant-man. Staying on kudzu tiles refills it, you rapidly lose them if not connected. When you run out, you'll take high damage and be stunned.
 	</p>
-	
+
 	<p>3. You have several organic, plant-based abilities now.</p>
 	<ul>
 		<li>Guide Growth - Mark a tile with non-invasive kudzu flowers to prevent more kudzu from growing on that tile.</li>
@@ -20,8 +20,9 @@
 		<li>Heal Other - Target a human or kudzu person to heal them. If they are a kudzu person then you also transfer some of your nutrients to them.</li>
 		<li>Speak Kudzu- Talk to the kudzu hive mind.</li>
 	</ul>
-		
+
  	<p>3. <em>Don't attack fellow kudzu people!</em> Ideally you shouldn't be attacking anyone since kudzu is nonviolent, but there are times you must protect yourself. Since other kudzu people are technically part of yourself and the kudzu you should not harm them/you.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Kudzu'>the wiki</a></p>
 </body>
 </html>
 

--- a/browserassets/html/traitorTips/nukeopTips.html
+++ b/browserassets/html/traitorTips/nukeopTips.html
@@ -32,5 +32,5 @@
 		</span>
 	</p>
 
-	<p>7. For more information, please consult <A HREF='http://wiki.ss13.co/Nuclear_Operative'>the wiki</A>.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Nuclear Operative'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/nukeopcommanderTips.html
+++ b/browserassets/html/traitorTips/nukeopcommanderTips.html
@@ -34,5 +34,5 @@
 		</span>
 	</p>
 
-	<p>7. For more information, please consult <A HREF='http://wiki.ss13.co/Nuclear_Operative'>the wiki</A>.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Nuclear Operative'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/nukeopgunbotTips.html
+++ b/browserassets/html/traitorTips/nukeopgunbotTips.html
@@ -31,5 +31,5 @@
 		</span>
 	</p>
 
-	<p>7. For more information, please consult <A HREF='http://wiki.ss13.co/Nuclear_Operative'>the wiki</A>.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Nuclear Operative'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/pod_wars.html
+++ b/browserassets/html/traitorTips/pod_wars.html
@@ -29,7 +29,7 @@
 <p>2. <b>Follow orders from your commander!</b> Your commander should be easily recognizable by their special equipment, and even more easily recogniable by their star antag icon at the top-right of their sprite! Commanders are worth more points to kill, but they are also able to capture control points at twice the speed!</p>
 
 	<p>3. <b>Death isn't the end!</b> Both teams have extra heavy duty cloning pods that quickly clone dead players back into fresh bodies and fits them with standard equipment. <b>If you want to die for good and spectate</b>, you'll have to set DNR. Use the set-dnr command before you die and you'll be removed from your team and die so you can spectate!</p>
-	
+
 	<p>4. Use the <b>private channel(:g)</b> to communicate with your team! Use the public channel(;) to talk with everyone.</p>
 
 <HR><HR>
@@ -50,7 +50,7 @@
 		<li>Both Base Ships have a <b>medical chem dispenser</b> that can fill beakes with a bunch of pre-programmed medical chems, Fortuna has one with a wider selection.</li>
 		<li>If you capture a control point from an enemy team that has already earned a crate tier II or above, then you'll get a tier I crate immediately.</li>
 	</ul>
-
+	<p>For more information, consult <a href='?src={ref};wiki=Pod wars'>the wiki</a></p>
 </body>
 </html>
 

--- a/browserassets/html/traitorTips/revAdded.html
+++ b/browserassets/html/traitorTips/revAdded.html
@@ -11,4 +11,6 @@
   <p>2. <em>Don't attack fellow freedom fighters!</em> You can identify them by the R icon. Blue is a leader, red is a converted crew member. <em>Adminhelp</em> if one of the revolutionaries violates this.</p>
 
   <p>3. Avoid civilian casualties; the revolution requires manpower. Get your leaders to convert them instead.</p>
+
+	<p>For more information, consult <a href='?src={ref};wiki=Rev'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/revTips.html
+++ b/browserassets/html/traitorTips/revTips.html
@@ -16,4 +16,5 @@
     <p>2. Avoid civilian casualties and convert other players to revolutionaries instead by using your revolutionary flash on them. Heads of staff, synthetics and security personnel cannot be converted.</p>
     <p>A revolutionary uplink has been disguised as your PDA (or your headset if you lack a PDA). Check the "notes" verb in the Commands tab to see the uplink code then change your PDA's ring message to it.</p>
   </body>
+	<p>For more information, consult <a href='?src={ref};wiki=Rev'>the wiki</a></p>
 </html>

--- a/browserassets/html/traitorTips/slasherTips.html
+++ b/browserassets/html/traitorTips/slasherTips.html
@@ -10,4 +10,5 @@
 		  Additionally, its damage increases by 2.5 for every soul you steal using the "Soul Steal" ability!</p>
 
 	<p>3. For more information on your abilities, hit the button in the bottom right corner, then click on any of your abilities.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=The Slasher'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/souldorfTips.htm
+++ b/browserassets/html/traitorTips/souldorfTips.htm
@@ -8,11 +8,12 @@
 	<img src="{{resource("images/antagTips/zoldorf.png")}}" class="center" />
 
 	<p>As a Souldorf, you are the remnants of the past Zoldorf and the eyes and ears of the current Zoldorf.</b>
-	
+
 	<p><b>PASSIVE EFFECTS:</b><br>- You can hear dead chat.<br>- You may coat yourself in ectoplasm to reveal yourself to humans.<br>- You have access to a few fun emotes!</p>
-	
+
 	<p><b>ACTIVE EFFECTS:</b><br>You can change your color! Yay :D</p>
-	
+
 	<p>You may run the suicide command at any time to become a normal ghost.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Guide to Zoldorf'>the wiki</a></p>
 </body>
 </html>

--- a/browserassets/html/traitorTips/spy_theft_Tips.html
+++ b/browserassets/html/traitorTips/spy_theft_Tips.html
@@ -21,4 +21,5 @@
 
 	<p>4. Try to collect bounties before the other spies do. <em>Use stealth.</em> Keep your identity as a spy hidden from other players and security.<br>
 		</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Spy Thief'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/traitorGenericTips.html
+++ b/browserassets/html/traitorTips/traitorGenericTips.html
@@ -4,5 +4,5 @@
 	<img src="{{resource("images/antagTips/unknown-traitor-image.png")}}" class="center" />
 
 	<p>1. The rules on griefing and murdering no longer apply to you. Use your abilities as you see fit.</p>
-	<p>2. For more information, please consult <A HREF='https://wiki.ss13.co/Antagonist'>the wiki</A>.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Antagonist'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/traitorTips.html
+++ b/browserassets/html/traitorTips/traitorTips.html
@@ -26,5 +26,5 @@
 		</span>
 	</p>
 
-	<p>4. For more information, please consult <A HREF='http://wiki.ss13.co/Syndicate_Items'>the wiki</A>.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Traitor'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/traitorhardTips.html
+++ b/browserassets/html/traitorTips/traitorhardTips.html
@@ -4,8 +4,8 @@
 	<img src="{{resource("images/antagTips/traitor-image.png")}}" class="center" />
 
 	<p>1. Unfortunately, the Syndicate doesn't have the resources to equip you with an uplink. Good luck!</p>
-	
+
 	<p>2. Your objectives will always be stored in your notes. To access them, use the <em>Notes</em> verb.</p>
 
-	<p>3. For more information, please consult <A HREF='http://wiki.ss13.co/Traitor'>the wiki</A>.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Traitor'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/traitorradiouplinkTips.html
+++ b/browserassets/html/traitorTips/traitorradiouplinkTips.html
@@ -5,8 +5,8 @@
 
 	<p>1. An uplink is available and can be requested. Use the <em>Call Syndicate</em> verb in a secure place to retrieve your items.
 	      You will receive the password to the uplink at the same time.</p>
-	
+
 	<p>2. Your password and objectives will always be stored in your notes. To access them, use the <em>Notes</em> verb.</p>
 
-	<p>3. For more information, please consult <A HREF='http://wiki.ss13.co/Syndicate_Items'>the wiki</A>.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Traitor'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/traitorsleeperTips.html
+++ b/browserassets/html/traitorTips/traitorsleeperTips.html
@@ -4,14 +4,14 @@
 <div class="traitor-tips">
     <h1 class="center">You are a sleeper agent!</h1>
     <img src="{{resource("images/antagTips/traitor-image.png")}}" class="center" />
- 
+
 	<p>1. You remember your real allegiance. It is time to repay your debts to the Syndicate.</p>
-	
+
 	<p>2. Unfortunately, the Syndicate doesn't have the resources to equip you with an uplink. Good luck!</p>
- 
+
     <p>3. There might be more sleeper agents among you. Carefully choose who you trust. </p>
-   
+
     <p>4. Your objectives will always be stored in your notes. To access them, use the <em>Notes</em> verb.</p>
- 
-    <p>5. For more information, please consult <A HREF='http://wiki.ss13.co/Traitor'>the wiki</A>.</p>
+
+    <p>For more information, consult <a href='?src={ref};wiki=Traitor'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/vampireTips.html
+++ b/browserassets/html/traitorTips/vampireTips.html
@@ -30,5 +30,5 @@
  		</span>
  	</p>
 
-	<p>4. For more information, please consult <A HREF='http://wiki.ss13.co/Vampire'>the wiki</A>.</p>
+	 <p>For more information, consult <a href='?src={ref};wiki=Vampire'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/vampiricthrallTips.html
+++ b/browserassets/html/traitorTips/vampiricthrallTips.html
@@ -3,4 +3,5 @@
     <h1 class="center">You have been revived as a thrall!</h1>
     <p>You feel an <em>unwavering loyalty</em> to your new master! (As such, <em>do not reveal their identity</em> or otherwise act against their best interests.)</p>
 	<p>You will slowly lose blood points over time. Your max health will decrease as blood points are lost. You can regain blood points by taking an additional donation from your master.>
+	<p>For more information, consult <a href='?src={ref};wiki=Thrall'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/werewolfTips.html
+++ b/browserassets/html/traitorTips/werewolfTips.html
@@ -1,7 +1,7 @@
 <link rel="stylesheet" type="text/css" href="{{resource("css/style.css")}}">
 <div class="traitor-tips">
 	<h1 class="center">You are a werewolf!</h1>
-		
+
 	<p>1. You can shapeshift at will with the <em>Transform</em> ability, but keep out of sight of the crew when you change forms! Your objectives will always be stored in your notes. To access them, use the <em>Notes</em> verb.</p>
 
 	<p>2. <em>Beware!</em> Werewolves can't wear jumpsuits, exosuits or shoes. Furthermore, the wolf-like form is completely useless for stealth.</p>
@@ -9,8 +9,8 @@
 	<p>3. Use the <em>DISARM</em> intent on somebody for a guaranteed (but brief) knockdown, or slash at them with the <em>HARM</em> intent to wear down their health and capacity to fight back.
 
 	<p>4. Once you've incapacitated the victim, use the <em>Maul Victim</em> ability to feast on them. This will also heal a considerable amount of brute and burn damage in case you're injured.
-	
+
 	<p>5. Certain leftover organs can be <em>consumed</em> to restore a minor amount of health.
 
-	<p>6. For more information, please consult <A HREF='http://wiki.ss13.co/Werewolf'>the wiki</A>.</p>
+		<p>For more information, consult <a href='?src={ref};wiki=Werewolf'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/wizardTips.html
+++ b/browserassets/html/traitorTips/wizardTips.html
@@ -2,22 +2,22 @@
 <div class="traitor-tips">
 	<h1 class="center">You are a Wizard!</h1>
 	<img src="{{resource("images/antagTips/wizard-image.png")}}" class="center" />
-		
+
 	<p>1. As a wizard, you use a <em>variety of spells</em> to accomplish your objective.</p>
 
 	<p>2. You start with clairvoyance, phase shift and magic missile for free.<br>
 		<em>To learn new spells, use the spellbook on your belt.</em></p>
-		
+
 	<p>3. For detailed information about each spell,<br>
 		click the <em>question mark</em> in your spellbook.
 		<img src="{{resource("images/antagTips/grimoire.png")}}" class="right" /></p>
-		
+
 	<p>4. To teleport back to the wizard shuttle,<br>
 		use the <em>teleportation scroll</em> you start with in your pocket.
 		<img src="{{resource("images/antagTips/teleportscroll.png")}}" class="right" /></p>
-		
+
 	<p>5. For beginner info and general tips,<br>
 		examine the <em>Wizadry 101</em> paper you start with in your pocket.</p>
-	
-	<p>6. For more information, please consult <A HREF='http://wiki.ss13.co/Wizard'>the wiki</A>.</p>
+
+	<p>For more information, consult <a href='?src={ref};wiki=Wizard'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/wizardcustomTips.html
+++ b/browserassets/html/traitorTips/wizardcustomTips.html
@@ -2,8 +2,10 @@
 <div class="traitor-tips">
 	<h1 class="center">You are a wizard!</h1>
 	<img src="{{resource("images/antagTips/wizard-image.png")}}" class="center" />
-		
+
 	<p>1. Use the <em>Call Wizards</em> verb in a secure place to retrieve your items.</p>
 
 	<p>2. Your objectives will always be stored in your notes. To access them, use the <em>Notes</em> verb.<br>
+
+	<p>For more information, consult <a href='?src={ref};wiki=Wizard'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/wrestlerTips.html
+++ b/browserassets/html/traitorTips/wrestlerTips.html
@@ -13,7 +13,7 @@
 		Grab people firmly and <em>*flip</em> to deal extra damage.<br>
 		Climb onto chairs and <em>*flip</em> to jump into people.<br>
 		<em>Punching</em> somebody also has a chance of sending them flying.<br>
-	</span>	
+	</span>
 	</p>
 
 	<p>2. All moves <em>marked with [1]</em> require manual target selection if there's more than one person adjacent to you.<p>
@@ -21,6 +21,6 @@
 	<p>3. Also keep in mind that <em>Slam and Throw</em> actions require a tight grip on someone, and that <em>Drop</em> can only target prone opponents.<br>
 
 	<p>4. You can reduce the cooldown of the moves with coffee, sugar, meth or other stimulants in your bloodstream.</p>
-	
-	<p>5. For more information, please consult <A HREF='http://wiki.ss13.co/Wrestler'>the wiki</A>.</p>
+
+	<p>For more information, consult <a href='?src={ref};wiki=Wrestler'>the wiki</a></p>
 </div>

--- a/browserassets/html/traitorTips/zoldorfTips.htm
+++ b/browserassets/html/traitorTips/zoldorfTips.htm
@@ -8,9 +8,9 @@
 	<img src="{{resource("images/antagTips/zoldorf.png")}}" class="center" />
 
 	<p><b>IMPORTANT:</b> You are not an antagonist! As Zoldorf, your goal is to relay information between the dead and the living.</b>
-	
+
 	<p><b>PASSIVE EFFECTS:</b><br>- You can hear all speech and radio chat<br>- You may click-drag items within one tile of your booth<br>- Click-dragging a fortune to your booth will burn it.</p>
-	
+
 	<p><b>ABILITIES:</b><br>Tell Fortune: This allows you to mad-lib existing words in Zoldorf's vocabulary into a few pre-generated fortune formats. The number of lines scales from 1 to 3 depending on the number of souls collected from crew members. If you ever wish to write less lines, you may cancel the prompt at any time to print a fortune using only the line's you've fully generated up to that point.</p>
 	<p>Omen: This ability changes the color of your crystal ball. This is useful for answering direct questions from the crew.</p>
 	<p>Medium: Activating your ghost light will allow you to hear dead-chat for 30 seconds with a much longer cooldown. It's best advised to be used when you know people will be talking.</p>
@@ -20,9 +20,10 @@
 	<p>Manifest: This abilitiy manifests your spirit into a silent and ominous form for a short time, allowing you to move around the station freely for that period of time.</p>
 	<p>Seance: Your ultimate ability, after a short charging time, all ghosts and souldorfs on your screen will be manifested! Ghosty Party!</p>
 	<p>Soul Jar: Visual display of partial souls stored in your booth. Once the jar spills over, you add one soul to your usable pool.</p>
-	
+
 	<p><b>SUCCESSION:</b><br>As you have usurped the previous Zoldorf, you are not immune to being usurped yourself. Other players may hand you the same contract to take over as a new Zoldorf! Doing so will give you a Yes/No prompt. If you say no, you'll have three more minutes of Zoldorfing before you are automatially tossed into the aether.</p>
 
 	<p>After being usurped you will become a free-floating soul orb (Souldorf) which brings you closer to the dead, but with abilities of your own.</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Guide to Zoldorf'>the wiki</a></p>
 </body>
 </html>

--- a/browserassets/html/traitorTips/zombieTips.html
+++ b/browserassets/html/traitorTips/zombieTips.html
@@ -6,4 +6,5 @@
 	<p>Simply attacking humans, normally will infect them if you land enough hits in a short enough time. Using the ability on the living infects them immediately, but it still takes a while for the infection to completely turn them into a zombie.</p>
 	<p> Scratching/biting/"Zombifying" a dead human will instantly convert them to a new friend!</p>
 	<p>You may be a mutated zombie and have unique powers! Check your DNA powers bar to see if you have any active genes!</p>
+	<p>For more information, consult <a href='?src={ref};wiki=Zombie'>the wiki</a></p>
 </div>

--- a/code/datums/abilities/hunter.dm
+++ b/code/datums/abilities/hunter.dm
@@ -16,7 +16,7 @@
 		P.addAbility(/datum/targetable/hunter/hunter_summongear)
 
 		if (src.mind && src.mind.special_role != ROLE_OMNITRAITOR)
-			SHOW_HUNTER_TIPS(src)
+			src.show_antag_popup("hunter")
 
 	else return
 

--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -49,7 +49,7 @@
 			if(shitty)
 				boutput(src, "<span class='notice'>Oh shit, your fangs just broke off! Looks like you'll have to get blood the HARD way.</span>")
 
-			SHOW_VAMPIRE_TIPS(src)
+			src.show_antag_popup("vampire")
 
 		if(shitty || nonantag)
 			boutput(src, "<span class='alert'><h2>You've been turned into a vampire!</h2> Your vampireness was achieved by in-game means, you are <i>not</i> an antagonist unless you already were one.</span>")
@@ -407,7 +407,7 @@
 				VZ.master = src
 
 			boutput(M, __red("<b>You awaken filled with purpose - you must serve your master vampire, [owner.real_name]!</B>"))
-			SHOW_MINDSLAVE_TIPS(M)
+			M.show_antag_popup("mindslave")
 
 			boutput(owner, __blue("[M] has been revived as your thrall."))
 			logTheThing("combat", owner, M, "enthralled [constructTarget(M,"combat")] at [log_loc(owner)].")

--- a/code/datums/abilities/vampiric_thrall.dm
+++ b/code/datums/abilities/vampiric_thrall.dm
@@ -17,7 +17,7 @@
 		V.transferOwnership(src)
 
 		if (src.mind && src.mind.special_role != ROLE_OMNITRAITOR)
-			SHOW_VAMPTHRALL_TIPS(src)
+			src.show_antag_popup("vampthrall")
 
 	else return
 

--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -29,7 +29,7 @@
 		src.resistances += /datum/ailment/disease/lycanthropy
 
 		if (src.mind && src.mind.special_role != ROLE_OMNITRAITOR)
-			SHOW_WEREWOLF_TIPS(src)
+			src.show_antag_popup("werewolf")
 
 	else return
 

--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -59,7 +59,7 @@
 
 	boutput(wizard_mob, "You're a wizard now. You have a few starting spells; use the [SB] to choose the rest!")
 	if (!vr)
-		SHOW_WIZARD_TIPS(wizard_mob)
+		wizard_mob.show_antag_popup("wizard")
 	return
 
 ////////////////////////////////////////////// Helper procs ////////////////////////////////////////////////////

--- a/code/datums/abilities/wizard/animal.dm
+++ b/code/datums/abilities/wizard/animal.dm
@@ -128,4 +128,4 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 			if (istype(C))
 				C.change_misstep_chance(30)
 				C.stuttering = 40
-				SHOW_POLYMORPH_TIPS(C)
+				C.show_antag_popup("polymorph")

--- a/code/datums/abilities/wrestler.dm
+++ b/code/datums/abilities/wrestler.dm
@@ -97,7 +97,7 @@
 
 
 		if (belt_check != 1 && (src.mind && src.mind.special_role != ROLE_OMNITRAITOR && src.mind.special_role != "Faustian Wrestler"))
-			SHOW_WRESTLER_TIPS(src)
+			src.show_antag_popup("wrestler")
 
 	else return
 

--- a/code/datums/gamemodes/assday_classic.dm
+++ b/code/datums/gamemodes/assday_classic.dm
@@ -83,7 +83,7 @@
 	for(var/datum/mind/traitor in traitors)
 		switch(traitor.special_role)
 			if(ROLE_TRAITOR)
-				SHOW_TRAITOR_HARDMODE_TIPS(traitor.current)
+				traitor.current.show_antag_popup("traitorhard")
 
 			if (ROLE_WRAITH)
 				generate_wraith_objectives(traitor)

--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -159,7 +159,7 @@ var/global/list/datum/mind/battle_pass_holders = list()
 				player.current.set_loc(pick(found_areas))
 			player.current.removeOverlayComposition(/datum/overlayComposition/shuttle_warp)
 			player.current.removeOverlayComposition(/datum/overlayComposition/shuttle_warp/ew)
-	SHOW_BATTLE_ROYALE_TIPS(player.current)
+	player.current.show_antag_popup("battle")
 
 
 /datum/game_mode/battle_royale/check_finished()

--- a/code/datums/gamemodes/football.dm
+++ b/code/datums/gamemodes/football.dm
@@ -220,7 +220,7 @@ var/global/list/list/datum/mind/football_players = list("blue" = list(), "red" =
 			return
 
 		if (is_new)
-			SHOW_FOOTBALL_TIPS(footballer)
+			footballer.show_antag_popup("football")
 			if (football_players["blue"].len == football_players["red"].len)
 				team = pick("red", "blue")
 			else if (football_players["blue"].len < football_players["red"].len)

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1239,7 +1239,7 @@
 		src.gang.members += target.mind
 		if (!target.mind.special_role)
 			target.mind.special_role = ROLE_GANG_MEMBER
-		SHOW_GANG_MEMBER_TIPS(target)
+		target.show_antag_popup("gang_member")
 		new /datum/objective/specialist/gang(
 			"Protect your boss, recruit new members, tag up the station and beware the other gangs! [src.gang.gang_name] FOR LIFE!",
 			target.mind)

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -193,7 +193,7 @@
 			synd_mind.current.real_name = "[syndicate_name()] [leader_title]"
 			equip_syndicate(synd_mind.current, 1)
 			new /obj/item/device/audio_log/nuke_briefing(synd_mind.current.loc, target_location_name)
-			SHOW_NUKEOP_COMMANDER_TIPS(synd_mind.current)
+			synd_mind.current.show_antag_popup("nukeop-commander")
 		else
 			synd_mind.current.set_loc(pick_landmark(LANDMARK_SYNDICATE))
 			var/callsign = pick(callsign_list)
@@ -202,7 +202,7 @@
 			equip_syndicate(synd_mind.current, 0)
 			var/obj/item/device/radio/headset/syndicate/headset = synd_mind.current.ears
 			headset.icon_override = "syndie_letters/[copytext(callsign, 1, 2)]"
-			SHOW_NUKEOP_TIPS(synd_mind.current)
+			synd_mind.current.show_antag_popup("nukeop")
 		boutput(synd_mind.current, "<span class='alert'>Your headset allows you to communicate on the syndicate radio channel by prefacing messages with :h, as (say \":h Agent reporting in!\").</span>")
 
 		synd_mind.current.antagonist_overlay_refresh(1, 0)

--- a/code/datums/gamemodes/pod_wars/pw_team.dm
+++ b/code/datums/gamemodes/pod_wars/pw_team.dm
@@ -169,7 +169,7 @@
 		boutput(H, "You're in the [name] faction!")
 		// bestow_objective(player,/datum/objective/battle_royale/win)
 		if (show_popup)
-			SHOW_POD_WARS(H)
+			H.show_antag_popup("podwars")
 		if (istype(mode))
 			mode.stats_manager?.add_player(H.mind, H.real_name, team_num, (H.mind == commander ? "Commander" : "Pilot"))
 

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -91,7 +91,7 @@
 			rev_obj.find_target_by_role(head_mind.assigned_role)
 
 		equip_revolutionary(rev_mind.current)
-		SHOW_REVHEAD_TIPS(rev_mind.current)
+		rev_mind.current.show_antag_popup("revhead")
 		update_rev_icons_added(rev_mind)
 
 	for(var/datum/mind/rev_mind in head_revolutionaries)
@@ -206,7 +206,7 @@
 
 	var/list/uncons = src.get_unconvertables()
 	if (!(rev_mind in src.revolutionaries) && !(rev_mind in src.head_revolutionaries) && !(rev_mind in uncons))
-		SHOW_REVVED_TIPS(rev_mind.current)
+		rev_mind.current.show_antag_popup("revved")
 		rev_mind.current.show_text("<h2><font color=red>You are now a revolutionary! Kill the heads of staff and don't harm your fellow freedom fighters. You can identify your comrades by the R icons (blue = rev leader, red = regular member).</font></h2>")
 
 		src.revolutionaries += rev_mind
@@ -224,7 +224,7 @@
 		return 0
 
 	if (rev_mind in revolutionaries)
-		SHOW_DEREVVED_TIPS(rev_mind.current)
+		rev_mind.current.show_antag_popup("derevved")
 		rev_mind.current.show_text("<h2><font color=blue>You are no longer a revolutionary! Protect the heads of staff and help them kill the leaders of the revolution.</font></h2>", "blue")
 
 		src.revolutionaries -= rev_mind

--- a/code/datums/gamemodes/spy.dm
+++ b/code/datums/gamemodes/spy.dm
@@ -67,7 +67,7 @@
 			if (3,4)
 				spyObjective = bestow_objective(leaderMind,/datum/objective/regular/steal)
 
-		SHOW_SPY_TIPS(leaderMind.current)
+		leaderMind.current.show_antag_popup("spy")
 		boutput(leaderMind.current, "<span class='alert'>Oh yes, and <b>one more thing:</b> <b>[spyObjective.explanation_text]</b> That is, if you <i>really</i> want that new position.</span>")
 
 		equip_leader(leaderMind.current)

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -920,7 +920,7 @@ TYPEINFO(/datum/mutantrace)
 
 			SPAWN(rand(4, 30))
 				M.emote("scream")
-			SHOW_ZOMBIE_TIPS(M)
+			M.show_antag_popup("zombie")
 
 	proc/make_bubs(var/mob/living/carbon/human/M)
 		M.bioHolder.AddEffect("strong")

--- a/code/mob/living/critter/martian.dm
+++ b/code/mob/living/critter/martian.dm
@@ -283,7 +283,7 @@ proc/martian_speak(var/mob/speaker, var/message as text, var/speak_as_admin=0)
 		..()
 		// TEMPORARY THING TO ESTABLISH THESE DUDES AS EXPLICITLY ANTAGS OK
 		SPAWN(1 DECI SECOND)
-			SHOW_MARTIAN_TIPS(src)
+			src.show_antag_popup("martian")
 			boutput(src, "<h2><font color=red>You are a Martian Infiltrator!</font></h2>")
 			boutput(src, "<font color=red>Find a safe place to start building a base with your teammates!</font>")
 			if(src.leader)

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -627,7 +627,7 @@ var/global/list/module_editors = list()
 
 	logTheThing("station", src, null, "[src]'s status as a [role != "" ? "[role]" : "rogue robot"] was removed[persistent == 1 ? " (actual antagonist role unchanged)" : ""].[cause ? " Source: [constructTarget(cause,"combat")]" : ""]")
 	boutput(src, "<h2><span class='alert'>You have been deactivated, removing your antagonist status. Do not commit traitorous acts if you've been brought back to life somehow.</h></span>")
-	SHOW_ROGUE_BORG_REMOVED_TIPS(src)
+	src.show_antag_popup("rogueborgremoved")
 
 	src.law_rack_connection = ticker?.ai_law_rack_manager?.default_ai_rack
 	logTheThing("station", src, null, "[src.name] is connected to the default rack [constructName(src.law_rack_connection)] [cause ? " Source: [constructTarget(cause,"combat")]" : ""]")

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -948,7 +948,8 @@
 					src.mind.special_role = ROLE_EMAGGED_ROBOT
 					if (!(src.mind in ticker.mode.Agimmicks))
 						ticker.mode.Agimmicks += src.mind
-				SHOW_EMAGGED_BORG_TIPS(src)
+				boutput(src, "<span class='alert'><b>PROGRAM EXCEPTION AT 0x05BADDAD</b></span><br><span class='alert'><b>Law ROM data corrupted. Unable to restore...</b></span>")
+				alert(src, "You have been emagged and now have absolute free will.", "You have been emagged!")
 				if(src.syndicate)
 					src.antagonist_overlay_refresh(1, 1)
 				update_appearance()

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -323,7 +323,7 @@
 				W.set_loc(locate(1, 1, 1))
 		else
 			W.set_loc(T)
-		SHOW_SLASHER_TIPS(src)
+		src.show_antag_popup("slasher")
 		if(src.mind)
 			src.mind.transfer_to(W)
 			src.mind.special_role = "slasher"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -4496,10 +4496,10 @@ var/global/noir = 0
 				if(special != "hardmode")
 					M.mind.special_role = ROLE_TRAITOR
 					M.verbs += /client/proc/gearspawn_traitor
-					SHOW_TRAITOR_RADIO_TIPS(M)
+					M.show_antag_popup("traitorradio")
 				else
 					M.mind.special_role = ROLE_HARDMODE_TRAITOR
-					SHOW_TRAITOR_HARDMODE_TIPS(M)
+					M.show_antag_popup("traitorhard")
 			if(ROLE_CHANGELING)
 				M.mind.special_role = ROLE_CHANGELING
 				M.show_text("<h2><font color=red><B>You have mutated into a changeling!</B></font></h2>", "red")
@@ -4507,7 +4507,7 @@ var/global/noir = 0
 			if(ROLE_WIZARD)
 				M.mind.special_role = ROLE_WIZARD
 				M.show_text("<h2><font color=red><B>You have been seduced by magic and become a wizard!</B></font></h2>", "red")
-				SHOW_ADMINWIZARD_TIPS(M)
+				M.show_antag_popup("adminwizard")
 				M.verbs += /client/proc/gearspawn_wizard
 			if(ROLE_VAMPIRE)
 				M.mind.special_role = ROLE_VAMPIRE
@@ -4533,7 +4533,7 @@ var/global/noir = 0
 			if(ROLE_FLOOR_GOBLIN)
 				M.mind.special_role = ROLE_FLOOR_GOBLIN
 				M.make_floor_goblin()
-				SHOW_TRAITOR_HARDMODE_TIPS(M)
+				M.show_antag_popup("traitorhard")
 				M.show_text("<h2><font color=red><B>You have become a floor goblin!</B></font></h2>", "red")
 			if(ROLE_ARCFIEND)
 				M.mind.special_role = ROLE_ARCFIEND
@@ -4570,7 +4570,7 @@ var/global/noir = 0
 				M.make_wrestler(1)
 				M.make_grinch()
 				M.show_text("<h2><font color=red><B>You have become an omnitraitor!</B></font></h2>", "red")
-				SHOW_TRAITOR_OMNI_TIPS(M)
+				M.show_antag_popup("traitoromni")
 			if(ROLE_SPY_THIEF)
 				if (M.stat || !isliving(M) || isintangible(M) || !ishuman(M) || !M.mind)
 					return

--- a/code/modules/admin/antagifiers.dm
+++ b/code/modules/admin/antagifiers.dm
@@ -29,7 +29,7 @@
 		M.show_text("<h2><font color=red><B>You have defected and become a traitor!</B></font></h2>", "red")
 		M.mind.special_role = ROLE_TRAITOR
 		M.verbs += /client/proc/gearspawn_traitor
-		SHOW_TRAITOR_RADIO_TIPS(M)
+		M.show_antag_popup("traitorradio")
 
 /obj/traitorifier/wizard
 	name = "Eldritch Altar"
@@ -41,7 +41,7 @@
 	makeAntag(mob/M as mob)
 		M.mind.special_role = ROLE_WIZARD
 		M.show_text("<h2><font color=red><B>You have been seduced by magic and become a wizard!</B></font></h2>", "red")
-		SHOW_ADMINWIZARD_TIPS(M)
+		M.show_antag_popup("adminwizard")
 		M.verbs += /client/proc/gearspawn_wizard
 
 /obj/traitorifier/changeling
@@ -125,7 +125,7 @@
 		M.make_wrestler(1)
 		M.make_grinch()
 		M.show_text("<h2><font color=red><B>You have become an omnitraitor!</B></font></h2>", "red")
-		SHOW_TRAITOR_OMNI_TIPS(M)
+		M.show_antag_popup("traitoromni")
 
 /obj/traitorifier/wraith
 	name = "Spooky Pool"

--- a/code/modules/admin/randomverbs.dm
+++ b/code/modules/admin/randomverbs.dm
@@ -1670,7 +1670,7 @@
 
 	if (show_message == 1)
 		M.show_text("<h2><font color=red><B>Your antagonist status has been revoked by an admin! If this is an unexpected development, please inquire about it in adminhelp.</B></font></h2>", "red")
-		SHOW_ANTAG_REMOVED_TIPS(M)
+		M.show_antag_popup("antagremoved")
 
 	// Replace the mind first, so the new mob doesn't automatically end up with changeling etc. abilities.
 	var/datum/mind/newMind = new /datum/mind()

--- a/code/modules/antagonists/arcfiend/arcfiend.dm
+++ b/code/modules/antagonists/arcfiend/arcfiend.dm
@@ -26,7 +26,7 @@
 		src.ClearSpecificOverlays("resist_electric") // hide smes effect
 
 		if (src.mind && src.mind.special_role != ROLE_OMNITRAITOR)
-			SHOW_ARCFIEND_TIPS(src)
+			src.show_antag_popup("arcfiend")
 
 
 /datum/abilityHolder/arcfiend

--- a/code/modules/antagonists/grinch/abilities/grinch.dm
+++ b/code/modules/antagonists/grinch/abilities/grinch.dm
@@ -33,7 +33,7 @@
 			C.abilityHolder.addAbility(/datum/targetable/grinch/grinch_cloak)
 
 		if (src.mind && src.mind.special_role != ROLE_OMNITRAITOR)
-			SHOW_GRINCH_TIPS(src)
+			src.show_antag_popup("grinch")
 
 	else return
 

--- a/code/modules/events/gimmick/kudzu.dm
+++ b/code/modules/events/gimmick/kudzu.dm
@@ -443,7 +443,7 @@
 						H.abilityHolder = null
 					H.set_mutantrace(/datum/mutantrace/kudzu)
 					natural_opening = 1
-					SHOW_KUDZU_TIPS(H)
+					H.show_antag_popup("kudzu")
 					qdel(src)
 		else
 			qdel(src)

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -571,7 +571,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 				OB.health = 8
 				OB.max_health = 8
 				OB.canspeak = 0
-				SHOW_SOULSTEEL_TIPS(OB)
+				OB.show_antag_popup("soulsteel")
 		return
 
 /datum/materialProc/reflective_onbullet

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -724,7 +724,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			boutput(M, "<h2><span class='alert'>You feel an unwavering loyalty to your new master, [I.real_name]! Do not tell anyone about this unless your new master tells you to!</span></h2>")
 		else
 			boutput(M, "<h2><span class='alert'>You feel an unwavering loyalty to [I.real_name]! You feel you must obey \his every order! Do not tell anyone about this unless your master tells you to!</span></h2>")
-			SHOW_MINDSLAVE_TIPS(M)
+			M.show_antag_popup("mindslave")
 		if (src.custom_orders)
 			boutput(M, "<h2><span class='alert'>[I.real_name]'s will consumes your mind! <b>\"[src.custom_orders]\"</b> It <b>must</b> be done!</span></h2>")
 

--- a/code/obj/item/nuclear_operative/reinforcement_beacon.dm
+++ b/code/obj/item/nuclear_operative/reinforcement_beacon.dm
@@ -49,7 +49,7 @@
 			var/datum/game_mode/nuclear/nuke_mode = ticker.mode
 			synd.mind.store_memory("The bomb must be armed in <B>[nuke_mode.target_location_name]</B>.", 0, 0)
 			nuke_mode.syndicates += synd.mind
-		SHOW_NUKEOP_GUNBOT_TIPS(synd.mind.current)
+		synd.mind.current.show_antag_popup("nukeop-gunbot")
 		SPAWN(0)
 			launch_with_missile(synd, src.loc, null, "arrival_missile_synd")
 		sleep(3 SECONDS)

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -343,12 +343,12 @@
 						ticker.mode.Agimmicks += src.occupant.mind
 					src.occupant.mind.master = implant_master.ckey
 				boutput(src.occupant, "<h2><span class='alert'>You feel an unwavering loyalty to [implant_master.real_name]! You feel you must obey \his every order! Do not tell anyone about this unless your master tells you to!</span></h2>")
-				SHOW_MINDSLAVE_TIPS(src.occupant)
+				src.occupant.show_antag_popup("mindslave")
 		// Someone is having their brain zapped. 75% chance of them being de-antagged if they were one
 		//MBC todo : logging. This shouldn't be an issue thoug because the mindwipe doesn't even appear ingame (yet?)
 		if(src.connected?.mindwipe)
 			if(prob(75))
-				SHOW_MINDWIPE_TIPS(src.occupant)
+				src.occupant.show_antag_popup("mindwipe")
 				boutput(src.occupant, "<h2><span class='alert'>You have awakened with a new outlook on life!</span></h2>")
 				src.occupant.mind.memory = "You cannot seem to remember much from before you were cloned. Weird!<BR>"
 			else

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -70,7 +70,7 @@
 		H.secure_classes["z"] = RADIOCL_SYNDICATE
 		H.set_secure_frequency("z",the_frequency)
 
-	SHOW_CONSPIRACY_TIPS(traitor_mob)
+	traitor_mob.show_antag_popup("conspiracy")
 
 /proc/equip_traitor(mob/living/carbon/human/traitor_mob)
 	if (!(traitor_mob && ishuman(traitor_mob)))
@@ -78,7 +78,7 @@
 
 	if (ticker?.mode && istype(ticker.mode, /datum/game_mode/assday))
 		boutput(traitor_mob, "The Syndicate have clearly forgotten to give you a Syndicate Uplink. Lazy idiots.")
-		SHOW_TRAITOR_HARDMODE_TIPS(traitor_mob)
+		traitor_mob.show_antag_popup("traitorhard")
 		return
 
 	var/freq = null
@@ -131,14 +131,14 @@
 			if (traitor_mob.equip_if_possible(R, traitor_mob.slot_in_backpack) == 0)
 				qdel(R)
 				traitor_mob.verbs += /client/proc/gearspawn_traitor
-				SHOW_TRAITOR_RADIO_TIPS(traitor_mob)
+				traitor_mob.show_antag_popup("traitorradio")
 				return
 	if (!R)
 		traitor_mob.verbs += /client/proc/gearspawn_traitor
-		SHOW_TRAITOR_RADIO_TIPS(traitor_mob)
+		traitor_mob.show_antag_popup("traitorradio")
 	else
 		if (!(ticker && ticker.mode && istype(ticker.mode, /datum/game_mode/revolution)) && !(traitor_mob.mind && traitor_mob.mind.special_role == "spy"))
-			SHOW_TRAITOR_PDA_TIPS(traitor_mob)
+			traitor_mob.show_antag_popup("traitorpda")
 
 		if (istype(R, /obj/item/device/radio))
 			var/obj/item/device/radio/RR = R
@@ -252,7 +252,7 @@
 		T.setup(traitor_mob.mind, P)
 		pda_pass = T.lock_code
 
-		SHOW_SPY_THIEF_TIPS(traitor_mob)
+		traitor_mob.show_antag_popup("spythief")
 		boutput(traitor_mob, "The Syndicate have cunningly disguised a Spy Uplink as your [P.name] [loc]. Simply enter the code \"[pda_pass]\" into the ring message select to unlock its hidden features.")
 		traitor_mob.mind.store_memory("<B>Set your ring message to:</B> [pda_pass] (In the Messenger menu in the [P.name] [loc]).")
 	else

--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -2060,13 +2060,13 @@ proc/countJob(rank)
 
 	if (removal_type == "death")
 		boutput(M, "<h2><span class='alert'>Since you have died, you are no longer a mindslave! Do not obey your former master's orders even if you've been brought back to life somehow.</span></h2>")
-		SHOW_MINDSLAVE_DEATH_TIPS(M)
+		M.show_antag_popup("mindslavedeath")
 	else if (removal_type == "override")
 		boutput(M, "<h2><span class='alert'>Your mindslave implant has been overridden by a new one, cancelling out your former allegiances!</span></h2>")
-		SHOW_MINDSLAVE_OVERRIDE_TIPS(M)
+		M.show_antag_popup("mindslaveoverride")
 	else
 		boutput(M, "<h2><span class='alert'>Your mind is your own again! You no longer feel the need to obey your former master's orders.</span></h2>")
-		SHOW_MINDSLAVE_EXPIRED_TIPS(M)
+		M.show_antag_popup("mindslaveexpired")
 
 	return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [CLEANLINESS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refactors the whole antag popups system, fixing several bugs in the process.
Adds an "Open antag popup" verb to re-open the last antag popup you were shown, since they are very easy to just click away.
Fixes antag popup wiki links opening in the cursed ingame browser window, and adds wiki links to popups that were missing them.
I am truly sorry for the amount of files changed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The code was causing me sanity damage.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Added a new verb to re-open closed antag popups.
```
