### PR TITLE
Fixes rocketshoes button not clearing

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -194,6 +194,7 @@
 		if(R.uses < 0)
 			the_item.name = "Empty Rocket Shoes"
 			boutput(the_mob, "<span class='alert'>Your rocket shoes are empty.</span>")
+			the_item.hide_buttons()
 			R.abilities.Cut()
 			qdel(src)
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If used repeatedly until all charges have been expended, the rocket shoes ability button gets stuck in your ability bar with no way to clear it. Clicking it does nothing.

The bug occurs because the ability is coded to delete itself from the shoes on depletion, but as it doesn't clear the ability button you wind up with a useless button missing references - preventing it from being removed when you unequip the shoes. 

This PR adds the appropriate proc to get rid of the ability button and complete the deletion.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #6969 
