### PR TITLE
Fixes dog biscuit recipe not working as intended.

### DIFF
--- a/code/obj/submachine/cooking.dm
+++ b/code/obj/submachine/cooking.dm
@@ -530,7 +530,6 @@ table#cooktime a#start {
 			#endif
 			src.recipes += new /datum/cookingrecipe/cake_custom(src)
 			src.recipes += new /datum/cookingrecipe/meatloaf(src)
-			src.recipes += new /datum/cookingrecipe/hotdog(src)
 			src.recipes += new /datum/cookingrecipe/stroopwafel(src)
 			src.recipes += new /datum/cookingrecipe/cookie_spooky(src)
 			src.recipes += new /datum/cookingrecipe/cookie_jaffa(src)
@@ -587,6 +586,7 @@ table#cooktime a#start {
 			src.recipes += new /datum/cookingrecipe/hardboiled(src)
 			src.recipes += new /datum/cookingrecipe/bakedpotato(src)
 			src.recipes += new /datum/cookingrecipe/rice_ball(src)
+			src.recipes += new /datum/cookingrecipe/hotdog(src)
 
 	Topic(href, href_list)
 		if ((BOUNDS_DIST(src, usr) > 0 && (!issilicon(usr) && !isAI(usr))) || !isliving(usr) || iswraith(usr) || isintangible(usr))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently, the dog biscuit recipe outputs a hotdog, this is because the hotdog recipe (simple) is above the dog biscuit recipe (complex) in the code. This PR fixes that by putting the hotdog recipe under the "single-ingredient recipes" comment, since it only uses meatpaste.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8273