### PR TITLE
Put limit on ruptures per pipeline to reduce plate spinning

### DIFF
--- a/code/datums/pipeline.dm
+++ b/code/datums/pipeline.dm
@@ -5,6 +5,7 @@ datum/pipeline
 	var/list/obj/machinery/atmospherics/pipe/edges //Used for building networks
 
 	var/datum/pipe_network/network
+	var/list/cooldowns
 
 	var/alert_pressure = 0
 

--- a/code/modules/atmospherics/machinery/pipe.dm
+++ b/code/modules/atmospherics/machinery/pipe.dm
@@ -339,7 +339,7 @@ obj/machinery/atmospherics/pipe
 
 			var/pressure_difference = pressure - MIXTURE_PRESSURE(environment)
 
-			if(can_rupture && !GET_COOLDOWN(src, "rupture_protection") && pressure_difference > fatigue_pressure)
+			if(can_rupture && !GET_COOLDOWN(parent, "pipeline_rupture_protection") && !GET_COOLDOWN(src, "rupture_protection") && pressure_difference > fatigue_pressure)
 				var/rupture_prob = (pressure_difference - fatigue_pressure)/50000
 				if(prob(rupture_prob))
 					rupture(pressure_difference)
@@ -362,6 +362,8 @@ obj/machinery/atmospherics/pipe
 					if(prob(5/i))
 						new_rupture = i + 1
 						break
+			if(new_rupture > src.ruptured)
+				ON_COOLDOWN(parent, "pipeline_rupture_protection", 8 SECONDS + rand(4 SECONDS, 20 SECONDS))
 			ruptured = max(src.ruptured, new_rupture, 1)
 			src.desc = "A one meter section of ruptured pipe still looks salvageable through some careful welding."
 			UpdateIcon()
@@ -460,7 +462,7 @@ obj/machinery/atmospherics/pipe
 			src.ruptured = 0
 			desc = initial(desc)
 			UpdateIcon()
-			ON_COOLDOWN(src, "rupture_protection", 20 SECONDS + rand(10 SECONDS, 80 SECONDS))
+			ON_COOLDOWN(src, "rupture_protection", 20 SECONDS + rand(10 SECONDS, 100 SECONDS))
 
 		proc/reconstruct_pipe(mob/M, obj/item/rods/R)
 			if(istype(R) && istype(M))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol][balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an additional cooldown to the pipeline when a new rupture occurs or when gets worse.
Cooldown increased to allow for up to 20 seconds additional time for the next rupture to occur.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Good Idea: https://github.com/goonstation/goonstation/pull/8735#issuecomment-1138015952
Reduces plate spinning.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(+)Limits how quickly other pipes in the same pipeline can rupture.
```
