### PR TITLE
Adds General, Security, and Detective Intercoms to DetNet

### DIFF
--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -191,6 +191,43 @@
 		else
 			set_frequency(frequency)
 
+// -------------------- DetNet --------------------
+/obj/item/device/radio/intercom/detnet
+	name = "DetNet Intercom (General)"
+	locked_frequency = TRUE
+	device_color = RADIOC_STANDARD
+	layer = 3.2
+
+	initialize()
+		set_frequency(frequency)
+
+/obj/item/device/radio/intercom/detnet/security
+	name = "DetNet Intercom (Security)"
+	frequency = R_FREQ_SECURITY
+	secure_frequencies = list("g" = R_FREQ_SECURITY)
+	secure_classes = list("g" = R_FREQ_SECURITY)
+	locked_frequency = TRUE
+	device_color = RADIOC_SECURITY
+	layer = 3.1
+
+	initialize()
+		set_frequency(frequency)
+		set_secure_frequencies(src)
+
+/obj/item/device/radio/intercom/detnet/detective
+	name = "DetNet Intercom (???)"
+	frequency = R_FREQ_DETECTIVE
+	secure_frequencies = list("d" = R_FREQ_DETECTIVE)
+	secure_classes = list("d" = R_FREQ_DETECTIVE)
+	locked_frequency = TRUE
+	device_color = RADIOC_DETECTIVE
+	layer = 3
+
+	initialize()
+		set_frequency(frequency)
+		set_secure_frequencies(src)
+// ------------------------------------------------
+
 ////// adventure area intercoms
 
 /obj/item/device/radio/intercom/adventure/owlery

--- a/code/obj/item/device/radios/intercoms.dm
+++ b/code/obj/item/device/radios/intercoms.dm
@@ -206,7 +206,6 @@
 	frequency = R_FREQ_SECURITY
 	secure_frequencies = list("g" = R_FREQ_SECURITY)
 	secure_classes = list("g" = R_FREQ_SECURITY)
-	locked_frequency = TRUE
 	device_color = RADIOC_SECURITY
 	layer = 3.1
 
@@ -219,7 +218,6 @@
 	frequency = R_FREQ_DETECTIVE
 	secure_frequencies = list("d" = R_FREQ_DETECTIVE)
 	secure_classes = list("d" = R_FREQ_DETECTIVE)
-	locked_frequency = TRUE
 	device_color = RADIOC_DETECTIVE
 	layer = 3
 

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -38771,9 +38771,17 @@
 /area/sim/area2)
 "ckx" = (
 /obj/table/wood/auto,
-/obj/item/device/audio_log/wall_mounted{
-	desc = "A data logging utility represented as an audio logger.";
-	name = "Audiolog"
+/obj/item/device/radio/intercom/detnet/detective{
+	pixel_x = -4;
+	pixel_y = -13
+	},
+/obj/item/device/radio/intercom/detnet/security{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/device/radio/intercom/detnet{
+	pixel_x = -4;
+	pixel_y = 5
 	},
 /turf/unsimulated/floor/carpet{
 	dir = 1;
@@ -38860,7 +38868,14 @@
 /obj/item/pen{
 	desc = "It's a normal black ink pen. Looks like it has been chewed on."
 	},
+/obj/item/device/audio_log/wall_mounted{
+	desc = "A data logging utility represented as an audio logger.";
+	name = "Audiolog";
+	pixel_x = 13;
+	pixel_y = 4
+	},
 /obj/machinery/computer/security/wooden_tv/small{
+	pixel_x = -3;
 	pixel_y = 8
 	},
 /turf/unsimulated/floor/carpet{


### PR DESCRIPTION
[QoL] [Feature]


## About the PR:
Adds three intercoms to the DetNet beach, tuned to 145.9, 135.9, and 135.1 respectively. The frequencies are unable to be changed.
![DetNet](https://user-images.githubusercontent.com/88833499/173921673-e6398b71-21d6-42c7-9cd6-9f08f3478535.png)



## Why's this needed?
Detectives who enter DetNet often fall behind on radio chatter, and lack anyway to communicate with the station while inside. Originally, I planned to give everyone in VR headsets with the same channels as their currently worn ones, but it proved to create too many balance issues.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)DetNet is now equipped with three new intercoms, interfacing with General, Security, and the Detective's private channel, for all of the Detective's communication needs.
```
