### PR TITLE
Engineering Supply Crate Additions

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -294,6 +294,24 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Station Pressurization Crate"
 
+/datum/supply_packs/Disposal_Pipe_Cart
+	name = "Disposal Pipe Dispenser Cart"
+	desc = "Has a pesky staff assistant stolen your cart?"
+	category = "Engineering Department"
+	contains = list(/obj/machinery/disposal_pipedispenser/mobile)
+	cost = 4000
+	containertype = /obj/storage/crate
+	containername = "Replacement Disposal Cart Crate"
+
+/datum/supply_packs/Gas_Filtration
+	name = "Gas Filtration Machinery"
+	desc = "A two-piece set consisting of a Portable Air Pump and a Portable Air Scrubber."
+	category = "Engineering Department"
+	contains = list(/obj/machinery/portable_atmospherics/scrubber, /obj/machinery/portable_atmospherics/pump)
+	cost = 5000
+	containertype = /obj/storage/crate
+	containername = "Filtration Machinery Crate"
+
 /datum/supply_packs/generator
 	name = "Experimental Local Generator"
 	desc = "x1 Experimental Local Generator"
@@ -621,6 +639,15 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Assorted Glowsticks Crate - 4 pack"
 
+/datum/supply_packs/portable_fueltank
+	name = "Portable Welding Fuel Tank"
+	desc = "A single transportable fuel tank, for when you're on the move."
+	category = "Basic Materials"
+	contains = list(/obj/item/reagent_containers/food/drinks/fueltank )
+	cost = 1000
+	containertype = /obj/storage/crate
+	containername = "Portable Welding Tank Crate"
+f
 /datum/supply_packs/fueltank
 	name = "Welding Fuel Tank"
 	desc = "1x Welding Fuel Tank"

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -643,7 +643,7 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	name = "Portable Welding Fuel Tank"
 	desc = "A single transportable fuel tank, for when you're on the move."
 	category = "Basic Materials"
-	contains = list(/obj/item/reagent_containers/food/drinks/fueltank )
+	contains = list(/obj/item/reagent_containers/food/drinks/fueltank)
 	cost = 1000
 	containertype = /obj/storage/crate
 	containername = "Portable Welding Tank Crate"

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -294,7 +294,7 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Station Pressurization Crate"
 
-/datum/supply_packs/Disposal_Pipe_Cart
+/datum/supply_packs/disposal_pipe_cart
 	name = "Disposal Pipe Dispenser Cart"
 	desc = "Has a pesky staff assistant stolen your cart?"
 	category = "Engineering Department"
@@ -303,7 +303,7 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate
 	containername = "Replacement Disposal Cart Crate"
 
-/datum/supply_packs/Gas_Filtration
+/datum/supply_packs/gas_filtration
 	name = "Gas Filtration Machinery"
 	desc = "A two-piece set consisting of a Portable Air Pump and a Portable Air Scrubber."
 	category = "Engineering Department"

--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1640,18 +1640,6 @@ ABSTRACT_TYPE(/datum/supply_packs/complex)
 	containername = "Field Generator Crate (Cardlocked \[Engineering])"
 	access = access_engineering
 
-/datum/supply_packs/complex/atmos
-	name = "Atmospherics Supplies"
-	desc = "For when you need to be breathing."
-	category = "Basic Materials"
-	contains = list(/obj/item/tank/air,
-					/obj/item/tank/oxygen,
-					/obj/item/clothing/under/misc/atmospheric_technician)
-	frames = list(/obj/machinery/portable_atmospherics/scrubber = 2)
-	cost = 8000
-	containertype = /obj/storage/crate/wooden
-	containername = "Atmospherics Supplies"
-
 /datum/supply_packs/complex/winter
 	name = "Cold Weather Gear"
 	desc = "Warm winter gear to ward off the winter chills."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds three new supply pack options from QM. The major one is a replacement Disposal Pipe Cart, as someone stealing this early destroys the entire piping economy for engineering on several maps. The two minors ones are the portable fuel tank, as I know this has been something people have wanted for a while in QM, and a 2 piece set of a scrubber and air pump for atmos filtering.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've had quite a few rounds where I just am unable to fix pipe issues due to a staffie taking the pipe cart for their personal gimmick and then tossing it in a dark corner, never to be seen again. I know the devs want people to try and fix piping issues, so this is hopefully a push in the right direction so people aren't left without the tools for it. 

The portable fuel tank is just for convenience for people, portable fuel tanks are a hot commodity, and with the "semi-recent" welder fuel changes, an engineer/QM having one of these on hand is pretty nice. That and crime. People like crime. The filtration pack is more of a direct way to get a scrubber and an air pump, without having a ton of left over gear that nobody wants and just looks ugly on the ground. The "atmospherish" pack has a scrubber, but it also has several tanks of gases, and a gimmick jumpsuit for 8,000. We have the emergency pack for the tanks of gases, so ideally i'd like to just remove it, but i don't wanna step on any toes. I think the meme of it is kind of discourages people.

tl;dr... I don't like map dependant gear, and I'd like having options to get them without the map spawns for generic gear. 🐝 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)MomoBerry
(+)Removed Atmospherish Crate from Cargo. Added crates for pipe dispenser, portable fuel tanks, and a two piece scrubber/airtank set.
```
