### PR TITLE
Add missing rechargers to command teleporters.

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -17445,7 +17445,6 @@
 /area/station/quartermaster/cargobay)
 "caP" = (
 /obj/table/auto,
-/obj/item/hand_tele,
 /obj/decal/tile_edge/line/blue{
 	dir = 4;
 	icon_state = "line1"
@@ -17455,6 +17454,10 @@
 	dir = 9;
 	name = "autoname - SS13"
 	},
+/obj/machinery/recharger{
+	pixel_y = 5
+	},
+/obj/item/hand_tele,
 /turf/simulated/floor/black,
 /area/station/teleporter)
 "caW" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -8321,10 +8321,13 @@
 /area/station/maintenance/west)
 "axM" = (
 /obj/table/auto,
-/obj/item/hand_tele,
 /obj/machinery/light/small,
 /obj/cable,
 /obj/machinery/power/apc/autoname_west,
+/obj/machinery/recharger{
+	pixel_y = 5
+	},
+/obj/item/hand_tele,
 /turf/simulated/floor/purpleblack,
 /area/station/teleporter)
 "axN" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds missing rechargers to Kondaru and Destiny command teleporters.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Because someone forgot to add them there.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

Not needed.
