### PR TITLE
Ghostdrone fixes/improvements

### DIFF
--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -88,7 +88,7 @@
 		)
 
 		var/obj/item/tile/cardboard/T  =new /obj/item/tile/cardboard/(src)
-		T.amount = 600
+		T.amount = 500
 		src.tools += T
 		var/obj/item/cable_coil/W = new /obj/item/cable_coil(src)
 		W.amount = 1000

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -88,7 +88,7 @@
 		)
 
 		var/obj/item/tile/cardboard/T  =new /obj/item/tile/cardboard/(src)
-		T.amount = 500
+		T.amount = 600
 		src.tools += T
 		var/obj/item/cable_coil/W = new /obj/item/cable_coil(src)
 		W.amount = 1000

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -559,8 +559,13 @@
 
 /obj/item/proc/stack_item(obj/item/other)
 	var/added = 0
-	if(isrobot(other.loc) || isghostdrone(other.loc) || istype(other.loc, /obj/item/magtractor))
-		max_stack = 500
+	var/imrobot
+	var/imdrone
+	if((imrobot = isrobot(other.loc)) || (imdrone = isghostdrone(other.loc)) || istype(other.loc, /obj/item/magtractor))
+		if (imrobot)
+			max_stack = 500
+		else if (imdrone)
+			max_stack = 1000
 		if (other != src && check_valid_stack(src))
 			if (src.amount + other.amount > max_stack)
 				added = max_stack - other.amount

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -559,7 +559,7 @@
 
 /obj/item/proc/stack_item(obj/item/other)
 	var/added = 0
-	if(isrobot(other.loc))
+	if(isrobot(other.loc) || isghostdrone(other.loc) || istype(other.loc, /obj/item/magtractor))
 		max_stack = 500
 		if (other != src && check_valid_stack(src))
 			if (src.amount + other.amount > max_stack)

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -1170,6 +1170,7 @@ MATERIAL
 
 /obj/item/tile/cardboard // for drones
 	desc = "They keep the floor in a good and walkable condition. At least, they would if they were actually made of steel."
+	force = 0.0
 	New()
 		..()
 		var/datum/material/M = getMaterial("cardboard")

--- a/code/obj/item/building_materials.dm
+++ b/code/obj/item/building_materials.dm
@@ -1115,13 +1115,14 @@ MATERIAL
 		if (W.material && src.material && !isSameMaterial(W.material, src.material))
 			boutput(user, "<span class='alert'>You can't mix two stacks of different materials!</span>")
 			return
+		var/inMagtractor = istype(W.loc, /obj/item/magtractor)
 		var/success = stack_item(W)
 		if (!success)
 			boutput(user, "<span class='alert'>You can't put any more tiles in this stack!</span>")
 			return
-		if(!user.is_in_hands(src))
+		if(!(user.is_in_hands(src) || inMagtractor))
 			user.put_in_hand(src)
-		if(isrobot(user))
+		if(isrobot(user) || isghostdrone(user))
 			boutput(user, "<span class='notice'>You add [success] tiles to the stack. It now has [W.amount] tiles.</span>")
 		else
 			boutput(user, "<span class='notice'>You add [success] tiles to the stack. It now has [src.amount] tiles.</span>")

--- a/code/obj/item/magtractor.dm
+++ b/code/obj/item/magtractor.dm
@@ -261,4 +261,8 @@
 
 		return 1
 
+	Exited(Obj, newloc) // handles the held item going byebye
+		if(Obj == src.holding  && src.holder && processHeld)
+			actions.stopId("magpickerhold", src.holder)
+
 /obj/item/magtractor/abilities = list(/obj/ability_button/magtractor_toggle, /obj/ability_button/magtractor_drop)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
1. Cardboard floor tiles don't randomly crumple anymore when you place them.
2. Fixes an issue where you would drop tons of your cardboard floor tiles on the floor when trying to stack them with another cardboard floor tile on the floor. Now it actually puts them back in your cardboard floor tiles stack.
3. Magtractors actually drop deleted/missing items immediately now instead of holding onto nothing until the process loop catches up.
   So if you place the last floor tile you had in your magtractor, there isn't a random 0-2 second wait before your magtractor works again.
4. You can stack stuff in your magtractor properly now.
   So now, if there's a bunch of pried up floor tiles on the ground. then you don't have to individually pick up all of them and place them back on the ground, you can just pick up one tile, stack all of the rest on it, and then place them all.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8379
Fixes other magtractor and stacking related nonsense.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)CodeJester
(+)Using floor tiles as a ghostdrone is less awful now.
```
