### PR TITLE
Fix matter eating limbs #7761 / Items being held by diposed arms

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -196,7 +196,12 @@
 				affecting.heal_damage(4, 0)
 			owner.UpdateDamageIcon()
 
-		qdel(the_object)
+		if (istype(the_object,/obj/item/parts))
+			var/obj/item/parts/part = the_object
+			part.delete()
+			owner.holder.hud.update_hands()
+		else
+			qdel(the_object)
 
 		using = FALSE
 

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -199,7 +199,9 @@
 		if (istype(the_object,/obj/item/parts))
 			var/obj/item/parts/part = the_object
 			part.delete()
-			owner.holder.hud.update_hands()
+			if (ishuman(owner))
+				var/mob/living/carbon/human/H = owner
+				H.hud.update_hands()
 		else
 			qdel(the_object)
 

--- a/code/obj/item/mob_parts/human_parts.dm
+++ b/code/obj/item/mob_parts/human_parts.dm
@@ -365,6 +365,13 @@
 	slot = "l_arm"
 	handlistPart = "hand_left"
 
+	disposing()
+		if (src.holder)
+			if (ishuman(src.holder))
+				var/mob/living/carbon/human/H = src.holder
+				H.drop_from_slot(H?.l_hand)
+		. = ..()
+
 /obj/item/parts/human_parts/arm/right
 	name = "right arm"
 	desc = "Someone's right hand.... hand. Or arm, whatever."
@@ -373,6 +380,13 @@
 	slot = "r_arm"
 	side = "right"
 	handlistPart = "hand_right"
+
+	disposing()
+		if (src.holder)
+			if (ishuman(src.holder))
+				var/mob/living/carbon/human/H = src.holder
+				H.drop_from_slot(H?.r_hand)
+		. = ..()
 
 /obj/item/parts/human_parts/leg
 	name = "placeholder item (don't use this!)"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #7761 / #3353
Checks if the thing being matter eaten is a limb and uses the delete() proc instead of qdel.
Fix items being held by disposed arms, such as an admin adding an item arm via the limb panel or if they were matter eaten.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs.

Tested:
Red saw arm replacement
Removing limbs with katana
Removing item arms with katana
Adding/removing arm with surgery