### PR TITLE
Changes the chameleon suit to the chameleon outfit from #7469 in the infiltrator class crate

### DIFF
--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -522,7 +522,7 @@
 		/obj/item/dna_scrambler,
 		/obj/item/voice_changer,
 		/obj/item/card/emag,
-		/obj/item/clothing/under/chameleon,
+		/obj/item/storage/backpack/chameleon,
 		/obj/item/device/chameleon,
 		/obj/item/clothing/suit/space/syndicate/specialist,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/infiltrator)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the chameleon suit to the chameleon outfit from #7469 in the infiltrator class crate.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This will make an infiltrator nukie more viable, and it will  generally fit the class and would be logical, considering you can buy the whole outfit as a traitor now. 
Would also be great addition for the nukie gimmicks.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Chatauscours
(*)Changed the chameleon suit to the chameleon outfit in the infiltrator class crate.
```