### PR TITLE
Improve checks for equipping items to hands

### DIFF
--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2210,14 +2210,14 @@
 				return 1
 		if (slot_l_hand)
 			if (src.limbs.l_arm)
-				if (!istype(src.limbs.l_arm, /obj/item/parts/human_parts))
+				if (!istype(src.limbs.l_arm, /obj/item/parts/human_parts/arm) && !istype(src.limbs.l_arm, /obj/item/parts/robot_parts/arm))
 					return 0
 				if (istype(src.limbs.l_arm, /obj/item/parts/human_parts/arm/left/item))
 					return 0
 				return 1
 		if (slot_r_hand)
 			if (src.limbs.r_arm)
-				if (!istype(src.limbs.r_arm, /obj/item/parts/human_parts))
+				if (!istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm) && !istype(src.limbs.r_arm, /obj/item/parts/robot_parts/arm))
 					return 0
 				if (istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm/right/item))
 					return 0

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2208,8 +2208,20 @@
 		if (slot_l_store, slot_r_store)
 			if (I.w_class <= W_CLASS_SMALL && src.w_uniform)
 				return 1
-		if (slot_l_hand, slot_r_hand)
-			return 1
+		if (slot_l_hand)
+			if (src.limbs.l_arm)
+				if (!istype(src.limbs.l_arm, /obj/item/parts/human_parts))
+					return 0
+				if (istype(src.limbs.l_arm, /obj/item/parts/human_parts/arm/left/item))
+					return 0
+				return 1
+		if (slot_r_hand)
+			if (src.limbs.r_arm)
+				if (!istype(src.limbs.r_arm, /obj/item/parts/human_parts))
+					return 0
+				if (istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm/right/item))
+					return 0
+				return 1
 		if (slot_belt)
 			if ((I.flags & ONBELT) && src.w_uniform)
 				return 1
@@ -2222,6 +2234,8 @@
 			if (I.flags & ONBACK)
 				return 1
 		if (slot_wear_mask) // It's not pretty, but the mutantrace check will do for the time being (Convair880).
+			if (!src.organHolder.head)
+				return 0
 			if (istype(I, /obj/item/clothing/mask))
 				var/obj/item/clothing/M = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !M.compatible_species.Find(src.mutantrace.name)))
@@ -2230,15 +2244,23 @@
 				else
 					return 1
 		if (slot_ears)
+			if (!src.organHolder.head)
+				return 0
 			if (istype(I, /obj/item/clothing/ears) || istype(I,/obj/item/device/radio/headset))
 				return 1
 		if (slot_glasses)
+			if (!src.organHolder.head)
+				return 0
 			if (istype(I, /obj/item/clothing/glasses))
 				return 1
 		if (slot_gloves)
+			if ((!src.limbs.l_arm) && (!src.limbs.r_arm))
+				return 0
 			if (istype(I, /obj/item/clothing/gloves))
 				return 1
 		if (slot_head)
+			if (!src.organHolder.head)
+				return 0
 			if (istype(I, /obj/item/clothing/head))
 				var/obj/item/clothing/H = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !(src.mutantrace.name in H.compatible_species)))
@@ -2247,6 +2269,8 @@
 				else
 					return 1
 		if (slot_shoes)
+			if ((!src.limbs.l_leg) && (!src.limbs.r_leg))
+				return 0
 			if (istype(I, /obj/item/clothing/shoes))
 				var/obj/item/clothing/SH = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !(src.mutantrace.name in SH.compatible_species)))

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2214,6 +2214,12 @@
 					return FALSE
 				if (istype(src.limbs.l_arm, /obj/item/parts/human_parts/arm/left/item))
 					return FALSE
+				if (I.two_handed)
+					if (src.limbs.r_arm)
+						if(src.r_hand)
+							return FALSE
+					else
+						return FALSE
 				return TRUE
 		if (slot_r_hand)
 			if (src.limbs.r_arm)
@@ -2221,6 +2227,12 @@
 					return FALSE
 				if (istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm/right/item))
 					return FALSE
+				if (I.two_handed)
+					if (src.limbs.l_arm)
+						if(src.l_hand)
+							return FALSE
+					else
+						return FALSE
 				return TRUE
 		if (slot_belt)
 			if ((I.flags & ONBELT) && src.w_uniform)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -2207,112 +2207,112 @@
 	switch (slot)
 		if (slot_l_store, slot_r_store)
 			if (I.w_class <= W_CLASS_SMALL && src.w_uniform)
-				return 1
+				return TRUE
 		if (slot_l_hand)
 			if (src.limbs.l_arm)
 				if (!istype(src.limbs.l_arm, /obj/item/parts/human_parts/arm) && !istype(src.limbs.l_arm, /obj/item/parts/robot_parts/arm))
-					return 0
+					return FALSE
 				if (istype(src.limbs.l_arm, /obj/item/parts/human_parts/arm/left/item))
-					return 0
-				return 1
+					return FALSE
+				return TRUE
 		if (slot_r_hand)
 			if (src.limbs.r_arm)
 				if (!istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm) && !istype(src.limbs.r_arm, /obj/item/parts/robot_parts/arm))
-					return 0
+					return FALSE
 				if (istype(src.limbs.r_arm, /obj/item/parts/human_parts/arm/right/item))
-					return 0
-				return 1
+					return FALSE
+				return TRUE
 		if (slot_belt)
 			if ((I.flags & ONBELT) && src.w_uniform)
-				return 1
+				return TRUE
 		if (slot_wear_id)
 			if (istype(I, /obj/item/card/id) && src.w_uniform)
-				return 1
+				return TRUE
 			if (istype(I, /obj/item/device/pda2) && src.w_uniform) // removed the check for the ID card in here because tbh it was silly that you could only equip it to the ID slot when it had a card  :I
-				return 1
+				return TRUE
 		if (slot_back)
 			if (I.flags & ONBACK)
-				return 1
+				return TRUE
 		if (slot_wear_mask) // It's not pretty, but the mutantrace check will do for the time being (Convair880).
 			if (!src.organHolder.head)
-				return 0
+				return FALSE
 			if (istype(I, /obj/item/clothing/mask))
 				var/obj/item/clothing/M = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !M.compatible_species.Find(src.mutantrace.name)))
 					//DEBUG_MESSAGE("[src] can't wear [I].")
-					return 0
+					return FALSE
 				else
-					return 1
+					return TRUE
 		if (slot_ears)
 			if (!src.organHolder.head)
-				return 0
+				return FALSE
 			if (istype(I, /obj/item/clothing/ears) || istype(I,/obj/item/device/radio/headset))
-				return 1
+				return TRUE
 		if (slot_glasses)
 			if (!src.organHolder.head)
-				return 0
+				return FALSE
 			if (istype(I, /obj/item/clothing/glasses))
-				return 1
+				return TRUE
 		if (slot_gloves)
 			if ((!src.limbs.l_arm) && (!src.limbs.r_arm))
-				return 0
+				return FALSE
 			if (istype(I, /obj/item/clothing/gloves))
-				return 1
+				return TRUE
 		if (slot_head)
 			if (!src.organHolder.head)
-				return 0
+				return FALSE
 			if (istype(I, /obj/item/clothing/head))
 				var/obj/item/clothing/H = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !(src.mutantrace.name in H.compatible_species)))
 					//DEBUG_MESSAGE("[src] can't wear [I].")
-					return 0
+					return FALSE
 				else
-					return 1
+					return TRUE
 		if (slot_shoes)
 			if ((!src.limbs.l_leg) && (!src.limbs.r_leg))
-				return 0
+				return FALSE
 			if (istype(I, /obj/item/clothing/shoes))
 				var/obj/item/clothing/SH = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !(src.mutantrace.name in SH.compatible_species)))
 					//DEBUG_MESSAGE("[src] can't wear [I].")
-					return 0
+					return FALSE
 				else
-					return 1
+					return TRUE
 		if (slot_wear_suit)
 			if (istype(I, /obj/item/clothing/suit))
 				var/obj/item/clothing/SU = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !(src.mutantrace.name in SU.compatible_species)))
 					//DEBUG_MESSAGE("[src] can't wear [I].")
-					return 0
+					return FALSE
 				else
-					return 1
+					return TRUE
 		if (slot_w_uniform)
 			if (istype(I, /obj/item/clothing/under))
 				var/obj/item/clothing/U = I
 				if ((src.mutantrace && !src.mutantrace.uses_human_clothes && !(src.mutantrace.name in U.compatible_species)))
 					//DEBUG_MESSAGE("[src] can't wear [I].")
-					return 0
+					return FALSE
 				else
-					return 1
+					return TRUE
 		if (slot_in_backpack) // this slot is stupid
 			if (src.back && istype(src.back, /obj/item/storage))
 				var/obj/item/storage/S = src.back
 				if (S.contents.len < 7 && I.w_class <= W_CLASS_NORMAL)
-					return 1
+					return TRUE
 		if (slot_in_belt) // this slot is also stupid
 			if (src.belt && istype(src.belt, /obj/item/storage))
 				var/obj/item/storage/S = src.belt
 				if (S.contents.len < 7 && I.w_class <= W_CLASS_NORMAL)
-					return 1
-	return 0
+					return TRUE
+	return FALSE
 
 /mob/living/carbon/human/proc/equip_new_if_possible(path, slot)
 	var/obj/item/I = new path(src)
 	src.equip_if_possible(I, slot)
 	if(slot != slot_in_backpack && slot != slot_in_belt && src.get_slot(slot) != I)
 		qdel(I)
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /mob/living/carbon/human/proc/equip_if_possible(obj/item/I, slot)
 	if (can_equip(I, slot))

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -770,6 +770,9 @@
 	if(src.equipped_in_slot && src.cant_self_remove)
 		return 0
 
+	var/mob/living/carbon/human/target
+	if (ishuman(user))
+		target = user
 	if (!src.anchored)
 		if (!user.r_hand || !user.l_hand || (user.r_hand == src) || (user.l_hand == src))
 			if (!user.hand) //big messy ugly bad if() chunk here because we want to prefer active hand
@@ -782,9 +785,13 @@
 					user.u_equip(src)
 					. = user.put_in_hand(src, 0)
 				else if (!user.l_hand)
-					user.swap_hand(1)
-					user.u_equip(src)
-					. = user.put_in_hand(src, 1)
+					if (!target?.can_equip(src, target.slot_l_hand))
+						user.show_text("You need a free hand to do that!", "blue")
+						.= 0
+					else
+						user.swap_hand(1)
+						user.u_equip(src)
+						. = user.put_in_hand(src, 1)
 			else
 				if (user.l_hand == src)
 					.= 1
@@ -795,9 +802,13 @@
 					user.u_equip(src)
 					. = user.put_in_hand(src, 1)
 				else if (!user.r_hand)
-					user.swap_hand(0)
-					user.u_equip(src)
-					. = user.put_in_hand(src, 0)
+					if (!target?.can_equip(src, target.slot_r_hand))
+						user.show_text("You need a free hand to do that!", "blue")
+						.= 0
+					else
+						user.swap_hand(0)
+						user.u_equip(src)
+						. = user.put_in_hand(src, 0)
 
 		else
 			user.show_text("You need a free hand to do that!", "blue")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updates human.dm can_equip() to fail if the appropriate limbs are missing.
Updates item.dm try_put_hand_mousedrop() to use can_equip() when trying to add to a hand that is holding something, fixes #7896 
Adds can_equip() checks for two handed items.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Resulted in lost objects.
It made no sense you could put shoes and gloves on someone with no arms or legs.
Fixes some weirdness with item arms.
Fixes two handed items being able to be put on someone by another player but disappearing because their other hand was full/limb was missing.

Tested:
Spawning in as a fully equipped role (Nuclear Commander)
Round start as regular job (Captain).
Fully equipping all slots on a naked tdummy.
Attempting to equip tdummy with no limbs/head.
Self equipping/removing all slots.
Cluwning via admin and wizard spell.
Admin macho man, flock goblin, slasher conversion.
Call wizards verb.
Admin giving item arm, regular arm.
Trying to put an assault rifle on a tdummy holding an item or missing an arm.

This does result in some items failing to spawn if the target does not have the limbs and the method of conversion does not fully heal them first. For example, Call Wizards will not create the sandals with no legs or a staff with no arms.