### PR TITLE
Log gib deaths

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -229,6 +229,7 @@
 						the_mob:update_burning(1)
 						sleep(0.3 SECONDS)
 				the_mob.unlock_medal( "Too Fast Too Furious", 1 )
+				logTheThing("combat", the_mob, null, "was gibbed by rocket shoes at [log_loc(the_mob)].")
 				the_mob.gib()
 
 			return

--- a/code/WorkInProgress/Azungarstuff.dm
+++ b/code/WorkInProgress/Azungarstuff.dm
@@ -86,6 +86,7 @@
 					H.unkillable = 0
 				if(!M.stat) M.emote("scream")
 				src.visible_message("<span class='alert'><B>[M]</B> falls into the [src] and melts away!</span>")
+				logTheThing("combat", M, null, "was firegibbed by [src] ([src.type]) at [log_loc(M)].")
 				M.firegib() // thanks ISN!
 		else
 			src.visible_message("<span class='alert'><B>[O]</B> falls into the [src] and melts away!</span>")

--- a/code/WorkInProgress/Hydrothings.dm
+++ b/code/WorkInProgress/Hydrothings.dm
@@ -510,6 +510,7 @@ obj/item/gnomechompski/elf
 			if(probmult(10))
 				var/obj/critter/hootening/P = new/obj/critter/hootening(affected_mob.loc)
 				P.name = affected_mob.real_name
+				logTheThing("combat", affected_mob, null, "was gibbed by the disease [name] at [log_loc(affected_mob)].")
 				affected_mob.gib()
 
 /obj/item/reagent_containers/food/snacks/candy/butterscotch
@@ -1176,6 +1177,7 @@ obj/critter/madnessowl/switchblade
 				src.visible_message("<span class='alert'><B>[src]</B> throws a tantrum and smashes [BORG.name] to pieces!</span>")
 				playsound(src.loc, "sound/voice/animal/hoot.ogg", 75, 1)
 				playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Lowfi_1.ogg', 70, 1)
+				logTheThing("combat", src, BORG, "gibs [constructTarget(BORG,"combat")] at [log_loc(src)].")
 				BORG.gib()
 				src.target = null
 				src.boredom_countdown = 0

--- a/code/WorkInProgress/previouslyKeelinsStuff.dm
+++ b/code/WorkInProgress/previouslyKeelinsStuff.dm
@@ -441,6 +441,7 @@ var/reverse_mode = 0
 									boutput(user, "<span class='alert'>The relic explodes violently!</span>")
 									var/obj/effects/explosion/E = new/obj/effects/explosion( get_turf(src) )
 									E.fingerprintslast = src.fingerprintslast
+									logTheThing("user", user, null, "was gibbed by [src] ([src.type]) at [log_loc(user)].")
 									user:gib()
 									qdel(src)
 								if (4)
@@ -448,6 +449,7 @@ var/reverse_mode = 0
 									using = 1
 									harmless_smoke_puff( get_turf(src) )
 									playsound(user, "sound/effects/ghost2.ogg", 60, 0)
+									logTheThing("user", user, null, "was killed by [src] ([src.type]) at [log_loc(user)].")
 									user.flash(60)
 									var/mob/oldmob = user
 									oldmob.ghostize()

--- a/code/datums/abilities/revenant.dm
+++ b/code/datums/abilities/revenant.dm
@@ -549,6 +549,7 @@
 					H.emote("scream")
 				if (iterations > 12 && prob((iterations - 12) * 5))
 					H.visible_message("<span class='alert'>[H]'s body gives in to the telekinetic grip!</span>", "<span class='alert'>You are completely crushed.</span>")
+					logTheThing("combat", holder.owner, H, "gibs [constructTarget(H,"combat")] with the Revenant crush ability at [log_loc(holder.owner)].")
 					H.gib()
 					return
 				sleep(0.7 SECONDS)

--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -82,6 +82,7 @@
 				playsound(user.loc, "sound/impact_sounds/Slimy_Hit_3.ogg", 50, 1)
 
 				if(prob(get_brute_damage() - 50))
+					logTheThing("combat", user, src, "gibs [constructTarget(src,"combat")] breaking out of their stomach at [log_loc(src)].")
 					src.gib()
 
 /mob/living/carbon/gib(give_medal, include_ejectables)

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -614,6 +614,7 @@
 					SPAWN(1 SECOND)
 						src.wear_mask.set_loc(src.loc)
 						src.wear_mask = null
+						logTheThing("combat", src, null, "was gibbed by emoting uguu at [log_loc(src)].")
 						src.gib()
 						return
 				else
@@ -677,6 +678,7 @@
 						src.say ("M'lady")
 						SPAWN(1 SECOND)
 							src.add_karma(-10)
+							logTheThing("combat", src, null, "was gibbed by emoting fedora tipping at [log_loc(src)].")
 							src.gib()
 
 			if ("hatstomp", "stomphat")

--- a/code/mob/living/critter/singularity.dm
+++ b/code/mob/living/critter/singularity.dm
@@ -109,15 +109,16 @@
       step_towards(M, src)
 
 /mob/living/critter/singularity/proc/eat(atom/movable/A)
-  // TODO: heal based on consumption?
-  if(src.affects_mobs && isliving(A))
-    var/mob/living/M = A
-    if(M && !istype(M, /mob/living/critter/singularity))
-      M.gib()
+	// TODO: heal based on consumption?
+	if(src.affects_mobs && isliving(A))
+		var/mob/living/M = A
+		if(M && !istype(M, /mob/living/critter/singularity))
+			logTheThing("combat", M, null, "was gibbed by [src] ([src.type]) at [log_loc(M)].")
+			M.gib()
   else if(isobj(A) && A.anchored != 2)
-    A.ex_act(1.0)
-    if(A)
-      qdel(A)
+		A.ex_act(1.0)
+		if(A)
+			qdel(A)
 
 
 /mob/living/critter/singularity/Crossed(atom/movable/A)

--- a/code/mob/living/critter/singularity.dm
+++ b/code/mob/living/critter/singularity.dm
@@ -115,7 +115,7 @@
 		if(M && !istype(M, /mob/living/critter/singularity))
 			logTheThing("combat", M, null, "was gibbed by [src] ([src.type]) at [log_loc(M)].")
 			M.gib()
-  else if(isobj(A) && A.anchored != 2)
+	else if(isobj(A) && A.anchored != 2)
 		A.ex_act(1.0)
 		if(A)
 			qdel(A)

--- a/code/mob/living/life/blood.dm
+++ b/code/mob/living/life/blood.dm
@@ -143,6 +143,7 @@
 		if (current_blood_amt >= 1000)
 			if (prob(clamp((current_blood_amt - 1000)/10, 0, 100))) //0% at 1000, 100% at 2000, linear scaling
 				owner.visible_message("<span class='alert'><b>[owner] bursts like a bloody balloon! Holy fucking shit!!</b></span>")
+				logTheThing("combat", owner, null, "gibbed due to having over 1000 units of blood at [log_loc(src)].")
 				owner.gib(TRUE) // :v
 				return ..()
 

--- a/code/modules/admin/buildmodes/adventure/elements/trap/lightning.dm
+++ b/code/modules/admin/buildmodes/adventure/elements/trap/lightning.dm
@@ -92,6 +92,8 @@
 								M.changeStatus("stunned", stun SECONDS)
 								boutput(M, "<b><span class='alert'>You feel a powerful shock course through your body!</span></b>")
 							else
+								if(ishuman(M))
+									logTheThing("combat", M, null, "was gibbed by [src] ([src.type]) at [log_loc(M)].")
 								M:gib()
 					else
 						for (var/mob/living/M in view(src, range))
@@ -105,6 +107,8 @@
 								M.changeStatus("stunned", stun SECONDS)
 								boutput(M, "<b><span class='alert'>You feel a powerful shock course through your body!</span></b>")
 							else
+								if(ishuman(M))
+									logTheThing("combat", M, null, "was gibbed by [src] ([src.type]) at [log_loc(M)].")
 								M:gib()
 					if (attack_amt)
 						playsound(src, "sound/effects/elec_bigzap.ogg", 40, 1)

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -646,6 +646,7 @@ datum
 						H.visible_message("<span class='alert'><b>[H] explodes in a shower of gibs, hair and piracy!</b></span>","<span class='alert'><b>Oh god, too much hair!</b></span>")
 						new /obj/item/clothing/glasses/eyepatch(get_turf(H))
 						new /obj/item/clothing/mask/moustache(get_turf(H))
+						logTheThing("combat", src, null, "was gibbed by the reagent [name].")
 						H.gib()
 						return
 					if(H.bioHolder.mobAppearance.customization_first.id != "dreads" || H.bioHolder.mobAppearance.customization_second.id != "fullbeard")
@@ -1123,6 +1124,7 @@ datum
 								boutput(M, "<span class='alert'><b>IT BURNS!!!!</b></span>")
 								sleep(0.2 SECONDS)
 								M.visible_message("<span class='alert'>[M] is consumed in flames!</span>")
+								logTheThing("combat", M, null, "was fire-gibbed by the reagent [name].")
 								M.firegib()
 
 				..()
@@ -4083,6 +4085,7 @@ datum
 								boutput(M, "<span class='alert'><b>IT BURNS!!!!</b></span>")
 								sleep(0.2 SECONDS)
 								M.visible_message("<span class='alert'>[M] is consumed in flames!</span>")
+								logTheThing("combat", M, null, "was fire-gibbed by the reagent [name].")
 								M.firegib()
 				..()
 

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1538,6 +1538,8 @@ datum
 					M.make_jittery(1000)
 					SPAWN(rand(20, 100))
 						var/turf/Mturf = get_turf(M)
+						if (ishuman(M))
+							logTheThing("combat", M, null, "was transformed into a dog by reagent [name] at [log_loc(M)].")
 						M.gib()
 						new /obj/critter/dog/george (Mturf)
 					return
@@ -1576,6 +1578,8 @@ datum
 					M.setStatusMin("weakened", 15 SECONDS * mult)
 					M.make_jittery(1000)
 					SPAWN(rand(20, 100))
+						if (ishuman(M))
+							logTheThing("combat", M, null, "was owlgibbed by reagent [name] at [log_loc(M)].")
 						M.owlgib(control_chance = 100)
 					return
 				..()
@@ -2123,6 +2127,7 @@ datum
 							H.visible_message("<span class='alert bold'>[H] is torn apart from the inside as some weird floaty thing rips its way out of their body! Holy fuck!!</span>")
 							var/mob/living/critter/flock/bit/B = new()
 							B.set_loc(get_turf(H))
+							logTheThing("combat", H, null, "was gibbed by reagent [name] at [log_loc(H)].")
 							H.gib()
 					else
 						// DO SPOOKY THINGS
@@ -3363,6 +3368,8 @@ datum
 				one_with_everything(M)
 				#else
 				M.ex_act(1)
+				if (ishuman(M))
+					logTheThing("combat", M, null, "was gibbed by reagent [name] at [log_loc(M)].")
 				M.gib()
 				#endif
 				M.reagents.del_reagent(src.id)
@@ -3395,6 +3402,8 @@ datum
 			on_mob_life(var/mob/M, var/mult = 1)
 				..()
 				M.ex_act(1)
+				if (isliving(M))
+					logTheThing("combat", M, null, "was gibbed by reagent [name] at [log_loc(M)].")
 				M.gib()
 				M.reagents.del_reagent(src.id)
 

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -564,6 +564,7 @@ datum
 						B.desc = "This bee looks very much like [M.real_name]. How peculiar."
 						B.beeKid = "#ffdddd"
 						B.UpdateIcon()
+						logTheThing("combat", M, null, "was gibbed by reagent [name].")
 						M.gib()
 				..()
 
@@ -725,6 +726,7 @@ datum
 								bleed(H, 500, 5) // you'll be gibbed in a moment you don't need it anyway
 								H.visible_message("<span class='alert'><B>A huge bee bursts out of [H]! OH FUCK!</B></span>")
 								qdel(H.organHolder.heart)
+								logTheThing("combat", H, null, "was gibbed by reagent [name].")
 								H.gib()
 				..()
 
@@ -1213,6 +1215,7 @@ datum
 					M.make_jittery(1000)
 					SPAWN(rand(20, 100))
 						if (M) //ZeWaka: Fix for null.gib
+							logTheThing("combat", M, null, "was gibbed by reagent [name].")
 							M.gib()
 					return
 

--- a/code/modules/events/black_hole.dm
+++ b/code/modules/events/black_hole.dm
@@ -78,6 +78,7 @@
 				qdel(A)
 			else if (isliving(A))
 				var/mob/living/L = A
+				logTheThing("combat", L, null, "was elecgibbed by [src] ([src.type]) at [log_loc(L)].")
 				L.elecgib()
 				src.get_fed(10)
 
@@ -129,6 +130,7 @@
 
 	Bumped(atom/A)
 		if (isliving(A))
+			logTheThing("combat", A, null, "was gibbed by [src] ([src.type]) at [log_loc(A)].")
 			A:gib()
 		else if(isobj(A))
 			var/obj/O = A

--- a/code/modules/events/minor/trader.dm
+++ b/code/modules/events/minor/trader.dm
@@ -118,4 +118,6 @@
 		if(ismob(AM))
 			var/mob/M = AM
 			boutput(AM, "<span class='alert'><b>Your body is destroyed as the merchant shuttle passes [pick("an eldritch decomposure field", "a life negation ward", "a telekinetic assimilation plant", "a swarm of matter devouring nanomachines", "an angry Greek god", "a burnt-out coder", "a death ray fired millenia ago from a galaxy far, far away")].</b></span>")
+			if(isliving(M))
+				logTheThing("combat", M, null, "was gibbed by trying to hide on a merchant shuttle.")
 			M.gib()

--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -71,6 +71,8 @@
 			for(var/mob/M in view(7, src.loc))
 				shake_camera(M, 20, 8)
 				if(gib_mobs && M.loc == src.loc && isliving(M) && !isintangible(M))
+					if(isliving(M))
+						logTheThing("combat", M, null, "was gibbed by [src] ([src.type]) at [log_loc(M)].")
 					M.gib(1, 1)
 			sleep(0.5 SECONDS)
 			if (obj_path && no_lootbox)

--- a/code/modules/hydroponics/plants_alien.dm
+++ b/code/modules/hydroponics/plants_alien.dm
@@ -80,6 +80,7 @@ ABSTRACT_TYPE(/datum/plant/artifact)
 		else if(focus_level <= 6)
 			boutput(M, "<span style=\"color:red;font-size:3em\">Run.</span>")
 		else
+			logTheThing("combat", M, null, "was gibbed by [src] ([src.type]) at [log_loc(M)].")
 			if (M.organHolder)
 				var/obj/brain = M.organHolder.drop_organ("brain")
 				brain?.throw_at(get_edge_cheap(get_turf(M), pick(cardinal)), 16, 3)

--- a/code/modules/medical/diseases/edisons_disease.dm
+++ b/code/modules/medical/diseases/edisons_disease.dm
@@ -66,6 +66,7 @@
 				affected_mob.make_jittery(1000)
 				SPAWN(rand(20, 100))
 					if (affected_mob)
+						logTheThing("combat", affected_mob, null, "was gibbed by the disease [name] at [log_loc(affected_mob)].")
 						var/list/gibs = affected_mob.gib()
 						for(var/obj/decal/cleanable/gib in gibs)
 							update_light(gib, rand(2,6))

--- a/code/modules/medical/diseases/gbs.dm
+++ b/code/modules/medical/diseases/gbs.dm
@@ -37,7 +37,9 @@
 				affected_mob.changeStatus("weakened", 15 SECONDS)
 				affected_mob.make_jittery(1000)
 				SPAWN(rand(20, 100))
-					if (affected_mob) affected_mob.gib()
+					if (affected_mob)
+						logTheThing("combat", affected_mob, null, "was gibbed by the disease [name] at [log_loc(affected_mob)].")
+						affected_mob.gib()
 				return
 		else
 			return

--- a/code/modules/medical/diseases/parasites.dm
+++ b/code/modules/medical/diseases/parasites.dm
@@ -75,6 +75,7 @@
 				while(babyspiders-- > 0)
 					new/obj/critter/spider/ice/baby(affected_mob.loc)
 				affected_mob.visible_message("<span class='alert'><b>[affected_mob] bursts open! Holy fuck!</b></span>")
+				logTheThing("combat", affected_mob, null, "was gibbed by the disease [name] at [log_loc(affected_mob)].")
 				affected_mob:gib()
 				return
 

--- a/code/modules/medical/diseases/robotic_transformation.dm
+++ b/code/modules/medical/diseases/robotic_transformation.dm
@@ -64,6 +64,7 @@
 					affected_mob.gib()
 					qdel(affected_mob)
 				else if (ishuman(affected_mob))
+					logTheThing("combat", affected_mob, null, "was transformed into a cyborg by the disease [name] at [log_loc(affected_mob)].")
 					gibs(T, null, null, bdna, btype)
 					affected_mob:Robotize_MK2(1)
 

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -974,6 +974,7 @@
 			if(owner.reagents.has_reagent("anti_fart"))
 				owner.visible_message("<span class='alert'><b>[owner.name]</b> swells up. That can't be good.</span>")
 				boutput(owner, "<span class='alert'><b>Oh god.</b></span>")
+				logTheThing("combat", owner, null, "was gibbed by superfarting while containing anti_fart at [log_loc(owner)].")
 				indigestion_gib()
 				return 1
 

--- a/code/modules/networks/computer3/mainframe2/telesci.dm
+++ b/code/modules/networks/computer3/mainframe2/telesci.dm
@@ -701,6 +701,7 @@ proc/is_teleportation_allowed(var/turf/T)
 				return
 			if("gib")
 				for(var/mob/living/M in src.loc)
+					logTheThing("combat", M, null, "was gibbed by a telescience fault at [log_loc(M)].")
 					M.gib()
 				return
 			if("majormutate")

--- a/code/modules/power/pt_laser.dm
+++ b/code/modules/power/pt_laser.dm
@@ -586,11 +586,13 @@
 			make_cleanable( /obj/decal/cleanable/ash,src.loc)
 			L.unlock_medal("For Your Ohm Good", 1)
 			L.visible_message("<b>[L.name] is vaporised by the [src]!</b>")
+			logTheThing("combat", L, null, "was elecgibbed by the PTL at [log_loc(L)].")
 			L.elecgib()
 			return 1 //tells the caller to remove L from the laser's affecting_mobs
 		if(1e11+1 to INFINITY) //you really, REALLY fucked up this time buddy
 			L.unlock_medal("For Your Ohm Good", 1)
 			L.visible_message("<b>[L.name] is detonated by the [src]!</b>")
+			logTheThing("combat", L, null, "was explosively gibbed by the PTL at [log_loc(L)].")
 			L.blowthefuckup(min(1+round(power/1e12),20),0)
 			return 1 //tells the caller to remove L from the laser's affecting_mobs
 

--- a/code/obj/artifacts/artifact_objects/wish_granter.dm
+++ b/code/obj/artifacts/artifact_objects/wish_granter.dm
@@ -63,6 +63,7 @@
 						N.flash(3 SECONDS)
 						if(N.client)
 							shake_camera(N, 6, 16)
+					logTheThing("combat", user, null, "was turned into a gold statue by wishgranter [src] at [log_loc(user)].")
 					user.become_statue(getMaterial("gold"),"A statue of someone very wealthy", TRUE)
 
 				if("I wish for great power!")
@@ -72,6 +73,7 @@
 					for(var/obj/OB in affected)
 						SPAWN(0.6 SECONDS)
 							qdel(OB)
+					logTheThing("combat", user, null, "was elecgibbed by wishgranter [src] at [log_loc(user)].")
 					user.elecgib()
 		else
 			switch(wish)

--- a/code/obj/artifacts/faults.dm
+++ b/code/obj/artifacts/faults.dm
@@ -131,6 +131,7 @@ ABSTRACT_TYPE(/datum/artifact_fault/)
 		var/turf/T = get_turf(O)
 		T.visible_message("<span class='alert'><b>The [cosmeticSource.name] utterly annihilates [user.name]!</b></span>")
 		playsound(T, "sound/effects/elec_bigzap.ogg", 40, 1) // seriously 100 volume on this file? Are you trying to deafen players?
+		logTheThing("combat", user, null, "was elecgibbed by an artifact fault from [O] at [log_loc(user)].")
 		user.elecgib()
 
 /datum/artifact_fault/explode

--- a/code/obj/critter/Brullbar.dm
+++ b/code/obj/critter/Brullbar.dm
@@ -251,6 +251,7 @@
 				src.visible_message("<span class='alert'><B>[src]</B> throws a tantrum and smashes [BORG.name] to pieces!</span>")
 				playsound(src.loc, "sound/voice/animal/brullbar_scream.ogg", 75, 1)
 				playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Lowfi_1.ogg', 70, 1)
+				logTheThing("combat", src, BORG, "gibs [constructTarget(BORG,"combat")] at [log_loc(src)].")
 				BORG.gib()
 				src.target = null
 				src.boredom_countdown = 0

--- a/code/obj/critter/pets_small_animals.dm
+++ b/code/obj/critter/pets_small_animals.dm
@@ -691,6 +691,7 @@ var/list/shiba_names = list("Maru", "Coco", "Foxtrot", "Nectarine", "Moose", "Pe
 			src.visible_message("<span class='combat'><B>[src]</B> stares at [M], channeling its newfound power!</span>")
 			SPAWN(1 SECOND)
 				boutput(M, "<span class='alert'><BIG><B>[voidSpeak("WELP, GUESS YOU SHOULDN'T BELIEVE EVERYTHING YOU READ!")]</B></BIG></span>")
+				logTheThing("combat", M, null, "was deleted by using a void crown on [src] at [log_loc(src)].")
 				var/mob/dead/observer/O = M.ghostize()
 				if(O)
 					O.set_loc(M.loc)

--- a/code/obj/critter/sword.dm
+++ b/code/obj/critter/sword.dm
@@ -618,6 +618,7 @@
 			for (var/mob/living/M in get_center())
 				if (isintangible(M) || IS_ARRIVALS(get_area(M))) continue
 				if(prob(69))								//Nice.
+					logTheThing("user", M, null, "was gibbed by [src] ([src.type]) at [log_loc(M)].")
 					M.gib()
 				else
 					random_brute_damage(M, 120)

--- a/code/obj/item/card.dm
+++ b/code/obj/item/card.dm
@@ -249,6 +249,7 @@ GAUNTLET CARDS
 		O.icon = 'icons/effects/214x246.dmi'
 		O.icon_state = "explosion"
 		SPAWN(3.5 SECONDS) qdel(O)
+		logTheThing("combat", user, null, "was gibbed by the explosive Captain's Spare at [log_loc(user)].")
 		user.gib()
 
 /obj/item/card/id/attack_self(mob/user as mob)

--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -350,6 +350,7 @@
 			if(!foiled)
 				user.take_brain_damage(1000)
 			else
+				logTheThing("combat", user, null, "was partygibbed by [src] at [log_loc(src)].")
 				user.partygib(1)
 
 /obj/item/card_group //since "playing_card"s are singular cards, card_groups handling groups of playing_cards in the form of either a deck or hand

--- a/code/obj/item/zoldorfmisc.dm
+++ b/code/obj/item/zoldorfmisc.dm
@@ -294,6 +294,7 @@
 				deck.inuse = 0
 				user.u_equip(deck)
 				deck.set_loc(get_turf(user))
+				logTheThing("combat", user, null, "was gibbed by Zoldorf's crusher card at [log_loc(user)].")
 				user.gib(1)
 			if("Geneticist")
 				var/list/effectpool = list("xray","hulk","breathless","thermal_resist","regenerator","detox")
@@ -426,6 +427,7 @@
 					return
 				if(isrestrictedz(user.z))
 					boutput(user, "<span class='alert'>You are suddenly zapped apart!</span>")
+					logTheThing("user", user, null, "was gibbed for trying to use Zoldorf's presto scroll at [log_loc(user)].")
 					user.gib()
 
 				var/list/randomturfs = new/list()

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -584,6 +584,7 @@
 			for(var/x in end_location)
 				if(isliving(x) && !isintangible(x))
 					var/mob/living/M = x
+					logTheThing("combat", M, null, "was gibbed by an arriving shuttle at [log_loc(M)].")
 					M.gib(1)
 				if(istype(x, /obj/storage))
 					var/obj/storage/S = x
@@ -659,6 +660,7 @@
 		for(var/mob/living/L in end_location) // oh dear, stay behind the yellow line kids
 			if(!isintangible(L))
 				SPAWN(1 DECI SECOND)
+					logTheThing("combat", L, null, "was gibbed by an elevator at [log_loc(L)].")
 					L.gib()
 		start_location.move_contents_to(end_location, /turf/simulated/floor/arctic_elevator_shaft)
 		location = 0
@@ -729,6 +731,7 @@
 		for(var/mob/living/L in end_location) // oh dear, stay behind the yellow line kids
 			if(!isintangible(L))
 				SPAWN(1 DECI SECOND)
+					logTheThing("combat", L, null, "was gibbed by an elevator at [log_loc(L)].")
 					L.gib()
 			bioele_accident()
 		start_location.move_contents_to(end_location, /turf/unsimulated/floor/setpieces/ancient_pit/shaft)

--- a/code/obj/machinery/shitty_grill.dm
+++ b/code/obj/machinery/shitty_grill.dm
@@ -66,6 +66,7 @@
 				return
 			else
 				boutput(user, "<span class='alert'>Your hubris will not be tolerated.</span>")
+				logTheThing("user", user, null, "was gibbed by [src] ([src.type]) at [log_loc(user)].")
 				user.gib()
 				qdel(W)
 				return

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -879,6 +879,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 
 	if(user.get_burn_damage() >= 500) //This person has way too much BURN, they've probably been shocked a lot! Let's destroy them!
 		user.visible_message("<span style=\"color:red;font-weight:bold;\">[user.name] was disintegrated by the [src.name]!</span>")
+		logTheThing("user", user, null, "was elecgibbed by [src] ([src.type]) at [log_loc(user)].")
 		user.elecgib()
 		return
 	else

--- a/code/obj/martian.dm
+++ b/code/obj/martian.dm
@@ -44,6 +44,7 @@
 					var/datum/human_limbs/HL = H.limbs
 					HL.sever("both_arms", user)
 				else
+					logTheThing("user", user, null, "was gibbed by [src] ([src.type]) at [log_loc(user)].")
 					user.gib()
 				icon_state = "crevice1"
 				desc = "The crevice has closed"

--- a/code/z_adventurezones/biodome.dm
+++ b/code/z_adventurezones/biodome.dm
@@ -420,6 +420,7 @@ SYNDICATE DRONE FACTORY AREAS
 					H.unkillable = 0
 				if(!M.stat) M.emote("scream")
 				src.visible_message("<span class='alert'><B>[M]</B> falls into the [src] and melts away!</span>")
+				logTheThing("combat", M, null, "was firegibbed by [src] ([src.type]) at [log_loc(M)].")
 				M.firegib() // thanks ISN!
 		else
 			src.visible_message("<span class='alert'><B>[O]</B> falls into the [src] and melts away!</span>")

--- a/code/z_adventurezones/lavamoon.dm
+++ b/code/z_adventurezones/lavamoon.dm
@@ -1545,6 +1545,7 @@ var/global/iomoon_blowout_state = 0 //0: Hasn't occurred, 1: Moon is irradiated 
 		playsound(src.loc, "sound/effects/mag_iceburstimpact.ogg", 25, 1)
 
 		for(var/mob/living/L in get_turf(src))
+			logTheThing("combat", L, null, "was gibbed by [src] ([src.type]) at [log_loc(L)].")
 			L.gib()
 
 		set_density(1)

--- a/code/z_adventurezones/meatland.dm
+++ b/code/z_adventurezones/meatland.dm
@@ -1529,6 +1529,7 @@ var/list/meatland_fx_sounds = list('sound/ambience/spooky/Meatzone_Squishy.ogg',
 			else
 				L.visible_message("<span class='alert'><b>[L] is gored by [src]!</b></span>", "<span class='alert'><b>OH SHIT</b></span>")
 				playsound(src.loc, "sound/impact_sounds/Flesh_Break_1.ogg", 50, 1)
+				logTheThing("combat", L, null, "was gibbed by [src] ([src.type]) at [log_loc(L)].")
 				L.gib()
 
 		src.icon_state = "fangdoor1"

--- a/code/z_adventurezones/solarium.dm
+++ b/code/z_adventurezones/solarium.dm
@@ -59,6 +59,7 @@ var/global/the_sun = null
 					SPAWN(1 SECOND)
 						user.visible_message("<span class='alert'><b>[user]</b> burns away into ash! It's almost as though being that close to a star wasn't a great idea!</span>",\
 						"<span class='alert'><b>You burn away into ash! It's almost as though being that close to a star wasn't a great idea!</b></span>")
+						logTheThing("combat", user, null, "was firegibbed by [src] ([src.type]) at [log_loc(user)].")
 						user.firegib()
 				else
 					user.unlock_medal("Helios", 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds logging of cause to gib, elec gib and fire gib deaths.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's not very useful to have someone die from Ghost Chili and just have "gibbed" in the log.