### PR TITLE
Organises The NTSO's Inventory, Alongside Minor Equipment Changes And General Cleanup

### DIFF
--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -1219,7 +1219,7 @@
 			boutput(target, "<span class='alert'>You're already in a gang, you can't switch sides!</span>")
 			return
 
-		if(target.mind.assigned_role in list("Security Officer", "Security Assistant", "Vice Officer","Part-time Vice Officer","Head of Security","Captain","Head of Personnel","Communications Officer", "Medical Director", "Chief Engineer", "Research Director", "Detective", "Nanotrasen Security Consultant"))
+		if(target.mind.assigned_role in list("Security Officer", "Security Assistant", "Vice Officer","Part-time Vice Officer","Head of Security","Captain","Head of Personnel","Communications Officer", "Medical Director", "Chief Engineer", "Research Director", "Detective", "Nanotrasen Security Consultant", "Nanotrasen Special Operative"))
 			boutput(target, "<span class='alert'>You are too responsible to join a gang!</span>")
 			return
 

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2387,24 +2387,25 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	allow_traitors = 0
 	allow_spy_theft = 0
 	cant_spawn_as_rev = 1
+	receives_badge = 1
+	receives_miranda = 1
 	receives_implant = /obj/item/implant/health
 	slot_back = list(/obj/item/storage/backpack/NT)
-	slot_belt = list(/obj/item/storage/belt/security)
+	slot_belt = list(/obj/item/storage/belt/security/ntso)
 	slot_jump = list(/obj/item/clothing/under/misc/turds)
 	slot_suit = list(/obj/item/clothing/suit/space/ntso)
 	slot_head = list(/obj/item/clothing/head/helmet/space/ntso)
 	slot_foot = list(/obj/item/clothing/shoes/swat)
+	slot_glov = list(/obj/item/clothing/gloves/swat/NT)
+	slot_eyes = list(/obj/item/clothing/glasses/sunglasses/sechud)
 	slot_ears = list(/obj/item/device/radio/headset/command/nt) //needs their own secret channel
-	slot_mask = list(/obj/item/clothing/mask/breath)
+	slot_mask = list(/obj/item/clothing/mask/gas/NTSO)
 	slot_card = /obj/item/card/id/command
-	slot_poc1 = list(/obj/item/spacecash/fivehundred)
-	slot_poc2 = list(/obj/item/storage/pouch/bullet_9mm)
-	items_in_backpack = list(/obj/item/gun/energy/ntgun,
-							/obj/item/device/pda2/heads,
-							/obj/item/old_grenade/stinger/frag,
-							/obj/item/storage/firstaid/regular,
-							/obj/item/storage/pouch/powercell_medium,
-							/obj/item/gun/kinetic/pistol)
+	slot_poc1 = list(/obj/item/device/pda2/heads)
+	slot_poc2 = list(/obj/item/storage/ntsc_pouch/ntso)
+	items_in_backpack = list(/obj/item/storage/firstaid/regular,
+							/obj/item/clothing/head/NTberet,
+							/obj/item/spacecash/fivehundred)
 
 	New()
 		..()
@@ -2434,7 +2435,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	receives_miranda = 1
 	receives_implant = /obj/item/implant/health
 	slot_back = list(/obj/item/storage/backpack/NT)
-	slot_belt = list(/obj/item/storage/belt/security/ntso) //special secbelt subtype that spawns with the NTSO gear inside
+	slot_belt = list(/obj/item/storage/belt/security/ntsc) //special secbelt subtype that spawns with the NTSO gear inside
 	slot_jump = list(/obj/item/clothing/under/misc/turds)
 	slot_head = list(/obj/item/clothing/head/NTberet)
 	slot_foot = list(/obj/item/clothing/shoes/swat)

--- a/code/lists/jobs.dm
+++ b/code/lists/jobs.dm
@@ -80,7 +80,7 @@ var/list/page_departments = list(
 	return all_jobs
 
 var/list/command_jobs = list("Captain", "Medical Director", "Research Director", "Head of Personnel", "Head of Security", "Chief Engineer", "Communications Officer"/*"Clown"*/)
-var/list/security_jobs = list("Head of Security", "Nanotrasen Security Consultant", "Security Officer", "Security Assistant", "Detective")
+var/list/security_jobs = list("Head of Security", "Nanotrasen Security Consultant", "Nanotrasen Special Operative", "Security Officer", "Security Assistant", "Detective")
 var/list/engineering_jobs = list("Chief Engineer", "Engineer", "Mechanic", "Miner", "Quartermaster")
 var/list/medsci_jobs = list("Research Director", "Medical Director", "Medical Doctor", "Scientist", "Roboticist", "Geneticist")
 var/list/service_jobs = list("Head of Personnel", "Bartender", "Chef", "Botanist", "Rancher", "Clown", "Chaplain", "Janitor")

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -663,6 +663,8 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 		return ..(hit_atom)
 
 	ntso // A Clock 180 that comes preloaded with 9mm rounds for NTSOs.
+		desc = "Jokingly called a \"Gunarang\" in some circles. Uses 9mm rounds."
+
 		New()
 			..()
 			default_magazine = /obj/item/ammo/bullets/bullet_9mm

--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -662,6 +662,15 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 
 		return ..(hit_atom)
 
+	ntso // A Clock 180 that comes preloaded with 9mm rounds for NTSOs.
+		New()
+			..()
+			default_magazine = /obj/item/ammo/bullets/bullet_9mm
+			ammo = new default_magazine
+			set_current_projectile(new/datum/projectile/bullet/bullet_9mm)
+			projectiles = list(current_projectile)
+			UpdateIcon()
+
 /obj/item/gun/kinetic/SMG_briefcase
 	name = "secure briefcase"
 	icon = 'icons/obj/items/storage.dmi'

--- a/code/obj/item/storage/ammo_pouches.dm
+++ b/code/obj/item/storage/ammo_pouches.dm
@@ -172,7 +172,7 @@
 	/obj/item/instrument/whistle,\
 	/obj/item/reagent_containers/food/snacks/donut/custom/frosted)
 
-/obj/item/storage/ntso_pouch
+/obj/item/storage/ntsc_pouch
 	name = "tacticool pouch"
 	desc = "A dump pouch for various security accessories, partially-loaded magazines, or maybe even a snack! Attaches to virtually any webbing system through an incredibly complex and very patented Nanotrasen design."
 	icon_state = "ammopouch-large"
@@ -184,6 +184,10 @@
 	/obj/item/handcuffs/guardbot = 2,
 	/obj/item/device/flash,
 	/obj/item/reagent_containers/food/snacks/candy/candyheart)
+
+	ntso
+		spawn_contents = list(/obj/item/gun/kinetic/clock_188/boomerang/ntso,
+		/obj/item/ammo/bullets/bullet_9mm = 4)
 
 /obj/item/storage/emp_grenade_pouch
 	name = "EMP grenade pouch"

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -692,10 +692,11 @@
 	/obj/item/gun/energy/wavegun,
 	/obj/item/gun/kinetic/revolver,
 	/obj/item/gun/kinetic/zipgun,
-	/obj/item/clothing/mask/gas/NTSO,
+	/obj/item/clothing/mask/gas/NTSO, //added so the NTSO mask can be clipped to the belt, maybe good to do with all gas masks?
 	/obj/item/gun/energy/tasersmg,
-	/obj/item/gun/energy/signifer2, //added so the NTSO mask can be clipped to the belt, maybe good to do with all gas masks?
-	/obj/item/device/prisoner_scanner)
+	/obj/item/gun/energy/signifer2,
+	/obj/item/device/prisoner_scanner,
+	/obj/item/gun/energy/ntgun)
 	in_list_or_max = 1
 
 // kiki's detective shoulder (holster)
@@ -729,8 +730,11 @@
 	assistant
 		spawn_contents = list(/obj/item/barrier, /obj/item/device/detective_scanner, /obj/item/device/ticket_writer)
 
+	ntsc
+		spawn_contents = list(/obj/item/gun/energy/signifer2, /obj/item/gun/kinetic/clock_188, /obj/item/baton/ntso, /obj/item/instrument/whistle, /obj/item/clothing/mask/gas/NTSO, /obj/item/storage/ntsc_pouch, /obj/item/barrier) //secbelt subtype that only spawns on NTSO, not in vendor
+
 	ntso
-		spawn_contents = list(/obj/item/gun/energy/signifer2, /obj/item/gun/kinetic/clock_188, /obj/item/baton/ntso, /obj/item/instrument/whistle, /obj/item/clothing/mask/gas/NTSO, /obj/item/storage/ntso_pouch, /obj/item/barrier) //secbelt subtype that only spawns on NTSO, not in vendor
+		spawn_contents = list(/obj/item/gun/energy/ntgun, /obj/item/old_grenade/stinger/frag, /obj/item/ammo/power_cell/med_power = 5)
 
 	baton
 		spawn_contents = list(/obj/item/baton, /obj/item/barrier, /obj/item/requisition_token/security/utility)

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -74914,7 +74914,7 @@
 /obj/storage/secure/closet/fridge{
 	name = "incredible closetfridge"
 	},
-/obj/item/storage/ntso_pouch{
+/obj/item/storage/ntsc_pouch{
 	desc = "A dump pouch for various security accessories. This one has definitely seen better days.";
 	name = "stained tacticool pouch";
 	pixel_x = 5;


### PR DESCRIPTION
[QoL] [Cleanliness]


## About the PR:
Security belts can now hold laser assault rifles, and the NTSO's has been moved there, alongside their frag grenade and five powercells; the powercell pouch has been removed. The Branwen pistol has been replaced with a Clock 180 and been moved to their pocket pouch, which has been upgraded to the same type of pouch NTSCs use. NTSOs now have an NT gas mask in place of their breath mask, SecHUDs, and NT SWAT gloves. Their PDA has been moved to their pocket, and their five hundred starting credits has been moved to their backpack. They now also recieve an NT beret, a badge, and the Miranda verb. NTSOs can no longer join gangs, and now have a place on the Security section of the manifest.



## Why's this needed?
It was always a pain to be made an NTSO and spend a few minutes organising my inventory, for a role that is meant to be an admin-spawned immediate responce to chaos. NTSOs being in possession of a Syndicate-issue pistol also raised a few eyebrows, a Clock seems more thematically fitting, as does providing them with NT gear.