### PR TITLE
Add an alternative Saltpetre recipe

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2864,7 +2864,7 @@ datum
 			reaction_speed = 1
 			mix_phrase = "A putrid odor pours from the mixture as a white crystalline substance leaches into the water."
 			mix_sound = 'sound/misc/fuse.ogg'
-
+			
 			on_reaction(var/datum/reagents/holder, created_volume)
 				// water byproduct
 				// some nitrification processes create additional water.
@@ -2872,7 +2872,7 @@ datum
 				
 				// fake pee and nasty poo
 				// make for a stinky stew
-				var/location = get_turf(holder.my_atom)
+				var/turf/location = get_turf(holder.my_atom)
 				location.fluid_react_single("miasma", created_volume, airborne = 1)
 
 		jenkem // moved this down so improperly mixed nutrients yield jenkem instead

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2850,6 +2850,25 @@ datum
 			result_amount = 3
 			mix_phrase = "A white crystalline substance condenses out of the mixture."
 			mix_sound = 'sound/misc/fuse.ogg'
+		
+		slow_saltpetre 
+			name = "slow saltpetre"
+			id = "slow_saltpetre"
+			result = "saltpetre" 
+			// compost turns ammonia into nitrates
+			// nitrates are extracted from "soil" with water
+			// potash purifies nitrates into saltpetre
+			required_reagents = list("ammonia" = 1, "poo" = 1, "potash" = 1, "water" = 1)
+			result_amount = 2
+			instant = 0 // Potash filtering takes some time.
+			reaction_speed = 1
+			mix_phrase = "A white crystalline substance leaches into the water."
+			mix_sound = 'sound/misc/fuse.ogg'
+
+			// water byproduct
+			// some nitrification processes create additional water.
+			on_reaction(var/datum/reagents/holder, created_volume)
+				holder.add_reagent("water", created_volume,,holder.total_temperature)
 
 		jenkem // moved this down so improperly mixed nutrients yield jenkem instead
 			name = "Jenkem"

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2855,10 +2855,11 @@ datum
 			name = "slow saltpetre"
 			id = "slow_saltpetre"
 			result = "saltpetre" 
-			// compost turns ammonia into nitrates
+			// fungus turns compost into ammonium
+			// compost bacteria turns ammonium into nitrates
 			// nitrates are extracted from "soil" with water
 			// potash purifies nitrates into saltpetre
-			required_reagents = list("ammonia" = 1, "poo" = 1, "potash" = 1, "water" = 1)
+			required_reagents = list("space_fungus" = 1, "poo" = 1, "potash" = 1, "water" = 1)
 			result_amount = 2
 			instant = 0 // Potash filtering takes time.
 			reaction_speed = 1
@@ -2869,9 +2870,7 @@ datum
 				// water byproduct
 				// some nitrification processes create additional water.
 				holder.add_reagent("water", created_volume,,holder.total_temperature)
-				
-				// fake pee and nasty poo
-				// make for a stinky stew
+				// disgusting
 				var/turf/location = get_turf(holder.my_atom)
 				location.fluid_react_single("miasma", created_volume, airborne = 1)
 

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2860,15 +2860,20 @@ datum
 			// potash purifies nitrates into saltpetre
 			required_reagents = list("ammonia" = 1, "poo" = 1, "potash" = 1, "water" = 1)
 			result_amount = 2
-			instant = 0 // Potash filtering takes some time.
+			instant = 0 // Potash filtering takes time.
 			reaction_speed = 1
-			mix_phrase = "A white crystalline substance leaches into the water."
+			mix_phrase = "A putrid odor pours from the mixture as a white crystalline substance leaches into the water."
 			mix_sound = 'sound/misc/fuse.ogg'
 
-			// water byproduct
-			// some nitrification processes create additional water.
 			on_reaction(var/datum/reagents/holder, created_volume)
+				// water byproduct
+				// some nitrification processes create additional water.
 				holder.add_reagent("water", created_volume,,holder.total_temperature)
+				
+				// fake pee and nasty poo
+				// make for a stinky stew
+				var/location = get_turf(holder.my_atom)
+				location.fluid_react_single("miasma", created_volume, airborne = 1)
 
 		jenkem // moved this down so improperly mixed nutrients yield jenkem instead
 			name = "Jenkem"

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2850,11 +2850,11 @@ datum
 			result_amount = 3
 			mix_phrase = "A white crystalline substance condenses out of the mixture."
 			mix_sound = 'sound/misc/fuse.ogg'
-		
-		slow_saltpetre 
+
+		slow_saltpetre
 			name = "slow saltpetre"
 			id = "slow_saltpetre"
-			result = "saltpetre" 
+			result = "saltpetre"
 			// fungus turns compost into ammonium
 			// compost bacteria turns ammonium into nitrates
 			// nitrates are extracted from "soil" with water
@@ -2865,13 +2865,13 @@ datum
 			reaction_speed = 1
 			mix_phrase = "A putrid odor pours from the mixture as a white crystalline substance leaches into the water."
 			mix_sound = 'sound/misc/fuse.ogg'
-			
-			on_reaction(var/datum/reagents/holder, created_volume)
+
+			on_reaction(var/datum/reagents/holder, var/created_volume)
 				// water byproduct
 				// some nitrification processes create additional water.
 				holder.add_reagent("water", created_volume,,holder.total_temperature)
 				// disgusting
-				var/turf/location = get_turf(holder.my_atom)
+				var/turf/location = pick(holder.covered_turf())
 				location.fluid_react_single("miasma", created_volume, airborne = 1)
 
 		jenkem // moved this down so improperly mixed nutrients yield jenkem instead


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature][help wanted][input wanted]

This is my first PR and my first time coding in DM so a confirmation that I didn't burn everything down would be great.

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Relevant previous discussion here: https://forum.ss13.co/showthread.php?tid=18910
This adds a new method for the industrial production of Saltpetre. 
This method is non-instant and produces miasma as it occurs. The recipe is:
```
(1) Space Fungus + (1) Compost + (1) Potash + (1) Water -> (2) Saltpetre + (2) Water
```
Previously discussed, a big concern was that this would make it too easy to produce large amounts of Black Powder rapidly. This method is not only time-gated and largely restricted to Botany, it is also somewhat obvious as it produces large amounts of miasma in the process due to the "decomposition" of the compost. It is comparable to buying formula from Cargo in terms of speed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

This is discussed more in the linked thread. In essence, large botany crews need a way to obtain large amounts of Saltpetre without grinding Cargo to dust, and using Urine directly is too slow.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ohjoy
(*)Added a new non-instant recipe for Saltpetre that produces miasma as it occurs: (1) Space Fungus + (1) Compost + (1) Potash + (1) Water -> (2) Saltpetre + (2) Water
```