### PR TITLE
Cargo pod fix

### DIFF
--- a/code/modules/transport/pods/secondary_system.dm
+++ b/code/modules/transport/pods/secondary_system.dm
@@ -158,7 +158,7 @@
 	return
 
 /obj/item/shipcomponent/secondary_system/cargo/deactivate()
-	for(var/obj/O in load) //Drop cargo.
+	for(var/atom/movable/O in load) //Drop cargo.
 		src.unload(O)
 	return
 

--- a/code/modules/transport/pods/secondary_system.dm
+++ b/code/modules/transport/pods/secondary_system.dm
@@ -285,8 +285,6 @@
 		playsound(src.loc, "sound/machines/buzz-sigh.ogg", 50, 0)
 		return 1 // invalid cargo
 
-	C.set_loc(src.loc)
-	sleep(0.2 SECONDS)
 	C.set_loc(src)
 	load += C
 	playsound(src.loc, "sound/machines/ping.ogg", 50, 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #8556 by making unload properly effect /atom/movable
Also fixes a weird issue where things would be `set_loc`'d into the pod and then `set_loc`'d into the cargo hold, which would screw up the passenger count on pods, which caused some issues with being able to modify parts when you shouldn't be able to.
