### PR TITLE
Security health implants only send out an alert on death.

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -281,13 +281,6 @@ THROWING DARTS
 			probably_my_record["h_imp"] = "[src.sensehealth()]"
 		..()
 
-	on_crit()
-		if(inafterlife(src.owner))
-			return
-		DEBUG_MESSAGE("[src] calling to report crit")
-		health_alert()
-		..()
-
 	on_death()
 		if(inafterlife(src.owner))
 			return

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -281,6 +281,13 @@ THROWING DARTS
 			probably_my_record["h_imp"] = "[src.sensehealth()]"
 		..()
 
+	on_crit()
+		if(inafterlife(src.owner))
+			return
+		DEBUG_MESSAGE("[src] calling to report crit")
+		health_alert()
+		..()
+
 	on_death()
 		if(inafterlife(src.owner))
 			return
@@ -313,6 +320,9 @@ THROWING DARTS
 
 /obj/item/implant/health/security
 	name = "health implant - security issue"
+
+	on_crit()
+		return
 
 	New()
 		mailgroups.Add(MGD_SECURITY)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr removes the ability for security health implants sending out health alerts upon people entering crit. This means that now security health implants only send out an alert upon reaching death. Normal health implants behavior is unaffected.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This change is primarily designed to nerf  competent security teams. With the competence of security recently, clearer indications of when security is alerted, and/or the alerts happening later on should help with the situation of 5 sec offs swarming a single antag. When someone enters critical is most of the time unclear during combat, unlike death which has very clear indicators (death gasp + examine text). Not only that, but for weaker weapons and/or longer battles, the time between someone entering crit and them dying can be far longer. This should give antags more time to deal with killed people, and also a more clear indicator on when security is going to come swarm.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Security health implants now only send out an alert on death, normal health implants behavior is unaffected.
```
