### PR TITLE
Fix some plant icons and improve do_update_icon

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -76,6 +76,7 @@
 /datum/plantmutation/corn/clear
 	crop = /obj/item/reagent_containers/food/snacks/plant/corn/clear
 	iconmod = "CornClear"
+	name_prefix = "Clear "
 	assoc_reagents = list("ethanol")
 
 /datum/plantmutation/corn/pepper

--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -90,12 +90,13 @@
 /datum/plantmutation/peas/ammonia
 	crop = /obj/item/reagent_containers/food/snacks/plant/peas/ammonia
 	iconmod = "GoldenPeas"
+	name_prefix = "Golden "
 	assoc_reagents = list("ammonia")
 
 // Grape Mutations
 
 /datum/plantmutation/grapes/green
-	name_prefix = "green "
+	name_prefix = "Green "
 	crop = /obj/item/reagent_containers/food/snacks/plant/grape/green
 	iconmod = "GrapeGreen"
 	assoc_reagents = list("insulin")
@@ -193,7 +194,7 @@
 
 /datum/plantmutation/beans/jelly // hehehe
 	name = "Jelly Bean"
-	name_prefix = "jelly"
+	name_prefix = "Jelly"
 	iconmod = "BeanJelly"
 	assoc_reagents = list("VHFCS")
 	crop = /obj/item/reagent_containers/food/snacks/candy/jellybean/someflavor
@@ -220,14 +221,14 @@
 
 /datum/plantmutation/chili/chilly
 	name = "Chilly"
-	name_prefix = "chilly "
+	name_prefix = "Chilly "
 	iconmod = "ChiliChilly" // IM SORRY THIS IS ALL IN THE NAME OF A VAGUELY CONSISTENT AND PREDICTABLE NAMING CONVENTION
 	crop = /obj/item/reagent_containers/food/snacks/plant/chili/chilly
 	assoc_reagents = list("cryostylane")
 
 /datum/plantmutation/chili/ghost
 	name = "Fiery Chili"
-	name_prefix = "fiery "
+	name_prefix = "Fiery "
 	iconmod = "ChiliGhost"
 	crop = /obj/item/reagent_containers/food/snacks/plant/chili/ghost_chili
 	PTrange = list(75,null)
@@ -239,7 +240,7 @@
 /datum/plantmutation/eggplant/literal
 	name = "Free-Range Eggplant"
 	dont_rename_crop = true
-	name_prefix = "free range "
+	name_prefix = "Free range "
 	iconmod = "EggplantEggs"
 	crop = /obj/item/reagent_containers/food/snacks/ingredient/egg
 
@@ -247,12 +248,12 @@
 
 /datum/plantmutation/wheat/durum
 	name = "Durum Wheat"
-	name_prefix = "durum "
+	name_prefix = "Durum "
 	crop = /obj/item/plant/wheat/durum
 
 /datum/plantmutation/wheat/steelwheat
 	name = "steel wheat"
-	name_prefix = "steel "
+	name_prefix = "Steel "
 	iconmod = "WheatSteel"
 	assoc_reagents = list("iron")
 	crop = /obj/item/plant/wheat/metal
@@ -271,7 +272,7 @@
 
 /datum/plantmutation/oat/salt
 	name = "Salted Oats"
-	name_prefix = "salted "
+	name_prefix = "Salted "
 	iconmod = "OatSalt"
 	assoc_reagents = list("salt")
 	crop = /obj/item/plant/oat/salt

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -244,7 +244,7 @@
 	var/image/water_meter = null
 	var/image/plant_sprite = null
 	var/grow_level = 1 // Same as the above except for current plant growth
-	var/do_update_icon = 0 // this is now a var on the pot itself so you can actually call it outside of process()
+	var/do_update_icon = FALSE // this is now a var on the pot itself so you can actually call it outside of process()
 	var/do_update_water_icon = 1 // this handles the water overlays specifically (water and water level) It's set to 1 by default so it'll update on spawn
 	var/growth_rate = 2
 		// We have this here as a check for whether or not the plant needs to update its sprite.
@@ -325,10 +325,6 @@
 
 	process()
 		..()
-
-		if(do_update_icon)
-			UpdateIcon()
-			update_name()
 
 			// We skip every other tick. Another cpu-conserving measure.
 		if(!src.current || src.dead)
@@ -482,21 +478,21 @@
 
 		if(current_growth_level != src.grow_level)
 			src.grow_level = current_growth_level
-			do_update_icon = 1
+			src.do_update_icon = TRUE
 
 		if(!harvest_warning && HYPcheck_if_harvestable())
 			src.harvest_warning = 1
-			do_update_icon = 1
+			src.do_update_icon = TRUE
 		else if(harvest_warning && !HYPcheck_if_harvestable())
 			src.harvest_warning = 0
-			do_update_icon = 1
+			src.do_update_icon = TRUE
 
 		if(!health_warning && src.health <= growing.starthealth / 2)
 			src.health_warning = 1
-			do_update_icon = 1
+			src.do_update_icon = TRUE
 		else if(health_warning && src.health > growing.starthealth / 2)
 			src.health_warning = 0
-			do_update_icon = 1
+			src.do_update_icon = TRUE
 
 		// Have we lost all health or growth, or used up all available harvests? If so, this plant
 		// should now die. Sorry, that's just life! Didn't they teach you the curds and the peas?
@@ -504,7 +500,7 @@
 			HYPkillplant()
 			return
 
-		if(do_update_icon)
+		if(src.do_update_icon)
 			UpdateIcon()
 			update_name()
 
@@ -863,14 +859,13 @@
 				if(alert("Clear this tray?",,"Yes","No") == "Yes")
 					usr.visible_message("<b>[usr.name]</b> dumps out the tray's contents.")
 					src.reagents.clear_reagents()
-					src.do_update_icon = 1
 					logTheThing("combat", usr, null, "cleared a hydroponics tray containing [current.name] at [log_loc(src)]")
 					HYPdestroyplant()
 		else
 			if(alert("Clear this tray?",,"Yes","No") == "Yes")
 				usr.visible_message("<b>[usr.name]</b> dumps out the tray's contents.")
 				src.reagents.clear_reagents()
-				src.do_update_icon = 1
+
 		return
 
 	MouseDrop_T(atom/over_object as obj, mob/user as mob) // ty to Razage for the initial code
@@ -1580,6 +1575,7 @@
 
 		src.generation = 0
 		UpdateIcon()
+		update_name()
 		post_alert("event_cleared")
 
 	proc/HYPdamageplant(var/damage_source, var/damage_amount, var/bypass_resistance = 0)

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -865,7 +865,8 @@
 			if(alert("Clear this tray?",,"Yes","No") == "Yes")
 				usr.visible_message("<b>[usr.name]</b> dumps out the tray's contents.")
 				src.reagents.clear_reagents()
-
+				UpdateIcon()
+				update_name()
 		return
 
 	MouseDrop_T(atom/over_object as obj, mob/user as mob) // ty to Razage for the initial code


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #1723
Adds the missing name_prefix to some plant mutations.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These plants would come through with blank names in the plant pot.
do_update_icon in the process loop could be a bit aggressive resulting in dead dead dead dead dead dead dead... trays. 