### PR TITLE
Moves The Arrivals Status Display On Destiny

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -38433,6 +38433,10 @@
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/hallway/secondary/exit)
+"mFz" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crewquarters/cryotron)
 "mFK" = (
 /obj/machinery/firealarm{
 	layer = 3.5;
@@ -56821,9 +56825,6 @@
 	},
 /obj/table/round/auto,
 /obj/machinery/computer/tour_console,
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
 /turf/simulated/floor/darkblue/checker,
 /area/station/crew_quarters/fitness)
 "wsM" = (
@@ -108080,7 +108081,7 @@ xUg
 xUg
 xUg
 faU
-vMh
+mFz
 qyS
 lBQ
 lBQ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the arrivals status display on destiny to stop overlap


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Whoops

