### PR TITLE
Makes the Revhead antag popup more descriptive.

### DIFF
--- a/browserassets/html/traitorTips/revTips.html
+++ b/browserassets/html/traitorTips/revTips.html
@@ -15,6 +15,7 @@
     </ul>
     <p>2. Avoid civilian casualties and convert other players to revolutionaries instead by using your revolutionary flash on them. Heads of staff, synthetics and security personnel cannot be converted.</p>
     <p>A revolutionary uplink has been disguised as your PDA (or your headset if you lack a PDA). Check the "notes" verb in the Commands tab to see the uplink code then change your PDA's ring message to it.</p>
+		<p>3. You cannot abandon your mission! Do not, under any circumstances, leave the station Z-Level. If you do, you will be treated as dead!</p>
   </body>
 	<p>For more information, consult <a href='?src={ref};wiki=Rev'>the wiki</a></p>
 </html>

--- a/browserassets/html/traitorTips/revTips.html
+++ b/browserassets/html/traitorTips/revTips.html
@@ -15,7 +15,7 @@
     </ul>
     <p>2. Avoid civilian casualties and convert other players to revolutionaries instead by using your revolutionary flash on them. Heads of staff, synthetics and security personnel cannot be converted.</p>
     <p>A revolutionary uplink has been disguised as your PDA (or your headset if you lack a PDA). Check the "notes" verb in the Commands tab to see the uplink code then change your PDA's ring message to it.</p>
-		<p>3. You cannot abandon your mission! Do not, under any circumstances, leave the station Z-Level. If you do, you will be treated as dead!</p>
-	</body>
+	  <p>3. You cannot abandon your mission! Do not, under any circumstances, leave the station Z-Level. If you do, you will be treated as dead!</p>
+  </body>
 	<p>For more information, consult <a href='?src={ref};wiki=Rev'>the wiki</a></p>
 </html>

--- a/browserassets/html/traitorTips/revTips.html
+++ b/browserassets/html/traitorTips/revTips.html
@@ -15,7 +15,7 @@
     </ul>
     <p>2. Avoid civilian casualties and convert other players to revolutionaries instead by using your revolutionary flash on them. Heads of staff, synthetics and security personnel cannot be converted.</p>
     <p>A revolutionary uplink has been disguised as your PDA (or your headset if you lack a PDA). Check the "notes" verb in the Commands tab to see the uplink code then change your PDA's ring message to it.</p>
-		<p>3. You cannot abandon your mission! Do not, under any circumstances, leave the station Z-Level. If you do, you will be treated as dead!</p>
+  	<p>3. You cannot abandon your mission! Do not, under any circumstances, leave the station Z-Level. If you do, you will be treated as dead!</p>
   </body>
 	<p>For more information, consult <a href='?src={ref};wiki=Rev'>the wiki</a></p>
 </html>

--- a/browserassets/html/traitorTips/revTips.html
+++ b/browserassets/html/traitorTips/revTips.html
@@ -15,7 +15,7 @@
     </ul>
     <p>2. Avoid civilian casualties and convert other players to revolutionaries instead by using your revolutionary flash on them. Heads of staff, synthetics and security personnel cannot be converted.</p>
     <p>A revolutionary uplink has been disguised as your PDA (or your headset if you lack a PDA). Check the "notes" verb in the Commands tab to see the uplink code then change your PDA's ring message to it.</p>
-	  <p>3. You cannot abandon your mission! Do not, under any circumstances, leave the station Z-Level. If you do, you will be treated as dead!</p>
+		<p>3. You cannot abandon your mission! Do not, under any circumstances, leave the station Z-Level. If you do, you will be treated as dead!</p>
   </body>
 	<p>For more information, consult <a href='?src={ref};wiki=Rev'>the wiki</a></p>
 </html>

--- a/browserassets/html/traitorTips/revTips.html
+++ b/browserassets/html/traitorTips/revTips.html
@@ -15,7 +15,7 @@
     </ul>
     <p>2. Avoid civilian casualties and convert other players to revolutionaries instead by using your revolutionary flash on them. Heads of staff, synthetics and security personnel cannot be converted.</p>
     <p>A revolutionary uplink has been disguised as your PDA (or your headset if you lack a PDA). Check the "notes" verb in the Commands tab to see the uplink code then change your PDA's ring message to it.</p>
-  	<p>3. You cannot abandon your mission! Do not, under any circumstances, leave the station Z-Level. If you do, you will be treated as dead!</p>
+    <p>3. You cannot abandon your mission! Do not, under any circumstances, leave the station Z-Level. If you do, you will be treated as dead!</p>
   </body>
 	<p>For more information, consult <a href='?src={ref};wiki=Rev'>the wiki</a></p>
 </html>

--- a/browserassets/html/traitorTips/revTips.html
+++ b/browserassets/html/traitorTips/revTips.html
@@ -13,7 +13,7 @@
       <li>Chief Engineer, Research Director, Medical Director<br>
       </li>
     </ul>
-    <p>2. Avoid civilian casualties and convert other players to revolutionaries instead by using your revolutionary flash on them. Heads of staff, synthetics and security personnel cannot be converted.</p>
+    <p>2. Avoid civilian casualties and convert other players to revolutionaries instead by using any flash on them. Heads of staff, synthetics and security personnel cannot be converted.</p>
     <p>A revolutionary uplink has been disguised as your PDA (or your headset if you lack a PDA). Check the "notes" verb in the Commands tab to see the uplink code then change your PDA's ring message to it.</p>
     <p>3. You cannot abandon your mission! Do not, under any circumstances, leave the station Z-Level. If you do, you will be treated as dead!</p>
   </body>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updates the Revhead antag popup, adding in a third point explaining that you can't leave the Z-Level. Also changes the part regarding the revolutionary flash.
![obraz](https://user-images.githubusercontent.com/93096874/169871936-f02ca74d-47ea-4f44-a491-af4bee2f995c.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's pretty dumb that a really important condition that literally can severely handicap the rev team is completely unsaid in-game. This obviously causes a ton of confusion in first time Revheads. sometimes leading to round that end in 10 or less minutes because all of them leave the station.

