### PR TITLE
Fixes borgs not being stunned by certain projectiles

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -882,7 +882,7 @@
 		if (damage < 1)
 			return
 
-		if(P.proj_data.ks_ratio == 0)
+		if(P.proj_data.ks_ratio <= 0.1)
 			src.do_disorient(clamp(P.power*4, P.proj_data.power*2, P.power+80), weakened = P.power*2, stunned = P.power*2, disorient = min(P.power, 80), remove_stamina_below_zero = 0) //bad hack, but it'll do
 			src.emote("twitch_v")// for the above, flooring stam based off the power of the datum is intentional
 		for (var/obj/item/roboupgrade/R in src.contents)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the `ks_ratio` threshold for triggering a borg to be stunned by a projectile from 0 to 0.1.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes certain damaging stun rounds not stunning borgs, namely signifier and flock incapacitor (post #8711)