### PR TITLE
Apr22 Requisition Tuneup Batch

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -391,6 +391,7 @@ var/list/admin_verbs = list(
 		/client/proc/cmd_modify_market_variables,
 		/client/proc/BK_finance_debug,
 		/client/proc/BK_alter_funds,
+		/client/proc/TestMarketReq,
 		/client/proc/debug_pools,
 		/client/proc/debug_variables,
 		/client/proc/debug_global_variable,

--- a/code/modules/economy/requisition/rc_aid.dm
+++ b/code/modules/economy/requisition/rc_aid.dm
@@ -108,9 +108,9 @@ ABSTRACT_TYPE(/datum/rc_entry/item/basictool)
 		src.flavor_desc = "[pick(desc_helpsite)] requires additional supplies [pick(desc_tense)] [pick(desc_crisis)]. [pick(desc_emphasis)]"
 		src.payout += rand(0,60) * 10
 
-		if(prob(80))
+		if(prob(60))
 			src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/brutepatch,rand(1,4)*30)
-		if(prob(80))
+		if(prob(70))
 			src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/burnpatch,rand(1,4)*30)
 
 		if(!length(src.rc_entries)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/hypospray,rand(2,5))
@@ -160,14 +160,14 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 	container_name = "Patches"
 	name = "styptic powder"
 	chem_ids = "styptic_powder"
-	feemod = 25
+	feemod = 50
 
 /datum/rc_entry/reagent/burnpatch
 	contained_in = /obj/item/reagent_containers/patch
 	container_name = "Patches"
 	name = "silver sulfadiazine"
 	chem_ids = "silver_sulfadiazine"
-	feemod = 25
+	feemod = 50
 
 /datum/rc_entry/item/lgloves
 	name = "latex glove pair"

--- a/code/modules/economy/requisition/rc_aid.dm
+++ b/code/modules/economy/requisition/rc_aid.dm
@@ -325,7 +325,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 			if("furnace fuel")
 				src.rc_entries += rc_buildentry(/datum/rc_entry/stack/char,rand(24,36))
 			if("liquid fuel")
-				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/fuel,rand(40,60)*10)
+				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/fuel,rand(30,40)*10)
 			if("coffee")
 				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/coffee,rand(24,36)*10)
 
@@ -339,7 +339,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 /datum/rc_entry/reagent/fuel
 	name = "welding-grade liquid fuel"
 	chem_ids = "fuel"
-	feemod = 10
+	feemod = 25
 
 /datum/rc_entry/reagent/coffee
 	name = "coffee"

--- a/code/modules/economy/requisition/rc_aid.dm
+++ b/code/modules/economy/requisition/rc_aid.dm
@@ -11,7 +11,7 @@ ABSTRACT_TYPE(/datum/req_contract/aid)
 
 /datum/req_contract/aid/wrecked
 	//name = "Breach Recovery"
-	payout = 2000
+	payout = 4000
 	var/list/namevary = list("Breach Recovery","Breach Response","Integrity Failure","Crisis Response","Disaster Assistance","Disaster Response")
 	var/list/desc_placejob = list("research","mining","security","cargo transfer")
 	var/list/desc_placetype = list("vessel","ship","station","outpost")
@@ -23,7 +23,7 @@ ABSTRACT_TYPE(/datum/req_contract/aid)
 		src.name = pick(namevary)
 		src.flavor_desc = "An affiliated [pick(desc_placejob)] [pick(desc_placetype)] has [pick(desc_enhancer1)] a [pick(desc_enhancer2)] [pick(desc_whatborked)]"
 		src.flavor_desc += " and requires repair supplies as soon as possible."
-		src.payout += rand(0,60) * 10
+		src.payout += rand(0,80) * 10
 
 		var/suitsets = rand(2,4)
 
@@ -40,49 +40,49 @@ ABSTRACT_TYPE(/datum/req_contract/aid)
 /datum/rc_entry/item/spacesuit
 	name = "space suit"
 	typepath = /obj/item/clothing/suit/space
-	feemod = 1260
+	feemod = 2250
 
 /datum/rc_entry/item/spacehelmet
 	name = "space helmet"
 	typepath = /obj/item/clothing/head/helmet/space
-	feemod = 1260
+	feemod = 1900
 
 /datum/rc_entry/stack/steelsheet
 	name = "NT-spec steel sheet"
 	typepath = /obj/item/sheet/steel
-	feemod = 15
+	feemod = 30
 
 ABSTRACT_TYPE(/datum/rc_entry/item/basictool)
 /datum/rc_entry/item/basictool/crowbar
 	name = "crowbar"
 	typepath = /obj/item/crowbar
-	feemod = 130
+	feemod = 250
 
 /datum/rc_entry/item/basictool/screwdriver
 	name = "screwdriver"
 	typepath = /obj/item/screwdriver
-	feemod = 140
+	feemod = 220
 
 /datum/rc_entry/item/basictool/wirecutters
 	name = "wirecutters"
 	typepath = /obj/item/wirecutters
-	feemod = 140
+	feemod = 240
 
 /datum/rc_entry/item/basictool/wrench
 	name = "wrench"
 	typepath = /obj/item/wrench
-	feemod = 140
+	feemod = 220
 
 /datum/rc_entry/item/basictool/welder
 	name = "welding tool"
 	typepath = /obj/item/weldingtool
-	feemod = 220
+	feemod = 480
 
 
 
 /datum/req_contract/aid/triage
 	//name = "Medical Aid"
-	payout = 3000
+	payout = 5000
 	var/list/namevary = list("Medical Aid","Medical Emergency","Triage Support","Aid Request","Critical Condition")
 	var/list/desc_helpsite = list("A medical facility","An affiliated station's medical bay","A triage center","A medical outpost","Our nearest station")
 	var/list/desc_tense = list("to assist with","after heavy load due to","to restock after")
@@ -106,16 +106,18 @@ ABSTRACT_TYPE(/datum/rc_entry/item/basictool)
 	New()
 		src.name = pick(namevary)
 		src.flavor_desc = "[pick(desc_helpsite)] requires additional supplies [pick(desc_tense)] [pick(desc_crisis)]. [pick(desc_emphasis)]"
-		src.payout += rand(0,40) * 10
+		src.payout += rand(0,60) * 10
+
+		if(prob(80))
+			src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/brutepatch,rand(1,4)*30)
+		if(prob(80))
+			src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/burnpatch,rand(1,4)*30)
+
+		if(!length(src.rc_entries)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/hypospray,rand(2,5))
 
 		for(var/S in concrete_typesof(/datum/rc_entry/item/surgical))
 			if(prob(50))
 				src.rc_entries += rc_buildentry(S,rand(1,4))
-
-		if(prob(80))
-			src.rc_entries += rc_buildentry(/datum/rc_entry/item/bandage,rand(3,8))
-		else
-			src.rc_entries += rc_buildentry(/datum/rc_entry/item/hypospray,rand(2,5))
 
 		if(prob(70))
 			src.rc_entries += rc_buildentry(/datum/rc_entry/item/lgloves,rand(3,8))
@@ -125,7 +127,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/basictool)
 
 ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 /datum/rc_entry/item/surgical
-	feemod = 240
+	feemod = 350
 
 	scalpel
 		name = "scalpel"
@@ -133,7 +135,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 
 	saw
 		name = "circular saw"
-		feemod = 250
+		feemod = 520
 		typepath = /obj/item/circular_saw
 
 	scissors
@@ -150,34 +152,43 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 
 	stapler
 		name = "staple gun"
-		feemod = 330
+		feemod = 780
 		typepath = /obj/item/staple_gun
 
-/datum/rc_entry/item/bandage
-	name = "bandage roll"
-	feemod = 210
-	typepath = /obj/item/bandage
+/datum/rc_entry/reagent/brutepatch
+	contained_in = /obj/item/reagent_containers/patch
+	container_name = "Patches"
+	name = "styptic powder"
+	chem_ids = "styptic_powder"
+	feemod = 25
+
+/datum/rc_entry/reagent/burnpatch
+	contained_in = /obj/item/reagent_containers/patch
+	container_name = "Patches"
+	name = "silver sulfadiazine"
+	chem_ids = "silver_sulfadiazine"
+	feemod = 25
 
 /datum/rc_entry/item/lgloves
 	name = "latex glove pair"
-	feemod = 150
+	feemod = 300
 	typepath = /obj/item/clothing/gloves/latex
 
 /datum/rc_entry/item/hypospray
 	name = "hypospray"
-	feemod = 500
+	feemod = 900
 	typepath = /obj/item/reagent_containers/hypospray
 
 /datum/rc_entry/item/med_analyzer
 	name = "health analyzer"
-	feemod = 800
+	feemod = 1200
 	typepath = /obj/item/device/analyzer/healthanalyzer
 
 
 
 /datum/req_contract/aid/geeksquad
 	//name = "Computer Failure"
-	payout = 2500
+	payout = 4800
 	var/list/namevary = list("Systems Failure","Short Circuit","Computer Overload","Electronics Failure","Systems Breakdown")
 	var/list/desc_wherebork = list("research","mining","security","cargo transfer","communications","deep-space survey")
 	var/list/desc_whobork = list("vessel","ship","station","outpost")
@@ -209,7 +220,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 	New()
 		src.name = pick(namevary)
 		src.flavor_desc = "An affiliated [pick(desc_wherebork)] [pick(desc_whobork)] has [pick(desc_whybork)] [pick(desc_howmuchbork)] its [pick(desc_sys)]. [pick(desc_emphasis)]"
-		src.payout += rand(0,40) * 10
+		src.payout += rand(0,60) * 10
 
 		if(prob(70)) src.rc_entries += rc_buildentry(/datum/rc_entry/item/mainboard,rand(1,3))
 		if(prob(60))
@@ -232,54 +243,54 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 /datum/rc_entry/item/mainboard
 	name = "computer mainboard"
 	typepath = /obj/item/motherboard
-	feemod = 1240
+	feemod = 1840
 
 /datum/rc_entry/item/cardscan
 	name = "ID scanner module"
 	typepath = /obj/item/peripheral/card_scanner
 	exactpath = TRUE
-	feemod = 1120
+	feemod = 2300
 
 /datum/rc_entry/item/netcard
 	name = "wired network card"
 	typepath = /obj/item/peripheral/network/powernet_card
 	exactpath = TRUE
-	feemod = 1080
+	feemod = 2080
 
 /datum/rc_entry/item/interfaceboard
 	name = "AI interface board"
 	typepath = /obj/item/ai_interface
-	feemod = 2500
+	feemod = 5000
 
 /datum/rc_entry/item/t_ray
 	name = "T-ray scanner"
 	typepath = /obj/item/device/t_scanner
-	feemod = 680
+	feemod = 1280
 
 /datum/rc_entry/item/soldering
 	name = "soldering iron"
 	typepath = /obj/item/electronics/soldering
-	feemod = 520
+	feemod = 820
 
 /datum/rc_entry/item/multitool
 	name = "multitool"
 	typepath = /obj/item/device/multitool
-	feemod = 900
+	feemod = 2800
 
 /datum/rc_entry/stack/cable
 	name = "lengths of electrical cabling"
 	typepath = /obj/item/cable_coil
-	feemod = 30
+	feemod = 50
 
 
 
 /datum/req_contract/aid/supplyshort
 	//name = "Supply Chain Failure"
-	payout = 2400
+	payout = 4500
 	var/list/namevary = list("Urgent Restock","Supply Crisis","Supply Chain Failure","Short Stock","Emergency Resupply")
 	var/list/desc_placejob = list("research","mining","hydroponics","civilian","Nanotrasen")
 	var/list/desc_place = list("vessel","station","outpost","colony")
-	var/list/desc_shortage = list("food","rations","food and water","furnace fuel","liquid fuel","coffee","certain herbs")
+	var/list/desc_shortage = list("food","rations","food and water","furnace fuel","liquid fuel","coffee")
 	var/list/desc_after = list("after","due to","following")
 	var/list/desc_whybork = list(
 		"its regular supply shuttle experiencing a disastrous hull breach",
@@ -317,24 +328,18 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/fuel,rand(40,60)*10)
 			if("coffee")
 				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/coffee,rand(24,36)*10)
-			if("certain herbs")
-				src.rc_entries += rc_buildentry(/datum/rc_entry/item/medherb/alpha,rand(12,18))
-				if(prob(60))
-					src.rc_entries += rc_buildentry(/datum/rc_entry/item/medherb/beta,rand(12,18))
-				else
-					src.rc_entries += rc_buildentry(/datum/rc_entry/item/medherb/gamma,rand(8,14))
 
 		..()
 
 /datum/rc_entry/stack/char
 	name = "char ore"
 	commodity = /datum/commodity/ore/char
-	feemod = 50
+	feemod = 80 //on top of market char price
 
 /datum/rc_entry/reagent/fuel
 	name = "welding-grade liquid fuel"
 	chem_ids = "fuel"
-	feemod = 6
+	feemod = 10
 
 /datum/rc_entry/reagent/coffee
 	name = "coffee"
@@ -345,38 +350,4 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 		"expresso",
 		"energydrink"
 	)
-	feemod = 10
-
-/datum/rc_entry/item/medherb
-	name = "medical herb"
-	typepath = /obj/item/plant/herb
-	commodity = /datum/commodity/herbs
-	feemod = 160
-	var/list/herblist = list()
-
-	alpha
-		herblist = list(
-			/obj/item/plant/herb/asomna,
-			/obj/item/plant/herb/commol,
-			/obj/item/plant/herb/contusine
-		)
-
-	beta
-		herblist = list(
-			/obj/item/plant/herb/mint,
-			/obj/item/plant/herb/nureous,
-			/obj/item/plant/herb/venne
-		)
-
-	gamma
-		herblist = list(
-			/obj/item/plant/herb/cannabis,
-			/obj/item/plant/herb/sassafras,
-			/obj/item/plant/herb/tobacco
-		)
-
-	New()
-		var/obj/plantalyze = pick(src.herblist)
-		src.name = initial(plantalyze.name)
-		src.typepath = plantalyze
-		..()
+	feemod = 20

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -57,7 +57,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/caterfood)
 /datum/rc_entry/item/caterfood/soup
 	name = "pre-portioned soup bowl"
 	typepath = /obj/item/reagent_containers/food/snacks/soup
-	feemod = 980
+	feemod = 1160
 
 /datum/rc_entry/item/caterfood/salad
 	name = "pre-portioned salad"

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -403,7 +403,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/reagent/cola
 	name = "cola"
 	chem_ids = "cola"
-	feemod = 15
+	feemod = 20
 
 /datum/rc_entry/item/chaps
 	name = "assless chaps"
@@ -444,7 +444,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	var/list/namevary = list("Structural Setup","Brick by Brick","New Construction","Building Supply","Structure Fabrication")
 	var/list/desc_thingbuilt = list("A planetary barracks","A new deluxe retreat","A new station wing","An affiliated construction project")
 	var/list/desc_progress = list("currently underway","delayed by supply difficulties","planned for near-term assembly","commissioned by a third party")
-	var/list/desc_resource = list("stone","turf seed","window treatment","wood","detailing metal")
+	var/list/desc_resource = list("stone","turf seed","window treatment","wood","solvent","detailing metal")
 	var/list/desc_flavorize = list(
 		null,
 		" Packing material will be returned to you for reuse if possible.",
@@ -476,6 +476,8 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/silicate,rand(3,10)*10*req_quant)
 			if("wood")
 				src.rc_entries += rc_buildentry(/datum/rc_entry/item/plank,rand(5,12)*req_quant)
+			if("solvent")
+				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/acetone,rand(4,8)*10)
 			if("detailing metal")
 				if(prob(70))
 					src.rc_entries += rc_buildentry(/datum/rc_entry/stack/cobryl,rand(1,6)*req_quant)
@@ -492,6 +494,8 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 					src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/silicate,rand(3,10)*10)
 				if("wood")
 					src.rc_entries += rc_buildentry(/datum/rc_entry/item/plank,rand(5,12))
+				if("solvent")
+					src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/acetone,rand(4,8)*10)
 				if("detailing metal")
 					if(prob(70))
 						src.rc_entries += rc_buildentry(/datum/rc_entry/stack/cobryl,rand(1,6))
@@ -522,6 +526,11 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	typepath = /obj/item/plank
 	exactpath = TRUE
 	feemod = 470
+
+/datum/rc_entry/reagent/acetone
+	name = "acetone"
+	chem_ids = "acetone"
+	feemod = 18
 
 /datum/rc_entry/stack/cobryl
 	name = "cobryl"

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -442,7 +442,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	//name = "Architecture Deluxe"
 	payout = 5200
 	var/list/namevary = list("Structural Setup","Brick by Brick","New Construction","Building Supply","Structure Fabrication")
-	var/list/desc_thingbuilt = list("A planetary barracks","A new deluxe retreat","A new station wing","An affiliated construction project")
+	var/list/desc_thingbuilt = list("A planetary habitation site","A new deluxe retreat","A new station wing","An affiliated construction project")
 	var/list/desc_progress = list("currently underway","delayed by supply difficulties","planned for near-term assembly","commissioned by a third party")
 	var/list/desc_resource = list("stone","turf seed","window treatment","wood","solvent","detailing metal")
 	var/list/desc_flavorize = list(
@@ -450,7 +450,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 		" Packing material will be returned to you for reuse if possible.",
 		" Prompt delivery would be heavily appreciated.",
 		" Site foreman is growing agitated with delays; price offered is above market rate.",
-		" Please pack precisely as specified; excess items are unwelcome and will not be accepted.",
+		" Please pack precisely as specified; excess will cause hassle on our end.",
 		" Goods need not be in perfect condition."
 	)
 
@@ -477,7 +477,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 			if("wood")
 				src.rc_entries += rc_buildentry(/datum/rc_entry/item/plank,rand(5,12)*req_quant)
 			if("solvent")
-				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/acetone,rand(4,8)*10)
+				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/acetone,rand(4,8)*10*req_quant)
 			if("detailing metal")
 				if(prob(70))
 					src.rc_entries += rc_buildentry(/datum/rc_entry/stack/cobryl,rand(1,6)*req_quant)
@@ -525,7 +525,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 	name = "wooden plank"
 	typepath = /obj/item/plank
 	exactpath = TRUE
-	feemod = 470
+	feemod = 1220
 
 /datum/rc_entry/reagent/acetone
 	name = "acetone"

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -308,7 +308,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 
 		if (prob(70)) //pizza party
 			src.rc_entries += rc_buildentry(/datum/rc_entry/stack/pizza,rand(2,3)*6)
-			src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/cola,rand(4,8)*10)
+			src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/cola,rand(10,20)*10)
 
 		switch (rand(1, 50)) //Special Outcomes Zone
 			if (1)

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -9,8 +9,8 @@ ABSTRACT_TYPE(/datum/req_contract/civilian)
 
 /datum/req_contract/civilian/event_catering
 	name = "Event Catering"
-	payout = 6000
-	weight = 70
+	payout = 9000
+	weight = 60
 	var/list/desc_event = list("reception","formal event","welcoming party","going-away party","commemorative dinner","dinner")
 	var/list/desc_honorific = list("an esteemed","an infamous","a famous","a renowned")
 	var/list/desc_origin = list(" Nanotrasen"," Martian"," freelancing"," frontier"," - if only barely -"," retired")
@@ -29,14 +29,14 @@ ABSTRACT_TYPE(/datum/req_contract/civilian)
 
 	New()
 		src.flavor_desc = "A [pick(desc_event)] is being held for [pick(desc_honorific)][pick(desc_origin)] [pick(desc_role)]. [pick(desc_bonusflavor)]"
-		src.payout += rand(0,50) * 10
+		src.payout += rand(0,100) * 10
 
 		for(var/S in concrete_typesof(/datum/rc_entry/item/caterfood))
 			if(prob(60))
-				src.rc_entries += rc_buildentry(S,rand(8,16))
+				src.rc_entries += rc_buildentry(S,rand(2,5)*2) //4 to 10
 
 		if(!length(src.rc_entries))
-			src.rc_entries += rc_buildentry(/datum/rc_entry/item/caterfood/sandwich,rand(16,30))
+			src.rc_entries += rc_buildentry(/datum/rc_entry/item/caterfood/sandwich,18)
 
 		for(var/S in concrete_typesof(/datum/rc_entry/reagent/caterdrink))
 			if(prob(40))
@@ -47,53 +47,53 @@ ABSTRACT_TYPE(/datum/rc_entry/item/caterfood)
 /datum/rc_entry/item/caterfood/sandwich
 	name = "sandwich"
 	typepath = /obj/item/reagent_containers/food/snacks/sandwich
-	feemod = 660
+	feemod = 1400
 
 /datum/rc_entry/item/caterfood/burger
 	name = "burger"
 	typepath = /obj/item/reagent_containers/food/snacks/burger
-	feemod = 660
+	feemod = 1550
 
 /datum/rc_entry/item/caterfood/soup
 	name = "pre-portioned soup bowl"
 	typepath = /obj/item/reagent_containers/food/snacks/soup
-	feemod = 560
+	feemod = 980
 
 /datum/rc_entry/item/caterfood/salad
 	name = "pre-portioned salad"
 	typepath = /obj/item/reagent_containers/food/snacks/salad
-	feemod = 500
+	feemod = 920
 
 ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/reagent/caterdrink/appletini
 	name = "appletini"
 	chem_ids = "appletini"
-	feemod = 60
+	feemod = 90
 
 /datum/rc_entry/reagent/caterdrink/fruitpunch
 	name = "fruit punch"
 	chem_ids = "fruit_punch"
-	feemod = 60
+	feemod = 90
 
 /datum/rc_entry/reagent/caterdrink/spacecuba
 	name = "space-cuba libre"
 	chem_ids = "libre"
-	feemod = 30
+	feemod = 50
 
 /datum/rc_entry/reagent/caterdrink/margarita
 	name = "margarita"
 	chem_ids = "margarita"
-	feemod = 20
+	feemod = 40
 
 /datum/rc_entry/reagent/caterdrink/champagne
 	name = "champagne"
 	chem_ids = "champagne"
-	feemod = 24
+	feemod = 50
 
 
 /datum/req_contract/civilian/furnishing
 	//name = "Interior Outfitting"
-	payout = 2200
+	payout = 3200
 	var/list/namevary = list("Interior Outfitting","Furnishing Assistance","Interior Decorating","Occupancy Preparations","Last-Minute Furnishing")
 	var/list/desc_whatitdoes = list("A new gaming","An extraction","A medical","A research","A cartographic","A transit")
 	var/list/desc_whatitis = list("vessel","station","platform","outpost")
@@ -131,7 +131,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/stack/floortiles
 	name = "floor tile"
 	typepath = /obj/item/tile
-	feemod = 40
+	feemod = 60
 
 /datum/rc_entry/reagent/carpet
 	name = "liquid carpet"
@@ -141,32 +141,32 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/item/table
 	name = "table"
 	typepath = /obj/item/furniture_parts/table
-	feemod = 200
+	feemod = 300
 
 /datum/rc_entry/item/rack
 	name = "rack part set"
 	typepath = /obj/item/furniture_parts/rack
-	feemod = 180
+	feemod = 250
 
 /datum/rc_entry/item/chair
 	name = "folding chair"
 	typepath = /obj/item/chair/folded
-	feemod = 180
+	feemod = 230
 
 /datum/rc_entry/item/light_bulb
 	name = "light bulb"
 	typepath = /obj/item/light/bulb
-	feemod = 50
+	feemod = 90
 
 /datum/rc_entry/item/light_tube
 	name = "light bulb"
 	typepath = /obj/item/light/tube
-	feemod = 50
+	feemod = 80
 
 
 /datum/req_contract/civilian/greytide
 	//name = "Crew Embarcation"
-	payout = 1500
+	payout = 1800
 	var/list/namevary = list("Crew Embarcation","Crew Onboarding","New Hands on Deck","Expedited Outfitting","Personnel Rotation")
 	var/list/desc_task = list("mining","hydroponics","cargo handling","engineering","medical","research","cartographic")
 	var/list/desc_place = list("vessel","station","platform","outpost")
@@ -207,17 +207,17 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/item/jumpsuit
 	name = "black jumpsuit"
 	typepath = /obj/item/clothing/under/color
-	feemod = 300
+	feemod = 450
 	exactpath = TRUE
 
 	any
 		name = "single-color jumpsuit"
-		feemod = 200
+		feemod = 300
 		exactpath = FALSE
 
 	scrubs
 		name = "medical scrubs"
-		feemod = 380
+		feemod = 680
 		typepath = /obj/item/clothing/under/scrub
 		exactpath = FALSE
 
@@ -248,12 +248,12 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/item/backpack
 	name = "backpack"
 	typepath = /obj/item/storage/backpack
-	feemod = 400
+	feemod = 800
 
 /datum/rc_entry/item/shoes
 	name = "pair of shoes"
 	typepath = /obj/item/clothing/shoes
-	feemod = 220
+	feemod = 380
 
 /datum/rc_entry/item/headset
 	name = "radio headset"
@@ -263,7 +263,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/item/literallyanyfood
 	name = "solid food, preferably nutritious"
 	typepath = /obj/item/reagent_containers/food/snacks
-	feemod = 140
+	feemod = 250
 
 /datum/rc_entry/reagent/water
 	name = "water"
@@ -273,8 +273,9 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 
 /datum/req_contract/civilian/birthdaybash
 	//name = "Birthday Party"
-	payout = 2000
+	payout = 3500
 	hide_item_payouts = TRUE
+	weight = 80
 	var/list/namevary = list("Birthday Party","Birthday Bash","Surprise Party","One Year Older")
 	var/list/desc_event = list("party","celebration","gathering","party","event") //yes party twice
 
@@ -387,44 +388,44 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/item/cake
 	name = "cake"
 	typepath = /obj/item/reagent_containers/food/snacks/cake
-	feemod = 1600
+	feemod = 2500
 
 /datum/rc_entry/item/cookie
 	name = "cookie"
 	typepath = /obj/item/reagent_containers/food/snacks/cookie
-	feemod = 360
+	feemod = 600
 
 /datum/rc_entry/stack/pizza
 	name = "slices' worth of pizza"
 	typepath = /obj/item/reagent_containers/food/snacks/pizza
-	feemod = 100
+	feemod = 120
 
 /datum/rc_entry/reagent/cola
 	name = "cola"
 	chem_ids = "cola"
-	feemod = 12
+	feemod = 15
 
 /datum/rc_entry/item/chaps
 	name = "assless chaps"
 	typepath = /obj/item/clothing/under/gimmick/chaps
-	feemod = 1600
+	feemod = 5000
 
 /datum/rc_entry/item/grapes
 	name = "grapes"
 	typepath = /obj/item/reagent_containers/food/snacks/plant/grape
 	commodity = /datum/commodity/produce
-	feemod = 180
+	feemod = 400
 
 /datum/rc_entry/item/banana
 	name = "banana"
 	typepath = /obj/item/reagent_containers/food/snacks/plant/banana
 	commodity = /datum/commodity/produce
-	feemod = 160
+	feemod = 250
 
 /datum/rc_entry/item/cannabis
 	name = "cannabis"
 	commodity = /datum/commodity/drugs/cannabis
-	feemod = 160
+	feemod = 420
 
 /datum/rc_entry/reagent/glitter
 	name = "glitter"
@@ -434,4 +435,102 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/rc_entry/item/paperhat
 	name = "paper hat"
 	typepath = /obj/item/clothing/head/paper_hat
-	feemod = 80
+	feemod = 110
+
+
+/datum/req_contract/civilian/architecture
+	//name = "Architecture Deluxe"
+	payout = 5200
+	var/list/namevary = list("Structural Setup","Brick by Brick","New Construction","Building Supply","Structure Fabrication")
+	var/list/desc_thingbuilt = list("A planetary barracks","A new deluxe retreat","A new station wing","An affiliated construction project")
+	var/list/desc_progress = list("currently underway","delayed by supply difficulties","planned for near-term assembly","commissioned by a third party")
+	var/list/desc_resource = list("stone","turf seed","window treatment","wood","detailing metal")
+	var/list/desc_flavorize = list(
+		null,
+		" Packing material will be returned to you for reuse if possible.",
+		" Prompt delivery would be heavily appreciated.",
+		" Site foreman is growing agitated with delays; price offered is above market rate.",
+		" Please pack precisely as specified; excess items are unwelcome and will not be accepted.",
+		" Goods need not be in perfect condition."
+	)
+
+
+	New()
+		src.name = pick(namevary)
+		var/req1 = pick(desc_resource)
+		var/req2 = pick(desc_resource)
+		var/req_quant = 1 //if this is 2, doubles the first and skips the second
+		if(req1 == req2) //allow doubling up, but have the description and additions handle it gracefully
+			req_quant = 2
+			src.flavor_desc = "[pick(desc_thingbuilt)] [pick(desc_progress)] is in need of considerable additional [req1] before further progress can be made.[pick(desc_flavorize)]"
+		else
+			src.flavor_desc = "[pick(desc_thingbuilt)] [pick(desc_progress)] is in need of additional [req1] and [req2] before further progress can be made.[pick(desc_flavorize)]"
+		src.payout += rand(0,50) * 10
+
+		switch(req1)
+			if("stone")
+				src.rc_entries += rc_buildentry(/datum/rc_entry/stack/rock,rand(8,14)*2*req_quant)
+			if("turf seed")
+				src.rc_entries += rc_buildentry(/datum/rc_entry/seed/grass,rand(20,30)*req_quant)
+			if("window treatment")
+				src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/silicate,rand(3,10)*10*req_quant)
+			if("wood")
+				src.rc_entries += rc_buildentry(/datum/rc_entry/item/plank,rand(5,12)*req_quant)
+			if("detailing metal")
+				if(prob(70))
+					src.rc_entries += rc_buildentry(/datum/rc_entry/stack/cobryl,rand(1,6)*req_quant)
+				else
+					src.rc_entries += rc_buildentry(/datum/rc_entry/stack/syreline,rand(3,5)*req_quant)
+
+		if(req_quant == 1)
+			switch(req2)
+				if("stone")
+					src.rc_entries += rc_buildentry(/datum/rc_entry/stack/rock,rand(8,14)*2)
+				if("turf seed")
+					src.rc_entries += rc_buildentry(/datum/rc_entry/seed/grass,rand(20,30))
+				if("window treatment")
+					src.rc_entries += rc_buildentry(/datum/rc_entry/reagent/silicate,rand(3,10)*10)
+				if("wood")
+					src.rc_entries += rc_buildentry(/datum/rc_entry/item/plank,rand(5,12))
+				if("detailing metal")
+					if(prob(70))
+						src.rc_entries += rc_buildentry(/datum/rc_entry/stack/cobryl,rand(1,6))
+					else
+						src.rc_entries += rc_buildentry(/datum/rc_entry/stack/syreline,rand(3,5))
+
+		..()
+
+/datum/rc_entry/stack/rock
+	name = "rock"
+	typepath = /obj/item/raw_material/rock
+	feemod = 250
+
+/datum/rc_entry/seed/grass
+	name = "grass seed"
+	cropname = "Grass"
+	feemod = 300
+
+/datum/rc_entry/reagent/silicate
+	contained_in = /obj/item/reagent_containers/glass
+	container_name = "Bottles"
+	name = "liquid silicate"
+	chem_ids = "silicate"
+	feemod = 18
+
+/datum/rc_entry/item/plank
+	name = "wooden plank"
+	typepath = /obj/item/plank
+	exactpath = TRUE
+	feemod = 470
+
+/datum/rc_entry/stack/cobryl
+	name = "cobryl"
+	commodity = /datum/commodity/ore/cobryl
+	typepath_alt = /obj/item/material_piece/cobryl
+	feemod = 450
+
+/datum/rc_entry/stack/syreline
+	name = "syreline"
+	commodity = /datum/commodity/ore/syreline
+	typepath_alt = /obj/item/material_piece/syreline
+	feemod = 1100

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -9,7 +9,7 @@ ABSTRACT_TYPE(/datum/req_contract/scientific)
 
 /datum/req_contract/scientific/internalaffairs //get it?
 	//name = "Don't Ask Too Many Questions"
-	payout = 2500
+	payout = 5000
 	weight = 80
 	var/list/namevary = list("Organ Analysis","Organ Research","Biolab Supply","Biolab Partnership","ERROR: CANNOT VERIFY ORIGIN")
 	var/list/desc_begins = list("conducting","performing","beginning","initiating","seeking supplies for","organizing")
@@ -30,12 +30,13 @@ ABSTRACT_TYPE(/datum/req_contract/scientific)
 
 ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 /datum/rc_entry/item/organ
-	feemod = 400
+	feemod = 550
 	exactpath = TRUE
 
-/datum/rc_entry/item/organ/brain
-	name = "brain"
-	commodity = /datum/commodity/bodyparts/brain
+/datum/rc_entry/item/organ/appendix
+	name = "appendix"
+	feemod = 400
+	commodity = /datum/commodity/bodyparts/appendix
 
 /datum/rc_entry/item/organ/heart
 	name = "heart"
@@ -53,7 +54,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 
 /datum/req_contract/scientific/spectrometry
 	//name = "Totally Will Not Result In A Resonance Cascade"
-	payout = 1200
+	payout = 3300
 	var/list/namevary = list("Beamline Calibration","Spectral Analysis","Chromatic Analysis","Refraction Survey")
 	var/list/desc_wherestudy = list(
 		"Optics calibration laboratory",
@@ -91,35 +92,35 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 /datum/rc_entry/item/lens
 	name = "nano-fabricated lens"
 	typepath = /obj/item/lens
-	feemod = 1000
+	feemod = 2000
 
 /datum/rc_entry/stack/gemstone
 	name = "non-anomalous gemstone"
 	typepath = /obj/item/raw_material/gemstone
-	feemod = 2500
+	feemod = 3500
 
 /datum/rc_entry/stack/telec
 	name = "telecrystal"
 	commodity = /datum/commodity/ore/telecrystal
 	typepath_alt = /obj/item/material_piece/telecrystal
-	feemod = 1240
+	feemod = 1240 //augmented by commodity price
 
 /datum/rc_entry/reagent/cryox
 	name = "cryoxadone coolant"
 	chem_ids = "cryoxadone"
-	feemod = 60
+	feemod = 90
 
 /datum/rc_entry/item/lambdarod
 	name = "Lambda phase-control rod"
 	typepath = /obj/item/interdictor_rod
 	exactpath = TRUE
-	feemod = 6000
+	feemod = 11000
 
 
 
 /datum/req_contract/scientific/botanical
 	//name = "Feed Me, Seymour (Butz)"
-	payout = 2500
+	payout = 3500
 	var/list/namevary = list("Botanical Prototyping","Hydroponic Acclimation","Cultivar Propagation","Plant Genotype Study")
 	var/list/desc_wherestudy = list(
 		"An affiliated hydroponics lab",
@@ -149,7 +150,9 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 		if(prob(60)) src.rc_entries += rc_buildentry(/datum/rc_entry/seed/scientific/fruit,rand(1,3))
 		if(!length(src.rc_entries) || prob(50)) src.rc_entries += rc_buildentry(/datum/rc_entry/seed/scientific/crop,rand(1,3))
 		if(length(src.rc_entries) == 1 || prob(30)) src.rc_entries += rc_buildentry(/datum/rc_entry/seed/scientific/veg,rand(1,3))
-		if(length(src.rc_entries) == 3) src.item_rewarders += new /datum/rc_itemreward/strange_seed
+		if(length(src.rc_entries) == 3)
+			src.payout += 8000
+			src.item_rewarders += new /datum/rc_itemreward/strange_seed
 
 		src.item_rewarders += new /datum/rc_itemreward/plant_cartridge
 		..()

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -120,7 +120,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 
 /datum/req_contract/scientific/botanical
 	//name = "Feed Me, Seymour (Butz)"
-	payout = 3500
+	payout = 2500
 	var/list/namevary = list("Botanical Prototyping","Hydroponic Acclimation","Cultivar Propagation","Plant Genotype Study")
 	var/list/desc_wherestudy = list(
 		"An affiliated hydroponics lab",
@@ -150,9 +150,8 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 		if(prob(60)) src.rc_entries += rc_buildentry(/datum/rc_entry/seed/scientific/fruit,rand(1,3))
 		if(!length(src.rc_entries) || prob(50)) src.rc_entries += rc_buildentry(/datum/rc_entry/seed/scientific/crop,rand(1,3))
 		if(length(src.rc_entries) == 1 || prob(30)) src.rc_entries += rc_buildentry(/datum/rc_entry/seed/scientific/veg,rand(1,3))
-		if(length(src.rc_entries) == 3)
-			src.payout += 8000
-			src.item_rewarders += new /datum/rc_itemreward/strange_seed
+		if(length(src.rc_entries) == 3) src.item_rewarders += new /datum/rc_itemreward/strange_seed
+		src.payout += 8000 * length(src.rc_entries)
 
 		src.item_rewarders += new /datum/rc_itemreward/plant_cartridge
 		..()
@@ -160,7 +159,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 /datum/rc_entry/seed/scientific
 	name = "genetically fussy seed"
 	cropname = "Durian"
-	feemod = 4000
+	feemod = 1000
 	var/crop_genpath = /datum/plant
 
 	fruit

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -30,7 +30,7 @@ ABSTRACT_TYPE(/datum/req_contract/scientific)
 
 ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 /datum/rc_entry/item/organ
-	feemod = 550
+	feemod = 2550
 	exactpath = TRUE
 
 /datum/rc_entry/item/organ/appendix

--- a/code/modules/economy/requisition/rc_special.dm
+++ b/code/modules/economy/requisition/rc_special.dm
@@ -69,7 +69,7 @@ ABSTRACT_TYPE(/datum/req_contract/special/surgery)
 /datum/req_contract/special/surgery/organ_swap
 	name = "Organ Swap"
 	weight = 50
-	payout = 5000
+	payout = 8000
 	var/mob/living/carbon/human/target
 	var/target_organs = list()
 	sendingCrate = new /obj/storage/crate/wooden
@@ -171,12 +171,12 @@ ABSTRACT_TYPE(/datum/req_contract/special/surgery)
 /datum/req_contract/special/pizza_party
 	name = "Pizza Party"
 	req_sheet = new /obj/item/paper/requisition/pizza_party
-	payout = 1300 //pizza adds from 2400 to 3600
+	payout = 2500 //pizza adds from 2400 to 3600
 
 	nt
 		name = "Pizza Party (NanoTrasen)"
 		req_sheet = new /obj/item/paper/requisition/pizza_party/nt
-		payout = 1800
+		payout = 3300
 
 	New()
 		src.rc_entries += rc_buildentry(/datum/rc_entry/stack/pizza,rand(20,30)*6)
@@ -187,7 +187,7 @@ ABSTRACT_TYPE(/datum/req_contract/special/surgery)
 ABSTRACT_TYPE(/datum/req_contract/special/chef)
 /datum/req_contract/special/chef
 	weight = 50
-	payout = 2000
+	payout = 12000
 	req_sheet = new /obj/item/paper/requisition/food_order
 	var/mealflag = MEAL_TIME_BREAKFAST
 	var/list/cornucopia = list()

--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -304,20 +304,46 @@ ABSTRACT_TYPE(/datum/req_contract)
 			src.payout += rce.feemod * rce.count
 
 	proc/requisify(obj/storage/crate/sell_crate)
-		var/contents = list() //everything in crate
+		var/contents_index = list() //registry of everything in crate, including contents of item containers within it
 		var/contents_to_cull = list() //things consumed to fulfill the requisition, extras are sent back
 		var/successes_needed = length(src.rc_entries) //decremented with each successful fulfillment, reach 0 to win
 
-		contents += sell_crate.contents
-		for(var/obj/item/storage/S in contents)
-			contents |= S.get_all_contents()
+		contents_index += sell_crate.contents
+
+		for(var/obj/item/storage/S in sell_crate.contents)
+			contents_index += S.get_all_contents()
 
 		. = REQ_RETURN_NOSALE //by default return no success
-		for(var/atom/A in contents)
+
+		//item boxes can require evaluation of items that don't physically exist, so they need special logic
+		for(var/obj/item/item_box/IB in contents_index)
+			LAGCHECK(LAG_LOW)
+			contents_index -= IB
+			if(IB.item_amount < 1) return //no empty or infinite box evals
+			contents_index += IB.contents //evaluate real items through conventional means
+			var/illusory_contents = IB.item_amount - length(IB.contents) //how many nonexistent items we have to iterate over
+			var/box_satisfies = FALSE
+
+			if(illusory_contents && IB.contained_item)
+				var/testbench_item = new IB.contained_item //create a temporary example item to check
+				while(illusory_contents > 0)
+					illusory_contents--
+					for(var/datum/rc_entry/shoppin in rc_entries)
+						if(shoppin.rc_eval(testbench_item))
+							box_satisfies = TRUE
+				qdel(testbench_item)
+
+			if(box_satisfies)
+				contents_to_cull += IB
+
+		for(var/atom/A in contents_index)
 			LAGCHECK(LAG_LOW)
 			for(var/datum/rc_entry/shoppin in rc_entries)
 				if(shoppin.rc_eval(A)) //found something that the requisition asked for, let it know
-					contents_to_cull |= A
+					if(A.loc != sell_crate && isobj(A.loc)) //if you sent your stuff in an item container, it'll be kept
+						contents_to_cull |= A.loc
+					else
+						contents_to_cull += A
 
 		for(var/datum/rc_entry/shopped in rc_entries)
 			if(shopped.rollcount >= shopped.count)
@@ -325,7 +351,7 @@ ABSTRACT_TYPE(/datum/req_contract)
 
 		if(!successes_needed)
 			if(src.req_code == "REQ-THIRDPARTY") //third party sales do not preserve leftover items, returns are only done if there is an item reward
-				for(var/atom/X in contents)
+				for(var/atom/X in contents_index)
 					if(X) qdel(X)
 				return REQ_RETURN_FULLSALE
 			if(src.pinned) shippingmarket.has_pinned_contract = FALSE //tell shipping market pinned contract was fulfilled

--- a/code/modules/economy/requisition/requisition_contracts.dm
+++ b/code/modules/economy/requisition/requisition_contracts.dm
@@ -11,6 +11,32 @@
 	entryize.count = number_of
 	return entryize
 
+/**
+ * Proc to test a standard market contract for functionality. Test special orders with random event trigger instead.
+ *
+ * Will add the contract to requisitions list and pin the contract, ignoring the one-pin limit or any contract type pin restrictions.
+ * Don't use this in live rounds, pin behavior will be wonky.
+ */
+/client/proc/TestMarketReq()
+	SET_ADMIN_CAT(ADMIN_CAT_DEBUG)
+	set name = "Requisition Test"
+	set desc = "Generates a specified requisition path and pins it to market."
+
+	var/contract_path = input("Specify type path", "Requisition", null, null)
+	if (!contract_path) return
+	if (istext(contract_path))
+		contract_path = text2path(contract_path)
+	if (!ispath(contract_path))
+		boutput(usr, "<span class='alert'>Requisition test failed - no path specified.</span>")
+		return
+	var/datum/req_contract/new_contract = new contract_path
+	if(!istype(new_contract))
+		boutput(usr, "<span class='alert'>Requisition test failed - invalid type path.</span>")
+		return
+	shippingmarket.req_contracts += new_contract
+	new_contract.pinned = TRUE
+	boutput(usr, "Pinned [new_contract.name] to shipping market.")
+
 //contract entries: contract creation instantiates these for "this much of whatever"
 //these entries each have their own "validation protocol", automatically set up when instantiated
 
@@ -95,7 +121,7 @@ ABSTRACT_TYPE(/datum/rc_entry/stack)
 		. = ..()
 		if(rollcount >= count) return // Standard skip-if-complete
 		if(!istype(eval_item)) return // If it's not an item, it's not a stackable
-		if(eval_item.type == typepath || (typepath_alt && eval_item.type == typepath_alt))
+		if(istype(eval_item,typepath) || (typepath_alt && istype(eval_item,typepath_alt)))
 			rollcount += eval_item.amount
 			. = TRUE // Let manager know passed eval item is claimed by contract
 

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -419,6 +419,7 @@
 					pdaSignal.data = list("address_1"="00000000", "command"="text_message", "sender_name"="CARGO-MAILBOT",  "group"=list(MGD_CARGO, MGA_SALES), "sender"="00000000", "message"="[returnmsg]")
 					pdaSignal.transmission_method = TRANSMISSION_RADIO
 					radio_controller.get_frequency(FREQ_PDA).post_packet_without_source(pdaSignal)
+					return
 			if(req_contracts.Find(contract_to_clear))
 				req_contracts -= contract_to_clear
 				complete_orders += contract_to_clear

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -1068,7 +1068,7 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 		src.temp += "Requisition Code: [RC.req_code]<br><br>"
 		if(RC.flavor_desc) src.temp += "[RC.flavor_desc]<br><br>"
 		src.temp += "[RC.requis_desc]"
-		if(RC.req_class == AID_CONTRACT)
+		if(RC.req_class == AID_CONTRACT && !RC.pinned) // Cannot ordinarily be pinned. Unpin support included for contract testing.
 			src.temp += "URGENT - Cannot Be Reserved<br>"
 		else
 			src.temp += "<A href='[topicLink("pin_contract","\ref[RC]")]'>[RC.pinned ? "Unpin Contract" : "Pin Contract"]</A><br>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Balance and improvement pass to QM requisitions.

- Bulk of this update is increasing payouts; base payouts and per-item fee modifiers have been buffed, with particular emphasis on Aid contracts due to their time-sensitive nature. A few weightings have also been adjusted.
- A new debug proc, /client/proc/TestMarketReq() ("Requisition Test"), has been introduced. It allows you to directly add a certain path of contract to the market in "test mode", automatically pinning the newly-generated contract (even if it's an Aid contract or a contract is already pinned) for ease of validation. Slightly adjusted the QM console logic to account for this.
- A new Civilian contract has been added, pertaining to construction; flavor-wise, this is earlier in the construction process than the interior outfitting contract, and requires one or two possible resources from a short but varied list.
- The "medical emergency" Aid contract no longer has bandages as a possible requirement, instead requiring styptic powder or silver sulfadiazine delivered within patches. To support this, the reagent entry type has been upgraded to optionally support specification of what the desired reagents must be contained in.
- The "supply chain failure" Aid contract can no longer require medical herbs due to the complexity of acquisition being wildly out of line for a time-limited contract. It also requires less fuel when it's of the fuel variant, and the fuel payout has been drastically increased, receiving over 4x the per-unit reward.
- The "event catering" Civilian contract now requires dramatically fewer of each selected food item. Per-item rewards for food are also some of the more significantly increased fee modifiers.
- The "organ research" Scientific contract can no longer require the brain as a target organ, instead favoring the appendix (which receives a small supplementary bonus due to the appendix's low market valuation, in addition to the blanket buffs from the balance pass).
- The "botanical prototyping" Scientific contract now scales its payout primarily by the amount of unique seed variants that are required, as this is the primary metric of difficulty in fulfilling the contract. Peak payout is slightly lower, but average payout will be dramatically higher.
- Drastically increased the payout from the special-order event which requires particular food items.
- Entries that can use commodity prices are now standardized to not replace an explicitly-specified path if it exists.
- Path checking for stack entries now uses istype, fixing a bug where certain stacks would fail to be accepted by contracts due to being a subtype.
- Return for insufficient goods now actually uses a literal return, preventing erroneous empty sale messages from appearing periodically.
- Item boxes (of the non-storage, "stacking" type) now process through requisition evaluation correctly, by adding real contents to the main list and simulating the un-created contents.
- Items contained in object storage of some sort will now mark that object storage as used by the requisition, instead of the individual contents.
 
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Requisitions are currently somewhat undertuned to serve as an alternative to the more dominant money-making methods for Quartermasters, even taking the "spammy" strategies into account; the new values may be slightly over- or under-tuned in a few cases, but should broadly help ensure that requisitions are worth the time of the people fulfilling them.

(Also fixes up a few wack behaviors.)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(*)QM requisitions have received a buff / balancing pass, and a new civilian contract variant.
```
