### PR TITLE
Fixes dormant flockdrones having active AI

### DIFF
--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -96,7 +96,7 @@
 	src.dormant = TRUE
 	src.ai?.die()
 	actions.stop_all(src)
-
+	src.is_npc = FALSE
 	if (!src.flock)
 		return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Flockless drones didn't have their `is_npc` var set properly so wandered around.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad