### PR TITLE
Moves flockdrone control icon into the center

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -20,7 +20,6 @@
 
 	///Custom contextActions list so we can handle opening them ourselves
 	var/list/datum/contextAction/contexts = list()
-	contextLayout = new /datum/contextLayout/experimentalcircle
 
 	var/damaged = 0 // used for state management for description showing, as well as preventing drones from screaming about being hit
 
@@ -62,8 +61,13 @@
 		else
 			emote("beep")
 			say(pick_string("flockmind.txt", "flockdrone_created"))
-
+	var/datum/contextLayout/experimentalcircle/layout = new
+	layout.center = TRUE
+	src.contextLayout = layout
+	src.contexts += new /datum/contextAction/flockdrone/control
 	for (var/type as anything in childrentypesof(/datum/contextAction/flockdrone))
+		if (type == /datum/contextAction/flockdrone/control)
+			continue
 		src.contexts += new type
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOCK_THING, src)
 	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, FALSE, FALSE)

--- a/code/modules/interface/multiContext/context_layouts.dm
+++ b/code/modules/interface/multiContext/context_layouts.dm
@@ -202,6 +202,8 @@ var/list/datum/contextAction/globalContextActions = null
 
 /datum/contextLayout/experimentalcircle
 	var/dist
+	///If true the first button in the list will be rendered in the center of the circle
+	var/center = FALSE
 
 	New(var/Dist = 32)
 		dist = Dist
@@ -219,7 +221,7 @@ var/list/datum/contextAction/globalContextActions = null
 			screenX = (screenCenter.x - target.x) * -1 * 32
 			screenY = (screenCenter.y - target.y) * -1 * 32
 
-		var/anglePer = round(360 / buttons.len)
+		var/anglePer = round(360 / (length(buttons) - (center ? 1 : 0)))
 
 		var/count = 0
 
@@ -235,7 +237,9 @@ var/list/datum/contextAction/globalContextActions = null
 
 			var/offX = round(dist * cos(anglePer * count)) + round(sizeX / 2)
 			var/offY = round(dist * sin(anglePer * count)) + round(sizeY / 2)
-
+			if (center && count == 0)
+				offX = round(sizeX / 2)
+				offY = round(sizeY / 2)
 			var/matrix/trans = new /matrix
 			trans = trans.Reset()
 			trans.Translate(offX, offY)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Modifies the circle contextLayout to allow putting one button in the center and then does that for flockdrone contextActions.
![image](https://user-images.githubusercontent.com/20713227/174189632-60bcbc1d-7478-4b1f-831d-fff328fd3d2c.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More intuitive, simple two clicks to control a drone as it's the most common/immediate action you would want.
