### PR TITLE
Adds oculine to carrots, removes it from Sunrise Venne

### DIFF
--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -938,6 +938,7 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	make_reagents()
 		..()
 		reagents.add_reagent("juice_carrot",5)
+		reagents.add_reagent("oculine",5)
 
 /obj/item/reagent_containers/food/snacks/plant/pumpkin
 	name = "pumpkin"

--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -471,7 +471,7 @@
 	name_prefix = "Sunrise "
 	iconmod = "VenneCurative"
 	crop = /obj/item/plant/herb/venne/curative
-	assoc_reagents = list("oculine","mannitol","mutadone")
+	assoc_reagents = list("mannitol","mutadone")
 	chance = 5
 
 // Houttuynia Cordata Mutations


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes oculine from Sunrise Venne and adds it to carrots!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sunrise venne having 4 extractable chemicals felt like a little much. So...into carrots goes.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Shiiba
(+)Removes oculine from sunrise venne.
(+)Adds oculine to carrots.
```
