### PR TITLE
#8311 Cogmap2 Bot Storage APC area

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -56571,10 +56571,11 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "W APC";
-	pixel_x = -24
+	pixel_x = -24;
+	areastring = "Robot Depot"
 	},
 /turf/simulated/floor/plating,
-/area/station/science/bot_storage)
+/area/station/maintenance/southeast)
 "cwC" = (
 /obj/machinery/launcher_loader/south,
 /turf/simulated/floor/plating,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fix #8311 
Change the area of the APC tile and use areastring.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Outdated approach to APC area.