### PR TITLE
Fix and simplify chemicompiler heating code

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -99,6 +99,7 @@ datum
 			src.total_temperature = new_temp
 			if (react)
 				temperature_react()
+				handle_reactions()
 
 		proc/temperature_react() //Calls the temperature reaction procs without changing the temp.
 			for(var/reagent_id in reagent_list)

--- a/code/modules/chemistry/chemicompiler_core.dm
+++ b/code/modules/chemistry/chemicompiler_core.dm
@@ -844,7 +844,7 @@
 	if(abs(difference) <= h_change_cap)
 		heating_in_progress = 0
 
-	R.set_reagent_temp(heater_temp, 1)
+	R.set_reagent_temp(heater_temp, TRUE)
 
 	return heating_in_progress
 

--- a/code/modules/chemistry/chemicompiler_core.dm
+++ b/code/modules/chemistry/chemicompiler_core.dm
@@ -837,18 +837,14 @@
 	var/difference = temp- R.total_temperature
 
 	if (difference >= 0)
-		heater_temp = R.total_temperature+ 2*min(difference,h_change_cap)
+		heater_temp = R.total_temperature+ min(ceil(difference),h_change_cap)
 	else
-		heater_temp = R.total_temperature+ 2*max(difference,-h_change_cap)
+		heater_temp = max(1,R.total_temperature+ max(round(difference),-h_change_cap))
 
-	if(heater_temp <= 0)
-		//we can't set the heater below 0, so temp lowers slower
-		if (abs(difference) <= 1)
-			heating_in_progress = 0
-	else if(abs(difference) <= h_change_cap)
+	if(abs(difference) <= h_change_cap)
 		heating_in_progress = 0
 
-	R.temperature_reagents(heater_temp, R.total_volume*100, R.composite_heat_capacity, h_change_cap)
+	R.set_reagent_temp(heater_temp, 1)
 
 	return heating_in_progress
 

--- a/code/modules/chemistry/chemicompiler_core.dm
+++ b/code/modules/chemistry/chemicompiler_core.dm
@@ -830,23 +830,25 @@
 	var/obj/item/reagent_containers/holder = reservoirs[rid]
 	var/datum/reagents/R = holder.reagents
 	var/heating_in_progress = 1
-	//while(R.total_volume && heating_in_progress)
 
 	//heater settings
-	var/h_exposed_volume = 10
-	var/h_divisor = 10
 	var/h_change_cap = 25
+	var/heater_temp
+	var/difference = temp- R.total_temperature
 
-	var/element_temp = R.total_temperature < temp ? 9000 : 0												//Sidewinder7: Smart heating system. Allows the CC to heat at full power for more of the duration, and prevents reheating of reacted elements.
-	var/max_temp_change = abs(R.total_temperature - temp)
-	var/next_temp_change = clamp((abs(R.total_temperature - element_temp) / h_divisor), 1, h_change_cap)	// Formula used by temperature_reagents() to determine how much to change the temp
-	if(next_temp_change >= max_temp_change)																	// Check if this tick will cause the temperature to overshoot if heated/cooled at full power. Use >= to prevent reheating in the case the values line up perfectly
-		element_temp = (((R.total_temperature - (R.total_temperature-temp)*h_divisor) * (R.total_volume+h_exposed_volume)) - (R.total_temperature*R.total_volume))/h_exposed_volume
+	if (difference >= 0)
+		heater_temp = R.total_temperature+ 2*min(difference,h_change_cap)
+	else
+		heater_temp = R.total_temperature+ 2*max(difference,-h_change_cap)
+
+	if(heater_temp <= 0)
+		//we can't set the heater below 0, so temp lowers slower
+		if (abs(difference) <= 1)
+			heating_in_progress = 0
+	else if(abs(difference) <= h_change_cap)
 		heating_in_progress = 0
 
-	h_divisor = 35/h_divisor*100 // quick hack because idk wtf is going on here - Emily
-
-	R.temperature_reagents(element_temp, h_exposed_volume, h_divisor, h_change_cap)
+	R.temperature_reagents(heater_temp, R.total_volume*100, R.composite_heat_capacity, h_change_cap)
 
 	return heating_in_progress
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Simplifies the chemicompiler heating code, so that it stops reverse-engineering the exact heat requirements for a given exposed volume and instead just performs unexplainable feats of _microwave science_ to heat/cool the entire volume of the beaker the perfect amount.

There's no difference from the compiler in terms of speed, but it should just be back to being 100% accurate with heating again. which could break user scripts built around its' broken-ness

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Right now the compiler does some reverse engineering of the pre-heat capacity code, which broke once heat capacity was changed. It wasn't very readable either. This fixes it and i think is a lot more readable and stable than the previous code.

Set temperature might actually end up being the appropriate reagent proc at this point, but I'm not 100% certain if anything relies on temperature_reagents, so i'll stay safe.
