### PR TITLE
Fix lingering chest item references

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3114,7 +3114,7 @@
 	if (M && M.zone_sel && M.zone_sel.selecting == "chest" && src.chest_item != null && (src.chest_item in src.contents))
 		logTheThing("combat", M, src, "activates [src.chest_item] embedded in [src]'s chest cavity at [log_loc(src)]")
 		SPAWN(0) //might sleep/input/etc, and we don't want to hold anything up
-			activate_chest_item()
+			src.chest_item.AttackSelf(src)
 	return
 
 /mob/living/carbon/human/proc/chest_item_dump_reagents_on_flip()
@@ -3185,18 +3185,16 @@
 		// Make copy of item on ground
 		var/obj/item/outChestItem = src.chest_item
 		outChestItem.set_loc(get_turf(src))
-		activate_chest_item()
+		src.chest_item.AttackSelf(src)
 		src.chest_item = null
 		return
-	activate_chest_item()
-
-///Little wrapper proc to clean up the reference in case AttackSelf moves the chest item outside the mob (items that dispose inside the mob get handled in /obj/item/disposing())
-/mob/living/carbon/human/proc/activate_chest_item() //For edge cases like mousetrap roller assemblies
 	src.chest_item.AttackSelf(src)
-	SPAWN(1 SECOND)
-		if (chest_item?.loc != src)
-			chest_item = null
-			chest_item_sewn = 0
+
+///Clear chest item if it escapes/gets disposed
+/mob/living/carbon/human/Exited(atom/movable/thing)
+	if (thing == chest_item)
+		chest_item = null
+		chest_item_sewn = 0
 
 /mob/living/carbon/human/attackby(obj/item/W, mob/M)
 	if (src.parry_or_dodge(M))

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3192,6 +3192,7 @@
 
 ///Clear chest item if it escapes/gets disposed
 /mob/living/carbon/human/Exited(atom/movable/thing)
+	..()
 	if (thing == chest_item)
 		chest_item = null
 		chest_item_sewn = 0

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3114,7 +3114,7 @@
 	if (M && M.zone_sel && M.zone_sel.selecting == "chest" && src.chest_item != null && (src.chest_item in src.contents))
 		logTheThing("combat", M, src, "activates [src.chest_item] embedded in [src]'s chest cavity at [log_loc(src)]")
 		SPAWN(0) //might sleep/input/etc, and we don't want to hold anything up
-			src.chest_item.AttackSelf(src)
+			activate_chest_item()
 	return
 
 /mob/living/carbon/human/proc/chest_item_dump_reagents_on_flip()
@@ -3185,10 +3185,18 @@
 		// Make copy of item on ground
 		var/obj/item/outChestItem = src.chest_item
 		outChestItem.set_loc(get_turf(src))
-		src.chest_item.AttackSelf(src)
+		activate_chest_item()
 		src.chest_item = null
 		return
+	activate_chest_item()
+
+///Little wrapper proc to clean up the reference in case AttackSelf moves the chest item outside the mob (items that dispose inside the mob get handled in /obj/item/disposing())
+/mob/living/carbon/human/proc/activate_chest_item() //For edge cases like mousetrap roller assemblies and gifts
 	src.chest_item.AttackSelf(src)
+	SPAWN(1 SECOND)
+		if (chest_item?.loc != src)
+			chest_item = null
+			chest_item_sewn = 0
 
 /mob/living/carbon/human/attackby(obj/item/W, mob/M)
 	if (src.parry_or_dodge(M))

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -3191,7 +3191,7 @@
 	activate_chest_item()
 
 ///Little wrapper proc to clean up the reference in case AttackSelf moves the chest item outside the mob (items that dispose inside the mob get handled in /obj/item/disposing())
-/mob/living/carbon/human/proc/activate_chest_item() //For edge cases like mousetrap roller assemblies and gifts
+/mob/living/carbon/human/proc/activate_chest_item() //For edge cases like mousetrap roller assemblies
 	src.chest_item.AttackSelf(src)
 	SPAWN(1 SECOND)
 		if (chest_item?.loc != src)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1465,11 +1465,6 @@
 			var/mob/M = src.loc
 			M.u_equip(src)
 
-			if (ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if (H.chest_item == src)
-					H.chest_item = null
-					H.chest_item_sewn = 0
 
 			//mbc GC tooltips (this wont 100% kill tooltip deletions but itll help?
 			if	(M.client && M.client.tooltipHolder)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1465,6 +1465,12 @@
 			var/mob/M = src.loc
 			M.u_equip(src)
 
+			if (ishuman(M))
+				var/mob/living/carbon/human/H = M
+				if (H.chest_item == src)
+					H.chest_item = null
+					H.chest_item_sewn = 0
+
 			//mbc GC tooltips (this wont 100% kill tooltip deletions but itll help?
 			if	(M.client && M.client.tooltipHolder)
 				for (var/datum/tooltip/tip in M.client.tooltipHolder.tooltips)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -1465,7 +1465,6 @@
 			var/mob/M = src.loc
 			M.u_equip(src)
 
-
 			//mbc GC tooltips (this wont 100% kill tooltip deletions but itll help?
 			if	(M.client && M.client.tooltipHolder)
 				for (var/datum/tooltip/tip in M.client.tooltipHolder.tooltips)

--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -454,7 +454,7 @@
 		logTheThing("bombing", user, null, "releases a [src] (Payload: [src.payload]) at [log_loc(user)]. Direction: [dir2text(user.dir)].")
 
 		src.armed = 1
-		if (src.mousetrap)
+		if (!(src.mousetrap?.armed))
 			src.mousetrap.armed = 1 // Must be armed or it won't work in mousetrap.triggered().
 			src.mousetrap.set_armer(user)
 		src.set_density(1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[cleanliness][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR:

-Adds a couple bits of code to try and always clean up chest item references in weird edge cases: One is when an item is disposed while inside the mob (grenades, gifts) and the other is when using an item changes its location upon use (I can only think of the mousetrap/roller assembly for this one)

-Fixes a signal re-registering error that occurs when a mousetrap roller assembly is activated and it tries to arm a mousetrap that was already armed when the assembly was crafted.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
closes #8196 and prevents an insignificant type of memory leak
Prevents people from keeping (a very limited selection of) disposed items around on station.