### PR TITLE
Adds hemolymph to more creatures and adjusts colors

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1717,7 +1717,7 @@ TYPEINFO(/datum/mutantrace)
 		. = ..()
 		if(ishuman(M))
 			M.blood_id = "hemolymph"
-			//H.blood_color = "009E81"
+			//H.blood_color = "#009E81"
 			M.mob_flags |= SHOULD_HAVE_A_TAIL
 		APPLY_ATOM_PROPERTY(M, PROP_MOB_RADPROT, src, 100)
 

--- a/code/mob/living/critter/firefly.dm
+++ b/code/mob/living/critter/firefly.dm
@@ -11,6 +11,7 @@ TYPEINFO(/mob/living/critter/small_animal/firefly)
 	hand_count = 2
 	icon = 'icons/mob/insect.dmi'
 	icon_state = "firefly"
+	blood_id = "hemolymph"
 	var/light_color = "#ADFF2F"
 	var/image/bulb
 	var/image/bulb_light
@@ -280,6 +281,7 @@ TYPEINFO(/mob/living/critter/small_animal/dragonfly)
 	hand_count = 2
 	icon = 'icons/mob/insect.dmi'
 	icon_state = "dragonfly"
+	blood_id = "hemolymph"
 
 	speechverb_say = "bzzs"
 	speechverb_exclaim = "bzzts"

--- a/code/mob/living/critter/small_animal.dm
+++ b/code/mob/living/critter/small_animal.dm
@@ -2332,6 +2332,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	desc = "It doesn't have any arms or legs so it's kind of like a snake, but it's gross and unthreatening instead of cool and dangerous."
 	icon_state = "slug"
 	icon_state_dead = "slug-dead"
+	blood_id = "hemolymph"
 	speechverb_say = "blorps"
 	speechverb_exclaim = "bloops"
 	speechverb_ask = "burbles"
@@ -2366,6 +2367,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	desc = "It's basically just a slug with a shell on it. This makes it less gross."
 	icon_state = "snail"
 	icon_state_dead = "snail-dead"
+	blood_id = "hemolymph"
 	health_brute = 10
 	health_burn = 10
 	slime_chance = 11
@@ -2456,6 +2458,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	name = "moth"
 	real_name = "moth"
 	desc = "Ew a moth. Hope it doesn't get into the wardrobe."
+	blood_id = "hemolymph"
 
 	New()
 		..()
@@ -2479,6 +2482,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	speechverb_exclaim = "bzzts"
 	speechverb_ask = "pesters"
 	death_text = "%src% splats."
+	blood_id = "hemolymph"
 	flags = TABLEPASS | DOORPASS
 	fits_under_table = 1
 	base_move_delay = 1.3
@@ -2539,6 +2543,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	hand_count = 2
 	icon_state = "sqwibby"
 	icon_state_dead = "sqwibby-dead"
+	blood_id = "hemolymph"
 	speechverb_say = "bzzs"
 	speechverb_exclaim = "bzzts"
 	speechverb_ask = "pesters"
@@ -3092,6 +3097,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	real_name = "crab"
 	desc = "Snip snap"
 	icon_state = "crab_party"
+	blood_id = "hemolymph"
 	hand_count = 2
 	speechverb_say = "snips"
 	speechverb_gasp = "claks"
@@ -3135,6 +3141,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	real_name = "crab"
 	desc = "Snip snap"
 	icon_state = "crab_party"
+	blood_id = "hemolymph"
 	hand_count = 2
 	speechverb_say = "snips"
 	speechverb_exclaim = "snaps"
@@ -3258,6 +3265,7 @@ var/list/mob_bird_species = list("smallowl" = /mob/living/critter/small_animal/b
 	desc = "This is an alien hallucigenia."
 	icon_state = "hallucigenia"
 	icon_state_dead = "hallucigenia-dead"
+	blood_id = "hemolymph"
 	speechverb_say = "clicks"
 	speechverb_exclaim = "screeches"
 	speechverb_ask = "chitters"

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3183,9 +3183,9 @@ datum
 			//taste = "metallic yet slightly bitter"
 			description = "Hemolymph is a blood-like bodily fluid found in many invertibrates that derives its blue-green color from the presence of copper proteins."
 			reagent_state = LIQUID
-			fluid_r = 6
-			fluid_b = 161
-			fluid_g = 125
+			fluid_r = 4
+			fluid_b = 165
+			fluid_g = 144
 
 
 		vomit


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

As the title says- there's a few bug type critters that don't have hemolymph, but should. Furthermore, the old color was a little bit too close to water in puddles on the floor, so I adjusted it.

![image](https://user-images.githubusercontent.com/96703882/172731658-320d1763-3dfb-47ad-87cf-48de33d5eee0.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
flies shouldn't bleed red :/

