### PR TITLE
Cow-people can now graze on bushes

### DIFF
--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -372,7 +372,7 @@
 			boutput(user, "<span class='notice'>You pick at the ruined bush, looking for any leafs to graze on, but cannot find any.</span>")
 			return
 		else if (destroyed)
-			return ..()
+			return
 
 		user.lastattacked = src
 		if (iscow(user) && user.a_intent == INTENT_HELP)	//Bonsai trees are delicious to cow-people
@@ -388,7 +388,7 @@
 				user.changeStatus("food_hp_up", 2 MINUTES)
 				user.changeStatus("food_energized", 2 MINUTES)
 				return
-		return ..()
+		..()
 
 	attackby(obj/item/W, mob/user)
 		if (!W) return

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -301,7 +301,6 @@
 		else
 			user.changeStatus("food_hp_up", 20 SECONDS)
 			user.visible_message("<span class='notice'>[user] takes a bite out of [src].</span>", "<span class='notice'>You munch on some of [src]'s leaves, like any normal human would.</span>")
-			var/mob/living/carbon/human/H = user
 			H.sims?.affectMotive("Hunger", 10)
 
 		if(src.bites <= 0)

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -301,8 +301,9 @@
 		else
 			user.changeStatus("food_hp_up", 20 SECONDS)
 			user.visible_message("<span class='notice'>[user] takes a bite out of [src].</span>", "<span class='notice'>You munch on some of [src]'s leaves, like any normal human would.</span>")
-			var/mob/living/carbon/human/H = user
-			H.sims?.affectMotive("Hunger", 10)
+			if (istype(user, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = user
+				H.sims?.affectMotive("Hunger", 10)
 
 		if(src.bites <= 0)
 			destroy()

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -280,7 +280,7 @@
 		src.take_damage(W.force)
 		user.visible_message("<span class='alert'><b>[user] hacks at [src] with [W]!</b></span>")
 
-	proc/graze(mob/user)
+	proc/graze(mob/living/carbon/human/user)
 		src.bites -= 1
 		var/desired_mask = (src.bites / initial(src.bites)) * 5
 		desired_mask = round(desired_mask)
@@ -301,9 +301,8 @@
 		else
 			user.changeStatus("food_hp_up", 20 SECONDS)
 			user.visible_message("<span class='notice'>[user] takes a bite out of [src].</span>", "<span class='notice'>You munch on some of [src]'s leaves, like any normal human would.</span>")
-			if (istype(user, /mob/living/carbon/human))
-				var/mob/living/carbon/human/H = user
-				H.sims?.affectMotive("Hunger", 10)
+			var/mob/living/carbon/human/H = user
+			H.sims?.affectMotive("Hunger", 10)
 
 		if(src.bites <= 0)
 			destroy()

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -281,8 +281,7 @@
 		src.bites -= 1
 		var/desired_mask = (src.bites / initial(src.bites)) * 5
 		desired_mask = round(desired_mask)
-		desired_mask = max(1,desired_mask)
-		desired_mask = min(desired_mask, 5)
+		desired_mask = clamp(desired_mask, 1, 5)
 
 		if (desired_mask != current_mask)
 			current_mask = desired_mask
@@ -295,7 +294,7 @@
 			user.setStatus("weakened", 3 SECONDS)
 			user.visible_message("<span class='notice'>[user] takes a bite out of [src] and chokes on the plastic leaves.</span>", "<span class='alert'>You munch on some of [src]'s leaves, but realise too late it's made of plastic. You start choking!</span>")
 			user.take_oxygen_deprivation(20)
-			user.losebreath+=2
+			user.losebreath += 2
 		else
 			user.changeStatus("food_hp_up", 20 SECONDS)
 			user.visible_message("<span class='notice'>[user] takes a bite out of [src].</span>", "<span class='notice'>You munch on some of [src]'s leaves, like any normal human would.</span>")

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -191,32 +191,7 @@
 
 		user.lastattacked = src
 		if (iscow(user) && user.a_intent == INTENT_HELP)	//Cow people may want to eat some of the bush's leaves
-			src.bites -= 1
-			var/desired_mask = (src.bites / initial(src.bites)) * 5
-			desired_mask = round(desired_mask)
-			desired_mask = max(1,desired_mask)
-			desired_mask = min(desired_mask, 5)
-
-			if (desired_mask != current_mask)
-				current_mask = desired_mask
-				src.add_filter("bite", 0, alpha_mask_filter(icon=icon('icons/obj/foodNdrink/food.dmi', "eating[desired_mask]")))
-
-			eat_twitch(user)
-			playsound(user, "sound/items/eatfood.ogg", rand(10,50), 1)
-
-			if (is_plastic)
-				user.setStatus("weakened", 3 SECONDS)
-				user.visible_message("<span class='notice'>[user] takes a bite out of [src] and chokes on the plastic leaves.</span>", "<span class='alert'>You munch on some of [src]'s leaves, but realise too late it's made of plastic. You start choking!</span>")
-				user.take_oxygen_deprivation(20)
-				user.losebreath+=2
-			else
-				user.changeStatus("food_hp_up", 20 SECONDS)
-				user.visible_message("<span class='notice'>[user] takes a bite out of [src].</span>", "<span class='notice'>You munch on some of [src]'s leaves, like any normal human would.</span>")
-				var/mob/living/carbon/human/H = user
-				H.sims?.affectMotive("Hunger", 10)
-
-			if(src.bites <= 0)
-				destroy()
+			graze(user)
 			return 0
 
 		playsound(src, "sound/impact_sounds/Bush_Hit.ogg", 50, 1, -1)
@@ -302,6 +277,35 @@
 		src.take_damage(W.force)
 		user.visible_message("<span class='alert'><b>[user] hacks at [src] with [W]!</b></span>")
 
+	proc/graze(mob/user)
+		src.bites -= 1
+		var/desired_mask = (src.bites / initial(src.bites)) * 5
+		desired_mask = round(desired_mask)
+		desired_mask = max(1,desired_mask)
+		desired_mask = min(desired_mask, 5)
+
+		if (desired_mask != current_mask)
+			current_mask = desired_mask
+			src.add_filter("bite", 0, alpha_mask_filter(icon=icon('icons/obj/foodNdrink/food.dmi', "eating[desired_mask]")))
+
+		eat_twitch(user)
+		playsound(user, "sound/items/eatfood.ogg", rand(10,50), 1)
+
+		if (is_plastic)
+			user.setStatus("weakened", 3 SECONDS)
+			user.visible_message("<span class='notice'>[user] takes a bite out of [src] and chokes on the plastic leaves.</span>", "<span class='alert'>You munch on some of [src]'s leaves, but realise too late it's made of plastic. You start choking!</span>")
+			user.take_oxygen_deprivation(20)
+			user.losebreath+=2
+		else
+			user.changeStatus("food_hp_up", 20 SECONDS)
+			user.visible_message("<span class='notice'>[user] takes a bite out of [src].</span>", "<span class='notice'>You munch on some of [src]'s leaves, like any normal human would.</span>")
+			var/mob/living/carbon/human/H = user
+			H.sims?.affectMotive("Hunger", 10)
+
+		if(src.bites <= 0)
+			destroy()
+		return 0
+
 	proc/take_damage(var/damage_amount = 5)
 		src.health -= damage_amount
 		if (src.health <= 0)
@@ -366,29 +370,20 @@
 			if (M.mind && M.mind.assigned_role == "Captain")
 				boutput(M, "<span class='alert'>You suddenly feel hollow. Something very dear to you has been lost.</span>")
 
-	attack_hand(mob/user)
-		if (!user) return
-		if (destroyed && iscow(user) && user.a_intent == INTENT_HELP)
-			boutput(user, "<span class='notice'>You pick at the ruined bush, looking for any leafs to graze on, but cannot find any.</span>")
-			return
-		else if (destroyed)
-			return
-
+	graze(mob/user)
 		user.lastattacked = src
-		if (iscow(user) && user.a_intent == INTENT_HELP)	//Bonsai trees are delicious to cow-people
-			if (user.mind && user.mind.assigned_role == "Captain")
-				boutput(user, "<span class='notice'>You catch yourself almost taking a bite out of your precious bonzai but stop just in time!</span>")
-				return
-			else
-				boutput(user, "<span class='alert'>I don't think the Captain is going to be too happy about this...</span>")
-				user.visible_message("<b><span class='alert'>[user] violently grazes on [src]!</span></b>", "<span class='notice'>You voraciously devour the bonzai, what a feast!</span>")
-				src.interesting = "Inexplicably, the genetic code of the bonsai tree has the words 'fuck [user.real_name]' encoded in it over and over again."
-				src.destroy()
-				user.changeStatus("food_deep_burp", 2 MINUTES)
-				user.changeStatus("food_hp_up", 2 MINUTES)
-				user.changeStatus("food_energized", 2 MINUTES)
-				return
-		..()
+		if (user.mind && user.mind.assigned_role == "Captain")
+			boutput(user, "<span class='notice'>You catch yourself almost taking a bite out of your precious bonzai but stop just in time!</span>")
+			return
+		else
+			boutput(user, "<span class='alert'>I don't think the Captain is going to be too happy about this...</span>")
+			user.visible_message("<b><span class='alert'>[user] violently grazes on [src]!</span></b>", "<span class='notice'>You voraciously devour the bonzai, what a feast!</span>")
+			src.interesting = "Inexplicably, the genetic code of the bonsai tree has the words 'fuck [user.real_name]' encoded in it over and over again."
+			src.destroy()
+			user.changeStatus("food_deep_burp", 2 MINUTES)
+			user.changeStatus("food_hp_up", 2 MINUTES)
+			user.changeStatus("food_energized", 2 MINUTES)
+			return
 
 	attackby(obj/item/W, mob/user)
 		if (!W) return

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -180,6 +180,7 @@
 				qdel(src)
 			else
 				src.take_damage(45)
+
 	attack_hand(mob/user)
 		if (!user) return
 		if (destroyed && iscow(user) && user.a_intent == INTENT_HELP)
@@ -189,21 +190,7 @@
 			return ..()
 
 		user.lastattacked = src
-		if (iscow(user) && user.a_intent == INTENT_HELP)
-			if (istype(src, /obj/shrub/captainshrub))
-				if (user.mind && user.mind.assigned_role == "Captain")
-					boutput(user, "<span class='notice'>You catch yourself almost taking a bite out of your precious bonzai but stop just in time!</span>")
-					return
-				else
-					boutput(user, "<span class='alert'>I don't think the Captain is going to be too happy about this...</span>")
-					user.visible_message("<b><span class='alert'>[user] violently grazes on [src]!</span></b>", "<span class='notice'>You voraciously devour the bonzai, what a feast!</span>")
-					src.interesting = "Inexplicably, the genetic code of the bonsai tree has the words 'fuck [user.real_name]' encoded in it over and over again."
-					src.destroy()
-					user.changeStatus("food_deep_burp", 2 MINUTES)
-					user.changeStatus("food_hp_up", 2 MINUTES)
-					user.changeStatus("food_energized", 2 MINUTES)
-					return
-
+		if (iscow(user) && user.a_intent == INTENT_HELP)	//Cow people may want to eat some of the bush's leaves
 			src.bites -= 1
 			var/desired_mask = (src.bites / initial(src.bites)) * 5
 			desired_mask = round(desired_mask)
@@ -378,6 +365,30 @@
 		for (var/mob/living/M in mobs)
 			if (M.mind && M.mind.assigned_role == "Captain")
 				boutput(M, "<span class='alert'>You suddenly feel hollow. Something very dear to you has been lost.</span>")
+
+	attack_hand(mob/user)
+		if (!user) return
+		if (destroyed && iscow(user) && user.a_intent == INTENT_HELP)
+			boutput(user, "<span class='notice'>You pick at the ruined bush, looking for any leafs to graze on, but cannot find any.</span>")
+			return
+		else if (destroyed)
+			return ..()
+
+		user.lastattacked = src
+		if (iscow(user) && user.a_intent == INTENT_HELP)	//Bonsai trees are delicious to cow-people
+			if (user.mind && user.mind.assigned_role == "Captain")
+				boutput(user, "<span class='notice'>You catch yourself almost taking a bite out of your precious bonzai but stop just in time!</span>")
+				return
+			else
+				boutput(user, "<span class='alert'>I don't think the Captain is going to be too happy about this...</span>")
+				user.visible_message("<b><span class='alert'>[user] violently grazes on [src]!</span></b>", "<span class='notice'>You voraciously devour the bonzai, what a feast!</span>")
+				src.interesting = "Inexplicably, the genetic code of the bonsai tree has the words 'fuck [user.real_name]' encoded in it over and over again."
+				src.destroy()
+				user.changeStatus("food_deep_burp", 2 MINUTES)
+				user.changeStatus("food_hp_up", 2 MINUTES)
+				user.changeStatus("food_energized", 2 MINUTES)
+				return
+		return ..()
 
 	attackby(obj/item/W, mob/user)
 		if (!W) return

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -159,9 +159,9 @@
 	var/time_between_uses = 400 // The default time between uses.
 	var/override_default_behaviour = 0 // When this is set to 1, the additional_items list will be used to dispense items.
 	var/list/additional_items = list() // See above.
-	var/bites = 5 // How many bites can cow people take out of it?
-	var/current_mask = 5 // The mask used to show bite marks
-	var/is_plastic = FALSE // Is the bush actually made out of plastic?
+	var/bites = 5 /// How many bites can cow people take out of it?
+	var/current_mask = 5 /// The mask used to show bite marks
+	var/is_plastic = FALSE /// Is the bush actually made out of plastic?
 
 	New()
 		..()

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -301,7 +301,7 @@
 		else
 			user.changeStatus("food_hp_up", 20 SECONDS)
 			user.visible_message("<span class='notice'>[user] takes a bite out of [src].</span>", "<span class='notice'>You munch on some of [src]'s leaves, like any normal human would.</span>")
-			H.sims?.affectMotive("Hunger", 10)
+			user.sims?.affectMotive("Hunger", 10)
 
 		if(src.bites <= 0)
 			destroy()

--- a/code/obj/decorations.dm
+++ b/code/obj/decorations.dm
@@ -159,9 +159,12 @@
 	var/time_between_uses = 400 // The default time between uses.
 	var/override_default_behaviour = 0 // When this is set to 1, the additional_items list will be used to dispense items.
 	var/list/additional_items = list() // See above.
-	var/bites = 5 /// How many bites can cow people take out of it?
-	var/current_mask = 5 /// The mask used to show bite marks
-	var/is_plastic = FALSE /// Is the bush actually made out of plastic?
+	/// How many bites can cow people take out of it?
+	var/bites = 5
+	/// The mask used to show bite marks
+	var/current_mask = 5
+	/// Is the bush actually made out of plastic?
+	var/is_plastic = FALSE
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cow people can now click on the bushes spread around the station on help intent to graze on them, gaining minor food buffs and removing visible bites from the bush.
This alleviates the hunger motive on the rp servers.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cow-people need a more balanced diet. Also provides a fun way to fix your hunger motive, get some very minor foodbuffs, and also makes the captain's bonsai an interesting target.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Bartimeus973
(+)Cow people can now graze on bushes. Watch out for plastic replicas!
```
