### PR TITLE
Allow borg satchels and scoops to dump contained ore

### DIFF
--- a/code/modules/materials/Mat_Processing.dm
+++ b/code/modules/materials/Mat_Processing.dm
@@ -137,7 +137,7 @@
 			S.UpdateIcon()
 			return
 
-		if (W.cant_drop) //For borg held items
+		else if (W.cant_drop) //For borg held items
 			boutput(user, "<span class='alert'>You can't put that in [src] when it's attached to you!</span>")
 			return ..()
 

--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -885,9 +885,7 @@
 			. = TRUE
 
 	attackby(obj/item/W as obj, mob/user as mob)
-		if (W.cant_drop) //For borg held items
-			boutput(user, "<span class='alert'>You can't put that in [src] when it's attached to you!</span>")
-			return ..()
+
 		if (istype(W, /obj/item/ore_scoop))
 			var/obj/item/ore_scoop/scoop = W
 			W = scoop.satchel
@@ -909,11 +907,12 @@
 			if (.)
 				user.visible_message("<b>[user.name]</b> loads [W] into [src].")
 				playsound(src, sound_load, 40, 1)
-
 		else if (load_reclaim(W, user))
 			boutput(user, "You load [W] into [src].")
 			playsound(src, sound_load, 40, 1)
-
+		else if (W.cant_drop)
+			boutput(user, "<span class='alert'>You can't put that in [src] when it's attached to you!</span>")
+			return ..()
 		else
 			. = ..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves some cant_drop checks to after ore scoop/satchel dumping tests

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Matches how carbons handle ore dumping.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(+)Cyborgs can now dump the contents of their ore scoop and satchels into material processors and the Rockbox
```
