### PR TITLE
status display

### DIFF
--- a/code/obj/machinery/status_display.dm
+++ b/code/obj/machinery/status_display.dm
@@ -18,6 +18,8 @@
 	density = 0
 	mats = 14
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_MULTITOOL
+	var/glow_in_dark_screen = TRUE
+	var/image/screen_image
 
 	var/mode = 1	// 0 = Blank
 					// 1 = Shuttle timer
@@ -59,6 +61,15 @@
 		UpdateOverlays(crt_image, "crt")
 
 		MAKE_DEFAULT_RADIO_PACKET_COMPONENT(null, frequency)
+
+		if(glow_in_dark_screen)
+			src.screen_image = image('icons/obj/status_display.dmi', src.icon_state, -1)
+			screen_image.plane = PLANE_LIGHTING
+			screen_image.blend_mode = BLEND_ADD
+			screen_image.layer = LIGHTING_LAYER_BASE
+			screen_image.color = list(0.33,0.33,0.33, 0.33,0.33,0.33, 0.33,0.33,0.33)
+			src.UpdateOverlays(screen_image, "screen_image")
+
 
 	// timed process
 	process()
@@ -143,6 +154,14 @@
 						repeat_update = TRUE
 
 				update_display_lines(line1,line2)
+
+		if(glow_in_dark_screen) // should re-add the glow if power is restored
+			screen_image.plane = PLANE_LIGHTING
+			screen_image.blend_mode = BLEND_ADD
+			screen_image.layer = LIGHTING_LAYER_BASE
+			screen_image.color = list(0.33,0.33,0.33, 0.33,0.33,0.33, 0.33,0.33,0.33)
+			src.UpdateOverlays(screen_image, "screen_image")
+
 
 	proc/set_message(var/m1, var/m2)
 		if(m1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes status displays glow in the dark when powered on.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bit odd that they don't, and it helps to make them more readable in low-light spots and when they are in spots like the cog1 airbridge.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)Status display screens' now glow in the dark!
```
