### PR TITLE
Adds a Mimicry Equipment Pack to Cargo

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -717,17 +717,27 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	containertype = /obj/storage/crate/pizza
 	containername = "Soft Soft Pizza Delivery"
 
+/datum/supply_packs/mimicry
+	name = "Mimicry Equipment"
+	desc = "Entertainers burn bright, only to fade away in silence."
+	category = "Civilian Department"
+	contains = list(/obj/item/storage/box/costume/mime/alt,
+		/obj/item/baguette,
+		/obj/item/cigpacket,
+		/obj/item/device/light/zippo)
+	cost = 500
+	containertype = /obj/storage/crate/packing
+	containername = "Mimicry Equipment"
+
 /datum/supply_packs/clown
 	name = "Comedy Equipment"
 	desc = "Entertainers burn bright but die young, outfit a new one with this crate!"
 	category = "Civilian Department"
-	contains = list(
-		/obj/item/storage/box/costume/clown/recycled,
+	contains = list(/obj/item/storage/box/costume/clown/recycled,
 		/obj/item/instrument/bikehorn,
 		/obj/item/bananapeel,
 		/obj/item/reagent_containers/food/snacks/pie/cream,
-		/obj/item/storage/box/balloonbox,
-	)
+		/obj/item/storage/box/balloonbox)
 	cost = 500
 	containertype = /obj/storage/crate/packing
 	containername = "Comedy Equipment"


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
There's a lot of traders, many are not well known. Geoff sells some mime gear, although just the clothing. I wanted to add this crate to contrast with the clown equipment, obviously bundled with standard mime gear. This contains a classic baguette, a duo of a pack of cigarettes and a zippo lighter, and the alternate mime costume.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A lot of items are at certain vendors that are generally not common knowledge, and the UI for traders is a little annoying to use, and requires a bank account and ID. The mime costumes are already sold from geoff in the clown hole, but I'd also like cargo to sell a mime bundle, to contrast with the clown bundle. Bundle has (generally) the entire basic mime aesthetic, instead of just the costume like Geoff. 

tl;dr I really like mime, and some other players really like mime. I'll be making mime traitor gear as well, as I'm aiming to have mime become a mainline job-slot instead of a post round in the future 🐌 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Momoberry
(+)Added a Mimicry crate to cargo. It comes with a standard issue baguette, full mime attire, a pack of cigarettes and a Zippo.
```
