### PR TITLE
Fix runtime on Flockmind death

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -460,6 +460,8 @@ var/flock_signal_unleashed = FALSE
 		aH.updateCompute()
 
 /datum/flock/proc/getComplexDroneCount()
+	if (!src.units)
+		return 0
 	return length(src.units[/mob/living/critter/flock/drone/])
 
 /datum/flock/proc/toggleDeconstructionFlag(var/atom/target)


### PR DESCRIPTION
[RUNTIME]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a runtime that occurs on Flockmind death (can't access units[/mob/living/critter/flock/drone/] with units null).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtime fix