### PR TITLE
Increases flash material cost.

### DIFF
--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -10,7 +10,7 @@
 	throw_range = 10
 	flags = FPRINT | TABLEPASS| CONDUCT | ONBELT
 	item_state = "electronic"
-	mats = 2
+	mats = list("MET-1" = 3, "CON-1" = 5, "DEN-1" = 5)
 
 	var/status = 1 // Bulb still functional?
 	var/secure = 1 // Access panel still secured?


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently the cost is 2 mats, which is split between crystal/metal/conductive. That means that you can probably make 50 flashes from the robotics fab due to how material costs are. This will bump that number to about 10 by default.  I'm not sure if this will be a big enough price, I'm not attached to this cost at all.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This MIGHT make flashes a little bit less of free thing from fabricators but not make them obnoxious to create.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)Increased the material cost of flashes
```
