### PR TITLE
Fixes opening through thindows

### DIFF
--- a/code/obj/storage/large_storage_parent.dm
+++ b/code/obj/storage/large_storage_parent.dm
@@ -792,7 +792,7 @@
 		set desc = "Open or close the closet/crate/whatever. Woah!"
 		set category = "Local"
 
-		if (usr.stat || !usr.can_use_hands() || isAI(usr))
+		if (usr.stat || !usr.can_use_hands() || isAI(usr) || !can_reach(usr, src))
 			return
 
 		return toggle()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[TRIVAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Opening and closing a large storage object through a thindow with the verb will no longer work.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Make thindow less buggy