### PR TITLE
Allows flockmind and traces to issue drag and drop move commands to drones

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -323,6 +323,22 @@
 	else
 		..()
 
+/mob/living/critter/flock/drone/mouse_drop(atom/over_object, src_location, over_location, over_control, params)
+	. = ..()
+	if (isdead(src) || isnull(src.flock))
+		return
+	if (!isflockmob(usr))
+		return
+	var/mob/living/intangible/flock/flock_controller = usr
+	if (istype(usr, /mob/living/critter/flock))
+		var/mob/living/critter/flock/flock_mob = usr
+		flock_controller = flock_mob.controller
+	if (!isalive(flock_controller))
+		return // flock mind/trace is stunned or dead
+	if (flock_controller.flock != src.flock)
+		return // this isn't our drone
+	src.rally(over_location)
+
 /mob/living/critter/flock/drone/hotkey(var/name)
 	switch (name)
 		if("equip")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [FEATURE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Allows flock mind and traces to drag and drop flock drones onto things to request that they move to them, if possible.
* Works even when possessing a drone
https://streamable.com/dpzbzy

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* Improved controls


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Sovexe
(+)Flockminds and traces may now issue movement commands to drones by clicking and dragging them onto a destination.
```
