### PR TITLE
Makes the lawbringer not understand strange alien languages

### DIFF
--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1368,7 +1368,8 @@
 		//Do I need to check for this? I can't imagine why anyone would pass the wrong var here...
 		if (!islist(msg))
 			return
-
+		if (lang_id != "english")
+			return
 		//only work if the voice is the same as the voice of your owner fingerprints.
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
@@ -1376,8 +1377,7 @@
 				are_you_the_law(M, msg[1])
 				return
 		else
-			if (lang_id != "feather") //snowflake check because birds do not speak english
-				are_you_the_law(M, msg[1])
+			are_you_the_law(M, msg[1])
 			return //AFAIK only humans have fingerprints/"palmprints(in judge dredd)" so just ignore any talk from non-humans arlight? it's not a big deal.
 
 		if(!src.projectiles && !src.projectiles.len > 1)

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1376,7 +1376,8 @@
 				are_you_the_law(M, msg[1])
 				return
 		else
-			are_you_the_law(M, msg[1])
+			if (!isflockmob(M)) //snowflake check because birds do not speak english
+				are_you_the_law(M, msg[1])
 			return //AFAIK only humans have fingerprints/"palmprints(in judge dredd)" so just ignore any talk from non-humans arlight? it's not a big deal.
 
 		if(!src.projectiles && !src.projectiles.len > 1)

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1361,7 +1361,7 @@
 	hear_talk(mob/M as mob, msg, real_name, lang_id)
 		var/turf/T = get_turf(src)
 		if (M in range(1, T))
-			src.talk_into(M, msg, null, real_name, lang_id)
+			src.talk_into(M, msg, real_name, lang_id)
 
 	//can only handle one name at a time, if it's more it doesn't do anything
 	talk_into(mob/M as mob, msg, real_name, lang_id)
@@ -1376,7 +1376,7 @@
 				are_you_the_law(M, msg[1])
 				return
 		else
-			if (!isflockmob(M)) //snowflake check because birds do not speak english
+			if (lang_id != "feather") //snowflake check because birds do not speak english
 				are_you_the_law(M, msg[1])
 			return //AFAIK only humans have fingerprints/"palmprints(in judge dredd)" so just ignore any talk from non-humans arlight? it's not a big deal.
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Flockdrones "I am the law" bombed in playtesting, goddamnit.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Birds do not speak english so the lawbringer should not explode. Also flock devs hate fun.