### PR TITLE
Adds Security Assistant Requisition Tokens To Special Equipment Lockers

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -374,6 +374,7 @@
 	reinforced = TRUE
 	req_access = list(access_maxsec)
 	spawn_contents = list(/obj/item/requisition_token/security = 2,
+	/obj/item/requisition_token/security/assistant = 2,
 	/obj/item/turret_deployer/riot = 2,
 	/obj/item/clothing/glasses/nightvision = 2,
 	/obj/item/clothing/glasses/sunglasses,


### PR DESCRIPTION
[QoL] [Wiki]


## About the PR:
Adds two Security Assistant requisition tokens to the special equipment lockers in the Armoury.



## Why's this needed? 
On occasion, some crew members will request to be promoted or transferred to Security; if it is their first time in the department, the HoS may instead provide them with the equipment of an Assistant rather than that of an Officer, or if the HoS is unwilling to hand out Officer gear to promoted crew. Additionally serves to provide backup equipment to Assistants who have died and lost their gear.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Two Security Assistant requisition tokens can now be found inside the special equipment lockers in the Armoury.
```
