### PR TITLE
Removes Mr. Fisting from the monkey name list

### DIFF
--- a/strings/names/monkey.txt
+++ b/strings/names/monkey.txt
@@ -142,7 +142,6 @@ names@=
 	Sgt. Cory
 	Gunter Flange
 	Robutt
-	Mr. Fisting
 	Jimmy Shits
 	Scorpio
 	Mr. Pantaloons


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Monkeys will now no longer spawn with the name Mr. Fisting.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
do we have to, i mean come on