### PR TITLE
Fixes critter mouths eating cakes/loaves in a bite

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -375,7 +375,7 @@
 		if (isitem(target))
 			var/obj/item/potentially_food = target
 			if (potentially_food.edible)
-				potentially_food.Eat(user, user, 1)
+				potentially_food.attack(user, user)
 
 	help(mob/target, var/mob/user)
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Critters have a mouth limb that directly calls eat() on anything edible.

Cakes and loaves are edible, but they have overrides on attack to stop people demolishing them in one gulp. Mouths bypass this interaction and eat the cake, bypassing checks & interactions and leading to slightly buggy behaviour: the cake does not expect to be eaten, it expects to be sliced.

This PR replaces the eat() proc with the attack() proc to preserve the expected behaviour.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8242