### PR TITLE
Fixes the flash recipes.

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1329,8 +1329,8 @@ ABSTRACT_TYPE(/datum/manufacture)
 
 /datum/manufacture/flash
 	name = "Flash"
-	item_paths = list("CRY-1","CON-1")
-	item_amounts = list(2,2)
+	item_paths = list("MET-1","CON-1""CRY-1")
+	item_amounts = list(3,5,5)
 	item_outputs = list(/obj/item/device/flash)
 	time = 15 SECONDS
 	create = 1

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1329,7 +1329,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 
 /datum/manufacture/flash
 	name = "Flash"
-	item_paths = list("MET-1","CON-1""CRY-1")
+	item_paths = list("MET-1","CON-1","CRY-1")
 	item_amounts = list(3,5,5)
 	item_outputs = list(/obj/item/device/flash)
 	time = 15 SECONDS

--- a/code/obj/item/device/flash.dm
+++ b/code/obj/item/device/flash.dm
@@ -10,7 +10,7 @@
 	throw_range = 10
 	flags = FPRINT | TABLEPASS| CONDUCT | ONBELT
 	item_state = "electronic"
-	mats = list("MET-1" = 3, "CON-1" = 5, "DEN-1" = 5)
+	mats = list("MET-1" = 3, "CON-1" = 5, "CRY-1" = 5)
 
 	var/status = 1 // Bulb still functional?
 	var/secure = 1 // Access panel still secured?


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Turns out, manufacturer recipes are separate than the item's material cost after being scanned by a mech scanner, never knew that. Also I mixed up crystal mats with dense mats.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
My bad, I really I should've investigated a bit further in #8809.
