### PR TITLE
Fix foam dart barrier duplication

### DIFF
--- a/code/modules/items/specials/ItemSpecials.dm
+++ b/code/modules/items/specials/ItemSpecials.dm
@@ -1966,10 +1966,7 @@ ABSTRACT_TYPE(/datum/item_special/spark)
 		bullet_act(var/obj/projectile/P)
 			if (!P.goes_through_mobs)
 				var/obj/projectile/Q = shoot_reflected_to_sender(P, src)
-				if (istype(Q.proj_data, /datum/projectile/bullet/foamdart))
-					qdel(P)
-				else
-					P.die()
+				P.die()
 
 				src.visible_message("<span class='alert'>[src] reflected [Q.name]!</span>")
 				playsound(src.loc, 'sound/impact_sounds/Energy_Hit_1.ogg', 40, 0.1, 0, 2.6)

--- a/code/modules/items/specials/ItemSpecials.dm
+++ b/code/modules/items/specials/ItemSpecials.dm
@@ -1932,7 +1932,7 @@ ABSTRACT_TYPE(/datum/item_special/spark)
 		density = 1
 		del_self = 0
 		clash_time = -1
-	
+
 
 		//mouse_opacity = 1
 		var/bump_count = 0
@@ -1966,7 +1966,10 @@ ABSTRACT_TYPE(/datum/item_special/spark)
 		bullet_act(var/obj/projectile/P)
 			if (!P.goes_through_mobs)
 				var/obj/projectile/Q = shoot_reflected_to_sender(P, src)
-				P.die()
+				if (istype(Q.proj_data, /datum/projectile/bullet/foamdart))
+					qdel(P)
+				else
+					P.die()
 
 				src.visible_message("<span class='alert'>[src] reflected [Q.name]!</span>")
 				playsound(src.loc, 'sound/impact_sounds/Energy_Hit_1.ogg', 40, 0.1, 0, 2.6)

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -439,9 +439,16 @@ toxic - poisons
 	dissipation_rate = 0
 	ie_type = null
 
-	on_end(var/obj/projectile/O)
+	on_hit(atom/hit, direction, obj/projectile/P)
 		..()
-		var/turf/T = get_turf(O)
+		drop_as_ammo(P)
+
+	on_max_range_die(obj/projectile/P)
+		..()
+		drop_as_ammo(P)
+
+	proc/drop_as_ammo(obj/projectile/P)
+		var/turf/T = get_turf(P)
 		if(T)
 			var/obj/item/ammo/bullets/foamdarts/ammo_dropped = new /obj/item/ammo/bullets/foamdarts (T)
 			ammo_dropped.amount_left = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes foam dart spawning to be either on hit or when it stops moving due to maximum shot distance, instead of when it's deleted.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8700

## In-game Demo
https://user-images.githubusercontent.com/91498627/170890518-c72db4e1-cc77-4478-99e9-ac7244880bb7.mp4


