### PR TITLE
Fixes cake reagent over-capping

### DIFF
--- a/code/modules/food_and_drink/cakes.dm
+++ b/code/modules/food_and_drink/cakes.dm
@@ -445,7 +445,7 @@
 	proc/unstack(var/mob/user)
 		var/obj/item/reagent_containers/food/snacks/cake/s = new /obj/item/reagent_containers/food/snacks/cake
 
-		src.reagents.trans_to(s,(src.reagents.total_volume/3))
+		src.reagents.trans_to(s,(src.reagents.total_volume/src.clayer))
 		for(var/food_effect in src.food_effects)
 			s.food_effects |= food_effect
 		s.quality = src.quality


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cakes are capped at 100u of reagents, resulting in a max of 300u for a three-tier cake.

When you unstack a cake, a third of the reagents are transferred to the unstacked cake - makes sense if there are three layers (100u transferred), less so if there are two (66 units transferred). In doing this it enables you to exceed the cap on the remaining piece of cake (133u). Additionally, depending on the order you restack the cake you may wind up losing some of your reagents when it rounds it down to the 200u cap.

This PR updates the amount of reagents transferred to be `total_volume / number of layers`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7331