### PR TITLE
Fix Flocktrace players not existing when dying in a Flockdrone

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -172,7 +172,7 @@
 		controller = null
 		src.update_health_icon()
 
-/mob/living/critter/flock/drone/proc/release_control_abrupt()
+/mob/living/critter/flock/drone/proc/release_control_abrupt(give_alert = TRUE)
 	src.flock?.hideAnnotations(src)
 	src.is_npc = TRUE
 	if(src.client && !controller)
@@ -196,7 +196,8 @@
 		controller.mind.key = key
 		controller.mind.current = controller
 		ticker.minds += controller.mind
-	boutput(controller, "<span class='flocksay'><b>\[SYSTEM: Control of drone [src.real_name] ended abruptly.\]</b></span>")
+	if (give_alert)
+		boutput(controller, "<span class='flocksay'><b>\[SYSTEM: Control of drone [src.real_name] ended abruptly.\]</b></span>")
 	if (istype(controller, /mob/living/intangible/flock/flockmind))
 		flock.removeAnnotation(src, FLOCK_ANNOTATION_FLOCKMIND_CONTROL)
 	else

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -93,6 +93,9 @@
 
 /mob/living/intangible/flock/trace/death(gibbed, suicide = FALSE)
 	. = ..()
+	if (istype(src.loc, /mob/living/critter/flock/drone))
+		var/mob/living/critter/flock/drone/F = src.loc
+		F.release_control()
 	if(src.client)
 		if (suicide)
 			flock_speak(null, "Flocktrace [src.real_name] relinquishes their computational designation and reintegrates themselves back into the Flock.", src.flock)

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -95,7 +95,9 @@
 	. = ..()
 	if (istype(src.loc, /mob/living/critter/flock/drone))
 		var/mob/living/critter/flock/drone/F = src.loc
-		F.release_control()
+		F.release_control_abrupt(FALSE)
+		if (F.z == Z_LEVEL_STATION)
+			flock_speak(null, "Control of drone [F.real_name] surrended.", src.flock)
 	if(src.client)
 		if (suicide)
 			flock_speak(null, "Flocktrace [src.real_name] relinquishes their computational designation and reintegrates themselves back into the Flock.", src.flock)


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where Flocktraces, when dying inside a Flockdrone for compute reasons, would be in a state of not existing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, fixes #8817.