### PR TITLE
Make flockdrone projectiles pass through flockdmobs and fix point blanking

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -308,7 +308,7 @@
 		animate_flock_passthrough(src)
 		return TRUE
 	else
-		return !src.density
+		return ..()
 
 /mob/living/critter/flock/drone/MouseDrop_T(mob/living/target, mob/user)
 	if(!target || !user)
@@ -1008,6 +1008,11 @@
 	cooldown = 15
 	reload_time = 60
 	reloading_str = "recharging"
+
+/datum/limb/gun/flock_stunner/point_blank(mob/living/target, mob/living/user)
+	if (isflockmob(target))
+		return
+	return ..()
 
 /datum/limb/gun/flock_stunner/attack_range(atom/target, var/mob/living/critter/flock/drone/user, params)
 	if(!target || !user)

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -104,6 +104,11 @@
 	src.flock.removeDrone(src)
 	src.flock = null
 
+/mob/living/critter/flock/projCanHit(var/datum/projectile/P)
+	if(istype(P, /datum/projectile/energy_bolt/flockdrone))
+		return FALSE
+	return ..()
+
 /mob/living/critter/flock/bullet_act(var/obj/projectile/P)
 	if(istype(P.proj_data, /datum/projectile/energy_bolt/flockdrone))
 		src.visible_message("<span class='notice'>[src] harmlessly absorbs [P].</span>")

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -104,7 +104,7 @@
 	src.flock.removeDrone(src)
 	src.flock = null
 
-/mob/living/critter/flock/projCanHit(var/datum/projectile/P)
+/mob/living/critter/flock/projCanHit(datum/projectile/P)
 	if(istype(P, /datum/projectile/energy_bolt/flockdrone))
 		return FALSE
 	return ..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Make flockdrone projectiles pass through flockdmobs and fixes an issue with point blanking causing floaty ghost projectiles.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AI flockdrones mostly just hit each other when trying to attack, making them near useless in large groups (which should be when they are scariest)
Also I can atomize the bugfix if needed, I'm just being lazy.