### PR TITLE
Removes Secoff lite AA from RP

### DIFF
--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -215,9 +215,14 @@
 						access_research, access_hydro, access_ranch, access_mail, access_ai_upload, access_pathology)
 		if("Head of Security")
 #ifdef RP_MODE
-			var/list/hos_access = get_all_accesses()
-			hos_access += access_maxsec
-			return hos_access
+			return list(access_security, access_carrypermit, access_contrabandpermit, access_maxsec, access_brig, access_securitylockers, access_forensics_lockers, access_armory,
+						access_tox, access_tox_storage, access_chemistry, access_medical, access_morgue, access_medlab,
+						access_emergency_storage, access_change_ids, access_eva, access_heads, access_medical_lockers,
+						access_all_personal_lockers, access_tech_storage, access_maint_tunnels, access_bar, access_janitor,
+						access_crematorium, access_kitchen, access_robotics, access_cargo,
+						access_research, access_dwaine_superuser, access_hydro, access_ranch, access_mail, access_ai_upload,
+						access_engineering, access_teleporter, access_engineering_engine, access_engineering_power, access_engineering_control,
+						access_mining, access_pathology, access_construction, access_external_airlocks, access_mining_shuttle, access_hangar)
 #else
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_maxsec, access_brig, access_securitylockers, access_forensics_lockers, access_armory,
 						access_tox, access_tox_storage, access_chemistry, access_medical, access_morgue, access_medlab,
@@ -262,7 +267,7 @@
 				access_medical, access_medlab, access_morgue, access_securitylockers,
 				access_chemistry, access_carrypermit, access_contrabandpermit,
 				access_emergency_storage, access_kitchen,
-				access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_construction, access_hydro, access_mail,
+				access_bar, access_janitor, access_crematorium, access_cargo, access_construction, access_hydro, access_mail,
 				access_engineering, access_maint_tunnels, access_external_airlocks,
 				access_tech_storage, access_engineering_engine, access_mining_shuttle,
 				access_engineering_control, access_research, access_hangar,

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -265,7 +265,7 @@
 				access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_construction, access_hydro, access_mail,
 				access_engineering, access_maint_tunnels, access_external_airlocks,
 				access_tech_storage, access_engineering_storage, access_engineering_eva,
-				access_engineering_power, access_engineering_engine, access_mining_shuttle,
+				access_engineering_engine, access_mining_shuttle,
 				access_engineering_control, access_engineering_mechanic, access_mining, access_mining_outpost,
 				access_research, access_engineering_atmos, access_hangar, access_ranch, access_pathology)
 #else

--- a/code/procs/access.dm
+++ b/code/procs/access.dm
@@ -260,14 +260,13 @@
 #ifdef RP_MODE // trying out giving them more access for RP
 			return list(access_security, access_brig, access_forensics_lockers, access_armory,
 				access_medical, access_medlab, access_morgue, access_securitylockers,
-				access_tox, access_tox_storage, access_chemistry, access_carrypermit, access_contrabandpermit,
-				access_emergency_storage, access_chapel_office, access_kitchen,
+				access_chemistry, access_carrypermit, access_contrabandpermit,
+				access_emergency_storage, access_kitchen,
 				access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_construction, access_hydro, access_mail,
 				access_engineering, access_maint_tunnels, access_external_airlocks,
-				access_tech_storage, access_engineering_storage, access_engineering_eva,
-				access_engineering_engine, access_mining_shuttle,
-				access_engineering_control, access_engineering_mechanic, access_mining, access_mining_outpost,
-				access_research, access_engineering_atmos, access_hangar, access_ranch, access_pathology)
+				access_tech_storage, access_engineering_engine, access_mining_shuttle,
+				access_engineering_control, access_research, access_hangar,
+				access_ranch, access_pathology)
 #else
 			return list(access_security, access_carrypermit, access_contrabandpermit, access_securitylockers, access_brig, access_maint_tunnels,
 			access_medical, access_morgue, access_crematorium, access_research, access_cargo, access_engineering, access_engineering_control,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[input wanted] [balance] 
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Secoffs on RP have effectively light all access, with only head offices being unable to be opened by your average secoff. HoSes have AA for some reason on top of their already exclusive access. This pull requests removes that, with HoS getting the same access on the non RP servers plus what RP sec gets. RP sec loses most of their engineering access, most of their medical access, and most of their science access. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Why do secoffs need this much access on the RP server of all places. Aside from it discourgaing interactions it also makes it so security is the be all do all of the station, as they can access everything of note and as a result are asked to do everything. This PR aims to remove that abilty from secoffs, so they now are only able to access the lobby areas of departments and must find and ask another member of the department to come with them. Or get the AI to do it, which is already at their whim. This also gives antags a small advantage as there is now places they can go that security cannot.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Eagle
(+)Adjustments to secoffs and HoS accesses on the RP servers have been made. They are now for the most part only able to enter the lobbies of departments. If they need to go somewhere else, they gotta bring a pal from the department. 
```
