### PR TITLE
Makes a normal wingrille placeholder

### DIFF
--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -987,16 +987,26 @@
 
 
 	auto
-		name = "reinforced autowindow grille spawner"
+		name = "autowindow grille spawner (will apply in time)"
 		win_path = "/obj/window/auto/reinforced"
 		full_win = 1
 		no_dirs = 1
-		icon_state = "r-wingrille_f"
+		icon_state = "wingrille_f"
+
+		reinforced
+			name = "reinforced autowindow grille spawner"
+			win_path = "/obj/window/auto/reinforced"
+			icon_state = "r-wingrille_f"
 
 		crystal
-			name = "crystal autowindow grille spawner"
+			name = "crystal autowindow grille spawner (will apply in time)"
 			win_path = "/obj/window/auto/crystal/reinforced"
 			icon_state = "p-wingrille_f"
+
+			reinforced
+				name = "reinforced crystal autowindow grille spawner"
+				win_path = "/obj/window/auto/crystal/reinforced"
+				icon_state = "pr-wingrille_f"
 
 		tuff
 			name = "tuff stuff reinforced autowindow grille spawner"

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -987,7 +987,7 @@
 
 
 	auto
-		name = "autowindow grille spawner (will apply in time)"
+		name = "autowindow grille spawner (will place nonreinf soon)"
 		win_path = "/obj/window/auto/reinforced"
 		full_win = 1
 		no_dirs = 1
@@ -999,7 +999,7 @@
 			icon_state = "r-wingrille_f"
 
 		crystal
-			name = "crystal autowindow grille spawner (will apply in time)"
+			name = "crystal autowindow grille spawner (will place nonreinf soon)"
 			win_path = "/obj/window/auto/crystal/reinforced"
 			icon_state = "p-wingrille_f"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes normal wingrille placeholders. At the moment both wingrilles and rwingrilles have the same functionality of placing reinforced windows. Reinforced windows should be changed to the new reinforced wingrille path.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows for normal wingrilles in the future once other maps are set.
