### PR TITLE
Adds round result message to scorescreen where appropriate

### DIFF
--- a/code/datums/gamemodes/blob.dm
+++ b/code/datums/gamemodes/blob.dm
@@ -123,7 +123,7 @@
 		return 0
 	return 1
 
-/datum/game_mode/blob/declare_completion()
+/datum/game_mode/blob/victory_msg()
 	var/list/blobs = list()
 	for (var/datum/mind/M in traitors)
 		if (!M)
@@ -135,10 +135,11 @@
 			continue
 		if (isblob(M.current))
 			blobs += M.current
-
 	if (!blobs.len)
-		boutput(world, "<span style='font-size:20px; color:red'><b>Station victory!</b> - All blobs have been exterminated!")
+		return "<span style='font-size:20px; color:red'><b>Station victory!</b> - All blobs have been exterminated!"
 	else
-		boutput(world, "<span style='font-size:20px; color:red'><b>Blob victory!</b> - The crew has failed to stop the overmind! The station is lost to the blob!")
+		return "<span style='font-size:20px; color:red'><b>Blob victory!</b> - The crew has failed to stop the overmind! The station is lost to the blob!"
 
+/datum/game_mode/blob/declare_completion()
+	boutput(world, src.victory_msg())
 	..()

--- a/code/datums/gamemodes/blob.dm
+++ b/code/datums/gamemodes/blob.dm
@@ -136,9 +136,9 @@
 		if (isblob(M.current))
 			blobs += M.current
 	if (!blobs.len)
-		return "<span style='font-size:20px; color:red'><b>Station victory!</b> - All blobs have been exterminated!"
+		return "<span style='font-size:20px'><b>Station victory!</b> - All blobs have been exterminated!</span>"
 	else
-		return "<span style='font-size:20px; color:red'><b>Blob victory!</b> - The crew has failed to stop the overmind! The station is lost to the blob!"
+		return "<span style='font-size:20px'><b>Blob victory!</b> - The crew has failed to stop the overmind! The station is lost to the blob!</span>"
 
 /datum/game_mode/blob/declare_completion()
 	boutput(world, src.victory_msg())

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -61,6 +61,10 @@
 		return 1
 	return 0
 
+///An optional message to indicate who won the round
+/datum/game_mode/proc/victory_msg()
+	return ""
+
 // Did some streamlining here (Convair880).
 /datum/game_mode/proc/declare_completion()
 	var/list/datum/mind/antags = list()

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -273,43 +273,40 @@
 
 	return 0
 
-/datum/game_mode/nuclear/declare_completion()
+/datum/game_mode/nuclear/victory_msg()
 	switch(finished)
 		if(-2) // Major Synd Victory - nuke successfully detonated
-			boutput(world, "<FONT size = 3><B>Total Syndicate Victory</B></FONT>")
-			boutput(world, "The operatives have destroyed [station_name(1)]!")
-#ifdef DATALOGGER
-			game_stats.Increment("traitorwin")
-#endif
+			return "<FONT size = 3><B>Total Syndicate Victory</B></FONT><br>\
+					The operatives have destroyed [station_name(1)]!"
 		if(-1) // Minor Synd Victory - station abandoned while nuke armed
-			boutput(world, "<FONT size = 3><B>Syndicate Victory</B></FONT>")
-			boutput(world, "The crew of [station_name(1)] abandoned the [station_or_ship()] while the bomb was armed! The [station_or_ship()] will surely be destroyed!")
-#ifdef DATALOGGER
-			game_stats.Increment("traitorwin")
-#endif
+			return "<FONT size = 3><B>Syndicate Victory</B></FONT><br>\
+					The crew of [station_name(1)] abandoned the [station_or_ship()] while the bomb was armed! The [station_or_ship()] will surely be destroyed!"
 		if(0) // Uhhhhhh
-			boutput(world, "<FONT size = 3><B>Stalemate</B></FONT>")
-			boutput(world, "Everybody loses!")
+			return "<FONT size = 3><B>Stalemate</B></FONT><br>\
+					Everybody loses!"
 		if(1) // Minor Crew Victory - station evacuated, bombing averted, operatives survived
-			boutput(world, "<FONT size = 3><B>Crew Victory</B></FONT>")
-			boutput(world, "The crew of [station_name(1)] averted the bombing! However, some of the operatives survived.")
-#ifdef DATALOGGER
-			game_stats.Increment("traitorloss")
-#endif
+			return "<FONT size = 3><B>Crew Victory</B></FONT><br>\
+					The crew of [station_name(1)] averted the bombing! However, some of the operatives survived."
 		if(2) // Major Crew Victory - bombing averted, all ops dead/captured
-			boutput(world, "<FONT size = 3><B>Total Crew Victory</B></FONT>")
-			boutput(world, "The crew of [station_name(1)] averted the bombing and eliminated all Syndicate operatives!")
-#ifdef DATALOGGER
-			game_stats.Increment("traitorloss")
-#endif
+			return "<FONT size = 3><B>Total Crew Victory</B></FONT><br>\
+					The crew of [station_name(1)] averted the bombing and eliminated all Syndicate operatives!"
+
+/datum/game_mode/nuclear/declare_completion()
+	boutput(world, src.victory_msg())
 
 	if(finished > 0)
 		var/value = world.load_intra_round_value("nukie_loss")
+#ifdef DATALOGGER
+			game_stats.Increment("traitorloss")
+#endif
 		if(isnull(value))
 			value = 0
 		world.save_intra_round_value("nukie_loss", value + 1)
 	else if(finished < 0)
 		var/value = world.load_intra_round_value("nukie_win")
+#ifdef DATALOGGER
+			game_stats.Increment("traitorwin")
+#endif
 		if(isnull(value))
 			value = 0
 		world.save_intra_round_value("nukie_win", value + 1)

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -297,7 +297,7 @@
 	if(finished > 0)
 		var/value = world.load_intra_round_value("nukie_loss")
 #ifdef DATALOGGER
-			game_stats.Increment("traitorloss")
+		game_stats.Increment("traitorloss")
 #endif
 		if(isnull(value))
 			value = 0
@@ -305,7 +305,7 @@
 	else if(finished < 0)
 		var/value = world.load_intra_round_value("nukie_win")
 #ifdef DATALOGGER
-			game_stats.Increment("traitorwin")
+		game_stats.Increment("traitorwin")
 #endif
 		if(isnull(value))
 			value = 0

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -408,6 +408,14 @@
 		return 0
 	return 1
 
+/datum/game_mode/revolution/victory_msg()
+	switch (finished)
+		if(1)
+			return "<span class='alert'><FONT size = 3><B> The heads of staff were killed or abandoned the [station_or_ship()]! The revolutionaries win!</B></FONT></span>"
+		if(2)
+			return "<span class='alert'><FONT size = 3><B> The heads of staff managed to stop the revolution!</B></FONT></span>"
+		if(3)
+			return "<span class='alert'><FONT size = 3><B> Everyone was terminated! CentCom wins!</B></FONT></span>"
 
 /datum/game_mode/revolution/declare_completion()
 

--- a/code/procs/scorestats.dm
+++ b/code/procs/scorestats.dm
@@ -378,7 +378,10 @@ var/datum/score_tracker/score_tracker
 		return
 
 	if (!score_tracker.score_text)
-		score_tracker.score_text = {"<B>Round Statistics and Score</B><BR><HR>"}
+		score_tracker.score_text = ticker.mode.victory_msg()
+		if (length(score_tracker.score_text))
+			score_tracker.score_text += "<br><br>"
+		score_tracker.score_text += {"<B>Round Statistics and Score</B><BR><HR>"}
 		score_tracker.score_text += "<B><U>TOTAL SCORE: [round(score_tracker.final_score_all)]%</U></B>"
 		if(round(score_tracker.final_score_all) == 69)
 			score_tracker.score_text += " <b>nice</b>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the round result message that no-one ever sees in chat due to it instantly being buried under 5 pages of spam and mindslaves to the top of the scorescreen window where it can be instantly closed instead.
![image](https://user-images.githubusercontent.com/20713227/167149013-8d2c7747-1e0c-4ca8-97cb-eabb912cda26.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Slightly less people at the end of every rev/blob/nuke round asking who won, plus I want to add it for flock


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Added round victory messages to the scorescreen popup, will hopefully reduce "OOC: who won tho" by up to 12%!
```
