### PR TITLE
Engineering toolboxes now come with glass and metal sheets

### DIFF
--- a/code/obj/item/storage/toolbox.dm
+++ b/code/obj/item/storage/toolbox.dm
@@ -78,7 +78,7 @@
 		/obj/item/electronics/soldering,
 		/obj/item/device/t_scanner,
 		/obj/item/cable_coil,
-		/obj/item/sheet/glass/reinforced/fullstack,
+		/obj/item/sheet/glass/fullstack,
 		/obj/item/sheet/steel/reinforced/fullstack,
 		/obj/item/reagent_containers/food/snacks/plant/banana,)
 

--- a/code/obj/item/storage/toolbox.dm
+++ b/code/obj/item/storage/toolbox.dm
@@ -74,13 +74,13 @@
 	/obj/item/device/analyzer/atmospheric)
 
 	engineer_spawn
-		spawn_contents = list(/obj/item/device/analyzer/atmospheric/upgraded,\
-		/obj/item/electronics/soldering,\
-		/obj/item/device/t_scanner,\
-		/obj/item/cable_coil,\
-		/obj/item/reagent_containers/food/snacks/sandwich/pb,\
-		/obj/item/reagent_containers/food/snacks/plant/banana,\
-		/obj/item/reagent_containers/food/drinks/milk)
+		spawn_contents = list(/obj/item/device/analyzer/atmospheric/upgraded,
+		/obj/item/electronics/soldering,
+		/obj/item/device/t_scanner,
+		/obj/item/cable_coil,
+		/obj/item/sheet/glass/reinforced/fullstack,
+		/obj/item/sheet/steel/reinforced/fullstack,
+		/obj/item/reagent_containers/food/snacks/plant/banana,)
 
 	yellow_tools
 		spawn_contents = list(/obj/item/screwdriver/yellow,\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The milk and pbj has been replaced by 50 glass sheets and 50 metal sheets


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The ones in engineering storage can easily be gone, and these are pretty essiental to the job. Also this should hopefully make the toolboxes more used instead of them being tossed on a table and forgotten.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Engineering toolboxes now come with metal and glass sheets.
```
