### PR TITLE
Fixes poly/cluwne seeming castable whilst stunned

### DIFF
--- a/code/datums/abilities/wizard/animal.dm
+++ b/code/datums/abilities/wizard/animal.dm
@@ -64,7 +64,7 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 
 /datum/action/bar/polymorph
 	duration = 2 SECONDS
-	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_ACTION
 	id = "polymorph_spell"
 
 	var/datum/targetable/spell/animal/spell

--- a/code/datums/abilities/wizard/animal.dm
+++ b/code/datums/abilities/wizard/animal.dm
@@ -54,6 +54,10 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 			boutput(holder.owner, "Your target must be human!")
 			return 1
 
+		if(!can_act(holder.owner))
+			boutput(holder.owner, "You can't cast this whilst incapacitated!")
+			return 1
+
 		var/mob/living/carbon/human/H = target
 
 		if (targetSpellImmunity(H, TRUE, 2))
@@ -64,7 +68,7 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 
 /datum/action/bar/polymorph
 	duration = 2 SECONDS
-	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_ACTION
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	id = "polymorph_spell"
 
 	var/datum/targetable/spell/animal/spell

--- a/code/datums/abilities/wizard/cluwne.dm
+++ b/code/datums/abilities/wizard/cluwne.dm
@@ -30,7 +30,7 @@
 
 /datum/action/bar/icon/cluwne_spell
 	duration = 1.5 SECONDS
-	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_ACTION
 	id = "cluwne_spell"
 	icon = 'icons/ui/actions.dmi'
 	icon_state = "cluwne"

--- a/code/datums/abilities/wizard/cluwne.dm
+++ b/code/datums/abilities/wizard/cluwne.dm
@@ -20,6 +20,10 @@
 			boutput(holder.owner, "Your target must be human!")
 			return 1
 
+		if(!can_act(holder.owner))
+			boutput(holder.owner, "You can't cast this whilst incapacitated!")
+			return 1
+
 		var/mob/living/carbon/human/H = target
 
 		if (targetSpellImmunity(H, TRUE, 2))
@@ -30,7 +34,7 @@
 
 /datum/action/bar/icon/cluwne_spell
 	duration = 1.5 SECONDS
-	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_ACTION
+	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	id = "cluwne_spell"
 	icon = 'icons/ui/actions.dmi'
 	icon_state = "cluwne"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Following #6380 polymorph & cluwneing around were given action bars. 

The action bars are interruptible by stuns, so whilst you can start the action bar while stunned it will nearly always fail at around 70% completion and put the spell on cooldown.

This PR adds an check+early return to cast(), preventing these spells from being channelled if the user can't act.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The spell should either be successfully castable whilst stunned, or outright uncastable whilst stunned (ie: like in a sanctuary, or with the teleport scroll). Suggesting to the wizard player it is castable with an action bar, then having it inevitably fail at around 70%, isn't good feedback to the player.