### PR TITLE
Block Football Field From Being Teleported To

### DIFF
--- a/code/WorkInProgress/zamujasa.dm
+++ b/code/WorkInProgress/zamujasa.dm
@@ -570,6 +570,7 @@
 	force_fullbright = 1
 	icon_state = "purple"
 	dont_log_combat = TRUE
+	teleport_blocked = 1
 
 /area/football/field
 	name = "Space American Football Field"
@@ -619,6 +620,7 @@
 	icon_state = "landmark"
 	deleted_on_start = TRUE
 	add_to_landmarks = FALSE
+
 
 	New()
 		football_spawns[src.name] += src.loc

--- a/code/WorkInProgress/zamujasa.dm
+++ b/code/WorkInProgress/zamujasa.dm
@@ -621,7 +621,6 @@
 	deleted_on_start = TRUE
 	add_to_landmarks = FALSE
 
-
 	New()
 		football_spawns[src.name] += src.loc
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This prevents the football area on the football z-level from being accessible through the telescience teleporter.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Unlike other z-levels, the stadium has nothing to explore and no way to get back outside of the hand teleporters and telescience. This often results in people who are stuck there going braindead or suiciding, due to it being worse than being killed. At least with death, you can do other things.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)The football stadium/field/locker room is no longer accessible through the teleporter.
```
