### PR TITLE
make clow cards numbered again

### DIFF
--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -1008,7 +1008,7 @@
 			var/obj/item/playing_card/card = new /obj/item/playing_card(src)
 			stored_cards += card
 			card.icon_state = "clow-1-1"
-			card.name = "Clow Card"
+			card.name = "\proper Clow Card #[i]"
 			update_card_information(card)
 			card.update_stored_info()
 		update_group_sprite()

--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -1008,7 +1008,7 @@
 			var/obj/item/playing_card/card = new /obj/item/playing_card(src)
 			stored_cards += card
 			card.icon_state = "clow-1-1"
-			card.name = "\proper Clow Card #[i]"
+			card.name = "Clow Card #[i]"
 			update_card_information(card)
 			card.update_stored_info()
 		update_group_sprite()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #8353 
Looks like the numbering was removed in #3740 . This restores it.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
To distinguish clow cards? I mean, idk what you would do with these, I haven't seen the show!

