### PR TITLE
Fixes fire elemental name when in fire form

### DIFF
--- a/code/datums/abilities/wizard/phaseshift.dm
+++ b/code/datums/abilities/wizard/phaseshift.dm
@@ -343,6 +343,7 @@
 
 
 	firepoof
+		name = "fireball"
 		icon_state = "fireball"
 		icon = 'icons/obj/wizard.dmi'
 		flags = TABLEPASS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fire elementals are called "bat" when in fire form.

This is because fire form is just a reskinned bat form, and the name of the dummy object you go inside wasn't overridden.

This PR overrides the name of the dummy object with "fireball" when in fire form.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8722
