### PR TITLE
Adds special goggles to oshan.

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -44463,6 +44463,12 @@
 /obj/machinery/synthomatic,
 /turf/simulated/floor/green,
 /area/research_outpost/pathology)
+"cwj" = (
+/obj/item/storage/secure/ssafe/diner_arcade{
+	pixel_x = -30
+	},
+/turf/simulated/floor/black,
+/area/diner/dining)
 "cxr" = (
 /obj/item/reagent_containers/food/drinks/bottle/fancy_beer,
 /turf/simulated/floor/plating/random,
@@ -122083,7 +122089,7 @@ aqn
 aPB
 cab
 cai
-cao
+cwj
 aPB
 caG
 caJ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title says it all. Should let people get these when the map is oshan.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These things are pretty cool but it's kinda a bummer to not be able to get them on this map.
