### PR TITLE
Decreases spy bounty refresh interval to 15 minutes on classic.

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -13,7 +13,7 @@
 	var/const/waittime_l = 600	// Minimum after round start to send threat information to printer
 	var/const/waittime_h = 1800	// Maximum after round start to send threat information to printer
 
-	var/const/bounty_refresh_interval = 25 MINUTES
+	var/const/bounty_refresh_interval = 15 MINUTES
 	var/last_refresh_time = 0
 
 	var/const/spies_possible = 7

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -13,7 +13,11 @@
 	var/const/waittime_l = 600	// Minimum after round start to send threat information to printer
 	var/const/waittime_h = 1800	// Maximum after round start to send threat information to printer
 
+#ifdef RP_MODE
+	var/const/bounty_refresh_interval = 25 MINUTES
+#else
 	var/const/bounty_refresh_interval = 15 MINUTES
+#endif
 	var/last_refresh_time = 0
 
 	var/const/spies_possible = 7


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr changes the refresh interval for spy thief bounties to refresh once every 15 minutes instead of once every 25 minutes for classic. On roleplay the 25 minute refresh interval is maintained.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currenlty spies is pretty slow pace wise, by allowing them to get more items and making spies rush more to get items, this should help increase the pace a lot.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)The bounty refresh interval for spies has been decreased from 25 minutes to 15 minutes on classic. For roleplay the refresh interval remains at 25 minutes.
```
