### PR TITLE
Allow players to deconstruct APCs

### DIFF
--- a/_std/machinery.dm
+++ b/_std/machinery.dm
@@ -26,6 +26,7 @@
 #define HIGHLOAD  (1<<4)		//! Status flag: using a lot of power
 #define EMP_SHORT (1<<5)		//! Status flag: 1 second long emp duration, avoid stacking emp faster than 1Hz
 #define REQ_PHYSICAL_ACCESS (1<<6) //! Can only be interacted with if adjacent and physical
+#define BUILDING (1<<7) //! Status flag: machine being built by a player
 
 //recharger stuff
 #define CELLRATE 0.002  // multiplier for watts per tick <> cell storage (eg: .002 means if there is a load of 1000 watts, 20 units will be taken from a cell per second)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -25,6 +25,7 @@ var/zapLimiter = 0
 	plane = PLANE_NOSHADOW_ABOVE
 	req_access = list(access_engineering_power)
 	object_flags = CAN_REPROGRAM_ACCESS
+	deconstruct_flags = DECON_ACCESS | DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER| DECON_WIRECUTTERS | DECON_MULTITOOL
 	netnum = -1		// set so that APCs aren't found as powernet nodes
 	text = ""
 	var/area/area
@@ -118,6 +119,17 @@ var/zapLimiter = 0
 		noaicontrol
 			noalerts = 1
 			aidisabled = 1
+
+/obj/machinery/power/apc/was_deconstructed_to_frame()
+	equipment = autoset(equipment, 0) // Make extra sure everything is off before we remove the terminal and stuff
+	lighting = autoset(lighting, 0)
+	environ = autoset(environ, 0)
+	qdel(terminal)
+	SPAWN(0.5 SECONDS)
+		src.update()
+
+/obj/machinery/power/apc/was_built_from_frame()
+	src.New()
 
 /proc/RandomAPCWires()
 	//to make this not randomize the wires, just set index to 1 and increment it in the flag for loop (after doing everything else).

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -278,6 +278,7 @@ MATERIAL
 				L["computer"] = "Console Frame (5 Sheets)"
 				L["hcomputer"] = "Computer Frame (5 Sheets)"
 				L["vending"] = "Vending Machine Frame (3 Sheets)"
+				L["apc"] = "APC Frame (10 Sheets)"
 		if (src?.material.material_flags & MATERIAL_CRYSTAL)
 			L["smallwindow"] = "Thin Window"
 			L["bigwindow"] = "Large Window (2 Sheets)"
@@ -512,6 +513,16 @@ MATERIAL
 					a_icon = 'icons/obj/vending.dmi'
 					a_icon_state = "standard-frame"
 					a_name = "a vending machine frame"
+
+				if("apc")
+					if(!amount_check(10,usr)) return
+					a_type = /obj/machinery/power/apc
+					a_amount = 1
+					a_cost = 10
+					a_icon = 'icons/obj/power.dmi' // or whatever
+					a_icon_state = "apc0"
+					a_name = "an APC frame"
+
 				if("construct")
 					var/turf/T = get_turf(usr)
 					var/area/A = get_area (usr)

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -980,11 +980,11 @@
 /obj/proc/was_built_from_frame(mob/user, newly_built)
 	.= 0
 
-/obj/proc/build_deconstruction_buttons()
+/obj/proc/build_deconstruction_buttons(mob/user as mob)
 	.= 0
 
 	if (deconstruct_flags & DECON_ACCESS)
-		if (src.has_access_requirements())
+		if (src.allowed(user))
 			return
 
 	if (deconstruct_flags)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allowing more station objects to be removed by players is a good move. Fixes the rotation issues on deconstructing and then reconstructing player-built APCs as well.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Players can scan and build APCs just fine, but not deconstruct? Wierd.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)MeggalBozale
(+)APCs can now be deconstructed.
```
