### PR TITLE
Fix runtime and a bug for Flockmind dying while a Flocktrace offer is up

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -67,7 +67,7 @@
 	last_cast = world.time + cooldown
 	holder.updateButtons()
 	SPAWN(cooldown + 5)
-		holder.updateButtons()
+		holder?.updateButtons()
 
 /////////////////////////////////////////
 

--- a/code/mob/living/intangible/flock/flockmind.dm
+++ b/code/mob/living/intangible/flock/flockmind.dm
@@ -131,7 +131,7 @@
 	message_admins("Sending Flocktrace offer to eligible ghosts. They have [ghost_confirmation_delay / 10] seconds to respond.")
 	var/list/candidates = dead_player_list(FALSE, ghost_confirmation_delay, text_messages)
 
-	if (!src) // doesnt work yet
+	if (src.disposed)
 		message_admins("[src.real_name] has died during a Flocktrace respawn offer event.")
 		logTheThing("admin", null, null, "No Flocktraces were created for [src.real_name] due to their death.")
 		return TRUE


### PR DESCRIPTION
[RUNTIME][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a runtime that occurs that if a Flockmind dies while a Flocktrace offer is up, along with fixing a bug where the right admin messaging/logging wasn't being done.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtime and bug fixes