### PR TITLE
Fix powernets in random rooms

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -547,6 +547,7 @@ var/f_color_selector_handler/F_Color_Selector
 	UPDATE_TITLE_STATUS("Building random station rooms")
 	Z_LOG_DEBUG("World/Init", "Setting up random rooms...")
 	buildRandomRooms()
+	makepowernets()
 
 	UPDATE_TITLE_STATUS("Generating terrain")
 	Z_LOG_DEBUG("World/Init", "Setting perlin noise terrain...")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #8985 by rebuilding powernets immediately after random rooms are placed. 

Note: if you're testing with build mode, you still need to press the "Fix Powernets" verb to get that working. This only fixes the issue when the room is loaded properly.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I want machines in my random rooms to work.