### PR TITLE
Corrects Sulfonal For Mult on Life Cycle

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1121,6 +1121,7 @@ datum
 			depletion_rate = 0.1
 			var/counter = 1
 			var/remove_buff = 0
+			var/fainted = FALSE
 			blob_damage = 2
 			threshold = THRESHOLD_INIT
 
@@ -1146,11 +1147,12 @@ datum
 				switch(counter+= (1 * mult))
 					if (1 to 10)
 						if (probmult(7)) M.emote("yawn")
-					if (11 to 20)
+					if (10 to 20)
 						M.setStatus("drowsy", 40 SECONDS)
-					if (21)
-						M.emote("faint")
-					if (22 to INFINITY)
+					if (20 to INFINITY)
+						if(!fainted)
+							M.emote("faint")
+							fainted = TRUE
 						if (prob(20))
 							M.emote("faint")
 							M.setStatusMin("paralysis", 8 SECONDS * mult)

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1145,11 +1145,11 @@ datum
 					M.changeStatus("stimulants", -10 SECONDS * mult)
 
 				switch(counter+= (1 * mult))
-					if (1 to 10)
+					if (1 to 11)
 						if (probmult(7)) M.emote("yawn")
-					if (10 to 20)
+					if (11 to 21)
 						M.setStatus("drowsy", 40 SECONDS)
-					if (20 to INFINITY)
+					if (21 to INFINITY)
 						if(!fainted)
 							M.emote("faint")
 							fainted = TRUE


### PR DESCRIPTION
[LABEL][bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR restores the function of sulfonal always making the affected faint on the determined cycle, as it was before mult was a thing.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This fixes the sulfonal behavior to be as it was intended before mult. Neurotoxin code does the same with the fainted int, so sulfonal probably should too.
