### PR TITLE
changes the number of morphine autoinjectors in the sec morphine utility box from 4 to 6

### DIFF
--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -27,8 +27,8 @@
 /obj/item/storage/box/morphineinjectors
 	name = "morphine autoinjector box"
 	icon_state = "box"
-	desc = "Contains four morphine autoinjectors, for security use"
-	spawn_contents = list(/obj/item/reagent_containers/emergency_injector/morphine = 4)
+	desc = "Contains six morphine autoinjectors, for security use"
+	spawn_contents = list(/obj/item/reagent_containers/emergency_injector/morphine = 6)
 
 /obj/item/storage/lunchbox/robustdonuts
 	name = "robust donuts lunchbox"

--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -283,7 +283,7 @@
 /datum/materiel/utility/morphineinjectors
 	name = "Morphine Autoinjectors"
 	path = /obj/item/storage/box/morphineinjectors
-	description = "Four Morphine Autoinjectors, capable of ensuring you move at the best possible speed while injured without slowdowns...or used as a makeshift tranquilizer if overdosed."
+	description = "Six Morphine Autoinjectors, capable of ensuring you move at the best possible speed while injured without slowdowns...or used as a makeshift tranquilizer if overdosed."
 
 /datum/materiel/utility/donuts
 	name = "Robust(ed) Donuts"


### PR DESCRIPTION
[BALANCE]

## About the PR
adds 2 more morphine autoinjectors to the utility box that security officers can purchase from the vendor, bringing the total number of autoinjectors in the box from 4 to 6

## Why's this needed?
by all accounts the morphine autoinjector box Kinda Sucks in comparison to the other shit you can get for one utility credit. this adjustment aims to make it less of an easy skip by adding More Morphine, thus making it so you can tranquilize maybe 2 people instead of maybe 1. maybe you can barter with your extras if you're feeling entrepreneurial? the opportunities are truly endless

## Changelog
```changelog
(u)Waffleloffle
(+)Upped the number of morphine autoinjectors in Security's morphine autoinjector box utility purchase from 4 to 6.
```
