### PR TITLE
Rework name tags to only use images

### DIFF
--- a/_std/plane.dm
+++ b/_std/plane.dm
@@ -5,7 +5,6 @@
 #define PLANE_NOSHADOW_BELOW -101
 #define PLANE_DEFAULT -100
 #define PLANE_NOSHADOW_ABOVE -99
-#define PLANE_EXAMINE -96
 #define PLANE_HIDDENGAME -95
 #define PLANE_LIGHTING -90
 #define PLANE_SELFILLUM -80
@@ -87,8 +86,6 @@ client
 		add_plane(new /atom/movable/screen/plane_parent(PLANE_NOSHADOW_BELOW, name = "noshadow_below_plane"))
 		add_plane(new /atom/movable/screen/plane_parent(PLANE_DEFAULT, name = "game_plane"))
 		add_plane(new /atom/movable/screen/plane_parent(PLANE_NOSHADOW_ABOVE, name = "noshadow_above_plane"))
-		var/atom/examine_plane = add_plane(new /atom/movable/screen/plane_parent(PLANE_EXAMINE, name = "examine_plane"))
-		examine_plane.alpha = 0
 		add_plane(new /atom/movable/screen/plane_parent(PLANE_LIGHTING, appearance_flags = NO_CLIENT_COLOR, blend_mode = BLEND_MULTIPLY, mouse_opacity = 0, name = "lighting_plane"))
 		add_plane(new /atom/movable/screen/plane_parent(PLANE_SELFILLUM, appearance_flags = NO_CLIENT_COLOR, blend_mode = BLEND_ADD, mouse_opacity = 0, name = "selfillum_plane"))
 		add_plane(new /atom/movable/screen/plane_parent(PLANE_ABOVE_LIGHTING, name = "emissive_plane"))

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -36,6 +36,7 @@
 	//var/atom/movable/screen/zone_sel/zone_sel = null
 	var/datum/hud/zone_sel/zone_sel = null
 	var/atom/movable/name_tag/name_tag
+	var/mob_hovered_over = null
 
 	var/obj/item/device/energy_shield/energy_shield = null
 
@@ -3095,11 +3096,15 @@
 
 
 /mob/MouseEntered(location, control, params)
-	if(usr.client.check_key(KEY_EXAMINE))
-		src.name_tag?.show_images(usr.client, FALSE, TRUE)
+	var/mob/M = usr
+	M.mob_hovered_over = src
+	if(M.client.check_key(KEY_EXAMINE))
+		src.name_tag?.show_images(M.client, FALSE, TRUE)
 
 /mob/MouseExited(location, control, params)
-	src.name_tag?.show_images(usr.client, usr.client.check_key(KEY_EXAMINE) && HAS_ATOM_PROPERTY(usr, PROP_MOB_EXAMINE_ALL_NAMES) ? TRUE : FALSE, FALSE)
+	var/mob/M = usr
+	M.mob_hovered_over = null
+	src.name_tag?.show_images(M.client, M.client.check_key(KEY_EXAMINE) && HAS_ATOM_PROPERTY(M, PROP_MOB_EXAMINE_ALL_NAMES) ? TRUE : FALSE, FALSE)
 
 /mob/proc/get_pronouns()
 	RETURN_TYPE(/datum/pronouns)

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -35,7 +35,7 @@
 
 	//var/atom/movable/screen/zone_sel/zone_sel = null
 	var/datum/hud/zone_sel/zone_sel = null
-	var/atom/movable/name_tag/outer/name_tag
+	var/atom/movable/name_tag/name_tag
 
 	var/obj/item/device/energy_shield/energy_shield = null
 
@@ -489,8 +489,6 @@
 /mob/Logout()
 
 	//logTheThing("diary", src, null, "logged out", "access") <- sometimes shits itself and has been known to out traitors. Disabling for now.
-	src.last_client?.get_plane(PLANE_EXAMINE)?.alpha = 0
-
 	SEND_SIGNAL(src, COMSIG_MOB_LOGOUT)
 
 	tgui_process?.on_logout(src)
@@ -3098,10 +3096,10 @@
 
 /mob/MouseEntered(location, control, params)
 	if(usr.client.check_key(KEY_EXAMINE))
-		src.name_tag?.show_hover(usr.client)
+		src.name_tag?.show_images(usr.client, FALSE, TRUE)
 
 /mob/MouseExited(location, control, params)
-	src.name_tag?.hide_hover(usr.client)
+	src.name_tag?.show_images(usr.client, usr.client.check_key(KEY_EXAMINE) && HAS_ATOM_PROPERTY(usr, PROP_MOB_EXAMINE_ALL_NAMES) ? TRUE : FALSE, FALSE)
 
 /mob/proc/get_pronouns()
 	RETURN_TYPE(/datum/pronouns)

--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -15,6 +15,9 @@
 		if (keys & KEY_EXAMINE)
 			for (var/mob/M as anything in mobs)
 				M.name_tag?.show_images(src.client, TRUE, FALSE)
+			if (src.mob_hovered_over)
+				var/mob/M = src.mob_hovered_over
+				M.name_tag?.show_images(src.client, FALSE, TRUE)
 		else
 			for (var/mob/M as anything in mobs)
 				M.name_tag?.show_images(src.client, FALSE, FALSE)

--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -11,15 +11,20 @@
 	return ..()
 
 /mob/keys_changed(keys, changed)
-	if (changed & KEY_EXAMINE && HAS_ATOM_PROPERTY(src, PROP_MOB_EXAMINE_ALL_NAMES) && src.client)
+	if (changed & KEY_EXAMINE && src.client)
 		if (keys & KEY_EXAMINE)
-			for (var/mob/M as anything in mobs)
-				M.name_tag?.show_images(src.client, TRUE, FALSE)
+			if (HAS_ATOM_PROPERTY(src, PROP_MOB_EXAMINE_ALL_NAMES))
+				for (var/mob/M as anything in mobs)
+					M.name_tag?.show_images(src.client, TRUE, FALSE)
 			if (src.mob_hovered_over)
 				var/mob/M = src.mob_hovered_over
 				M.name_tag?.show_images(src.client, FALSE, TRUE)
 		else
-			for (var/mob/M as anything in mobs)
+			if (HAS_ATOM_PROPERTY(src, PROP_MOB_EXAMINE_ALL_NAMES))
+				for (var/mob/M as anything in mobs)
+					M.name_tag?.show_images(src.client, FALSE, FALSE)
+			else if (src.mob_hovered_over)
+				var/mob/M = src.mob_hovered_over
 				M.name_tag?.show_images(src.client, FALSE, FALSE)
 
 	if (src.use_movement_controller)

--- a/code/mob/input.dm
+++ b/code/mob/input.dm
@@ -11,11 +11,13 @@
 	return ..()
 
 /mob/keys_changed(keys, changed)
-	if (changed & KEY_EXAMINE)
-		if (keys & KEY_EXAMINE && HAS_ATOM_PROPERTY(src, PROP_MOB_EXAMINE_ALL_NAMES))
-			src.client?.get_plane(PLANE_EXAMINE).alpha = 255
+	if (changed & KEY_EXAMINE && HAS_ATOM_PROPERTY(src, PROP_MOB_EXAMINE_ALL_NAMES) && src.client)
+		if (keys & KEY_EXAMINE)
+			for (var/mob/M as anything in mobs)
+				M.name_tag?.show_images(src.client, TRUE, FALSE)
 		else
-			src.client?.get_plane(PLANE_EXAMINE).alpha = 0
+			for (var/mob/M as anything in mobs)
+				M.name_tag?.show_images(src.client, FALSE, FALSE)
 
 	if (src.use_movement_controller)
 		var/datum/movement_controller/controller = src.use_movement_controller.get_movement_controller()

--- a/code/modules/interface/name_tag.dm
+++ b/code/modules/interface/name_tag.dm
@@ -1,7 +1,7 @@
 /image/name_tag_examine
 	plane = PLANE_NOSHADOW_ABOVE
 	maptext_x = -64
-	maptext_y = -5
+	maptext_y = -6
 	maptext_width = 160
 	maptext_height = 48
 	icon = null
@@ -13,7 +13,7 @@
 /image/name_tag_examine_hover
 	plane = PLANE_NOSHADOW_ABOVE
 	maptext_x = -64
-	maptext_y = -5 - 8 // -7 to accomodate extra text
+	maptext_y = -6 - 7 // -7 to accomodate extra text
 	maptext_width = 160
 	maptext_height = 48
 	icon = null

--- a/code/modules/interface/name_tag.dm
+++ b/code/modules/interface/name_tag.dm
@@ -1,4 +1,16 @@
-/image/name_tag_hover
+/image/name_tag_examine
+	plane = PLANE_NOSHADOW_ABOVE
+	maptext_x = -64
+	maptext_y = -5
+	maptext_width = 160
+	maptext_height = 48
+	icon = null
+	appearance_flags = PIXEL_SCALE
+
+	proc/set_name(new_name)
+		src.maptext = "<span class='pixel c ol' style='font-size: 6px;'>[new_name]</span>"
+
+/image/name_tag_examine_hover
 	plane = PLANE_NOSHADOW_ABOVE
 	maptext_x = -64
 	maptext_y = -5 - 8 // -7 to accomodate extra text
@@ -15,24 +27,19 @@
 	alpha = 180
 	icon = null
 	mouse_opacity = 0
-
-/atom/movable/name_tag/outer
-	var/atom/movable/name_tag/inner/inner
-	var/image/name_tag_hover/hover_image
+	var/image/name_tag_examine/ex_image
+	var/image/name_tag_examine_hover/ex_hover_image
 	var/cur_name = null
 	var/cur_extra = null
 
 	New()
 		..()
-		inner = new
-		hover_image = new(null, src)
-		src.vis_contents += inner
+		ex_image = new(null, src)
+		ex_hover_image = new(null, src)
 
 	disposing()
-		dispose(inner)
-		dispose(hover_image)
-		src.vis_contents -= inner
-		inner = null
+		dispose(ex_image)
+		dispose(ex_hover_image)
 		..()
 
 	proc/set_visibility(visible)
@@ -44,27 +51,22 @@
 			if(paren_pos)
 				new_name = copytext(new_name, 1, paren_pos)
 		if(new_name != src.cur_name)
-			src.inner.set_name(new_name)
-			src.hover_image.set_name(new_name, cur_extra)
+			src.ex_image.set_name(new_name)
+			src.ex_hover_image.set_name(new_name, cur_extra)
 			src.cur_name = new_name
 
 	proc/set_extra(new_extra)
 		if(new_extra != src.cur_extra)
-			src.hover_image.set_name(cur_name, new_extra)
+			src.ex_hover_image.set_name(cur_name, new_extra)
 			src.cur_extra = new_extra
 
-	proc/show_hover(client/client)
-		client.images |= src.hover_image
+	proc/show_images(client/client, ex, ex_hover)
+		if (ex)
+			client.images |= src.ex_image
+		else
+			client.images -= src.ex_image
 
-	proc/hide_hover(client/client)
-		client.images -= src.hover_image
-
-/atom/movable/name_tag/inner
-	plane = PLANE_EXAMINE
-	maptext_x = -64
-	maptext_y = -5
-	maptext_width = 160
-	maptext_height = 48
-
-	proc/set_name(new_name)
-		src.maptext = "<span class='pixel c ol' style='font-size: 6px;'>[new_name]</span>"
+		if (ex_hover)
+			client.images |= src.ex_hover_image
+		else
+			client.images -= src.ex_hover_image


### PR DESCRIPTION
[REWORK][BUG - MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR reworks how name tags are done. It makes it so that the name tag movable on them that is only viewable by those with the PROP_MOB_EXAMINE_ALL_NAMES property when holding alt to examine is an image instead of an atom, and changes code in the game to support that.

Fixes a bug where if you have the PROP_MOB_EXAMINE_ALL_NAMES property, holding alt over a person will show both of the person's name tags.

Fixes a bug where if you don't have the PROP_MOB_EXAMINE_ALL_NAMES property, pressing and holding alt over a person wouldn't show the person's name tag.

Fixes a bug where if you don't have the PROP_MOB_EXAMINE_ALL_NAMES property, releasing alt over a person would still show their name tag.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It allows for name tag overrides for certain clients for mobs with a unique name tag created that couldn't be done if the client's mob had the PROP_MOB_EXAMINE_ALL_NAMES property.

Example:
The round type is Flock, assuming Flockdrones have a unique name tag created for them that contains their true name.

If an AI holds alt, they will see the appearance name of every mob on their screen. Flockdrones will appear as, ex., "strange object."

If a Flockmind holds alt they will, like an AI, see the appearance name of every regular mob on their screen. However, Flockdrones will instead appear as their true name, ex. re.tu.xi.

Bug fixes