### PR TITLE
Adds A Unique Objective For Arcfiends

### DIFF
--- a/_std/macros/antagchecks.dm
+++ b/_std/macros/antagchecks.dm
@@ -13,6 +13,7 @@
 #define iswrestler(x) ((istype(x, /mob/living/carbon/human) || istype(x, /mob/living/critter)) && (x:get_ability_holder(/datum/abilityHolder/wrestler) != null || HAS_ATOM_PROPERTY(x, PROP_MOB_PASSIVE_WRESTLE)))
 #define iswraith(x) istype(x, /mob/wraith)
 #define ispoltergeist(x) istype(x, /mob/wraith/poltergeist)
+#define isarcfiend(x) (istype(x, /mob/living/carbon/human) && x:get_ability_holder(/datum/abilityHolder/arcfiend) != null)
 
 #define isblob(x) istype(x, /mob/living/intangible/blob_overmind)
 #define isspythief(x) (istype(x, /mob/living/carbon/human) && x:mind && x:mind:special_role == ROLE_SPY_THIEF)

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -398,12 +398,8 @@
 			objective_set_path = /datum/objective_set/werewolf
 			antag.current.make_werewolf()
 
-		if (ROLE_ARCFIEND) // TODO: EV objectives
-		#ifdef RP_MODE
-			objective_set_path = pick(typesof(/datum/objective_set/traitor/rp_friendly))
-		#else
-			objective_set_path = pick(typesof(/datum/objective_set/traitor))
-		#endif
+		if (ROLE_ARCFIEND)
+			objective_set_path = /datum/objective_set/arcfiend
 			antag.current.make_arcfiend()
 
 	if (!isnull(objective_set_path)) // Cannot create objects of type null. [wraiths use a special proc]

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -1405,10 +1405,8 @@ ABSTRACT_TYPE(/datum/objective/conspiracy)
 		explanation_text = "Accumulate at least [powercount] units of charge in total."
 
 	check_completion()
-		if (owner.current && owner.current.get_arcfiend_power(1) >= powercount)
-			return 1
-		else
-			return 0
+		var/datum/abilityHolder/arcfiend/AH = owner.current?.get_ability_holder(/datum/abilityHolder/arcfiend)
+		return (AH?.lifetime_energy >= powercount)
 
 /////////////////////////////////////////////////////////
 // Neatly packaged objective sets for your convenience //

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -1398,9 +1398,9 @@ ABSTRACT_TYPE(/datum/objective/conspiracy)
 
 	set_up()
 #ifdef RP_MODE
-		powergoal = rand(150,200) * 10
+		powergoal = rand(350,400) * 10
 #else
-		powergoal = rand(210,250) * 10
+		powergoal = rand(450,500) * 10
 #endif
 		explanation_text = "Accumulate at least [powergoal] units of charge in total."
 

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -1398,9 +1398,9 @@ ABSTRACT_TYPE(/datum/objective/conspiracy)
 
 	set_up()
 #ifdef RP_MODE
-		powercount = rand(80,120) * 10
+		powercount = rand(150,200) * 10
 #else
-		powercount = rand(150,250) * 10
+		powercount = rand(210,250) * 10
 #endif
 		explanation_text = "Accumulate at least [powercount] units of charge in total."
 

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -1394,19 +1394,19 @@ ABSTRACT_TYPE(/datum/objective/conspiracy)
 /////////////////////////////////////////////////////////
 
 /datum/objective/specialist/powerdrain // this is basically just a repurposed vamp objective, but it should work.
-	var/powercount
+	var/powergoal
 
 	set_up()
 #ifdef RP_MODE
-		powercount = rand(150,200) * 10
+		powergoal = rand(150,200) * 10
 #else
-		powercount = rand(210,250) * 10
+		powergoal = rand(210,250) * 10
 #endif
-		explanation_text = "Accumulate at least [powercount] units of charge in total."
+		explanation_text = "Accumulate at least [powergoal] units of charge in total."
 
 	check_completion()
 		var/datum/abilityHolder/arcfiend/AH = owner.current?.get_ability_holder(/datum/abilityHolder/arcfiend)
-		return (AH?.lifetime_energy >= powercount)
+		return (AH?.lifetime_energy >= powergoal)
 
 /////////////////////////////////////////////////////////
 // Neatly packaged objective sets for your convenience //

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -1390,6 +1390,27 @@ ABSTRACT_TYPE(/datum/objective/conspiracy)
 		return 1
 
 /////////////////////////////////////////////////////////
+// Arcfiend Objectives                                 //
+/////////////////////////////////////////////////////////
+
+/datum/objective/specialist/powerdrain // this is basically just a repurposed vamp objective, but it should work.
+	var/powercount
+
+	set_up()
+#ifdef RP_MODE
+		powercount = rand(80,120) * 10
+#else
+		powercount = rand(150,250) * 10
+#endif
+		explanation_text = "Accumulate at least [powercount] units of charge in total."
+
+	check_completion()
+		if (owner.current && owner.current.get_arcfiend_power(1) >= powercount)
+			return 1
+		else
+			return 0
+
+/////////////////////////////////////////////////////////
 // Neatly packaged objective sets for your convenience //
 /////////////////////////////////////////////////////////
 
@@ -1458,6 +1479,11 @@ ABSTRACT_TYPE(/datum/objective/conspiracy)
 /datum/objective_set/blob
 	objective_list = list(/datum/objective/specialist/blob)
 	escape_choices = list(/datum/objective/escape/survive)
+
+/datum/objective_set/arcfiend
+	objective_list = list(/datum/objective/specialist/powerdrain)
+	escape_choices = list(/datum/objective/escape,
+	/datum/objective/escape/hijack)
 
 // Wraith not listed since it has its own dedicated proc
 

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -768,6 +768,7 @@ a.latejoin-card:hover {
 
 			if (ROLE_ARCFIEND)
 				traitor.special_role = ROLE_ARCFIEND
+				objective_set_path = /datum/objective_set/arcfiend
 				traitormob.make_arcfiend()
 			#ifdef RP_MODE
 				objective_set_path = pick(typesof(/datum/objective_set/traitor/rp_friendly))

--- a/code/modules/antagonists/arcfiend/arcfiend.dm
+++ b/code/modules/antagonists/arcfiend/arcfiend.dm
@@ -28,6 +28,15 @@
 		if (src.mind && src.mind.special_role != ROLE_OMNITRAITOR)
 			src.show_antag_popup("arcfiend")
 
+/mob/proc/get_arcfiend_power(var/lifetime_energy = 0)
+	if (!isarcfiend(src))
+		return 0
+
+	var/datum/abilityHolder/arcfiend/AH = src.get_ability_holder(/datum/abilityHolder/arcfiend)
+	if (AH && istype(AH))
+		return AH.get_arcfiend_power(lifetime_energy)
+	else
+		return 0
 
 /datum/abilityHolder/arcfiend
 	usesPoints = 1
@@ -46,6 +55,12 @@
 		src.lifetime_energy += add_points
 		var/points = min((MAX_ARCFIEND_POINTS - src.points), add_points)
 		. = ..(points, target_ah_type)
+
+	proc/get_arcfiend_power(var/total_power = 0)
+		if (total_power)
+			return src.lifetime_energy
+		else
+			return src.points
 
 ABSTRACT_TYPE(/datum/targetable/arcfiend)
 /datum/targetable/arcfiend

--- a/code/modules/antagonists/arcfiend/arcfiend.dm
+++ b/code/modules/antagonists/arcfiend/arcfiend.dm
@@ -28,15 +28,6 @@
 		if (src.mind && src.mind.special_role != ROLE_OMNITRAITOR)
 			src.show_antag_popup("arcfiend")
 
-/mob/proc/get_arcfiend_power(var/lifetime_energy = 0)
-	if (!isarcfiend(src))
-		return 0
-
-	var/datum/abilityHolder/arcfiend/AH = src.get_ability_holder(/datum/abilityHolder/arcfiend)
-	if (AH && istype(AH))
-		return AH.get_arcfiend_power(lifetime_energy)
-	else
-		return 0
 
 /datum/abilityHolder/arcfiend
 	usesPoints = 1

--- a/code/modules/antagonists/arcfiend/arcfiend.dm
+++ b/code/modules/antagonists/arcfiend/arcfiend.dm
@@ -56,12 +56,6 @@
 		var/points = min((MAX_ARCFIEND_POINTS - src.points), add_points)
 		. = ..(points, target_ah_type)
 
-	proc/get_arcfiend_power(var/total_power = 0)
-		if (total_power)
-			return src.lifetime_energy
-		else
-			return src.points
-
 ABSTRACT_TYPE(/datum/targetable/arcfiend)
 /datum/targetable/arcfiend
 	name = "base arcfiend ability (you should never see me)"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds an objective for arcfiends to go for, involving draining a total of a certain amount of power.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, arcfiends do not have any unique objectives. This fixes that by giving them objectives that fit them.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Add a new objective for Arcfiends!
```
