### PR TITLE
Floating things no longer track blood

### DIFF
--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -293,6 +293,8 @@
 		return
 	if (HAS_ATOM_PROPERTY(src, PROP_MOB_BLOOD_TRACKING_ALWAYS) && (tracked_blood["count"] > 0))
 		return
+	if (HAS_ATOM_PROPERTY(src, PROP_ATOM_FLOATING))
+		return
 	var/turf/T = get_turf(src)
 	var/obj/decal/cleanable/blood/dynamic/tracks/B = null
 	if (T.messy > 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Anything with `PROP_ATOM_FLOATING` no longer tracks blood.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Seems odd for flockdrones and so on to leave footprints.