### PR TITLE
Runtime "unit tests" for map correctness

### DIFF
--- a/code/modules/unit_tests/map_correctness.dm
+++ b/code/modules/unit_tests/map_correctness.dm
@@ -91,7 +91,7 @@ proc/check_blinds_switches()
 	var/list/invalid_blinds_ids = list()
 	for_by_tcl(blinds, /obj/window_blinds)
 		if(isnull(blinds.mySwitch))
-			invalid_blinds_ids |= blinds.id
+			invalid_blinds_ids |= (blinds.id || "null")
 	if(length(invalid_blinds_ids))
 		CRASH("Blinds IDs without switches:\n" + jointext(invalid_blinds_ids, "\n"))
 

--- a/code/modules/unit_tests/map_correctness.dm
+++ b/code/modules/unit_tests/map_correctness.dm
@@ -6,6 +6,13 @@ proc/check_map_correctness()
 	check_missing_navbeacons()
 	check_apcs_wired()
 	check_objects_in_walls()
+	check_window_turfs()
+	check_door_turfs()
+	check_networked_data_terminals()
+	check_blinds_switches()
+	check_apcless_station_areas()
+	check_lightswitchless_station_areas()
+	check_unsimulated_station_turfs()
 
 proc/check_missing_navbeacons()
 	var/list/all_beacons = list()
@@ -37,14 +44,87 @@ proc/check_apcs_wired()
 		var/problematic_areas_text = jointext(problematic_areas, ", ")
 		CRASH("APCs without cables: " + problematic_areas_text)
 
-proc/check_objects_in_walls()
+proc/check_objects_in_walls(z_level=Z_LEVEL_STATION)
 	var/list/log_lines = list()
-	for(var/obj/O in world)
-		var/turf/T = O.loc
-		if(!O.anchored && istype(T) && T?.density)
-			log_lines += "[O] [O.type] on [T.x], [T.y], [T.z]) in [T.loc]"
+	for(var/turf/simulated/wall/T in block(locate(1, 1, z_level), locate(world.maxx, world.maxy, z_level)))
+		for(var/obj/O in T)
+			if(!O.anchored)
+				log_lines += "[O] [O.type] on [T.x], [T.y], [T.z] in [T.loc]"
+	for(var/turf/unsimulated/wall/T in block(locate(1, 1, z_level), locate(world.maxx, world.maxy, z_level)))
+		for(var/obj/O in T)
+			if(!O.anchored)
+				log_lines += "[O] [O.type] on [T.x], [T.y], [T.z] in [T.loc]"
 	if(length(log_lines))
 		CRASH("Unanchored objects in walls:\n" + jointext(log_lines, "\n"))
 
+proc/check_door_turfs()
+	var/list/log_lines = list()
+	for_by_tcl(door, /obj/machinery/door)
+		var/turf/T = door.loc
+		if(istype(T.loc, /turf/space) || T.density)
+			log_lines += "[door] [door.type] on [T.x], [T.y], [T.z] in [T.loc]"
+	if(length(log_lines))
+		CRASH("Doors on invalid turfs:\n" + jointext(log_lines, "\n"))
+
+proc/check_window_turfs()
+	var/list/log_lines = list()
+	for(var/obj/window/window in world)
+		var/turf/T = window.loc
+		if(istype(T.loc, /turf/space) || T.density)
+			log_lines += "[window] [window.type] on [T.x], [T.y], [T.z] in [T.loc]"
+	if(length(log_lines))
+		CRASH("Windows on invalid turfs:\n" + jointext(log_lines, "\n"))
+
+proc/check_networked_data_terminals()
+	var/list/log_lines = list()
+	for(var/obj/machinery/networked/networked in world)
+		if(!(locate(/obj/machinery/power/data_terminal) in networked.loc))
+			var/turf/T = networked.loc
+			log_lines += "[networked] [networked.type] on [T.x], [T.y], [T.z] in [T.loc]"
+	for(var/turf/T in job_start_locations["AI"])
+		if(!(locate(/obj/machinery/power/data_terminal) in T))
+			log_lines += "AI start landmark on [T.x], [T.y], [T.z] in [T.loc]"
+	if(length(log_lines))
+		CRASH("Terminal-less machinery:\n" + jointext(log_lines, "\n"))
+
+proc/check_blinds_switches()
+	var/list/invalid_blinds_ids = list()
+	for_by_tcl(blinds, /obj/window_blinds)
+		if(isnull(blinds.mySwitch))
+			invalid_blinds_ids |= blinds.id
+	if(length(invalid_blinds_ids))
+		CRASH("Blinds IDs without switches:\n" + jointext(invalid_blinds_ids, "\n"))
+
+proc/check_apcless_station_areas()
+	var/list/log_lines = list()
+	for(var/area/station/AR in get_accessible_station_areas())
+		if(isnull(AR.area_apc))
+			log_lines += "[AR]"
+	if(length(log_lines))
+		CRASH("Station areas without APCs:\n" + jointext(log_lines, "\n"))
+
+proc/check_lightswitchless_station_areas()
+	var/list/log_lines = list()
+	for(var/area/station/AR in get_accessible_station_areas())
+		if(istype(AR, /area/station/maintenance))
+			continue
+		var/has_lights = locate(/obj/machinery/light) in AR.machines
+		if(!has_lights)
+			continue
+		var/has_lightswitches = locate(/obj/machinery/light_switch) in AR.machines
+		if(!has_lightswitches)
+			log_lines += "[AR]"
+	if(length(log_lines))
+		CRASH("Station areas without light switches:\n" + jointext(log_lines, "\n"))
+
+proc/check_unsimulated_station_turfs()
+	var/list/log_lines = list()
+	for(var/turf/unsimulated/T in block(locate(1, 1, Z_LEVEL_STATION), locate(world.maxx, world.maxy, Z_LEVEL_STATION)))
+		if(!istype(T.loc, /area/station) || istype(T.loc, /area/station/hallway/secondary/oshan_arrivals) || \
+				istype(T.loc, /area/station/hangar/arrivals) || istype(T.loc, /area/station/crewquarters/cryotron))
+			continue
+		log_lines += "[T] [T.type] on [T.x], [T.y], [T.z] in [T.loc]"
+	if(length(log_lines))
+		CRASH("Unsimulated station turfs:\n" + jointext(log_lines, "\n"))
 
 // #endif

--- a/code/modules/unit_tests/map_correctness.dm
+++ b/code/modules/unit_tests/map_correctness.dm
@@ -1,10 +1,11 @@
 /// Not quite a unit test but achieves the same goal. Ran for each map unlike actual unit tests.
 
-#ifdef RUNTIME_CHECKING
+// #ifdef RUNTIME_CHECKING
 
 proc/check_map_correctness()
 	check_missing_navbeacons()
 	check_apcs_wired()
+	check_objects_in_walls()
 
 proc/check_missing_navbeacons()
 	var/list/all_beacons = list()
@@ -36,5 +37,14 @@ proc/check_apcs_wired()
 		var/problematic_areas_text = jointext(problematic_areas, ", ")
 		CRASH("APCs without cables: " + problematic_areas_text)
 
+proc/check_objects_in_walls()
+	var/list/log_lines = list()
+	for(var/obj/O in world)
+		var/turf/T = O.loc
+		if(!O.anchored && istype(T) && T?.density)
+			log_lines += "[O] [O.type] on [T.x], [T.y], [T.z]) in [T.loc]"
+	if(length(log_lines))
+		CRASH("Unanchored objects in walls:\n" + jointext(log_lines, "\n"))
 
-#endif
+
+// #endif

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -43239,7 +43239,7 @@
 	name = "mail junction (pod bay checkpoint)"
 	},
 /obj/storage/closet/wardrobe/orange,
-/turf/unsimulated/floor/red/side{
+/turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/checkpoint/podbay)
@@ -43250,7 +43250,7 @@
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/computer3/generic/secure_data,
-/turf/unsimulated/floor/red/side{
+/turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/checkpoint/podbay)
@@ -43261,14 +43261,14 @@
 	pixel_y = 24;
 	text = "NF"
 	},
-/turf/unsimulated/floor/red/side{
+/turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/checkpoint/podbay)
 "bRI" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/unsimulated/floor/red/side{
+/turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/checkpoint/podbay)
@@ -43285,7 +43285,7 @@
 	pixel_y = 8
 	},
 /obj/disposalpipe/segment/mail/bent/south,
-/turf/unsimulated/floor/red/side{
+/turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/checkpoint/podbay)
@@ -48838,10 +48838,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"cem" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/southeast)
 "cen" = (
 /obj/machinery/light/small,
 /obj/disposalpipe/segment/mail/bent/north,
@@ -67758,7 +67754,7 @@
 /obj/disposalpipe/trunk/transport{
 	dir = 1
 	},
-/turf/unsimulated/floor/red/side,
+/turf/simulated/floor/red/side,
 /area/station/security/checkpoint/podbay)
 "cVU" = (
 /obj/wingrille_spawn/auto/crystal,
@@ -74285,7 +74281,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_south,
-/turf/unsimulated/floor/red/side,
+/turf/simulated/floor/red/side,
 /area/station/security/checkpoint/podbay)
 "dki" = (
 /turf/simulated/floor/shuttlebay{
@@ -77076,7 +77072,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/unsimulated/floor/red/side,
+/turf/simulated/floor/red/side,
 /area/station/security/checkpoint/podbay)
 "gky" = (
 /obj/cable{
@@ -77803,7 +77799,7 @@
 /area/shuttle/research/outpost)
 "jNp" = (
 /obj/item/paper/book/from_file/monster_manual_revised,
-/turf/simulated/wall/asteroid,
+/turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "jNE" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -139910,7 +139906,7 @@ cdC
 cyX
 cAb
 aaa
-cem
+ceb
 cey
 ceX
 cib

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -8764,7 +8764,6 @@
 	},
 /obj/cable,
 /obj/decal/poster/wallsign/gym,
-/obj/wingrille_spawn/auto,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/fitness)
 "aJO" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -43976,6 +43976,11 @@
 	dir = 1
 	},
 /obj/machinery/networked/nuclear_charge,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "mFg" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -7550,6 +7550,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred2"
@@ -42948,7 +42949,9 @@
 /turf/space/fluid,
 /area/space)
 "cho" = (
-/obj/item/poster/titled_photo/bee,
+/obj/item/poster/titled_photo/bee{
+	anchored = 1
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/diner/dining)
 "chp" = (

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -43336,13 +43336,6 @@
 	dir = 4
 	},
 /area/owlery/staffhall)
-"cxk" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	req_access_txt = null
-	},
-/turf/unsimulated/wall/auto/reinforced/supernorn,
-/area/owlery/staffhall)
 "cxl" = (
 /turf/unsimulated/floor/arrival{
 	dir = 8
@@ -51677,6 +51670,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/unsimulated/floor/redblack{
 	dir = 4
 	},
@@ -52365,6 +52363,11 @@
 "cSU" = (
 /obj/table/reinforced/auto,
 /obj/machinery/networked/printer,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/unsimulated/floor/red,
 /area/syndicate_station/battlecruiser)
 "cSV" = (
@@ -92201,7 +92204,7 @@ aBY
 aBY
 aBY
 aBY
-cxk
+aBY
 aBY
 aBY
 cyF

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -731,6 +731,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/radiostation/bridge)
 "acn" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so runtime checking on GitHub CI will do some basic checks of whether maps have some easy to detect errors.

Current checks:

- Missing followup navbeacons on patrols and tours
- APCs without cables attached
- Unanchored objects on walls
- Windows on space or walls
- Doors on space or walls
- Networked machinery without data terminals
- Blinds without switches
- Station areas without APCs
- Non-maint station areas with lights and without light switches
- Unsimulated turfs in non-arrivals station areas

Someone (ideally not me) should fix all the map mistakes revelaed by this PR (or tell me to change how the checks are done) before this PR gets merged. Feel free to PR your map fixes either to master or to the `map-correctness` branch.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Helps catch mistakes early.
