### PR TITLE
Adds Heavyweight mobAI flag

### DIFF
--- a/_std/defines/mob.dm
+++ b/_std/defines/mob.dm
@@ -2,21 +2,22 @@
 /// For mobs who can hear everything (mainly observer ghossts)
 #define MOB_HEARS_ALL 1
 // God Ecaps
-#define SPEECH_REVERSE 2
-#define SPEECH_BLOB 4		//yes
-#define SEE_THRU_CAMERAS 8	//for ai eye
-#define IS_BONEY 16			//for skeletals
-#define UNUSED_32 32
-#define UNUSED_64 64
-#define UNUSED_128 128
-#define UNUSED_256 256
-#define UNUSED_512 512
-#define AT_GUNPOINT 1024 	//quick check for guns holding me at gunpoint
-#define IGNORE_SHIFT_CLICK_MODIFIER 2048 //shift+click doesn't retrigger a SHIFT keypress - use for mobs that sprint on shift and not on mobs that use shfit for bolting doors etc
-#define LIGHTWEIGHT_AI_MOB 4096		//not a part of the normal 'mobs' list so it wont show up in searches for observe admin etc, has its own slowed update rate on Life() etc
-#define USR_DIALOG_UPDATES_RANGE 8192	//updateusrdialog will consider this mob as being able to 'attack_ai' and update its ui at range
-#define UNUSED_16384 16384
-#define SHOULD_HAVE_A_TAIL 32768 //Would we miss our tail if it comes off?
+#define SPEECH_REVERSE 1 << 1
+#define SPEECH_BLOB 1 << 2		//yes
+#define SEE_THRU_CAMERAS 1 << 3	//for ai eye
+#define IS_BONEY 1 << 4			//for skeletals
+#define UNUSED_32 1 << 5
+#define UNUSED_64 1 << 6
+#define UNUSED_128 1 << 7
+#define UNUSED_256 1 << 8
+#define UNUSED_512 1 << 9
+#define AT_GUNPOINT 1 << 10 	//quick check for guns holding me at gunpoint
+#define IGNORE_SHIFT_CLICK_MODIFIER 1 << 11 //shift+click doesn't retrigger a SHIFT keypress - use for mobs that sprint on shift and not on mobs that use shfit for bolting doors etc
+#define LIGHTWEIGHT_AI_MOB 1 << 12		//not a part of the normal 'mobs' list so it wont show up in searches for observe admin etc, has its own slowed update rate on Life() etc
+#define USR_DIALOG_UPDATES_RANGE 1 << 13	//updateusrdialog will consider this mob as being able to 'attack_ai' and update its ui at range
+#define UNUSED_16384 1 << 14
+#define SHOULD_HAVE_A_TAIL 1 << 15 //Would we miss our tail if it comes off?
+#define HEAVYWEIGHT_AI_MOB 1 << 16 //ai gets ticked every 0.1 seconds instead of the usual 1 seconds - gotta go fast
 
 //mob intent type defines
 #define INTENT_HARM "harm"

--- a/_std/defines/mob.dm
+++ b/_std/defines/mob.dm
@@ -2,22 +2,22 @@
 /// For mobs who can hear everything (mainly observer ghossts)
 #define MOB_HEARS_ALL 1
 // God Ecaps
-#define SPEECH_REVERSE 1 << 1
-#define SPEECH_BLOB 1 << 2		//yes
-#define SEE_THRU_CAMERAS 1 << 3	//for ai eye
-#define IS_BONEY 1 << 4			//for skeletals
-#define UNUSED_32 1 << 5
-#define UNUSED_64 1 << 6
-#define UNUSED_128 1 << 7
-#define UNUSED_256 1 << 8
-#define UNUSED_512 1 << 9
-#define AT_GUNPOINT 1 << 10 	//quick check for guns holding me at gunpoint
-#define IGNORE_SHIFT_CLICK_MODIFIER 1 << 11 //shift+click doesn't retrigger a SHIFT keypress - use for mobs that sprint on shift and not on mobs that use shfit for bolting doors etc
-#define LIGHTWEIGHT_AI_MOB 1 << 12		//not a part of the normal 'mobs' list so it wont show up in searches for observe admin etc, has its own slowed update rate on Life() etc
-#define USR_DIALOG_UPDATES_RANGE 1 << 13	//updateusrdialog will consider this mob as being able to 'attack_ai' and update its ui at range
-#define UNUSED_16384 1 << 14
-#define SHOULD_HAVE_A_TAIL 1 << 15 //Would we miss our tail if it comes off?
-#define HEAVYWEIGHT_AI_MOB 1 << 16 //ai gets ticked every 0.1 seconds instead of the usual 1 seconds - gotta go fast
+#define SPEECH_REVERSE (1 << 1)
+#define SPEECH_BLOB (1 << 2)		//yes
+#define SEE_THRU_CAMERAS (1 << 3)	//for ai eye
+#define IS_BONEY (1 << 4)			//for skeletals
+#define UNUSED_32 (1 << 5)
+#define UNUSED_64 (1 << 6)
+#define UNUSED_128 (1 << 7)
+#define UNUSED_256 (1 << 8)
+#define UNUSED_512 (1 << 9)
+#define AT_GUNPOINT (1 << 10) 	//quick check for guns holding me at gunpoint
+#define IGNORE_SHIFT_CLICK_MODIFIER (1 << 11) //shift+click doesn't retrigger a SHIFT keypress - use for mobs that sprint on shift and not on mobs that use shfit for bolting doors etc
+#define LIGHTWEIGHT_AI_MOB (1 << 12)		//not a part of the normal 'mobs' list so it wont show up in searches for observe admin etc, has its own slowed update rate on Life() etc
+#define USR_DIALOG_UPDATES_RANGE (1 << 13)	//updateusrdialog will consider this mob as being able to 'attack_ai' and update its ui at range
+#define UNUSED_16384 (1 << 14)
+#define SHOULD_HAVE_A_TAIL (1 << 15) //Would we miss our tail if it comes off?
+#define HEAVYWEIGHT_AI_MOB (1 << 16) //ai gets ticked every 0.2 seconds instead of the usual 1 seconds - gotta go fast
 
 //mob intent type defines
 #define INTENT_HARM "harm"

--- a/code/datums/controllers/process/mob_ai.dm
+++ b/code/datums/controllers/process/mob_ai.dm
@@ -18,15 +18,15 @@ datum/controller/process/mob_ai
 			//this spreads out mob ticks, which still happen once every 6 seconds, but not all at the same time
 			if(isnull(M.ai_tick_schedule))
 				M.ai_tick_schedule = rand(0,30) //if you need bigger delays in the future, don't forget to increase this number proportionally
-			var/refnum = M.ai_tick_schedule + ticks
-			if ((M.mob_flags & LIGHTWEIGHT_AI_MOB) && (refnum % 30) == 0) //call life() with a slowed update rate on mobs we manage that arent part of the standard mobs list
+			var/ticknum = M.ai_tick_schedule + ticks
+			if ((M.mob_flags & LIGHTWEIGHT_AI_MOB) && (ticknum % 30) == 0) //call life() with a slowed update rate on mobs we manage that arent part of the standard mobs list
 				if( M.z == 4 && !Z4_ACTIVE ) continue
 				if (istype(X, /mob/living))
 					var/mob/living/L = X
 					L.Life(src)
 				scheck()
 
-			if ((refnum % 15) == 0)
+			if ((ticknum % 15) == 0)
 				M.handle_stamina_updates()
 				if (!M.client) continue
 
@@ -38,7 +38,7 @@ datum/controller/process/mob_ai
 							M.abilityHolder.next_update = 10 SECONDS
 				scheck()
 
-			if((M.mob_flags & HEAVYWEIGHT_AI_MOB) || (refnum % 5) == 0) //either we can tick every time, or we tick every 1 second
+			if((M.mob_flags & HEAVYWEIGHT_AI_MOB) || (ticknum % 5) == 0) //either we can tick every time, or we tick every 1 second
 				var/mob/living/L = M
 				if((isliving(M) && (L.is_npc || L.ai_active) || !isliving(M)))
 					if(istype(X, /mob/living/carbon/human))

--- a/code/datums/controllers/process/mob_ai.dm
+++ b/code/datums/controllers/process/mob_ai.dm
@@ -14,10 +14,11 @@ datum/controller/process/mob_ai
 			if (!M)
 				continue
 
-			//in case it isn't obvious, what we're doing here is taking a unique ref in the form [0x00000000] and mod 30ing it to determine if a mob should tick
-			//this spreads out lightweight mob ticks, which still happen once every 6 seconds, but not all at the same time
-			//text2num returns null on a bad input, and null % num == 0 (lol DM) so it's all good, if a little hacky
-			var/refnum = text2num(copytext("\ref[M]",4,12)) + ticks
+			//in case it isn't obvious, what we're doing here is giving each mob a raffle ticket, and mod 30ing it to determine if a mob should tick
+			//this spreads out mob ticks, which still happen once every 6 seconds, but not all at the same time
+			if(isnull(M.ai_tick_schedule))
+				M.ai_tick_schedule = rand(0,30) //if you need bigger delays in the future, don't forget to increase this number proportionally
+			var/refnum = M.ai_tick_schedule + ticks
 			if ((M.mob_flags & LIGHTWEIGHT_AI_MOB) && (refnum % 30) == 0) //call life() with a slowed update rate on mobs we manage that arent part of the standard mobs list
 				if( M.z == 4 && !Z4_ACTIVE ) continue
 				if (istype(X, /mob/living))

--- a/code/datums/controllers/process/mob_ai.dm
+++ b/code/datums/controllers/process/mob_ai.dm
@@ -3,7 +3,7 @@
 datum/controller/process/mob_ai
 	setup()
 		name = "Mob AI"
-		schedule_interval = 1.6 SECONDS
+		schedule_interval = 0.1 SECONDS
 
 	doWork()
 		for(var/X in ai_mobs)
@@ -14,59 +14,39 @@ datum/controller/process/mob_ai
 			if (!M)
 				continue
 
-			if (M.mob_flags & LIGHTWEIGHT_AI_MOB) //call life() with a slowed update rate on mobs we manage that arent part of the standard mobs list
+			if ((M.mob_flags & LIGHTWEIGHT_AI_MOB) && ticks % 60 == 0) //call life() with a slowed update rate on mobs we manage that arent part of the standard mobs list
 				if( M.z == 4 && !Z4_ACTIVE ) continue
-				if ((ticks % 5) == 0)
-					if (istype(X, /mob/living))
-						var/mob/living/L = X
-						L.Life(src)
-					scheck()
-
-				if ((ticks % 3) == 0)
-					M.handle_stamina_updates()
-					if (!M.client) continue
-
-					if (M.abilityHolder && !M.abilityHolder.composite_owner)
-						if (world.time >= M.abilityHolder.next_update) //after a failure to update (no abbilities!!) wait 10 seconds instead of checking again next process
-							if (M.abilityHolder.updateCounters() > 0)
-								M.abilityHolder.next_update = 1 SECOND
-							else
-								M.abilityHolder.next_update = 10 SECONDS
-					scheck()
-
-			var/mob/living/L = M
-			if((isliving(M) && (L.is_npc || L.ai_active) || !isliving(M)))
-				if(istype(X, /mob/living/carbon/human))
-					var/mob/living/carbon/human/H = X
-					if(H.uses_mobai && H.ai)
-						H.ai.tick()
-					else
-						H.ai_process()
-					scheck()
-				else if(istype(X,/mob/living/critter))
-					var/mob/living/critter/C = X
-					if(C.is_npc && C.ai)
-						C.ai.tick()
-				else if(M.ai)
-					M.ai.tick()
-					scheck()
-
-		//we actually remove fish from Mobs list to save on some server load. sorry. commenting this out for now
-		/*
-		for(var/mob/living/critter/aquatic/A in mobs)
-			if(A.is_npc && A.ai)
-				A.ai.tick()
+				if (istype(X, /mob/living))
+					var/mob/living/L = X
+					L.Life(src)
 				scheck()
-		*/
 
-		/*var/currentTick = ticks
-		for(var/obj/critter in critters)
-			tick_counter = world.timeofday
+			if ((ticks % 30) == 0)
+				M.handle_stamina_updates()
+				if (!M.client) continue
 
-			critter:process()
+				if (M.abilityHolder && !M.abilityHolder.composite_owner)
+					if (world.time >= M.abilityHolder.next_update) //after a failure to update (no abbilities!!) wait 10 seconds instead of checking again next process
+						if (M.abilityHolder.updateCounters() > 0)
+							M.abilityHolder.next_update = 1 SECOND
+						else
+							M.abilityHolder.next_update = 10 SECONDS
+				scheck()
 
-			tick_counter = world.timeofday - tick_counter
-			if (critter && tick_counter > 0)
-				detailed_count["[critter.type]"] += tick_counter
-
-			scheck(currentTick)*/
+			if((M.mob_flags & HEAVYWEIGHT_AI_MOB) || ticks % 10 == 0) //either we can tick every time, or we tick every 1 second
+				var/mob/living/L = M
+				if((isliving(M) && (L.is_npc || L.ai_active) || !isliving(M)))
+					if(istype(X, /mob/living/carbon/human))
+						var/mob/living/carbon/human/H = X
+						if(H.uses_mobai && H.ai)
+							H.ai.tick()
+						else
+							H.ai_process()
+						scheck()
+					else if(istype(X,/mob/living/critter))
+						var/mob/living/critter/C = X
+						if(C.is_npc && C.ai)
+							C.ai.tick()
+					else if(M.ai)
+						M.ai.tick()
+						scheck()

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -213,6 +213,8 @@
 	var/last_move_dir = null
 
 	var/datum/aiHolder/ai = null
+	/// used for load balancing mob_ai ticks
+	var/ai_tick_schedule = null
 
 	var/last_pulled_time = 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This was originally on the flock repo as a joke, but it turns out it might be a good idea anyway.

Essentially this PR adds a new class of mobAI ` HEAVYWEIGHT_AI_MOB` which ticks at 10 ticks per second. It also modifies normal mobAI to tick once per second instead of once per 1.6 seconds, and  `LIGHTWEIGHT_AI_MOB` now ticks once every 6 seconds. Mob stamina is updated once every 3 seconds for all classes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
MobAI was ticking a little slow, and it made it a bit harder to do rapid pursuit style mobai without relying on the old gross have-a-bunch-of-if-statements-in-Life() approach. Also we might use it for flock in the future if it isn't too expensive.

These should probably be used sparingly, because if you're doing 100 expensive AI tasks 10 times a second the server might get upset.

Also I changed all the nearby mob defines to use bit shifting because it makes waka happy.
