### PR TITLE
Replaces old door and window in destiny telesci

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -20976,10 +20976,10 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "dHi" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/blast{
 	dir = 1;
 	doordir = "left";
@@ -21488,7 +21488,6 @@
 	name = "Crew Quarters P02"
 	})
 "dUl" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -21498,10 +21497,12 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/door/airlock/gannets/glass/chemistry{
-	name = "glass airlock-'Teleporter Pad'";
-	req_access_txt = ""
+/obj/machinery/door/airlock/pyro/glass{
+	dir = 4;
+	name = "Teleporter Pad";
+	req_access_txt = null
 	},
+/obj/firedoor_spawn,
 /obj/machinery/door/poddoor/blast{
 	dir = 1;
 	id = "scienceteleporter2";
@@ -21773,8 +21774,8 @@
 /turf/space,
 /area/station/engine/core)
 "eaG" = (
-/obj/wingrille_spawn/reinforced,
 /obj/cable,
+/obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/blast{
 	dir = 1;
 	doordir = "right";


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Refreshes a very old window and door in destiny telesci.
Before: 
![old telesci](https://user-images.githubusercontent.com/95481182/170931828-934762fc-6ba8-4bd7-b5da-8428ecd4e47e.png)
After:
![new telesci](https://user-images.githubusercontent.com/95481182/170931851-563cd2f7-4c22-43a1-b82e-dbf07d0b8992.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because I want to rip my eyes off each time I look at this.

