### PR TITLE
Add price for cold weather qm crate

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1631,6 +1631,7 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 					/obj/item/reagent_containers/food/drinks/chickensoup = 2,
 					/obj/item/reagent_containers/food/drinks/coffee = 2)
 	frames = list(/obj/machinery/space_heater = 2)
+	cost = 3000
 
 /datum/supply_packs/complex/hydrostarter
 	name = "Hydroponics: Starter Crate"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sets the cost of the cold weather crate to 3000 (as it was previously). Did a quick manual scan of the other supply packs and didn't see any obvious outliers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
No freebies!
Fixes #8248
