### PR TITLE
makes nukies spawn with a syndicate field protective mask

### DIFF
--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -270,25 +270,16 @@
 		synd_mob.equip_if_possible(new /obj/item/katana_sheath/nukeop(synd_mob), synd_mob.slot_r_hand)
 		synd_mob.equip_if_possible(new /obj/item/device/nukeop_commander_uplink(synd_mob), synd_mob.slot_l_hand)
 	else
-		//synd_mob.equip_if_possible(new /obj/item/clothing/head/helmet/swat(synd_mob), synd_mob.slot_head)
-		//synd_mob.equip_if_possible(new /obj/item/clothing/suit/armor/vest(synd_mob), synd_mob.slot_wear_suit)
 		synd_mob.equip_if_possible(new /obj/item/device/radio/headset/syndicate(synd_mob), synd_mob.slot_ears)
 
-	//synd_mob.equip_if_possible(new /obj/item/reagent_containers/pill/tox(synd_mob), synd_mob.slot_in_backpack)
 	synd_mob.equip_if_possible(new /obj/item/clothing/under/misc/syndicate(synd_mob), synd_mob.slot_w_uniform)
 	synd_mob.equip_if_possible(new /obj/item/clothing/shoes/swat/noslip(synd_mob), synd_mob.slot_shoes)
 	synd_mob.equip_if_possible(new /obj/item/clothing/gloves/swat(synd_mob), synd_mob.slot_gloves)
 	synd_mob.equip_if_possible(new /obj/item/storage/backpack/syndie/tactical(synd_mob), synd_mob.slot_back)
-	synd_mob.equip_if_possible(new /obj/item/clothing/mask/breath(synd_mob), synd_mob.slot_wear_mask)
+	synd_mob.equip_if_possible(new /obj/item/clothing/mask/gas/swat/syndicate(synd_mob), synd_mob.slot_wear_mask)
 	synd_mob.equip_if_possible(new /obj/item/clothing/glasses/sunglasses(synd_mob), synd_mob.slot_glasses)
 	synd_mob.equip_if_possible(new /obj/item/requisition_token/syndicate(synd_mob), synd_mob.slot_r_store)
 	synd_mob.equip_if_possible(new /obj/item/tank/emergency_oxygen(synd_mob), synd_mob.slot_l_store)
-/*
-	var/obj/item/uplink/syndicate/U = new /obj/item/uplink/syndicate/alternate(synd_mob)
-	if (synd_mob.mind && istype(synd_mob.mind))
-		U.setup(synd_mob.mind)
-	synd_mob.equip_if_possible(U, synd_mob.slot_r_store)
-*/
 
 	var/obj/item/card/id/syndicate/I = new /obj/item/card/id/syndicate(synd_mob) // for whatever reason, this is neccessary
 	if(leader)

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -75168,16 +75168,8 @@
 	})
 "sdh" = (
 /obj/rack,
-/obj/item/clothing/mask/gas/swat/syndicate,
-/obj/item/clothing/mask/gas/swat/syndicate,
-/obj/item/clothing/mask/gas/swat/syndicate,
-/obj/item/clothing/mask/gas/swat/syndicate,
-/obj/item/clothing/mask/gas/swat/syndicate,
-/obj/item/clothing/mask/gas/swat/syndicate,
-/obj/item/clothing/mask/gas/swat/syndicate,
-/obj/item/clothing/mask/gas/swat/syndicate,
-/obj/item/clothing/mask/gas/swat/syndicate,
-/obj/item/clothing/mask/gas/swat/syndicate,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/breath,
 /turf/unsimulated/floor/darkpurple,
 /area/syndicate_station/battlecruiser)
 "seK" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][QOL][MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

1. makes nukies start with nukie gas masks as opposed to normal breath masks (nukies always could get them but had to grab them from the rack)
2. removes old commented code from the equip_syndicate proc
3. replaces the 10 spare nukie gas masks on the rack with 5 breath masks and 5 normal gas masks (for infil use)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Seeing more than half the nukie team die from sarin because someone didnt throw the grenade far enough and they didnt have internals on is way too common. This prevents it.



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(*) Nuclear Operatives now get syndicate field protective masks by default instead of breath masks.
(*) Due to the above change the rack with spare syndicate field protective masks has been edited to have 5 breath masks and 5 normal gas masks, this is for infil use.
```
