### PR TITLE
Splits Med/Hydro Restock Purchase

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1154,16 +1154,23 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Necessities Vending Machine Restocking Pack"
 
-/datum/supply_packs/med_hydro_vending_restock
-	name = "Medical/Hydroponics Vending Machine Restocking Pack"
-	desc = "Various Vending Machine Restock Cartridges for Med/Hydro"
+/datum/supply_packs/catering_vending_restock
+	name = "Catering Vending Machine Restocking Pack"
+	desc = "Various Vending Machine Restock Cartridges for catering"
 	contains = list(/obj/item/vending/restock_cartridge/hydroponics,
-					/obj/item/vending/restock_cartridge/medical,
-					/obj/item/vending/restock_cartridge/medical_public,
 					/obj/item/vending/restock_cartridge/kitchen)
-	cost = 3000
+	cost = 1000
 	containertype = /obj/storage/crate
-	containername = "Med/Hydro Vending Machine Restocking Pack"
+	containername = "Catering Vending Machine Restocking Pack"
+
+/datum/supply_packs/medical_vending_restock
+	name = "Medical Vending Machine Restock Pack"
+	desc = "Various Vending Machine Restock Cartridges for medical"
+	contains = list(/obj/item/vending/restock_cartridge/medical,
+					/obj/item/vending/restock_cartridge/medical_public,)
+	cost = 2000
+	containertype = /obj/storage/crate
+	containername = "Medical Vending Machine Restocking Pack"
 
 /datum/supply_packs/security_vending_restock
 	name = "Security Vending Machine Restocking Pack"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr splits the med/hydro restock cartridge purchase from qm to be two separate purchases.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's a bit weird that they are part of the same purchase, considering they are part of two separate departments. This often results in half of the cartridges going unused, as botany ordering these won't have use for the med carts, and med won't have use for the kitchen/hydro carts.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)The med/hydro restock cartridges purchase from qm has been split into two separate purchases.
```
