### PR TITLE
Ghostdrones autopry when replacing floortiles

### DIFF
--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -1220,6 +1220,9 @@
 			var/obj/item/MTI = MT.holding
 			if (MTI && (MTI.tool_flags & tool_flag))
 				return MT.holding
+		I = locate(/obj/item/tool/omnitool) in src.tools //Try the omnitool if all else fails
+		if (I && (I.tool_flags & tool_flag))
+			return I
 		return null
 
 	hotkey(name)

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1807,6 +1807,13 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 		var/obj/item/tile/T = C
 		if(intact)
 			var/obj/P = user.find_tool_in_hand(TOOL_PRYING)
+
+			if (isghostdrone(user)) // Give the drones a little QOL so cleaning up welderbombs isn't a complete PITA
+				var/mob/living/silicon/ghostdrone/drone = user
+				var/obj/item/tool/omnitool/omni = locate(/obj/item/tool/omnitool) in drone.tools
+				if (omni?.tool_flags & TOOL_PRYING)
+					P = omni
+
 			if (!P)
 				return
 			// Call ourselves w/ the tool, then continue

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1807,13 +1807,6 @@ DEFINE_FLOORS(solidcolor/black/fullbright,
 		var/obj/item/tile/T = C
 		if(intact)
 			var/obj/P = user.find_tool_in_hand(TOOL_PRYING)
-
-			if (isghostdrone(user)) // Give the drones a little QOL so cleaning up welderbombs isn't a complete PITA
-				var/mob/living/silicon/ghostdrone/drone = user
-				var/obj/item/tool/omnitool/omni = locate(/obj/item/tool/omnitool) in drone.tools
-				if (omni?.tool_flags & TOOL_PRYING)
-					P = omni
-
 			if (!P)
 				return
 			// Call ourselves w/ the tool, then continue


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Ghostdrones can now auto-pry floors when placing tiles, provided they left their omnitool on prying.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cleaning up burnt/broken tiles as a ghostdrone is probably one of the bigger PITAs that the role has, and there tend to be a lot of broken/burnt tiles.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Ghostdrones can now auto-pry floors when placing tiles, provided they left their omnitool on prying
```
