### PR TITLE
Fixes constructed stun batons having the wrong icon

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -64,6 +64,8 @@
 			AddComponent(/datum/component/cell_holder, new from_frame_cell_type)
 
 		SEND_SIGNAL(src, COMSIG_CELL_USE, INFINITY) //also drain the cell out of spite
+		src.is_active = FALSE
+		src.UpdateIcon()
 
 	disposing()
 		processing_items -= src


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Mechanic constructed stun batons spawned with the on icon despite having no charge, leading to an on looking baton that does not stun or update when used.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I hit a wizard with one and am now coping.