### PR TITLE
Adds new spacebux purchase: Teleporter Malfunction - Start in the VOID

### DIFF
--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -35,6 +35,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/limbless,\
 	new /datum/bank_purchaseable/legless,\
 	new /datum/bank_purchaseable/space_diner,\
+	new /datum/bank_purchaseable/tele_malfunction,\
 	new /datum/bank_purchaseable/mail_order,\
 	new /datum/bank_purchaseable/missile_arrival,\
 	new /datum/bank_purchaseable/lunchbox,\
@@ -466,6 +467,23 @@ var/global/list/persistent_bank_purchaseables =	list(\
 			for(var/turf/T in get_area_turfs(/area/diner/dining, 1))
 				start = T
 				break
+			if (!start)
+				return 0
+			if (istype(M.loc, /obj/storage)) // for stowaways
+				var/obj/storage/S = M.loc
+				S.set_loc(start)
+			else
+				M.set_loc(start)
+			return 1
+
+	tele_malfunction
+		name = "Teleporter Malfunction"
+		cost = 5000
+		icon = 'icons/obj/adventurezones/void.dmi'
+		icon_state = "fissure"
+
+		Create(var/mob/living/M)
+			var/list/start = get_turf(locate(/obj/dfissure_from)) //VOID starting location
 			if (!start)
 				return 0
 			if (istype(M.loc, /obj/storage)) // for stowaways


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new spacebux purchase Teleporter Malfunction. It costs 5000 spacebux, and allows you to start in the Void. Functionally equivalent to the Diner Patron purchase, but forces start at the beginning of the void area identical to the void teleporter malfunction.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
1) Shows people how easy it is to add new spacebux purchases! Why not add your own?
2) I thought it'd be neat.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Adds new Spacebux purchase: Teleporter Malfunction
```
