### PR TITLE
Ramen and udon noodles actually heal you and make sense now

### DIFF
--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -2844,7 +2844,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/soup)
 	icon = 'icons/obj/foodNdrink/food_meals.dmi'
 	icon_state = "ramen"
 	needfork = TRUE
-	amount = 5
+	heal_amt = 2
+	bites_left = 5
 	initial_volume = 20
 	initial_reagents = "soysauce"
 	food_effects = list("food_brute","food_energized","food_warm")
@@ -2855,7 +2856,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/soup)
 	icon = 'icons/obj/foodNdrink/food_meals.dmi'
 	icon_state = "udon"
 	needfork = TRUE
-	amount = 5
+	heal_amt = 3
+	bites_left = 5
 	initial_volume = 20
 	initial_reagents = "soysauce"
 	food_effects = list("food_hp_up","food_explosion_resist","food_warm")
@@ -2866,7 +2868,8 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/soup)
 	icon = 'icons/obj/foodNdrink/food_meals.dmi'
 	icon_state = "udon_curry"
 	needfork = TRUE
-	amount = 5
+	heal_amt = 3
+	bites_left = 5
 	initial_volume = 20
 	initial_reagents = "currypowder"
 	food_effects = list("food_hp_up","food_refreshed","food_warm")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
RAMEN/UDON NOW HAVE `heal_amt` AND `amount` HAS BEEN REPLACED BY `bites_left` BECAUSE I CAN'T READ WHAT VARIABLES FUCKING MEAN AND RAMEN CAN'T BE FUCKING STACKED HELLO????


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
FUCK!! FUCK!!!!! MY KNEES!
![image](https://user-images.githubusercontent.com/66253095/166130966-695a337d-9a1f-4822-90a8-c4ca8881c4ea.png)
