### PR TITLE
Turns off the pop-up on the base type obj/decal/poster

### DIFF
--- a/code/obj/decal/poster.dm
+++ b/code/obj/decal/poster.dm
@@ -9,7 +9,7 @@
 	density = 0
 	var/imgw = 600
 	var/imgh = 400
-	var/popup_win = 1
+	var/popup_win = 0
 	layer = EFFECTS_LAYER_BASE
 	plane = PLANE_NOSHADOW_ABOVE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
For some reason obj/decal/poster displays wizard tips on examine? There's a comment in the code drawing attention to this fact? 

The poster is currently used in four locations (z2 twice, oshan, halloween14), but as it's a parent type it would be very easy for map makers to reintroduce it elsewhere.

This PR sidesteps the issue by turning off the popup window for the base type. Subtypes reactivate it already as necessary.

![image](https://user-images.githubusercontent.com/86617057/170152234-31f9a05c-b79c-4e70-be0f-dea9cafee379.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8639
