### PR TITLE
Makes Flock turbo deadly

### DIFF
--- a/code/mob/living/critter/ai.dm
+++ b/code/mob/living/critter/ai.dm
@@ -68,6 +68,8 @@ var/list/ai_move_scheduled = list()
 
 	proc/switch_to(var/datum/aiTask/task)
 		current_task = task
+		if(task?.ai_turbo)
+			owner.mob_flags |= HEAVYWEIGHT_AI_MOB
 		task?.switched_to()
 
 	proc/tick()
@@ -84,6 +86,8 @@ var/list/ai_move_scheduled = list()
 
 			var/datum/aiTask/T = current_task.next_task()
 			if (T)
+				if(current_task.ai_turbo)
+					owner.mob_flags &= ~HEAVYWEIGHT_AI_MOB
 				switch_to(T)
 				T.reset()
 
@@ -197,6 +201,8 @@ var/list/ai_move_scheduled = list()
 	var/name = "task"
 	var/datum/aiHolder/holder = null
 	var/atom/target = null
+	/// if this is set, temporarily give this mob the HEAVYWEIGHT_AI mob flag for the duration of this task
+	var/ai_turbo = FALSE
 
 	New(parentHolder)
 		..()

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -709,6 +709,7 @@ stare
 	target_range = 12
 	var/shoot_range = 6
 	var/run_range = 3
+	ai_turbo = TRUE
 	var/list/dummy_params = list("icon-x" = 16, "icon-y" = 16)
 
 /datum/aiTask/timed/targeted/flockdrone_shoot/proc/precondition()
@@ -798,6 +799,7 @@ stare
 	weight = 15
 	max_dist = 12
 	can_be_adjacent_to_target = TRUE
+	ai_turbo = TRUE
 
 /datum/aiTask/sequence/goalbased/flockdrone_capture/New(parentHolder, transTask)
 	..(parentHolder, transTask)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Basically adds a flag to aitask that lets a mob be temporarily bumped up to `HEAVYWEIGHT_AI` like for example, during combat.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flock is slow to respond during combat and it shouldn't be. But it doesn't need to be fast all the time.
