### PR TITLE
Rename NT Security Consultant to NT Security Contractor.

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1219,7 +1219,7 @@
 			boutput(target, "<span class='alert'>You're already in a gang, you can't switch sides!</span>")
 			return
 
-		if(target.mind.assigned_role in list("Security Officer", "Security Assistant", "Vice Officer","Part-time Vice Officer","Head of Security","Captain","Head of Personnel","Communications Officer", "Medical Director", "Chief Engineer", "Research Director", "Detective", "Nanotrasen Security Consultant"))
+		if(target.mind.assigned_role in list("Security Officer", "Security Assistant", "Vice Officer","Part-time Vice Officer","Head of Security","Captain","Head of Personnel","Communications Officer", "Medical Director", "Chief Engineer", "Research Director", "Detective", "Nanotrasen Security Contractor"))
 			boutput(target, "<span class='alert'>You are too responsible to join a gang!</span>")
 			return
 

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -322,7 +322,7 @@
 				ucs += player.mind
 			else
 				var/role = player.mind.assigned_role
-				if(role in list("Captain", "Head of Security", "Security Assistant", "Head of Personnel", "Chief Engineer", "Research Director", "Medical Director", "Head of Mining", "Security Officer", "Security Assistant", "Vice Officer", "Part-time Vice Officer", "Detective", "AI", "Cyborg", "Nanotrasen Special Operative", "Nanotrasen Security Consultant","Communications Officer"))
+				if(role in list("Captain", "Head of Security", "Security Assistant", "Head of Personnel", "Chief Engineer", "Research Director", "Medical Director", "Head of Mining", "Security Officer", "Security Assistant", "Vice Officer", "Part-time Vice Officer", "Detective", "AI", "Cyborg", "Nanotrasen Special Operative", "Nanotrasen Security Contractor","Communications Officer"))
 					ucs += player.mind
 	//for(var/mob/living/carbon/human/player in mobs)
 

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -70,7 +70,7 @@
 	// Adjust reward based off target job to estimate risk level
 		if (job == "Head of Security" || job == "Captain")
 			return 3
-		else if (job == "Medical Director" || job == "Head of Personnel" || job == "Chief Engineer" || job == "Research Director" || job == "Nanotrasen Security Consultant" || job == "Security Officer" || job == "Detective")
+		else if (job == "Medical Director" || job == "Head of Personnel" || job == "Chief Engineer" || job == "Research Director" || job == "Nanotrasen Security Contractor" || job == "Security Officer" || job == "Detective")
 			return 2
 		else
 			return 1

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2419,7 +2419,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 // Use this one for late respawns to dael with existing antags. they are weaker cause they dont get a laser rifle or frags
 /datum/job/special/nt_security
 	linkcolor = "#3348ff"
-	name = "Nanotrasen Security Consultant"
+	name = "Nanotrasen Security Contractor"
 	limit = 1 // backup during HELL WEEK. players will probably like it
 	wages = PAY_TRADESMAN
 	requires_whitelist = 1

--- a/code/lists/jobs.dm
+++ b/code/lists/jobs.dm
@@ -80,12 +80,12 @@ var/list/page_departments = list(
 	return all_jobs
 
 var/list/command_jobs = list("Captain", "Medical Director", "Research Director", "Head of Personnel", "Head of Security", "Chief Engineer", "Communications Officer"/*"Clown"*/)
-var/list/security_jobs = list("Head of Security", "Nanotrasen Security Consultant", "Security Officer", "Security Assistant", "Detective")
+var/list/security_jobs = list("Head of Security", "Nanotrasen Security Contractor", "Security Officer", "Security Assistant", "Detective")
 var/list/engineering_jobs = list("Chief Engineer", "Engineer", "Mechanic", "Miner", "Quartermaster")
 var/list/medsci_jobs = list("Research Director", "Medical Director", "Medical Doctor", "Scientist", "Roboticist", "Geneticist")
 var/list/service_jobs = list("Head of Personnel", "Bartender", "Chef", "Botanist", "Rancher", "Clown", "Chaplain", "Janitor")
 
-var/list/command_gimmicks = list("Head of Mining", "Nanotrasen Security Consultant" /* NTSC isn't a gimmick role, but for the sake of sorting, it practically is*/)
+var/list/command_gimmicks = list("Head of Mining", "Nanotrasen Security Contractor" /* NTSC isn't a gimmick role, but for the sake of sorting, it practically is*/)
 var/list/security_gimmicks = list("Vice Officer", "Part-time Vice Officer", "Forensic Technician")
 var/list/engineering_gimmicks = list("Head of Mining", "Station Builder", "Atmospherish Technician", "Technical Assistant")
 var/list/medsci_gimmicks = list("Medical Specialist", "Toxins Researcher", "Chemist", "Research Assistant", "Medical Assistant", "Test Subject", "Pharmacist", "Psychiatrist", "Psychologist", "Psychotherapist", "Therapist", "Counselor")

--- a/code/mob/living/carbon/human/normal.dm
+++ b/code/mob/living/carbon/human/normal.dm
@@ -144,7 +144,7 @@
 /mob/living/carbon/human/normal/ntsc
 	New()
 		..()
-		JobEquipSpawned("Nanotrasen Security Consultant")
+		JobEquipSpawned("Nanotrasen Security Contractor")
 
 /mob/living/carbon/human/normal/inspector
 	New()

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -1366,7 +1366,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/soup)
 	var/style_step = 1
 
 	heal(var/mob/M)
-		if(ishuman(M) && (M.job in list("Security Officer", "Head of Security", "Detective", "Nanotrasen Security Consultant", "Security Assistant", "Part-time Vice Officer")))
+		if(ishuman(M) && (M.job in list("Security Officer", "Head of Security", "Detective", "Nanotrasen Security Contractor", "Security Assistant", "Part-time Vice Officer")))
 			src.heal_amt *= 2
 			..()
 			src.heal_amt /= 2

--- a/code/procs/crew_credits.dm
+++ b/code/procs/crew_credits.dm
@@ -36,7 +36,7 @@ var/global/crew_creds = null
 					continue
 
 				// Security?
-				if("Head of Security","Security Officer","Detective","Vice Officer","Part-time Vice Officer","Security Assistant","Lawyer","Nanotrasen Security Consultant","Nanotrasen Special Operative")
+				if("Head of Security","Security Officer","Detective","Vice Officer","Part-time Vice Officer","Security Assistant","Lawyer","Nanotrasen Security Contractor","Nanotrasen Special Operative")
 					round_security.Add(M)
 					continue
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[INPUT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Find-replace NT Security Consultant with NT Security Contractor and nothing else.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I believe this is a good compromise; taking into account the need to transition away from the connotations around the previous on-station NTSO appellation while also being more descriptive of the role of an NTSC in practice. It starts with the same letter so there shouldn't be any confusion with the other (and currently named as such) NTSO role.