### PR TITLE
Fix Mining Outpost lounge area air.

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -21120,7 +21120,7 @@
 /obj/railing/orange/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/airless/carpet/office,
+/turf/simulated/floor/carpet/office,
 /area/mining/hangar)
 "cvi" = (
 /obj/decal/fakeobjects{
@@ -21403,7 +21403,7 @@
 	network = "Mining";
 	tag = ""
 	},
-/turf/simulated/floor/airless/carpet/office,
+/turf/simulated/floor/carpet/office,
 /area/mining/hangar)
 "hme" = (
 /obj/indestructible/shuttle_corner{
@@ -21630,7 +21630,7 @@
 /obj/item/device/radio/intercom/engineering{
 	dir = 4
 	},
-/turf/simulated/floor/airless/carpet/office,
+/turf/simulated/floor/carpet/office,
 /area/mining/hangar)
 "jVk" = (
 /obj/decal/fakeobjects/lightbulb_broken{
@@ -21642,7 +21642,7 @@
 /obj/stool/chair/comfy{
 	dir = 4
 	},
-/turf/simulated/floor/airless/carpet/office,
+/turf/simulated/floor/carpet/office,
 /area/mining/hangar)
 "jZt" = (
 /obj/machinery/door/unpowered/shuttle,
@@ -21848,7 +21848,7 @@
 /obj/stool/chair/comfy{
 	dir = 8
 	},
-/turf/simulated/floor/airless/carpet/office,
+/turf/simulated/floor/carpet/office,
 /area/mining/hangar)
 "mea" = (
 /turf/simulated/floor/caution/east,
@@ -21911,7 +21911,7 @@
 /obj/item/decoration/ashtray{
 	pixel_x = -3
 	},
-/turf/simulated/floor/airless/carpet/office,
+/turf/simulated/floor/carpet/office,
 /area/mining/hangar)
 "mHM" = (
 /obj/decal/tile_edge/stripe/big{
@@ -22292,7 +22292,7 @@
 	},
 /obj/table/wood/round/champagne,
 /obj/machinery/phone,
-/turf/simulated/floor/airless/carpet/office,
+/turf/simulated/floor/carpet/office,
 /area/mining/hangar)
 "pfn" = (
 /obj/decal/fakeobjects{
@@ -22482,7 +22482,7 @@
 /turf/unsimulated/floor/white/grime,
 /area/timewarp/ship)
 "rbG" = (
-/turf/simulated/floor/airless/carpet/office,
+/turf/simulated/floor/carpet/office,
 /area/mining/hangar)
 "rdq" = (
 /obj/decal/cleanable/gangtag{
@@ -22597,7 +22597,7 @@
 /area/helldrone)
 "sjy" = (
 /obj/stool/chair/comfy,
-/turf/simulated/floor/airless/carpet/office,
+/turf/simulated/floor/carpet/office,
 /area/mining/hangar)
 "skQ" = (
 /obj/decal/timeplug{
@@ -22939,7 +22939,7 @@
 /obj/item/device/radio/intercom/cargo{
 	dir = 4
 	},
-/turf/simulated/floor/airless/carpet/office,
+/turf/simulated/floor/carpet/office,
 /area/mining/hangar)
 "vPx" = (
 /obj/decal/fakeobjects/lightbulb_broken,

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -22415,12 +22415,6 @@
 /obj/structure/woodwall,
 /turf/simulated/floor/plating/airless,
 /area/derelict_ai_sat)
-"qum" = (
-/turf/space,
-/turf/simulated/floor/stairs{
-	dir = 1
-	},
-/area/mining/hangar)
 "qyC" = (
 /obj/decal/fakeobjects{
 	anchored = 1;
@@ -71589,7 +71583,7 @@ vjf
 iZr
 vjf
 iZr
-qum
+vjf
 rbG
 rbG
 maw


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - TRIVIAL][MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Two changes to the mining outpost turfs:
1. Remove a single stacked space turf
2. Switches the lounge to use the non-`airless` version of the carpet, since it's a sealed room

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Fixes #8277