### PR TITLE
Fixes RD outfit showing the wrong name while using the Chameleon Remote/Outfit.

### DIFF
--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -1737,7 +1737,7 @@
 		backpack_type = new/datum/chameleon_backpack_pattern
 
 	research_director
-		name = "Medical Director"
+		name = "Research Director"
 		jumpsuit_type = new/datum/chameleon_jumpsuit_pattern/rank/research_director
 		hat_type = new/datum/chameleon_hat_pattern/fancy
 		suit_type = new/datum/chameleon_suit_pattern/labcoat


### PR DESCRIPTION
[BUG - MINOR]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #8470.
