### PR TITLE
Cyborgs use selected voice pitch for speech sounds

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -2234,6 +2234,10 @@
 			if("High")
 				vocal_pitch = 1.25
 
+	// hacky, but this is used for says etc.
+	get_age_pitch_for_talk()
+		return vocal_pitch
+
 	proc/pick_module()
 		if(src.module) return
 		if(!src.freemodule) return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR substitutes the cyborg's selected `vocal_pitch` for the age calculation on `get_age_pitch_for_talk`

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#8493 changed the pitch emote (birdwell/scream) sounds to use a new voice_pitch variable - however, speech procs still rely on a vocal pitch represented by age. 

This hack is the dirty, easy way out, but I don't think refactoring `/mob/living/say` is appropriate at this time. 