### PR TITLE
Adds Gender check to Cyborgs changing pitch of voice to match

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -296,6 +296,14 @@
 		var/message
 		var/maptext_out = 0
 		var/custom = 0
+		var/brain_gender_pitch = 0
+
+		// gives female brains a slightly higher voice pitch than default.
+		switch(gender)
+			if("female")
+				brain_gender_pitch = 1.25
+			else
+				brain_gender_pitch = 1.0
 
 		switch(lowertext(act))
 
@@ -502,7 +510,7 @@
 
 			if ("birdwell", "burp")
 				if (src.emote_check(voluntary, 50))
-					playsound(src.loc, 'sound/vox/birdwell.ogg', 50, 1, channel=VOLUME_CHANNEL_EMOTE)
+					playsound(src.loc, 'sound/vox/birdwell.ogg', 50, 1, 0, src.get_age_pitch() * brain_gender_pitch, channel=VOLUME_CHANNEL_EMOTE)
 					message = "<b>[src]</b> birdwells."
 
 			if ("scream")
@@ -510,7 +518,7 @@
 					if (narrator_mode)
 						playsound(src.loc, 'sound/vox/scream.ogg', 50, 1, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
 					else
-						playsound(src, src.sound_scream, 80, 0, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
+						playsound(src, src.sound_scream, 80, 0, 0, src.get_age_pitch() * brain_gender_pitch, channel=VOLUME_CHANNEL_EMOTE)
 					message = "<b>[src]</b> screams!"
 
 			if ("johnny")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check to cyborgs that modifies the pitch of their voice based on the gender of the original brain. It stands to reason that a brain from a person with an originally feminine voice would continue to speak with that characteristic after implanting into a borg body. 



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It is often jarring to have a feminine character suddenly lose that characteristic after implantation into a borg body. Some parity with their original characteristics seems approriate. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
```changelog
(u)zcrow
(*) Adds pitch modulation to Cyborg screams and birdwells based on the gender choice of the brain inside. 
```
