### PR TITLE
destiny engineering changes

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -584,7 +584,7 @@
 "ack" = (
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingun;
+	displayed = new/obj/item/captaingun;
 	pixel_y = 8
 	},
 /obj/machinery/light/incandescent{
@@ -787,7 +787,9 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/heads)
@@ -2562,7 +2564,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/heads)
@@ -3295,7 +3299,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 8;
@@ -4513,7 +4519,9 @@
 /area/station/hallway/primary/central)
 "asc" = (
 /turf/simulated/floor/carpet/blue/standard/edge/west,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "asg" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -4668,7 +4676,9 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /turf/simulated/floor/carpet/blue/standard/narrow/east,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "asF" = (
 /obj/cable{
 	icon_state = "0-8"
@@ -5118,7 +5128,9 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/cable,
+/obj/cable/yellow{
+	dir = 4
+	},
 /obj/item/device/radio/intercom/engineering,
 /turf/simulated/floor/neutral/side{
 	dir = 8
@@ -6269,7 +6281,9 @@
 /turf/simulated/floor/sanitary,
 /area/station/medical/medbay/restroom)
 "azG" = (
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -7699,7 +7713,9 @@
 	},
 /obj/table/round/auto,
 /turf/simulated/floor/darkblue/checker,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "aFX" = (
 /obj/decal/tile_edge/line/blue{
 	icon_state = "line1"
@@ -9273,17 +9289,8 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
-	},
-/obj/machinery/light/incandescent/harsh{
-	dir = 8;
-	nostick = 1
-	},
-/turf/simulated/floor/yellowblack/corner,
-/area/station/engine/engineering/ce)
+/turf/simulated/floor/black,
+/area/station/engine/core)
 "aLv" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -9291,7 +9298,17 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/yellowblack,
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/window_blinds/cog2{
+	dir = 4
+	},
+/turf/simulated/floor/plating/random,
 /area/station/engine/engineering/ce)
 "aLx" = (
 /obj/cable{
@@ -10574,7 +10591,9 @@
 /area/station/hallway/primary/west)
 "aSR" = (
 /turf/simulated/floor/carpet/blue/standard,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "aSU" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 8
@@ -11102,7 +11121,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "aVH" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -11147,10 +11166,12 @@
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "aVN" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/cable,
+/obj/cable/yellow{
+	dir = 4
+	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/engine/gas)
@@ -11276,10 +11297,10 @@
 	},
 /area/station/solar/west)
 "aWq" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto,
@@ -11302,10 +11323,10 @@
 /turf/simulated/floor/blue,
 /area/station/science/lab)
 "aWE" = (
-/obj/cable{
+/obj/wingrille_spawn/auto,
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/engine/gas)
 "aWH" = (
@@ -11561,7 +11582,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/sw,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "aXD" = (
 /obj/decal/tile_edge/line/green{
 	dir = 1;
@@ -11879,7 +11902,7 @@
 /turf/simulated/floor/black,
 /area/station/ranch)
 "aZC" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/decal/poster/wallsign/hazard_hotloop,
@@ -11996,10 +12019,10 @@
 	},
 /area/station/crew_quarters/fitness)
 "bay" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -12601,7 +12624,9 @@
 "beT" = (
 /obj/forcefield/energyshield/perma,
 /turf/simulated/floor/stairs/medical/wide/other,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "beU" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -13071,7 +13096,9 @@
 	layer = 3.9
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/nw,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "bhT" = (
 /obj/decal/tile_edge/line/black{
 	dir = 10;
@@ -13443,7 +13470,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/engineering/ce)
+/area/station/engine/core)
 "bkD" = (
 /obj/decal/tile_edge/stripe{
 	dir = 4
@@ -13465,9 +13492,6 @@
 	dir = 10
 	},
 /obj/disposalpipe/segment,
-/obj/machinery/light/emergency{
-	dir = 1
-	},
 /obj/cable{
 	icon_state = "2-4"
 	},
@@ -14256,7 +14280,7 @@
 	icon_state = "line1"
 	},
 /obj/machinery/bot/floorbot,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -14282,7 +14306,7 @@
 /turf/simulated/floor/yellow/side,
 /area/station/engine/engineering)
 "bqe" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/engineering/alt{
@@ -14316,7 +14340,7 @@
 /area/station/bridge)
 "bqA" = (
 /obj/item/constructioncone,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/yellow,
@@ -14435,7 +14459,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/decal/poster/wallsign/engineering,
@@ -14445,7 +14469,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -14669,7 +14693,7 @@
 	dir = 6;
 	name = "autoname  - SS13"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/cable,
@@ -14802,19 +14826,19 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 9
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "btr" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/engine,
@@ -14906,8 +14930,11 @@
 	dir = 8;
 	name = "Engine Output Monitoring"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
+	},
+/obj/machinery/light/emergency{
+	dir = 4
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 8
@@ -14943,7 +14970,7 @@
 /obj/machinery/power/furnace/thermo{
 	fuel = 100
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/random,
@@ -15028,21 +15055,6 @@
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "bvn" = (
-/obj/table/reinforced/auto,
-/obj/machinery/light/emergency{
-	dir = 4
-	},
-/obj/item/chem_grenade/firefighting{
-	pixel_y = 10
-	},
-/obj/item/chem_grenade/firefighting{
-	pixel_y = 8
-	},
-/obj/machinery/cell_charger,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
 /turf/simulated/floor/yellow/side{
 	dir = 8
 	},
@@ -15054,7 +15066,7 @@
 	pixel_y = 1;
 	target_pressure = 1e+031
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -15202,7 +15214,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "bvV" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 5
@@ -15365,7 +15379,7 @@
 /area/station/crew_quarters/bar)
 "bwU" = (
 /obj/machinery/meter,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
@@ -15410,14 +15424,17 @@
 /turf/space,
 /area/station/com_dish/auxdish)
 "bxd" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 9
 	},
 /obj/machinery/meter,
-/obj/cable{
+/obj/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine,
@@ -15433,17 +15450,22 @@
 /turf/simulated/floor/plating/random,
 /area/station/security/brig)
 "bxx" = (
-/obj/machinery/phone/wall{
-	pixel_y = 32
+/obj/cable{
+	icon_state = "1-2"
 	},
-/obj/reagent_dispensers/watertank/fountain,
+/obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe,
+/obj/machinery/door/airlock/pyro/glass{
+	name = "Community Center";
+	dir = 4
+	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "bxE" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
@@ -15454,13 +15476,13 @@
 	on = 1;
 	transfer_rate = 1000
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "bxO" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -15472,7 +15494,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 10
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/engine,
@@ -15515,7 +15537,7 @@
 	},
 /area/station/engine/engineering)
 "byb" = (
-/obj/cable,
+/obj/cable/yellow,
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 1;
@@ -15560,7 +15582,7 @@
 	name = "Combustion Chamber Heat Shield";
 	opacity = 0
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
@@ -15577,11 +15599,13 @@
 	name = "Combustion Chamber Heat Shield";
 	opacity = 0
 	},
-/obj/cable,
-/obj/cable{
+/obj/cable/yellow{
+	dir = 4
+	},
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto/crystal,
@@ -15598,7 +15622,7 @@
 	name = "Combustion Chamber Heat Shield";
 	opacity = 0
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
@@ -15621,13 +15645,13 @@
 	setup_tag = "ENGINE"
 	},
 /obj/machinery/power/data_terminal,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/engine/vacuum,
@@ -16418,7 +16442,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "bBA" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/valve{
@@ -16432,7 +16456,7 @@
 	level = 2
 	},
 /obj/machinery/meter,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
@@ -16449,7 +16473,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "bBI" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/portable_atmospherics/scrubber,
@@ -16638,7 +16662,9 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "bFn" = (
 /obj/decal/tile_edge/line/red{
 	dir = 4;
@@ -16783,7 +16809,7 @@
 	name = "Cold Loop Outlet Meter";
 	tag = "Cold Loop Outlet Meter"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -17219,16 +17245,22 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "bWh" = (
-/obj/cable{
-	icon_state = "2-4"
+/obj/table/reinforced/auto,
+/obj/machinery/cell_charger,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/obj/item/chem_grenade/firefighting{
+	pixel_y = 10
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13"
+/obj/item/chem_grenade/firefighting{
+	pixel_y = 8
 	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/west)
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
+/area/station/engine/engineering)
 "bWm" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -17596,13 +17628,13 @@
 /obj/machinery/light/emergency{
 	dir = 1
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "cfC" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/junction{
@@ -18060,7 +18092,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -19122,7 +19156,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/cable,
+/obj/cable/yellow{
+	dir = 4
+	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
@@ -19264,9 +19300,11 @@
 	name = "Head of Personnel's Quarters"
 	})
 "cTp" = (
-/obj/disposalpipe/segment,
+/obj/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/fitness)
+/area/station/engine/power)
 "cTA" = (
 /obj/decal/tile_edge/line/red{
 	dir = 4;
@@ -19318,7 +19356,9 @@
 /area/station/security/equipment)
 "cUy" = (
 /turf/simulated/floor/carpet/blue/standard/innercorner/east,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "cUC" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 4;
@@ -19529,10 +19569,10 @@
 /area/station/security/main)
 "cXh" = (
 /obj/machinery/light,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
@@ -19879,7 +19919,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/external,
@@ -20043,6 +20083,15 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/clown)
+"dkd" = (
+/obj/disposalpipe/segment,
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Engine Room"
+	},
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_engine,
+/turf/simulated/floor/black,
+/area/station/engine/core)
 "dkp" = (
 /obj/decal/tile_edge/line/white{
 	dir = 4;
@@ -20470,14 +20519,15 @@
 /turf/simulated/floor,
 /area/station/hangar/qm)
 "duw" = (
-/obj/cable,
-/obj/disposalpipe/segment/mail,
-/obj/cable{
-	icon_state = "0-2"
+/obj/decal/tile_edge/line/yellow{
+	dir = 8;
+	icon_state = "line1"
 	},
-/obj/wingrille_spawn/auto/crystal,
-/turf/simulated/floor/plating/random,
-/area/station/engine/core)
+/obj/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
 "duC" = (
 /obj/machinery/door_control{
 	id = "qm_dock";
@@ -20542,7 +20592,9 @@
 	name = "Hot Loop Combustion Chamber Meter";
 	tag = "Hot Loop Combustion Chamber Meter"
 	},
-/obj/cable,
+/obj/cable/yellow{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -20596,7 +20648,7 @@
 	},
 /area/station/science/teleporter)
 "dwD" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -21317,9 +21369,18 @@
 /turf/simulated/floor/grass/random,
 /area/station/hydroponics/bay)
 "dPX" = (
-/obj/disposalpipe/segment,
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/engine/engineering/ce)
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/obj/reagent_dispensers/watertank/fountain,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "dQf" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -21421,7 +21482,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "dSf" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/binary/volume_pump{
@@ -21457,7 +21518,7 @@
 	can_rupture = 0;
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -22310,7 +22371,9 @@
 /area/station/crew_quarters/lounge/starboard)
 "eql" = (
 /turf/simulated/floor/carpet/blue/standard/edge/se,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "equ" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/southwest{
 	dir = 1
@@ -23212,7 +23275,7 @@
 	},
 /area/station/science/chemistry)
 "eFo" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -23437,7 +23500,7 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "eKe" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -23503,16 +23566,17 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "eLS" = (
+/obj/machinery/light/emergency{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe,
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe,
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Community Center"
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/crew_quarters/lounge)
+/area/station/crew_quarters/fitness)
 "eMg" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/storage/warehouse)
@@ -23710,7 +23774,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "eQz" = (
 /obj/storage/secure/closet/engineering/mechanic,
 /obj/decal/tile_edge/line/black{
@@ -23851,13 +23917,13 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "eUD" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/binary/pump{
@@ -24067,6 +24133,9 @@
 	dir = 4
 	},
 /obj/shrub,
+/obj/machinery/light/emergency{
+	dir = 4
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "eYI" = (
@@ -24129,10 +24198,10 @@
 	name = "Genetic Research"
 	})
 "eZL" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -24247,7 +24316,7 @@
 	level = 2
 	},
 /obj/machinery/meter,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
@@ -24329,7 +24398,7 @@
 	icon_state = "line1"
 	},
 /obj/machinery/disposal_pipedispenser/mobile,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -24952,7 +25021,7 @@
 	},
 /area/station/engine/elect)
 "frn" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/black{
@@ -24999,7 +25068,7 @@
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
 "fsk" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/wingrille_spawn/auto/crystal,
@@ -25070,7 +25139,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "fuY" = (
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/detectives_office)
@@ -25664,6 +25735,9 @@
 	icon_state = "4-8"
 	},
 /obj/shrub,
+/obj/machinery/light/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "fLO" = (
@@ -26036,10 +26110,10 @@
 /area/station/science/chemistry)
 "fUL" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/engine,
@@ -26069,8 +26143,8 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
 "fVD" = (
-/obj/cable,
-/obj/cable{
+/obj/cable/yellow,
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -26082,7 +26156,7 @@
 	name = "Control Room Heat Shield";
 	opacity = 0
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/disposalpipe/segment/mail,
@@ -26542,7 +26616,9 @@
 	})
 "gfZ" = (
 /turf/simulated/floor/carpet/blue/standard/edge/south,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "ggS" = (
 /obj/machinery/atmospherics/pipe/manifold{
 	dir = 4;
@@ -27217,11 +27293,6 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname  - SS13"
-	},
 /obj/cable{
 	icon_state = "1-8"
 	},
@@ -27548,15 +27619,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "gGo" = (
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1
-	},
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/west)
+/turf/simulated/floor/black,
+/area/station/engine/engineering/ce)
 "gGr" = (
 /obj/decal/tile_edge/line/white{
 	icon_state = "line1"
@@ -27613,10 +27677,10 @@
 	},
 /area/station/crew_quarters/courtroom)
 "gIg" = (
-/turf/simulated/floor/yellow/side{
-	dir = 1
-	},
-/area/station/engine/engineering)
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable,
+/turf/simulated/floor/plating/random,
+/area/station/crew_quarters/fitness)
 "gIq" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -27692,10 +27756,6 @@
 /area/station/engine/core)
 "gMx" = (
 /obj/machinery/shieldgenerator/energy_shield,
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1
-	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/west)
 "gMK" = (
@@ -27951,7 +28011,9 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/security/detectives_office)
@@ -28159,16 +28221,16 @@
 /turf/simulated/floor/purple,
 /area/station/science/artifact)
 "gXP" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/landmark/spawner{
 	name = "monkeyspawn_rathen"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
@@ -29045,7 +29107,7 @@
 /area/space)
 "hsY" = (
 /obj/decal/poster/wallsign/space,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -29562,7 +29624,7 @@
 	dir = 4
 	},
 /obj/machinery/power/data_terminal,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -30164,7 +30226,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/medical/medbay/treatment)
 "icv" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -30405,7 +30467,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
@@ -31700,26 +31764,20 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	nostick = 1
-	},
 /obj/cable{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/east)
 "iZt" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 6;
-	name = "autoname - SS13"
+/obj/machinery/door/airlock/pyro/command/alt{
+	name = "Chief Engineer's Office";
+	dir = 8
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/random,
-/area/station/maintenance/west)
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_chief,
+/turf/simulated/floor/yellow,
+/area/station/engine/engineering/ce)
 "iZS" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -32903,7 +32961,7 @@
 /area/station/hydroponics/bay)
 "jFj" = (
 /obj/machinery/computer/power_monitor,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
@@ -33180,7 +33238,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
 "jMx" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -33199,6 +33257,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "jNB" = (
@@ -34285,9 +34344,6 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/light/emergency{
-	dir = 4
-	},
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
@@ -34581,7 +34637,9 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "kDO" = (
 /obj/disposalpipe/trunk{
 	dir = 1
@@ -34748,7 +34806,9 @@
 	name = "bot navigation beacon"
 	},
 /turf/simulated/floor/carpet/blue/standard,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "kHn" = (
 /obj/lattice{
 	dir = 6;
@@ -34853,10 +34913,10 @@
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
@@ -34975,7 +35035,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -35574,7 +35634,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/stool/chair/couch/blue,
+/obj/stool/chair/couch/blue{
+	dir = 4
+	},
+/obj/machinery/phone/wall{
+	pixel_y = 32
+	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "leZ" = (
@@ -36172,7 +36237,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/interrogation)
 "lvm" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
@@ -36321,7 +36386,7 @@
 /turf/simulated/floor/red/checker,
 /area/station/security/main)
 "lys" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
@@ -36384,7 +36449,9 @@
 /obj/cable,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "lCd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -36774,11 +36841,11 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/hallway/secondary/exit)
 "lOs" = (
-/obj/cable,
-/obj/cable{
+/obj/cable/yellow,
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -36791,7 +36858,12 @@
 	opacity = 0
 	},
 /obj/disposalpipe/segment/mail,
-/obj/wingrille_spawn/auto/crystal,
+/obj/machinery/door/airlock/pyro/engineering/alt{
+	dir = 4;
+	name = "Engine Room"
+	},
+/obj/access_spawn/engineering_engine,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "lOt" = (
@@ -37517,9 +37589,6 @@
 	pixel_x = 8;
 	pixel_y = 28
 	},
-/obj/stool/chair/couch/blue{
-	dir = 4
-	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
 "mhN" = (
@@ -37541,11 +37610,15 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe{
 	dir = 4
+	},
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
+	},
+/obj/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/specialroom/arcade,
 /area/station/crew_quarters/lounge)
@@ -38087,7 +38160,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "mwq" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -38256,10 +38329,10 @@
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/lobby)
 "mBt" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow,
@@ -38356,7 +38429,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
@@ -38436,7 +38509,9 @@
 "mFz" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "mFK" = (
 /obj/machinery/firealarm{
 	layer = 3.5;
@@ -38833,10 +38908,10 @@
 	},
 /area/station/crew_quarters/bar)
 "mQo" = (
-/obj/cable{
+/obj/wingrille_spawn/auto,
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
 /area/station/engine/gas)
 "mQr" = (
@@ -38966,6 +39041,9 @@
 /turf/simulated/floor,
 /area/station/hangar/sec)
 "mUL" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/yellow,
 /area/station/engine/engineering/ce)
 "mUP" = (
@@ -39048,6 +39126,8 @@
 /obj/item/chem_grenade/metalfoam,
 /obj/item/old_grenade/oxygen,
 /obj/decal/tile_edge/stripe/extra_big,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "mYh" = (
@@ -39154,7 +39234,9 @@
 	name = "Crew Lounge"
 	},
 /turf/simulated/floor/wood,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "nba" = (
 /turf/simulated/floor/greenblack{
 	dir = 8
@@ -39280,7 +39362,7 @@
 /area/station/hallway/primary/east)
 "neD" = (
 /obj/disposalpipe/segment/mail,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -39342,7 +39424,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 10
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
@@ -39928,7 +40010,7 @@
 /turf/simulated/floor/engine,
 /area/station/engine/core)
 "nut" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/valve{
@@ -39970,10 +40052,10 @@
 	},
 /area/station/crew_quarters/quartersC)
 "nvn" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/machinery/door/airlock/pyro/glass/engineering{
@@ -40484,13 +40566,18 @@
 /turf/space,
 /area/station/turret_protected/armory_outside)
 "nHL" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
 /obj/storage/crate/rcd/CE,
-/turf/simulated/floor/yellowblack{
-	dir = 1
+/obj/wingrille_spawn/auto,
+/obj/cable{
+	icon_state = "0-4"
 	},
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/window_blinds/cog2{
+	dir = 4
+	},
+/turf/simulated/floor/plating/random,
 /area/station/engine/engineering/ce)
 "nHW" = (
 /obj/stool/chair/wooden{
@@ -40563,6 +40650,19 @@
 /obj/item/device/radio/intercom/cargo{
 	dir = 8
 	},
+/obj/machinery/computer/power_monitor/smes{
+	name = "Engine Output Monitoring";
+	dir = 8
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light_switch/west{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = -14
+	},
 /turf/simulated/floor/black,
 /area/station/engine/engineering/ce)
 "nKl" = (
@@ -40625,7 +40725,7 @@
 /turf/simulated/floor/black,
 /area/station/hallway/primary/east)
 "nMB" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -40633,6 +40733,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
+"nMH" = (
+/obj/decal/tile_edge/line/yellow{
+	dir = 8;
+	icon_state = "line1"
+	},
+/obj/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/mining/staff_room)
 "nNv" = (
 /obj/item_dispenser/handcuffs,
 /obj/table/reinforced/auto,
@@ -41223,9 +41333,6 @@
 /area/station/ai_monitored/storage/eva)
 "odT" = (
 /obj/disposalpipe/segment/mail,
-/obj/machinery/light/emergency{
-	dir = 8
-	},
 /obj/machinery/drainage,
 /turf/simulated/floor/black,
 /area/station/hallway/primary/central)
@@ -41442,7 +41549,7 @@
 /area/station/crew_quarters/heads)
 "oiR" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -41470,11 +41577,11 @@
 /turf/simulated/floor/specialroom/clown,
 /area/station/crew_quarters/clown)
 "ojm" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/station/engine/gas)
@@ -41717,7 +41824,7 @@
 /turf/simulated/floor/purple/checker,
 /area/station/janitor/supply)
 "otQ" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -42121,7 +42228,7 @@
 /area/station/library)
 "oCt" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/light/emergency{
@@ -42635,7 +42742,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "oTg" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/cable{
@@ -42758,7 +42865,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor,
@@ -43072,10 +43179,9 @@
 	dir = 4;
 	nostick = 1
 	},
-/obj/table/reinforced/auto,
-/obj/machinery/cell_charger,
-/obj/item/cell/supercell/charged,
-/obj/item/cell/supercell/charged,
+/obj/storage/secure/closet/command/chief_engineer,
+/obj/item/clothing/suit/space/engineer,
+/obj/item/clothing/head/helmet/space/engineer,
 /turf/simulated/floor/carpet{
 	dir = 6;
 	icon_state = "fblue6"
@@ -43284,7 +43390,9 @@
 /obj/cable,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "pim" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -43403,16 +43511,11 @@
 /turf/simulated/floor/yellow/side,
 /area/station/atmos/highcap_storage)
 "pmH" = (
-/obj/cable{
-	icon_state = "1-2"
+/obj/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/light/emergency{
-	dir = 8
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
-	},
-/area/station/crew_quarters/fitness)
+/turf/simulated/floor/black,
+/area/station/hallway/primary/east)
 "pmI" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /turf/simulated/floor/plating/random,
@@ -43911,7 +44014,9 @@
 	name = "Station Intercom"
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/ne,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "pCF" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -44117,7 +44222,7 @@
 	can_rupture = 0;
 	dir = 5
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -44169,10 +44274,7 @@
 	},
 /area/station/crew_quarters/courtroom)
 "pJD" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/external{
@@ -44548,20 +44650,17 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/disposal)
 "pTY" = (
-/obj/cable{
-	icon_state = "0-8"
-	},
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/data_terminal,
-/obj/machinery/computer/power_monitor/smes{
-	name = "Engine Output Monitoring"
-	},
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/yellowblack,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/table/reinforced/auto,
+/obj/machinery/cell_charger,
+/obj/item/cell/supercell/charged,
+/obj/item/cell/supercell/charged,
+/turf/simulated/floor/yellowblack/corner,
 /area/station/engine/engineering/ce)
 "pUm" = (
 /obj/item/device/radio/beacon,
@@ -44595,7 +44694,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/cable,
 /obj/cable{
 	icon_state = "0-2"
@@ -44956,7 +45057,7 @@
 /obj/machinery/computer/power_monitor/smes{
 	name = "Engine Output Monitoring"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/data_terminal,
@@ -45047,7 +45148,7 @@
 /obj/machinery/atmospherics/pipe/manifold{
 	level = 2
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/engine,
@@ -45552,14 +45653,16 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "qzc" = (
 /obj/cable{
 	icon_state = "0-4"
 	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
-/area/station/engine/engineering/ce)
+/area/station/engine/core)
 "qzq" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4;
@@ -45848,10 +45951,10 @@
 	name = "Hot Loop Outlet Meter";
 	tag = "Hot Loop Outlet Meter"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -46081,7 +46184,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "0-8"
 	},
@@ -46211,15 +46316,15 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/command/alt{
-	name = "Chief Engineer's Office"
-	},
 /obj/firedoor_spawn,
 /obj/access_spawn/engineering_chief,
-/turf/simulated/floor/wood{
-	icon_state = "wooden"
+/obj/machinery/door/airlock/pyro/glass/engineering{
+	name = "Engine Room"
 	},
-/area/station/engine/engineering/ce)
+/obj/firedoor_spawn,
+/obj/access_spawn/engineering_engine,
+/turf/simulated/floor/black,
+/area/station/engine/core)
 "qOi" = (
 /obj/landmark{
 	icon_state = "x3";
@@ -46250,7 +46355,7 @@
 /area/station/maintenance/west)
 "qON" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/light,
@@ -46715,7 +46820,7 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "rco" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/pyro/engineering{
@@ -46890,7 +46995,7 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay/surgery)
 "rjk" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/black{
@@ -47498,7 +47603,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/random,
@@ -47619,7 +47724,7 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "rDf" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold{
@@ -48063,7 +48168,7 @@
 	name = "Hot Loop Inlet Meter";
 	tag = "Hot Loop Inlet Meter"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
@@ -48829,7 +48934,9 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "smP" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -48894,10 +49001,10 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/wingrille_spawn/auto/crystal,
@@ -48930,7 +49037,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/artifact)
 "spT" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
@@ -49068,7 +49175,9 @@
 /area/station/crew_quarters/arcade)
 "sud" = (
 /obj/disposalpipe/segment/brig,
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/cable{
 	icon_state = "0-4"
 	},
@@ -49081,11 +49190,8 @@
 /area/station/maintenance/disposal)
 "swa" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/insulated{
-	can_rupture = 0
 	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 9
@@ -49576,7 +49682,9 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/blast{
 	density = 0;
 	dir = 4;
@@ -50045,8 +50153,8 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/yellowblack{
-	dir = 1
+/turf/simulated/floor/yellowblack/corner{
+	dir = 8
 	},
 /area/station/engine/engineering/ce)
 "sYk" = (
@@ -50367,8 +50475,13 @@
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe{
 	dir = 9
 	},
-/turf/simulated/floor/specialroom/arcade,
-/area/station/crew_quarters/lounge)
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/fitness)
 "tdq" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -50780,7 +50893,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "tnU" = (
 /obj/stool/bench/red,
 /obj/disposalpipe/segment/brig{
@@ -50954,15 +51069,10 @@
 /turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "tuM" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 5;
-	name = "autoname  - SS13"
-	},
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
@@ -51275,16 +51385,11 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/storage/secure/closet/command/chief_engineer,
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/item/clothing/head/helmet/space/engineer,
-/obj/item/clothing/suit/space/engineer,
-/turf/simulated/floor/yellowblack/corner{
-	dir = 8
-	},
-/area/station/engine/engineering/ce)
+/turf/simulated/floor/black,
+/area/station/engine/core)
 "tFf" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -51649,8 +51754,10 @@
 	nostick = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/color_pipe/green_pipe,
-/turf/simulated/floor/specialroom/arcade,
-/area/station/crew_quarters/lounge)
+/turf/simulated/floor/wood{
+	icon_state = "wooden"
+	},
+/area/station/crew_quarters/fitness)
 "tPy" = (
 /obj/item/device/radio/intercom/engineering{
 	dir = 8
@@ -51711,8 +51818,8 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northeast)
 "tRs" = (
-/obj/cable,
-/obj/cable{
+/obj/cable/yellow,
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/blast{
@@ -51757,7 +51864,7 @@
 	name = "Cold Loop Radiator Meter";
 	tag = "Cold Loop Radiator Meter"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
@@ -52557,15 +52664,13 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
 "unV" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/cable/yellow,
+/obj/disposalpipe/segment/mail,
+/obj/wingrille_spawn/auto/crystal,
+/obj/cable/yellow{
+	icon_state = "0-4"
 	},
-/obj/machinery/door/airlock/pyro/external{
-	dir = 8
-	},
-/obj/firedoor_spawn,
-/obj/access_spawn/engineering_engine,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/plating/random,
 /area/station/engine/core)
 "uof" = (
 /obj/machinery/light/incandescent/cool{
@@ -52637,7 +52742,7 @@
 	dir = 6;
 	icon_state = "line2"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/storage/crate,
@@ -52728,7 +52833,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "usG" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/line/yellow{
@@ -52870,6 +52975,9 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
+/obj/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/yellowblack,
 /area/station/engine/engineering/ce)
 "uxB" = (
@@ -52964,7 +53072,9 @@
 "uyz" = (
 /obj/forcefield/energyshield/perma,
 /turf/simulated/floor/stairs/medical/wide,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "uyP" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -53300,7 +53410,7 @@
 /area/station/security/detectives_office)
 "uFs" = (
 /obj/disposalpipe/segment,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/pyro/glass/mining{
@@ -53431,7 +53541,9 @@
 "uIi" = (
 /obj/landmark/start/latejoin,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "uIs" = (
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
@@ -53580,7 +53692,7 @@
 	dir = 8;
 	icon_state = "line1"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
@@ -54354,7 +54466,9 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "vcl" = (
-/obj/cable,
+/obj/cable/yellow{
+	dir = 4
+	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating/random,
 /area/station/engine/core)
@@ -54694,7 +54808,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/hangar/main)
 "vmY" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -54847,7 +54961,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical,
 /obj/item/storage/box/cablesbox,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
@@ -54900,7 +55014,9 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
@@ -55252,7 +55368,9 @@
 /turf/simulated/floor/plating/random,
 /area/station/science/storage)
 "vAL" = (
-/obj/window_blinds/cog2,
+/obj/window_blinds/cog2{
+	dir = 4
+	},
 /obj/cable,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
@@ -55390,7 +55508,7 @@
 	broadcasting = 0;
 	dir = 8
 	},
-/obj/stool/chair/moveable,
+/obj/storage/crate/rcd/CE,
 /turf/simulated/floor/yellowblack/corner{
 	dir = 1
 	},
@@ -55420,7 +55538,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/mining/staff_room)
 "vGG" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -55478,7 +55596,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "vIc" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -55524,7 +55642,7 @@
 	name = "Cold Loop Inlet Meter";
 	tag = "Cold Loop Inlet Meter"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
@@ -55582,7 +55700,9 @@
 /area/station/security/brig)
 "vMh" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "vMG" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
@@ -55838,7 +55958,7 @@
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/solar/east)
 "vVi" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -56054,7 +56174,7 @@
 /turf/simulated/floor,
 /area/station/quartermaster/cargobay)
 "wac" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/yellow,
@@ -56141,7 +56261,7 @@
 /turf/simulated/floor/red,
 /area/station/security/main)
 "wcA" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/decal/tile_edge/line/yellow{
@@ -56154,6 +56274,9 @@
 	},
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
+	},
+/obj/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/mining/staff_room)
@@ -56232,7 +56355,7 @@
 	},
 /obj/item/pen,
 /obj/item/stamp,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
@@ -56513,16 +56636,13 @@
 	icon_state = "line2"
 	},
 /obj/disposalpipe/segment/mail,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/cable{
-	icon_state = "1-4"
 	},
 /obj/decal/tile_edge/line/yellow{
 	icon_state = "line1"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -56641,16 +56761,16 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/core)
 "wpw" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/landmark/start{
 	name = "Engineer"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
@@ -56719,10 +56839,10 @@
 	name = "autoname - SS13"
 	},
 /obj/machinery/power/apc/autoname_north,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/yellow,
@@ -56901,16 +57021,16 @@
 /area/station/crew_quarters/lounge/port)
 "wuF" = (
 /obj/item/extinguisher,
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/landmark/start{
 	name = "Engineer"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/decal/tile_edge/stripe/corner/extra_big2{
@@ -57100,6 +57220,7 @@
 /turf/simulated/floor/grey,
 /area/station/library)
 "wyY" = (
+/obj/stool/chair/moveable,
 /turf/simulated/floor/yellowblack{
 	dir = 1
 	},
@@ -57127,7 +57248,9 @@
 /area/station/maintenance/southwest)
 "wAa" = (
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "wAi" = (
 /obj/lattice,
 /obj/warp_beacon{
@@ -57285,6 +57408,9 @@
 	icon_state = "1-4"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/obj/machinery/light/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/engine,
@@ -57490,7 +57616,7 @@
 /turf/simulated/floor/sanitary,
 /area/station/hallway/primary/east/restroom)
 "wIG" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -58609,13 +58735,13 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/storage/crate/furnacefuel,
+/obj/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor,
 /area/station/engine/gas)
 "xnF" = (
@@ -58828,8 +58954,8 @@
 	},
 /area/station/medical/medbay)
 "xsD" = (
-/obj/cable,
-/obj/cable{
+/obj/cable/yellow,
+/obj/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/disposalpipe/segment/mail,
@@ -59153,7 +59279,7 @@
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	can_rupture = 0
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
@@ -59223,7 +59349,7 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "xCG" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/cold_sink/freezer{
@@ -59275,7 +59401,7 @@
 /obj/decal/tile_edge/line/black{
 	icon_state = "line1"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/light,
@@ -59811,7 +59937,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/library)
 "xUh" = (
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/beacon,
@@ -59827,6 +59953,11 @@
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname  - SS13"
 	},
 /turf/simulated/floor/engine,
 /area/station/engine/core)
@@ -60026,11 +60157,12 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light_switch/west{
-	dir = 4
+/obj/machinery/light/incandescent/harsh{
+	dir = 8;
+	nostick = 1
 	},
-/turf/simulated/floor/black,
-/area/station/engine/engineering/ce)
+/turf/simulated/floor/yellow,
+/area/station/engine/core)
 "xZF" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/atmos/highcap_storage)
@@ -60077,7 +60209,9 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating/random,
-/area/station/crewquarters/cryotron)
+/area/station/hallway/secondary/oshan_arrivals{
+	name = "Destiny Arrivals"
+	})
 "ybu" = (
 /obj/disposalpipe/trunk,
 /obj/machinery/disposal/small{
@@ -60198,7 +60332,7 @@
 /obj/machinery/atmospherics/valve{
 	name = "combustion feed valve"
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/tile_edge/stripe/extra_big{
@@ -60249,7 +60383,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/cable{
+/obj/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/danger_highvolt,
@@ -85728,7 +85862,7 @@ aag
 aaa
 eov
 eov
-iZt
+sLT
 tRI
 ovJ
 aVk
@@ -90859,7 +90993,7 @@ aag
 aag
 aaa
 eov
-gGo
+xqq
 aCp
 odn
 kkt
@@ -98396,7 +98530,7 @@ aaa
 aaa
 eov
 eov
-bWh
+xqq
 lfI
 vBV
 vBV
@@ -102070,7 +102204,7 @@ jeF
 nfp
 kxW
 mMP
-gIg
+qnP
 isa
 awu
 xrf
@@ -102372,7 +102506,7 @@ yag
 dHP
 yag
 dHP
-qnP
+bWh
 isa
 ncb
 lck
@@ -104489,7 +104623,7 @@ fUL
 bBB
 dvy
 dSD
-tvK
+cTp
 nmP
 leZ
 jOo
@@ -106577,7 +106711,7 @@ aPl
 lSq
 aIH
 xSc
-wzM
+dPX
 jFR
 bbx
 gBi
@@ -107794,7 +107928,7 @@ xIx
 eLS
 tPc
 tdl
-xZd
+gIg
 iwo
 omO
 wDh
@@ -108093,10 +108227,10 @@ cRe
 lVh
 bap
 cKp
-cTp
-dPX
+cKp
+uQP
 bkC
-mTM
+rMl
 qzc
 rMl
 uMk
@@ -108395,12 +108529,12 @@ uYk
 scC
 bCw
 mov
-pmH
+mov
 qNS
 aLt
 xZy
 tFc
-uQP
+dkd
 bkH
 nus
 ukK
@@ -108700,7 +108834,7 @@ kwU
 nhz
 mTM
 aLv
-mUL
+iZt
 nHL
 rMl
 bpo
@@ -109002,7 +109136,7 @@ twD
 nlU
 wJw
 pTY
-mUL
+gGo
 sXU
 rVK
 mkp
@@ -109920,7 +110054,7 @@ orV
 gGR
 rgz
 rMl
-unV
+pJD
 uAP
 umD
 mtm
@@ -110220,8 +110354,8 @@ mwq
 xsD
 xsD
 xsD
-xsD
-duw
+unV
+bBz
 wmp
 cQT
 ncP
@@ -110522,8 +110656,8 @@ tLe
 olI
 oGa
 tiC
-tiC
-tiC
+nMH
+duw
 wcA
 uFs
 pFI
@@ -112337,7 +112471,7 @@ vQD
 cKW
 ouE
 ouE
-dTY
+pmH
 xHM
 wVR
 vbS
@@ -128912,7 +129046,7 @@ aaa
 aaa
 aaa
 aag
-aOw
+aaa
 pBO
 bVX
 hwe


### PR DESCRIPTION
[qol]

## About the PR 
does a few things to improve access and use of destiny engineering dept:
- makes all the wires connected to the TEG grid yellow for ease of identification
- adds a door between the TEG core and the power room so engineers don't have to cut through gas storage to get there
- re-structures CE's office a little so there's now a direct hall between the fitness room and the TEG core

minor: deleted some redundant pipes

AHHHHHHHHHHHHH MAJOR: fixes destiny arrivals to be rad-proof.

so now there's four exits from the TEG core instead of just two

## Why's this needed?
easier movement between rooms; ease of identification of main power lines for fixing/hotwiring