### PR TITLE
Fixes pathfinding not checking Cross for objects

### DIFF
--- a/_std/pathfinding.dm
+++ b/_std/pathfinding.dm
@@ -450,7 +450,7 @@
 					else //we must be a public door
 						continue
 				return FALSE
-		else if(!A.Cross(passer))
+		if(!A.Cross(passer))
 			return FALSE
 
 #undef CAN_STEP


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The JPS pathfinding used by mob AI wasn't checking `Cross` for objects, even though a few objects implement it, leading to the AI trying to path through plastic flaps and getting stuck.

![image](https://user-images.githubusercontent.com/20713227/167096302-b931416f-95c4-4df8-8b53-01c7e2db8c5e.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flockdrones being stuck is bad