### PR TITLE
Makes QM functional on destiny when the shield is on.

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -119584,8 +119584,8 @@ gzN
 xQd
 vwV
 oiF
-aaa
-aaa
+aag
+aag
 aag
 aaa
 aaa
@@ -119887,8 +119887,8 @@ dRu
 jCC
 hsb
 aaa
-aag
-aag
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -120188,8 +120188,8 @@ vSs
 ltk
 oiF
 oiF
-aaa
 aag
+aaa
 aaa
 aaa
 aaa
@@ -120489,9 +120489,9 @@ gVT
 hax
 oiF
 oiF
-aaa
-aaa
 aag
+aag
+aaa
 aaa
 aaa
 aaa
@@ -120793,7 +120793,7 @@ qOX
 vwH
 aaa
 aaa
-aag
+aaa
 aaa
 aaa
 aaa
@@ -121092,10 +121092,10 @@ wSq
 jGF
 ppd
 qXK
-aaa
-aaa
 aag
 aag
+aag
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds 2 little holes in the destiny shield for QM so they can do their job when the shield is on. This should make QM players a lot less annoyed when the shields get turned on (for whatever reason).
![image](https://user-images.githubusercontent.com/40079883/171988001-06eef079-7d67-414c-b9c5-9befcb7be8d4.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's not fun for QM when they are just flat out not able to do anything cause somebody pressed the funny button.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)QM is now functional on destiny when the shields are on.
```
