### PR TITLE
Fixes aconite healing werewolves on pull()

### DIFF
--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -406,7 +406,7 @@
 			return ..()
 		else
 			boutput(user, "<span class='alert'>You can't drag that aconite! It burns!</span>")
-			user.take_toxin_damage(-10)
+			user.take_toxin_damage(10)
 			return
 
 // FLOWERS //


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When werewolves attempt to drag aconite they are inflicted with negative toxin damage, healing them.

This PR removes the double negative, meaning werewolves are damaged by dragging aconite again.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Werewolves should be damaged by aconite not healed.