### PR TITLE
Make proximity sensor toggle USE_PROXIMITY

### DIFF
--- a/code/obj/item/device/prox_sensor.dm
+++ b/code/obj/item/device/prox_sensor.dm
@@ -5,7 +5,7 @@
 	var/timing = 0.0
 	var/time = null
 	flags = FPRINT | TABLEPASS| CONDUCT
-	event_handler_flags = USE_PROXIMITY | USE_FLUID_ENTER
+	event_handler_flags = USE_FLUID_ENTER
 	w_class = W_CLASS_SMALL
 	item_state = "electronic"
 	m_amt = 300
@@ -54,6 +54,7 @@
 			src.armed = 1
 			src.time = 0
 			src.timing = 0
+			src.event_handler_flags |= USE_PROXIMITY
 			src.UpdateIcon()
 
 
@@ -127,6 +128,10 @@
 			src.master.add_dialog(usr)
 		if (href_list["arm"])
 			src.armed = !src.armed
+			if (src.armed)
+				src.event_handler_flags |= USE_PROXIMITY
+			else
+				src.event_handler_flags = src.event_handler_flags & ~USE_PROXIMITY
 			src.UpdateIcon()
 			if(timing || armed) processing_items |= src
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[REWORK]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes proximity sensor toggle USE_PROXIMITY instead of sitting there using it all the damn time.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wasteful to leave this active.
This does not touch #1495 , someone smarter than me will need to work out how to resolve this.