### PR TITLE
fix some material values and stuff

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -539,7 +539,7 @@
 
 	New()
 		..()
-		setProperty("density", 25)
+		setProperty("density", 40)
 		setProperty("hard", 30)
 		addTrigger(triggersTemp, new /datum/materialProc/molitz_temp())
 		addTrigger(triggersOnHit, new /datum/materialProc/molitz_on_hit())
@@ -554,9 +554,9 @@
 
 		New()
 			..()
-			..()
-			removeTrigger(triggersTemp, /datum/materialProc/molitz_temp) // no need to remove molitz_on_hit, all it
-			addTrigger(triggersTemp, new /datum/materialProc/molitz_temp/agent_b()) // does is call molitz_temp
+			// no need to remove molitz_on_hit, all it does is call molitz_temp
+			removeTrigger(triggersTemp, /datum/materialProc/molitz_temp)
+			addTrigger(triggersTemp, new /datum/materialProc/molitz_temp/agent_b())
 			return
 
 /datum/material/crystal/claretine
@@ -862,10 +862,10 @@
 	color = "#B5E0FF"
 	alpha = 80
 	quality = 45
+	value = 1000
 
 	New()
 		..()
-		value = 1000
 		setProperty("reflective", 90)
 		setProperty("density", 85)
 		setProperty("hard", 85)
@@ -897,10 +897,10 @@
 /datum/material/crystal/wizard
 	quality = 50
 	alpha = 100
+	value = 650
 
 	New()
 		..()
-		value = 650
 		setProperty("density", 60)
 		setProperty("hard", 60)
 		addTrigger(triggersOnAdd, new /datum/materialProc/enchanted_add())


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
PR #7443 was merged, caused some issues
f95ecbf2d13b254c73d76d8230b8d56ecee52928 and 3abd20d12f3663caa2ebe4c5eff6dea55634d462 were made to fix some of them, but some things are a bit messed up now

- I change molitz to have density 40 again, so it once more counts as DEN-1, dense crystalline matter, so people can make the low tier RCD cartridges with it again.
- I remove the double parent call from molitz beta.
- I move the value setting on wizard crystal and starstone from the New() to the default values.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I believe it was not an intended change to make molitz unable to make RCD cartridges.
Double parent call and value setting in parent may cause issues.
![image](https://user-images.githubusercontent.com/35579460/168723725-70c642cc-11bf-4eae-b316-0d77cd8a6ccf.png)
