### PR TITLE
Changes some cargo orders to come as frames

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -359,19 +359,6 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Janitorial Supplies"
 
-/datum/supply_packs/hydrostarter
-	name = "Hydroponics: Starter Crate"
-	desc = "x2 Watering Cans, x4 Compost Bags, x2 Weedkiller bottles, x2 Plant Analyzers, x4 Plant Trays"
-	category = "Civilian Department"
-	contains = list(/obj/item/reagent_containers/glass/wateringcan = 2,
-					/obj/item/reagent_containers/glass/compostbag = 4,
-					/obj/item/reagent_containers/glass/bottle/weedkiller = 2,
-					/obj/item/plantanalyzer = 2,
-					/obj/machinery/plantpot = 4)
-	cost = 500
-	containertype = /obj/storage/crate
-	containername = "Hydroponics: Starter Crate"
-
 /datum/supply_packs/hydronutrient
 	name = "Hydroponics: Nutrient Pack"
 	desc = "x15 Nutrient Formulas"
@@ -803,13 +790,6 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate/wooden
 	containername = "RCD Replacement"
 
-/datum/supply_packs/winter
-	name = "Cold Weather Gear"
-	desc = "Warm winter gear to ward off the winter chills."
-	contains = list(/obj/item/clothing/suit/wintercoat = 5,
-					/obj/machinery/space_heater = 2,
-					/obj/item/reagent_containers/food/drinks/chickensoup = 2,
-					/obj/item/reagent_containers/food/drinks/coffee = 2)
 	cost = 3000
 	containertype = /obj/storage/crate/packing
 	containername = "Cold Weather Gear"
@@ -825,26 +805,6 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	cost = 7500
 	containertype = /obj/storage/crate/wooden
 	containername = "Robuddy Kit"
-
-/datum/supply_packs/meteor
-	name = "Meteor Shield System"
-	desc = "It'll do in a pinch but your ship should really have it's own shields."
-	contains = list(/obj/machinery/shieldgenerator/meteorshield = 4)
-	cost = 2500
-	containertype = /obj/storage/crate/wooden
-	containername = "Meteor Shield System"
-
-/datum/supply_packs/atmos
-	name = "Atmospherics Supplies"
-	desc = "For when you need to be breathing."
-	category = "Basic Materials"
-	contains = list(/obj/item/tank/air,
-					/obj/item/tank/oxygen,
-					/obj/machinery/portable_atmospherics/scrubber = 2,
-					/obj/item/clothing/under/misc/atmospheric_technician)
-	cost = 8000
-	containertype = /obj/storage/crate/wooden
-	containername = "Atmospherics Supplies"
 
 /datum/supply_packs/reclaimer
 	name = "Reclaimed Reclaimer"
@@ -918,16 +878,6 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/secure/crate
 	containername = "Singularity Generator Crate (Cardlocked \[Chief Engineer])"
 	access = access_engineering_chief
-
-/datum/supply_packs/field_generator
-	name = "Field Generator Crate"
-	desc = "The four goal-posts needed to contain a singularity."
-	category = "Engineering Department"
-	contains = list(/obj/machinery/field_generator = 4)
-	cost = 40000
-	containertype = /obj/storage/secure/crate
-	containername = "Field Generator Crate (Cardlocked \[Engineering])"
-	access = access_engineering
 
 /datum/supply_packs/emitter
 	name = "Emitter Crate"
@@ -1646,6 +1596,58 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	cost = 15000
 	containertype = /obj/storage/crate
 	containername = "Operating Room kit"
+
+/datum/supply_packs/complex/field_generator
+	name = "Field Generator Crate"
+	desc = "The four goal-posts needed to contain a singularity. Comes as frames to solder."
+	category = "Engineering Department"
+	frames = list(/obj/machinery/field_generator = 4)
+	cost = 40000
+	containertype = /obj/storage/secure/crate
+	containername = "Field Generator Crate (Cardlocked \[Engineering])"
+	access = access_engineering
+
+/datum/supply_packs/complex/atmos
+	name = "Atmospherics Supplies"
+	desc = "For when you need to be breathing."
+	category = "Basic Materials"
+	contains = list(/obj/item/tank/air,
+					/obj/item/tank/oxygen,
+					/obj/item/clothing/under/misc/atmospheric_technician)
+	frames = list(/obj/machinery/portable_atmospherics/scrubber = 2)
+	cost = 8000
+	containertype = /obj/storage/crate/wooden
+	containername = "Atmospherics Supplies"
+
+/datum/supply_packs/complex/meteor
+	name = "Meteor Shield System"
+	desc = "It'll do in a pinch but your ship should really have it's own shields. Soldering required."
+	frames = list(/obj/machinery/shieldgenerator/meteorshield = 4)
+	cost = 2500
+	containertype = /obj/storage/crate/wooden
+	containername = "Meteor Shield System"
+
+/datum/supply_packs/complex/winter
+	name = "Cold Weather Gear"
+	desc = "Warm winter gear to ward off the winter chills."
+	contains = list(/obj/item/clothing/suit/wintercoat = 5,
+					/obj/item/reagent_containers/food/drinks/chickensoup = 2,
+					/obj/item/reagent_containers/food/drinks/coffee = 2)
+	frames = list(/obj/machinery/space_heater = 2)
+
+/datum/supply_packs/complex/hydrostarter
+	name = "Hydroponics: Starter Crate"
+	desc = "x2 Watering Cans, x4 Compost Bags, x2 Weedkiller bottles, x2 Plant Analyzers, x4 Plant Trays frames"
+	category = "Civilian Department"
+	contains = list(/obj/item/reagent_containers/glass/wateringcan = 2,
+					/obj/item/reagent_containers/glass/compostbag = 4,
+					/obj/item/reagent_containers/glass/bottle/weedkiller = 2,
+					/obj/item/plantanalyzer = 2,
+					/obj/machinery/plantpot = 4)
+	frames = list(/obj/machinery/plantpot = 4)
+	cost = 500
+	containertype = /obj/storage/crate
+	containername = "Hydroponics: Starter Crate"
 
 /datum/supply_packs/complex/robotics_kit
 	name = "Robotics kit"

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -806,6 +806,14 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate/wooden
 	containername = "Robuddy Kit"
 
+/datum/supply_packs/meteor
+	name = "Meteor Shield System"
+	desc = "It'll do in a pinch but your ship should really have it's own shields."
+	contains = list(/obj/machinery/shieldgenerator/meteorshield = 4)
+	cost = 2500
+	containertype = /obj/storage/crate/wooden
+	containername = "Meteor Shield System"
+
 /datum/supply_packs/reclaimer
 	name = "Reclaimed Reclaimer"
 	desc = "Jeez, be more careful with it next time!"
@@ -1619,14 +1627,6 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	containertype = /obj/storage/crate/wooden
 	containername = "Atmospherics Supplies"
 
-/datum/supply_packs/complex/meteor
-	name = "Meteor Shield System"
-	desc = "It'll do in a pinch but your ship should really have it's own shields. Soldering required."
-	frames = list(/obj/machinery/shieldgenerator/meteorshield = 4)
-	cost = 2500
-	containertype = /obj/storage/crate/wooden
-	containername = "Meteor Shield System"
-
 /datum/supply_packs/complex/winter
 	name = "Cold Weather Gear"
 	desc = "Warm winter gear to ward off the winter chills."
@@ -1637,13 +1637,12 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 
 /datum/supply_packs/complex/hydrostarter
 	name = "Hydroponics: Starter Crate"
-	desc = "x2 Watering Cans, x4 Compost Bags, x2 Weedkiller bottles, x2 Plant Analyzers, x4 Plant Trays frames"
+	desc = "x2 Watering Cans, x4 Compost Bags, x2 Weedkiller bottles, x2 Plant Analyzers, x4 Plant Tray frames"
 	category = "Civilian Department"
 	contains = list(/obj/item/reagent_containers/glass/wateringcan = 2,
 					/obj/item/reagent_containers/glass/compostbag = 4,
 					/obj/item/reagent_containers/glass/bottle/weedkiller = 2,
-					/obj/item/plantanalyzer = 2,
-					/obj/machinery/plantpot = 4)
+					/obj/item/plantanalyzer = 2)
 	frames = list(/obj/machinery/plantpot = 4)
 	cost = 500
 	containertype = /obj/storage/crate


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As suggested here: https://forum.ss13.co/showthread.php?tid=18463
This PR changes some cargo orders and turns the bulky machines inside into frames.
This changes the following crates:
-Hydroponics: Stater Crate
-Cold Weather Gear
-Field generators
-Atmospheric supplies


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having the machines come as frames helps both reduce the hassle that came when someone accidentaly opened the crate and you had to haul all the machines one by one, and also lets you ditch the crate entirely and put the items in your backpack.

I didnt include a solder, since most other crates with frames didnt come with one and also taking into account the fact that cargo has a general manufacturer where soldering irons can be made.

I also didnt change the crates where there was only one big machine inside, since you can pull that one with little trouble if the crate ends up being open.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Bartimeus973
(+)Some bulky cargo orders now come as frames.
```
