### PR TITLE
Changes the nuke ops uplink sprite.

### DIFF
--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -457,6 +457,9 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 		purchase_flags = UPLINK_TRAITOR
 
 	nukeop
+		name = "syndicate operative uplink"
+		desc = "An uplink terminal that allows you to order weapons and items."
+		icon_state = "uplink"
 		purchase_flags = UPLINK_NUKE_OP
 
 	rev


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Wiki] [Sprites]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Swaps the sprite of the nuke ops uplink to the unique one that was made a while back. This should make it seem a little more like it's specificly a nukie thing and not a random ass radio. I did NOT make this sprite as it was in the device dmi this whole time.
![image](https://user-images.githubusercontent.com/40079883/168677197-a1bb74e9-b487-4f90-a85c-f821562b2f3e.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The station bounced radio one just seems odd. Is it supposed to be one in disguise? But why disguise it if the nukies are the only around when it's used? And also the disguise not commonly used so it will seem out of place. It just doesn't make sense from a design perspective.
