### PR TITLE
Allows more objects to be deconstructed

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -339,7 +339,7 @@
 	light_type = /obj/item/light/bulb/emergency
 	allowed_type = /obj/item/light/bulb/emergency
 	on = 0
-	removable_bulb = 0
+	removable_bulb = 1
 
 	exitsign
 		name = "illuminated exit sign"

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -281,6 +281,7 @@
 	desc = "A bin for containing bedsheets."
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "bedbin"
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH
 	var/amount = 23.0
 	anchored = 1.0
 
@@ -308,6 +309,7 @@
 	desc = "A bin for containing towels."
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "bedbin"
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH
 	var/amount = 23.0
 	anchored = 1.0
 

--- a/code/obj/decal/poster.dm
+++ b/code/obj/decal/poster.dm
@@ -7,6 +7,7 @@
 	anchored = 1
 	opacity = 0
 	density = 0
+	deconstruct_flags = DECON_WIRECUTTERS
 	var/imgw = 600
 	var/imgh = 400
 	var/popup_win = 0

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -416,6 +416,7 @@
 	icon_state = "ppot0"
 	anchored = 1
 	density = 0
+	deconstruct_flags = DECON_SCREWDRIVER
 
 	New()
 		..()

--- a/code/obj/item/device/mic_amp_etc.dm
+++ b/code/obj/item/device/mic_amp_etc.dm
@@ -126,6 +126,7 @@
 	anchored = 1
 	density = 1
 	mats = 15
+	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_MULTITOOL
 
 	New()
 		. = ..()

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1216,7 +1216,6 @@
 	var/spawn_chance = 0 // How likely is this couch to spawn something?
 	var/last_use = 0 // To prevent spam.
 	var/time_between_uses = 400 // The default time between uses.
-	deconstruct_flags = DECON_WRENCH
 	var/list/items = list (/obj/item/device/light/zippo,
 	/obj/item/wrench,
 	/obj/item/device/multitool,

--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1216,6 +1216,7 @@
 	var/spawn_chance = 0 // How likely is this couch to spawn something?
 	var/last_use = 0 // To prevent spam.
 	var/time_between_uses = 400 // The default time between uses.
+	deconstruct_flags = DECON_WRENCH
 	var/list/items = list (/obj/item/device/light/zippo,
 	/obj/item/wrench,
 	/obj/item/device/multitool,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the following objects to be deconstructed:
-Wall-mounted Potted plants
-Most posters and signs
-Loudspeakers
-Linen/Bedsheet bins

Also allows you to remove the bulbs of emergency lights and as such to also destroy them with lamp manufacturers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A poster shouldnt be harder to get rid of than a fridge or a manufacturer.
Emergency lights were strangely invincible, this fixes that.
Allows mechanics and others to make big construction projects without having to worry about items stubborly refusing to move.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Bartimeus973
(+)Posters, wall-mounted potted plants, loudspeakers and linen/bedsheet bins can now be deconstructed.
```
