### PR TITLE
Remove PDA control of off-station securitrons

### DIFF
--- a/assets/maps/prefabs/prefab_dreamplaza.dmm
+++ b/assets/maps/prefabs/prefab_dreamplaza.dmm
@@ -477,7 +477,8 @@
 "qa" = (
 /obj/decal/cleanable/dirt/dirt3,
 /obj/machinery/bot/secbot/neon{
-	emagged = 2
+	emagged = 2;
+	control_freq = 0
 	},
 /turf/simulated/floor/terrazzo/white,
 /area/prefab/dreamplaza)

--- a/assets/maps/prefabs/prefab_secbot_academy.dmm
+++ b/assets/maps/prefabs/prefab_secbot_academy.dmm
@@ -226,7 +226,9 @@
 /obj/stool/chair/comfy{
 	dir = 4
 	},
-/obj/machinery/bot/secbot,
+/obj/machinery/bot/secbot{
+	control_freq = 0
+	},
 /turf/simulated/floor/wood,
 /area/prefab/secbot_academy)
 "iR" = (
@@ -878,7 +880,9 @@
 /obj/stool/chair{
 	dir = 8
 	},
-/obj/machinery/bot/secbot,
+/obj/machinery/bot/secbot{
+	control_freq = 0
+	},
 /turf/simulated/floor/wood,
 /area/prefab/secbot_academy)
 "Pg" = (
@@ -984,7 +988,8 @@
 	},
 /obj/machinery/bot/secbot{
 	desc = "A little security robot.  He seems to be filling out paperwork... somehow.";
-	name = "Principal Boop"
+	name = "Principal Boop";
+	control_freq = 0
 	},
 /turf/simulated/floor/carpet/purple/fancy,
 /area/prefab/secbot_academy)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the control frequency on secbots in the dreamplaza mall and secbot academy prefabs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Securitrons not created by station crew shouldn't be controlled or listed in crew PDA apps.
Fixes #8232