### PR TITLE
Cure For Kuru

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4111,3 +4111,11 @@ datum
 			mix_phrase = "The mixture comes together slowly. It doesn't seem like it wants to be here."
 			required_reagents = list("poor_cement" = 1, "silicon_dioxide" = 5, "water" = 1)
 			result_amount = 7
+
+		prion_G127
+			name = "prion G127"
+			id = "prion_G127"
+			result = "prion_G127"
+			mix_phrase = "The proteins in the mixture mutate!"
+			required_reagents = list("dna_mutagen" = 1, "prions" = 1, "mannitol" = 1, "epinephrine" = 1, "diethylamine" = 1)
+			result_amount = 1

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -4112,10 +4112,10 @@ datum
 			required_reagents = list("poor_cement" = 1, "silicon_dioxide" = 5, "water" = 1)
 			result_amount = 7
 
-		prion_G127
-			name = "prion G127"
-			id = "prion_G127"
-			result = "prion_G127"
-			mix_phrase = "The proteins in the mixture mutate!"
+		enzyme_G127
+			name = "enzyme G127"
+			id = "enzyme_G127"
+			result = "enzyme_G127"
+			mix_phrase = "The enzymes in the mixture mutate!"
 			required_reagents = list("dna_mutagen" = 1, "prions" = 1, "mannitol" = 1, "epinephrine" = 1, "diethylamine" = 1)
 			result_amount = 1

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -1529,3 +1529,20 @@ datum
 			fluid_g = 220
 			fluid_b = 200
 			transparency = 230
+
+		medical/prion_G127 // cures kuru
+			name = "prion G127"
+			id = "prion_G127"
+			description = "A protein of prions that can cure kuru."
+			reagent_state = LIQUID
+			fluid_r = 251
+			fluid_g = 72
+			fluid_b = 196
+
+			on_mob_life(var/mob/living/M, var/mult = 1)
+				if(!M) M = holder.my_atom
+				for(var/datum/ailment_data/disease/virus in M.ailments)
+					if(probmult(10) && istype(virus.master,/datum/ailment/disease/kuru))
+						M.cure_disease(virus)
+				..()
+				return

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -1530,10 +1530,10 @@ datum
 			fluid_b = 200
 			transparency = 230
 
-		medical/prion_G127 // cures kuru
-			name = "prion G127"
-			id = "prion_G127"
-			description = "A protein of prions that can cure kuru."
+		medical/enzyme_G127 // cures kuru
+			name = "enzyme G127"
+			id = "enzyme_G127"
+			description = "An enzyme that can cure kuru."
 			reagent_state = LIQUID
 			fluid_r = 251
 			fluid_g = 72

--- a/code/modules/medical/diseases/kuru.dm
+++ b/code/modules/medical/diseases/kuru.dm
@@ -1,7 +1,7 @@
 /datum/ailment/disease/kuru
 	name = "Space Kuru"
 	max_stages = 4
-	cure = "Incurable"
+	cure = "Prion G127"
 	associated_reagent = "prions"
 	affected_species = list("Human")
 

--- a/code/modules/medical/diseases/kuru.dm
+++ b/code/modules/medical/diseases/kuru.dm
@@ -1,7 +1,7 @@
 /datum/ailment/disease/kuru
 	name = "Space Kuru"
 	max_stages = 4
-	cure = "Prion G127"
+	cure = "Enzyme G127"
 	associated_reagent = "prions"
 	affected_species = list("Human")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE] [BALANCE] [INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr adds a new chem, prion G127. It cures kuru, and is made with 1 part mannitol, epinephrine, prions, stable mutagen, and diethylamine. I based it off of the irl prion G127 protein.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, kuru is one of the only diseases that lack a cure. Combine this with the fact that it is super deadly, and you get guaranteed death with no counter-play. Adding in a chem that is difficult to make that can cure kuru will let med save some people, while keeping kuru as a useful kill disease.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Nanotrasen has developed a new cure for kuru, prion G127! It can be made by combining prions with stable mutagen, diethylamine, mannitol, and epinephrine.
```
