### PR TITLE
Fixes wizards being able to use the teleport scroll while stunned

### DIFF
--- a/code/datums/abilities/wizard/teleport.dm
+++ b/code/datums/abilities/wizard/teleport.dm
@@ -18,7 +18,7 @@
 		return 1
 
 // These two procs were so similar that I combined them (Convair880).
-/mob/proc/teleportscroll(var/effect = 0, var/perform_check = 0, var/obj/item_to_check = null, var/datum/targetable/spell/teleport/spell)
+/mob/proc/teleportscroll(var/effect = 0, var/perform_check = 0, var/obj/item_to_check = null, var/datum/targetable/spell/teleport/spell, var/abort_if_incapacitated = FALSE)
 	var/voice_grim = "sound/voice/wizard/TeleportGrim.ogg"
 	var/voice_fem = "sound/voice/wizard/TeleportFem.ogg"
 	var/voice_other = "sound/voice/wizard/TeleportLoud.ogg"
@@ -60,10 +60,14 @@
 	else
 		A = tgui_input_list(src, "Area to jump to", "Teleportation", tele_areas)
 
+	if(abort_if_incapacitated && !can_act(src))
+		boutput(src, "<span class='alert'>Not when you're incapacitated.</span>")
+		return 0
+
 	if(!thearea)
 		if (isnull(A))
 			boutput(src, "<span class='alert'>Invalid area selected.</span>")
-			return 1
+			return 0
 		thearea = get_telearea(A)
 
 	if (!thearea || !istype(thearea))

--- a/code/obj/item/misc_wizard_stuff.dm
+++ b/code/obj/item/misc_wizard_stuff.dm
@@ -48,9 +48,7 @@
 	if ((usr.contents.Find(src) || (in_interact_range(src, usr) && istype(src.loc, /turf))))
 		src.add_dialog(usr)
 		if (href_list["spell_teleport"])
-			if (!can_act(H))
-				return
-			if (src.uses >= 1 && usr.teleportscroll(1, 1, src) == 1)
+			if (src.uses >= 1 && usr.teleportscroll(1, 1, src, null, TRUE) == 1)
 				src.uses -= 1
 		if (ismob(src.loc))
 			attack_self(src.loc)


### PR DESCRIPTION
[BUG]

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title. Also fixes an issue where teleport scroll charges would still be depleted if the player cancelled the input window.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes regression introduced in https://github.com/goonstation/goonstation/pull/7700