### PR TITLE
Spacebux: start on fire

### DIFF
--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -34,6 +34,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 
 	new /datum/bank_purchaseable/limbless,\
 	new /datum/bank_purchaseable/legless,\
+	new /datum/bank_purchaseable/hellfire,\
 	new /datum/bank_purchaseable/space_diner,\
 	new /datum/bank_purchaseable/mail_order,\
 	new /datum/bank_purchaseable/missile_arrival,\
@@ -454,6 +455,21 @@ var/global/list/persistent_bank_purchaseables =	list(\
 						boutput( H, "<span class='notice'><b>You haven't got a leg to stand on!</b></span>" )
 				return 1
 			return 0
+
+	hellfire
+		name = "Pyromaniac"
+		cost = 1000
+		icon = 'icons/misc/critter.dmi'
+		icon_state = "fire_elemental"
+		icon_dir = SOUTH
+
+		Create(mob/living/M)
+			if(ishuman(M))
+				SPAWN(6 SECONDS)
+					M.set_burning(rand(60,120))
+					playsound(M, 'sound/effects/flame.ogg', 50, 0)
+					M.visible_message("<span class='alert'>[M] spontaneously combusts!</span>")
+				return TRUE
 
 	space_diner
 		name = "Space Diner Patron"


### PR DESCRIPTION
[feature]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Add a spacebux purchase to start on fire with a random duration of 1 to 2 minutes after a short delay.

![image](https://user-images.githubusercontent.com/65367576/165767591-1fe8dd5b-f116-423c-aa8e-bc6aeb283bb3.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Who wouldn't want to become a discount fire elemental?

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Stonepillar
(+)New spacebux purchase: Pyromaniac - Start on fire!
```
