### PR TITLE
Adds lawyers to normal gimmick jobs, reduces lawyers' access

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1107,7 +1107,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 	name = "Lawyer"
 	linkcolor = "#FF0000"
 	wages = PAY_DOCTORATE
-	limit = 0
+	limit = 1
 	receives_badge = 1
 	slot_jump = list(/obj/item/clothing/under/misc/lawyer)
 	slot_foot = list(/obj/item/clothing/shoes/black)

--- a/code/map.dm
+++ b/code/map.dm
@@ -489,7 +489,6 @@ var/global/list/mapNames = list(
 		/datum/job/civilian/bartender = 2,
 		/datum/job/civilian/janitor = 3,
 		/datum/job/civilian/chaplain = 2,
-		/datum/job/special/lawyer = 1,
 		/datum/job/special/atmospheric_technician = 1
 	)
 

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -280,7 +280,7 @@
 		if("Detective", "Forensic Technician")
 			return list(access_brig, access_carrypermit, access_contrabandpermit, access_security, access_forensics_lockers, access_morgue, access_maint_tunnels, access_crematorium, access_medical, access_research)
 		if("Lawyer")
-			return list(access_maint_tunnels, access_security, access_brig)
+			return list(access_maint_tunnels, access_security)
 
 		///////////////////////////// Medical
 		if("Medical Doctor")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes it so lawyers are a standard gimmick slot available throughout the week, rather than only being available during Thursday or on horizon. Only 1 slot is available outside of Thursday. It also removes brig access from lawyers.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Lawyers can add a lot of rp for antags that have been brigged, however their limit to only being available on a map or a day of the week makes these scenarios limited in how often they can happen.. Making a slot available will help to make this more common. I've also removed brig access from lawyers to reduce how much they can interfere with security.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)Lawyers no longer have brig access.
(+)A lawyer slot is now available for late-joining players throughout the entire week!
```
