### PR TITLE
Removes Mule Bot Purchase On Atlas

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -546,6 +546,7 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Robotics Crate"
 
+#ifndef MAP_OVERRIDE_ATLAS
 /datum/supply_packs/mulebot
 	name = "Replacement Mulebot"
 	desc = "x1 Mulebot"
@@ -554,6 +555,7 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	cost = 750
 	containertype = /obj/storage/crate
 	containername = "Replacement Mulebot Crate"
+#endif
 
 /datum/supply_packs/dressup
 	name = "Novelty Clothing Crate"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[REMOVE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr removes the mule bot qm purchase from the buy list whenever the map is atlas.



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Atlas is a bit too small for mule bots to be practical, so instead of letting qm buy a mule bot they can't use, it will instead be unavailable for purchase.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)Mule bots can no longer be bought while on Atlas.
```
