### PR TITLE
Remove misplaced cog1 wingrilles

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -55313,10 +55313,6 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/cafeteria)
-"iHu" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/chapel/sanctuary)
 "iJV" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -123924,7 +123920,7 @@ aMr
 aNC
 aMI
 aPG
-iHu
+baL
 aXQ
 aXQ
 aXQ
@@ -124525,7 +124521,7 @@ baL
 aKa
 baL
 aXQ
-iHu
+baL
 aXQ
 aXQ
 aXQ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes two wingrilles from cog1's chapel that had rwalls under them, which seem like they were accidentally added in #1753 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When we say that a wall needs windows in it we don't mean it like this

closes #8343 