### PR TITLE
Donut 3 detective, arcade and fuq pipe fix

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -8307,10 +8307,7 @@
 	dir = 10
 	},
 /obj/decal/cleanable/dirt/jen,
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/junction/middle/north,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
 "cfg" = (
@@ -10760,10 +10757,7 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/disposalpipe/junction/left/east,
 /turf/simulated/floor/white,
 /area/station/crewquarters/fuq3)
 "cSv" = (
@@ -13182,6 +13176,9 @@
 /obj/item/storage/wall/clothingrack/clothes4{
 	dir = 4
 	},
+/obj/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor/white,
 /area/station/crewquarters/fuq3)
 "dDy" = (
@@ -15000,6 +14997,12 @@
 	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
+"eda" = (
+/obj/disposalpipe/segment{
+	dir = 8
+	},
+/turf/simulated/wall/auto/jen,
+/area/station/crewquarters/fuq3)
 "edf" = (
 /obj/machinery/door/airlock/pyro/medical/alt{
 	dir = 4
@@ -56562,7 +56565,7 @@
 	dir = 1;
 	pixel_y = 16
 	},
-/obj/disposalpipe/junction/right/west,
+/obj/disposalpipe/junction/left/east,
 /turf/simulated/floor/greenwhite/other{
 	dir = 1
 	},
@@ -138489,7 +138492,7 @@ svU
 svU
 svU
 svU
-svU
+eda
 svU
 svU
 svU


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes the Donut 3 trash pipes forming a closed loop in det office, fux store and arcade. 
Old: 
![old pipes](https://user-images.githubusercontent.com/95481182/171861312-b6a7fdb9-bf85-4bff-94ca-e7e6102f92d7.png)
New:
![new pipes](https://user-images.githubusercontent.com/95481182/171861331-15f31a67-198b-486f-bed0-04f78e7f2b9d.png)



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because we need the trash to go to disposals and not to the det's office.


## Changelog
Not needed.