### PR TITLE
Implement get_target short circuits in flock ai

### DIFF
--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -443,7 +443,6 @@ stare
 		F.hud?.update_hands() // for observers
 
 /datum/aiTask/sequence/goalbased/deposit/get_targets()
-	var/mob/living/critter/flock/drone/F = holder.owner
 	. = list()
 	for (var/obj/flock_structure/ghost/O as anything in by_type[/obj/flock_structure/ghost])
 		if (IN_RANGE(holder.owner, O, max_dist))

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -443,8 +443,8 @@ stare
 		F.hud?.update_hands() // for observers
 
 /datum/aiTask/sequence/goalbased/deposit/get_targets()
-	. = list()
 	var/mob/living/critter/flock/drone/F = holder.owner
+	. = list()
 	for (var/obj/flock_structure/ghost/O as anything in by_type[/obj/flock_structure/ghost])
 		if (O.flock == F.flock && O.goal > O.currentmats && IN_RANGE(holder.owner, O, max_dist))
 			. += O

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -182,9 +182,9 @@ stare
 	for(var/turf/simulated/floor/T in view(max_dist, holder.owner))
 		if(F?.flock && !F.flock.isTurfFree(T, F.real_name))
 			continue
-		. += T
-		break
-	. = get_path_to(holder.owner, ., max_dist*2, 1)
+		. = get_path_to(holder.owner, list(T), max_dist*2, 1)
+		if (length(.))
+			return
 
 ////////
 

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -444,8 +444,9 @@ stare
 
 /datum/aiTask/sequence/goalbased/deposit/get_targets()
 	. = list()
+	var/mob/living/critter/flock/drone/F = holder.owner
 	for (var/obj/flock_structure/ghost/O as anything in by_type[/obj/flock_structure/ghost])
-		if (IN_RANGE(holder.owner, O, max_dist))
+		if (O.flock == F.flock && O.goal > O.currentmats && IN_RANGE(holder.owner, O, max_dist))
 			. += O
 	. = get_path_to(holder.owner, ., max_dist*2, 1)
 

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -121,8 +121,8 @@ stare
 	for(var/turf/simulated/floor/feather/F in view(max_dist, holder.owner))
 		// let's not spam eggs all the time
 		if(isnull(locate(/obj/flock_structure/egg) in F))
-			. += F
-	. = get_path_to(holder.owner, ., max_dist*2, can_be_adjacent_to_target)
+			. = get_path_to(holder.owner, list(F), max_dist*2, can_be_adjacent_to_target)
+			if (length(.)) return
 
 ////////
 
@@ -176,16 +176,14 @@ stare
 		for(var/turf/simulated/floor/feather/T in view(max_dist, holder.owner))
 			return FALSE
 
-
 /datum/aiTask/sequence/goalbased/nest/get_targets()
 	. = list()
 	var/mob/living/critter/flock/F = holder.owner
-
 	for(var/turf/simulated/floor/T in view(max_dist, holder.owner))
-		if(!isfeathertile(T))
-			if(F?.flock && !F.flock.isTurfFree(T, F.real_name))
-				continue
-			. += T
+		if(F?.flock && !F.flock.isTurfFree(T, F.real_name))
+			continue
+		. += T
+		break
 	. = get_path_to(holder.owner, ., max_dist*2, 1)
 
 ////////
@@ -249,8 +247,9 @@ stare
 	for(var/turf/simulated/T in view(max_dist, holder.owner))
 		if (!valid_target(T))
 			continue // this tile's been claimed by someone else
-		. += T
-	. = get_path_to(holder.owner, ., max_dist*2, 1)
+		. = get_path_to(holder.owner, list(T), max_dist*2, 1)
+		if(length(.))
+			return
 
 ////////
 
@@ -333,7 +332,9 @@ stare
 			locate(/obj/storage) in T))
 			if(F?.flock && !F.flock.isTurfFree(T, F.real_name))
 				continue
-			. += T
+			. = get_path_to(holder.owner, list(T), max_dist, 1)
+			if(length(.))
+				return
 
 	// if there are absolutely no walls/doors/closets in view, and no reserved tiles, then fine, you can have a floor tile
 	if(!length(.))
@@ -341,8 +342,9 @@ stare
 			if(!isfeathertile(T))
 				if(F?.flock && !F.flock.isTurfFree(T, F.real_name))
 					continue
-				. += T
-	. = get_path_to(holder.owner, ., max_dist*2, 1)
+				. = get_path_to(holder.owner, list(T), max_dist, 1)
+				if(length(.))
+					return
 
 ////////
 
@@ -443,9 +445,9 @@ stare
 /datum/aiTask/sequence/goalbased/deposit/get_targets()
 	var/mob/living/critter/flock/drone/F = holder.owner
 	. = list()
-	for(var/obj/flock_structure/ghost/S in view(max_dist, F))
-		if(S.flock == F.flock && S.goal > S.currentmats)
-			. += S
+	for (var/obj/flock_structure/ghost/O as anything in by_type[/obj/flock_structure/ghost])
+		if (IN_RANGE(holder.owner, O, max_dist))
+			. += O
 	. = get_path_to(holder.owner, ., max_dist*2, 1)
 
 ////////
@@ -640,8 +642,9 @@ stare
 		if(!I.anchored && I.loc != holder.owner)
 			if(istype(I, /obj/item/game_kit))
 				continue
-			. += I
-	. = get_path_to(holder.owner, ., max_dist*2, 1)
+			. = get_path_to(holder.owner, list(I), max_dist, 1)
+			if(length(.))
+				return
 
 ////////
 

--- a/code/obj/flock/structure/flock_structure_ghost.dm
+++ b/code/obj/flock/structure/flock_structure_ghost.dm
@@ -15,6 +15,7 @@
 
 /obj/flock_structure/ghost/New(var/atom/location, building = null, var/datum/flock/F = null, goal = 0)
 	..(location, F)
+	START_TRACKING
 	if(building)
 		var/obj/flock_structure/b = building
 		icon = initial(b.icon)
@@ -44,6 +45,10 @@
 	if(blocked)
 		qdel(src)
 		flock_speak(null, "ERROR: Build area is blocked by an obstruction.", flock)
+
+/obj/flock_structure/ghost/disposing()
+	STOP_TRACKING
+	. = ..()
 
 /obj/flock_structure/ghost/Click(location, control, params)
 	if (("alt" in params2list(params)) || !istype(usr, /mob/living/intangible/flock/flockmind))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [PERFORMANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Short circuits a bunch of `get_target` procs so just return the first result they can path too, instead of path finding to dozens of objects


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
* performance gains, significantly reduces the amount of pathfinding attempted
![image](https://user-images.githubusercontent.com/33204415/174230621-62b8ee24-572f-430b-80d9-7812aadd7820.png)

old: 
![image](https://user-images.githubusercontent.com/33204415/174233916-df8588fc-0319-4536-a675-4ed4d170e380.png)

