### PR TITLE
The hand labeler now fits in the Belt slot

### DIFF
--- a/code/obj/item/pens_writing_etc.dm
+++ b/code/obj/item/pens_writing_etc.dm
@@ -681,7 +681,7 @@
 	desc = "Make things seem more important than they really are with the hand labeler!<br/>Can also name your fancy new area by naming the fancy new APC you created for it."
 	var/label = null
 	var/labels_left = 10
-	flags = FPRINT | TABLEPASS | SUPPRESSATTACK
+	flags = FPRINT | TABLEPASS | SUPPRESSATTACK | ONBELT
 	rand_pos = 1
 
 	get_desc()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds ONBELT flag to the hand labeler

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Small QoL for rampant crate-labellng QMs. Also frustrates me on a personal level.