### PR TITLE
Add AI plating kits to existing AIs

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -507,6 +507,16 @@ var/list/ai_emotions = list("Happy" = "ai_happy",\
 				user.unlock_medal("Law 1: Don't be an asshat", 1)
 		return
 
+	else if(istype(W,/obj/item/ai_plating_kit))
+		if(src.coreSkin != "default") // to avoid having your hard-earned skin being lost because someone bought the clown one or something
+			user.show_message("<span class='alert'>[src] already has a plating kit installed!")
+		else
+			var/obj/item/ai_plating_kit/kit = W
+			src.setSkin(kit.skin)
+			playsound(src.loc, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
+			user.visible_message("<span class='notice'>[user] permanently installs the [W] on [src]!</span>")
+			qdel(W)
+
 	else ..()
 	src.update_appearance()
 
@@ -2670,13 +2680,13 @@ ABSTRACT_TYPE(/obj/item/ai_plating_kit)
 
 /obj/item/ai_plating_kit/syndicate
 	name = "AI Frame Plating Kit"
-	desc = "A kit for putting the plating on an AI frame! WARNING: Choking hazard, not intended for children under 3 years. <i>(Syndicate AI system not included)</i>"
+	desc = "A kit for putting the plating on an AI! WARNING: Choking hazard, not intended for children under 3 years. <i>(Syndicate AI system not included)</i>"
 	icon_state = "syndie_kit" // get it???
 	skin = "syndicate"
 	contraband = 1 // crime
 
 /obj/item/ai_plating_kit/clown
 	name = "AI Frame Plating Kit"
-	desc = "A kit for putting the plating on an AI frame! WARNING: Choking hazard, not intended for children under 3 years. It smells funny."
+	desc = "A kit for putting the plating on an AI! WARNING: Choking hazard, not intended for children under 3 years. It smells funny."
 	icon_state = "clown_kit"
 	skin = "clown"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This allows you to add AI frame plating kits to existing AIs, though only default ones - if they already have another skin, you will not be able to. This is hopefully intended to make it harder to be a goober and take away an AI player's cool skin that they managed to get.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

People have been asking me for a while to add this and here we are, only a few months late! Just a QoL thing, and simplifies things, since it's not clear that you had to use this on an AI frame and not an existing AI.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Nexusuxen
(+)AI plating kits can now be applied to existing AIs that have the default skin!
```
