### PR TITLE
Scuttlebot qol and balance

### DIFF
--- a/code/mob/living/critter/scuttlebot.dm
+++ b/code/mob/living/critter/scuttlebot.dm
@@ -7,11 +7,13 @@
 	hand_count = 1
 	can_help = 1
 	can_throw = 1
-	can_grab = 1
+	can_grab = 0
 	can_disarm = 1
 	fits_under_table = 1
 	icon_state = "scuttlebot"
 	speechverb_say = "beeps"
+	speechverb_exclaim = "boops"
+	speechverb_ask = "beeps curiously"
 	var/health_brute = 25
 	var/health_brute_vuln = 1
 	var/health_burn = 25
@@ -46,6 +48,14 @@
 			return prob(50)
 		else
 			return ..()
+
+	specific_emotes(var/act, var/param = null, var/voluntary = 0)
+		switch (act)
+			if ("scream")
+				if (src.emote_check(voluntary, 50))
+					playsound(src, "sound/voice/screams/robot_scream.ogg" , 60, 1, channel=VOLUME_CHANNEL_EMOTE)
+					return "<b>[src]</b> screams!"
+		return null
 
 	death(var/gibbed)
 		if (controller != null)//Lets put the person back in their body first to avoid death messages

--- a/code/mob/living/critter/scuttlebot.dm
+++ b/code/mob/living/critter/scuttlebot.dm
@@ -7,13 +7,11 @@
 	hand_count = 1
 	can_help = 1
 	can_throw = 1
-	can_grab = 0
+	can_grab = 1
 	can_disarm = 1
 	fits_under_table = 1
 	icon_state = "scuttlebot"
 	speechverb_say = "beeps"
-	speechverb_exclaim = "boops"
-	speechverb_ask = "beeps curiously"
 	var/health_brute = 25
 	var/health_brute_vuln = 1
 	var/health_burn = 25
@@ -48,14 +46,6 @@
 			return prob(50)
 		else
 			return ..()
-
-	specific_emotes(var/act, var/param = null, var/voluntary = 0)
-		switch (act)
-			if ("scream")
-				if (src.emote_check(voluntary, 50))
-					playsound(src, "sound/voice/screams/robot_scream.ogg" , 60, 1, channel=VOLUME_CHANNEL_EMOTE)
-					return "<b>[src]</b> screams!"
-		return null
 
 	death(var/gibbed)
 		if (controller != null)//Lets put the person back in their body first to avoid death messages

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -402,7 +402,7 @@
 //Goggles used to assume control of a linked scuttlebot
 /obj/item/clothing/glasses/scuttlebot_vr
 	name = "Scuttlebot remote controller"
-	desc = "A pair of VR goggles connected to a remote scuttlebot."
+	desc = "A pair of VR goggles connected to a remote scuttlebot. Use them on the scuttlebot to turn it back into a hat."
 	icon_state = "vr"
 	item_state = "sunglasses"
 	var/mob/living/critter/scuttlebot/connected_scuttlebot = null

--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -402,7 +402,7 @@
 //Goggles used to assume control of a linked scuttlebot
 /obj/item/clothing/glasses/scuttlebot_vr
 	name = "Scuttlebot remote controller"
-	desc = "A pair of VR goggles connected to a remote scuttlebot. Use them on the scuttlebot to turn it back into a hat."
+	desc = "A pair of VR goggles connected to a remote scuttlebot."
 	icon_state = "vr"
 	item_state = "sunglasses"
 	var/mob/living/critter/scuttlebot/connected_scuttlebot = null

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -282,7 +282,7 @@ proc/filter_trait_hats(var/type)
 	desc = "Someone who wears this will look very smart. It looks a bit heavier than it should."
 
 	attack_self(mob/user)
-		boutput(user, "You reach inside the hat and pull out a pair of goggles. The scuttlebot wakes up!")
+		boutput(user, "You reach inside the hat and pull out a pair of goggles. The scuttlebot wakes up! Use the goggles on the bot to make it dormant again.")
 		new /mob/living/critter/scuttlebot(get_turf(src))
 		qdel(src)
 	setupProperties()

--- a/code/obj/item/clothing/hats.dm
+++ b/code/obj/item/clothing/hats.dm
@@ -282,7 +282,7 @@ proc/filter_trait_hats(var/type)
 	desc = "Someone who wears this will look very smart. It looks a bit heavier than it should."
 
 	attack_self(mob/user)
-		boutput(user, "You reach inside the hat and pull out a pair of goggles. The scuttlebot wakes up! Use the goggles on the bot to make it dormant again.")
+		boutput(user, "You reach inside the hat and pull out a pair of goggles. The scuttlebot wakes up!")
 		new /mob/living/critter/scuttlebot(get_turf(src))
 		qdel(src)
 	setupProperties()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
QOL:
-Makes it a bit more obvious you can use the glasses on the scuttlebot to hide it back into a hat.
-Adds speechverbs for exclaim and ask. ("beeps" and "boops curiously" respectively)
-Adds a scream emote to the scuttlebot

Balance:
Removes the scuttlebot's ability to grab people.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QOL is just nice, People seem to not know you can fold the bot back into a hat since it wasnt really written anywhere, now it is.

About the balance patch: Scuttlebots being able to grab people leads to some issues since they can squeeze through doors, are generally quite hard to catch, and can use items. A scuttlebot can pin people and move around, neckgrab, or toss people into a vending machine. It could also flash someone, grab them quickly, lead them to an airlock or the grinder through any doors, depowered or bolted, and immediattly toss them into it.
I believe the ability to hold items is already good enough for now, and i can see about re-buffing it a bit later, for now grabbing people looks a bit overtuned.

