### PR TITLE
Clarion nanomed changes

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -16596,10 +16596,6 @@
 /obj/item/device/radio/intercom/medical,
 /turf/simulated/floor/white/checker,
 /area/station/medical/medbay/treatment1)
-"aHZ" = (
-/obj/machinery/vending/medical,
-/turf/simulated/wall/auto/supernorn,
-/area/station/medical/medbay/treatment1)
 "aIa" = (
 /obj/ladder{
 	desc = "Is this supposed to be here?";
@@ -18111,6 +18107,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/vending/medical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "aLF" = (
@@ -31759,6 +31756,7 @@
 	dir = 5;
 	icon_state = "line1"
 	},
+/obj/machinery/vending/medical,
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "bpP" = (
@@ -75211,7 +75209,7 @@ aCR
 aFd
 aEa
 aGX
-aHZ
+aGX
 aGX
 aGX
 aLD


### PR DESCRIPTION
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes some nanomed placement changes for Clarion.

Replaces a nanomed that was inside a wall:
Here

![image](https://user-images.githubusercontent.com/53062374/173258402-efe4d5c0-a7e4-476b-9164-912722481e4e.png)

to here

![image](https://user-images.githubusercontent.com/53062374/173258414-bcea8ab9-f500-4547-8169-fc6dddfd8e0a.png)

Also adds a nanomed here

![image](https://user-images.githubusercontent.com/53062374/173258424-2430cf61-6fdd-4ac5-a556-852e51795378.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Nanomed was inside a wall

Seemed like common maps played at least had three nanomeds in medbay, Clarion only had two