### PR TITLE
Wizards refuse to use technology weapons

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -104,6 +104,8 @@
 	var/needOnMouseMove = 0 //If 1, we check all the stuff required for onMouseMove for this. Leave this off unless required. Might cause extra lag.
 	var/contraband = 0 // If nonzero, bots consider this a thing people shouldn't be carrying without authorization
 	var/edible = 0 // can you eat the thing?
+	/// Prevent wizards from using this technology
+	var/wizard_blacklist = FALSE
 
 	/*_____*/
 	/*Other*/

--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -11,6 +11,7 @@
 	flags = FPRINT | TABLEPASS| CONDUCT | ONBELT
 	item_state = "electronic"
 	mats = 2
+	wizard_blacklist = TRUE	// Wizards cannot use technology
 
 	var/status = 1 // Bulb still functional?
 	var/secure = 1 // Access panel still secured?

--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -67,6 +67,7 @@ A Flamethrower in various states of assembly
 	move_triggered = 1
 	spread_angle = 0
 	shoot_delay = 1 SECOND
+	wizard_blacklist = TRUE	// Wizards do not use technology based weapons
 
 	New()
 		..()

--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -691,6 +691,9 @@
 
 
 /obj/item/gun/try_grab(var/mob/living/target, var/mob/living/user)
+	if (iswizard(user) && src.wizard_blacklist)
+		user.show_text("<span class='combat bold'>The thought of using [src] fills you with revulsion at technology!</span>")
+		return FALSE
 	src.hide_attack = 1
 
 	if (..())

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -15,6 +15,7 @@
 	var/can_swap_cell = 1
 	muzzle_flash = null
 	inventory_counter_enabled = 1
+	wizard_blacklist = TRUE	// Wizards cannot use energy based guns
 
 	New()
 		var/cell = null

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -52,6 +52,8 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 
 	var/fire_animation = FALSE //Used for guns that have animations when firing
 
+	wizard_blacklist = FALSE // Kinetic guns are generally not too advanced for wizards
+
 	buildTooltipContent()
 		. = ..()
 		if(current_projectile)
@@ -263,6 +265,9 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	if (isghostdrone(user))
 		user.show_text("<span class='combat bold'>Your internal law subroutines kick in and prevent you from using [src]!</span>")
 		return FALSE
+	if (iswizard(user) && src.wizard_blacklist)
+		user.show_text("<span class='combat bold'>The thought of using [src] fills you with revulsion at technology!</span>")
+		return FALSE
 	var/is_dual_wield = 0
 	//Ok. i know it's kind of dumb to add this param 'second_shot' to the shoot_point_blank proc just to make sure pointblanks don't repeat forever when we could just move these checks somewhere else.
 	//but if we do the double-gun checks here, it makes stuff like double-hold-at-gunpoint-pointblanks easier!
@@ -373,6 +378,9 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 /obj/item/gun/proc/shoot(var/target,var/start,var/mob/user,var/POX,var/POY,var/is_dual_wield)
 	if (isghostdrone(user))
 		user.show_text("<span class='combat bold'>Your internal law subroutines kick in and prevent you from using [src]!</span>")
+		return FALSE
+	if (iswizard(user) && src.wizard_blacklist)
+		user.show_text("<span class='combat bold'>The thought of using [src] fills you with revulsion at technology!</span>")
 		return FALSE
 	if (!canshoot())
 		if (ismob(user))

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -27,6 +27,7 @@
 	stamina_cost = 21
 	stamina_crit_chance = 5
 	item_function_flags = USE_INTENT_SWITCH_TRIGGER
+	wizard_blacklist = TRUE	// Wizards cannot use technology
 
 	var/icon_on = "stunbaton_active"
 	var/icon_off = "stunbaton"
@@ -221,6 +222,9 @@
 
 	attack_self(mob/user as mob)
 		src.add_fingerprint(user)
+		if (iswizard(user) && src.wizard_blacklist)
+			user.show_text("<span class='combat bold'>The thought of using [src] fills you with revulsion at technology!</span>")
+			return
 
 		if (!(SEND_SIGNAL(src, COMSIG_CELL_CHECK_CHARGE, cost_normal) & CELL_SUFFICIENT_CHARGE) && !(src.is_active))
 			boutput(user, "<span class='alert'>The [src.name] doesn't have enough power to be turned on.</span>")
@@ -247,6 +251,9 @@
 
 	attack(mob/M as mob, mob/user as mob)
 		src.add_fingerprint(user)
+		if (iswizard(user) && src.wizard_blacklist)
+			user.show_text("<span class='combat bold'>The thought of using [src] fills you with revulsion at technology!</span>")
+			return
 
 		if(check_target_immunity( M ))
 			user.show_message("<span class='alert'>[M] seems to be warded from attacks!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements a blacklist var on obj/item and adds appropriate checks to items to prevent usage:

- [x] Flash
- [x] Stun batons
- [x] Energy guns
- [x] Flamethrowers

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This idea has been discussed a bit before, there was a previous PR to make wizards clumsy with technology. Instead of clumsy this PR makes wizards revolted by technology based weapons and refuse to use them.
Wizards get a huge amount of mobility and damage from their spells. At the moment the best play is to blast a security officer, steal their equipment and then have all the power of sec gear and wizard spells in one. While very fun for the wizard this has made them capable of lasting entire hour long rounds rampaging.

This PR is not intended to be a comprehensive block of ALL technology. I don't think it would help us to get bogged down in preventing wizards from using vending machines, the aim is to reduce combat equipment available to wizards.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Wizards can no longer use technology based equipment: All energy ranged weapons, stun batons, flashes, flamethrowers.
```
