### PR TITLE
Fixes being able to pull things while handcuffed

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1070,7 +1070,7 @@
 	if(src.pulling)
 		src.remove_pulling()
 
-	if(!can_reach(src, A))
+	if(!can_reach(src, A) || src.restrained())
 		return
 
 	pulling = A


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You can pull things while handcuffed if you use the pull right click option, this doesn't seem intentional since it doesn't work with control click?
Found this while trying to fix flockdrones pulling while floorrunning.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad