### PR TITLE
Fixes a minor flock chat bug

### DIFF
--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -1052,7 +1052,8 @@
 		if(istype(M, /mob/living/intangible/flock/flockmind) && !(istype(mob_speaking, /mob/living/intangible/flock/flockmind)) && M:flock == flock)
 			thisR = flockmindRendered
 		if ((istype(M, /mob/dead/observer)||M.client.holder) && mob_speaking?.mind)
+			thisR = rendered
 			thisR = "<span class='adminHearing' data-ctx='[M.client.chatOutput.getContextFlags()]'>[thisR]</span>"
 
 		if(thisR != "")
-			M.show_message(thisR, 2)
+			boutput(M, thisR)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes some flock chat messages being displayed twice to ghosts and absolutely nothing else.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
@Tarmunora 