### PR TITLE
Random 3x5 Room: Monkey Medical Malpractice 

### DIFF
--- a/assets/maps/random_rooms/3x5/monkeysurgery.dmm
+++ b/assets/maps/random_rooms/3x5/monkeysurgery.dmm
@@ -8,13 +8,21 @@
 /area/dmm_suite/clear_area)
 "e" = (
 /obj/machinery/drainage,
-/obj/item/parts/human_parts/arm/left,
+/obj/item/parts/human_parts/arm/left{
+	pixel_y = -2;
+	pixel_x = -17
+	},
 /turf/simulated/floor/damaged2,
 /area/dmm_suite/clear_area)
 "i" = (
 /obj/decal/cleanable/blood/gibs/body,
 /obj/decal/cleanable/blood/splatter,
 /obj/item/parts/human_parts/leg/left,
+/obj/item/parts/human_parts/leg/right{
+	dir = 8;
+	pixel_y = 3;
+	pixel_x = -5
+	},
 /turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "l" = (
@@ -32,8 +40,8 @@
 /area/dmm_suite/clear_area)
 "s" = (
 /obj/surgery_tray,
-/obj/random_item_spawner/med_kit,
-/obj/random_item_spawner/medicine,
+/obj/random_item_spawner/medicine/one,
+/obj/random_item_spawner/med_kit/one,
 /turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "u" = (
@@ -50,7 +58,6 @@
 /turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "A" = (
-/obj/item/parts/human_parts/leg/right,
 /obj/decal/cleanable/dirt/dirt2,
 /obj/machinery/light/incandescent/harsh,
 /turf/simulated/floor,
@@ -75,7 +82,10 @@
 /area/dmm_suite/clear_area)
 "Y" = (
 /obj/machinery/drainage,
-/obj/item/parts/human_parts/arm/right,
+/obj/item/parts/human_parts/arm/right{
+	pixel_y = -2;
+	pixel_x = 16
+	},
 /turf/simulated/floor,
 /area/dmm_suite/clear_area)
 

--- a/assets/maps/random_rooms/3x5/monkeysurgery.dmm
+++ b/assets/maps/random_rooms/3x5/monkeysurgery.dmm
@@ -1,8 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/surgery_tray,
-/obj/random_item_spawner/med_tool/few,
 /obj/decal/cleanable/dirt/dirt2,
+/obj/random_item_spawner/med_tool/two,
+/obj/item/reagent_containers/food/snacks/ingredient/meatpaste,
 /turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "e" = (
@@ -20,7 +21,7 @@
 /obj/storage/crate/bloody,
 /obj/random_item_spawner/organs/bloody/one_to_three,
 /obj/item/clothing/suit/monkey,
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "m" = (
 /obj/machinery/computer3/generic/med_data,
@@ -32,7 +33,7 @@
 "s" = (
 /obj/surgery_tray,
 /obj/random_item_spawner/med_kit,
-/obj/random_item_spawner/medicine/few,
+/obj/random_item_spawner/medicine,
 /turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "u" = (
@@ -66,7 +67,6 @@
 /obj/machinery/optable,
 /obj/item/toy/plush/small/monkey,
 /obj/decal/cleanable/blood/gibs/body,
-/obj/fluid_spawner/polluted_filth/blood,
 /turf/simulated/floor/scorched2,
 /area/dmm_suite/clear_area)
 "W" = (

--- a/assets/maps/random_rooms/3x5/monkeysurgery.dmm
+++ b/assets/maps/random_rooms/3x5/monkeysurgery.dmm
@@ -1,0 +1,94 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/surgery_tray,
+/obj/random_item_spawner/med_tool/few,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"e" = (
+/obj/machinery/drainage,
+/obj/item/parts/human_parts/arm/left,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"i" = (
+/obj/decal/cleanable/blood/gibs/body,
+/obj/decal/cleanable/blood/splatter,
+/obj/item/parts/human_parts/leg/left,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"l" = (
+/obj/storage/crate/bloody,
+/obj/random_item_spawner/organs/bloody/one_to_three,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"m" = (
+/obj/machinery/computer3/generic/med_data,
+/obj/machinery/light/incandescent/harsh{
+	dir = 1
+	},
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"s" = (
+/obj/surgery_tray,
+/obj/random_item_spawner/med_kit,
+/obj/random_item_spawner/medicine/few,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"u" = (
+/obj/decal/cleanable/blood,
+/obj/machinery/light/incandescent/harsh,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"w" = (
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/blood,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"x" = (
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"A" = (
+/obj/item/parts/human_parts/leg/right,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"O" = (
+/obj/decal/cleanable/blood/tracks,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"Q" = (
+/obj/decal/cleanable/blood/drip/high,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"S" = (
+/obj/machinery/optable,
+/obj/item/toy/plush/small/monkey,
+/obj/decal/cleanable/blood/gibs/body,
+/obj/fluid_spawner/polluted_filth/blood,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+"Y" = (
+/obj/machinery/drainage,
+/obj/item/parts/human_parts/arm/right,
+/turf/simulated/floor/plating/random,
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+m
+Q
+Y
+a
+A
+"}
+(2,1,1) = {"
+O
+w
+S
+i
+x
+"}
+(3,1,1) = {"
+l
+x
+e
+s
+u
+"}

--- a/assets/maps/random_rooms/3x5/monkeysurgery.dmm
+++ b/assets/maps/random_rooms/3x5/monkeysurgery.dmm
@@ -2,22 +2,24 @@
 "a" = (
 /obj/surgery_tray,
 /obj/random_item_spawner/med_tool/few,
-/turf/simulated/floor/plating/random,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "e" = (
 /obj/machinery/drainage,
 /obj/item/parts/human_parts/arm/left,
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor/damaged2,
 /area/dmm_suite/clear_area)
 "i" = (
 /obj/decal/cleanable/blood/gibs/body,
 /obj/decal/cleanable/blood/splatter,
 /obj/item/parts/human_parts/leg/left,
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "l" = (
 /obj/storage/crate/bloody,
 /obj/random_item_spawner/organs/bloody/one_to_three,
+/obj/item/clothing/suit/monkey,
 /turf/simulated/floor/plating/random,
 /area/dmm_suite/clear_area)
 "m" = (
@@ -25,50 +27,56 @@
 /obj/machinery/light/incandescent/harsh{
 	dir = 1
 	},
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor/damaged2,
 /area/dmm_suite/clear_area)
 "s" = (
 /obj/surgery_tray,
 /obj/random_item_spawner/med_kit,
 /obj/random_item_spawner/medicine/few,
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "u" = (
 /obj/decal/cleanable/blood,
-/obj/machinery/light/incandescent/harsh,
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "w" = (
 /obj/iv_stand,
 /obj/item/reagent_containers/iv_drip/blood,
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "x" = (
-/turf/simulated/floor/plating/random,
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "A" = (
 /obj/item/parts/human_parts/leg/right,
-/turf/simulated/floor/plating/random,
+/obj/decal/cleanable/dirt/dirt2,
+/obj/machinery/light/incandescent/harsh,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "O" = (
 /obj/decal/cleanable/blood/tracks,
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "Q" = (
 /obj/decal/cleanable/blood/drip/high,
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "S" = (
 /obj/machinery/optable,
 /obj/item/toy/plush/small/monkey,
 /obj/decal/cleanable/blood/gibs/body,
 /obj/fluid_spawner/polluted_filth/blood,
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor/scorched2,
+/area/dmm_suite/clear_area)
+"W" = (
+/obj/decal/cleanable/dirt,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 "Y" = (
 /obj/machinery/drainage,
 /obj/item/parts/human_parts/arm/right,
-/turf/simulated/floor/plating/random,
+/turf/simulated/floor,
 /area/dmm_suite/clear_area)
 
 (1,1,1) = {"
@@ -83,7 +91,7 @@ O
 w
 S
 i
-x
+W
 "}
 (3,1,1) = {"
 l


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds in a new random room: the remnants of a mad medical experiment to turn man into monkey, with dubious results. 



## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Random rooms are fun. Also is a potential crime room/room for a criminal to rush into and pray they get lucky with the medical spawns. Or pretend to be a monkey. Could be abused however due to it having a functional surgical table, so might not be the best fit. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

![hrmmmgjakhfg](https://user-images.githubusercontent.com/105123457/172497697-3a24f53b-3181-4ff6-95cf-cbd572de4da7.png)

