### PR TITLE
Prevent shuttle hotbox on RP

### DIFF
--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -456,11 +456,9 @@
 	if (A)
 		if (emergency_shuttle.location == SHUTTLE_LOC_STATION)
 			if (istype(A, /area/shuttle/escape/station))
-				message_admins("station block")
 				return
 		else if (emergency_shuttle.location == SHUTTLE_LOC_TRANSIT)
 			if (istype(A, /area/shuttle/escape/transit))
-				message_admins("transit block")
 				return
 	#endif
 	START_TRACKING_CAT(TR_CAT_BURNING_ITEMS)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -451,16 +451,6 @@
 /obj/item/proc/combust(obj/item/W) // cogwerks- flammable items project
 	if(src.burning || (src in by_cat[TR_CAT_BURNING_ITEMS]))
 		return
-	#ifdef RP_MODE
-	var/area/A = get_area(src)
-	if (A)
-		if (emergency_shuttle.location == SHUTTLE_LOC_STATION)
-			if (istype(A, /area/shuttle/escape/station))
-				return
-		else if (emergency_shuttle.location == SHUTTLE_LOC_TRANSIT)
-			if (istype(A, /area/shuttle/escape/transit))
-				return
-	#endif
 	START_TRACKING_CAT(TR_CAT_BURNING_ITEMS)
 	src.visible_message("<span class='alert'>[src] catches on fire!</span>")
 	src.burning = 1

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -451,6 +451,18 @@
 /obj/item/proc/combust(obj/item/W) // cogwerks- flammable items project
 	if(src.burning || (src in by_cat[TR_CAT_BURNING_ITEMS]))
 		return
+	#ifdef RP_MODE
+	var/area/A = get_area(src)
+	if (A)
+		if (emergency_shuttle.location == SHUTTLE_LOC_STATION)
+			if (istype(A, /area/shuttle/escape/station))
+				message_admins("station block")
+				return
+		else if (emergency_shuttle.location == SHUTTLE_LOC_TRANSIT)
+			if (istype(A, /area/shuttle/escape/transit))
+				message_admins("transit block")
+				return
+	#endif
 	START_TRACKING_CAT(TR_CAT_BURNING_ITEMS)
 	src.visible_message("<span class='alert'>[src] catches on fire!</span>")
 	src.burning = 1

--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -65,6 +65,17 @@
 			JOB_XP(user, "Botanist", 2)
 
 	combust_ended()
+		// Prevent RP shuttle hotboxing
+		#ifdef RP_MODE
+		var/area/A = get_area(src)
+		if (A)
+			if (emergency_shuttle.location == SHUTTLE_LOC_STATION)
+				if (istype(A, /area/shuttle/escape/station))
+					return
+			else if (emergency_shuttle.location == SHUTTLE_LOC_TRANSIT)
+				if (istype(A, /area/shuttle/escape/transit))
+					return
+		#endif
 		var/turf/T = get_turf(src)
 		if (T.allow_unrestricted_hotbox) // traitor hotboxing
 			src.reagents.maximum_volume *= HERB_HOTBOX_MULTIPLIER


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents plants igniting on the shuttle if the server is on roleplay mode.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It feels like 1/4 of admin helps from RP are about shuttle hotboxing.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)RP shuttles have been fitted with the newly developed hotbox shields to reduce complaints.
```
