### PR TITLE
Allows you to use the RCD for ghetto limb surgeries

### DIFF
--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -419,26 +419,26 @@ Broken RCD + Effects
 						log_construction(user, "built a light fixture to a wall ([W])")
 
  // Express limb surgery with an RCD
-	attack(mob/living/carbon/human/M as mob, mob/living/carbon/user as mob)
+	attack(mob/living/carbon/human/M, mob/living/carbon/user)
 
 		var/obj/item/parts/surgery_target = null
 		var/is_missing = 0
 		if (surgeryCheck(M, user) && (user.zone_sel.selecting in list("l_arm","r_arm","l_leg","r_leg", "chest")) && (src.mode == RCD_MODE_DECONSTRUCT)) //In surgery conditions and aiming for a limb or an ass in deconstruction mode? Time for ghetto surgery
 			if (user.zone_sel.selecting == "chest") //Ass begone
 				if (M.organHolder.butt == null)
-					user.visible_message("<span class='alert'><b>Tries to remove [M]'s butt, but its already gone!</b> </span>")
+					user.visible_message("<span class='alert'><b>Tries to remove [M]'s butt, but it's already gone!</b> </span>")
 					return
 				else
 					surgery_target = M.organHolder.get_organ("butt")
 			else if (user.zone_sel.selecting in list("l_arm","r_arm","l_leg","r_leg")) // Is the limb we are aiming for missing?
 				if (M.limbs.vars[user.zone_sel.selecting] == null)
-					user.visible_message("<span class='alert'><b>Tries to remove one of [M]'s limbs, but its already gone!</b> </span>")
+					user.visible_message("<span class='alert'><b>Tries to remove one of [M]'s limbs, but it's already gone!</b> </span>")
 					return
 				else
 					surgery_target = M.limbs.vars[user.zone_sel.selecting]
 
 			if (surgery_target != null && do_thing(user, surgery_target, "removing [M]'s [surgery_target]", matter_remove_limb, time_remove_limb))
-				if (ishuman(user) && user?.bioHolder.HasEffect("clumsy") && prob(40)) //Clowns get a chance to tear off their own limb
+				if (ishuman(user) && user.bioHolder.HasEffect("clumsy") && prob(40)) //Clowns get a chance to tear off their own limb
 					var/mob/living/carbon/human/H = user
 					if (user.zone_sel.selecting == "chest")
 						if (H.organHolder.butt == null)

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -110,6 +110,9 @@ Broken RCD + Effects
 	var/matter_remove_light_fixture = 1
 	var/time_remove_light_fixture = 3 SECONDS
 
+	var/matter_remove_limb = 6
+	var/time_remove_limb = 3 SECONDS
+
 	var/shits_sparks = 1
 
 	var/material_name = "steel"
@@ -415,6 +418,47 @@ Broken RCD + Effects
 						W.attach_light_fixture_parts(user, LB, TRUE)
 						log_construction(user, "built a light fixture to a wall ([W])")
 
+ // Express limb surgery with an RCD
+	attack(mob/living/carbon/human/M as mob, mob/living/carbon/user as mob)
+
+		if(surgeryCheck(M, user) && (user.zone_sel.selecting in list("l_arm","r_arm","l_leg","r_leg")) && (src.mode == RCD_MODE_DECONSTRUCT)) //In surgery conditions and aiming for a limb in deconstruction mode? Time for ghetto surgery
+			if (M.limbs.vars[user.zone_sel.selecting] == null) // Is the limb we are aiming for missing?
+				user.visible_message("<span class='alert'><b>Tries to remove one of [M]'s limbs, but its already gone!</b> </span>")
+			else
+				var/obj/item/parts/surgery_limb = M.limbs.vars[user.zone_sel.selecting]
+				if (do_thing(user, surgery_limb, "removing one of [M]'s limbs", matter_remove_limb, time_remove_limb))
+					if (ishuman(user) && user?.bioHolder.HasEffect("clumsy") && prob(40)) //Clowns get a chance to tear off their own limb
+						var/mob/living/carbon/human/H = user
+
+						if (H.limbs.vars[user.zone_sel.selecting] == null) //Cant remove a limb that isnt there, hurt yourself really badly instead
+							playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
+							user.visible_message("<span class='alert'><b>[user] messes up really badly with the [src] and maims themselves! </b> </span>")
+							random_brute_damage(user, 25)
+							H.changeStatus("weakened", 3 SECONDS)
+							take_bleeding_damage(user, null, 20, DAMAGE_CUT, 1)
+							user.emote("scream")
+							JOB_XP(user, "Clown", 3)
+
+						else	//Limb's here? We lose it
+							surgery_limb = H.limbs.vars[user.zone_sel.selecting]
+							surgery_limb.remove()
+							qdel(surgery_limb)
+							playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
+							user.visible_message("<span class='alert'><b>[user] holds the [src] by the wrong end and removes his own [surgery_limb]! </b> </span>")
+							random_brute_damage(user, 15)
+							take_bleeding_damage(user, null, 15, DAMAGE_CUT, 1)
+							user.emote("scream")
+							JOB_XP(user, "Clown", 3)
+
+					else
+						surgery_limb.remove()
+						qdel(surgery_limb)
+						random_brute_damage(M, 10)
+						take_bleeding_damage(M, null, 10)
+						playsound(M.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
+						user.visible_message("<span class='alert'>Deconstructs [M]'s [surgery_limb] with the RCD.</span>")
+		else //Not in surgery conditions or aiming for a limb? Do a normal hit
+			return ..()
 
 /* flesh wall creation code
 // holy jesus christ

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -421,69 +421,72 @@ Broken RCD + Effects
  // Express limb surgery with an RCD
 	attack(mob/living/carbon/human/M, mob/living/carbon/user)
 
-		var/obj/item/parts/surgery_target = null
-		var/is_missing = 0
-		if (surgeryCheck(M, user) && (user.zone_sel.selecting in list("l_arm","r_arm","l_leg","r_leg", "chest")) && (src.mode == RCD_MODE_DECONSTRUCT)) //In surgery conditions and aiming for a limb or an ass in deconstruction mode? Time for ghetto surgery
-			if (user.zone_sel.selecting == "chest") //Ass begone
-				if (M.organHolder.butt == null)
-					user.visible_message("<span class='alert'><b>Tries to remove [M]'s butt, but it's already gone!</b> </span>")
-					return
-				else
-					surgery_target = M.organHolder.get_organ("butt")
-			else if (user.zone_sel.selecting in list("l_arm","r_arm","l_leg","r_leg")) // Is the limb we are aiming for missing?
-				if (M.limbs.vars[user.zone_sel.selecting] == null)
-					user.visible_message("<span class='alert'><b>Tries to remove one of [M]'s limbs, but it's already gone!</b> </span>")
-					return
-				else
-					surgery_target = M.limbs.vars[user.zone_sel.selecting]
-
-			if (surgery_target != null && do_thing(user, surgery_target, "removing [M]'s [surgery_target]", matter_remove_limb, time_remove_limb))
-				if (ishuman(user) && user.bioHolder.HasEffect("clumsy") && prob(40)) //Clowns get a chance to tear off their own limb
-					var/mob/living/carbon/human/H = user
-					if (user.zone_sel.selecting == "chest")
-						if (H.organHolder.butt == null)
-							is_missing = 1
+		if (issilicon(user))
+			return ..()
+		else
+			var/obj/item/parts/surgery_target = null
+			var/is_missing = 0
+			if (surgeryCheck(M, user) && (user.zone_sel.selecting in list("l_arm","r_arm","l_leg","r_leg", "chest")) && (src.mode == RCD_MODE_DECONSTRUCT)) //In surgery conditions and aiming for a limb or an ass in deconstruction mode? Time for ghetto surgery
+				if (user.zone_sel.selecting == "chest") //Ass begone
+					if (M.organHolder.butt == null)
+						user.visible_message("<span class='alert'><b>Tries to remove [M]'s butt, but it's already gone!</b> </span>")
+						return
 					else
-						if (H.limbs.vars[user.zone_sel.selecting] == null) //Cant remove a limb that isnt there
-							is_missing = 1
+						surgery_target = M.organHolder.get_organ("butt")
+				else if (user.zone_sel.selecting in list("l_arm","r_arm","l_leg","r_leg")) // Is the limb we are aiming for missing?
+					if (M.limbs.vars[user.zone_sel.selecting] == null)
+						user.visible_message("<span class='alert'><b>Tries to remove one of [M]'s limbs, but it's already gone!</b> </span>")
+						return
+					else
+						surgery_target = M.limbs.vars[user.zone_sel.selecting]
 
-					if(is_missing == 1) //The limb/ass is already missing, maim yourself instead
-						playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
-						user.visible_message("<span class='alert'><b>[user] messes up really badly with [src] and maims themselves! </b> </span>")
-						random_brute_damage(user, 35)
-						H.changeStatus("weakened", 3 SECONDS)
-						take_bleeding_damage(user, null, 25, DAMAGE_CUT, 1)
-						user.emote("scream")
-						JOB_XP(user, "Clown", 3)
-
-					else	//Limb's here? We lose it
+				if (surgery_target != null && do_thing(user, surgery_target, "removing [M]'s [surgery_target]", matter_remove_limb, time_remove_limb))
+					if (ishuman(user) && user.bioHolder.HasEffect("clumsy") && prob(40)) //Clowns get a chance to tear off their own limb
+						var/mob/living/carbon/human/H = user
 						if (user.zone_sel.selecting == "chest")
-							var/B = user.organHolder.drop_organ("butt")
+							if (H.organHolder.butt == null)
+								is_missing = 1
+						else
+							if (H.limbs.vars[user.zone_sel.selecting] == null) //Cant remove a limb that isnt there
+								is_missing = 1
+
+						if(is_missing == 1) //The limb/ass is already missing, maim yourself instead
+							playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
+							user.visible_message("<span class='alert'><b>[user] messes up really badly with [src] and maims themselves! </b> </span>")
+							random_brute_damage(user, 35)
+							H.changeStatus("weakened", 3 SECONDS)
+							take_bleeding_damage(user, null, 25, DAMAGE_CUT, 1)
+							user.emote("scream")
+							JOB_XP(user, "Clown", 3)
+
+						else	//Limb's here? We lose it
+							if (user.zone_sel.selecting == "chest")
+								var/B = user.organHolder.drop_organ("butt")
+								qdel(B)
+							else
+								surgery_target = H.limbs.vars[user.zone_sel.selecting]
+								surgery_target.remove()
+								qdel(surgery_target)
+							playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
+							user.visible_message("<span class='alert'><b>[user] holds the [src] by the wrong end and removes their own [surgery_target]! </b> </span>")
+							random_brute_damage(user, 25)
+							take_bleeding_damage(user, null, 20, DAMAGE_CUT, 1)
+							user.emote("scream")
+							JOB_XP(user, "Clown", 3)
+
+					else
+						if (user.zone_sel.selecting == "chest")
+							var/B = M.organHolder.drop_organ("butt")
 							qdel(B)
 						else
-							surgery_target = H.limbs.vars[user.zone_sel.selecting]
 							surgery_target.remove()
 							qdel(surgery_target)
-						playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
-						user.visible_message("<span class='alert'><b>[user] holds the [src] by the wrong end and removes their own [surgery_target]! </b> </span>")
-						random_brute_damage(user, 25)
-						take_bleeding_damage(user, null, 20, DAMAGE_CUT, 1)
-						user.emote("scream")
-						JOB_XP(user, "Clown", 3)
-
-				else
-					if (user.zone_sel.selecting == "chest")
-						var/B = M.organHolder.drop_organ("butt")
-						qdel(B)
-					else
-						surgery_target.remove()
-						qdel(surgery_target)
-					random_brute_damage(M, 25)
-					take_bleeding_damage(M, null, 20)
-					playsound(M.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
-					user.visible_message("<span class='alert'>Deconstructs [M]'s [surgery_target] with the RCD.</span>")
-		else //Not in surgery conditions or aiming for a limb? Do a normal hit
-			return ..()
+						random_brute_damage(M, 25)
+						take_bleeding_damage(M, null, 20)
+						playsound(M.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
+						user.visible_message("<span class='alert'>Deconstructs [M]'s [surgery_target] with the RCD.</span>")
+			else //Not in surgery conditions or aiming for a limb? Do a normal hit
+				return ..()
 
 /* flesh wall creation code
 // holy jesus christ

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -451,14 +451,10 @@ Broken RCD + Effects
 								user_limb_is_missing = true
 
 						if(user_limb_is_missing == true) //The limb/ass is already missing, maim yourself instead
-							playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
 							user.visible_message("<span class='alert'><b>[user] messes up really badly with [src] and maims themselves! </b> </span>")
 							random_brute_damage(user, 35)
 							H.changeStatus("weakened", 3 SECONDS)
 							take_bleeding_damage(user, null, 25, DAMAGE_CUT, 1)
-							user.emote("scream")
-							JOB_XP(user, "Clown", 3)
-
 						else	//Limb's here? We lose it
 							if (user.zone_sel.selecting == "chest")
 								var/B = user.organHolder.drop_organ("butt")
@@ -467,12 +463,12 @@ Broken RCD + Effects
 								surgery_target = H.limbs.vars[user.zone_sel.selecting]
 								surgery_target.remove()
 								qdel(surgery_target)
-							playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
 							user.visible_message("<span class='alert'><b>[user] holds the [src] by the wrong end and removes their own [surgery_target]! </b> </span>")
 							random_brute_damage(user, 25)
 							take_bleeding_damage(user, null, 20, DAMAGE_CUT, 1)
-							user.emote("scream")
-							JOB_XP(user, "Clown", 3)
+						playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
+						user.emote("scream")
+						JOB_XP(user, "Clown", 3)
 
 					else
 						if (user.zone_sel.selecting == "chest")

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -425,7 +425,7 @@ Broken RCD + Effects
 			return ..()
 		else
 			var/obj/item/parts/surgery_target = null
-			var/is_missing = 0
+			var/user_limb_is_missing = false
 			if (surgeryCheck(M, user) && (user.zone_sel.selecting in list("l_arm","r_arm","l_leg","r_leg", "chest")) && (src.mode == RCD_MODE_DECONSTRUCT)) //In surgery conditions and aiming for a limb or an ass in deconstruction mode? Time for ghetto surgery
 				if (user.zone_sel.selecting == "chest") //Ass begone
 					if (M.organHolder.butt == null)
@@ -445,12 +445,12 @@ Broken RCD + Effects
 						var/mob/living/carbon/human/H = user
 						if (user.zone_sel.selecting == "chest")
 							if (H.organHolder.butt == null)
-								is_missing = 1
+								user_limb_is_missing = true
 						else
 							if (H.limbs.vars[user.zone_sel.selecting] == null) //Cant remove a limb that isnt there
-								is_missing = 1
+								user_limb_is_missing = true
 
-						if(is_missing == 1) //The limb/ass is already missing, maim yourself instead
+						if(user_limb_is_missing == true) //The limb/ass is already missing, maim yourself instead
 							playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
 							user.visible_message("<span class='alert'><b>[user] messes up really badly with [src] and maims themselves! </b> </span>")
 							random_brute_damage(user, 35)

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -449,7 +449,7 @@ Broken RCD + Effects
 
 					if(is_missing == 1) //The limb/ass is already missing, maim yourself instead
 						playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
-						user.visible_message("<span class='alert'><b>[user] messes up really badly with the [src] and maims themselves! </b> </span>")
+						user.visible_message("<span class='alert'><b>[user] messes up really badly with [src] and maims themselves! </b> </span>")
 						random_brute_damage(user, 25)
 						H.changeStatus("weakened", 3 SECONDS)
 						take_bleeding_damage(user, null, 20, DAMAGE_CUT, 1)

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -450,9 +450,9 @@ Broken RCD + Effects
 					if(is_missing == 1) //The limb/ass is already missing, maim yourself instead
 						playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
 						user.visible_message("<span class='alert'><b>[user] messes up really badly with [src] and maims themselves! </b> </span>")
-						random_brute_damage(user, 25)
+						random_brute_damage(user, 35)
 						H.changeStatus("weakened", 3 SECONDS)
-						take_bleeding_damage(user, null, 20, DAMAGE_CUT, 1)
+						take_bleeding_damage(user, null, 25, DAMAGE_CUT, 1)
 						user.emote("scream")
 						JOB_XP(user, "Clown", 3)
 
@@ -466,8 +466,8 @@ Broken RCD + Effects
 							qdel(surgery_target)
 						playsound(user.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
 						user.visible_message("<span class='alert'><b>[user] holds the [src] by the wrong end and removes their own [surgery_target]! </b> </span>")
-						random_brute_damage(user, 15)
-						take_bleeding_damage(user, null, 15, DAMAGE_CUT, 1)
+						random_brute_damage(user, 25)
+						take_bleeding_damage(user, null, 20, DAMAGE_CUT, 1)
 						user.emote("scream")
 						JOB_XP(user, "Clown", 3)
 
@@ -478,8 +478,8 @@ Broken RCD + Effects
 					else
 						surgery_target.remove()
 						qdel(surgery_target)
-					random_brute_damage(M, 10)
-					take_bleeding_damage(M, null, 10)
+					random_brute_damage(M, 25)
+					take_bleeding_damage(M, null, 20)
 					playsound(M.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
 					user.visible_message("<span class='alert'>Deconstructs [M]'s [surgery_target] with the RCD.</span>")
 		else //Not in surgery conditions or aiming for a limb? Do a normal hit

--- a/code/obj/item/rcd.dm
+++ b/code/obj/item/rcd.dm
@@ -423,6 +423,8 @@ Broken RCD + Effects
 
 		if (issilicon(user))
 			return ..()
+		else if (length(working_on) > 0) //Lets not get too crazy
+			boutput(user, "<span class='notice'>[src] is already working on something else.</span>")
 		else
 			var/obj/item/parts/surgery_target = null
 			var/user_limb_is_missing = false


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You can now use an RCD with some matter and on deconstruction mode to remove people's limbs. They still need to be in surgery conditions which means either on a surgery table, drugged and buckled to a bed, or unconscious on a table.

The process takes 3 seconds, is messy, loud and doesnt leave the limb behind since its "deconstructed". This is very unsafe for clowns.

Also it can remove asses if you aim for the torso.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ghetto surgery is fun! Funny alternatives to normal tools is something i'd like to see more of!


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Bartimeus973
(+)You can now use an RCD on deconstruction mode for limb surgery!
```
