### PR TITLE
Delay Pipe Rupture Post Repair

### DIFF
--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -339,7 +339,7 @@ obj/machinery/atmospherics/pipe
 
 			var/pressure_difference = pressure - MIXTURE_PRESSURE(environment)
 
-			if(can_rupture && pressure_difference > fatigue_pressure)
+			if(can_rupture && !GET_COOLDOWN(src, "rupture_protection") && pressure_difference > fatigue_pressure)
 				var/rupture_prob = (pressure_difference - fatigue_pressure)/50000
 				if(prob(rupture_prob))
 					rupture(pressure_difference)
@@ -460,6 +460,7 @@ obj/machinery/atmospherics/pipe
 			src.ruptured = 0
 			desc = initial(desc)
 			UpdateIcon()
+			ON_COOLDOWN(src, "rupture_protection", 20 SECONDS + rand(10 SECONDS, 80 SECONDS))
 
 		proc/reconstruct_pipe(mob/M, obj/item/rods/R)
 			if(istype(R) && istype(M))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol][feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stops pipes from bursting for 30-110 seconds after being repaired.  Allows crew to work around unmitigated pipe pressure by sacrificing engagement in repairing pipes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Delay rupture post pipe burst to improve ability for coordinated game play


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(+)Atmos pipes will take some time to rupture after being repaired.
```
