### PR TITLE
Change flock absorbtion to lifeprocess, add mult support

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -1066,7 +1066,6 @@
 			temp.setMaterialAppearance(temp.material)
 	..()
 
-
 ABSTRACT_TYPE(/datum/lifeprocess/flock)
 /datum/lifeprocess/flock/absorbtion
 	process()

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -42,6 +42,7 @@
 
 	..()
 	abilityHolder = new /datum/abilityHolder/critter/flockdrone(src)
+	add_lifeprocess(/datum/lifeprocess/flock/absorbtion)
 
 	SPAWN(3 SECONDS)
 		//this is terrible, but diffracting a drone immediately causes a runtime
@@ -409,62 +410,6 @@
 				qdel(G) //in case they don't fall over from our shock
 			src.antigrab_counter = 0
 
-	var/obj/item/I = absorber.item
-
-	if (!I)
-		return
-
-	var/health_absorbed = min(src.health_absorb_rate, I.health)
-	if (absorber.instant_absorb && !absorber.ignore_amount)
-		boutput(src, "<span class='alert'>[I] is weak enough that it breaks apart instantly!</span>")
-		src.resources += round(src.resources_per_health * health_absorbed * I.amount)
-	else
-		I.health -= health_absorbed
-		src.resources += round(src.resources_per_health * health_absorbed)
-		if (I.health > 0 || (I.health == 0 && I.amount > 1 && !absorber.ignore_amount))
-			playsound(src, "sound/effects/sparks[rand(1, 6)].ogg", 50, 1)
-		if (I.health > 0)
-			return
-		if (I.amount > 1 && !absorber.ignore_amount)
-			if (initial(I.health))
-				I.health = initial(I.health)
-			else
-				I.set_health()
-			I.change_stack_amount(-1)
-			return
-
-	playsound(src, "sound/impact_sounds/Energy_Hit_1.ogg", 50, 1)
-
-	if(length(I.contents))
-		var/anything_tumbled = FALSE
-		for(var/obj/O in I.contents)
-			if(istype(O, /obj/item))
-				O.set_loc(src.loc)
-				anything_tumbled = TRUE
-			else
-				qdel(O)
-		if(anything_tumbled)
-			src.visible_message("<span class='alert'>The contents of [I] tumble out of [src].</span>",
-				"<span class='alert'>The contents of [I] tumble out of you.</span>",
-				"<span class='alert'>You hear things fall onto the floor.</span")
-
-	if (istype(I, /obj/item/flockcache))
-		var/obj/item/flockcache/C = I
-		src.resources += C.resources
-		boutput(src, "<span class='notice'>You break down the resource cache, adding <span class='bold'>[C.resources]</span> resource[C.resources > 1 ? "s" : null] to your own. </span>")
-	else if(istype(I, /obj/item/organ/heart/flock))
-		var/obj/item/organ/heart/flock/F = I
-		if (F.resources == 0)
-			boutput(src, "<span class='notice'>[F]'s resource cache is assimilated, but contains no resources.</span>")
-		else
-			src.resources += F.resources
-			boutput(src, "<span class='notice'>You assimilate [F]'s resource cache, adding <span class='bold'>[F.resources]</span> resource[F.resources > 1 ? "s" : null] to your own.</span>")
-	else
-		boutput(src, "<span class='notice'>You finish converting [I] into resources.</span>")
-	qdel(I)
-	absorber.item = null
-
-
 /mob/living/critter/flock/drone/process_move(keys)
 	if(keys & KEY_RUN && src.resources >= 1)
 		if(!src.floorrunning && isfeathertile(src.loc))
@@ -690,6 +635,7 @@
 	remove_lifeprocess(/datum/lifeprocess/sight)
 	remove_lifeprocess(/datum/lifeprocess/skin)
 	remove_lifeprocess(/datum/lifeprocess/statusupdate)
+	remove_lifeprocess(/datum/lifeprocess/flock/absorbtion)
 
 /mob/living/critter/flock/drone/death(var/gibbed)
 	if(src.controller)
@@ -1119,3 +1065,63 @@
 		if(temp.material)
 			temp.setMaterialAppearance(temp.material)
 	..()
+
+
+ABSTRACT_TYPE(/datum/lifeprocess/flock)
+/datum/lifeprocess/flock/absorbtion
+	process()
+		var/mob/living/critter/flock/drone/flock_owner = owner
+		if (!istype(flock_owner)) return
+		var/obj/item/I = flock_owner.absorber.item
+		if (!I)
+			return
+		var/mult = get_multiplier()
+		var/health_absorbed = min((flock_owner.health_absorb_rate * mult), I.health)
+		if (flock_owner.absorber.instant_absorb && !flock_owner.absorber.ignore_amount)
+			boutput(flock_owner, "<span class='alert'>[I] is weak enough that it breaks apart instantly!</span>")
+			flock_owner.resources += round(flock_owner.resources_per_health * health_absorbed * I.amount)
+		else
+			I.health -= health_absorbed
+			flock_owner.resources += round(flock_owner.resources_per_health * health_absorbed)
+			if (I.health > 0 || (I.health == 0 && I.amount > 1 && !flock_owner.absorber.ignore_amount))
+				playsound(flock_owner, "sound/effects/sparks[rand(1, 6)].ogg", 50, 1)
+			if (I.health > 0)
+				return
+			if (I.amount > 1 && !flock_owner.absorber.ignore_amount)
+				if (initial(I.health))
+					I.health = initial(I.health)
+				else
+					I.set_health()
+				I.change_stack_amount(-1)
+				return
+
+		playsound(flock_owner, "sound/impact_sounds/Energy_Hit_1.ogg", 50, 1)
+
+		if(length(I.contents))
+			var/anything_tumbled = FALSE
+			for(var/obj/O in I.contents)
+				if(istype(O, /obj/item))
+					O.set_loc(flock_owner.loc)
+					anything_tumbled = TRUE
+				else
+					qdel(O)
+			if(anything_tumbled)
+				flock_owner.visible_message("<span class='alert'>The contents of [I] tumble out of [flock_owner].</span>",
+					"<span class='alert'>The contents of [I] tumble out of you.</span>",
+					"<span class='alert'>You hear things fall onto the floor.</span")
+
+		if (istype(I, /obj/item/flockcache))
+			var/obj/item/flockcache/C = I
+			flock_owner.resources += C.resources
+			boutput(flock_owner, "<span class='notice'>You break down the resource cache, adding <span class='bold'>[C.resources]</span> resource[C.resources > 1 ? "s" : null] to your own. </span>")
+		else if(istype(I, /obj/item/organ/heart/flock))
+			var/obj/item/organ/heart/flock/F = I
+			if (F.resources == 0)
+				boutput(flock_owner, "<span class='notice'>[F]'s resource cache is assimilated, but contains no resources.</span>")
+			else
+				flock_owner.resources += F.resources
+				boutput(flock_owner, "<span class='notice'>You assimilate [F]'s resource cache, adding <span class='bold'>[F.resources]</span> resource[F.resources > 1 ? "s" : null] to your own.</span>")
+		else
+			boutput(flock_owner, "<span class='notice'>You finish converting [I] into resources.</span>")
+		qdel(I)
+		flock_owner.absorber.item = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Moves absorbtion code out of `Life()` and into its own `lifeprocess`
* Health removed from item now uses life loop multiplier


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Life loop is very slow on live server by design
