### PR TITLE
Makes cameras in AI core/upload locked to the AI

### DIFF
--- a/code/mob/living/silicon/hivebot.dm
+++ b/code/mob/living/silicon/hivebot.dm
@@ -70,6 +70,7 @@
 			src.cell = new /obj/item/cell/shell_cell/charged (src)
 		src.camera = new /obj/machinery/camera(src)
 		src.camera.c_tag = src.name
+		src.camera.ai_only = TRUE
 
 	..()
 	src.botcard.access = get_all_accesses()

--- a/code/obj/machinery/camera.dm
+++ b/code/obj/machinery/camera.dm
@@ -14,6 +14,8 @@
 	anchored = 1.0
 	var/invuln = null
 	var/last_paper = 0
+	///Cameras only the AI can see through
+	var/ai_only = FALSE
 
 	//This camera is a node pointing to the other bunch of cameras nearby for AI movement purposes
 	var/obj/machinery/camera/c_north = null
@@ -122,7 +124,10 @@
 
 /obj/machinery/camera/New()
 	..()
-
+	var/area/area = get_area(src)
+	//if only these had a common parent...
+	if (istype(area, /area/station/turret_protected/ai) || istype(area, /area/station/turret_protected/ai_upload) || istype(area, /area/station/turret_protected/AIsat))
+		src.ai_only = TRUE
 	START_TRACKING
 	SPAWN(1 SECOND)
 		addToNetwork()

--- a/code/obj/machinery/computer/security.dm
+++ b/code/obj/machinery/computer/security.dm
@@ -82,7 +82,7 @@
 
 		if(!closest)
 			return
-		else if (!closest.camera_status)
+		else if (!closest.camera_status || closest.ai_only)
 			boutput(user, "<span class='alert'>ERROR. Cannot connect to camera.</span>")
 			playsound(src.loc, "sound/machines/buzz-sigh.ogg", 10, 0)
 			return

--- a/code/obj/machinery/computer/security/security_cameras_chui.dm
+++ b/code/obj/machinery/computer/security/security_cameras_chui.dm
@@ -41,8 +41,8 @@ chui/window/security_cameras
 		for (var/obj/machinery/camera/C in L)
 			if (C.network == owner.network)
 				. = "[C.c_tag][C.camera_status ? null : " (Deactivated)"]"
-				// Don't draw if it's in favorites
-				if (C in owner.favorites)
+				// Don't draw if it's in favorites or AI core/upload
+				if ((C in owner.favorites) || C.ai_only)
 					continue
 				// &#128190; is save symbol
 				cameras_list += \

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1720,6 +1720,13 @@
 "en" = (
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
+"eo" = (
+/obj/lattice{
+	dir = 9;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space,
+/area/station/turret_protected/ai)
 "ep" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -4642,7 +4649,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "lP" = (
 /obj/disposalpipe/segment{
 	dir = 4
@@ -6506,7 +6513,7 @@
 "qj" = (
 /obj/machinery/turret,
 /turf/simulated/floor/delivery,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "qk" = (
 /obj/cable{
 	d1 = 1;
@@ -6529,7 +6536,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "qn" = (
 /obj/submachine/seed_vendor,
 /turf/simulated/floor/green,
@@ -6656,7 +6663,7 @@
 /area/station/maintenance/north)
 "qD" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "qE" = (
 /turf/simulated/floor/black,
 /area/station/engine/substation/west)
@@ -6887,7 +6894,7 @@
 	},
 /obj/machinery/computer3/terminal/zeta,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "rh" = (
 /obj/machinery/computer3/terminal/network{
 	name = "CENTCOM Terminal";
@@ -6909,7 +6916,7 @@
 	tag = ""
 	},
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "ri" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4;
@@ -6922,7 +6929,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/blue,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "rk" = (
 /obj/cable{
 	d1 = 4;
@@ -6930,7 +6937,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "rl" = (
 /obj/machinery/power/apc/autoname_east,
 /obj/cable{
@@ -6938,7 +6945,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/blue,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "rm" = (
 /obj/table/auto,
 /obj/item/paper/book/from_file/hydroponicsguide,
@@ -7022,7 +7029,7 @@
 "rw" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "rx" = (
 /obj/machinery/light{
 	dir = 8;
@@ -7462,7 +7469,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "ss" = (
 /obj/landmark/start{
 	name = "Cyborg"
@@ -7480,7 +7487,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "st" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -7488,7 +7495,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "su" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -7513,12 +7520,12 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "sx" = (
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "sy" = (
 /obj/submachine/seed_manipulator{
 	dir = 4
@@ -7704,7 +7711,7 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "sW" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -7774,7 +7781,7 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "td" = (
 /obj/lattice{
 	dir = 4;
@@ -8044,7 +8051,7 @@
 	},
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "tE" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -8054,7 +8061,7 @@
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "tF" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
@@ -8066,7 +8073,7 @@
 	},
 /obj/access_spawn/ai_upload,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "tG" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -8077,7 +8084,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "tH" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
@@ -8109,7 +8116,7 @@
 	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "tJ" = (
 /obj/machinery/light{
 	dir = 4;
@@ -8121,7 +8128,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "tK" = (
 /obj/table/auto,
 /obj/item/device/light/lava_lamp,
@@ -8622,19 +8629,19 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "uM" = (
 /obj/landmark/start{
 	name = "Cyborg"
 	},
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "uN" = (
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "uO" = (
 /obj/cable{
 	d1 = 1;
@@ -8656,7 +8663,7 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "uQ" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -8933,7 +8940,7 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "vu" = (
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
@@ -8949,7 +8956,7 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "vx" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/cold{
 	dir = 6
@@ -9021,15 +9028,15 @@
 /obj/table/auto,
 /obj/item/aiModule/freeform,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "vI" = (
 /turf/simulated/floor/blue,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "vJ" = (
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "vK" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -9041,7 +9048,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 1
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "vL" = (
 /obj/table/auto,
 /obj/item/bee_egg_carton,
@@ -9064,7 +9071,7 @@
 "vO" = (
 /obj/securearea,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "vP" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/hydroponics/bay)
@@ -9373,19 +9380,19 @@
 /obj/item/aiModule/protectStation,
 /obj/item/aiModule/conservePower,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "wI" = (
 /obj/machinery/computer/robotics,
 /obj/machinery/light{
 	light_type = /obj/item/light/tube/blueish
 	},
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "wJ" = (
 /obj/table/auto,
 /obj/item/aiModule/makeCaptain,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "wK" = (
 /obj/machinery/vending/hydroponics,
 /turf/simulated/floor/green,
@@ -9930,7 +9937,7 @@
 	icon_state = "delivery2"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "xU" = (
 /obj/storage/secure/closet/engineering/mining,
 /turf/simulated/floor/yellow/side,
@@ -11200,7 +11207,7 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "Bd" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/maintenance/southeast)
@@ -16734,7 +16741,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "Pc" = (
 /obj/submachine/chicken_incubator,
 /obj/item/reagent_containers/food/snacks/ingredient/egg{
@@ -17504,6 +17511,9 @@
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/black,
 /area/station/storage/tech)
+"QM" = (
+/turf/space,
+/area/station/turret_protected/ai)
 "QP" = (
 /obj/cable{
 	d1 = 4;
@@ -17756,6 +17766,13 @@
 	},
 /turf/simulated/floor,
 /area/station/mining/refinery)
+"Ry" = (
+/obj/lattice{
+	dir = 6;
+	icon_state = "lattice-dir-b"
+	},
+/turf/space,
+/area/station/turret_protected/ai)
 "RA" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -19284,14 +19301,14 @@
 	},
 /obj/machinery/light/small/blueish,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "VN" = (
 /obj/machinery/light{
 	light_type = /obj/item/light/tube/blueish
 	},
 /obj/table/auto,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "VO" = (
 /obj/table/reinforced/auto,
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -19923,7 +19940,7 @@
 /obj/table/auto,
 /obj/random_item_spawner/ai_experimental,
 /turf/simulated/floor/circuit,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "Xz" = (
 /obj/table/round/auto,
 /obj/machinery/computer/tour_console,
@@ -20764,7 +20781,7 @@
 /obj/securearea,
 /obj/machinery/light/incandescent/blueish,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai)
 "ZL" = (
 /obj/machinery/light{
 	dir = 8;
@@ -61766,11 +61783,11 @@ tB
 pw
 tB
 oF
-aa
+QM
 qD
 VM
 qD
-aa
+QM
 yV
 yA
 Zy
@@ -62068,11 +62085,11 @@ kl
 kl
 kl
 kl
-nB
+Ry
 vO
 lO
 ZK
-yf
+eo
 AD
 RE
 Zy

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -9880,7 +9880,7 @@
 /obj/item/aiModule/makeCaptain,
 /obj/random_item_spawner/ai_experimental,
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aBe" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -12553,7 +12553,7 @@
 	},
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aHT" = (
 /obj/decal/poster/wallsign/escape_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -15055,7 +15055,7 @@
 /area/station/storage/tech)
 "aOl" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aOm" = (
 /obj/cable{
 	d1 = 1;
@@ -16117,14 +16117,14 @@
 	tag = ""
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aQM" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aQN" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -16138,7 +16138,7 @@
 	text = "NF"
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aQO" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -16146,7 +16146,7 @@
 	},
 /obj/machinery/computer3/terminal/zeta,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aQP" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -16154,7 +16154,7 @@
 	},
 /obj/machinery/networked/radio,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aQQ" = (
 /obj/shrub{
 	dir = 10
@@ -17478,7 +17478,7 @@
 /obj/item/disk/data/floppy/read_only/network_progs,
 /obj/item/disk/data/floppy/read_only/research_progs,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aTH" = (
 /obj/machinery/computer3/generic/med_data,
 /obj/machinery/power/data_terminal,
@@ -17520,7 +17520,7 @@
 	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aTJ" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -17541,7 +17541,7 @@
 /obj/item/disk/data/floppy/read_only/security_progs,
 /obj/item/disk/data/floppy/read_only/terminal_os,
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aTL" = (
 /obj/wingrille_spawn/auto,
 /obj/machinery/door/poddoor/pyro/shutters{
@@ -18796,7 +18796,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aWH" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -18806,7 +18806,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aWI" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -18815,7 +18815,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aWJ" = (
 /obj/decal/tile_edge/line/green{
 	dir = 8;
@@ -18829,7 +18829,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aWK" = (
 /obj/machinery/turret{
 	dir = 9
@@ -18838,7 +18838,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/circuit/green,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aWL" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -20276,7 +20276,7 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "aZZ" = (
 /obj/cable{
 	d1 = 4;
@@ -20285,7 +20285,7 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "baa" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -20297,7 +20297,7 @@
 	},
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bab" = (
 /obj/machinery/door/airlock/pyro/glass/command{
 	name = "Core"
@@ -20305,11 +20305,11 @@
 /obj/machinery/door/firedoor/pyro,
 /obj/access_spawn/heads,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bac" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bad" = (
 /obj/machinery/power/data_terminal,
 /obj/cable{
@@ -21633,7 +21633,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -21645,17 +21645,17 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcT" = (
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcU" = (
 /obj/table/auto,
 /obj/item/aiModule/freeform,
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bcV" = (
 /obj/wingrille_spawn/auto,
 /obj/cable,
@@ -22791,13 +22791,13 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfR" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfS" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -22814,7 +22814,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfT" = (
 /obj/cable{
 	d1 = 4;
@@ -22826,7 +22826,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfU" = (
 /obj/cable{
 	d1 = 4;
@@ -22839,7 +22839,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 4
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfV" = (
 /obj/cable{
 	d1 = 4;
@@ -22855,7 +22855,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfW" = (
 /obj/cable{
 	d1 = 4;
@@ -22882,7 +22882,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfX" = (
 /obj/machinery/turretid{
 	layer = 9.1;
@@ -22897,7 +22897,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/darkblue/checker,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bfY" = (
 /obj/machinery/light{
 	dir = 1;
@@ -24141,7 +24141,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 10
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biQ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -24150,7 +24150,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biR" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -24164,14 +24164,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biS" = (
 /obj/disposalpipe/segment/transport{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/blueblack,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biT" = (
 /obj/table/auto,
 /obj/item/aiModule/oneHuman,
@@ -24181,7 +24181,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 6
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "biU" = (
 /obj/machinery/atmospherics/valve,
 /obj/disposalpipe/segment{
@@ -25382,7 +25382,7 @@
 "blJ" = (
 /obj/decal/poster/wallsign/medbay_right,
 /turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "blK" = (
 /turf/simulated/floor/darkblue,
 /area/station/bridge)
@@ -30367,7 +30367,7 @@
 	},
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bzc" = (
 /obj/machinery/atmospherics/pipe/simple/color_pipe/cyan_pipe/horizontal,
 /obj/machinery/light{
@@ -32779,7 +32779,7 @@
 	},
 /mob/living/silicon/hivebot/eyebot,
 /turf/simulated/floor/black,
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "bFl" = (
 /obj/machinery/light{
 	dir = 1;
@@ -55463,7 +55463,7 @@
 /turf/simulated/floor/blueblack{
 	dir = 8
 	},
-/area/station/turret_protected/Zeta)
+/area/station/turret_protected/ai_upload)
 "kss" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/darkblue,
@@ -60169,6 +60169,9 @@
 /obj/disposalpipe/segment/transport,
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
+"vtX" = (
+/turf/space,
+/area/station/turret_protected/ai_upload)
 "vvy" = (
 /turf/unsimulated/grasstodirt{
 	dir = 9
@@ -101247,7 +101250,7 @@ aBZ
 aBZ
 aBn
 aAC
-aaa
+vtX
 uav
 aJK
 aJS


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes cameras in AI core/upload (also eyebot cameras) only usable by the AI.
Also fixes Atlas AI core not using an AI core area for some godforsaken reason.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Since the law rack changes the standard procedure if the AI does anything even slightly odd is for security to immediately check their cams to see if there's a conspicuous fourth law in the rack. This makes any attempt to subtly rogue the AI impossible since security can essentially just check the AI laws at any time.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(*)Security cameras in AI core/upload can now only be used by the AI.
```
