### PR TITLE
Flockdrone vision

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -66,6 +66,7 @@
 	for (var/type as anything in childrentypesof(/datum/contextAction/flockdrone))
 		src.contexts += new type
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOCK_THING, src)
+	src.see_invisible = INVIS_FLOCK
 	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, FALSE, FALSE)
 
 /mob/living/critter/flock/drone/disposing()

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -126,6 +126,9 @@
 	pilot.set_loc(src)
 	controller = pilot
 	src.client?.color = null
+	//hack to make night vision apply instantly
+	var/datum/lifeprocess/sight/sight_process = src.lifeprocesses[/datum/lifeprocess/sight]
+	sight_process?.Process()
 	src.hud?.update_intent()
 	if (istype(pilot, /mob/living/intangible/flock/flockmind))
 		flock.addAnnotation(src, FLOCK_ANNOTATION_FLOCKMIND_CONTROL)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -66,7 +66,6 @@
 	for (var/type as anything in childrentypesof(/datum/contextAction/flockdrone))
 		src.contexts += new type
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOCK_THING, src)
-	src.see_invisible = INVIS_FLOCK
 	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, FALSE, FALSE)
 
 /mob/living/critter/flock/drone/disposing()

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -62,6 +62,7 @@
 	APPLY_ATOM_PROPERTY(src, PROP_MOB_RADPROT, src, 100)
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOATING, src)
 	APPLY_ATOM_PROPERTY(src, PROP_MOB_AI_UNTRACKABLE, src)
+	APPLY_ATOM_PROPERTY(src, PROP_MOB_NIGHTVISION, src)
 
 	// do not automatically set up a flock if one is not provided
 	// flockless drones act differently

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -16,6 +16,7 @@
 	mat_appearances_to_ignore = list("gnesis")
 	mat_changename = FALSE
 	mat_changedesc = FALSE
+	see_invisible = INVIS_FLOCK
 	// HEALTHS
 	var/health_brute = 1
 	var/health_burn = 1
@@ -61,7 +62,6 @@
 	APPLY_ATOM_PROPERTY(src, PROP_MOB_RADPROT, src, 100)
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOATING, src)
 	APPLY_ATOM_PROPERTY(src, PROP_MOB_AI_UNTRACKABLE, src)
-	src.see_invisible = INVIS_CLOAK
 
 	// do not automatically set up a flock if one is not provided
 	// flockless drones act differently

--- a/code/mob/living/life/sight.dm
+++ b/code/mob/living/life/sight.dm
@@ -28,7 +28,7 @@
 					human_owner.see_invisible = INVIS_CLOAK
 
 			if (istype(owner, /mob/living/critter/flock))
-				owner.see_invisible = INVIS_CLOAK
+				owner.see_invisible = INVIS_FLOCK
 
 ////Dead sight
 		var/turf/T = owner.eye ? get_turf(owner.eye) : get_turf(owner) //They might be in a closet or something idk


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Flockcritters had the wrong `see_invisible` being set in `lifeprocess/sight` for some reason, meaning they couldn't see invisible flock things (including pings)
They also had default human vision, now they have night vision.
![image](https://user-images.githubusercontent.com/20713227/171510292-0e7d0af1-448e-4833-b457-d59f7d70cab0.png)
(includes a gross hack to make night vision apply instantly, please let me know if there's a better way)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I saw a conversation of "THAT TILE" *ping* "WHAT TILE?!" *ping* "THAT TILE RIGHT THERE" during a playtest, this seems bad for a feature meant to encourage cooperation.
Flockdrones spend a lot of time lurking around dark maint tunnels, having them unable to see anything beyond their own small glow was a problem. They still have worse night vision than the full bright view flockminds and traces get.