### PR TITLE
Reduces the amount of players needed to get higher blob counts

### DIFF
--- a/code/datums/gamemodes/blob.dm
+++ b/code/datums/gamemodes/blob.dm
@@ -26,7 +26,7 @@
 			num_players++
 
 	var/i = rand(-5, 0)
-	var/num_blobs = clamp(round((num_players + i) / 20), blobs_minimum, blobs_possible)
+	var/num_blobs = clamp(round((num_players + i) / 18), blobs_minimum, blobs_possible)
 
 	var/list/possible_blobs = get_possible_enemies(ROLE_BLOB, num_blobs)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Reduces the players needed to get 4 blobs from at least 70 players down to at least 63.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previous number was too high, so 4 blobs was like never seen. This should make them seen now.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Adjusted blob scaling so 4 should hopefully be seen. If something is bad please yell or something k thanks.
```
