### PR TITLE
Add straightjackets and haloperidol syringes to Donut 3 medical

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -11095,18 +11095,10 @@
 /obj/machinery/light/incandescent/cool,
 /obj/disposalpipe/segment/mail,
 /obj/table/glass/auto,
-/obj/item/storage/box/health_upgrade_kit{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/device/analyzer/healthanalyzer{
-	pixel_x = -15;
-	pixel_y = 5
-	},
-/obj/item/device/analyzer/healthanalyzer{
-	pixel_x = -13;
-	pixel_y = -3
-	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/reagent_containers/syringe/haloperidol,
+/obj/item/reagent_containers/syringe/haloperidol,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "cXs" = (
@@ -35352,6 +35344,8 @@
 /area/station/bridge)
 "kcs" = (
 /obj/disposalpipe/junction/left/south,
+/obj/table/glass/auto,
+/obj/random_item_spawner/med_kit/one,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "kcx" = (
@@ -47408,7 +47402,18 @@
 "nGs" = (
 /obj/disposalpipe/segment/mail,
 /obj/table/glass/auto,
-/obj/random_item_spawner/med_kit/one,
+/obj/item/storage/box/health_upgrade_kit{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_x = -15;
+	pixel_y = 5
+	},
+/obj/item/device/analyzer/healthanalyzer{
+	pixel_x = -13;
+	pixel_y = -3
+	},
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "nGx" = (


### PR DESCRIPTION
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds two straightjackets and two haloperidol syringes to the Donut 3 medical department.

![image](https://user-images.githubusercontent.com/53062374/173257691-a12f2f22-7bdc-48b6-9e46-83c8a02976d7.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Donut 3 medical doesn't have them, which is inconvenient for when someone has diseases that require haloperidol to be cured or for similar situations.