### PR TITLE
Fix being able to put a component cabinet on a surgery tray because signals

### DIFF
--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1627,7 +1627,7 @@ keeping this here because I want to make something else with it eventually
 
 	proc/attach(obj/item/I as obj)
 		if(I.anchored) return
-		else if (istype(I, /obj/item/mechanics))
+		else if (istype(I, /obj/item/mechanics) || istype(I, /obj/item/storage/mechanics))
 			return
 		src.attached_objs.Add(I) // attach the item to the table
 		I.glide_size = 0 // required for smooth movement with the tray


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Blacklist mechanics storage components from the surgery tray.  The handheld one too just in case there is some future way to use it as well.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Same breaking of restrictions as #8128 just with a different method.
[The bug] Enables connections of infinite distance because the component can be moved while anchored.
[The bug] Enables connections to components in really weird non-player-accessible places.

https://user-images.githubusercontent.com/65367576/167296063-82b3cd4e-155e-47cf-968a-7c1562bbe184.mp4


