### PR TITLE
Fix 8362 - Bugged duplicate cyborg items

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -604,29 +604,31 @@
 		if (!istype(W, /obj/item/clothing/mask) && !istype(W, /obj/item/clothing/head) && !istype(W, /obj/item/clothing/under) && !istype(W, /obj/item/clothing/suit))
 			boutput(user, "<span class='alert'>This type of is not compatible.</span>")
 			return
+		if (W.loc == src)
+			return
 		if (user.contents.Find(W))
-			user.drop_item()
+			user.drop_item(W)
 		W.set_loc(src)
 		boutput(user, "You insert [W].")
 		src.clothes.Add(W)
 
 	else if (istype(W, /obj/item/robot_module))
 		if (user.contents.Find(W))
-			user.drop_item()
+			user.drop_item(W)
 		W.set_loc(src)
 		boutput(user, "You insert [W].")
 		src.modules.Add(W)
 
 	else if (istype(W, /obj/item/roboupgrade))
 		if (user.contents.Find(W))
-			user.drop_item()
+			user.drop_item(W)
 		W.set_loc(src)
 		boutput(user, "You insert [W].")
 		src.upgrades.Add(W)
 
 	else if (istype(W, /obj/item/cell))
 		if (user.contents.Find(W))
-			user.drop_item()
+			user.drop_item(W)
 		W.set_loc(src)
 		boutput(user, "You insert [W].")
 		src.cells.Add(W)
@@ -636,7 +638,8 @@
 		src.cabling += C.amount
 		boutput(user, "You insert [W]. [src] now has [src.cabling] cable available.")
 		if (user.contents.Find(W))
-			user.drop_item()
+			user.drop_item(W)
+		W.set_loc(src)
 		qdel(W)
 
 	else if (istype(W, /obj/item/reagent_containers/glass))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Possibly fixes #8362. Heck if I know how to reproduce that.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Location confusion is bad.

As far as I can tell, the mousedrop causes a second attackby causing Add to get called again. I _think_ if we just check W.loc it should avoid this. Also didn't see why we avoided specifying W in drop_item(W) when we just checked if it was in contents.