### PR TITLE
Removes mobile robot suit from clothing booth

### DIFF
--- a/code/modules/vending/clothingbooth_items.dm
+++ b/code/modules/vending/clothingbooth_items.dm
@@ -1100,17 +1100,6 @@ ABSTRACT_TYPE(/datum/clothingbooth_item/costume)
 	name = "Columbian Mobster Suit"
 	path = /obj/item/clothing/under/misc/colmob
 
-/datum/clothingbooth_item/costume/mobilesuit
-	name = "Mobile Robot Suit"
-	path = /obj/item/clothing/suit/gimmick/mobile_suit
-	cost = PAY_EXECUTIVE
-
-/datum/clothingbooth_item/costume/mobilesuithelmet
-	name = "Mobile Robot Helmet"
-	path = /obj/item/clothing/head/mobile_suit
-	slot = SLOT_HEAD
-	cost = PAY_EXECUTIVE/2
-
 /datum/clothingbooth_item/costume/dinerdress_mint
 	name = "Mint Diner Waitress's Dress"
 	path = /obj/item/clothing/under/gimmick/dinerdress_mint


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As title

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Per Gannets' request. Ideally you'd ask him but it's something to do with the suit being an azone thing I think?