### PR TITLE
Fixes double firelock in Destiny central maint

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -34907,7 +34907,6 @@
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
 "kMO" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the game spawning two firelocks in destiny central maint: one of them being preplaced on the map direcly and the other using a firelock spawn.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Beauty and inner peace.

