### PR TITLE
Tiered CDC crates

### DIFF
--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -176,3 +176,21 @@
 		name = "Lab Monkey Crate"
 		desc = "Warning: Contains live monkeys!"
 		req_access = list(access_medical_lockers, access_tox_storage)
+
+	cdctier1
+		name = "Low-Risk CDC Pathogen Sample Crate"
+		desc = "Contains a pathogen sample with unknown properties."
+		//req access = special permits (access.dm)
+		spawn_contents = list(/obj/item/paper/cdc_pamphlet)
+
+	cdctier2
+		name = "Medium-Risk CDC Pathogen Sample Crate"
+		desc = "Contains a pathogen sample with unknown properties."
+		//req access = special permits (access.dm)
+		spawn_contents = list(/obj/item/paper/cdc_pamphlet)
+
+	cdctier3
+		name = "High-Risk CDC Pathogen Sample Crate"
+		desc = "Contains a pathogen sample with unknown properties."
+		//req access = special permits (access.dm)
+		spawn_contents = list(/obj/item/paper/cdc_pamphlet)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds three new secure medical crates to be implemented in the reworked CDC.

Patho Rework Design Docs (feel free to add comments there):
https://hackmd.io/@XyzzyThePretender/B10Kp-DP5
https://hackmd.io/@XyzzyThePretender/SJv6BtTP5
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Part of my rework plan to move the CDC's role away from finding cures to delivering bounty pathogens for investigation.
