### PR TITLE
Cyborg Magtractors

### DIFF
--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1473,6 +1473,8 @@ var/datum/action_controller/actions
 				if (our_drone.cell.charge >= hpm_cost * 2)
 					duration /= 3
 					our_drone.cell.use(hpm_cost)
+			if(isrobot(owner))
+				duration /= 3
 
 	onInterrupt(var/flag) //They did something else while picking it up. I guess you dont have to do anything here unless you want to.
 		..()

--- a/code/datums/controllers/action_controls.dm
+++ b/code/datums/controllers/action_controls.dm
@@ -1516,6 +1516,10 @@ var/datum/action_controller/actions
 		if(picker == null || owner == null) //Interrupt if the user or the magpicker dont exist.
 			interrupt(INTERRUPT_ALWAYS)
 			return
+		var/obj/item/magtractor/cyborg/borg_mag = picker
+		if(istype(borg_mag) && !borg_mag.checktype(borg_mag.holding)) //Interrupt if the item isn't actually allowed.
+			interrupt(INTERRUPT_ALWAYS)
+			return
 
 	onEnd()
 		..()

--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -249,6 +249,10 @@
 
 	death(gibbed)
 		logTheThing("combat", src, null, "was destroyed at [log_loc(src)].")
+		//So the CYBORG cant pick up an item and then die, sending the item ~to the void~
+		var/obj/item/magtractor/mag = locate(/obj/item/magtractor) in src.module?.tools
+		var/obj/item/magHeld = mag?.holding ? mag.holding : null
+		if (magHeld) magHeld.set_loc(get_turf(src))
 		src.mind?.register_death()
 		if (src.syndicate)
 			src.remove_syndicate("death")
@@ -1851,6 +1855,13 @@
 		if (module_states[i])
 			if (src.module)
 				var/obj/I = module_states[i]
+				var/obj/item/magtractor/mag = I
+				if (istype(mag) && mag.holding)
+					actions.stopId("magpickerhold", src)
+					hud.update_tools()
+					hud.update_equipment()
+					update_appearance()
+					return
 				if (isitem(I))
 					var/obj/item/IT = I
 					IT.dropped(src) // Handle light datums and the like.

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -697,7 +697,7 @@
 		I.play_note(note,user)
 
 	checkRequirements(atom/target, mob/user)
-		. = ((user.equipped() == target) || target.density && target.loc == get_turf(target) && BOUNDS_DIST(user, target) == 0 && istype(target,/obj/item/instrument))
+		. = ((user.equipped() == target) || (target in user.equipped_list(1)) || target.density && target.loc == get_turf(target) && BOUNDS_DIST(user, target) == 0 && istype(target,/obj/item/instrument))
 
 	special
 		icon_background = "key_special"

--- a/code/modules/interface/multiContext/context_actions.dm
+++ b/code/modules/interface/multiContext/context_actions.dm
@@ -697,7 +697,7 @@
 		I.play_note(note,user)
 
 	checkRequirements(atom/target, mob/user)
-		. = ((user.equipped() == target) || (target in user.equipped_list(1)) || target.density && target.loc == get_turf(target) && BOUNDS_DIST(user, target) == 0 && istype(target,/obj/item/instrument))
+		. = ((user.equipped() == target) || (isrobot(user) && (target in user.equipped_list(1))) || target.density && target.loc == get_turf(target) && BOUNDS_DIST(user, target) == 0 && istype(target,/obj/item/instrument))
 
 	special
 		icon_background = "key_special"

--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -12,6 +12,7 @@
 /datum/robot/module_tool_creator/recursive/module/brobocop
 	definitions = list(
 		/obj/item/noisemaker,
+		/obj/item/magtractor/cyborg/brobocop,
 		/obj/item/robot_foodsynthesizer,
 		/obj/item/reagent_containers/food/drinks/bottle/beer/borg,
 		/obj/item/reagent_containers/food/drinks/drinkingglass/pitcher,
@@ -69,6 +70,7 @@
 		/obj/item/lamp_manufacturer,
 		/obj/item/device/camera_viewer,
 		// TODO: some sort of nutrient dispenser?
+		/obj/item/magtractor/cyborg/civilian,
 		/obj/item/kitchen/utensil/knife/bread,
 		/obj/item/ladle,
 		/obj/item/kitchen/rollingpin/light,
@@ -128,6 +130,7 @@
 		#ifdef MAP_OVERRIDE_OSHAN
 			/obj/item/mining_tool/power_shovel/borg,
 		#endif
+		/obj/item/magtractor/cyborg/engineering,
 		/datum/robot/module_tool_creator/item_type/amount/steel_tile,
 		/datum/robot/module_tool_creator/item_type/amount/steel_rod,
 		/datum/robot/module_tool_creator/item_type/amount/steel_sheet,

--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -474,6 +474,8 @@ TRAYS
 			. += "There's [(src.amount > 0) ? src.amount : "no" ] [src.contained_food_name][s_es(src.amount)] in [src]."
 
 	attackby(obj/item/W as obj, mob/user as mob)
+		if(istype(W, /obj/item/magtractor))
+			return Attackhand(user)
 		if(src.amount >= src.max_amount)
 			boutput(user, "You can't fit anything else in [src]!")
 			return

--- a/code/obj/item/magtractor.dm
+++ b/code/obj/item/magtractor.dm
@@ -285,6 +285,12 @@
 		if(allowed_types)
 			src.allowed_types = allowed_types
 
+	process()
+		..()
+		if ((src.holding && !checktype(src.holding)) && src.holder && processHeld) //If the item is not an allowed type somehow
+			actions.stopId("magpickerhold", src.holder)
+			processHeld = 0
+
 	attackby(obj/item/W as obj, mob/user as mob)
 		var/mob/living/silicon/robot/robo = user
 		if(istype(robo) && !(W in robo.module?.tools))

--- a/code/obj/item/magtractor.dm
+++ b/code/obj/item/magtractor.dm
@@ -266,7 +266,7 @@
 
 		return 1
 
-	Exited(Obj, newloc) // THIS FIXES ISSUES WITH QDELED ITEMS WHY IS THIS NOT USED MORE
+	Exited(Obj, newloc) // handles the held item going byebye
 		if(Obj == src.holding)
 			actions.stopId("magpickerhold", src.holder)
 

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -166,7 +166,7 @@
 					if(src.check_can_hold(I) > 0 && !I.anchored)
 						src.Attackby(I, user, S)
 				return
-			if(!does_not_open_in_pocket)
+			if(!does_not_open_in_pocket && !istype(W, /obj/item/magtractor))
 				attack_hand(user)
 			switch (canhold)
 				if(0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE][WIKI][INPUT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 3 specialized magtractors to certain cyborg modules in order to allow cyborgs to accomplish certain tasks that can normally only be done with hands. These magtractors always have high-power mode enabled, but all of them are limited to only being able to carry specific types of items that fit their designated module's purpose.

### Foodtractor
Available for the Civilian cyborg module. Only allows you to pick up food items, such as ingredients, completed dishes, and produce.

### Constructotractor
Available for the Engineering cyborg module. Only allows you to pick up sheets, rods, tiles, cables, and furniture parts.

### Harmonitractor
Available for the Brobocop cyborg module. Only allows you to pick up instruments.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

### Foodtractor
Allows civilian cyborgs to finally make (probably) every food in the kitchen, just a bit less efficiently than human chefs due to the 1 second pickup time and only 1 slot for carrying food.

### Constructotractor
Lets engineering cyborgs build tables, make reinforced windows, use different colors of cables, etc.

### Harmonitractor
Lets brobocop cyborgs play musical instruments so they can be more entertaining.

## To-Do
- [ ] Unique Foodtractor sprites
- [ ] Unique Constructotractor sprites
- [ ] Unique Harmonitractor sprites

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)CodeJester
(*)Civilian Cyborgs now have a foodtractor for picking up and interacting with food items. Become a true Iron Chef!
(*)Engineering Cyborgs now have a constructotractor, allowing them to pick up material sheets and build tables that humans will inevitably kill each other with.
(*)Brobocop Cyborgs now have a harmonitractor for picking up and playing instruments. They always were metalheads.
```
