### PR TITLE
Makes operating tables deconstructable

### DIFF
--- a/code/obj/machinery/optable.dm
+++ b/code/obj/machinery/optable.dm
@@ -73,7 +73,6 @@
 	if (issilicon(user)) return
 	if (istype(W, /obj/item/electronics/scanner)) return // hack
 	if (istype(W, /obj/item/deconstructor)) return //deconstruct_flags
-	if (istype(W, /obj/item/deconstructor/borg)) return //deconstruct_flags
 	if (istype(W, /obj/item/grab))
 		if(ismob(W:affecting))
 			var/mob/M = W:affecting

--- a/code/obj/machinery/optable.dm
+++ b/code/obj/machinery/optable.dm
@@ -12,6 +12,7 @@
 
 	var/obj/machinery/computer/operating/computer = null
 	var/id = 0.0
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR
 
 /obj/machinery/optable/New()
 	..()
@@ -71,6 +72,8 @@
 /obj/machinery/optable/attackby(obj/item/W as obj, mob/user as mob)
 	if (issilicon(user)) return
 	if (istype(W, /obj/item/electronics/scanner)) return // hack
+	if (istype(W, /obj/item/deconstructor)) return //deconstruct_flags
+	if (istype(W, /obj/item/deconstructor/borg)) return //deconstruct_flags
 	if (istype(W, /obj/item/grab))
 		if(ismob(W:affecting))
 			var/mob/M = W:affecting


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes operating tables deconstructable using the deconstruction tool available to mechacnics or borgs.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I've seen people ask if it's possible for renovating operating rooms/robotics, with seemingly the only option being to mechscan then obliterate them. This makes it much easier to move them around and redesign rooms.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Munien
(+)Operating tables are now deconstructable. 
```
