### PR TITLE
Makes pawnstar trait cost 0 trait points

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -530,7 +530,7 @@
 	category = list("trinkets")
 
 /obj/trait/pawnstar
-	name = "Pawn Star (-1) \[Trinkets\]"
+	name = "Pawn Star (0) \[Trinkets\]"
 	cleanName = "Pawn Star"
 	desc = "You sold your trinket before you departed for the station. You start with a bonus of 25% of your starting cash in your inventory."
 	id = "pawnstar"

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -535,7 +535,7 @@
 	desc = "You sold your trinket before you departed for the station. You start with a bonus of 25% of your starting cash in your inventory."
 	id = "pawnstar"
 	icon_state = "pawnP"
-	points = -1
+	points = 0
 	category = list("trinkets")
 
 /obj/trait/beestfriend


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mostly quality of life, having to dispose of a trinket every round gets annoying. Also this trait is not worth 1 trait point, at most you get 500 credits, more realistically like 125. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)Pawnstar now costs 0 trait points
```
