### PR TITLE
Fix Flock conversion bugs

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -632,15 +632,13 @@ var/flock_signal_unleashed = FALSE
 
 // made into a global proc so a reagent can use it
 // simple enough: if object path matches key, replace with instance of value
-// if value is null, just delete object
 // !!!! priority is determined by list order !!!!
 // if you have a subclass, it MUST go first in the list, or the first type that matches will take priority (ie, the superclass)
 // see /obj/machinery/light/small/floor and /obj/machinery/light for examples of this
 /var/list/flock_conversion_paths = list(
 	/obj/grille/steel = /obj/grille/flock,
 	/obj/window = /obj/window/auto/feather,
-	/obj/machinery/door/airlock = /obj/machinery/door/feather,
-	/obj/machinery/door = null,
+	/obj/machinery/door = /obj/machinery/door/feather,
 	/obj/stool = /obj/stool/chair/comfy/flock,
 	/obj/table = /obj/table/flock/auto,
 	/obj/machinery/light/small/floor = /obj/machinery/light/flock/floor,
@@ -684,41 +682,42 @@ var/flock_signal_unleashed = FALSE
 			FL = new /obj/lattice/flock(T)
 
 	for(var/obj/O in T)
-		if(istype(O, /obj/machinery/door/feather))
-			// repair door
-			var/obj/machinery/door/feather/door = O
-			door.heal_damage()
-			animate_flock_convert_complete(O)
-		else if (istype(O, /obj/machinery/camera))
+		if (istype(O, /obj/machinery/camera))
 			var/obj/machinery/camera/cam = O
 			if (cam.camera_status)
 				cam.break_camera()
-		else
-			for(var/keyPath in flock_conversion_paths) //types are converted with priority determined by list order
-				var/obj/replacementPath = flock_conversion_paths[keyPath] //put subclasses ahead of superclasses in the flock_conversion_paths list
-				if(istype(O, keyPath))
-					if(isnull(replacementPath))
+			continue
+		for(var/keyPath in flock_conversion_paths)
+			if (!istype(O, keyPath))
+				continue
+			if (istype(O, /obj/machinery))
+				if (istype(O, /obj/machinery/door))
+					if (istype(O, /obj/machinery/door/firedoor/pyro) || istype(O, /obj/machinery/door/window) || istype(O, /obj/machinery/door/airlock/pyro/glass/windoor) || istype(O, /obj/machinery/door/poddoor/pyro/shutters) || istype(O, /obj/machinery/door/unpowered/wood))
 						qdel(O)
-					else
-						var/dir = O.dir
-						var/obj/converted = new replacementPath(T)
-						// if the object is a closet, it might not have spawned its contents yet
-						// so force it to do that first
-						if(istype(O, /obj/storage))
-							var/obj/storage/S = O
-							if(!isnull(S.spawn_contents))
-								S.make_my_stuff()
-						// if the object has contents, move them over!!
-						for (var/obj/stored_obj in O)
-							stored_obj.set_loc(converted)
-						for (var/mob/M in O)
-							M.set_loc(converted)
-						qdel(O)
-						converted.set_dir(dir)
-						animate_flock_convert_complete(converted)
-					break //we found and converted the type, don't convert it again
-
-
+						break
+				if (istype(O, /obj/machinery/computer))
+					if (istype(O, /obj/machinery/computer/card/portable) || istype(O, /obj/machinery/computer/security/wooden_tv) || istype(O, /obj/machinery/computer/secure_data/detective_computer) || istype(O, /obj/machinery/computer/airbr) || istype(O, /obj/machinery/computer/tanning) || istype(O, /obj/machinery/computer/tour_console) || istype(O, /obj/machinery/computer/arcade) || istype(O, /obj/machinery/computer/tetris))
+						break
+				if (istype(O, /obj/machinery/light/lamp) || istype(O, /obj/machinery/computer3/generic/personal) || istype(O, /obj/machinery/computer3/luggable))
+					break
+			var/dir = O.dir
+			var/replacementPath = flock_conversion_paths[keyPath]
+			var/obj/converted = new replacementPath(T)
+			// if the object is a closet, it might not have spawned its contents yet
+			// so force it to do that first
+			if(istype(O, /obj/storage))
+				var/obj/storage/S = O
+				if(!isnull(S.spawn_contents))
+					S.make_my_stuff()
+			// if the object has contents, move them over!!
+			for (var/obj/stored_obj in O)
+				stored_obj.set_loc(converted)
+			for (var/mob/M in O)
+				M.set_loc(converted)
+			qdel(O)
+			converted.set_dir(dir)
+			animate_flock_convert_complete(converted)
+			break
 	return T
 
 /proc/mass_flock_convert_turf(var/turf/T, datum/flock/F)


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows podbay doors to be converted to Flock doors and fixes various other conversion bugs.

It allows podbay doors and some door type shutters to be converted to Flockdoors.
These:
![image](https://user-images.githubusercontent.com/53062374/172981009-99e45e2c-bcaf-4e6e-b6b1-26c7d7ba6ba9.png)

These where used as doors:
![image](https://user-images.githubusercontent.com/53062374/172981031-466f65e8-4280-4e73-b4f5-46f926821d27.png)

It also removes healing Flockdoors on conversion, which isn't needed since the health will already be full on initial conversion, and the door will be recreated on any future tile conversions.

It also fixes Flockdoors being deleted if the tile they were on was not Flock and converted, it fixes windoors being made into Flockdoors, and it fixes converting various instances of machinery to compute nodes that shouldn't be converted.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fixes