### PR TITLE
Allow Flockdrones to pass through Flock cages

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -300,6 +300,9 @@
 /mob/living/critter/flock/drone/Cross(atom/movable/mover)
 	if(isflockmob(mover))
 		return TRUE
+	else if (istype(mover, /obj/flock_structure/cage))
+		animate_flock_passthrough(src)
+		return TRUE
 	else
 		return !src.density
 

--- a/code/obj/flock/cage.dm
+++ b/code/obj/flock/cage.dm
@@ -13,6 +13,7 @@
 	alpha = 192
 	anchored = FALSE
 	hitTwitch = FALSE
+	passthrough = TRUE
 	var/atom/occupant = null
 	var/obj/target = null
 	var/eating_occupant = FALSE
@@ -45,16 +46,6 @@
 				var/mob/living/M = iced
 				M.addOverlayComposition(/datum/overlayComposition/flockmindcircuit)
 			occupant = iced
-
-		UpdateIcon()
-
-	update_icon()
-		. = ..()
-		src.underlays = list()
-		for(var/atom/O in src.contents)
-			src.underlays += O.appearance
-		UpdateOverlays(image(src.icon,src.icon_state,layer = EFFECTS_LAYER_UNDER_1),"icecube_layer")
-
 
 	proc/getHumanPiece(var/mob/living/carbon/human/H)
 		// prefer inventory items before limbs, and limbs before organs
@@ -163,10 +154,6 @@
 			src.visible_message("<span class='alert bold'>[src] rips what's left of its occupant to shreds!</span>")
 			flock.achieve(FLOCK_ACHIEVEMENT_CAGE_HUMAN)
 
-	Enter(atom/movable/O)
-		. = ..()
-		UpdateIcon()
-
 	proc/spawnEgg()
 		src.visible_message("<span class='notice'>[src] spits out a device!</span>")
 		var/obj/flock_structure/egg/egg = new(get_turf(src), src.flock)
@@ -237,8 +224,6 @@
 				reagents.add_reagent(target_fluid, 10)
 				qdel(target)
 				target = null
-
-		UpdateIcon()
 
 		if(occupant)
 			if(eating_occupant && prob(20))


### PR DESCRIPTION
[QOL][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that Flockdrones can pass through Flock cages.

Removes Flock cages from showing their contents inside the cage for the moment, otherwise Flockdrones appear to be under the cage and can still fire out. Not sure if there was a way to get around having outside mobs appear over while contents appear under.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flockdrones crowding up the areas they're in, especially at front lines of attackers, makes it a lot harder to bring someone who's been successfully caged into your base without it constantly getting stuck on drones.
