### PR TITLE
fix chemicompiler allowing empty vials (again)

### DIFF
--- a/code/modules/chemistry/chemicompiler_core.dm
+++ b/code/modules/chemistry/chemicompiler_core.dm
@@ -807,7 +807,7 @@
 		RS.trans_to(RT, amount, index = index)
 	if (target == 11)
 		// Generate pill
-		if(RS.total_volume >= 1)
+		if(RS.total_volume >= 1 && amount > 0)
 			showMessage("[src.holder] makes an alarming grinding noise!")
 			var/obj/item/reagent_containers/pill/P = new(get_turf(src.holder))
 			RS.trans_to(P, amount, index = index)
@@ -816,7 +816,7 @@
 			showMessage("[src.holder] doesn't have enough reagents to make a pill.")
 	if (target == 12)
 		// Generate vial
-		if(RS.total_volume >= 1)
+		if(RS.total_volume >= 1 && amount > 0)
 			var/obj/item/reagent_containers/glass/vial/plastic/V = new(get_turf(src.holder))
 			RS.trans_to(V, amount, index = index)
 			showMessage("[src.holder] ejects a vial of some unknown substance.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fix an issue where if you put in a beaker with some chemicals, but set the ax register to 0, it will still transfer nothing and you still get infinite item generator to crash the server in a jiffy.

Reported by, and fixed on behalf of @ZWRh3

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Intended functionality of 8b45c8cf3124dd93c915ab233a3e26a71e8d3f88
Stops an easy way to get enough items to cause lag
