### PR TITLE
Makes wall mounted defibs not infinitely renewable

### DIFF
--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -644,6 +644,11 @@ CONTAINS:
 	mats = 25
 	var/obj/item/robodefibrillator/mounted/defib = null
 
+	New()
+		..()
+		if (!defib)
+			src.defib = new /obj/item/robodefibrillator/mounted(src)
+
 	emag_act()
 		..()
 		return defib?.emag_act()
@@ -671,8 +676,11 @@ CONTAINS:
 		if (isAI(user) || isintangible(user) || isobserver(user)) return
 		user.lastattacked = src
 		..()
-		if (!defib)
-			src.defib = new /obj/item/robodefibrillator/mounted(src)
+		if(!defib || QDELETED(defib))
+			defib = null // ditch the ref, just in case we're QDEL'd but defib is still holding on
+			return //maybe a bird ate it
+		if(defib.loc != src)
+			return //if someone else has it, don't put it in user's hand
 		user.put_in_hand_or_drop(src.defib)
 		src.defib.parent = src
 		playsound(src, "sound/items/pickup_defib.ogg", 65, vary=0.2)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Wall mounted defibs would spawn a new defib if you destroyed the old one, making infinite resources for flock. Is bad.
Now you only get one defib per wall mount, and if it gets destroyed you don't get a new one.

Also I fixed a minor issue where you could click on a defib mount while someone else had the defib to teleport it from their hand to yours.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes stonepillars/goon-flock#174
