### PR TITLE
Adds two product satchels to civilian cyborg modules

### DIFF
--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -59,6 +59,8 @@
 		/obj/item/device/igniter,
 		/obj/item/saw/cyborg,
 		/obj/item/satchel/hydro, // TODO: make more versatile version
+		/obj/item/satchel/hydro,
+		/obj/item/satchel/hydro,
 		/obj/item/paper_bin/robot,
 		/obj/item/reagent_containers/glass/bucket, // TODO: make large version
 		/obj/item/spraybottle/cleaner/robot,


### PR DESCRIPTION
[QOL][WIKI]
## About the PR
Adds two additional product satchels to civilian cyborg modules, which makes a total of three.
## Why's this needed?
Botany and Kitchen often have a large quantity and variety of products to organize and move. Having only one satchel seems limited to handle this, adding two more will allow them to manage better.
```changelog
(u)Boussard's Bargains Budget Bot
(+)Civilian cyborg modules now have three product satchels.
```