### PR TITLE
Fixes RCDs being shipped in wrong crates at a wrong price

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -827,10 +827,6 @@ f
 	containertype = /obj/storage/crate/wooden
 	containername = "RCD Replacement"
 
-	cost = 3000
-	containertype = /obj/storage/crate/packing
-	containername = "Cold Weather Gear"
-
 /datum/supply_packs/buddy
 	name = "Thinktronic Build Your Own Buddy Kit"
 	desc = "Assemble your very own working Robuddy, one part per week."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes what looks to be an oopsie making spare RCDs getting shipped in the wrong crates (cold weather crates that were removed recently) at 3000/unit and not 60 000/ unit.
Fixes #9062

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix.


