### PR TITLE
Adds A New Item: The Spybox! Spies Start With Them Instead of A Flash-Camera

### DIFF
--- a/browserassets/html/traitorTips/spy_theft_Tips.html
+++ b/browserassets/html/traitorTips/spy_theft_Tips.html
@@ -16,8 +16,8 @@
 		</span>
 	</p>
 
-	<p>3. You have been provided with a special <em>spy camera</em> that functions as a secret flash. Don't lose it!<br>
-		Use it in hand to change it between photo mode and flash mode.</p>
+	<p>3. You have been provided with a special <em>box</em> that can transform into either a camera with a hidden flash or a hat that turns into a scuttlebot. Don't lose it!<br>
+		Use the camera/hat in hand to change their mode.</p>
 
 	<p>4. Try to collect bounties before the other spies do. <em>Use stealth.</em> Keep your identity as a spy hidden from other players and security.<br>
 		</p>

--- a/code/obj/item/device/spythiefbox.dm
+++ b/code/obj/item/device/spythiefbox.dm
@@ -1,28 +1,23 @@
-/obj/item/device/spytheifbox // the box spy thieves start with to choose their item
-	name = "storage"
+/obj/item/device/spybox // the box spy thieves start with to choose their item
+	name = "Box"
 	icon = 'icons/obj/items/storage.dmi'
-	icon_state = "blank_box"
+	icon_state = "box"
 	desc = "A box that can hold a number of small items. There appears to be a button on it"
 	inhand_image_icon = 'icons/mob/inhand/hand_storage.dmi'
 	item_state = "box"
 
 
-	attack_self(var/mob/M)
-		..()
-		choose_item()
+	attack_self()
+		var/list/L = list("Spy Camera", "Scuttlebot")
+		var/result = tgui_input_list(usr, "Choose a device", "Transforming box...", L)
 
-		var/mob/living/carbon/human/H = holder.owner
-
-
-
-	proc/choose_item(var/mob/living/carbon/human/C)
-		var/list/choices = list()
-		choices += ("Camera with built-in flash")
-		choices += ("Scuttlebot")
-
-		var/choice = input("Choose which item you want: ", "Select Item", null) as null|anything in choices
-		if (!choice)
-			boutput(holder.owner, __blue("You leave the box alone."))
-			return 1
-		var/choice_index = choices.Find(choice)
-
+		if(result == null)
+			return
+		if(result == "Spy Camera")
+			var/spycamera = new /obj/item/camera/spy(get_turf(src))
+			usr.put_in_hand_or_drop(spycamera)
+		if(result == "Scuttlebot")
+			var/scuttlebot = new /obj/item/clothing/head/det_hat/folded_scuttlebot(get_turf(src))
+			usr.put_in_hand_or_drop(scuttlebot)
+		boutput(usr, "<span class='notice'>The box transforms into a [result]!</span>")
+		qdel(src)

--- a/code/obj/item/device/spythiefbox.dm
+++ b/code/obj/item/device/spythiefbox.dm
@@ -1,0 +1,28 @@
+/obj/item/device/spytheifbox // the box spy thieves start with to choose their item
+	name = "storage"
+	icon = 'icons/obj/items/storage.dmi'
+	icon_state = "blank_box"
+	desc = "A box that can hold a number of small items. There appears to be a button on it"
+	inhand_image_icon = 'icons/mob/inhand/hand_storage.dmi'
+	item_state = "box"
+
+
+	attack_self(var/mob/M)
+		..()
+		choose_item()
+
+		var/mob/living/carbon/human/H = holder.owner
+
+
+
+	proc/choose_item(var/mob/living/carbon/human/C)
+		var/list/choices = list()
+		choices += ("Camera with built-in flash")
+		choices += ("Scuttlebot")
+
+		var/choice = input("Choose which item you want: ", "Select Item", null) as null|anything in choices
+		if (!choice)
+			boutput(holder.owner, __blue("You leave the box alone."))
+			return 1
+		var/choice_index = choices.Find(choice)
+

--- a/code/obj/item/device/spythiefbox.dm
+++ b/code/obj/item/device/spythiefbox.dm
@@ -11,7 +11,7 @@
 		var/list/L = list("Spy Camera", "Scuttlebot")
 		var/result = tgui_input_list(usr, "Choose a device", "Transforming box...", L)
 
-		if(result == null)
+		if(result == null) // runtime be gone!
 			return
 		if(result == "Spy Camera")
 			var/spycamera = new /obj/item/camera/spy(get_turf(src))

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -177,13 +177,13 @@
 		return
 
 	if (!traitor_mob.r_store)
-		traitor_mob.equip_if_possible(new /obj/item/camera/spy(traitor_mob), traitor_mob.slot_r_store)
+		traitor_mob.equip_if_possible(new /obj/item/device/spybox(traitor_mob), traitor_mob.slot_r_store)
 	else if (!traitor_mob.l_store)
-		traitor_mob.equip_if_possible(new /obj/item/camera/spy(traitor_mob), traitor_mob.slot_l_store)
+		traitor_mob.equip_if_possible(new /obj/item/device/spybox(traitor_mob), traitor_mob.slot_l_store)
 	else if (istype(traitor_mob.back, /obj/item/storage/) && traitor_mob.back.contents.len < 7)
-		traitor_mob.equip_if_possible(new /obj/item/camera/spy(traitor_mob), traitor_mob.slot_in_backpack)
+		traitor_mob.equip_if_possible(new /obj/item/device/spybox(traitor_mob), traitor_mob.slot_in_backpack)
 	else
-		var/obj/F2 = new /obj/item/camera/spy(get_turf(traitor_mob))
+		var/obj/F2 = new /obj/item/device/spybox(get_turf(traitor_mob))
 		traitor_mob.put_in_hand_or_drop(F2)
 
 	var/pda_pass = null

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -1518,6 +1518,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\obj\item\device\radio.dm"
 #include "code\obj\item\device\scanners.dm"
 #include "code\obj\item\device\shield.dm"
+#include "code\obj\item\device\spythiefbox.dm"
 #include "code\obj\item\device\studio_monitor.dm"
 #include "code\obj\item\device\timer.dm"
 #include "code\obj\item\device\transfer_valve.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [FEATURE] [INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr gives spies a spybox to start with rather than a flash-camera. The box can transform into either the flash-camera, or a scuttlebot hat.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, spy theft rounds are rather slow, due to spies needing time to steal things and build up gear. It doesn't help that filling out photo rewards requires spies exposing themselves to some degree. Allowing them to choose a scuttlebot round start will help speed up the collection of smaller items and photos. Also let's them choose to use the camera flash if they feel like rping/choosing a more personal approach.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Spy thieves now start with a box that can turn into either a flash-camera or a scuttlebot hat1
```
