### PR TITLE
Replaces CE's Law Rack Blueprint With A Law Rack Manudrive

### DIFF
--- a/code/obj/item/manudrive.dm
+++ b/code/obj/item/manudrive.dm
@@ -44,6 +44,6 @@
 
 	law_rack //The law rack that the CE locker starts with
 		name = "Command ManuDrive: Artificial Intelligence Law Rack License"
-		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint protected by NT-approved DRM that permits the user to manufacture AI law racks."
+		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint that permits the user to manufacture AI law racks."
 		icon_state = "datadiskcom"
 		temp_recipe_string = list(/datum/manufacture/mechanics/lawrack)

--- a/code/obj/item/manudrive.dm
+++ b/code/obj/item/manudrive.dm
@@ -41,3 +41,9 @@
 		icon_state = "datadiskcom"
 		temp_recipe_string = list(/datum/manufacture/core_frame)
 		fablimit = 2
+
+	law_rack //The law rack that the CE locker starts with
+		name = "Command ManuDrive: Artificial Intelligence Law Rack License"
+		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint protected by NT-approved DRM that permits the user to manufacture AI law racks."
+		icon_state = "datadiskcom"
+		temp_recipe_string = list(/datum/manufacture/mechanics/lawrack)

--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -299,7 +299,8 @@
 /obj/storage/secure/closet/command/chief_engineer
 	name = "\improper Chief Engineer's locker"
 	req_access = list(access_engineering_chief)
-	spawn_contents = list(/obj/item/storage/toolbox/mechanical/yellow_tools,
+	spawn_contents = list(/obj/item/disk/data/floppy/manudrive/law_rack,
+	/obj/item/storage/toolbox/mechanical/yellow_tools,
 	/obj/item/storage/backpack/engineering,
 	/obj/item/storage/box/clothing/chief_engineer,
 	/obj/item/clothing/gloves/yellow,
@@ -323,8 +324,7 @@
 	/obj/item/clothing/suit/space/engineer,
 	/obj/item/clothing/head/helmet/space/engineer,
 #endif
-	/obj/item/device/radio/headset/command/ce,
-	/obj/item/paper/manufacturer_blueprint/lawrack)
+	/obj/item/device/radio/headset/command/ce)
 
 /* ==================== */
 /* ----- Security ----- */


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE] [BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This replaces the CE's law rack blueprint with an unlimited-use law rack manudrive.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Helps make adding/removing law racks to manufacturers less of a commitment, plus it's better than a one-time use blueprint.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)The CE's law rack blueprint has been swapped out with an unlimited-use law rack manudrive.
```
