### PR TITLE
Fixes law diff not handling ion laws properly

### DIFF
--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -506,7 +506,7 @@
 					if (islist(lawtext))
 						for (var/law in lawtext)
 							removed_laws += "<del class=\"alert\">[last_laws[i]["number"] + removed_law_offset]: [law]</del>"
-							if (lawtext.Find(law) != length(lawtext)) //screm
+							if ((law in lawtext) != length(lawtext)) //screm
 								removed_law_offset++
 					else
 						removed_laws += "<del class=\"alert\">[last_laws[i]["number"] + removed_law_offset]: [lawtext]</del>"

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -493,6 +493,7 @@
 	**/
 	proc/format_for_display(var/glue = "<br>")
 		var/law_counter = 1 //make the laws always sequential regardless of where in the rack they are
+		var/removed_law_offset = 0
 		var/list/lawOut = new
 		var/list/removed_laws = new
 
@@ -501,7 +502,13 @@
 			if(!module)
 				if (last_laws[i])
 					//load the law number and text from our saved law list
-					removed_laws += "<del class=\"alert\">[last_laws[i]["number"]]: [last_laws[i]["law"]]</del>"
+					var/lawtext = last_laws[i]["law"]
+					if (islist(lawtext))
+						for (var/law in lawtext)
+							removed_laws += "<del class=\"alert\">[last_laws[i]["number"] + removed_law_offset]: [law]</del>"
+							removed_law_offset++
+					else
+						removed_laws += "<del class=\"alert\">[last_laws[i]["number"] + removed_law_offset]: [lawtext]</del>"
 				continue
 			var/lt = module.get_law_text(TRUE)
 			var/class = "regular"

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -506,7 +506,7 @@
 					if (islist(lawtext))
 						for (var/law in lawtext)
 							removed_laws += "<del class=\"alert\">[last_laws[i]["number"] + removed_law_offset]: [law]</del>"
-							if ((law in lawtext) != length(lawtext)) //screm
+							if (lawtext.Find(law) != length(lawtext)) //screm
 								removed_law_offset++
 					else
 						removed_laws += "<del class=\"alert\">[last_laws[i]["number"] + removed_law_offset]: [lawtext]</del>"

--- a/code/obj/machinery/law_racks.dm
+++ b/code/obj/machinery/law_racks.dm
@@ -502,11 +502,12 @@
 			if(!module)
 				if (last_laws[i])
 					//load the law number and text from our saved law list
-					var/lawtext = last_laws[i]["law"]
+					var/list/lawtext = last_laws[i]["law"]
 					if (islist(lawtext))
 						for (var/law in lawtext)
 							removed_laws += "<del class=\"alert\">[last_laws[i]["number"] + removed_law_offset]: [law]</del>"
-							removed_law_offset++
+							if (lawtext.Find(law) != length(lawtext)) //screm
+								removed_law_offset++
 					else
 						removed_laws += "<del class=\"alert\">[last_laws[i]["number"] + removed_law_offset]: [lawtext]</del>"
 				continue


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
AI law diff wasn't handling ion laws with multiple law texts, leading to it displaying "Removed law: /list" when an ion law was removed. This fixes that by making format_for_display 12% more cursed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixing a bug I made