### PR TITLE
Replace fake sink on cog1

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -50306,7 +50306,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
 "cxU" = (
-/obj/decal/fakeobjects/sink,
+/obj/submachine/chef_sink,
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 21


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces a obj/decal/fakeobjects/sink in cog1 pathology with an actual sink.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8397, stops players being confused.