### PR TITLE
Nukies now come with flyzapper implants, flyzapper implants no longer zap nukies.

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -596,7 +596,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		. = ..()
 		elecflash(src, ., . * 2, TRUE)
 		for (var/mob/living/M in orange(. / 6 + 1, src.owner))
-			if (!isintangible(M))
+			if (!isintangible(M) && (!M.mind || M.mind.special_role != ROLE_NUKEOP)) // I dont feel like making a child for such a minor change.
 				var/dist = get_dist(src.owner, M) + 1
 				// arcflash uses some fucked up thresholds so trust me on this one
 				arcFlash(src.owner, M, (40000 * (4 - (0.4 * dist * log(dist)))) * (15 * log(.) + 3))
@@ -604,7 +604,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			if (prob(. * 7))
 				var/mob/living/target
 				for (var/mob/living/L in orange(machine, 2))
-					if (!isintangible(L))
+					if (!isintangible(L) && (!L.mind || L.mind.special_role != ROLE_NUKEOP))
 						target = L
 						break
 				if (target)

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -596,7 +596,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		. = ..()
 		elecflash(src, ., . * 2, TRUE)
 		for (var/mob/living/M in orange(. / 6 + 1, src.owner))
-			if (!isintangible(M) && (!M.mind || M.mind.special_role != ROLE_NUKEOP || M.mind.special_role != ROLE_NUKEOP_GUNBOT)) // I dont feel like making a child for such a minor change.
+			if (!isintangible(M) && !/mob/living/critter/robotic/sawfly && (!M.mind || M.mind.special_role != ROLE_NUKEOP || M.mind.special_role != ROLE_NUKEOP_GUNBOT)) // I dont feel like making a child for such a minor change.
 				var/dist = get_dist(src.owner, M) + 1
 				// arcflash uses some fucked up thresholds so trust me on this one
 				arcFlash(src.owner, M, (40000 * (4 - (0.4 * dist * log(dist)))) * (15 * log(.) + 3))
@@ -604,7 +604,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			if (prob(. * 7))
 				var/mob/living/target
 				for (var/mob/living/L in orange(machine, 2))
-					if (!isintangible(L) && (!L.mind || L.mind.special_role != ROLE_NUKEOP || L.mind.special_role != ROLE_NUKEOP_GUNBOT))
+					if (!isintangible(L) && !/mob/living/critter/robotic/sawfly && (!L.mind || L.mind.special_role != ROLE_NUKEOP || L.mind.special_role != ROLE_NUKEOP_GUNBOT))
 						target = L
 						break
 				if (target)

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -596,7 +596,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 		. = ..()
 		elecflash(src, ., . * 2, TRUE)
 		for (var/mob/living/M in orange(. / 6 + 1, src.owner))
-			if (!isintangible(M) && (!M.mind || M.mind.special_role != ROLE_NUKEOP)) // I dont feel like making a child for such a minor change.
+			if (!isintangible(M) && (!M.mind || M.mind.special_role != ROLE_NUKEOP || M.mind.special_role != ROLE_NUKEOP_GUNBOT)) // I dont feel like making a child for such a minor change.
 				var/dist = get_dist(src.owner, M) + 1
 				// arcflash uses some fucked up thresholds so trust me on this one
 				arcFlash(src.owner, M, (40000 * (4 - (0.4 * dist * log(dist)))) * (15 * log(.) + 3))
@@ -604,7 +604,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			if (prob(. * 7))
 				var/mob/living/target
 				for (var/mob/living/L in orange(machine, 2))
-					if (!isintangible(L) && (!L.mind || L.mind.special_role != ROLE_NUKEOP))
+					if (!isintangible(L) && (!L.mind || L.mind.special_role != ROLE_NUKEOP || L.mind.special_role != ROLE_NUKEOP_GUNBOT))
 						target = L
 						break
 				if (target)

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -297,7 +297,7 @@
 	I.icon = 'icons/obj/items/card.dmi'
 	synd_mob.equip_if_possible(I, synd_mob.slot_wear_id)
 
-	var/obj/item/implant/revenge/microbomb/M = new /obj/item/implant/revenge/microbomb(synd_mob)
+	var/obj/item/implant/revenge/zappy/M = new /obj/item/implant/revenge/zappy(synd_mob)
 	M.implanted = 1
 	synd_mob.implant.Add(M)
 	M.implanted(synd_mob)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [INPUT] [WIKI] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr gives nukies flyzapper implants. This pr also changes flyzapper behavior,  anyone with the mind of a nuclear operative or a gunbot will not be directly zapped, they will get minor disorient due to the larger elecflash. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Micros damage other nukies, which means the death of an operative further helps cascade the death of other operatives. Microbombs also contribute to depressurization, which hurt for the gamemode. Flyzappers also immediately destroy gear upon death through elec gib, unlike the prolonged destruction currently. This overall should both buff nukies and be better for the round.
Current flyzapper damage values (note the absence of people in a 3x3 area due to gibbing) (This does not include zapping from any machinery which also contribute to damage):
![image](https://user-images.githubusercontent.com/73148980/173707631-42c65772-858b-461c-a686-853c12e59d8d.png)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Nuclear Operatives now come with flyzapper implants, flyzapper implants have also been reprogrammed to not directly zap nuclear operatives.
```
