### PR TITLE
Replaces the battery in surplus crates with a thermonuclear battery cell + renames it.

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1061,7 +1061,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)
 
 /datum/syndicate_buylist/surplus/egun_upgrade
 	name = "Energy Gun Upgrade Pack"
-	item = /obj/item/ammo/power_cell/self_charging/mediumbig
+	item = /obj/item/ammo/power_cell/self_charging/bigmedium
 	cost = 2
 	desc = "An advanced self-charging power cell, the ideal upgrade for an energy gun!"
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1061,7 +1061,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)
 
 /datum/syndicate_buylist/surplus/egun_upgrade
 	name = "Advanced Energy Cell"
-	item = /obj/item/ammo/power_cell/self_charging/bigmedium
+	item = /obj/item/ammo/power_cell/self_charging/medium
 	cost = 2
 	desc = "An advanced self-charging power cell, the ideal upgrade for an energy weapon!"
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1061,7 +1061,7 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)
 
 /datum/syndicate_buylist/surplus/egun_upgrade
 	name = "Energy Gun Upgrade Pack"
-	item = /obj/item/ammo/power_cell/self_charging/disruptor
+	item = /obj/item/ammo/power_cell/self_charging/mediumbig
 	cost = 2
 	desc = "An advanced self-charging power cell, the ideal upgrade for an energy gun!"
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP

--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1060,10 +1060,10 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP
 
 /datum/syndicate_buylist/surplus/egun_upgrade
-	name = "Energy Gun Upgrade Pack"
+	name = "Advanced Energy Cell"
 	item = /obj/item/ammo/power_cell/self_charging/bigmedium
 	cost = 2
-	desc = "An advanced self-charging power cell, the ideal upgrade for an energy gun!"
+	desc = "An advanced self-charging power cell, the ideal upgrade for an energy weapon!"
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP
 
 // Why not, I guess? Cleaned up the old mine code, might as well use it (Convair880).

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1260,13 +1260,6 @@
 	charge = 200
 	recharge_rate = 20
 
-/obj/item/ammo/power_cell/self_charging/bigmedium
-	name = "Power Cell - Thermonuclear"
-	desc = "Utilizing dual Fission Fusion capabilities for a lower cost yet high power cell. Holds 250PU."
-	max_charge = 250
-	charge = 250
-	recharge_rate = 20
-
 /obj/item/ammo/power_cell/self_charging/big
 	name = "Power Cell - Fusion"
 	desc = "A self-contained cold fusion power cell that quickly recharges an internal capacitor. Holds 400PU."

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1262,10 +1262,10 @@
 
 /obj/item/ammo/power_cell/self_charging/bigmedium
 	name = "Power Cell - Thermonuclear"
-	desc = "Utilizing dual Fission Fusion capabilities for a lower cost yet high power cell. Holds 275PU."
-	max_charge = 275
-	charge = 275
-	recharge_rate = 25
+	desc = "Utilizing dual Fission Fusion capabilities for a lower cost yet high power cell. Holds 250PU."
+	max_charge = 250
+	charge = 250
+	recharge_rate = 20
 
 /obj/item/ammo/power_cell/self_charging/big
 	name = "Power Cell - Fusion"

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1255,10 +1255,17 @@
 
 /obj/item/ammo/power_cell/self_charging/mediumbig
 	name = "Power Cell - Fission"
-	desc = "Half the power of a Fusion model power cell with a tenth of the cost. Holds 200PU"
+	desc = "Half the power of a Fusion model power cell with a tenth of the cost. Holds 200PU."
 	max_charge = 200
 	charge = 200
 	recharge_rate = 20
+
+/obj/item/ammo/power_cell/self_charging/bigmedium
+	name = "Power Cell - Thermonuclear"
+	desc = "Utilizing dual Fission Fusion capabilities for a lower cost yet high power cell. Holds 275PU."
+	max_charge = 275
+	charge = 275
+	recharge_rate = 25
 
 /obj/item/ammo/power_cell/self_charging/big
 	name = "Power Cell - Fusion"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [WIKI] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr swaps the disruptor cell found in surplus crates with a new thermonuclear cell, featuring 250 charge and a recharge rate of 20.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Disruptor batteries are pretty bad and found easily elsewhere. This should make getting this battery out of a surplus crate much more attractive. The name previously was pretty unclear on what specifically it was and the new name should help clarify on that.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)Due to the syndicate finding out that traitor surplus's were getting surplus disruptor cells from 2037, the syndicate has replaced the energy cells that can be found in surplus crates with a far superior battery design.
```
