### PR TITLE
Fixes portable id computer turning brown

### DIFF
--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -57,7 +57,7 @@
 		..(loc)
 		src.set_loc(loc)
 		src.name = "foldable portable identification computer"
-		src.desc = "A briefcase with a identification computer inside. A breakthrough in briefcase technology!"
+		src.desc = "A briefcase with an identification computer inside. A breakthrough in briefcase technology!"
 		BLOCK_SETUP(BLOCK_BOOK)
 
 	attack_self(mob/user)
@@ -73,7 +73,7 @@
 
 		if(src.loc == user)
 			user.drop_from_slot(src)
-		user.visible_message("<span class='alert'>[user] unfolds the foldable portable idendification computer from a briefcase!</span>")
+		user.visible_message("<span class='alert'>[user] unfolds the foldable portable identification computer from a briefcase!</span>")
 		var/obj/machinery/computer/card/portable/T = new/obj/machinery/computer/card/portable()
 		T.set_loc(get_turf(src))
 		qdel(src)
@@ -104,26 +104,6 @@
 			case = null
 
 		..()
-
-	verb/fold_up()
-		set src in view(1)
-
-		if(usr.stat)
-			return
-
-		src.visible_message("<span class='alert'>[usr] folds [src] back up!</span>")
-		src.undeploy()
-		return
-
-	proc/undeploy()
-		if(!src.case)
-			src.case = new /obj/item/luggable_computer(src)
-			src.case.luggable = src
-
-		src.case.set_loc(get_turf(src))
-		src.set_loc(src.case)
-		src.deployed = 0
-		return
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/disk/data/floppy)) //IDK i just dont want to screw this up

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -84,6 +84,7 @@
 	density = 0
 	var/obj/item/cell/cell //We have limited power! Immersion!!
 	var/setup_charge_maximum = 15000
+	var/obj/item/luggable_computer/personal/case
 	var/deployed = 1
 
 	New()

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -60,31 +60,12 @@
 		src.desc = "A briefcase with an identification computer inside. A breakthrough in briefcase technology!"
 		BLOCK_SETUP(BLOCK_BOOK)
 
-	attack_self(mob/user)
-		deploy(user)
-
-	verb/unfold()
-		set src in view(1)
-		set category = "Local"
-		set name = "Unfold"
-		deploy(usr)
-
-	proc/deploy(var/mob/user)
-
-		if(src.loc == user)
-			user.drop_from_slot(src)
-		user.visible_message("<span class='alert'>[user] unfolds the foldable portable identification computer from a briefcase!</span>")
-		var/obj/machinery/computer/card/portable/T = new/obj/machinery/computer/card/portable()
-		T.set_loc(get_turf(src))
-		qdel(src)
-
 /obj/machinery/computer/card/portable
 	name = "portable identification computer"
 	icon_state = "idportC"
 	density = 0
 	var/obj/item/cell/cell //We have limited power! Immersion!!
 	var/setup_charge_maximum = 15000
-	var/obj/item/luggable_computer/personal/case
 	var/deployed = 1
 
 	New()
@@ -98,11 +79,6 @@
 		if (src.cell)
 			src.cell.dispose()
 			src.cell = null
-
-		if (case && case.loc == src)
-			case.dispose()
-			case = null
-
 		..()
 
 	attackby(obj/item/W as obj, mob/user as mob)

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -84,7 +84,6 @@
 	density = 0
 	var/obj/item/cell/cell //We have limited power! Immersion!!
 	var/setup_charge_maximum = 15000
-	var/obj/item/luggable_computer/personal/case //The object that holds us when we're all closed up.
 	var/deployed = 1
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There are two bug reports stating that the portable id computer was reverting to the default brown icon state when folding/refolding. I was actually unable to reproduce this bug at the time of testing without commenting out code and can see no changes that might have fixed this.

Looking at the code, there are two 'fold up' verbs:
 - verb/fold_up() within card.dm 
 - object.verbs += /obj/proc/foldUpIntoBriefcase verb from foldable.dm (via the component).

While both verbs appear in the right click drop down, "fold up" and "Fold up", they both call the verb from foldable.dm. 

Commenting out the AddComponent line, thereby forcing the game to call the verb from card.dm instead of foldable.dm, enables reproduction of the bug. This leads me to believe there's some kind of obscure race-condition happening that causes one verb to be used over the other, or perhaps something in how components are handled has been changed in the last two months.

Either way, this PR removes the redundant verbs from card.dm (including the redundant deploy verb) which should prevent the bug from reoccurring.  It also fixes a couple of typos I spotted.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7830
