### PR TITLE
Buff football cleats with noslip

### DIFF
--- a/code/obj/item/football.dm
+++ b/code/obj/item/football.dm
@@ -44,9 +44,10 @@
 
 /obj/item/clothing/shoes/cleats
 	name = "cleats"
-	desc = "Sharp cleats made for playing football at a professional level. They must be expensive!"
+	desc = "Sharp cleats made for playing football at a professional level. The cleats provide excellent grip. They must be expensive!"
 	icon_state = "cleats"
 	item_state = "bl_shoes"
+	c_flags = NOSLIP
 	kick_bonus = 6
 	step_sound = "step_plating"
 	step_priority = STEP_PRIORITY_LOW


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds NOSLIP to football cleats.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The football set is a bit of a mixed bag overall and you have to pick between cleats and noslips.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Football cleats now have extra grip.
```
