### PR TITLE
Move Rathens To Break Room On Donut 3

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -20578,15 +20578,6 @@
 /obj/storage/closet/emergency,
 /turf/simulated/floor/black,
 /area/station/medical/medbay)
-"fGh" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
-	},
-/obj/landmark/spawner{
-	name = "monkeyspawn_rathen"
-	},
-/turf/space,
-/area/station/engine/singcore)
 "fGq" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -64643,6 +64634,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
+"swZ" = (
+/obj/landmark/spawner{
+	name = "monkeyspawn_rathen"
+	},
+/turf/simulated/floor/carpet/green/fancy/edge{
+	dir = 9
+	},
+/area/station/engine/engineering/breakroom)
 "sxd" = (
 /turf/simulated/floor/orangeblack,
 /area/listeningpost)
@@ -74529,8 +74528,8 @@
 	icon_state = "tile1"
 	},
 /obj/item/clothing/head/helmet/camera{
-	pixel_y = -2;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -2
 	},
 /turf/simulated/floor/white,
 /area/station/science/teleporter)
@@ -146630,7 +146629,7 @@ rnd
 cKx
 wsM
 qna
-fGh
+qna
 ojz
 qna
 qna
@@ -150566,7 +150565,7 @@ mjE
 ewf
 mWJ
 hyP
-xqn
+swZ
 wqA
 mkB
 mTt


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr moves Mr. Rathens on Donut 3 from next to the singulo generator to the engineering break room.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, Mr. Rathens spawns next to the singularity generator and dies. This makes it so that engineering at least has the option to kill Rathens if they want, rather than the map making that discussion for them.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)Mr. Rathens has been rescued from the singularity generator area on Donut 3 and safely moved to the engineering break room.
```
