### PR TITLE
Fixed critters not being able to put things in lockers

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1203,7 +1203,7 @@
 		return O
 
 	drop_item()
-		..()
+		. = ..()
 		src.update_inhands()
 
 	proc/on_sleep()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Critter `drop_item` wasn't returning a value, causing the item to just drop on the floor instead of being placed in the locker, pretty sure this isn't intentional?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Basically we want flockdrones to be able to put things in lockers.