### PR TITLE
Fixes the clone scanner not using its own helper proc

### DIFF
--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -550,17 +550,7 @@ proc/find_ghost_by_key(var/find_key)
 			boutput(user, "<span class='notice'><B>The scanner is already occupied!</B></span>")
 			return
 
-		var/mob/M = G.affecting
-		M.set_loc(src)
-		src.occupant = M
-		src.icon_state = "scanner_1"
-
-		playsound(src.loc, "sound/machines/sleeper_close.ogg", 50, 1)
-
-		for(var/obj/O in src)
-			O.set_loc(src.loc)
-
-		src.add_fingerprint(user)
+		move_mob_inside(G.affecting)
 		qdel(G)
 		return
 

--- a/code/obj/machinery/computer/cloning.dm
+++ b/code/obj/machinery/computer/cloning.dm
@@ -471,7 +471,7 @@ proc/find_ghost_by_key(var/find_key)
 			return
 
 		if (target == user)
-			move_mob_inside(target)
+			move_mob_inside(target, user)
 		else if (can_operate(user))
 			var/previous_user_intent = user.a_intent
 			user.set_a_intent(INTENT_GRAB)
@@ -500,11 +500,11 @@ proc/find_ghost_by_key(var/find_key)
 		set src in oview(1)
 		set category = "Local"
 
-		move_mob_inside(usr)
+		move_mob_inside(usr, usr)
 		return
 
-	proc/move_mob_inside(var/mob/M)
-		if (!can_operate(M) || !ishuman(M)) return
+	proc/move_mob_inside(var/mob/M, var/mob/user)
+		if (!can_operate(user) || !ishuman(M)) return
 
 		M.remove_pulling()
 		M.set_loc(src)
@@ -514,7 +514,7 @@ proc/find_ghost_by_key(var/find_key)
 		for(var/obj/O in src)
 			O.set_loc(src.loc)
 
-		src.add_fingerprint(usr)
+		src.add_fingerprint(user)
 		src.connected?.updateUsrDialog()
 
 		playsound(src.loc, "sound/machines/sleeper_close.ogg", 50, 1)
@@ -550,7 +550,7 @@ proc/find_ghost_by_key(var/find_key)
 			boutput(user, "<span class='notice'><B>The scanner is already occupied!</B></span>")
 			return
 
-		move_mob_inside(G.affecting)
+		move_mob_inside(G.affecting, user)
 		qdel(G)
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The clone scanner had `move_mob_inside` written out twice, except one version didn't check if the target was human, leading to flockdrones and other things being put in the cloner, causing bugs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pretty sure this is how it's meant to work.
