### PR TITLE
wearing a mask that covers your mouth now prevents eating

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -224,6 +224,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				if (ishuman(M))
 					var/mob/living/carbon/human/H = M
 					var/obj/item/organ/stomach/tummy = H.get_organ("stomach")
+					var/obj/item/clothing/mask/mask = H.wear_mask
 					if (!istype(tummy) || (tummy.broken || tummy.get_damage() > tummy.MAX_DAMAGE))
 						M.visible_message("<span class='notice'>[M] tries to take a bite of [src], but can't swallow!</span>",\
 						"<span class='notice'>You try to take a bite of [src], but can't swallow!</span>")
@@ -231,6 +232,10 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 					if (!H.organHolder.head)
 						M.visible_message("<span class='notice'>[M] tries to take a bite of [src], but they have no head!</span>",\
 						"<span class='notice'>You try to take a bite of [src], but you have no head to chew with!</span>")
+						return 0
+					if (mask?.c_flags & COVERSMOUTH)
+						M.visible_message("<span class='notice'>[M] tries to take a bite of [src], but their mask is in the way!</span>",\
+						"<span class='notice'>You try to take a bite of [src], but your mask is in the way!</span>")
 						return 0
 
 				src.take_a_bite(M, user)
@@ -253,6 +258,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 				if (ishuman(M))
 					var/mob/living/carbon/human/H = M
 					var/obj/item/organ/stomach/tummy = H.get_organ("stomach")
+					var/obj/item/clothing/mask/mask = H.wear_mask
 					if (!istype(tummy) || (tummy.broken || tummy.get_damage() > tummy.MAX_DAMAGE))
 						user.tri_message("<span class='alert'><b>[user]</b>tries to feed [M] [src], but can't make [him_or_her(M)] swallow!</span>",\
 						user, "<span class='alert'>You try to feed [M] [src], but can't make [him_or_her(M)] swallow!</span>",\
@@ -262,6 +268,11 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 						user.tri_message("<span class='alert'><b>[user]</b>tries to feed [M] [src], but [he_or_she(M)] has no head!!</span>",\
 						user, "<span class='alert'>You try to feed [M] [src], but [he_or_she(M)] has no head!</span>",\
 						M, "<span class='alert'><b>[user]</b> tries to feed you [src], but you don't have a head!</span>")
+						return 0
+					if (mask?.c_flags & COVERSMOUTH)
+						user.tri_message("<span class='alert'><b>[user]</b> tries to feed [M] [src], but their mask is in the way!</span>",\
+						user, "<span class='alert'>You try to feed [M] [src], but their mask is in the way!</span>",\
+						M, "<span class='alert'><b>[user]</b> tries to feed you [src], but your mask is in the way!</span>")
 						return 0
 
 				actions.start(new/datum/action/bar/icon/forcefeed(M, src, src.icon, src.icon_state), user)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -384,6 +384,15 @@
 		return 0
 
 	if (M == user)
+
+		if (ishuman(M))
+			var/mob/living/carbon/human/H = M
+			var/obj/item/clothing/mask/mask = H.wear_mask
+			if (mask?.c_flags & COVERSMOUTH)
+				M.visible_message("<span class='notice'>[M] tries to take a bite of [src], but their mask is in the way!</span>",\
+				"<span class='notice'>You try to take a bite of [src], but your mask is in the way!</span>")
+				return 0
+
 		M.visible_message("<span class='notice'>[M] takes a bite of [src]!</span>",\
 		"<span class='notice'>You take a bite of [src]!</span>")
 
@@ -406,6 +415,16 @@
 		return 1
 
 	else
+
+		if (ishuman(M))
+			var/mob/living/carbon/human/H = M
+			var/obj/item/clothing/mask/mask = H.wear_mask
+			if (mask?.c_flags & COVERSMOUTH)
+				user.tri_message("<span class='alert'><b>[user]</b> tries to feed [M] [src], but their mask is in the way!</span>",\
+				user, "<span class='alert'>You try to feed [M] [src], but their mask is in the way!</span>",\
+				M, "<span class='alert'><b>[user]</b> tries to feed you [src], but your mask is in the way!</span>")
+				return 0
+
 		user.tri_message("<span class='alert'><b>[user]</b> tries to feed [M] [src]!</span>",\
 		user, "<span class='alert'>You try to feed [M] [src]!</span>",\
 		M, "<span class='alert'><b>[user]</b> tries to feed you [src]!</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
![image](https://user-images.githubusercontent.com/64938519/174408233-99046ccb-1e44-4275-8d9e-d0f5da702440.png)

This PR makes it so that wearing a mask that has coversmouth set will prevent eating food items.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

scientists and other gas mask enthusiasts have been able to phase food through gas masks for too long

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Skeletonman0
(+)Spacemen can nolonger magically phase food through masks that cover their mouth.
```
