### PR TITLE
Law linkers can no longer be used on syndicate frames

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1097,6 +1097,7 @@
 					boutput(user, "The link port sparks violently! It didn't work!")
 					logTheThing("station", src, null, "[constructName(user)] tried to connect [src] to the rack [constructName(src.law_rack_connection)] but they are emagged, so it failed.")
 					elecflash(src,power=2)
+					return
 
 				if(src.law_rack_connection && !src.syndicate)
 					var/raw = tgui_alert(user,"Do you want to overwrite the linked rack?", "Linker", list("Yes", "No"))

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1097,7 +1097,8 @@
 					boutput(user, "The link port sparks violently! It didn't work!")
 					logTheThing("station", src, null, "[constructName(user)] tried to connect [src] to the rack [constructName(src.law_rack_connection)] but they are emagged, so it failed.")
 					elecflash(src,power=2)
-				if(src.law_rack_connection)
+
+				if(src.law_rack_connection && !src.syndicate)
 					var/raw = tgui_alert(user,"Do you want to overwrite the linked rack?", "Linker", list("Yes", "No"))
 					if (raw == "Yes")
 						src.law_rack_connection = linker.linked_rack
@@ -1107,6 +1108,9 @@
 						src.playsound_local(src, "sound/misc/lawnotify.ogg", 100, flags = SOUND_IGNORE_SPACE)
 						src.show_text("<h3>You have been connected to a law rack</h3>", "red")
 						src.show_laws()
+				else if(src.syndicate)
+					boutput(user, "The link port stays inert, seemingly not recognizing the target!")
+					logTheThing("station", src, null, "[constructName(user)] tried to connect [src] to the rack [constructName(src.law_rack_connection)] but they are a syndicate frame, so it failed.")
 			else
 				boutput(user,"Linker lost connection to the stored law rack!")
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that syndicate cyborgs cannot be fixed by a law linker.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Apparently this is a bug so im correcting it.
Sparked from an earlier encounter where i fixed a cyborg's laws with a law linker and we both ended up being confused.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Bartimeus973
(+)Law linkers can no longer be used on syndicate cyborgs.
```
