### PR TITLE
Makes Strychnine Harder to flush

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1843,6 +1843,7 @@ datum
 			fluid_g = 244
 			fluid_b = 244
 			transparency = 255
+			flushing_multiplier = 0.25
 			depletion_rate = 0.2
 			var/ticks = 0
 			var/stage = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[LABEL][balancing]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I don't expect this to change much at all, i rarely see strychnine in use, but it's a real ~~horrible~~ cool chem and this will make it even more so! Getting rid of it shouldn't be super hard still, just you'll get to see more of the bone hurt juice after someone has it in them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This chem is cool but not used very often due to it's relatively slower action and ease of removal, making it a tad harder to get rid of would make it more dramatic, while still not exactly "meta" or super stackable with other chemicals. Also Strychnine IRL is kinda hard to get rid of your system so that's that.

```changelog
(u)Hans
(+)Made strychnine harder to flush.
```
