### PR TITLE
Gives secasses a single utility credit

### DIFF
--- a/code/obj/submachine/weapon_vendor.dm
+++ b/code/obj/submachine/weapon_vendor.dm
@@ -142,6 +142,7 @@
 	accepted_token(var/token)
 		if (istype(token, /obj/item/requisition_token/security/assistant))
 			src.credits[WEAPON_VENDOR_CATEGORY_ASSISTANT]++
+			src.credits[WEAPON_VENDOR_CATEGORY_UTILITY]++
 		else if (istype(token, /obj/item/requisition_token/security/utility))
 			src.credits[WEAPON_VENDOR_CATEGORY_UTILITY]++
 		else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] [INPUT] [BALANCE]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Alongside the standard assistant token, this also gives secasses a single utility credit.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I think this will be a nice way of allowing secasses to get familar with the purchases before they play secoff.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Security Assistant tokens now have a single utility credit.
```
