### PR TITLE
Flock replicate and nest aiTask's requires resource reservation

### DIFF
--- a/_std/macros/flock.dm
+++ b/_std/macros/flock.dm
@@ -29,3 +29,7 @@
 #define FLOCK_ACHIEVEMENT_CHEAT_STRUCTURES "all_structures"
 #define FLOCK_ACHIEVEMENT_CHEAT_COMPUTE "infinite_compute"
 #define FLOCK_ACHIEVEMENT_CAGE_HUMAN "human_dissection"
+
+// replication defs
+#define FLOCK_MIN_DESIRED_POP 10
+#define FLOCK_ADDITIONAL_RESOURCE_RESERVATION_PER_DRONE 7.5

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -113,7 +113,7 @@ stare
 /datum/aiTask/sequence/goalbased/replicate/precondition()
 	. = FALSE
 	var/mob/living/critter/flock/drone/F = holder.owner
-	if(F?.can_afford(FLOCK_LAY_EGG_COST))
+	if(F?.can_afford(FLOCK_LAY_EGG_COST + clamp((F.flock.getComplexDroneCount() - FLOCK_MIN_DESIRED_POP) * FLOCK_ADDITIONAL_RESOURCE_RESERVATION_PER_DRONE, 0, FLOCK_LAY_EGG_COST * 2)))
 		. = TRUE
 
 /datum/aiTask/sequence/goalbased/replicate/get_targets()
@@ -134,7 +134,7 @@ stare
 	var/mob/living/critter/flock/drone/F = holder.owner
 	if(!F)
 		return TRUE
-	if(F && !F.can_afford(FLOCK_LAY_EGG_COST + clamp((F.flock.getComplexDroneCount() - FLOCK_MIN_DESIRED_POP) * FLOCK_ADDITIONAL_RESOURCE_RESERVATION_PER_DRONE, 0, FLOCK_LAY_EGG_COST * 2)))
+	if(F && !F.can_afford(FLOCK_LAY_EGG_COST))
 		return TRUE
 	var/turf/simulated/floor/feather/N = get_turf(holder.owner)
 	if(!N)

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -163,6 +163,8 @@ stare
 	weight = 6
 	can_be_adjacent_to_target = TRUE
 	max_dist = 2
+	var/const/minimum_desired_population = 10
+	var/const/resource_reservation_per_drone = 7.5
 
 /datum/aiTask/sequence/goalbased/nest/New(parentHolder, transTask)
 	..(parentHolder, transTask)
@@ -171,7 +173,7 @@ stare
 /datum/aiTask/sequence/goalbased/nest/precondition()
 	. = FALSE
 	var/mob/living/critter/flock/drone/F = holder.owner
-	if(F?.can_afford(FLOCK_CONVERT_COST + FLOCK_LAY_EGG_COST))
+	if(F?.can_afford(FLOCK_CONVERT_COST + FLOCK_LAY_EGG_COST + clamp((F.flock.getComplexDroneCount() - minimum_desired_population) * resource_reservation_per_drone, 0, FLOCK_LAY_EGG_COST * 2)))
 		. = TRUE
 		for(var/turf/simulated/floor/feather/T in view(max_dist, holder.owner))
 			return FALSE

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -134,7 +134,7 @@ stare
 	var/mob/living/critter/flock/drone/F = holder.owner
 	if(!F)
 		return TRUE
-	if(F && !F.can_afford(FLOCK_LAY_EGG_COST))
+	if(F && !F.can_afford(FLOCK_LAY_EGG_COST + clamp((F.flock.getComplexDroneCount() - FLOCK_MIN_DESIRED_POP) * FLOCK_ADDITIONAL_RESOURCE_RESERVATION_PER_DRONE, 0, FLOCK_LAY_EGG_COST * 2)))
 		return TRUE
 	var/turf/simulated/floor/feather/N = get_turf(holder.owner)
 	if(!N)
@@ -163,8 +163,6 @@ stare
 	weight = 6
 	can_be_adjacent_to_target = TRUE
 	max_dist = 2
-	var/const/minimum_desired_population = 10
-	var/const/resource_reservation_per_drone = 7.5
 
 /datum/aiTask/sequence/goalbased/nest/New(parentHolder, transTask)
 	..(parentHolder, transTask)
@@ -173,7 +171,7 @@ stare
 /datum/aiTask/sequence/goalbased/nest/precondition()
 	. = FALSE
 	var/mob/living/critter/flock/drone/F = holder.owner
-	if(F?.can_afford(FLOCK_CONVERT_COST + FLOCK_LAY_EGG_COST + clamp((F.flock.getComplexDroneCount() - minimum_desired_population) * resource_reservation_per_drone, 0, FLOCK_LAY_EGG_COST * 2)))
+	if(F?.can_afford(FLOCK_CONVERT_COST + FLOCK_LAY_EGG_COST + clamp((F.flock.getComplexDroneCount() - FLOCK_MIN_DESIRED_POP) * FLOCK_ADDITIONAL_RESOURCE_RESERVATION_PER_DRONE, 0, FLOCK_LAY_EGG_COST * 2)))
 		. = TRUE
 		for(var/turf/simulated/floor/feather/T in view(max_dist, holder.owner))
 			return FALSE

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -100,7 +100,7 @@ stare
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 // REPLICATION GOAL
 // targets: valid nesting sites
-// precondition: FLOCK_LAY_EGG_COST resources
+// precondition: FLOCK_LAY_EGG_COST resources + 7.5 in reserve for every drone after the first 10 up to a max of 200 extra in reserve
 /datum/aiTask/sequence/goalbased/replicate
 	name = "replicating"
 	weight = 7
@@ -157,7 +157,7 @@ stare
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 // NEST + REPLICATION GOAL
 // targets: valid nesting sites
-// precondition: FLOCK_CONVERT_COST + FLOCK_LAY_EGG_COST resources, no flocktiles in view
+// precondition: FLOCK_CONVERT_COST + FLOCK_LAY_EGG_COST resources + 7.5 in reserve for every drone after the first 10 up to a max of 200 extra in reserve, no flocktiles in view
 /datum/aiTask/sequence/goalbased/nest
 	name = "nesting"
 	weight = 6


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds a scaling minimum resource reservation requirement to the nesting/replication ai task.
* The first 10 flock drones have no required resource reservation to encourage the flock to always attempt to maintain a bare minimum presence.
* Every drone after the tenth requires an additional 7.5 resources be held before the nesting task is considered
* At 40 additional drones (50 drones total in the flock) the reservation scaling halts, requiring an additional 200 resources to consider laying an egg for a grand total precondition cost of 300


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Prevents flock drones from multiplying near endlessly until resources are exhausted leaving you with an army of incapable drones and no ability to convert objects/turfs or to build structures.