### PR TITLE
Block lightbreaker in sanctuary

### DIFF
--- a/code/obj/item/device/lightbreaker.dm
+++ b/code/obj/item/device/lightbreaker.dm
@@ -40,6 +40,7 @@
 			if (L.status == 2 || L.status == 1)
 				continue
 			var/area/A = get_area(L)
+			// Protect lights in sanctuary and nukie battlecruiser
 			if(A?.sanctuary || istype(A, /area/syndicate_station))
 				continue
 			L.broken(1)

--- a/code/obj/item/device/lightbreaker.dm
+++ b/code/obj/item/device/lightbreaker.dm
@@ -35,13 +35,12 @@
 		return
 
 	proc/activate(mob/user as mob)
-		var/area/a = get_area(user)
-		if(a?.sanctuary)
-			boutput(user, "<span class='alert'>This doesn't seem to work here!</span>")
-			return 0
 		playsound(src.loc, "sound/effects/light_breaker.ogg", 75, 1, 5)
 		for (var/obj/machinery/light/L in view(7, user))
 			if (L.status == 2 || L.status == 1)
+				continue
+			var/area/A = get_area(L)
+			if(A?.sanctuary || istype(A, /area/syndicate_station))
 				continue
 			L.broken(1)
 

--- a/code/obj/item/device/lightbreaker.dm
+++ b/code/obj/item/device/lightbreaker.dm
@@ -35,6 +35,10 @@
 		return
 
 	proc/activate(mob/user as mob)
+		var/area/a = get_area(user)
+		if(a?.sanctuary)
+			boutput(user, "<span class='alert'>This doesn't seem to work here!</span>")
+			return 0
 		playsound(src.loc, "sound/effects/light_breaker.ogg", 75, 1, 5)
 		for (var/obj/machinery/light/L in view(7, user))
 			if (L.status == 2 || L.status == 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents lightbreakers working in sanctuary areas.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nukies kept breaking all the lights in the battlecruiser.