### PR TITLE
Quick change to allow Bulky items and storage containers to be plated.

### DIFF
--- a/code/obj/machinery/arc_electroplater.dm
+++ b/code/obj/machinery/arc_electroplater.dm
@@ -81,7 +81,7 @@
 			boutput(user, "<span class='alert'>That wouldn't possibly fit!</span>")
 			return
 
-		if (W.w_class > src.max_wclass || istype(W, /obj/item/storage/secure)) //can't do plates because of material duping with breaking them over your head
+		if (W.w_class > src.max_wclass || istype(W, /obj/item/storage/secure))
 			boutput(user, "<span class='alert'>There is no way that could fit!</span>")
 			return
 

--- a/code/obj/machinery/arc_electroplater.dm
+++ b/code/obj/machinery/arc_electroplater.dm
@@ -81,7 +81,7 @@
 			boutput(user, "<span class='alert'>That wouldn't possibly fit!</span>")
 			return
 
-		if (W.w_class > src.max_wclass || istype(W, /obj/item/storage/secure) || istype(W, /obj/item/plate)) //can't do plates because of material duping with breaking them over your head
+		if (W.w_class > src.max_wclass || istype(W, /obj/item/storage/secure)) //can't do plates because of material duping with breaking them over your head
 			boutput(user, "<span class='alert'>There is no way that could fit!</span>")
 			return
 

--- a/code/obj/machinery/arc_electroplater.dm
+++ b/code/obj/machinery/arc_electroplater.dm
@@ -13,7 +13,7 @@
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR | DECON_WELDER | DECON_WIRECUTTERS
 	var/obj/target_item = null
 	var/cooktime = 0
-	var/max_wclass = 3
+	var/max_wclass = 4
 	var/obj/item/material_piece/my_bar = null
 
 	New()
@@ -81,7 +81,7 @@
 			boutput(user, "<span class='alert'>That wouldn't possibly fit!</span>")
 			return
 
-		if (W.w_class > src.max_wclass || istype(W, /obj/item/storage) || istype(W, /obj/item/storage/secure) || istype(W, /obj/item/plate)) //can't do plates because of material duping with breaking them over your head
+		if (W.w_class > src.max_wclass || istype(W, /obj/item/storage/secure) || istype(W, /obj/item/plate)) //can't do plates because of material duping with breaking them over your head
 			boutput(user, "<span class='alert'>There is no way that could fit!</span>")
 			return
 


### PR DESCRIPTION
I did some testing for bugs, didn't notice any immediately off hand. If anybody remembers any old bugs that occurred, let me know and I'll try and fix em. 

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the Max Weight class to bulky, and allows storage containers to be plated.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I don't see many exploitable things happening from this off the top of my head, and i think it'd be fun for gimmicks and the like to have goofy backpacks and toolboxes made of weird materials. That and the occasional katana/csaber that blow up or teleports away seems funny. Plates are still blacklisted since they still have the duplication issue with the shards. I've tested the most obvious situations and nothing out of the ordinary has happened. Containers don't plate the items inside, and throwing the plated storage object destroys the objects inside.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Moberry
(+)Changed the Electroplater to allow bulky items and storage items.
```
