### PR TITLE
Adds more viarety in station/big station bounties, makes them more common.

### DIFF
--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -522,6 +522,7 @@
 	big_station_bounties[/obj/machinery/recharge_station] = 2
 
 	big_station_bounties[/obj/machinery/sleeper/port_a_medbay] = 1
+	big_station_bounties[/obj/machinery/port_a_brig] = 3
 	big_station_bounties[/obj/machinery/recharger] = 3
 
 	big_station_bounties[/obj/machinery/manufacturer/robotics] = 2

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -35,10 +35,10 @@
 	var/list/photo_bounties = list()				// Photos of people (Operates by text, because that's the only info that photos store)
 
 	var/const/organ_bounty_amt = 4
-	var/const/person_bounty_amt = 5
+	var/const/person_bounty_amt = 4
 	var/const/photo_bounty_amt = 4
-	var/const/station_bounty_amt = 4
-	var/const/big_station_bounty_amt = 2
+	var/const/station_bounty_amt = 5
+	var/const/big_station_bounty_amt = 3
 
 	var/list/possible_areas = list()
 	var/list/active_bounties = list()
@@ -335,7 +335,8 @@
 	station_bounties[/obj/item/disk/data/floppy/read_only/communications] = 2
 	station_bounties[/obj/item/disk/data/floppy/read_only/authentication] = 3
 	station_bounties[/obj/item/aiModule/freeform] = 3
-
+	station_bounties[/obj/item/aiModule/nanotrasen1] = 2
+	station_bounties[/obj/item/aiModule/nanotrasen2] = 2
 
 	station_bounties[/obj/item/cell] = 1
 	station_bounties[/obj/item/device/multitool] = 1
@@ -356,12 +357,13 @@
 	station_bounties[/obj/item/clothing/suit/armor/vest] = 2
 
 	station_bounties[/obj/item/robodefibrillator] = 1
-	station_bounties[/obj/item/remote/porter/port_a_medbay] = 1
+	station_bounties[/obj/item/remote/porter/port_a_medbay] = 2
 	station_bounties[/obj/item/staple_gun] = 1
 	station_bounties[/obj/item/storage/firstaid] = 1
 	station_bounties[/obj/item/circular_saw] = 1
 	station_bounties[/obj/item/reagent_containers/hypospray] = 1
 	station_bounties[/obj/item/paper/book/from_file/pharmacopia] = 1
+	station_bounties[/obj/item/reagent_containers/mender] = 2
 
 	station_bounties[/obj/item/reagent_containers/food/drinks/mug/HoS] = 1
 	station_bounties[/obj/item/reagent_containers/food/drinks/rum_spaced] = 2
@@ -376,6 +378,8 @@
 	station_bounties[/obj/captain_bottleship] = 3
 	station_bounties[/obj/item/hand_tele] = 3
 	station_bounties[/obj/item/card/id/captains_spare] = 3
+	station_bounties[/obj/item/rcd] = 2
+	station_bounties[/obj/item/rcd/construction/chiefEngineer] = 3
 
 	station_bounties[/obj/item/baton] = 2
 	station_bounties[/obj/item/gun/kinetic/riot40mm] = 2
@@ -384,6 +388,8 @@
 	station_bounties[/obj/item/captaingun] = 3
 	station_bounties[/obj/item/gun/energy/taser_gun] = 2
 	station_bounties[/obj/item/gun/energy/egun] = 3
+	station_bounties[/obj/item/gun/energy/pulse_rifle] = 3
+	station_bounties[/obj/item/gun/kinetic/riotgun] = 3
 
 
 	station_bounties[/obj/item/kitchen/utensil] = 1
@@ -423,17 +429,18 @@
 	station_bounties[/obj/item/clothing/glasses/visor] = 1
 	station_bounties[/obj/item/clothing/glasses/healthgoggles] = 1
 
-	station_bounties[/obj/item/clothing/suit/space/santa] = 1
-	station_bounties[/obj/item/clothing/suit/space/captain/blue] = 2
-	station_bounties[/obj/item/clothing/suit/space/captain/red] = 2
-	station_bounties[/obj/item/clothing/suit/space/captain] = 2
-	station_bounties[/obj/item/clothing/suit/space/engineer] = 1
-	station_bounties[/obj/item/clothing/suit/space/diving/security] = 2
-	station_bounties[/obj/item/clothing/suit/space/diving/civilian] = 1
-	station_bounties[/obj/item/clothing/suit/space/diving/command] = 2
-	station_bounties[/obj/item/clothing/suit/space/diving/engineering] = 1
-	station_bounties[/obj/item/clothing/suit/space] = 1
-
+	#ifdef UNDERWATER_MAP
+		station_bounties[/obj/item/clothing/suit/space/diving/security] = 2
+		station_bounties[/obj/item/clothing/suit/space/diving/civilian] = 1
+		station_bounties[/obj/item/clothing/suit/space/diving/command] = 2
+		station_bounties[/obj/item/clothing/suit/space/diving/engineering] = 1
+	#else
+		station_bounties[/obj/item/clothing/suit/space] = 1
+		station_bounties[/obj/item/clothing/suit/space/santa] = 1
+		station_bounties[/obj/item/clothing/suit/space/captain/blue] = 2
+		station_bounties[/obj/item/clothing/suit/space/captain/red] = 2
+		station_bounties[/obj/item/clothing/suit/space/captain] = 2
+		station_bounties[/obj/item/clothing/suit/space/engineer] = 1
 	station_bounties[/obj/item/tank/jetpack] = 1
 
 	station_bounties[/obj/item/storage/secure/sbriefcase] = 2
@@ -467,27 +474,32 @@
 	station_bounties[/obj/item/device/radio/headset/command/hos] = 3
 
 	// Big machinery (non portable) objects
-	big_station_bounties[/obj/machinery/vehicle/pod] = 1
-	big_station_bounties[/obj/machinery/vehicle/escape_pod] = 1
-	big_station_bounties[/obj/machinery/vehicle/cargo] = 1
-	big_station_bounties[/obj/machinery/vehicle/miniputt/nanoputt] = 1
-	big_station_bounties[/obj/machinery/vehicle/tank/minisub/secsub] = 1
-	big_station_bounties[/obj/machinery/vehicle/tank/minisub/mining] = 1
-	big_station_bounties[/obj/machinery/vehicle/tank/minisub/civilian] = 1
-	big_station_bounties[/obj/machinery/vehicle/tank/minisub/engineer] = 1
-	big_station_bounties[/obj/machinery/vehicle/tank/minisub/escape_sub] = 1
-	big_station_bounties[/obj/machinery/vehicle/tank/minisub] = 1
+
+	#ifdef UNDERWATER_MAP
+		big_station_bounties[/obj/machinery/vehicle/tank/minisub/secsub] = 1
+		big_station_bounties[/obj/machinery/vehicle/tank/minisub/mining] = 1
+		big_station_bounties[/obj/machinery/vehicle/tank/minisub/civilian] = 1
+		big_station_bounties[/obj/machinery/vehicle/tank/minisub/engineer] = 1
+		big_station_bounties[/obj/machinery/vehicle/tank/minisub/escape_sub] = 1
+		big_station_bounties[/obj/machinery/vehicle/tank/minisub] = 1
+	#else
+		big_station_bounties[/obj/machinery/vehicle/pod] = 1
+		big_station_bounties[/obj/machinery/vehicle/escape_pod] = 1
+		big_station_bounties[/obj/machinery/vehicle/cargo] = 1
+		big_station_bounties[/obj/machinery/vehicle/miniputt/nanoputt] = 1
 
 	big_station_bounties[/obj/machinery/power/reactor_stats] = 1
 	big_station_bounties[/obj/machinery/computer/supplycomp] = 1
 	big_station_bounties[/obj/machinery/computer3/generic/communications] = 1
 	big_station_bounties[/obj/machinery/computer3/terminal/zeta] = 1
+	big_station_bounties[/obj/machinery/networked/teleconsole] = 2
 	big_station_bounties[/obj/machinery/chem_dispenser] = 2
 	big_station_bounties[/obj/machinery/computer/announcement] = 2
 	big_station_bounties[/obj/machinery/computer/card] = 2
 	big_station_bounties[/obj/machinery/computer/genetics] = 2
 	big_station_bounties[/obj/machinery/computer/robotics] = 2
 	big_station_bounties[/obj/machinery/lawrack] = 3
+	big_station_bounties[/obj/machinery/turret] = 3
 
 	big_station_bounties[/obj/machinery/vending/medical] = 1
 	big_station_bounties[/obj/machinery/vending/port_a_nanomed] = 1
@@ -508,10 +520,10 @@
 	big_station_bounties[/obj/machinery/recharge_station] = 2
 
 	big_station_bounties[/obj/machinery/sleeper/port_a_medbay] = 1
-	big_station_bounties[/obj/machinery/port_a_brig] = 3
+	big_station_bounties[/obj/machinery/recharger] = 3
 
-	big_station_bounties[/obj/machinery/manufacturer/robotics] = 1
-	big_station_bounties[/obj/machinery/manufacturer/medical] = 1
+	big_station_bounties[/obj/machinery/manufacturer/robotics] = 2
+	big_station_bounties[/obj/machinery/manufacturer/medical] = 2
 	big_station_bounties[/obj/machinery/manufacturer/general] = 1
 
 	big_station_bounties[/obj/submachine/chef_oven] = 1
@@ -521,6 +533,7 @@
 	big_station_bounties[/obj/machinery/plantpot] = 1
 	big_station_bounties[/obj/machinery/partyalarm] = 1
 	big_station_bounties[/obj/pool_springboard] = 1
+	big_station_bounties[/obj/machinery/hydro_growlamp] = 1
 
 	big_station_bounties[/obj/reagent_dispensers/foamtank] = 1
 	big_station_bounties[/obj/reagent_dispensers/watertank/fountain] = 1
@@ -532,6 +545,8 @@
 
 	big_station_bounties[/obj/machinery/communications_dish] = 2
 	big_station_bounties[/obj/item/teg_semiconductor] = 2
+	big_station_bounties[/obj/machinery/power/smes] = 2
+	big_station_bounties[/obj/machinery/rkit] = 2
 	big_station_bounties[/obj/machinery/crusher] = 3
 
 	active_bounties.len = 0

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -430,17 +430,18 @@
 	station_bounties[/obj/item/clothing/glasses/healthgoggles] = 1
 
 	#ifdef UNDERWATER_MAP
-		station_bounties[/obj/item/clothing/suit/space/diving/security] = 2
-		station_bounties[/obj/item/clothing/suit/space/diving/civilian] = 1
-		station_bounties[/obj/item/clothing/suit/space/diving/command] = 2
-		station_bounties[/obj/item/clothing/suit/space/diving/engineering] = 1
+	station_bounties[/obj/item/clothing/suit/space/diving/security] = 2
+	station_bounties[/obj/item/clothing/suit/space/diving/civilian] = 1
+	station_bounties[/obj/item/clothing/suit/space/diving/command] = 2
+	station_bounties[/obj/item/clothing/suit/space/diving/engineering] = 1
 	#else
-		station_bounties[/obj/item/clothing/suit/space] = 1
-		station_bounties[/obj/item/clothing/suit/space/santa] = 1
-		station_bounties[/obj/item/clothing/suit/space/captain/blue] = 2
-		station_bounties[/obj/item/clothing/suit/space/captain/red] = 2
-		station_bounties[/obj/item/clothing/suit/space/captain] = 2
-		station_bounties[/obj/item/clothing/suit/space/engineer] = 1
+	station_bounties[/obj/item/clothing/suit/space] = 1
+	station_bounties[/obj/item/clothing/suit/space/santa] = 1
+	station_bounties[/obj/item/clothing/suit/space/captain/blue] = 2
+	station_bounties[/obj/item/clothing/suit/space/captain/red] = 2
+	station_bounties[/obj/item/clothing/suit/space/captain] = 2
+	station_bounties[/obj/item/clothing/suit/space/engineer] = 1
+	#endif
 	station_bounties[/obj/item/tank/jetpack] = 1
 
 	station_bounties[/obj/item/storage/secure/sbriefcase] = 2
@@ -476,17 +477,18 @@
 	// Big machinery (non portable) objects
 
 	#ifdef UNDERWATER_MAP
-		big_station_bounties[/obj/machinery/vehicle/tank/minisub/secsub] = 1
-		big_station_bounties[/obj/machinery/vehicle/tank/minisub/mining] = 1
-		big_station_bounties[/obj/machinery/vehicle/tank/minisub/civilian] = 1
-		big_station_bounties[/obj/machinery/vehicle/tank/minisub/engineer] = 1
-		big_station_bounties[/obj/machinery/vehicle/tank/minisub/escape_sub] = 1
-		big_station_bounties[/obj/machinery/vehicle/tank/minisub] = 1
+	big_station_bounties[/obj/machinery/vehicle/tank/minisub/secsub] = 1
+	big_station_bounties[/obj/machinery/vehicle/tank/minisub/mining] = 1
+	big_station_bounties[/obj/machinery/vehicle/tank/minisub/civilian] = 1
+	big_station_bounties[/obj/machinery/vehicle/tank/minisub/engineer] = 1
+	big_station_bounties[/obj/machinery/vehicle/tank/minisub/escape_sub] = 1
+	big_station_bounties[/obj/machinery/vehicle/tank/minisub] = 1
 	#else
-		big_station_bounties[/obj/machinery/vehicle/pod] = 1
-		big_station_bounties[/obj/machinery/vehicle/escape_pod] = 1
-		big_station_bounties[/obj/machinery/vehicle/cargo] = 1
-		big_station_bounties[/obj/machinery/vehicle/miniputt/nanoputt] = 1
+	big_station_bounties[/obj/machinery/vehicle/pod] = 1
+	big_station_bounties[/obj/machinery/vehicle/escape_pod] = 1
+	big_station_bounties[/obj/machinery/vehicle/cargo] = 1
+	big_station_bounties[/obj/machinery/vehicle/miniputt/nanoputt] = 1
+	#endif
 
 	big_station_bounties[/obj/machinery/power/reactor_stats] = 1
 	big_station_bounties[/obj/machinery/computer/supplycomp] = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The amount of person bounty amts has been reduced to 4 (mostly to keep the bounty total amount roughly equal) and the station_bounty_amt and big_station_bounty_amt has been upped by 1. Several higher impact items have been added to these lists (just look at code for this one). Oh also adds some ifdef for things so ocean stuff isnt a bounty on space maps and vice versa.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These types of items being stolen tend to have the most impact on the overall flow of the round. By having more of these items stolen, and the stolen items being more impactful, this should increase the impact spies directly have on a round.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)The amount of station/big station item bounties for spies has been increased.
```
