### PR TITLE
Makes flockdrones 24.7% more robust

### DIFF
--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -756,8 +756,10 @@ stare
 				owncritter.set_hand(3)
 			owncritter.set_dir(get_dir(owncritter, holder.target))
 			owncritter.hand_range_attack(holder.target, dummy_params)
+			var/datum/handHolder/HH = owncritter.hands[3]
+			var/datum/limb/gun/stunner = HH?.limb
 			if(dist < run_range)
-				if(prob(20))
+				if(prob(20) || stunner.is_on_cooldown())
 					// run
 					holder.move_away(holder.target,4)
 			else if(prob(30))
@@ -784,7 +786,7 @@ stare
 			F.flock.updateEnemy(T)
 			if(isliving(T))
 				var/mob/living/M = T
-				if(is_incapacitated(M))
+				if(!isalive(M) || (is_incapacitated(M) && prob(80)))
 					continue
 			. += T
 

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -539,6 +539,12 @@
 	if (!M) return
 	if (isflockmob(M)) return
 	if (!isdead(src) && src.flock)
+		if (!src.controller && prob(25) && (src in oviewers(M)))
+			var/datum/handHolder/HH = hands[3]
+			var/datum/limb/gun/flock_stunner/gun = HH.limb
+			//dummy params since we're not a real player
+			var/list/params = list("icon-x" = 16, "icon-y" = 16)
+			gun.attack_range(M, src, params)
 		if (!src.flock.isEnemy(M))
 			emote("scream")
 			say("[pick_string("flockmind.txt", "flockdrone_enemy")] [M]")

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -539,7 +539,7 @@
 	if (!M) return
 	if (isflockmob(M)) return
 	if (!isdead(src) && src.flock)
-		if (!src.controller && prob(25) && (src in oviewers(M)))
+		if (src.is_npc && prob(25) && (src in oviewers(M)))
 			var/datum/handHolder/HH = hands[3]
 			var/datum/limb/gun/flock_stunner/gun = HH.limb
 			//dummy params since we're not a real player


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives flockdrones a 25% chance to automatically shoot back when hit (if they are AI controlled and their stunner is not on cooldown)
Makes flockdrones always run away if they are close to a target and their stunner is on cooldown.
Gives flockdrones a 20% chance to shoot at incapacitated targets.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A staffie with a fire extinguisher can currently tear through quite a large amount of drones with very little chance of being caged, this should make fighting AI drones a little bit more scary and give flockminds/traces more opportunities to capture enemies.