### PR TITLE
Fixes auto/windows not updating neighbours on fasten/unfasten

### DIFF
--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -770,6 +770,7 @@
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (..(W, user))
 			src.UpdateIcon()
+			src.update_neighbors()
 
 	proc/update_neighbors()
 		for (var/turf/simulated/wall/auto/T in orange(1,src))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When fastened/unfastened from the floor (not the frame), autowindows update their icon (ie: from continuous to standalone). However the adjacent windows do not update, the result being one-way connections. This looks fine if you're removing window, but less so if you're adding it from a new direction.

This PR adds an update_neighbour proc in the appropriate location such that whenever `window/auto/attackby()` returns `1` the windows neighbours icons update; this occurs whenever the window is fastened/unfastened from the floor.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8736