### PR TITLE
Adds Status Displays Across Cog1

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -56416,6 +56416,10 @@
 /obj/access_spawn/medlab,
 /turf/simulated/floor/delivery,
 /area/station/medical/research)
+"jFB" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/market)
 "jFF" = (
 /obj/machinery/door/airlock/pyro/security{
 	name = "Interrogation Room";
@@ -61439,6 +61443,15 @@
 /obj/access_spawn/bar,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
+"spT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "sqK" = (
 /obj/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold{
@@ -97098,7 +97111,7 @@ iQw
 aho
 anH
 aoS
-aho
+jfN
 arJ
 asZ
 aum
@@ -98608,7 +98621,7 @@ alC
 amx
 aho
 aho
-jfN
+aho
 aho
 aho
 auX
@@ -102898,7 +102911,7 @@ bAt
 bxw
 bAt
 bzu
-bAt
+jFB
 bBr
 bCg
 bDb
@@ -105616,7 +105629,7 @@ buc
 bxy
 bxx
 bzy
-bxx
+hVW
 bxy
 bCh
 bDd
@@ -107124,7 +107137,7 @@ buV
 bvU
 buc
 bxx
-hVW
+bxx
 mCn
 bxx
 bxx
@@ -110181,7 +110194,7 @@ lbv
 ahh
 ceN
 vQt
-ceN
+kqf
 cdu
 cdu
 cdu
@@ -113802,7 +113815,7 @@ cbZ
 ciB
 cjL
 bBM
-kqf
+ceN
 adC
 adC
 kgh
@@ -116219,7 +116232,7 @@ ceN
 cjL
 clr
 cdw
-cmG
+spT
 cdw
 coY
 cdw

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -3913,6 +3913,9 @@
 	pixel_y = 4
 	},
 /obj/machinery/light/emergency,
+/obj/machinery/status_display{
+	pixel_y = -30
+	},
 /turf/simulated/floor/blue/corner,
 /area/station/crew_quarters/quarters)
 "alN" = (
@@ -7900,6 +7903,9 @@
 "awF" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
 	},
 /turf/simulated/floor/green/side{
 	dir = 1
@@ -14725,6 +14731,9 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
 /turf/simulated/floor/carpet{
 	dir = 4;
 	icon_state = "fred2"
@@ -15754,6 +15763,9 @@
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -39585,6 +39597,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
 /turf/simulated/floor/neutral/side{
 	dir = 4
 	},
@@ -42247,6 +42262,9 @@
 /obj/shrub{
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
 	},
 /turf/simulated/floor/wood,
 /area/station/medical/medbay/lobby)
@@ -55505,6 +55523,14 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"hVP" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/science/lobby)
+"hVW" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/turret_protected/ai_upload_foyer)
 "hXA" = (
 /obj/table/reinforced/industrial/auto,
 /obj/item/hand_labeler,
@@ -55902,6 +55928,10 @@
 /obj/firedoor_spawn,
 /turf/simulated/floor/delivery,
 /area/station/crew_quarters/cafeteria)
+"iJw" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/market)
 "iJV" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -56092,6 +56122,10 @@
 	},
 /turf/simulated/floor/red/corner,
 /area/station/security/main)
+"jfN" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/security/brig)
 "jfV" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -56282,6 +56316,17 @@
 /obj/disposalpipe/trunk/produce,
 /turf/simulated/floor/delivery,
 /area/station/hydroponics/bay)
+"jvb" = (
+/obj/grille/catwalk{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/simulated/floor/airless/plating/catwalk{
+	dir = 4
+	},
+/area/station/quartermaster/refinery)
 "jvO" = (
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
@@ -56884,6 +56929,10 @@
 	icon_state = "floor"
 	},
 /area/shuttle/arrival/station)
+"kqf" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/hallway/secondary/exit)
 "krl" = (
 /obj/cable,
 /obj/wingrille_spawn/auto,
@@ -58379,6 +58428,10 @@
 /obj/machinery/glass_recycler,
 /turf/simulated/floor/white,
 /area/station/medical/cdc)
+"ntv" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/cafeteria)
 "ntA" = (
 /obj/stool/chair/couch{
 	dir = 4
@@ -59041,6 +59094,9 @@
 	},
 /obj/cable/brown{
 	icon_state = "0-8"
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -61766,6 +61822,10 @@
 	name = "reinforced plating"
 	},
 /area/station/quartermaster/refinery)
+"sNI" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/auto/supernorn,
+/area/station/security/secwing)
 "sOG" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -64185,6 +64245,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/north)
+"wCc" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/simulated/floor/bluewhite{
+	dir = 1
+	},
+/area/station/medical/medbay)
 "wCy" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -98014,7 +98085,7 @@ bPJ
 bRd
 bWx
 bUa
-bVj
+hVP
 bWC
 bWC
 bZg
@@ -98537,7 +98608,7 @@ alC
 amx
 aho
 aho
-aho
+jfN
 aho
 aho
 auX
@@ -98553,7 +98624,7 @@ azN
 aHQ
 sjX
 aKp
-ayy
+sNI
 ayy
 aOc
 aMC
@@ -99793,7 +99864,7 @@ bmV
 bnG
 bgL
 bpe
-bfS
+iJw
 bfS
 bfS
 brd
@@ -104673,7 +104744,7 @@ cca
 cca
 cca
 cca
-coH
+wCc
 cpG
 cqL
 crO
@@ -107053,7 +107124,7 @@ buV
 bvU
 buc
 bxx
-bxx
+hVW
 mCn
 bxx
 bxx
@@ -111531,7 +111602,7 @@ apB
 apB
 apB
 apw
-apw
+ntv
 apw
 apw
 aFM
@@ -113731,7 +113802,7 @@ cbZ
 ciB
 cjL
 bBM
-ceN
+kqf
 adC
 adC
 kgh
@@ -131544,7 +131615,7 @@ bWm
 bWn
 bWn
 bWm
-gDG
+jvb
 gDG
 bWm
 bWn


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds status displays around cog1


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, they are only accessible through qm, and most people don't even realize they exist. Adding them to maps will help for them to be used more often.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Adds status displays to cog1 that the captain/head of personell/AI can use through their pda.
```
