### PR TITLE
Remove syndivision on borg death

### DIFF
--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -602,7 +602,7 @@ var/global/list/module_editors = list()
 	logTheThing("station", src, null, "[src]'s status as a [role != "" ? "[role]" : "rogue robot"] was removed[persistent == 1 ? " (actual antagonist role unchanged)" : ""].[cause ? " Source: [constructTarget(cause,"combat")]" : ""]")
 	boutput(src, "<h2><span class='alert'>You have been deactivated, removing your antagonist status. Do not commit traitorous acts if you've been brought back to life somehow.</h></span>")
 	src.show_antag_popup("rogueborgremoved")
-
+	src.antagonist_overlay_refresh(TRUE, TRUE) // Syndie vision deactivated.
 	src.law_rack_connection = ticker?.ai_law_rack_manager?.default_ai_rack
 	logTheThing("station", src, null, "[src.name] is connected to the default rack [constructName(src.law_rack_connection)] [cause ? " Source: [constructTarget(cause,"combat")]" : ""]")
 	src.syndicate = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes antag vision when syndicate status is removed from a borg (ie, by dying). 
Fixes #8720 


