### PR TITLE
fix conversion chamber bugs

### DIFF
--- a/code/modules/robotics/robot/robot_docking_station.dm
+++ b/code/modules/robotics/robot/robot_docking_station.dm
@@ -34,25 +34,21 @@
 	..()
 
 /obj/machinery/recharge_station/process(mult)
-	if (!src.conversion_chamber) //Syndie ones are nuclear powered or some shit idk
-		if (!(src.status & BROKEN))
-			// todo / at some point id like to fix the disparity between cells and 'normal power'
-			if (src.occupant)
-				src.power_usage = 500
-			else
-				src.power_usage = 50
-			..()
-		if (src.status & (NOPOWER | BROKEN))
-			if (src.occupant)
-				boutput(src.occupant, "<span class='alert'>You are automatically ejected from [src]!</span>")
-				src.go_out()
-				src.build_icon()
-			return
-
+	if (!(src.status & BROKEN))
+		src.power_usage = src.occupant ? 500 : 50
+		// syndicate gear is nuclear powered or something
+		if (src.conversion_chamber) src.power_usage = 0
+		..()
+	if (src.status & BROKEN || (src.status & NOPOWER && !conversion_chamber))
 		if (src.occupant)
-			src.process_occupant(mult)
+			boutput(src.occupant, "<span class='alert'>You are automatically ejected from [src]!</span>")
+			src.go_out()
+		return
 
-		use_power(power_usage)
+	if (src.occupant)
+		src.process_occupant(mult)
+
+	use_power(power_usage)
 	return 1
 
 /obj/machinery/recharge_station/allow_drop()
@@ -72,7 +68,7 @@
 	if (src.status & BROKEN)
 		boutput(user, "<span class='alert'>[src] is broken and cannot be used.</span>")
 		return
-	if (src.status & NOPOWER)
+	if (src.status & NOPOWER && !src.conversion_chamber)
 		boutput(user, "<span class='alert'>[src] is out of power and cannot be used.</span>")
 		return
 	if (!src.anchored)
@@ -654,32 +650,40 @@
 
 	else if (istype(W, /obj/item/grab))
 		var/obj/item/grab/G = W
-		if (!src.conversion_chamber)
-			boutput(user, "<span class='alert'>Humans cannot enter recharging stations.</span>")
-			return
-		if (!ishuman(G.affecting))
-			boutput(user, "<span class='alert'>Non-Humans are not compatible with this device.</span>")
-			return
-		if (isdead(G.affecting))
-			boutput(user, "<span class='alert'>[G.affecting] is dead and cannot be forced inside.</span>")
-			return
 		if (G.state == GRAB_PASSIVE)
 			boutput(user, "<span class='alert'>You need a tighter grip!</span>")
 			return
-
-		var/mob/living/carbon/human/H = G.affecting
-		logTheThing("combat", user, H, "puts [constructTarget(H,"combat")] into a conversion chamber at [log_loc(src)]")
-		user.visible_message("<span class='notice>[user] stuffs [H] into \the [src].")
-
-		H.remove_pulling()
-		H.set_loc(src)
-		src.add_fingerprint(user)
-		src.occupant = H
-		src.build_icon()
-		qdel(G)
+		if (src.move_human_inside(user, G.affecting))
+			qdel(G)
 
 	else
 		..()
+
+/// check if we may put this human inside the chamber
+/// on success returns true, else returns false
+/obj/machinery/recharge_station/proc/move_human_inside(mob/user, mob/victim)
+	if (!src.conversion_chamber)
+		boutput(user, "<span class='alert'>Humans cannot enter recharging stations.</span>")
+		return FALSE
+	if (!ishuman(victim))
+		boutput(user, "<span class='alert'>Non-Humans are not compatible with this device.</span>")
+		return FALSE
+	if (isdead(victim))
+		boutput(user, "<span class='alert'>[victim] is dead and cannot be forced inside.</span>")
+		return FALSE
+	if (!src.anchored)
+		boutput(user, "<span class='alert'>You must attach [src]'s floor bolts before the machine will work.</span>")
+		return FALSE
+
+	var/mob/living/carbon/human/H = victim
+	logTheThing("combat", user, H, "puts [constructTarget(H,"combat")] into a conversion chamber at [log_loc(src)]")
+	user.visible_message("<span class='notice>[user] stuffs [H] into \the [src].")
+
+	H.remove_pulling()
+	H.set_loc(src)
+	src.add_fingerprint(user)
+	src.occupant = H
+	src.build_icon()
 
 /obj/machinery/recharge_station/MouseDrop_T(atom/movable/AM as mob|obj, mob/user as mob)
 	if (BOUNDS_DIST(AM, user) > 0 || BOUNDS_DIST(src, user) > 0)
@@ -732,15 +736,7 @@
 		src.build_icon()
 
 	if (ishuman(AM))
-		var/mob/living/carbon/human/H = AM
-		logTheThing("combat", user, null, "puts [himself_or_herself(user)] into a conversion chamber at [log_loc(src)]")
-		user.visible_message("<span class='notice>[user] stuffs [himself_or_herself(user)] into \the [src].")
-
-		H.remove_pulling()
-		H.set_loc(src)
-		src.occupant = H
-		src.add_fingerprint(user)
-		src.build_icon()
+		src.move_human_inside(user, AM)
 
 /obj/machinery/recharge_station/proc/build_icon()
 	if (src.occupant)
@@ -886,6 +882,8 @@
 /obj/machinery/recharge_station/syndicate/attackby(obj/item/W as obj, mob/user as mob)
 	if (iswrenchingtool(W))
 		src.anchored = !src.anchored
+		if (!anchored)
+			src.go_out()
 		user.show_text("You [src.anchored ? "attach" : "release"] \the [src]'s floor clamps", "red")
 		playsound(src, "sound/items/Ratchet.ogg", 40, 0, 0)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #8384

- fixes conversion chambers not doing process, causing them to not work
- makes it so you can't move people inside the chamber while it is unanchored
- I unified the moving-human-inside-chamber process in a proc for this, so you can't move dead people inside a chamber by click-dragging and stuff like that
- makes it so if someone is inside the chamber, unanchoring will release them
- makes it so that conversion chambers actually work while unpowered


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad