### PR TITLE
Removes old electronics restock cartridge from cargo order

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1176,8 +1176,7 @@ ABSTRACT_TYPE(/datum/supply_packs)
 /datum/supply_packs/electronics_vending_restock
 	name = "Electronics Vending Machine Restocking Pack"
 	desc = "Various Vending Machine Restock Cartridges for electronics"
-	contains = list(/obj/item/vending/restock_cartridge/electronics,
-					/obj/item/vending/restock_cartridge/mechanics,
+	contains = list(/obj/item/vending/restock_cartridge/mechanics,
 					/obj/item/vending/restock_cartridge/computer3,
 					/obj/item/vending/restock_cartridge/floppy,
 					/obj/item/vending/restock_cartridge/pda)

--- a/code/obj/item/vending_restock.dm
+++ b/code/obj/item/vending_restock.dm
@@ -58,12 +58,6 @@
 	desc = "A cartridge that restocks cola vending machines."
 	vendingType = "cola"
 
-/obj/item/vending/restock_cartridge/electronics
-	name = "electronics restock cartridge"
-	icon_state = "electronics"
-	desc = "A cartridge that restocks electronics vending machines."
-	vendingType = "electronics"
-
 /obj/item/vending/restock_cartridge/mechanics
 	name = "mechanics restock cartridge"
 	icon_state = "mechanics"

--- a/code/obj/item/vending_restock.dm
+++ b/code/obj/item/vending_restock.dm
@@ -58,6 +58,12 @@
 	desc = "A cartridge that restocks cola vending machines."
 	vendingType = "cola"
 
+/obj/item/vending/restock_cartridge/electronics
+	name = "electronics restock cartridge"
+	icon_state = "electronics"
+	desc = "A cartridge that restocks electronics vending machines."
+	vendingType = "electronics"
+
 /obj/item/vending/restock_cartridge/mechanics
 	name = "mechanics restock cartridge"
 	icon_state = "mechanics"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[REMOVAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes #8189

The electronics restock cartriddge correlates to the old electronics vending machine (that was used for old mechanics) which from my searching, is used nowhere in modern stations.

The restock cartridge had no sprite and was included in the "Electronics Vending Machine Restocking Pack" with 4 other restock carts, but would be invisible and have no relevant use.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It would require an entirely new sprite, which while I would do, it has only 1 use that I had brought up to me and it is not on station
