### PR TITLE
Fixes Status Display Overlap In Cog2 Chapel

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -6977,6 +6977,9 @@
 	pixel_x = -10;
 	tag = ""
 	},
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/black,
 /area/station/chapel/sanctuary)
 "aqr" = (
@@ -6997,9 +7000,6 @@
 /area/station/chapel/sanctuary)
 "aqt" = (
 /obj/disposalpipe/segment/mail/bent/south,
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
 /turf/simulated/floor/carpet{
 	dir = 9;
 	icon_state = "fpurple2"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a status display and light overlapping in cog2's chapel.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Whoops.

