### PR TITLE
all items can be put into storages where they came from

### DIFF
--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -1421,6 +1421,7 @@
 	uses_multiple_icon_states = 1
 	var/list/clothing_choices = list()
 	spawn_contents = list()
+	can_hold = list(/obj/item/storage/belt/chameleon)
 
 	New()
 		..()

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -628,9 +628,7 @@
 	desc = "A specialized belt for treating patients outside medbay in the field. A unique attachment point lets you carry defibrillators."
 	icon_state = "injectorbelt"
 	item_state = "medical"
-	can_hold = list(
-		/obj/item/robodefibrillator
-	)
+	can_hold = list(/obj/item/robodefibrillator)
 	in_list_or_max = 1
 
 /obj/item/storage/belt/roboticist
@@ -656,8 +654,7 @@
 	item_state = "mining"
 	can_hold = list(
 		/obj/item/mining_tool,
-		/obj/item/mining_tools
-	)
+		/obj/item/mining_tools)
 	in_list_or_max = 1
 
 /obj/item/storage/belt/mining/prepared

--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -244,6 +244,7 @@
 
 /obj/item/storage/box/costume
 	icon_state = "costume"
+	can_hold = list(/obj/item/clothing/under)
 
 /obj/item/storage/box/costume/clown
 	name = "clown costume"

--- a/code/obj/item/storage/weapon_security.dm
+++ b/code/obj/item/storage/weapon_security.dm
@@ -348,6 +348,10 @@
 
 /obj/item/storage/box/costume/safari
 	name = "safari costume"
+	can_hold = list(/obj/item/boomerang,
+	/obj/item/clothing/under,
+	/obj/item/ammo/bullets/tranq_darts)
+	
 	spawn_contents = list(/obj/item/clothing/head/safari,\
 	/obj/item/clothing/under/gimmick/safari,\
 	/obj/item/boomerang,\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
subtypes of obj/storage often contained items that cant be put in by normal means allowing them to be taken out and but not put back in, this (hopefully) fixes it

- [x] fix subtypes of obj/storage that have such items in their spawn_contents
- [x] fix varedited spawn_contents containing such items
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
not being able to put stuff where it came from sucks especially for the traitor item that cant even put the ammo back in the box

<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->