### PR TITLE
Reorients two doors in Hemera

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -14996,6 +14996,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/external{
+	dir = 4;
 	name = "Compartment Hatch"
 	},
 /turf/simulated/floor,
@@ -15065,6 +15066,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
 	icon_state = "door_locked";
 	locked = 1;
 	name = "Damaged Glass Airlock";


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Two doors in Hemera are facing the wrong direction.

This PR reorients them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8800