### PR TITLE
Fixes #8223, where rev flashes would use a standard flashes animation for flashing.

### DIFF
--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -418,6 +418,7 @@
 	name = "revolutionary flash"
 	desc = "A device that emits an extremely bright light when used. Something about this device forces people to revolt, when flashed by a revolution leader."
 	icon_state = "rev_flash"
+	animation_type = "rev_flash2"
 
 	process_burnout(mob/user as mob)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] --> 

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes the issue of the Revolution Flash using the flashing animation of a standard Flash. @ #8223 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
General cleanliness and it looks nicer not flashing between two colour palettes. Also it's my first bug-fix, and it's kinda nice. 🐌 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
