### PR TITLE
changes rattlesnakes

### DIFF
--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -1509,20 +1509,25 @@
 	desc = "A rattlesnake in space."
 	icon_state = "rattlesnake"
 	dead_state = "rattlesnake_dead"
-	density = 1
+	density = 0
 	health = 50
 	aggressive = 1
 	defensive = 1
-	wanderer = 0
+	wanderer = 1
 	opensdoors = OBJ_CRITTER_OPENS_DOORS_NONE
 	atkcarbon = 1
 	atksilicon = 1
 	firevuln = 1
 	brutevuln = 1
 	angertext = "hisses at"
-	butcherable = 0
+	butcherable = 1
 	flags = NOSPLASH | OPENCONTAINER | TABLEPASS
 	flying = 0
+
+	CritterDeath()
+		..()
+		src.reagents.add_reagent("viper_venom", 40, null)
+		return
 
 	seek_target()
 		src.anchored = 0
@@ -1532,10 +1537,12 @@
 			if (issilicon(C) && !src.atksilicon) continue
 			if (C.health < 0) continue
 			if (C in src.friends) continue
+			if (isintangible(C)) continue
 
 			if(!src.attack)
 				switch(get_dist(src, C))
 					if (0 to 1)
+						src.mobile = 1
 						icon_state = "rattlesnake"
 						if (iscarbon(C) && src.atkcarbon) src.attack = 1
 						if (issilicon(C) && src.atksilicon) src.attack = 1
@@ -1545,16 +1552,22 @@
 							playsound(src.loc, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
 							C.emote("scream")
 					if (1 to 2)
+						src.mobile = 0
+						src.task = "thinking"
 						icon_state = "rattlesnake_rattle"
 						if(!ON_COOLDOWN(src, "Rattle", 6 SECONDS))
 							C.visible_message("<span class='combat'><B>[src]</B> is rattling, better not get much closer!</span>")
 							playsound(src.loc, "sound/musical_instruments/tambourine/tambourine_4.ogg", 80, 0, 0, 0.75)
 					if (2 to 3)
+						src.mobile = 0
+						src.task = "thinking"
 						icon_state = "rattlesnake_coiled"
 					if (3 to INFINITY)
+						src.mobile = 1
 						icon_state = "rattlesnake"
 
 			if (src.attack)
+				src.mobile = 1
 				icon_state = "rattlesnake"
 				src.target = C
 				src.oldtarget_name = C.name


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[LABEL][feature]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so rattlesnakes will wander about until someone gets close, then they'll stop wandering and do their regular coil up behaviour. Rattlesnakes are now also density = 0 mobs, meaning you can walk over them if you feel like taking the risk, so they won't be just blocking the hallways, they are also now butcherable, but with some bad results if you eat the meat.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I just thought these changes would be nice to have, + i wanted to do the wandering thing from the start, just didn't know how.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Hans
(+)Rattlesnakes now wander about and are butcherable.
```
