### PR TITLE
Cleans up a lot of antag popup jank

### DIFF
--- a/_std/macros/antag_popups.dm
+++ b/_std/macros/antag_popups.dm
@@ -7,7 +7,7 @@
 			html = ""
 
 		html += {"
-<title>Antag Popup Viewer</title>
+<title>Special Role Popup Viewer</title>
 <style>
 	a {text-decoration:none}
 	.antagType {padding:5px; margin-bottom:8px; border:1px solid black}
@@ -17,7 +17,9 @@
 	<a href='?src=\ref[src];action=traitorradio'>Radio Uplink</a> |
 	<a href='?src=\ref[src];action=traitorpda'>PDA Uplink</a> |
 	<a href='?src=\ref[src];action=traitorhard'>Hard Mode</a> |
-	<a href='?src=\ref[src];action=traitoromni'>Omnitraitor</a>
+	<a href='?src=\ref[src];action=traitoromni'>Omnitraitor</a> |
+	<a href='?src=\ref[src];action=traitorgeneric'>Generic</a> |
+	<a href='?src=\ref[src];action=sleeper'>Sleeper agent</a>
 </div>
 <div class='antagType' style='border-color:#AEC6CF'><b class='title' style='background:#AEC6CF'>Mindslave</b>
 	<a href='?src=\ref[src];action=mindslave'>Implanted</a> |
@@ -50,8 +52,9 @@
 	<a href='?src=\ref[src];action=vampzombie'>Vamp Zombie</a> |
 	<br><a href='?src=\ref[src];action=changeling'>Changeling</a> |
 	<a href='?src=\ref[src];action=handspider'>Handspider</a> |
-	<a href='?src=\ref[src];action=eyespider'>Eye/Butt Spider</a> |
-	<a href='?src=\ref[src];action=legworm'>Legworm</a>
+	<a href='?src=\ref[src];action=eyespider'>Eyespider</a> |
+	<a href='?src=\ref[src];action=legworm'>Legworm</a> |
+	<a href='?src=\ref[src];action=buttcrab'>Buttcrab</a>
 </div>
 <div class='antagType' style='border-color:#AEC6CF'><b class='title' style='background:#AEC6CF'>Flock</b>
 	<a href='?src=\ref[src];action=flocktrace'>Flocktrace</a> |
@@ -65,15 +68,22 @@
 	<a href='?src=\ref[src];action=battle'>Battle Royale</a> |
 	<a href='?src=\ref[src];action=martian'>Martian</a> |
 	<a href='?src=\ref[src];action=kudzu'>Kudzu Person</a> |
-	<a href='?src=\ref[src];action=slasher'>The Slasher</a>
+	<a href='?src=\ref[src];action=slasher'>The Slasher</a> |
 	<a href='?src=\ref[src];action=arcfiend'>Arcfiend Person</a>
+</div>
+<div class='antagType' style='border-color:#AEC6CF'><b class='title' style='background:#AEC6CF'>Ghost roles</b>
+	<a href='?src=\ref[src];action=ghostdrone'>Ghostdrone</a> |
+	<a href='?src=\ref[src];action=ghostcritter'>Ghostcritter</a> |
+	<a href='?src=\ref[src];action=ghostcritter_antag'>Antag ghostcritter</a> |
+	<a href='?src=\ref[src];action=ghostcritter_mentor'>Mentor ghostcritter</a>
 </div>
 <div class='antagType' style='border-color:#AEC6CF'><b class='title' style='background:#AEC6CF'>Misc</b>
 	<a href='?src=\ref[src];action=rogueborgremoved'>Rogue Borg Removed</a> |
 	<a href='?src=\ref[src];action=antagremoved'>Antag Removed</a> |
 	<a href='?src=\ref[src];action=soulsteel'>Soulsteel Posession</a> |
 	<a href='?src=\ref[src];action=mindwipe'>Cloner Mindwipe</a> |
-	<a href='?src=\ref[src];action=slasher_possession'>Slasher Possession</a>
+	<a href='?src=\ref[src];action=slasher_possession'>Slasher Possession</a> |
+	<a href='?src=\ref[src];action=souldorf'>Souldorf</a>
 </div>
 "}
 
@@ -111,6 +121,10 @@
 				filename = "html/traitorTips/traitorhardTips.html"
 			if ("traitoromni")
 				filename = "html/traitorTips/omniTips.html"
+			if ("traitorgeneric")
+				filename ="html/traitorTips/traitorGenericTips.html"
+			if ("sleeper")
+				filename = "html/traitorTips/traitorsleeperTips.html"
 
 			// mindslave
 			if ("mindslave")
@@ -170,6 +184,8 @@
 				filename = "html/mindslave/eyespider.html"
 			if ("legworm")
 				filename = "html/mindslave/legworm.html"
+			if ("buttcrab")
+				filename = "html/mindslave/buttcrab.html"
 
 			//flock
 			if("flocktrace")
@@ -203,6 +219,16 @@
 			if ("zombie")
 				filename = "html/traitorTips/zombieTips.html"
 
+			// ghost roles
+			if ("ghostdrone")
+				filename = "html/ghostdrone.html"
+			if ("ghostcritter")
+				filename = "html/ghostcritter.html"
+			if ("ghostcritter_antag")
+				filename = "html/ghostcritter_antag.html"
+			if ("ghostcritter_mentor")
+				filename = "html/ghostcritter_mentor.html"
+
 			// misc
 			if ("rogueborgremoved")
 				filename = "html/traitorTips/roguerobotRemoved.html"
@@ -217,6 +243,10 @@
 			if ("mindwipe")
 				window_title = "Mindwiped!"
 				filename = "html/mindwipe.html"
+			if ("zoldorf")
+				filename = "html/traitorTips/zoldorfTips.htm"
+			if ("souldorf")
+				filename = "html/traitorTips/souldorfTips.htm"
 
 		if (!filename)
 			return
@@ -226,7 +256,7 @@
 
 
 /client/proc/cmd_admin_antag_popups()
-	set name = "View Antag Popups"
+	set name = "View Special Role Popups"
 	SET_ADMIN_CAT(ADMIN_CAT_SERVER)
 	if (src.holder)
 		get_singleton(/datum/antagPopups).showPanel()
@@ -245,6 +275,6 @@
 		get_singleton(/datum/antagPopups).show_popup(src, popup_name)
 
 	verb/reopen_antag_popup()
-		set name = "Open antag popup"
+		set name = "Special role popup"
 		if (src.last_antag_popup)
 			src.show_antag_popup(src.last_antag_popup, FALSE)

--- a/browserassets/html/ghostdrone.html
+++ b/browserassets/html/ghostdrone.html
@@ -14,7 +14,7 @@
 		<strong>Ghostdrones are not a chance to come back and grief the station!</strong> Follow your laws! Welding airlocks, removing floors, and building obstructive walls are all forms of grief, and if you do this, <strong>you will be banned</strong>!
 	</p>
 	<p>
-		For more information, you can read the <a href="http://wiki.ss13.co/Ghostdrone">Ghostdrone</a> page.</p>
+		For more information, please consult <a href='?src={ref};wiki=Ghostdrone'>the wiki</a></p></p>
 	<p>
 
 	<h3>Your laws</h3>

--- a/browserassets/html/mindslave/buttcrab.html
+++ b/browserassets/html/mindslave/buttcrab.html
@@ -1,0 +1,12 @@
+<link rel="stylesheet" type="text/css" href="{{resource("css/style.css")}}">
+<div class="traitor-tips">
+    <h1 class="center">You have reawakened to serve your host changeling!</h1>
+    <p>You must <em>obey</em> their commands!<br>You are a very small, very smelly, and weak creature. You are still connected to the hivemind.</p>
+    <p>
+		Abilities
+		<span class="small indent">
+			<em>Fart</em> out a cloud of toxic gas.<br>
+			<em>Fartonium sting</em> a human to force them to fart.<br>
+            <em>Anti-fart sting</em> a human to prevent them from farting.<br>
+    </p>
+</div>

--- a/code/mob/living/carbon/human/slasher.dm
+++ b/code/mob/living/carbon/human/slasher.dm
@@ -255,7 +255,7 @@
 					remove_equipment(M)
 					return
 				if (O.mind)
-					O.Browse(grabResource("html/slasher_possession.html"),"window=slasher_possession;size=600x440;title=Slasher Possession")
+					O.show_antag_popup("slasher_possession", FALSE)
 					boutput(O, "<span class='bold' style='color:red;font-size:150%'>You have been temporarily removed from your body!</span>")
 				if(!src.mind || !O.mind)
 					src.visible_message("<span class='bold' style='color:red'>Something fucked up! Aborting possession, please let #imcoder know. Error Code: 102</span>")

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -1312,7 +1312,7 @@
 
 	boutput(G, "<span class='bold' style='color:red;font-size:150%'>You have become a Ghostdrone!</span><br><b>Humans, Cyborgs, and other living beings will appear only as static silhouettes, and you should avoid interacting with them.</b><br><br>You can speak to your fellow Ghostdrones by talking normally (default: push T). You can talk over deadchat with other ghosts by starting your message with ';'.")
 	if (G.mind)
-		G.Browse(grabResource("html/ghostdrone.html"),"window=ghostdrone;size=600x440;title=Ghostdrone Help")
+		G.show_antag_popup("ghostdrone")
 
 	SPAWN(1 SECOND)
 		G.show_laws_drone()

--- a/code/mob/transform_procs.dm
+++ b/code/mob/transform_procs.dm
@@ -625,9 +625,9 @@ var/list/antag_respawn_critter_types =  list(/mob/living/critter/small_animal/fl
 	C.original_name = selfmob.real_name
 
 	if (traitor)
-		C.Browse(grabResource("html/ghostcritter.html"),"window=ghostcritter_antag;size=600x400;title=Ghost Critter Help")
+		C.show_antag_popup("ghostcritter_antag")
 	else
-		C.Browse(grabResource("html/ghostcritter.html"),"window=ghostcritter;size=600x400;title=Ghost Critter Help")
+		C.show_antag_popup("ghostcritter")
 
 	//hacky fix : qdel brain to prevent reviving
 	if (C.organHolder)
@@ -666,7 +666,7 @@ var/list/antag_respawn_critter_types =  list(/mob/living/critter/small_animal/fl
 	C.literate = 0
 	C.original_name = selfmob.real_name
 
-	C.Browse(grabResource("html/ghostcritter_mentor.html"),"window=ghostcritter_mentor;size=600x400;title=Ghost Critter Help")
+	C.show_antag_popup("ghostcritter_mentor")
 	logTheThing("admin", C, null, "respawned as a mentor mouse at [log_loc(C)].")
 
 	//hacky fix : qdel brain to prevent reviving

--- a/code/mob/zoldorfmob.dm
+++ b/code/mob/zoldorfmob.dm
@@ -91,7 +91,7 @@
 
 		the_zoldorf = list()
 		spawn(0)
-			src << browse(grabResource("html/traitorTips/souldorfTips.htm"),"window=antagTips;titlebar=1;size=600x400;can_minimize=0;can_resize=0")
+			src.show_antag_popup("souldorf")
 
 	Login()
 		..()

--- a/code/modules/antagonists/changeling/abilities/changeling.dm
+++ b/code/modules/antagonists/changeling/abilities/changeling.dm
@@ -7,7 +7,7 @@
 		L.blood_id = "bloodc"
 
 	if (src.mind && !src.mind.is_changeling && (src.mind.special_role != ROLE_OMNITRAITOR))
-		src.Browse(grabResource("html/traitorTips/changelingTips.html"),"window=antagTips;size=600x400;title=Antagonist Tips")
+		src.show_antag_popup("changeling")
 
 	var/datum/abilityHolder/changeling/C = src.add_ability_holder(/datum/abilityHolder/changeling)
 	C.addAbility(/datum/targetable/changeling/abomination)

--- a/code/modules/antagonists/changeling/abilities/hivemind.dm
+++ b/code/modules/antagonists/changeling/abilities/hivemind.dm
@@ -79,7 +79,7 @@
 			spider.icon_prefix = "robo"
 			spider.UpdateIcon()
 
-		spider.Browse(grabResource("html/mindslave/handspider.html"),"window=antagTips;size=600x400;title=Antagonist Tips")
+		spider.show_antag_popup("handspider")
 		boutput(spider, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
 		boutput(spider, "<font color=red>You are a very small and weak creature that can fit into tight spaces. You are still connected to the hivemind.</font>")
 
@@ -176,7 +176,7 @@
 		H.hivemind += spider
 		spider.hivemind_owner = H
 
-		spider.Browse(grabResource("html/mindslave/eyespider.html"),"window=antagTips;size=600x400;title=Antagonist Tips")
+		spider.show_antag_popup("eyespider")
 		boutput(spider, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
 		boutput(spider, "<font color=red>You are a very small and weak creature that can fit into tight spaces, and see through walls. You are still connected to the hivemind.</font>")
 
@@ -274,7 +274,7 @@
 		H.hivemind += spider
 		spider.hivemind_owner = H
 
-		spider.Browse(grabResource("html/mindslave/legworm.html"),"window=antagTips;size=600x400;title=Antagonist Tips")
+		spider.show_antag_popup("legworm")
 		boutput(spider, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
 		boutput(spider, "<font color=red>You are a small creature that can deliver powerful kicks and fit into tight spaces. You are still connected to the hivemind.</font>")
 
@@ -358,7 +358,7 @@
 		H.hivemind += crab
 		crab.hivemind_owner = H
 
-		crab.Browse(grabResource("html/mindslave/eyespider.html"),"window=antagTips;size=600x400;title=Antagonist Tips")
+		crab.show_antag_popup("buttcrab")
 		boutput(crab, "<h2><font color=red>You have reawakened to serve your host [holder.owner]! You must follow their commands!</font></h2>")
 		boutput(crab, "<font color=red>You are a very small, very smelly, and weak creature. You are still connected to the hivemind.</font>")
 

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -145,7 +145,7 @@
 		logTheThing("admin", H, null, "awakened as a sleeper agent antagonist. Source: [source ? "[source]" : "random event"]")
 		H.show_text("<h2><font color=red><B>You have awakened as a syndicate sleeper agent!</B></font></h2>", "red")
 		H.mind.special_role = ROLE_SLEEPER_AGENT
-		H << browse(grabResource("html/traitorTips/traitorsleeperTips.html"),"window=antagTips;titlebar=1;size=600x400;can_minimize=0;can_resize=0")
+		H.show_antag_popup("sleeper")
 		if(!(H.mind in ticker.mode.traitors))
 			ticker.mode.traitors += H.mind
 		if (H.mind.current)

--- a/code/obj/zoldorf.dm
+++ b/code/obj/zoldorf.dm
@@ -242,7 +242,7 @@ var/global/list/datum/zoldorfitem/zoldorf_items = list()
 		src.souldorfs.Add(Z)
 		src.occupied = 1
 		the_zoldorf.Add(Z)
-		Z << browse(grabResource("html/traitorTips/zoldorfTips.htm"),"window=antagTips;titlebar=1;size=600x400;can_minimize=0;can_resize=0")
+		Z.show_antag_popup("zoldorf")
 		src.usurpgrace = world.time + 3000
 		src.YN = null
 		src.usurper = null

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -789,11 +789,11 @@ proc/antagify(mob/H, var/traitor_role, var/agimmick)
 		for(var/i = 0, i < num_objectives, i++)
 			var/select_objective = pick(eligible_objectives)
 			new select_objective(null, H.mind)
-			H << browse(grabResource("html/traitorTips/traitorhardTips.html"),"window=antagTips;titlebar=1;size=600x400;can_minimize=0;can_resize=0")
+			H.show_antag_popup("traitorhard")
 			ticker.mode.traitors |= H.mind
 	else
 		ticker.mode.Agimmicks |= H.mind
-		H << browse(grabResource("html/traitorTips/traitorGenericTips.html"),"window=antagTips;titlebar=1;size=600x400;can_minimize=0;can_resize=0")
+		H.show_antag_popup("traitorgeneric")
 	if (traitor_role)
 		H.mind.special_role = traitor_role
 	else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #9044, then I noticed how much else was broken
Refactors every instance of an antag popup not using the correct proc, fixing all the antag popups that weren't working with the open antag popup command (except that one wizard poster).
Adds an antag popup for buttcrabs against my better judgement.
Renames the antag popup verbs to call it "special role" instead, since a lot of them aren't exactly antags.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugfixes and jank left over from the last time I refactored this mess.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Renamed the "Open antag popup" verb to "Special role popup"
```
