### PR TITLE
increase player piano maximum note cap

### DIFF
--- a/code/obj/playable_piano.dm
+++ b/code/obj/playable_piano.dm
@@ -7,7 +7,7 @@
 
 #define MIN_TIMING 0.25
 #define MAX_TIMING 0.5
-#define MAX_NOTE_INPUT 2048
+#define MAX_NOTE_INPUT 15360
 
 /obj/player_piano //this is the big boy im pretty sure all this code is garbage
 	name = "player piano"


### PR DESCRIPTION
[qol]

## About the PR 
does the thing.
selected notecap is kinda arbitrary (again). it could also just be removed or changed to something even more rounded like 20,000. 

15,360 notes is enough for just about 120 measures of a song written in sixteenth divisions. for normal people, maybe 4 and a half minutes of music.


## Why's this needed? 
currently you can shove about 16 measures of a song in the player piano. i don't know of a song that's only 16 measures except maybe like twinkle, twinkle little star. also i really want to be able to transcribe and play an entire song. i think longer songs transcribed to player piano could be more fun, it might encourage more people to interact with it and try their favorite song versus just repetitive little loops that can get old to some people.
