### PR TITLE
Map fix batch 1: cogmap2, destiny, donut3, oshan, z2/z3

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -43239,7 +43239,7 @@
 	name = "mail junction (pod bay checkpoint)"
 	},
 /obj/storage/closet/wardrobe/orange,
-/turf/unsimulated/floor/red/side{
+/turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/checkpoint/podbay)
@@ -43250,7 +43250,7 @@
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/machinery/computer3/generic/secure_data,
-/turf/unsimulated/floor/red/side{
+/turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/checkpoint/podbay)
@@ -43261,14 +43261,14 @@
 	pixel_y = 24;
 	text = "NF"
 	},
-/turf/unsimulated/floor/red/side{
+/turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/checkpoint/podbay)
 "bRI" = (
 /obj/disposalpipe/segment,
 /obj/disposalpipe/segment/mail/horizontal,
-/turf/unsimulated/floor/red/side{
+/turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/checkpoint/podbay)
@@ -43285,7 +43285,7 @@
 	pixel_y = 8
 	},
 /obj/disposalpipe/segment/mail/bent/south,
-/turf/unsimulated/floor/red/side{
+/turf/simulated/floor/red/side{
 	dir = 1
 	},
 /area/station/security/checkpoint/podbay)
@@ -48838,10 +48838,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
-"cem" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/southeast)
 "cen" = (
 /obj/machinery/light/small,
 /obj/disposalpipe/segment/mail/bent/north,
@@ -67758,7 +67754,7 @@
 /obj/disposalpipe/trunk/transport{
 	dir = 1
 	},
-/turf/unsimulated/floor/red/side,
+/turf/simulated/floor/red/side,
 /area/station/security/checkpoint/podbay)
 "cVU" = (
 /obj/wingrille_spawn/auto/crystal,
@@ -74285,7 +74281,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/autoname_south,
-/turf/unsimulated/floor/red/side,
+/turf/simulated/floor/red/side,
 /area/station/security/checkpoint/podbay)
 "dki" = (
 /turf/simulated/floor/shuttlebay{
@@ -77076,7 +77072,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/unsimulated/floor/red/side,
+/turf/simulated/floor/red/side,
 /area/station/security/checkpoint/podbay)
 "gky" = (
 /obj/cable{
@@ -77803,7 +77799,7 @@
 /area/shuttle/research/outpost)
 "jNp" = (
 /obj/item/paper/book/from_file/monster_manual_revised,
-/turf/simulated/wall/asteroid,
+/turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "jNE" = (
 /obj/machinery/door/airlock/pyro/external{
@@ -139910,7 +139906,7 @@ cdC
 cyX
 cAb
 aaa
-cem
+ceb
 cey
 ceX
 cib

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -8764,7 +8764,6 @@
 	},
 /obj/cable,
 /obj/decal/poster/wallsign/gym,
-/obj/wingrille_spawn/auto,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/crew_quarters/fitness)
 "aJO" = (

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -43976,6 +43976,11 @@
 	dir = 1
 	},
 /obj/machinery/networked/nuclear_charge,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "mFg" = (

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -7550,6 +7550,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fred2"
@@ -42948,7 +42949,9 @@
 /turf/space/fluid,
 /area/space)
 "cho" = (
-/obj/item/poster/titled_photo/bee,
+/obj/item/poster/titled_photo/bee{
+	anchored = 1
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/diner/dining)
 "chp" = (

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -43336,13 +43336,6 @@
 	dir = 4
 	},
 /area/owlery/staffhall)
-"cxk" = (
-/obj/machinery/door/airlock/pyro/glass{
-	dir = 4;
-	req_access_txt = null
-	},
-/turf/unsimulated/wall/auto/reinforced/supernorn,
-/area/owlery/staffhall)
 "cxl" = (
 /turf/unsimulated/floor/arrival{
 	dir = 8
@@ -51677,6 +51670,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/unsimulated/floor/redblack{
 	dir = 4
 	},
@@ -52365,6 +52363,11 @@
 "cSU" = (
 /obj/table/reinforced/auto,
 /obj/machinery/networked/printer,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/unsimulated/floor/red,
 /area/syndicate_station/battlecruiser)
 "cSV" = (
@@ -92201,7 +92204,7 @@ aBY
 aBY
 aBY
 aBY
-cxk
+aBY
 aBY
 aBY
 cyF

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -731,6 +731,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/radiostation/bridge)
 "acn" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
cogmap2: security podbay unsimmed->simmed turf; stacked window; buried book by research outpost

destiny: stacked window

dount3: armory nuke has a data terminal and wire stem; is not connected to a network by default (same setup as Horizon's nuke)

oshan: RD's printer hooked up, sea diner poster fixed

z2: stacked owlery wall/window, syndie cruiser now has a working printer
z3: radio station printer now has a terminal. it might be better to fake-decal it since.. no network?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
map linting fixes