### PR TITLE
Fixes edgecase behavior in initial_setup.bat

### DIFF
--- a/initial_setup.bat
+++ b/initial_setup.bat
@@ -1,6 +1,6 @@
 @echo off
 cd +secret
-if exist __secret.dme (echo Secret File already exists & pause & exit) else (echo Attempting to create Secret File)
+if exist __secret.dme (echo Secret File already exists & pause & exit /B) else (echo Attempting to create Secret File)
 echo[ > __secret.dme
 if exist __secret.dme (echo Secret File successfully created) else (echo There was a problem with creating the Secret File)
 pause


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

If you run initial_setup.bat in an existing command line, and you've already got the requisite dummy secret file, it calls `exit`

The problem with this is `exit` will exit not just the script, but the whole shell.
Fix is simple, just pass `/B` as an arg.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It inconvenienced me. Also I'm trying to put off adding better sound support to /tg/ and I'm bored