### PR TITLE
Minor NTSC Description Changes

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2459,7 +2459,6 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 		if (!M)
 			return
 		M.traitHolder.addTrait("training_security")
-		M.show_text("<b>Defend the crew from all current threats!</b>", "blue")
 
 
 /datum/job/special/headminer

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -439,7 +439,7 @@
 
 /obj/item/clothing/head/helmet/space/ntso //recoloured nuke class suits for ntso vs syndicate specialist
 	name = "NT combat helmet"
-	desc = "A modified combat helmet for Nanotrasen paramilitary forces."
+	desc = "A modified combat helmet for Nanotrasen security forces."
 	icon_state = "ntso_specialist"
 	item_state = "ntso_specialist"
 

--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -119,7 +119,7 @@
 
 /obj/item/clothing/mask/gas/NTSO
 	name = "NT gas mask"
-	desc = "A close-fitting CBRN mask with dual filters and a tinted lens, designed to protect Nanotrasen paramilitary personnel from environmental threats."
+	desc = "A close-fitting CBRN mask with dual filters and a tinted lens, designed to protect Nanotrasen security personnel from environmental threats."
 	icon_state = "gas_mask_NT"
 	item_state = "gas_mask_NT"
 	color_r = 0.8 // cool blueberry nanotrasen tint provides disorientation resist

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1244,7 +1244,7 @@
 
 /obj/item/clothing/suit/space/ntso
 	name = "NT pressure suit"
-	desc = "A Nanotrasen paramilitary space suit, with an integrated chest rig."
+	desc = "A specialised Nanotrasen space suit, with an integrated chest rig."
 	icon_state = "ntso_specialist"
 	item_state = "ntso_specialist"
 

--- a/code/obj/item/clothing/uniforms.dm
+++ b/code/obj/item/clothing/uniforms.dm
@@ -740,7 +740,7 @@
 
 /obj/item/clothing/under/misc/turds
 	name = "NT combat uniform"
-	desc = "A Nanotrasen paramilitary jumpsuit."
+	desc = "A Nanotrasen security jumpsuit."
 	icon_state = "turdsuit"
 	item_state = "turdsuit"
 	team_num = TEAM_NANOTRASEN


### PR DESCRIPTION


## About the PR:
Changes all instances of "NanoTrasen paramilitary forces" to "NanoTrasen security forces" on the NTSC's clothing descriptions, and removes the "Defend the crew from all current threats!" prompt.



## Why's this needed?
Referring to NTSCs as paramilitary personnel is not overly fitting for their job role, nor the general sentiment surrounding them, and "Defend the crew from all current threats!" potentially leads to a validhunting mindset. Of course the first responce to any member of Security validhunting should be to ahelp it, but a Security role being presented as a member of a paramilitary does not help.