### PR TITLE
Fixes small spiders be able to lift people

### DIFF
--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -27,8 +27,6 @@
   - walruses
   - floating eye
   - pigs
-  - clownspiders
-   - cluwnespiders
   - bats
    - angry bats
    - Dr. Acula

--- a/code/mob/living/critter/spider.dm
+++ b/code/mob/living/critter/spider.dm
@@ -144,6 +144,7 @@
 	health_brute = 30
 	health_burn = 30
 	good_grip = 0
+	can_grab = 0
 	max_skins = 1
 	venom1 = "toxin"
 	venom2 = "black_goop"
@@ -159,6 +160,7 @@
 	health_brute = 5
 	health_burn = 5
 	good_grip = 0
+	can_grab = 0
 	max_skins = 1
 	venom1 = "toxin"
 	venom2 = "black_goop"
@@ -174,10 +176,10 @@
 	density = 0
 	flags = TABLEPASS
 	fits_under_table = 1
-	can_grab = 0 // Causes issues with tablepass, and doesn't make too much sense
 	health_brute = 25
 	health_burn = 25
 	good_grip = 0
+	can_grab = 0 // Causes issues with tablepass, and doesn't make too much sense
 	max_skins = 1
 	venom1 = "toxin"
 	venom2 = "black_goop"
@@ -195,6 +197,7 @@
 	health_burn = 10
 	health_burn_vuln = 1.5
 	good_grip = 0
+	can_grab = 0
 	venom1 = "toxin"
 	venom2 = "cryostylane"
 	bitesound = "sound/impact_sounds/Crystal_Hit_1.ogg"
@@ -237,6 +240,7 @@
 	venom2 = "spidereggs"
 	max_skins = 8
 	good_grip = 1
+	can_grab = 1
 
 /mob/living/critter/spider/spacerachnid
 	name = "spacerachnid"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Small spiders can lift and throw people despite having small_critter limbs which would usually disable this behaviour.

This is because small_critter limbs have an issmallanimal() check, but baby spiders aren't of path critter/small_animal/foo they're of path /critter/spider/foo.

Noting that medium spiders had their grabs outright disabled previously, small spiders now also have their grabs outright disabled. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8768 
