### PR TITLE
Adds Freezer Box Crates to Crate Manufacturer

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2830,6 +2830,14 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 	create = 1
 	category = "Miscellaneous"
 
+/datum/manufacture/freezer
+	name = "Freezer Crate"
+	item_paths = list("MET-1")
+	item_amounts = list(5)
+	item_outputs = list(/obj/storage/crate/freezer)
+	time = 10 SECONDS
+	create = 1
+	category = "Miscellaneous"
 /******************** GUNS *******************/
 
 /datum/manufacture/alastor

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2609,7 +2609,8 @@
 	/datum/manufacture/pizzabox,
 	/datum/manufacture/wooden,
 	/datum/manufacture/medical,
-	/datum/manufacture/biohazard)
+	/datum/manufacture/biohazard,
+	/datum/manufacture/freezer)
 
 	hidden = list(/datum/manufacture/classcrate)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This will add the freezer box crate type that usually stores organs or food to the crate manufacturer.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Its a semi-common crate type that I feel is missing from the crate manufacturer, and I think it will see use for RP purposes, like for shipping/storing organs/meat, fresh produce or drinks!


```changelog
(u)C.Clover
(+)Added option to print Freezer Crate from Crate manufacturer
```
