### PR TITLE
Player piano mechcomp integration

### DIFF
--- a/code/datums/components/mechComp_signals.dm
+++ b/code/datums/components/mechComp_signals.dm
@@ -285,6 +285,14 @@ TYPEINFO(/datum/component/mechanics_holder)
 	if(!IN_RANGE(receiver, trigger, WIDE_TILE_WIDTH))
 		boutput(user, "<span class='alert'>These two components are too far apart to connect.</span>")
 		return
+	var/atom/movable/moveable_target = comsig_target
+	if(istype(moveable_target) && !moveable_target.anchored)
+		boutput(user, "<span class='alert'>[moveable_target] must be anchored to connect it.</span>")
+		return
+	var/atom/movable/moveable_trigger = trigger
+	if(istype(moveable_trigger) && !moveable_trigger.anchored)
+		boutput(user, "<span class='alert'>[moveable_trigger] must be anchored to connect it.</span>")
+		return
 	if(!src.inputs.len)
 		boutput(user, "<span class='alert'>[receiver.name] has no input slots. Can not connect [trigger.name] as Trigger.</span>")
 		return

--- a/code/obj/playable_piano.dm
+++ b/code/obj/playable_piano.dm
@@ -257,6 +257,8 @@
 		is_busy = 0
 
 	proc/ready_piano(var/is_linked) //final checks to make sure stuff is right, gets notes into a compiled form for easy playsounding
+		if (is_busy)
+			return
 		is_busy = 1
 		if (note_volumes.len + note_octaves.len - note_names.len - note_accidentals.len)
 			src.visible_message("<span class='alert'>\The [src] makes a grumpy ratchetting noise and shuts down!</span>")
@@ -307,6 +309,8 @@
 			playsound(src, sound_name, note_volumes[curr_note],0,10,0)
 
 	proc/set_notes(var/given_notes)
+		if (is_busy)
+			return FALSE
 		if (length(note_input) > MAX_NOTE_INPUT)
 			return FALSE
 		src.note_input = given_notes
@@ -315,6 +319,8 @@
 		return TRUE
 
 	proc/set_timing(var/time_sel)
+		if (is_busy)
+			return FALSE
 		if (time_sel < MIN_TIMING || time_sel > MAX_TIMING)
 			return FALSE
 		src.timing = time_sel

--- a/code/obj/playable_piano.dm
+++ b/code/obj/playable_piano.dm
@@ -90,6 +90,7 @@
 					return
 				playsound(user, "sound/items/Screwdriver2.ogg", 65, 1)
 				src.anchored = 0
+				SEND_SIGNAL(src, COMSIG_MECHCOMP_RM_ALL_CONNECTIONS)
 				user.visible_message("[user] loosens the piano's castors!", "You loosen the piano's castors!")
 				return
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives the player piano 3 mechcomp inputs.
- Play
- Set Notes
- Set Timing
- Reset

Also gives an output that triggers when playing finishes.
Also did some minor refactoring I guess.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fun?
- Custom Jukebox
- Fun jingle for your shop
- Play Megalovania and demand payment for periods of silence (maybe don't do that one)

Sorry about the GIANT FLASHING PURPLE RECTANGLES in the video, I think my recording software did not like the tooltips.

https://user-images.githubusercontent.com/35579460/163493025-14978e19-e5c1-4cf2-936e-db4b153a29f5.mp4

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) Player pianos now have mechcomp integration.
```
