### PR TITLE
More Consistent Disposal Chute Throwing

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -212,9 +212,7 @@
 				if (!is_processing)
 					SubscribeToProcess()
 					is_processing = 1
-				update()
-			else
-				update()
+			update()
 		else
 			return ..()
 

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -196,47 +196,25 @@
 
 		if(isitem(MO))
 			var/obj/item/I = MO
+			I.set_loc(src)
+			update()
+			src.visible_message("<span class='alert'>\The [I] lands cleanly in \the [src]!</span>")
 
-			if(prob(20)) //It might land!
-				I.set_loc(get_turf(src))
-				if(prob(30)) //It landed cleanly!
-					I.set_loc(src)
-					update()
-					src.visible_message("<span class='alert'>\The [I] lands cleanly in \the [src]!</span>")
-				else	//Aaaa the tension!
-					src.visible_message("<span class='alert'>\The [I] teeters on the edge of \the [src]!</span>")
-					var/delay = rand(5, 15)
-					SPAWN(0)
-						var/in_x = I.pixel_x
-						for(var/d = 0; d < delay; d++)
-							if(I) I.pixel_x = in_x + rand(-1, 1)
-							sleep(0.1 SECONDS)
-						if(I) I.pixel_x = in_x
-					SPAWN(delay)
-						if(I && I.loc == src.loc)
-							if(prob(40)) //It goes in!
-								src.visible_message("<span class='alert'>\The [I] slips into \the [src]!</span>")
-								I.set_loc(src)
-							else
-								src.visible_message("<span class='alert'>\The [I] slips off of the edge of \the [src]!</span>")
-
-		else if (ishuman(MO))
-			var/mob/living/carbon/human/H = MO
-			H.set_loc(get_turf(src))
-			if(prob(30))
-				H.visible_message("<span class='alert'><B>[H] falls into the disposal outlet!</B></span>")
-				logTheThing("combat", H, null, "is thrown into a [src.name] at [log_loc(src)].")
-				H.set_loc(src)
-				if(prob(20))
-					src.visible_message("<span class='alert'><B><I>...accidentally hitting the handle!</I></B></span>")
-					H.show_text("<B><I>...accidentally hitting the handle!</I></B>", "red")
-					flush = 1
-					if (!is_processing)
-						SubscribeToProcess()
-						is_processing = 1
-					update()
-				else
-					update()
+		else if (istype(MO, /mob/living))
+			var/mob/living/H = MO
+			H.visible_message("<span class='alert'><B>[H] falls into the disposal outlet!</B></span>")
+			logTheThing("combat", H, null, "is thrown into a [src.name] at [log_loc(src)].")
+			H.set_loc(src)
+			if(prob(10) || H.bioHolder?.HasEffect("clumsy"))
+				src.visible_message("<span class='alert'><B><I>...accidentally hitting the handle!</I></B></span>")
+				H.show_text("<B><I>...accidentally hitting the handle!</I></B>", "red")
+				flush = 1
+				if (!is_processing)
+					SubscribeToProcess()
+					is_processing = 1
+				update()
+			else
+				update()
 		else
 			return ..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR:
- Changes throwing items and mobs into disposal chutes to always occur, instead of randomly/rarely occurring.
- Changes the check to enable throwing all throwable mobs into chutes. So you can throw Jones into a chute if you really wanted to
- Changes the chance for the chute to be set off when a mob is thrown in from 20% to 10%, because by making the chance a mob will enter the chute at all and therefore trigger the entire sequence of probabilities 100% from 30%, it -actually- increases the chance that throwing a mob into the chute will set it off from 6% to 10%. Should still be pretty rare.
- People with the clumsy mutation, such as clowns, will always set off the chute and be flushed when thrown in. Nice.

Implementation otherwise the same. Does not work on wall mounted chutes or mail chutes, like normal.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Throwing into chutes is a cool mechanic that takes advantage of the tons of things that throw you. However, you can't really effectively utilize it since it's pretty rare. This is meant to allow people to do more creative stuff by making it so you can *know* it'll work every time. I also personally feel that the chance to do literally nothing at all with no feedback is bad makes players think that the cool mechanic doesn't exist. There are other things that work like this but I think this one's the easiest to adjust and probably the most fun.

Some things enabled by this (that you could already do it's just like you had to be really lucky):

- Throwing trash bags into disposal chutes as janitor.
- Throwing Jones The Cat into a disposal chute
- Using clownshot to blast the clown into a disposal chute, which immediately flushes and sends them away
- Getting on a chair and flipping across a room into a chute to escape danger
- Using literally any source of throw to send whatever mob or item you want into a chute.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flaborized
(+)Throwing things into disposal chutes isn't luck based anymore, and you can throw more mobs into chutes. Clumsy people will always set the chute off when thrown in.
```
