### PR TITLE
Reagent machine fixes

### DIFF
--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -278,6 +278,12 @@
 			boutput(usr, "<span class='alert'>You can't use that as an output target.</span>")
 		return
 
+	Exited(Obj, newloc)
+		if(Obj == src.beaker && newloc == null)
+			src.beaker = null
+			src.UpdateIcon()
+			tgui_process.update_uis(src)
+
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -685,6 +691,12 @@
 		else
 			boutput(usr, "<span class='alert'>You can't use that as an output target.</span>")
 		return
+
+	Exited(Obj, newloc)
+		if(Obj == src.beaker && newloc == null)
+			src.beaker = null
+			icon_state = "mixer0"
+			src.updateUsrDialog()
 
 datum/chemicompiler_core/stationaryCore
 	statusChangeCallback = "statusChange"

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -34,9 +34,10 @@
 
 	attackby(var/obj/item/reagent_containers/glass/B as obj, var/mob/user as mob)
 
-		if(!istype(B, /obj/item/reagent_containers/glass))
-			return
+		if(istype(B, /obj/item/reagent_containers/glass))
+			tryInsert(B, user)
 
+	proc/tryInsert(obj/item/reagent_containers/glass/B, var/mob/user)
 		if (status & (NOPOWER|BROKEN))
 			user.show_text("[src] seems to be out of order.", "red")
 			return
@@ -164,7 +165,7 @@
 					return
 				var/obj/item/reagent_containers/glass/inserting = usr.equipped()
 				if(istype(inserting))
-					src.Attackby(inserting, usr)
+					tryInsert(inserting, usr)
 			if("adjustTemp")
 				src.target_temp = clamp(params["temperature"], 0, 1000)
 				src.UpdateIcon()

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -164,9 +164,7 @@
 					return
 				var/obj/item/reagent_containers/glass/inserting = usr.equipped()
 				if(istype(inserting))
-					src.beaker = inserting
-					usr.drop_item()
-					inserting.set_loc(src)
+					src.Attackby(inserting, usr)
 					src.UpdateIcon()
 			if("adjustTemp")
 				src.target_temp = clamp(params["temperature"], 0, 1000)

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -155,11 +155,8 @@
 						return
 					src.roboworking = null
 				else
-					container.set_loc(src.output_target)
+					container.set_loc(src.output_target) // causes Exited proc to be called
 					usr.put_in_hand_or_eject(container) // try to eject it into the users hand, if we can
-
-				src.beaker = null
-				src.UpdateIcon()
 			if("insert")
 				if (container)
 					return
@@ -392,11 +389,8 @@
 		else if (href_list["eject"])
 			var/obj/item/I = src.beaker
 			if (I)
-				I.set_loc(src.output_target)
+				I.set_loc(src.output_target) // causes Exited proc to be called
 			usr.put_in_hand_or_eject(I) // try to eject it into the users hand, if we can
-			beaker = null
-			icon_state = "mixer0"
-			src.updateUsrDialog()
 			return
 
 		else if (href_list["createpill"])

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -165,7 +165,6 @@
 				var/obj/item/reagent_containers/glass/inserting = usr.equipped()
 				if(istype(inserting))
 					src.Attackby(inserting, usr)
-					src.UpdateIcon()
 			if("adjustTemp")
 				src.target_temp = clamp(params["temperature"], 0, 1000)
 				src.UpdateIcon()

--- a/code/modules/chemistry/Chemistry-Machinery.dm
+++ b/code/modules/chemistry/Chemistry-Machinery.dm
@@ -278,7 +278,7 @@
 		return
 
 	Exited(Obj, newloc)
-		if(Obj == src.beaker && newloc == null)
+		if(Obj == src.beaker)
 			src.beaker = null
 			src.UpdateIcon()
 			tgui_process.update_uis(src)
@@ -389,9 +389,10 @@
 			attack_hand(usr)
 			return
 		else if (href_list["eject"])
-			if (src.beaker)
-				beaker.set_loc(src.output_target)
-			usr.put_in_hand_or_eject(beaker) // try to eject it into the users hand, if we can
+			var/obj/item/I = src.beaker
+			if (I)
+				I.set_loc(src.output_target)
+			usr.put_in_hand_or_eject(I) // try to eject it into the users hand, if we can
 			beaker = null
 			icon_state = "mixer0"
 			src.updateUsrDialog()
@@ -692,7 +693,7 @@
 		return
 
 	Exited(Obj, newloc)
-		if(Obj == src.beaker && newloc == null)
+		if(Obj == src.beaker)
 			src.beaker = null
 			icon_state = "mixer0"
 			src.updateUsrDialog()

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -257,10 +257,8 @@
 			var/obj/item/I = src.inserted
 			if (!I) boutput(usr, "<span class='alert'>No receptacle found to eject.</span>")
 			else
-				I.set_loc(src.loc)
+				I.set_loc(src.loc) // causes Exited proc to be called
 				usr.put_in_hand_or_eject(I) // try to eject it into the users hand, if we can
-				src.inserted = null
-			src.updateUsrDialog()
 
 		else if(href_list["ejectseeds"])
 			for (var/obj/item/seed/S in src.seeds)
@@ -870,10 +868,8 @@
 				if (!I)
 					return
 				if (I == src.extract_to) src.extract_to = null
-				TRANSFER_OR_DROP(src, I)
+				TRANSFER_OR_DROP(src, I) // causes Exited proc to be called
 				usr.put_in_hand_or_eject(I)
-				src.inserted = null
-				. = TRUE
 			if("insertcontainer")
 				if (src.inserted)
 					return

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -254,10 +254,11 @@
 			src.updateUsrDialog()
 
 		else if(href_list["ejectbeaker"])
-			if (!src.inserted) boutput(usr, "<span class='alert'>No receptacle found to eject.</span>")
+			var/obj/item/I = src.inserted
+			if (!I) boutput(usr, "<span class='alert'>No receptacle found to eject.</span>")
 			else
-				src.inserted.set_loc(src.loc)
-				usr.put_in_hand_or_eject(src.inserted) // try to eject it into the users hand, if we can
+				I.set_loc(src.loc)
+				usr.put_in_hand_or_eject(I) // try to eject it into the users hand, if we can
 				src.inserted = null
 			src.updateUsrDialog()
 
@@ -755,7 +756,7 @@
 		"}
 
 	Exited(Obj, newloc)
-		if(Obj == src.inserted && newloc == null)
+		if(Obj == src.inserted)
 			src.inserted = null
 			src.updateUsrDialog()
 
@@ -865,11 +866,12 @@
 		var/list/containers = src.getContainers()
 		switch(action)
 			if("ejectcontainer")
-				if (!src.inserted)
+				var/obj/item/I = src.inserted
+				if (!I)
 					return
-				if (src.inserted == src.extract_to) src.extract_to = null
-				TRANSFER_OR_DROP(src, src.inserted)
-				usr.put_in_hand_or_eject(src.inserted)
+				if (I == src.extract_to) src.extract_to = null
+				TRANSFER_OR_DROP(src, I)
+				usr.put_in_hand_or_eject(I)
 				src.inserted = null
 				. = TRUE
 			if("insertcontainer")
@@ -948,7 +950,7 @@
 		..()
 
 	Exited(Obj, newloc)
-		if(Obj == src.inserted && newloc == null)
+		if(Obj == src.inserted)
 			src.inserted = null
 			tgui_process.update_uis(src)
 

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -872,10 +872,7 @@
 					return
 				var/obj/item/inserting = usr.equipped()
 				if(istype(inserting, /obj/item/reagent_containers/glass/) || istype(inserting, /obj/item/reagent_containers/food/drinks/))
-					src.inserted = inserting
-					usr.drop_item()
-					inserting.set_loc(src)
-					if(!src.extract_to) src.extract_to = inserting
+					src.Attackby(inserting, usr)
 					. = TRUE
 			if("ejectingredient")
 				var/id = params["ingredient_id"]

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -754,6 +754,11 @@
 		<td class='r [DNA.alleles[7] ? "hyp-dominant" : ""]'>[DNA.endurance]</td>
 		"}
 
+	Exited(Obj, newloc)
+		if(Obj == src.inserted && newloc == null)
+			src.inserted = null
+			src.updateUsrDialog()
+
 ////// Reagent Extractor
 
 /obj/submachine/chem_extractor/
@@ -942,6 +947,10 @@
 
 		..()
 
+	Exited(Obj, newloc)
+		if(Obj == src.inserted && newloc == null)
+			src.inserted = null
+			tgui_process.update_uis(src)
 
 /obj/submachine/chem_extractor/proc/getContainers()
 	. = list(

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -879,7 +879,7 @@
 					return
 				var/obj/item/inserting = usr.equipped()
 				if(istype(inserting, /obj/item/reagent_containers/glass/) || istype(inserting, /obj/item/reagent_containers/food/drinks/))
-					src.Attackby(inserting, usr)
+					tryInsert(inserting, usr)
 					. = TRUE
 			if("ejectingredient")
 				var/id = params["ingredient_id"]
@@ -934,20 +934,23 @@
 
 	attackby(var/obj/item/W as obj, var/mob/user as mob)
 		if(istype(W, /obj/item/reagent_containers/glass/) || istype(W, /obj/item/reagent_containers/food/drinks/))
-			if (isrobot(user))
-				boutput(user, "This machine does not accept containers from robots!")
-				return
-			if(src.inserted)
-				boutput(user, "<span class='alert'>A container is already loaded into the machine.</span>")
-				return
-			src.inserted =  W
-			user.drop_item()
-			W.set_loc(src)
-			if(!src.extract_to) src.extract_to = W
-			boutput(user, "<span class='notice'>You add [W] to the machine!</span>")
-			src.ui_interact(user)
+			tryInsert(W, user)
 
 		..()
+
+	proc/tryInsert(var/obj/item/W, var/mob/user)
+		if (isrobot(user))
+			boutput(user, "This machine does not accept containers from robots!")
+			return
+		if(src.inserted)
+			boutput(user, "<span class='alert'>A container is already loaded into the machine.</span>")
+			return
+		src.inserted =  W
+		user.drop_item()
+		W.set_loc(src)
+		if(!src.extract_to) src.extract_to = W
+		boutput(user, "<span class='notice'>You add [W] to the machine!</span>")
+		src.ui_interact(user)
 
 	Exited(Obj, newloc)
 		if(Obj == src.inserted)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1. Fixes bugs with cyborgs pressing "Insert Beaker" on certain reagent machines, causing bad things to happen like having their beaker dropped on the ground or made unusable.
2. Fixes a few machines that broke whenever the beaker/bottle inside them suddenly got qdel'd (happens with biodegradable bottles from the chemmaster). This fix tries to change the reference towards the qdel'd bottle to null.
   Note that this PR does not fix every machine that has this issue. Any other reagent machine that does not deal with the inserted bottle if it is qdel'd could potentially break because of this issue, so they should be fixed as well in the future.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

These bugs caused runtimes, broke menus, and did other bad things