### PR TITLE
Fixes for Staff of Thunder

### DIFF
--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -127,7 +127,7 @@
 		if(spell.offensive && A.sanctuary)
 			boutput( src, "You cannot cast offensive spells in a sanctuary." )
 			return 0
-		if (spell.offensive == 1 && src.bioHolder.HasEffect("arcane_shame"))
+		if (spell.offensive && src.bioHolder.HasEffect("arcane_shame"))
 			boutput(src, "You are too consumed with shame to cast that spell!")
 			return 0
 	else

--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -106,7 +106,7 @@
 	if(src.stat)
 		boutput(src, "You can't cast spells while incapacitated.")
 		return 0
-	if (src.bioHolder.HasEffect("arcane_power") == 2)
+	if(src.bioHolder.HasEffect("arcane_power") == 2)
 		return 1
 	if(spell && istype(src.gloves, /obj/item/clothing/gloves/ring/wizard))
 		var/obj/item/clothing/gloves/ring/wizard/WR = src.gloves
@@ -119,16 +119,24 @@
 	if(!istype(src.head, /obj/item/clothing/head/wizard))
 		boutput(src, "You don't feel strong enough without a magical hat.")
 		return 0
-	var/area/getarea = get_area(src)
-	if(spell.offensive && getarea.sanctuary)
-		boutput( src, "You cannot cast offensive spells in a sanctuary." )
-		return 0
-	if(getarea.name == "Chapel" || getarea.name == "Chapel Office")
+	var/area/A = get_area(src)
+	if(istype(A, /area/station/chapel))
 		boutput(src, "You cannot cast spells on hallowed ground!")// Maybe if the station were more corrupted...")
 		return 0
-	if (spell.offensive == 1 && src.bioHolder.HasEffect("arcane_shame"))
-		boutput(src, "You are too consumed with shame to cast that spell!")
-		return 0
+	if(spell)
+		if(spell.offensive && A.sanctuary)
+			boutput( src, "You cannot cast offensive spells in a sanctuary." )
+			return 0
+		if (spell.offensive == 1 && src.bioHolder.HasEffect("arcane_shame"))
+			boutput(src, "You are too consumed with shame to cast that spell!")
+			return 0
+	else
+		if(A.sanctuary)
+			boutput( src, "You cannot cast offensive spells in a sanctuary." )
+			return 0
+		if(src.bioHolder.HasEffect("arcane_shame"))
+			boutput(src, "You are too consumed with shame to cast that spell!")
+			return 0
 	return 1
 
 /mob/living/critter/wizard_castcheck(var/datum/targetable/spell/spell = null)

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -244,7 +244,7 @@
 		if (istype(A, /area/station/chapel))
 			boutput(user, "<span class='alert'>You cannot summon lightning on holy ground!</span>") //phrasing works if either target or mob are in chapel heh
 			return
-		if (A?.sanctuary)
+		if (A?.sanctuary || istype(a, /area/wizard_station))
 			boutput(user, "<span class='alert'>You cannot summon lightning in this place!</span>")
 			return
 		if (thunder_charges <= 0)

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -244,7 +244,7 @@
 		if (istype(A, /area/station/chapel))
 			boutput(user, "<span class='alert'>You cannot summon lightning on holy ground!</span>") //phrasing works if either target or mob are in chapel heh
 			return
-		if (A?.sanctuary || istype(a, /area/wizard_station))
+		if (A?.sanctuary || istype(A, /area/wizard_station))
 			boutput(user, "<span class='alert'>You cannot summon lightning in this place!</span>")
 			return
 		if (thunder_charges <= 0)

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -238,21 +238,26 @@
 	pixelaction(atom/target, params, mob/user, reach)
 		if(!IN_RANGE(user, target, WIDE_TILE_WIDTH / 2))
 			return
-		if (istype(get_area(target), /area/station/chapel) || istype(get_area(user), /area/station/chapel))
+		if (!user.wizard_castcheck())
+			return
+		var/area/A = get_area(target)
+		if (istype(A, /area/station/chapel))
 			boutput(user, "<span class='alert'>You cannot summon lightning on holy ground!</span>") //phrasing works if either target or mob are in chapel heh
+			return
+		if (A?.sanctuary)
+			boutput(user, "<span class='alert'>You cannot summon lightning in this place!</span>")
 			return
 		if (thunder_charges <= 0)
 			boutput(user, "<span class='alert'>[name] is out of charges! Magically recall it to restore it's power.</span>")
 			return
-		if (iswizard(user))
-			thunder_charges -= 1
-			var/turf/T = get_turf(target)
-			var/obj/lightning_target/lightning = new/obj/lightning_target(T)
-			playsound(T, 'sound/effects/electric_shock_short.ogg', 70, 1)
-			lightning.caster = user
-			UpdateIcon()
-			flick("[icon_state]_fire", src)
-			..()
+		thunder_charges -= 1
+		var/turf/T = get_turf(target)
+		var/obj/lightning_target/lightning = new/obj/lightning_target(T)
+		playsound(T, 'sound/effects/electric_shock_short.ogg', 70, 1)
+		lightning.caster = user
+		UpdateIcon()
+		flick("[icon_state]_fire", src)
+		..()
 
 	attack_hand(var/mob/user as mob)
 		if (user.mind)

--- a/code/procs/lightning_bolt.dm
+++ b/code/procs/lightning_bolt.dm
@@ -10,7 +10,9 @@
 			boutput(M, "<span class='notice'>The lightning bolt arcs around you harmlessly.</span>")
 		if (M != caster && iswizard(M))
 			boutput(M, "<span class='notice'>The other wizard's lightning strike refuses to hurt you out of respect to other wizards.</span>")
-			return
+			continue
+		else if (check_target_immunity(M))
+			continue
 		else
 			M.TakeDamage("chest", 0, 10, 0, DAMAGE_BURN)
 			boutput(M, "<span class='alert'>You feel a strong electric shock!</span>")
@@ -35,6 +37,7 @@
 	icon_state = "residual_electricity"
 	density = 0
 	opacity = 0
+	anchored = 1
 	plane = PLANE_NOSHADOW_ABOVE
 	var/duration = 9 SECONDS
 	var/caster
@@ -48,7 +51,7 @@
 	Crossed(atom/movable/M as mob|obj)
 		if(iscarbon(M))
 			var/mob/living/L = M
-			if (L.bioHolder?.HasEffect("resist_electric") || L.traitHolder?.hasTrait("training_chaplain"))
+			if (L.bioHolder?.HasEffect("resist_electric") || L.traitHolder?.hasTrait("training_chaplain") || check_target_immunity(L))
 				return
 			if (L != src.caster && iswizard(L))
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
1. Refactor wizard_castcheck to also work with no spells and piggy back most checks off this.
2. Add sanctuary checks.
3. Add immunity checks.
4. Swap return in lightning_bolt wizard check for continue
5. Residual electricity wasn't anchored.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
1. Lets us use the standard wizard checks instead of more code.
2. Sanctuary wasn't covered in checks.
3. Immunity wasn't covered in checks.
4. For loop would return if it hit a wizard.
5. You could pull the electricity around.

Edit: Actually there is a balance change here, you now need the robe and hat to cast with the hat due to the standard checks.

There is a dazed effect when you hit another wizard. This seems to be the elecflash.