### PR TITLE
fixes hydra ammobag interaction

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1534,6 +1534,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 	max_ammo_capacity = 20
 	ammo_cats = list(AMMO_PISTOL_22)
 	default_magazine = /obj/item/ammo/bullets/bullet_22/smartgun
+	ammobag_magazines = list(/obj/item/ammo/bullets/bullet_22/smartgun)
 
 	New()
 		..()


### PR DESCRIPTION
## About the PR
adds a single line of code to make the ammo bag properly produce the same ammo the hydra now actually uses. if there's any other guns that improperly interact with the ammo bag i guess i could fix those too while this pr is open - but i only really noticed this
## Why's this needed?
i think the hydra is neat and this thing kind of bugged me when i was goofing around with it in the vr murderdome
## Changelog
i did not think it was necessary