### PR TITLE
Makes wired up grilles able to reroute arcflashes

### DIFF
--- a/code/procs/helpers.dm
+++ b/code/procs/helpers.dm
@@ -126,6 +126,19 @@ var/global/obj/flashDummy
 		var/obj/O = getFlashDummy()
 		O.set_loc(target)
 		target_r = O
+	if(wattage && isliving(target)) //Grilles can reroute arcflashes
+		for(var/obj/grille/L in range(target,1)) // check for nearby grilles
+			if(!L.ruined && L.anchored)
+				if (L.material?.hasProperty("electrical"))
+					if (prob(L.material?.getProperty("electrical")/2) && L.get_connection())
+						target = L
+						target_r = L
+						continue
+				else
+					if (prob(30) && L.get_connection()) // hopefully half the default is low enough
+						target = L
+						target_r = L
+						continue
 
 	playsound(target, "sound/effects/elec_bigzap.ogg", 30, 1)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

In a previous PR, i added functionality that allowed grilles that were plugged in to charge the powernet they were plugged into

At that time, i did not realize that arc flashes only targeted mobs. 

This is an attempt to make it possible to use this behavior in-game without using admin buildmode arcflashes.

The chance of the grilles adjacent to a target redirecting an arc flash in this PR is increased by matsci conductivity.
If the material does not have conductivity set, it will instead use a default value.

I am unsure if i made that default value low enough.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It allows the lightning rod behavior that grilles have to be usable ingame. 
This behavior was previously unable to be used by almost everyone

![image](https://user-images.githubusercontent.com/64938519/166164054-610f498f-23b9-4e01-9ce7-83b7611babbf.png)

