### PR TITLE
Fixes guardbuddies not sending perp name

### DIFF
--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -1986,10 +1986,6 @@
 			boutput(task.arrest_target, "<span class='alert'>[master] gently handcuffs you!  It's like the cuffs are hugging your wrists.</span>")
 			task.arrest_target:set_clothing_icon_dirty()
 
-		task.mode = 0
-		task.drop_arrest_target()
-		master.set_emotion("smug")
-
 		if (length(task.arrested_messages))
 			var/arrest_message = pick(task.arrested_messages)
 			master.speak(arrest_message)
@@ -1999,6 +1995,11 @@
 		var/turf/LT_loc = get_turf(last_target)
 		if(!LT_loc)
 			LT_loc = get_turf(master)
+
+		task.mode = 0
+		task.drop_arrest_target()
+		master.set_emotion("smug")
+
 		//////PDA NOTIFY/////
 		var/datum/signal/pdaSignal = get_free_signal()
 		var/message2send


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
 When guardbuddies arrest someone, they send out a pda message to the science mailgroup. However, sometimes it only says in the pda message where the person has been detained, not whom.

As discussed in #5866 the bug occurs because the task clears the value `arrest_target`, THEN tries to save the `arrest_target` as `last_target`; it always ends up saving a null `last_target`. The PDA message is based off of `last_target`.

This PR just moves the line that saves the `arrest_target` above the line that clears `arrest_target`.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #7767
Fixes #5866