### PR TITLE
adds robot command verb to select a voice pitch

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -296,6 +296,14 @@
 		var/message
 		var/maptext_out = 0
 		var/custom = 0
+		var/brain_gender_pitch = 0
+
+		// gives female brains a slightly higher voice pitch than default.
+		switch(gender)
+			if("female")
+				brain_gender_pitch = 1.25
+			else
+				brain_gender_pitch = 1.0
 
 		switch(lowertext(act))
 
@@ -502,7 +510,7 @@
 
 			if ("birdwell", "burp")
 				if (src.emote_check(voluntary, 50))
-					playsound(src.loc, 'sound/vox/birdwell.ogg', 50, 1, channel=VOLUME_CHANNEL_EMOTE)
+					playsound(src.loc, 'sound/vox/birdwell.ogg', 50, 1, 0, src.get_age_pitch() * brain_gender_pitch, channel=VOLUME_CHANNEL_EMOTE)
 					message = "<b>[src]</b> birdwells."
 
 			if ("scream")
@@ -510,7 +518,7 @@
 					if (narrator_mode)
 						playsound(src.loc, 'sound/vox/scream.ogg', 50, 1, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
 					else
-						playsound(src, src.sound_scream, 80, 0, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
+						playsound(src, src.sound_scream, 80, 0, 0, src.get_age_pitch() * brain_gender_pitch, channel=VOLUME_CHANNEL_EMOTE)
 					message = "<b>[src]</b> screams!"
 
 			if ("johnny")

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -504,7 +504,7 @@
 
 			if ("birdwell", "burp")
 				if (src.emote_check(voluntary, 50))
-					playsound(src.loc, 'sound/vox/birdwell.ogg', 50, 1, 0, src.get_age_pitch() * vocal_pitch, channel=VOLUME_CHANNEL_EMOTE) // vocal pitch added - isn't super noticeable since its already random
+					playsound(src.loc, 'sound/vox/birdwell.ogg', 50, 1, 0, vocal_pitch, channel=VOLUME_CHANNEL_EMOTE) // vocal pitch added
 					message = "<b>[src]</b> birdwells."
 
 			if ("scream")
@@ -512,7 +512,7 @@
 					if (narrator_mode)
 						playsound(src.loc, 'sound/vox/scream.ogg', 50, 1, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
 					else
-						playsound(src, src.sound_scream, 80, 0, 0, src.get_age_pitch() * vocal_pitch, channel=VOLUME_CHANNEL_EMOTE) // vocal pitch added
+						playsound(src, src.sound_scream, 80, 0, 0, vocal_pitch, channel=VOLUME_CHANNEL_EMOTE) // vocal pitch added
 					message = "<b>[src]</b> screams!"
 
 			if ("johnny")

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -75,6 +75,7 @@
 	var/sound_automaton_ratchet = 'sound/misc/automaton_ratchet.ogg'
 	var/sound_automaton_tickhum = 'sound/misc/automaton_tickhum.ogg'
 	var/sound_sad_robot = 'sound/voice/Sad_Robot.ogg'
+	var/vocal_pitch = 1.0 // set default vocal pitch
 
 	var/image/i_critdmg
 	var/image/i_panel
@@ -296,14 +297,7 @@
 		var/message
 		var/maptext_out = 0
 		var/custom = 0
-		var/brain_gender_pitch = 0
 
-		// gives female brains a slightly higher voice pitch than default.
-		switch(gender)
-			if("female")
-				brain_gender_pitch = 1.25
-			else
-				brain_gender_pitch = 1.0
 
 		switch(lowertext(act))
 
@@ -510,7 +504,7 @@
 
 			if ("birdwell", "burp")
 				if (src.emote_check(voluntary, 50))
-					playsound(src.loc, 'sound/vox/birdwell.ogg', 50, 1, 0, src.get_age_pitch() * brain_gender_pitch, channel=VOLUME_CHANNEL_EMOTE)
+					playsound(src.loc, 'sound/vox/birdwell.ogg', 50, 1, 0, src.get_age_pitch() * vocal_pitch, channel=VOLUME_CHANNEL_EMOTE) // vocal pitch added
 					message = "<b>[src]</b> birdwells."
 
 			if ("scream")
@@ -518,7 +512,7 @@
 					if (narrator_mode)
 						playsound(src.loc, 'sound/vox/scream.ogg', 50, 1, 0, src.get_age_pitch(), channel=VOLUME_CHANNEL_EMOTE)
 					else
-						playsound(src, src.sound_scream, 80, 0, 0, src.get_age_pitch() * brain_gender_pitch, channel=VOLUME_CHANNEL_EMOTE)
+						playsound(src, src.sound_scream, 80, 0, 0, src.get_age_pitch() * vocal_pitch, channel=VOLUME_CHANNEL_EMOTE) // vocal pitch added
 					message = "<b>[src]</b> screams!"
 
 			if ("johnny")
@@ -2224,6 +2218,20 @@
 			src.internal_pda.AttackSelf(src)
 		else
 			boutput(usr, "<span class='alert'><b>Internal PDA not found!</span>")
+
+	verb/change_voice_pitch()
+		set category = "Robot Commands"
+		set name = "Change vocal pitch"
+
+		var/list/vocal_pitches = list("Low", "Medium", "High")
+		var/vocal_pitch_choice = input("Select a vocal pitch", "Robot", null, null) in vocal_pitches
+		switch(vocal_pitch_choice)
+			if("Low")
+				vocal_pitch = 0.9
+			if("Medium")
+				vocal_pitch = 1.0
+			if("High")
+				vocal_pitch = 1.25
 
 	proc/pick_module()
 		if(src.module) return

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -504,7 +504,7 @@
 
 			if ("birdwell", "burp")
 				if (src.emote_check(voluntary, 50))
-					playsound(src.loc, 'sound/vox/birdwell.ogg', 50, 1, 0, src.get_age_pitch() * vocal_pitch, channel=VOLUME_CHANNEL_EMOTE) // vocal pitch added
+					playsound(src.loc, 'sound/vox/birdwell.ogg', 50, 1, 0, src.get_age_pitch() * vocal_pitch, channel=VOLUME_CHANNEL_EMOTE) // vocal pitch added - isn't super noticeable since its already random
 					message = "<b>[src]</b> birdwells."
 
 			if ("scream")

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2224,7 +2224,7 @@
 		set name = "Change vocal pitch"
 
 		var/list/vocal_pitches = list("Low", "Medium", "High")
-		var/vocal_pitch_choice = input("Select a vocal pitch", "Robot", null, null) in vocal_pitches
+		var/vocal_pitch_choice = tgui_input_list(src, "Select a vocal pitch:", "Robot Voice", vocal_pitches)
 		switch(vocal_pitch_choice)
 			if("Low")
 				vocal_pitch = 0.9


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Rethink of a previous PR. Borgs can now use a robot command verb to change the pitch of their "voice" from three options. 

[Demo](https://www.youtube.com/watch?v=BipLLJ_Vp84)

![image](https://user-images.githubusercontent.com/8256657/167260355-99295ebf-07a9-429f-9378-a9dcf86a1a39.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
With borgs allowed to express themselves through their names, clothing and facial expression (when equipped with the screen head), I thought it would be appropriate for them to choose a vocal pitch that better fits with their self expression. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zcrow
(*)Added "Change vocal pitch" verb to Robot Commands. Borgs can now modify their voices to better express themselves. 
```
