### PR TITLE
Flock grilles can't be wirecuttered, and chairs are our friends

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -859,7 +859,7 @@
 		return
 
 	// CONVERT TURF
-	if(!isturf(target) && (!HAS_ATOM_PROPERTY(target,PROP_ATOM_FLOCK_THING) || istype(target, /obj/lattice/flock)) && !istype(target, /obj/structure/girder))
+	if(!isturf(target) && (!HAS_ATOM_PROPERTY(target,PROP_ATOM_FLOCK_THING) || istype(target, /obj/lattice/flock)))
 		target = get_turf(target)
 
 	if(istype(target, /turf) && !istype(target, /turf/simulated) && !istype(target, /turf/space))

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -341,7 +341,7 @@
 			var/obj/O = new structurepath(target)
 			animate_flock_convert_complete(O)
 			playsound(target, "sound/misc/flockmind/flockdrone_build_complete.ogg", 40, 1)
-
+			O.AddComponent(/datum/component/flock_interest, F?.flock)
 /////////////////////////////////////////////////////////////////////////////////
 // EGG ACTION
 /////////////////////////////////////////////////////////////////////////////////

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -25,7 +25,7 @@
 	..()
 	setMaterial(getMaterial("gnesis"))
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOCK_THING, src)
-	src.AddComponent(/datum/component/flock_protection)
+	src.AddComponent(/datum/component/flock_protection, report_attack=FALSE)
 
 /obj/table/flock/special_desc(dist, mob/user)
 	if (!isflockmob(user))

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -80,7 +80,7 @@
 	..()
 	setMaterial(getMaterial("gnesis"))
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOCK_THING, src)
-	src.AddComponent(/datum/component/flock_protection)
+	src.AddComponent(/datum/component/flock_protection, report_unarmed=FALSE)
 
 /obj/stool/chair/comfy/flock/special_desc(dist, mob/user)
 	if (!isflockmob(user))

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -80,7 +80,7 @@
 	..()
 	setMaterial(getMaterial("gnesis"))
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOCK_THING, src)
-	src.AddComponent(/datum/component/flock_protection, report_unarmed=FALSE)
+	src.AddComponent(/datum/component/flock_protection, report_unarmed=FALSE, report_attack=FALSE)
 
 /obj/stool/chair/comfy/flock/special_desc(dist, mob/user)
 	if (!isflockmob(user))
@@ -313,6 +313,9 @@
 	mat_appearances_to_ignore = list("steel","gnesis")
 	mat_changename = FALSE
 	mat_changedesc = FALSE
+	can_be_snipped = FALSE
+	can_be_unscrewed = FALSE
+	can_build_window = FALSE
 
 	update_icon(special_icon_state, override_parent = TRUE) //fix for perspective grilles fucking these up
 		if (ruined)
@@ -361,45 +364,6 @@
 	if (user.a_intent != INTENT_HARM)
 		return
 	..()
-
-/obj/grille/flock/attackby(obj/item/W, mob/user) //override totally to prevent wirecutter snipping etc
-	//copy & paste from grille parent, removing the bits we don't want (window construction, snipping)
-	if (ispulsingtool(W) || istype(W, /obj/item/device/t_scanner))
-		var/net = get_connection()
-		if(!net)
-			boutput(user, "<span class='notice'>No electrical current detected.</span>")
-		else
-			boutput(user, "<span class='alert'>CAUTION: Dangerous electrical current detected.</span>")
-		return
-
-	if (istype(W, /obj/item/gun))
-		var/obj/item/gun/G = W
-		G.shoot_point_blank(src, user)
-		return
-
-	// electrocution check
-	var/OSHA_is_crying = 1
-	var/dmg_mod = 0
-	if ((src.material && src.material.hasProperty("electrical") && src.material.getProperty("electrical") < 30))
-		OSHA_is_crying = 0
-
-	if ((src.material && src.material.hasProperty("electrical") && src.material.getProperty("electrical") > 30))
-		dmg_mod = 60 - src.material.getProperty("electrical")
-
-	if (OSHA_is_crying && (BOUNDS_DIST(src, user) == 0) && shock(user, 100 - dmg_mod))
-		return
-
-	// Things that will electrocute you
-	user.lastattacked = src
-	attack_particle(user,src)
-	src.visible_message("<span class='alert'><b>[usr]</b> attacks [src] with [W].</span>")
-	playsound(src.loc, 'sound/impact_sounds/Metal_Hit_Light_1.ogg', 80, 1)
-	switch(W.hit_type)
-		if(DAMAGE_BURN)
-			damage_heat(W.force)
-		else
-			damage_blunt(W.force * 0.5)
-	return
 
 /obj/grille/flock/bullet_act(obj/projectile/P)
 	if (istype(P.proj_data, /datum/projectile/energy_bolt/flockdrone))

--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -22,6 +22,15 @@
 	pressure_resistance = 5*ONE_ATMOSPHERE
 	layer = GRILLE_LAYER
 	event_handler_flags = USE_FLUID_ENTER
+	///can you use wirecutters to dismantle it?
+	var/can_be_snipped = TRUE
+	///can you use a screwdriver to unanchor it?
+	var/can_be_unscrewed = TRUE
+	///can you use a multitool to check for current?
+	var/can_be_probed = TRUE
+	///can you use this as a base for a new window?
+	var/can_build_window = TRUE
+
 
 	New()
 		..()
@@ -349,7 +358,7 @@
 	attackby(obj/item/W, mob/user)
 		// Things that won't electrocute you
 
-		if (ispulsingtool(W) || istype(W, /obj/item/device/t_scanner))
+		if (can_be_probed && (ispulsingtool(W) || istype(W, /obj/item/device/t_scanner)))
 			var/net = get_connection()
 			if(!net)
 				boutput(user, "<span class='notice'>No electrical current detected.</span>")
@@ -357,7 +366,7 @@
 				boutput(user, "<span class='alert'>CAUTION: Dangerous electrical current detected.</span>")
 			return
 
-		else if(istype(W, /obj/item/sheet/))
+		else if(can_build_window && istype(W, /obj/item/sheet/))
 			var/obj/item/sheet/S = W
 			if (S.material && S.material.material_flags & MATERIAL_CRYSTAL && S.amount_check(2))
 				var/obj/window/WI
@@ -419,12 +428,12 @@
 
 		// Things that will electrocute you
 
-		if (issnippingtool(W))
+		if (can_be_snipped && issnippingtool(W))
 			damage_slashing(src.health_max)
 			src.visible_message("<span class='alert'><b>[usr]</b> cuts apart the [src] with [W].</span>")
 			playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
 
-		else if (isscrewingtool(W) && (istype(src.loc, /turf/simulated) || src.anchored))
+		else if (can_be_unscrewed && (isscrewingtool(W) && (istype(src.loc, /turf/simulated) || src.anchored)))
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			src.anchored = !( src.anchored )
 			src.stops_space_move = !(src.stops_space_move)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the flock protection components to chairs and tables, and makes them deconstructable again because they weren't for some reason.
Adds the flock protection components to flock barricades, and prevents crew from just snipping them with wirecutters or building windows off them.
Removes some dangling code about deconstructing girders which isn't used anymore.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some minor oversights, cleaner code.
