### PR TITLE
Adds Security records scanner

### DIFF
--- a/code/obj/item/device/pda2/cartridges.dm
+++ b/code/obj/item/device/pda2/cartridges.dm
@@ -189,6 +189,7 @@
 		New()
 			..()
 			src.root.add_file( new /datum/computer/file/pda_program/scan/forensic_scan(src))
+			src.root.add_file( new /datum/computer/file/pda_program/scan/secrecord_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/records/security(src))
 			src.root.add_file( new /datum/computer/file/pda_program/bot_control/secbot(src))
 			src.root.add_file( new /datum/computer/file/pda_program/portable_machinery_control/portabrig(src))
@@ -207,6 +208,7 @@
 			src.root.add_file( new /datum/computer/file/pda_program/scan/health_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/scan/reagent_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/scan/medrecord_scan(src))
+			src.root.add_file( new /datum/computer/file/pda_program/scan/secrecord_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/records/medical(src))
 			src.root.add_file( new /datum/computer/file/pda_program/records/security(src))
 			src.root.add_file( new /datum/computer/file/pda_program/bot_control/secbot(src))
@@ -229,6 +231,7 @@
 			src.root.add_file( new /datum/computer/file/pda_program/fileshare(src))
 			src.root.add_file( new /datum/computer/file/pda_program/scan/forensic_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/scan/health_scan(src))
+			src.root.add_file( new /datum/computer/file/pda_program/scan/secrecord_scan(src))
 			src.root.add_file( new /datum/computer/file/pda_program/records/security(src))
 			src.root.add_file( new /datum/computer/file/pda_program/security_ticket(src))
 			src.file_amount = src.file_used

--- a/code/obj/item/device/pda2/scanners.dm
+++ b/code/obj/item/device/pda2/scanners.dm
@@ -52,7 +52,7 @@
 	//Forensic scanner
 	forensic_scan
 		name = "Forensic Scan"
-		size = 8
+		size = 6
 
 		scan_atom(atom/A as mob|obj|turf|area)
 			if(..())
@@ -151,6 +151,20 @@
 
 			. = scan_medrecord(src.master, C, visible = 1)
 			update_medical_record(C)
+
+	secrecord_scan
+		name = "Secmate Scanner"
+		size = 2
+
+		scan_atom(atom/A as mob|obj|turf|area)
+			if (..())
+				return
+
+			if (!iscarbon(A))
+				return
+			var/mob/living/carbon/C = A
+
+			. = scan_secrecord(src.master, C, visible = 1)
 
 /datum/computer/file/electronics_scan
 	name = "scanfile"

--- a/code/procs/scanprocs.dm
+++ b/code/procs/scanprocs.dm
@@ -825,3 +825,32 @@
 
 	HYPgeneticanalysis(user, A, P, DNA) // Just use the existing proc.
 	return
+
+/proc/scan_secrecord(var/obj/item/device/pda2/pda, var/mob/M as mob, var/visible = 0)
+	if (!M)
+		return "<span class='alert'>ERROR: NO SUBJECT DETECTED</span>"
+
+	if (!ishuman(M))
+		return "<span class='alert'>ERROR: INVALID DATA FROM SUBJECT</span>"
+
+	if(visible)
+		animate_scanning(M, "#ef0a0a")
+
+	var/mob/living/carbon/human/H = M
+	var/datum/db_record/GR = data_core.general.find_record("name", H.name)
+	var/datum/db_record/SR = data_core.security.find_record("name", H.name)
+	if (!SR)
+		return "<span class='alert'>ERROR: NO RECORD FOUND</span>"
+
+	//Find security records program
+	var/list/programs = null
+	for (var/obj/item/disk/data/mod in pda.contents)
+		programs += mod.root.contents.Copy()
+	var/datum/computer/file/pda_program/records/security/record_prog = locate(/datum/computer/file/pda_program/records/security) in programs
+	if (!record_prog)
+		return "<span class='alert'>ERROR: NO SECURITY RECORD FILE</span>"
+	pda.run_program(record_prog)
+	record_prog.active1 = GR
+	record_prog.active2 = SR
+	record_prog.mode = 1
+	pda.AttackSelf(usr)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds the security records scanner program available on security, forensic and HOS cartridges. The functionnality is quite simple: you scan a person, the PDA opens up the record of that person through the PDA.
Also lowers the size of forensic scan app for 8 to 6, to let some space for this new program

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It is needed so we don't need to spend half an hour looking  through all of the 100 security records manually when checking the crimes of what is most likely a jailbird.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Chatauscours
(*)Added Security record scanner program for PDAs. Only available on ROBUST, Forensics and ROBUSTER cartridges.
```
