### PR TITLE
Fix Flockdoors blocking directional lighting

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -655,14 +655,6 @@ var/flock_signal_unleashed = FALSE
 	if(!T)
 		return
 
-	// take light values to copy over
-	var/RL_LumR = T.RL_LumR
-	var/RL_LumG = T.RL_LumG
-	var/RL_LumB = T.RL_LumB
-	var/RL_AddLumR = T.RL_AddLumR
-	var/RL_AddLumG = T.RL_AddLumG
-	var/RL_AddLumB = T.RL_AddLumB
-
 	if(istype(T, /turf/simulated/floor))
 		T.ReplaceWith("/turf/simulated/floor/feather", FALSE)
 		animate_flock_convert_complete(T)
@@ -688,15 +680,6 @@ var/flock_signal_unleashed = FALSE
 		var/obj/lattice/flock/FL = locate(/obj/lattice/flock) in T
 		if(!FL)
 			FL = new /obj/lattice/flock(T)
-	else // don't do this stuff if the turf is space, it fucks it up more
-		T.RL_Cleanup()
-		T.RL_LumR = RL_LumR
-		T.RL_LumG = RL_LumG
-		T.RL_LumB = RL_LumB
-		T.RL_AddLumR = RL_AddLumR
-		T.RL_AddLumG = RL_AddLumG
-		T.RL_AddLumB = RL_AddLumB
-		if (RL_Started) RL_UPDATE_LIGHT(T)
 
 	for(var/obj/O in T)
 		if(istype(O, /obj/machinery/door/feather))


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where Flockdoors were blocking directional lighting (ex. from flashlights) at least, including when open and in the spot they were in after destruction.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix, fixes #8923.