### PR TITLE
fixes some wording in the pod building process

### DIFF
--- a/code/modules/transport/pods/ships.dm
+++ b/code/modules/transport/pods/ships.dm
@@ -633,7 +633,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 				else
 					boutput(user, "<span class='alert'>These sheets aren't the right kind of material. You need metal!</span>")
 			else
-				boutput(user, "You shouldn't just leave all those circuits exposed! That's dangerous! You'll need three sheets of metal to cover it all up.")
+				boutput(user, "You shouldn't just leave all those circuits exposed! That's dangerous! You'll need [src.metal_amt] sheets of metal to cover it all up.")
 
 		if(6)
 			if(istype(W, src.engine_type))
@@ -729,7 +729,7 @@ ABSTRACT_TYPE(/obj/structure/vehicleframe)
 				qdel(src)
 
 			else
-				boutput(user, "You weren't thinking of heading out without a reinforced cockpit, were you? Put some reinforced glass on it! Three [src.glass_amt] will do.")
+				boutput(user, "You weren't thinking of heading out without a reinforced cockpit, were you? Put some reinforced glass on it! Just [src.glass_amt] sheets will do.")
 
 /*-----------------------------*/
 /*                             */


### PR DESCRIPTION
[bugfix]
## About the PR 
fixes a few src.mat_amt calls

## Why's this needed?
fixes #8331; now gives correct amount of metal sheets needed if someone examines and is trying to build a full pod (said three, requires five; inaccuracy bad)
