### PR TITLE
Makes Matter Eater correctly destroys objects

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -184,30 +184,33 @@
 
 		if (ishuman(owner))
 			var/mob/living/carbon/human/H = owner
+
+			// First, restore a little hunger, and heal our organs
 			if (isitem(the_object))
 				var/obj/item/the_item = the_object
 				H.sims?.affectMotive("Hunger", (the_item.w_class + 1) * 5) // +1 so tiny items still give a small boost
-			for(var/A in owner.organs)
-				var/obj/item/affecting = null
-				if (!owner.organs[A])    continue
-				affecting = owner.organs[A]
-				if (!isitem(affecting))
-					continue
-				affecting.heal_damage(4, 0)
-			owner.UpdateDamageIcon()
+				for(var/A in owner.organs)
+					var/obj/item/affecting = null
+					if (!owner.organs[A])
+						continue
+					affecting = owner.organs[A]
+					if (!isitem(affecting))
+						continue
+					affecting.heal_damage(4, 0)
+				owner.UpdateDamageIcon()
 
-		if (ishuman(owner))
-			var/mob/living/carbon/human/H = owner
+			// Then delete the actual item itself
+			// Organs and body parts have special behaviors we need to account for
 			if (istype(the_object, /obj/item/organ))
 				var/obj/item/organ/O = the_object
 				if (O.donor)
 					H.organHolder.drop_organ(the_object)
-				qdel(the_object)
 			else if (istype(the_object, /obj/item/parts))
 				var/obj/item/parts/part = the_object
 				part.delete()
 				H.hud.update_hands()
-		else
+
+		if (!QDELETED(the_object)) // Finally, ensure that the item is deleted regardless of what it is
 			qdel(the_object)
 
 		using = FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Resolves #8884 

Right now, Matter Eater won't qdel the item that you're eating due to the logic that makes it only being reachable if you aren't a human. This PR fixes that issue by making the item qdeleted regardless of your mob type at the end of the logic, assuming it hasn't already been disposed. It also consolidates the two separate `ishuman()` code blocks into a single check.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugfixes are good!

## Testing

I used the bioeffect manager on a local server to give myself Matter Eater and tried eating a few items, and noted that they disappeared correctly. I was also able to eat my own limbs and indeed my own organs, and they correctly disappeared.

While the effect should technically work on other mobs like critters, I couldn't get the ability button to show up while playing as a critter, so I can only say that it *should theoretically* work. If I missed something and I can actually make sure it works as is, lemme know.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ilysen
(+)The Matter Eater mutation now correctly deletes the item that you're eating.
```
