### PR TITLE
Use TGUI lists for common warp/teleport options

### DIFF
--- a/code/modules/transport/pods/engine.dm
+++ b/code/modules/transport/pods/engine.dm
@@ -82,24 +82,26 @@
 			boutput(usr, "[ship.ship_message("Ship must have ZERO relative velocity (be stopped) to calculate warp destination!")]")
 			playsound(src, "sound/machines/buzz-sigh.ogg", 50)
 
-
 	var/list/beacons = list()
+	var/list/count = list() // associative list of number of times names in beacons are used (if possibly occuring more than once)
 	//This is bad and dumb. I should turn the by_type[/obj/warp_beacon] list into a manager datum, but this is already taking too long. -kyle
 	//I realize the possiblity of a bug where if you sit here ready to warp when it's about to change and then warp, but whatever
 #if defined(MAP_OVERRIDE_POD_WARS)
 	var/pilot_team = get_pod_wars_team_num(ship?.pilot)
 	for(var/obj/warp_beacon/pod_wars/W in by_type[/obj/warp_beacon])
 		if (W.current_owner == pilot_team)
-			beacons += W
+			beacons[W.name] = W
 #else
 	for(var/obj/warp_beacon/W in by_type[/obj/warp_beacon])
-		beacons += W
+		count[W.name]++
+		beacons["[W.name][count[W.name] == 1 ? null : " #[count[W.name]]"]"] = W
 #endif
 	for (var/obj/machinery/tripod/T in machine_registry[MACHINES_MISC])
 		if (istype(T.bulb, /obj/item/tripod_bulb/beacon))
-			beacons += T
+			count[T.name]++
+			beacons["[T.name][count[T.name] == 1 ? null : " #[count[T.name]]"]"] = T
 	wormholeQueued = 1
-	var/obj/target = input(usr, "Please select a location to warp to.", "Warp Computer") as null|obj in beacons
+	var/obj/target = beacons[tgui_input_list(usr, "Please select a location to warp to.", "Warp Computer", sortList(beacons))]
 	if(!target)
 		wormholeQueued = 0
 		return

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -691,7 +691,7 @@
 			user.show_text("Error: no working teleporters detected.", "red")
 			return
 
-		var/t1 = input(user, "Please select a teleporter to lock in on.", "Target Selection") in L
+		var/t1 = tgui_input_list(user, "Please select a teleporter to lock in on.", "Target Selection", L)
 		if ((user.equipped() != src) || user.stat || user.restrained())
 			return
 		if (t1 == "None (Cancel)")

--- a/code/obj/item/teleportation.dm
+++ b/code/obj/item/teleportation.dm
@@ -228,7 +228,7 @@ Frequency:
 		users += user // We're about to show the UI
 		var/t1
 		if(user.client)
-			t1 = input(user, "Please select a teleporter to lock in on.", "Target Selection") in L
+			t1 = tgui_input_list(user, "Please select a teleporter to lock in on.", "Target Selection", L)
 		else
 			t1 = pick(L)
 		users -= user // We're done showing the UI

--- a/code/obj/machinery/computer/teleporter.dm
+++ b/code/obj/machinery/computer/teleporter.dm
@@ -54,7 +54,7 @@
 				areaindex[tmpname] = 1
 			L[tmpname] = I
 
-	var/desc = input("Please select a location to lock in.", "Locking Computer") as null|anything in L
+	var/desc = tgui_input_list(usr, "Please select a location to lock in.", "Locking Computer", sortList(L))
 	if (isnull(desc))
 		return
 	src.locked = L[desc]


### PR DESCRIPTION
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just changes the lists used for warp/teleport options for pod warp beacons, teleport computer options, hand tele options, and teleport gun options to TGUI lists.

Also sorts the beacon and teleport computer options by alphabetical order.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
TGUI

Alphabetical order is nice