### PR TITLE
Changes the current tail regrowth cooldown from 5 minutes to 2 minutes.

### DIFF
--- a/code/datums/abilities/lizard.dm
+++ b/code/datums/abilities/lizard.dm
@@ -75,7 +75,7 @@
 /datum/targetable/lizardAbility/regrow_tail
 	name = "Regrow Tail"
 	desc = "Regrow your tail... (If cast while you have a tail, shoot off your tail and regrow a new one)"
-	cooldown = 5 MINUTES
+	cooldown = 2 MINUTES
 	targeted = 0
 	pointCost = 2
 

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -1562,7 +1562,7 @@
 
 	New()
 		..()
-		maxsteps = rand(10,20)
+		maxsteps = rand(2,12)
 
 	proc/setup_overlays()
 		var/image/overlayprimary = image('icons/misc/critter.dmi', "twitchytail_colorkey1")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just changes the timer on the ability to be two minutes, as it felt too long to me at five minutes for the lack of gameplay implications it had. I'm wondering now if the wriggling time is too long, but i could actually not find the code for that feature. It wriggles around for a rather insane amount of time.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I wanted it. Other lizard players liked the idea, and lizard tends to be a "weaker" race than other options, so I'd like their goofy abilities to be less of a cooldown to balance it out. They don't have insane benefits like radproof or immunity to plasmaglass, etc. Two minutes is more than enough time to prevent people from spamming tails everywhere, which is why it got a significant cooldown in the first place.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)MomoBerry
(+)Adjusted the tail regrowth ability cooldown from five minutes down to two minutes.
```
