### PR TITLE
Add more antagonist medals

### DIFF
--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -496,6 +496,10 @@
 
 	..() // Admin-assigned antagonists or whatever.
 
+	if (finished == 1)
+		for(var/datum/mind/rev_mind as anything in head_revolutionaries)
+			if(rev_mind.current && !isdead(rev_mind.current))
+				rev_mind.current.unlock_medal("This station is ours!", TRUE)
 
 
 

--- a/code/datums/objective.dm
+++ b/code/datums/objective.dm
@@ -684,6 +684,7 @@ proc/create_fluff(datum/mind/target)
 		return 1
 
 /datum/objective/specialist/absorb
+	medal_name = "Many names, many faces"
 	var/absorb_count
 
 	set_up()
@@ -789,6 +790,7 @@ proc/create_fluff(datum/mind/target)
 		return 1
 
 /datum/objective/specialist/blob
+	medal_name = "Blob everywhere!"
 	var/blobtiletarget = 500
 
 	set_up()
@@ -973,6 +975,7 @@ proc/create_fluff(datum/mind/target)
 		return !failed
 
 /datum/objective/specialist/werewolf/feed
+	medal_name = "Good feasting"
 	var/feed_count = 0
 	var/target_feed_count
 	var/list/mob/mobs_fed_on = list() // Stores bioHolder.Uid of previous victims, so we can't feed on the same person multiple times.


### PR DESCRIPTION
[MEDAL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds some more antagonist related medals.

Changeling medal-
"Many names, many faces"
As a changeling, absorb your objective required number of victim absorptions and make it back to Centcomm alive.
![changeling](https://user-images.githubusercontent.com/53062374/172973837-757f50f3-7cfb-47a2-95a5-982d3c35a96d.png)

Blob medal-
"Blob everywhere!"
As a blob, grow your blob tile count to the number required by your objective required size.
![blob](https://user-images.githubusercontent.com/53062374/172973625-09ba77da-49e4-42f7-b277-12ac131820d5.png)

Head revolutionary medal-
"This station is ours!"
As a head revolutionary, live to see your revolution come to a success!
![rev](https://user-images.githubusercontent.com/53062374/172974885-d71380e8-7e98-47d5-bcb6-215df475368e.png)

Werewolf medal-
"Good feasting"
As a werewolf, reach your objective number of victims fed on.
![werewolf](https://user-images.githubusercontent.com/53062374/172974162-16e6f8a6-ad37-4539-a375-517f1cb7986c.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
These antagonists don't have any medals associated with them, except for werewolf but it isn't exclusive to them, and these things definitely do feel medal worthy.


## Changelog
```changelog
(u)FlameArrow57
(+)Added new medals for changeling, blob, head rev, and werewolf antagonists!
```
