### PR TITLE
Added spawnable custom wigs

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2799,43 +2799,17 @@
 	if (!src.bioHolder || !src.bioHolder.mobAppearance)
 		return null
 	var/obj/item/clothing/head/wig/W = new(src)
-	var/actuallyHasHair = 0
 	W.name = "[real_name]'s hair"
 	W.real_name = "[real_name]'s hair" // The clothing parent setting real_name is probably good for other stuff so I'll just do this
 	W.icon = 'icons/mob/human_hair.dmi'
 	W.icon_state = "bald" // Let's give the actual hair a chance to shine
-/* commenting this out and making it an overlay to fix issues with colors stacking
-	W.icon = 'icons/mob/human_hair.dmi'
-	W.icon_state = H.bioHolder.mobAppearance.customization_first.id
-	W.color = src.bioHolder.mobAppearance.customization_first_color
-	W.wear_image_icon = 'icons/mob/human_hair.dmi'
-	W.wear_image = image(W.wear_image_icon, W.icon_state)
-	W.wear_image.color = src.bioHolder.mobAppearance.customization_first_color*/
 
-	if (!istype(src.bioHolder.mobAppearance.customization_first,/datum/customization_style/none))
-		var/image/h_image = image('icons/mob/human_hair.dmi', src.bioHolder.mobAppearance.customization_first.id)
-		h_image.color = src.bioHolder.mobAppearance.customization_first_color
-		W.overlays += h_image
-		W.wear_image.overlays += h_image
-		actuallyHasHair = 1
+	var/hair_list = list()
+	hair_list[src.bioHolder.mobAppearance.customization_first.id] = src.bioHolder.mobAppearance.customization_first_color
+	hair_list[src.bioHolder.mobAppearance.customization_second.id] = src.bioHolder.mobAppearance.customization_second_color
+	hair_list[src.bioHolder.mobAppearance.customization_third.id] = src.bioHolder.mobAppearance.customization_third_color
 
-	if (!istype(src.bioHolder.mobAppearance.customization_second,/datum/customization_style/none))
-		var/image/f_image = image('icons/mob/human_hair.dmi', src.bioHolder.mobAppearance.customization_second.id)
-		f_image.color = src.bioHolder.mobAppearance.customization_second_color
-		W.overlays += f_image
-		W.wear_image.overlays += f_image
-		actuallyHasHair = 1
-
-
-	if (!istype(src.bioHolder.mobAppearance.customization_third,/datum/customization_style/none))
-		var/image/d_image = image('icons/mob/human_hair.dmi', src.bioHolder.mobAppearance.customization_third.id)
-		d_image.color = src.bioHolder.mobAppearance.customization_third_color
-		W.overlays += d_image
-		W.wear_image.overlays += d_image
-		actuallyHasHair = 1
-
-	if(!actuallyHasHair) // Guess they didnt have any, ah well
-		W.icon_state = "short"
+	W.setup_wig(hair_list)
 
 	return W
 

--- a/code/obj/ToSplit/barber_shop.dm
+++ b/code/obj/ToSplit/barber_shop.dm
@@ -18,6 +18,41 @@
 	desc = "You can't tell the difference, Honest!"
 	icon_state= "wig"
 
+	///Takes a list of style ids to colors and generates a wig from it
+	proc/setup_wig(var/style_list)
+		if (!style_list)
+			return
+		var/actuallyHasHair = FALSE
+		for (var/style_id in style_list)
+			if (style_id == "none")
+				continue
+			var/image/h_image = image('icons/mob/human_hair.dmi', style_id)
+			h_image.color = style_list[style_id]
+			src.overlays += h_image
+			src.wear_image.overlays += h_image
+			actuallyHasHair = TRUE
+		if (!actuallyHasHair)
+			src.icon_state = "short"
+
+///A type to allow you to spawn custom wigs from the map editor
+/obj/item/clothing/head/wig/spawnable
+	icon = 'icons/mob/human_hair.dmi'
+	icon_state = "bald"
+	var/first_id = "none"
+	var/first_color = "#101010"
+	var/second_id = "none"
+	var/second_color = "#101010"
+	var/third_id = "none"
+	var/third_color = "#101010"
+
+	New()
+		..()
+		var/hair_list = list()
+		hair_list[first_id] = first_color
+		hair_list[second_id] = second_color
+		hair_list[third_id] = third_color
+		src.setup_wig(hair_list)
+
 /obj/item/clothing/head/bald_cap
 	name = "bald cap"
 	desc = "You can't tell the difference, Honest!"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE] [MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a wig subtype to allow you to spawn custom wigs in maps and modifies the wig creation code to allow this (also in theory allows an admin to create a wig of every hair style in the game because why not)
The path is `/obj/item/clothing/head/wig/spawnable`
Example of how to set up the spawn.
![image](https://user-images.githubusercontent.com/20713227/166146502-149bc221-6e2c-46b3-a578-f302359ee20f.png)

(the branch name is 2 because I broke git slightly the first time)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Miss Helper in discord asked for it and I thought it was neat.