### PR TITLE
change equipped() to use length()

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -664,7 +664,7 @@ ABSTRACT_TYPE(/mob/living/critter)
 	equipped()
 		RETURN_TYPE(/obj/item)
 		if (active_hand)
-			if (hands.len >= active_hand)
+			if (length(src.hands) >= active_hand)
 				var/datum/handHolder/HH = hands[active_hand]
 				return HH.item
 		return null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

`null.len` runtimes bad

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Runtime discovered when testing stonepillars/goon-flock#289

