### PR TITLE
allow cows to wear cowboy boots

### DIFF
--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -342,6 +342,7 @@
 /obj/item/clothing/shoes/cowboy
 	name = "Cowboy boots"
 	icon_state = "cowboy"
+	compatible_species = list("human", "cow")
 
 /obj/item/clothing/shoes/cowboy/boom
 	name = "Boom Boots"
@@ -709,6 +710,7 @@
 	name = "Real Cowboy Boots"
 	icon_state = "westboot"
 	desc = "Perfect for riding horses, if only you had one!"
+	compatible_species = list("human", "cow")
 
 /obj/item/clothing/shoes/westboot/black
 	name = "Black Cowboy Boots"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows cowpeople to wear both types of cowboy boots.
Minor balance changes, since this is QoL for Rancher Cows who can now benefit from the faster railing-jump of rancher boots.
Cows do not benefit from their cow limbs increased kick damage while wearing shoes.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
come on
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(*) Cowpeople can now wear cowboy boots.
```
