### PR TITLE
fixes minor things on cogmap2

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -43259,7 +43259,11 @@
 /turf/space,
 /area/space)
 "bRC" = (
-/obj/machinery/r_door_control/podbay/security,
+/obj/machinery/r_door_control/podbay/security/new_walls/south{
+	name = "pod bay door control";
+	pixel_y = 0;
+	id = "hangar_sec2"
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/checkpoint/podbay)
 "bRD" = (

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -33933,7 +33933,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/space,
+/turf/simulated/floor/plating,
 /area/station/security/checkpoint/podbay)
 "bAj" = (
 /obj/machinery/light{


### PR DESCRIPTION
[bugfix]

## About the PR 
adds floor tile. re-does walls in listening post juuuust in case.
fixes the door linking thing in the sec podbay. did you know the controller was linked to the original sec hangar which meant every time you used the west podbay door control, you were opening the podbay doors in the primary security hangar?


## Why's this needed? 
fixes #8868 and fixes #8935
and fixes #8596 and fixes #8678
