### PR TITLE
make it so you can click afar when shortsighted

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -121,7 +121,7 @@
 		for (var/atom/A in src.objects)
 			C.screen -= A
 
-	proc/create_screen(id, name, icon, state, loc, layer = HUD_LAYER, dir = SOUTH, tooltipTheme = null, desc = null, customType = null)
+	proc/create_screen(id, name, icon, state, loc, layer = HUD_LAYER, dir = SOUTH, tooltipTheme = null, desc = null, customType = null, mouse_opacity = 1)
 		var/atom/movable/screen/hud/S
 		if (customType)
 			if (!ispath(customType, /atom/movable/screen/hud))
@@ -140,6 +140,7 @@
 		S.layer = layer
 		S.set_dir(dir)
 		S.tooltipTheme = tooltipTheme
+		S.mouse_opacity = mouse_opacity
 		src.objects += S
 
 		for (var/client/C in src.clients)

--- a/code/datums/hud/vision_impair.dm
+++ b/code/datums/hud/vision_impair.dm
@@ -2,7 +2,7 @@
 /datum/hud/vision_impair
 	New()
 		..()
-		create_screen("", "", 'icons/mob/hud_common.dmi', "vimpair", "WEST, SOUTH to CENTER-3, NORTH", HUD_LAYER_UNDER_4)
-		create_screen("", "", 'icons/mob/hud_common.dmi', "vimpair", "CENTER+3, SOUTH to EAST, NORTH", HUD_LAYER_UNDER_4)
-		create_screen("", "", 'icons/mob/hud_common.dmi', "vimpair", "CENTER-2, CENTER+3 to CENTER+2, NORTH", HUD_LAYER_UNDER_4)
-		create_screen("", "", 'icons/mob/hud_common.dmi', "vimpair", "CENTER-2, SOUTH to CENTER+2, CENTER-3", HUD_LAYER_UNDER_4)
+		create_screen("", "", 'icons/mob/hud_common.dmi', "vimpair", "WEST, SOUTH to CENTER-3, NORTH", HUD_LAYER_UNDER_4, mouse_opacity = FALSE)
+		create_screen("", "", 'icons/mob/hud_common.dmi', "vimpair", "CENTER+3, SOUTH to EAST, NORTH", HUD_LAYER_UNDER_4, mouse_opacity = FALSE)
+		create_screen("", "", 'icons/mob/hud_common.dmi', "vimpair", "CENTER-2, CENTER+3 to CENTER+2, NORTH", HUD_LAYER_UNDER_4, mouse_opacity = FALSE)
+		create_screen("", "", 'icons/mob/hud_common.dmi', "vimpair", "CENTER-2, SOUTH to CENTER+2, CENTER-3", HUD_LAYER_UNDER_4, mouse_opacity = FALSE)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Before when you were shortsighted you had about a 50/50 chance of clicks outside your sight area not registering properly because you clicked the checkered nearsightedness overlay instead.

Here I add a new argument to create_screen in the hud datum that allows you to set the mouse_opacity of the newly created screen item and use it to make the nearsightedness overlay not mouse-opaque.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I'm annoyed.