### PR TITLE
Removed reinforced walls from under windows in horizon robotics

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -39819,11 +39819,6 @@
 /obj/disposalpipe/segment/bent/south,
 /turf/simulated/floor/black,
 /area/station/medical/robotics)
-"bXs" = (
-/obj/grille/steel,
-/obj/window/auto/reinforced,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/robotics)
 "bXu" = (
 /obj/machinery/door/airlock/pyro/maintenance{
 	dir = 8
@@ -53256,8 +53251,8 @@
 /obj/disposalpipe/segment/cargo{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/medical/robotics)
+/turf/simulated/floor/plating,
+/area/space)
 "eSH" = (
 /obj/storage/closet/law,
 /obj/item/reagent_containers/patch/nicotine,
@@ -116701,9 +116696,9 @@ bzq
 bzv
 aXc
 aXc
-bXs
+aFG
 eQJ
-bXs
+aFG
 aEN
 jEd
 brW


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For some reason in the robotics of horizon there are walls under windows. Not anymore!


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's just most likely not intended to have those there.

Before:
![horizon robo old](https://user-images.githubusercontent.com/95481182/166144019-7f37b975-f08d-4684-9e17-470dfde89be4.png)

After:
![horizon robo new](https://user-images.githubusercontent.com/95481182/166143976-06beee91-14c6-4c92-9e32-65d0355c4aa6.png)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Chatauscours
(+)Removed reinforced walls from under windows in horizon robotics.
```
