### PR TITLE
Fixes some more wacky item health values

### DIFF
--- a/code/datums/controllers/sea_hotspot_controls.dm
+++ b/code/datums/controllers/sea_hotspot_controls.dm
@@ -1143,7 +1143,7 @@
 	burn_point = 220
 	burn_output = 900
 	burn_possible = 1
-	health = 100
+	health = 4
 	var/can_put_up = 1
 
 	examine(mob/user)

--- a/code/obj/item/book.dm
+++ b/code/obj/item/book.dm
@@ -19,7 +19,7 @@ Custom Books
 	burn_point = 400
 	burn_output = 1100
 	burn_possible = 1
-	health = 30
+	health = 4
 	//
 
 	stamina_damage = 2

--- a/code/obj/item/cigarette.dm
+++ b/code/obj/item/cigarette.dm
@@ -815,7 +815,7 @@
 	burn_point = 220
 	burn_output = 900
 	burn_possible = 1
-	health = 20
+	health = 4
 	var/match_amt = 6 // -1 for infinite
 	rand_pos = 1
 
@@ -894,7 +894,6 @@
 	burn_point = 220
 	burn_output = 600
 	burn_possible = 1
-	health = 10
 
 	/// 0 = unlit, 1 = lit, -1 is burnt out/broken or otherwise unable to be lit
 	var/on = 0

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -536,7 +536,6 @@
 	burn_point = 220
 	burn_output = 900
 	burn_possible = 1
-	health = 10
 
 	attackby(obj/item/W as obj, mob/user as mob)
 		if (istype(W, /obj/item/pen))

--- a/code/obj/item/clothing/shoes.dm
+++ b/code/obj/item/clothing/shoes.dm
@@ -14,11 +14,11 @@
 	compatible_species = list("human")
 	protective_temperature = 500
 	permeability_coefficient = 0.50
-		//cogwerks - burn vars
+	//cogwerks - burn vars
 	burn_point = 400
 	burn_output = 800
 	burn_possible = 1
-	health = 25
+	health = 5
 	tooltip_flags = REBUILD_DIST
 	var/step_sound = "step_default"
 	var/step_priority = STEP_PRIORITY_NONE

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -635,7 +635,7 @@
 	burn_output = 800
 	burn_possible = TRUE
 
-	health = 20
+	health = 4
 	rand_pos = FALSE
 	block_vision = TRUE
 
@@ -1575,7 +1575,6 @@
 	burn_possible = TRUE
 	burn_point = 450
 	burn_output = 800
-	health = 20
 
 	setupProperties()
 		..()

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -1209,7 +1209,6 @@
 	burn_point = 450
 	burn_output = 800
 	burn_possible = 1
-	health = 20
 	rand_pos = 0
 
 	setupProperties()

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -76,7 +76,6 @@ ABSTRACT_TYPE(/obj/item/turret_deployer)
 	desc = "A Nanotrasen Automatic Riot Control System Deployer. Use it in your hand to deploy."
 	icon_state = "st_deployer"
 	w_class = W_CLASS_BULKY
-	health = 125
 	icon_tag = "nt"
 	mats = list("INS-1"=10, "CON-1"=10, "CRY-1"=3, "MET-2"=2)
 	is_syndicate = 1

--- a/code/obj/item/deployable_turret.dm
+++ b/code/obj/item/deployable_turret.dm
@@ -16,6 +16,7 @@ ABSTRACT_TYPE(/obj/item/turret_deployer)
 	var/icon_tag = null
 	var/quick_deploy_fuel = 0
 	var/associated_turret = null //what kind of turret should this spawn?
+	var/turret_health = 100
 
 	New()
 		..()
@@ -38,7 +39,7 @@ ABSTRACT_TYPE(/obj/item/turret_deployer)
 
 	proc/spawn_turret(var/direct)
 		var/obj/deployable_turret/turret = new src.associated_turret(src.loc, direct)
-		turret.health = src.health // NO FREE REPAIRS, ASSHOLES
+		turret.health = src.turret_health // NO FREE REPAIRS, ASSHOLES
 		turret.damage_words = src.damage_words
 		turret.quick_deploy_fuel = src.quick_deploy_fuel
 		return turret
@@ -58,7 +59,7 @@ ABSTRACT_TYPE(/obj/item/turret_deployer)
 /obj/item/turret_deployer/syndicate
 	name = "NAS-T Deployer"
 	desc = "A Nuclear Agent Sentry Turret Deployer. Use it in your hand to deploy."
-	health = 250
+	turret_health = 250
 	icon_tag = "st"
 	quick_deploy_fuel = 2
 	associated_turret = /obj/deployable_turret/syndicate
@@ -74,6 +75,7 @@ ABSTRACT_TYPE(/obj/item/turret_deployer)
 /obj/item/turret_deployer/riot
 	name = "N.A.R.C.S. Deployer"
 	desc = "A Nanotrasen Automatic Riot Control System Deployer. Use it in your hand to deploy."
+	turret_health = 125
 	icon_state = "st_deployer"
 	w_class = W_CLASS_BULKY
 	icon_tag = "nt"
@@ -319,7 +321,7 @@ ABSTRACT_TYPE(/obj/deployable_turret)
 
 	proc/spawn_deployer()
 		var/obj/item/turret_deployer/deployer = new src.associated_deployer(src.loc)
-		deployer.health = src.health // NO FREE REPAIRS, ASSHOLES
+		deployer.turret_health = src.health // NO FREE REPAIRS, ASSHOLES
 		deployer.damage_words = src.damage_words
 		deployer.quick_deploy_fuel = src.quick_deploy_fuel
 		deployer.tooltip_rebuild = 1

--- a/code/obj/item/playing_cards.dm
+++ b/code/obj/item/playing_cards.dm
@@ -16,7 +16,6 @@
 	burn_point = 220
 	burn_output = 900
 	burn_possible = 2
-	health = 10
 	///what style of card sprite are we using?
 	var/card_style
 	///number of cards in a full deck (used for reference when updating stack size)

--- a/code/obj/item/space_cash.dm
+++ b/code/obj/item/space_cash.dm
@@ -17,7 +17,6 @@
 	burn_point = 400
 	burn_possible = 2
 	burn_output = 750
-	health = 10
 	amount = 1
 	max_stack = 1000000
 	stack_type = /obj/item/spacecash // so all cash types can stack iwth each other
@@ -242,7 +241,6 @@
 	throw_range = 8
 	w_class = W_CLASS_TINY
 	burn_possible = 0
-	health = 1000
 	amount = 1
 	max_stack = 1000000
 	stack_type = /obj/item/spacebux


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Some items still have weirdly high health values, this brings them more in line with the default health values.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flock balance, also it's just generally odd to have items with 1000 health despite not being able to burn.