### PR TITLE
Fix Flocktraces being made without enough compute

### DIFF
--- a/_std/macros/flock.dm
+++ b/_std/macros/flock.dm
@@ -21,6 +21,8 @@
 #define FLOCK_REPAIR_COST 10
 #define FLOCK_GHOST_DEPOSIT_AMOUNT 10
 
+#define FLOCKTRACE_COMPUTE_COST 100
+
 // achievements
 #define FLOCK_ACHIEVEMENT_CHEAT_STRUCTURES "all_structures"
 #define FLOCK_ACHIEVEMENT_CHEAT_COMPUTE "infinite_compute"

--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -175,18 +175,21 @@
 
 /datum/targetable/flockmindAbility/partitionMind
 	name = "Partition Mind"
-	desc = "Create a Flocktrace, using 100 compute."
 	icon_state = "awaken_drone"
 	cooldown = 60 SECONDS
 	targeted = FALSE
 	///Are we still waiting for ghosts to respond
 	var/waiting = FALSE
 
+/datum/targetable/flockmindAbility/partitionMind/New()
+	..()
+	src.desc = "Create a Flocktrace, using [FLOCKTRACE_COMPUTE_COST] compute."
+
 /datum/targetable/flockmindAbility/partitionMind/cast(atom/target)
 	if(waiting || ..())
 		return TRUE
 
-	if(!holder.pointCheck(100))
+	if(!holder.pointCheck(FLOCKTRACE_COMPUTE_COST))
 		return TRUE
 
 	var/mob/living/intangible/flock/flockmind/F = holder.owner

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -143,6 +143,12 @@
 		boutput(src, "<span class='flocksay'>Partition failure: unable to coalesce sentience.</span>")
 		return TRUE
 
+	if (!src.abilityHolder.pointCheck(FLOCKTRACE_COMPUTE_COST))
+		message_admins("A Flocktrace offer from [src.real_name] was sent but failed due to lack of compute.")
+		logTheThing("admin", null, null, "Flocktrace offer from [src.real_name] failed due to lack of compute.")
+		boutput(src, "<span class='flocksay'>Partition failure: Compute required unavailable.</span>")
+		return TRUE
+
 	var/mob/picked = pick(candidates)
 
 	message_admins("[picked.key] respawned as a Flocktrace under [src.real_name].")

--- a/code/mob/living/intangible/flock/flocktrace.dm
+++ b/code/mob/living/intangible/flock/flocktrace.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/misc/featherzone.dmi'
 	icon_state = "flocktrace"
 
-	compute = -100 //it is expensive to run more threads
+	compute = -FLOCKTRACE_COMPUTE_COST //it is expensive to run more threads
 
 /mob/living/intangible/flock/trace/New(atom/loc, datum/flock/F)
 	..()


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just fixes a bug where Flocktraces would still be spawned if there wasn't enough compute for them.

Also puts in a related define.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix