### PR TITLE
Redesigns Donut3 upload slightly

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2326,7 +2326,6 @@
 /area/station/hallway/primary/southeast)
 "aup" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /obj/disposalpipe/segment/mail{
@@ -3229,9 +3228,6 @@
 	},
 /obj/item/aiModule/makeCaptain{
 	pixel_y = -5
-	},
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 4
 	},
 /turf/simulated/floor/circuit/red,
 /area/station/turret_protected/ai_upload)
@@ -12657,6 +12653,15 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"dup" = (
+/obj/machinery/turret{
+	dir = 6
+	},
+/obj/decal/tile_edge/line/blue{
+	icon_state = "line1"
+	},
+/turf/simulated/floor/circuit,
+/area/station/turret_protected/ai_upload)
 "dut" = (
 /obj/cable{
 	d1 = 1;
@@ -16266,9 +16271,6 @@
 /area/station/science/storage)
 "eyn" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
 /obj/machinery/light/incandescent/cool/very,
 /obj/random_item_spawner/ai_experimental/one,
 /turf/simulated/floor/circuit/vintage,
@@ -16676,7 +16678,6 @@
 /area/station/maintenance/inner/se)
 "eDW" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /obj/disposalpipe/switch_junction/left/east{
@@ -21091,7 +21092,6 @@
 /area/station/science/storage)
 "fOt" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /obj/disposalpipe/switch_junction/left/east{
@@ -24941,7 +24941,6 @@
 /area/station/hallway/primary/west)
 "gXU" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /obj/decal/tile_edge/line/purple{
@@ -26526,7 +26525,6 @@
 /area/station/crew_quarters/garden)
 "hvd" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /obj/cable{
@@ -29494,13 +29492,11 @@
 /turf/simulated/floor/wood/seven,
 /area/station/security/detectives_office)
 "ink" = (
-/obj/machinery/turret{
-	dir = 10
-	},
 /obj/decal/tile_edge/line/blue{
 	dir = 6;
 	icon_state = "line1"
 	},
+/obj/item/device/radio/intercom/AI,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "inm" = (
@@ -35333,9 +35329,6 @@
 	},
 /obj/item/aiModule/emergency{
 	pixel_y = -1
-	},
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 4
 	},
 /obj/machinery/light/incandescent/cool/very,
 /obj/machinery/camera{
@@ -41716,7 +41709,6 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/item/device/radio/intercom/AI,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "lUm" = (
@@ -42070,9 +42062,6 @@
 /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 /area/station/security/brig/north_side)
 "maE" = (
-/obj/machinery/turret{
-	dir = 6
-	},
 /obj/decal/tile_edge/line/blue{
 	dir = 10;
 	icon_state = "line1"
@@ -42255,7 +42244,6 @@
 /area/station/turret_protected/armory_outside)
 "mdw" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /obj/machinery/light/incandescent/netural{
@@ -61526,7 +61514,6 @@
 /area/station/crew_quarters/arcade)
 "rBc" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /obj/disposalpipe/segment/mail,
@@ -63228,9 +63215,6 @@
 /area/station/science/testchamber)
 "saY" = (
 /obj/table/reinforced/auto,
-/obj/machinery/door/airlock/pyro/glass/windoor{
-	dir = 8
-	},
 /turf/simulated/floor/circuit/vintage,
 /area/station/turret_protected/ai_upload)
 "sbh" = (
@@ -66203,7 +66187,6 @@
 /area/station/security/main)
 "sWF" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /obj/disposalpipe/switch_junction/left/east{
@@ -67801,7 +67784,6 @@
 /area/station/hallway/primary/south)
 "tuY" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /obj/cable{
@@ -74469,9 +74451,13 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig/south_side)
 "vsn" = (
-/turf/simulated/wall/auto/reinforced/jen/blue{
-	icon_state = "R5"
+/obj/machinery/turret{
+	dir = 10
 	},
+/obj/decal/tile_edge/line/blue{
+	icon_state = "line1"
+	},
+/turf/simulated/floor/circuit,
 /area/station/turret_protected/ai_upload)
 "vsx" = (
 /obj/wingrille_spawn/auto,
@@ -76258,7 +76244,6 @@
 /area/station/chapel/sanctuary)
 "vQN" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /obj/disposalpipe/segment{
@@ -79253,7 +79238,6 @@
 /area/station/hallway/secondary/exit)
 "wJW" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /obj/disposalpipe/switch_junction/left/east{
@@ -84157,7 +84141,6 @@
 /area/station/security/checkpoint/podbay)
 "ycK" = (
 /obj/decal/tile_edge/line/blue{
-	dir = 1;
 	icon_state = "line1"
 	},
 /turf/simulated/floor/specialroom/medbay,
@@ -115787,7 +115770,7 @@ waP
 waP
 gKJ
 gKJ
-rdj
+idA
 idA
 lzA
 lOJ
@@ -116089,8 +116072,8 @@ pAL
 bsT
 mHL
 cNV
-idA
-wdS
+hAh
+dup
 aGR
 kcx
 lOJ
@@ -117297,7 +117280,7 @@ iap
 hjb
 mHL
 cNV
-fVZ
+hAh
 vsn
 saY
 eyn
@@ -117599,7 +117582,7 @@ xCJ
 mJN
 mHL
 rdj
-rdj
+fVZ
 fVZ
 cyp
 cyp


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Moves the turrets back one tile to allow them to actually shoot someone standing at the law rack.
- Removes the shutters over the law modules since they also blocked the turrets and aren't used in any other upload so _consistency_.
- Moves the intercom one tile over so it doesn't render on top of the law rack.

![image](https://user-images.githubusercontent.com/20713227/167292039-70e0aeb0-252e-446f-923e-58c64d497f0c.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previously you could just walk in and stand in front of the law rack before the turrets activated and be completely safe. This seems dumb, and no other map works like this.

also local AI main gets unrogued and makes a PR to cry about it

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Donut 3's AI upload chamber has been redesigned slightly to remove a safespot.
```
