### PR TITLE
Prevent some cases of drunk stumbling and flipping

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -2070,3 +2070,15 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 			return copytext(message, 2)
 	src.singing = 0
 	. =  message
+
+// can stumble or flip while drunk
+/mob/living/proc/can_drunk_act()
+	if (!src.canmove || !isturf(src.loc))
+		return FALSE
+	if (length(src.grabbed_by))
+		for (var/obj/item/grab/G in src.grabbed_by)
+			if (istype(G, /obj/item/grab/block))
+				continue
+			if (G.state > GRAB_PASSIVE)
+				return FALSE
+	return !src.lying && !((length(src.grabbed_by) || src.pulled_by) && src.hasStatus("handcuffed"))

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1811,7 +1811,7 @@
 										continue
 									if (M in combatflipped)
 										continue
-									if (src.reagents && src.reagents.get_reagent_amount("ethanol") > 10)
+									if (src.reagents?.get_reagent_amount("ethanol") > 10 && src.can_drunk_act())
 										if (!iswrestler(src) && src.traitHolder && !src.traitHolder.hasTrait("glasscannon"))
 											src.remove_stamina(STAMINA_FLIP_COST)
 											src.stamina_stun()
@@ -1825,7 +1825,7 @@
 										playsound(src.loc, pick(sounds_punch), 100, 1)
 										var/turf/newloc = M.loc
 										src.set_loc(newloc)
-									else
+									else if (!(src.reagents?.get_reagent_amount("ethanol") > 30))
 										message = "<B>[src]</B> flips in [M]'s general direction."
 									break
 					if(length(combatflipped))

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -162,7 +162,7 @@ datum
 						if (ethanol_amt >= 15)
 							if(probmult(10)) H.emote(pick("hiccup", "burp", "mumble", "grumble"))
 							H.stuttering += 1
-							if (H.canmove && isturf(H.loc) && probmult(10))
+							if (H.can_drunk_act() && probmult(10))
 								step(H, pick(cardinal))
 							if (prob(20)) H.make_dizzy(rand(3,5) * mult)
 						if (ethanol_amt >= 25)
@@ -175,7 +175,7 @@ datum
 								H.emote(pick("hiccup", "burp"))
 							if (probmult(15))
 								H.stuttering += rand(1,10)
-							if (H.canmove && isturf(H.loc) && probmult(8))
+							if (H.can_drunk_act() && probmult(8))
 								step(H, pick(cardinal))
 						if (ethanol_amt >= 55)
 							liver_damage = 0.4
@@ -184,7 +184,7 @@ datum
 							H.stuttering += 1
 							if (probmult(33))
 								H.change_eye_blurry(10 , 50)
-							if (H.canmove && isturf(H.loc) && probmult(15))
+							if (H.can_drunk_act() && probmult(15))
 								step(H, pick(cardinal))
 							if(prob(4))
 								H.change_misstep_chance(20 * mult)


### PR DESCRIPTION
[BUG][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just prevents some cases of drunk stumbling and flipping.

It makes it so you can't drunk stumble while grabbed aggressively or higher, laying down, or handcuffed and being pulled or grabbed.

It also makes it so you can't drunk flip for the same conditions, minus laying down since it's not applicable there.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Preventing drunk stumbling while lying down was more aimed at making it so you don't stumble/move off surgery tables, which is inconvenient for the person performing surgery, but figured it could make sense for any case of lying down.

It also fixes a bug of being able to drunk stumble, and a bit less likely to happen, being able to drunk flip, to escape from being handcuffed when you can't normally escape that way.

It seemed a bit inconvenient that you could drunk flip into someone and knock them down when you are aggressively grabbed or higher when that's not usually the case.