### PR TITLE
Fix stun baton off sprites not updating properly

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -149,6 +149,8 @@
 		else if (amount > 0)
 			SEND_SIGNAL(src, COMSIG_CELL_CHARGE, src.cost_normal * amount)
 
+		src.UpdateIcon()
+
 		if(istype(user)) // user can be a Securitron sometims, scream
 			user.update_inhands()
 		return
@@ -216,7 +218,6 @@
 			dude_to_stun.lastattacker = user
 			dude_to_stun.lastattackertime = world.time
 
-		src.UpdateIcon()
 		return
 
 	attack_self(mob/user as mob)


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where baton sprite inhands weren't actually updating to the off state when reaching zero charge, and it fixes a bug where when using the special disarm intent of the stun baton, the icon state wasn't updating to the off state.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fixes.