### PR TITLE
Artifact chem trigger expansion

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1093,7 +1093,7 @@
 				return
 
 			if(linker.linked_rack in ticker.ai_law_rack_manager.registered_racks)
-				if(src.emagged || src.syndicate)
+				if(src.emagged)
 					boutput(user, "The link port sparks violently! It didn't work!")
 					logTheThing("station", src, null, "[constructName(user)] tried to connect [src] to the rack [constructName(src.law_rack_connection)] but they are emagged, so it failed.")
 					elecflash(src,power=2)

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1093,7 +1093,7 @@
 				return
 
 			if(linker.linked_rack in ticker.ai_law_rack_manager.registered_racks)
-				if(src.emagged)
+				if(src.emagged || src.syndicate)
 					boutput(user, "The link port sparks violently! It didn't work!")
 					logTheThing("station", src, null, "[constructName(user)] tried to connect [src] to the rack [constructName(src.law_rack_connection)] but they are emagged, so it failed.")
 					elecflash(src,power=2)

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -189,7 +189,7 @@
 			src.ArtifactStimulus("carbtouch", round(volume / 5))
 		if("carbon","synthflesh","blood","bloodc","meat_slurry")
 			src.ArtifactStimulus("carbtouch", round(volume / 5)) //require at least 5 units
-		if("silicon","silicon_dioxide","nanites","corruptnanites","silicate")
+		if("silicon","silicon_dioxide","nanites","corruptnanites","goodnanites","silicate")
 			src.ArtifactStimulus("silitouch", round(volume / 5)) //require at least 5 units
 		if("radium")
 			src.ArtifactStimulus("radiate", round(volume / 10))

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -184,6 +184,10 @@
 		return
 	var/datum/artifact/A = src.artifact
 	switch(reagent_id)
+		if("carbon","synthflesh","blood","bloodc")
+			src.ArtifactStimulus("carbtouch", round(volume / 5)) //require at least 5 units
+		if("silicon","silicon_dioxide","nanites","corruptnanites","silicate")
+			src.ArtifactStimulus("silitouch", round(volume / 5)) //require at least 5 units
 		if("radium","porktonium")
 			src.ArtifactStimulus("radiate", round(volume / 10))
 		if("strange_reagent")

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -184,11 +184,14 @@
 		return
 	var/datum/artifact/A = src.artifact
 	switch(reagent_id)
-		if("carbon","synthflesh","blood","bloodc")
+		if("porktonium")
+			src.ArtifactStimulus("radiate", round(volume / 10))
+			src.ArtifactStimulus("carbtouch", round(volume / 5))
+		if("carbon","synthflesh","blood","bloodc","meat_slurry")
 			src.ArtifactStimulus("carbtouch", round(volume / 5)) //require at least 5 units
 		if("silicon","silicon_dioxide","nanites","corruptnanites","silicate")
 			src.ArtifactStimulus("silitouch", round(volume / 5)) //require at least 5 units
-		if("radium","porktonium")
+		if("radium")
 			src.ArtifactStimulus("radiate", round(volume / 10))
 		if("strange_reagent")
 			src.ArtifactStimulus("radiate", round(volume / 5))

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -187,14 +187,12 @@
 		if("porktonium")
 			src.ArtifactStimulus("radiate", round(volume / 10))
 			src.ArtifactStimulus("carbtouch", round(volume / 5))
-		if("carbon","synthflesh","blood","bloodc","meat_slurry")
+		if("synthflesh","blood","bloodc","meat_slurry") //not carbon, because it's about detecting *lifeforms*, not elements
 			src.ArtifactStimulus("carbtouch", round(volume / 5)) //require at least 5 units
-		if("silicon","silicon_dioxide","nanites","corruptnanites","goodnanites","silicate")
+		if("nanites","corruptnanites","goodnanites","flockdrone_fluid") //not silicon&friends for the same reason
 			src.ArtifactStimulus("silitouch", round(volume / 5)) //require at least 5 units
 		if("radium")
 			src.ArtifactStimulus("radiate", round(volume / 10))
-		if("strange_reagent")
-			src.ArtifactStimulus("radiate", round(volume / 5))
 		if("uranium","polonium")
 			src.ArtifactStimulus("radiate", round(volume / 2))
 		if("dna_mutagen","mutagen","omega_mutagen")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds carbon and silicon touch activating chems.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I want to activate all the artifacts with a smoke bomb.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Carbon and silicon touch artifacts can be activated with appropriate life-related and robot-related chems now.
```
