### PR TITLE
Adds Arcfiend To VR Antags

### DIFF
--- a/code/modules/admin/antagifiers.dm
+++ b/code/modules/admin/antagifiers.dm
@@ -233,5 +233,5 @@
 		icon_state = "apc0"
 
 		makeAntag(mob/living/carbon/human/M as mob)
-			M.make_arcfiend(1)
+			M.make_arcfiend()
 			boutput(M, "<span class='combat'>The simulation grants you a small portion of it's power.</span>")

--- a/code/modules/admin/antagifiers.dm
+++ b/code/modules/admin/antagifiers.dm
@@ -225,3 +225,13 @@
 			var/token = new /obj/item/requisition_token/syndicate/vr(get_turf(M))
 			M.put_in_hand_or_eject(token) // try to eject it into the users hand, if we can
 			boutput(M, "<span class='combat'>Redeem your freshly mined syndicoin in the nearby weapon vendor.</span>")
+
+	arcfiend
+		name = "ARCF13ND.EXE"
+		desc = "Turns you into an arcfiend, using a bit of the processing power of vr."
+		icon = 'icons/obj/power.dmi'
+		icon_state = "apc0"
+
+		makeAntag(mob/living/carbon/human/M as mob)
+			M.make_arcfiend(1)
+			boutput(M, "<span class='combat'>The simulation grants you a small portion of it's power.</span>")

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -70980,6 +70980,14 @@
 /obj/lattice,
 /turf/unsimulated/floor/void,
 /area/diner/cow)
+"gmI" = (
+/obj/table/reinforced/auto,
+/obj/traitorifier/virtual/arcfiend,
+/turf/unsimulated/floor/setpieces/gauntlet{
+	desc = "This place is going to be a fucking mess.";
+	name = "\proper the murderbox"
+	},
+/area/sim/gunsim)
 "gmY" = (
 /obj/machinery/lawrack/syndicate,
 /turf/unsimulated/floor/darkblue,
@@ -75190,6 +75198,13 @@
 	icon_state = "floor5"
 	},
 /area/wizard_station)
+"ssh" = (
+/obj/table/reinforced/auto,
+/turf/unsimulated/floor/setpieces/gauntlet{
+	desc = "This place is going to be a fucking mess.";
+	name = "\proper the murderbox"
+	},
+/area/sim/gunsim)
 "suO" = (
 /obj/machinery/shuttle/engine/heater{
 	dir = 1;
@@ -136079,8 +136094,8 @@ cim
 cim
 cim
 cim
-cim
 dfm
+cim
 cim
 cim
 cim
@@ -136377,12 +136392,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 cim
 cix
 ciw
 ciw
 ciw
+gmI
 clQ
 clP
 cmw
@@ -136679,11 +136694,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
 cim
 ciy
 ciw
 ckD
+ciw
 ciw
 ciw
 ciw
@@ -136981,11 +136996,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
 cim
 ciM
 ciw
 ckE
+ciw
 ciw
 ciw
 ciw
@@ -137283,12 +137298,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 cim
 ciN
 ciw
 ciw
 ciw
+ssh
 sfP
 mIR
 cmG
@@ -137585,7 +137600,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cim
 cim
 cim
 cim


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an arcfiend antagifier to the vr murderbox


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Being able to practice arcfiend stuff in vr would be nice, and there's not really anything with arcfiend that would break the murderbox.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)The VR murderbox has been upgraded with an arcfiend simulation.
```
