### PR TITLE
Fix robot limb attachment bugs

### DIFF
--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -506,7 +506,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/arm)
 
 		var/mob/living/carbon/human/H = M
 
-		if(H.limbs.vars.Find(src.slot) && H.limbs.vars[src.slot])
+		if(H.limbs.get_limb(user.zone_sel.selecting))
 			boutput(user, "<span class='alert'>[H.name] already has one of those!</span>")
 			return
 
@@ -721,11 +721,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts/leg)
 
 		var/mob/living/carbon/human/H = M
 
-		if(!(src.slot in H.limbs.vars))
-			boutput(user, "<span class='alert'>You can't find a way to fit that on.</span>")
-			return
-
-		if(H.limbs.vars[src.slot])
+		if(H.limbs.get_limb(user.zone_sel.selecting))
 			boutput(user, "<span class='alert'>[H.name] already has one of those!</span>")
 			return
 


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes two bugs with robot limb attaching. The first is a bug where you could attach the right robot arm limb to the wrong spot (ex. targeting right arm with a left robot arm while missing a left arm would attach it to your right arm). The second is fixing a missing message for the equivalent thing, but for legs.

I only tested fixing for these cases, so not aware if this would break anything else


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fixes