### PR TITLE
Adds Heart Damage To Arcfiend's Jolt

### DIFF
--- a/code/modules/antagonists/arcfiend/arcfiend.dm
+++ b/code/modules/antagonists/arcfiend/arcfiend.dm
@@ -351,7 +351,7 @@ ABSTRACT_TYPE(/datum/targetable/arcfiend)
  */
 /datum/targetable/arcfiend/jolt
 	name = "Jolt"
-	desc = "Release a series of powerful jolts into your target, eventually stopping their heart. When used on those resistant to electricity it can restart their heart instead."
+	desc = "Release a series of powerful jolts into your target, burning and eventually stopping their heart. When used on those resistant to electricity it can restart their heart instead."
 	icon_state = "jolt"
 	cooldown = 2 MINUTES
 	pointCost = 500

--- a/code/modules/antagonists/arcfiend/arcfiend.dm
+++ b/code/modules/antagonists/arcfiend/arcfiend.dm
@@ -413,6 +413,8 @@ ABSTRACT_TYPE(/datum/targetable/arcfiend)
 			target.shock(user, wattage, ignore_gloves = TRUE)
 			if (target.bioHolder?.HasEffect("resist_electric") && prob(20))
 				cure_arrest()
+			if (!target.bioHolder?.HasEffect("resist_electric")) //prevent the arcfiend from hurting their heart while shocking it
+				target.organHolder.damage_organ(0, 4, 0, "heart")
 			var/datum/effects/system/spark_spread/s = new /datum/effects/system/spark_spread
 			s.set_up(5, FALSE, target)
 			s.start()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds burn damage to the arcfiends Jolt ability, applied over the duration of the ability, to the heart. Being resistant to electricity from bioeffects prevents this. The total from testing is 60 heart damage.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, arcfiend's Jolt is just cardiac arrest, which doesn't do much on it's own, and can be cured with a defib, with a little bit of burn damage. Combine it with the fact that Jolt cost 500 power for the arcfiend to use, and it's not really an effective ability considering how expensive it is. Making it so burn damage is applied to the heart over the course of the action will give the ability more power, along with making it have some effect if interrupted early.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Arcfiend's Jolt ability will now apply burn damage to a target's heart throughout the ability if they do not have a gene resistant to electricity.
```
