### PR TITLE
Fixes signal registration on portable id computer

### DIFF
--- a/assets/maps/prefabs/prefab_customs_shuttle.dmm
+++ b/assets/maps/prefabs/prefab_customs_shuttle.dmm
@@ -430,7 +430,7 @@
 /turf/simulated/floor/damaged5,
 /area/prefab/crashed_hop_shuttle)
 "zB" = (
-/obj/item/acesscomputerunfolder,
+/obj/machinery/computer/card/portable,
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet/hop,
 /turf/simulated/floor/carpet/purple/standard/edge/se,

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -2751,7 +2751,7 @@ ABSTRACT_TYPE(/datum/manufacture/pod/weapon)
 	name = "ID Briefcase"
 	item_paths = list("CON-1","CRY-1","MET-1","gold")
 	item_amounts = list(25,15,35,2)
-	item_outputs = list(/obj/item/acesscomputerunfolder)
+	item_outputs = list(/obj/machinery/computer/card/portable)
 	time = 75 SECONDS
 	create = 1
 	category = "Resource"

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -66,6 +66,7 @@
 	density = 0
 	var/obj/item/cell/cell //We have limited power! Immersion!!
 	var/setup_charge_maximum = 15000
+	var/obj/item/luggable_computer/personal/case //The object that holds us when we're all closed up.
 	var/deployed = 1
 
 	New()
@@ -75,15 +76,27 @@
 		src.cell.maxcharge = setup_charge_maximum
 		src.cell.charge = src.cell.maxcharge
 
+		var/datum/component/foldable/fold_component = src.GetComponent(/datum/component/foldable) //Fold up into a briefcase the first spawn
+		if(!fold_component?.the_briefcase)
+			return
+		var/obj/item/objBriefcase/briefcase = fold_component.the_briefcase
+		if (briefcase)
+			briefcase.set_loc(get_turf(src))
+			src.set_loc(briefcase)
+
 	disposing()
 		if (src.cell)
 			src.cell.dispose()
 			src.cell = null
+
+		if (case && case.loc == src)
+			case.dispose()
+			case = null
+
 		..()
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/disk/data/floppy)) //IDK i just dont want to screw this up
-
 			return
 
 		else if (ispryingtool(W))

--- a/code/obj/machinery/computer/card.dm
+++ b/code/obj/machinery/computer/card.dm
@@ -66,7 +66,6 @@
 	density = 0
 	var/obj/item/cell/cell //We have limited power! Immersion!!
 	var/setup_charge_maximum = 15000
-	var/obj/item/luggable_computer/personal/case //The object that holds us when we're all closed up.
 	var/deployed = 1
 
 	New()
@@ -88,11 +87,6 @@
 		if (src.cell)
 			src.cell.dispose()
 			src.cell = null
-
-		if (case && case.loc == src)
-			case.dispose()
-			case = null
-
 		..()
 
 	attackby(obj/item/W as obj, mob/user as mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The HoP laptop briefcase currently doesn't initialise its foldable component properly, rendering it non-functional. 

This bug was accidently introduced by me in #8692 when I deleted the extra verbs: they'd been put there because the component only registers when the computer spawns (as I was doing when I was testing), but the prefab spawns it in briefcase form only. Without those extra verbs the briefcase can't be unfolded into the computer, so the component can't initialise.

This PR changes the prefab & manufacture recipe to spawn the computer instead of the briefcase, and adds a couple of lines to quickly fold it up into a briefcase the first time it spawns, preserving the look of the prefab.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8751, I feel guilty