### PR TITLE
Adds the jester costume set to Geoff's sell list

### DIFF
--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -2242,6 +2242,15 @@
 	comtype = /obj/item/storage/box/costume/mime/alt
 	desc = "This stuff will give you an edge in charades."
 
+/datum/commodity/costume/jester
+	comname = "Jester Costume Set."
+	comtype = /obj/item/storage/box/costume/jester
+	desc = "Travel back in time and become the medieval version of a clown. (does not provide time travel)"
+	price = 100 //the clown starts with 100 credits
+	baseprice = 100
+	upperfluc = 150
+	lowerfluc = -100
+
 /datum/commodity/backpack/breadpack
 	comname = "Bag-uette"
 	comtype = /obj/item/storage/backpack/breadpack

--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -2245,7 +2245,7 @@
 /datum/commodity/costume/jester
 	comname = "Jester Costume Set."
 	comtype = /obj/item/storage/box/costume/jester
-	desc = "Travel back in time and become the medieval version of a clown. (does not provide time travel)"
+	desc = "Travel back in time and become the medieval version of a clown. (Does not provide time travel)"
 	price = 300 //gotta work for it a little
 	baseprice = 100
 	upperfluc = 150

--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -2246,7 +2246,7 @@
 	comname = "Jester Costume Set."
 	comtype = /obj/item/storage/box/costume/jester
 	desc = "Travel back in time and become the medieval version of a clown. (does not provide time travel)"
-	price = 100 //the clown starts with 100 credits
+	price = 300 //standard price for most other costumes
 	baseprice = 100
 	upperfluc = 150
 	lowerfluc = -100

--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -2246,7 +2246,7 @@
 	comname = "Jester Costume Set."
 	comtype = /obj/item/storage/box/costume/jester
 	desc = "Travel back in time and become the medieval version of a clown. (does not provide time travel)"
-	price = 300 //standard price for most other costumes
+	price = 300 //gotta work for it a little
 	baseprice = 100
 	upperfluc = 150
 	lowerfluc = -100

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -1082,6 +1082,7 @@
 		src.goods_sell += new /datum/commodity/costume/mintwitch(src)
 		src.goods_sell += new /datum/commodity/costume/mime(src)
 		src.goods_sell += new /datum/commodity/costume/mime/alt(src) //suspenders and such
+		src.goods_sell += new /datum/commodity/costume/jester(src)
 		src.goods_sell += new /datum/commodity/backpack/breadpack(src)
 		src.goods_sell += new /datum/commodity/backpack/bearpack(src)
 		src.goods_sell += new /datum/commodity/backpack/turtlebrown(src)

--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -294,7 +294,7 @@
 
 /obj/item/storage/box/costume/jester
 	name = "jester costume"
-	desc = "a box that contains a jesters outfit"
+	desc = "A box that contains a jester's outfit"
 	spawn_contents = list(
 		/obj/item/clothing/head/jester,
 		/obj/item/clothing/mask/jester,

--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -292,6 +292,15 @@
 		/obj/item/clothing/shoes/black,
 	)
 
+/obj/item/storage/box/costume/jester
+	name = "jester costume"
+	desc = "a box that contains a jesters outfit"
+	spawn_contents = list(
+		/obj/item/clothing/head/jester,
+		/obj/item/clothing/mask/jester,
+		/obj/item/clothing/under/gimmick/jester,
+		/obj/item/clothing/shoes/jester,
+	)
 
 /obj/item/storage/box/costume/robuddy
 	name = "guardbuddy costume"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds the jester costume set to Geoff's sell list, which has the hat, mask, jumpsuit, and shoes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
as far as I can tell there is currently no way to get the full set of items anymore, and that is quite the shame to clowns who want to wear something that isn't a clown outfit.
