### PR TITLE
Adds flockgib admin verb

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2137,6 +2137,14 @@
 		animation.delaydispose()
 	qdel(src)
 
+/mob/proc/flockbit_gib()
+	src.visible_message("<span class='alert bold'>[src] is torn apart from the inside as some weird floaty thing rips its way out of their body! Holy fuck!!</span>")
+	var/mob/living/critter/flock/bit/B = new()
+	var/turf/T = get_turf(src)
+	B.set_loc(T)
+	make_cleanable(/obj/decal/cleanable/flockdrone_debris, T)
+	src.gib()
+
 // Man, there's a lot of possible inventory spaces to store crap. This should get everything under normal circumstances.
 // Well, it's hard to account for every possible matryoshka scenario (Convair880).
 /mob/proc/get_all_items_on_mob()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1173,7 +1173,7 @@ var/global/noir = 0
 				if (!M) return
 				usr.client.cmd_admin_flockgib(M)
 			else
-				tgui_alert(usr,"You need to be at least a Primary Admin to cluwne gib a dude.")
+				tgui_alert(usr,"You need to be at least a Primary Admin to flock gib a dude.")
 		if ("tysongib")
 			if( src.level >= LEVEL_PA )
 				var/mob/M = locate(href_list["target"])

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1167,6 +1167,13 @@ var/global/noir = 0
 				usr.client.cmd_admin_cluwnegib(M)
 			else
 				tgui_alert(usr,"You need to be at least a Primary Admin to cluwne gib a dude.")
+		if("flockgib")
+			if( src.level >= LEVEL_PA )
+				var/mob/M = locate(href_list["target"])
+				if (!M) return
+				usr.client.cmd_admin_flockgib(M)
+			else
+				tgui_alert(usr,"You need to be at least a Primary Admin to cluwne gib a dude.")
 		if ("tysongib")
 			if( src.level >= LEVEL_PA )
 				var/mob/M = locate(href_list["target"])

--- a/code/modules/admin/gibverbs.dm
+++ b/code/modules/admin/gibverbs.dm
@@ -201,6 +201,23 @@
 
 		M.buttgib()
 
+/client/proc/cmd_admin_flockgib(mob/M as mob in world)
+	SET_ADMIN_CAT(ADMIN_CAT_NONE)
+	set name = "Flockbit gib"
+	set popup_menu = 0
+
+	if (!src.holder)
+		boutput(src, "Only administrators may use this command.")
+		return
+
+	if (tgui_alert(src.mob, "Are you sure you want to gib [M]?", "Confirmation", list("Yes", "No")) == "Yes")
+		if(usr.key != M.key && M.client)
+			logTheThing("admin", usr, M, "has flockbit gibbed [constructTarget(M,"admin")]")
+			logTheThing("diary", usr, M, "has flockbit gibbed [constructTarget(M,"diary")]", "admin")
+			message_admins("[key_name(usr)] has flockbit gibbed [key_name(M)]")
+
+		M.flockbit_gib()
+
 /client/proc/cmd_admin_cluwnegib(mob/M as mob in world)
 	SET_ADMIN_CAT(ADMIN_CAT_NONE)
 	set name = "Cluwne Gib"

--- a/code/modules/admin/player_options.dm
+++ b/code/modules/admin/player_options.dm
@@ -193,8 +193,8 @@
 						<a href='[playeropt_link(M, "spidergib")]'>Spider</a> &bull;
 						<a href='[playeropt_link(M, "cluwnegib")]'>Cluwne</a> &bull;
 						<a href='[playeropt_link(M, "tysongib")]'>Tyson</a> &bull;
-						<a href='[playeropt_link(M, "damn")]'>(Un)Damn</a> &bull;
-						<a href='[playeropt_link(M, "flockgib")]'>Flock</a>
+						<a href='[playeropt_link(M, "flockgib")]'>Flock</a> &bull;
+						<a href='[playeropt_link(M, "damn")]'>(Un)Damn</a>
 					</div>
 					<div class='l'>Misc</div>
 					<div class='r'>

--- a/code/modules/admin/player_options.dm
+++ b/code/modules/admin/player_options.dm
@@ -193,7 +193,8 @@
 						<a href='[playeropt_link(M, "spidergib")]'>Spider</a> &bull;
 						<a href='[playeropt_link(M, "cluwnegib")]'>Cluwne</a> &bull;
 						<a href='[playeropt_link(M, "tysongib")]'>Tyson</a> &bull;
-						<a href='[playeropt_link(M, "damn")]'>(Un)Damn</a>
+						<a href='[playeropt_link(M, "damn")]'>(Un)Damn</a> &bull;
+						<a href='[playeropt_link(M, "flockgib")]'>Flock</a>
 					</div>
 					<div class='l'>Misc</div>
 					<div class='r'>

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2107,11 +2107,8 @@ datum
 					if(holder.get_reagent_amount(src.id) > 300)
 						// oh no
 						if(probmult(1)) // i hate you all, players
-							H.visible_message("<span class='alert bold'>[H] is torn apart from the inside as some weird floaty thing rips its way out of their body! Holy fuck!!</span>")
-							var/mob/living/critter/flock/bit/B = new()
-							B.set_loc(get_turf(H))
+							H.flockbit_gib()
 							logTheThing("combat", H, null, "was gibbed by reagent [name] at [log_loc(H)].")
-							H.gib()
 					else
 						// DO SPOOKY THINGS
 						if(holder.get_reagent_amount(src.id) < 100)

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)tue jun 14 22
+(u)LeahTheTech
+(*)Added flockgib verb and player option
 (t)mon apr 23 22
 (u)Amylizzle, LeahTheTech, FlameArrow57, Stonepillar
 (*)Rework of the Flockmind antagonist to a playable state. It should now be less likely to explode, give it a shot!


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds an admin verb to gib someone into an NPC flockbit, and corresponding entry on the player options panel.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Good for gimmicks and the next idiot who keeps demanding to "be flock" in OOC.