### PR TITLE
bandaid fix for voltagen

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -2816,15 +2816,16 @@ datum
 					arcFlash(grenade, A, 1 MEGA WATT, 0.75)
 
 			reaction_temperature(exposed_temperature, exposed_volume)
-				if (reacting)
-					return
+				if (volume >= 1) //bandaid fix for its lack of scaling allowing a stunlocking chemicompiler that runs forever, doesnt fix its lack of scaling
+					if (reacting)
+						return
 
-				reacting = 1
-				var/count = 0
-				for (var/mob/living/L in oview(5, get_turf(holder.my_atom)))
-					count++
-				for (var/mob/living/L in oview(5, get_turf(holder.my_atom)))
-					arcFlash(holder.my_atom, L, min(75000 / count, volume * 1000 / count))
+					reacting = 1
+					var/count = 0
+					for (var/mob/living/L in oview(5, get_turf(holder.my_atom)))
+						count++
+					for (var/mob/living/L in oview(5, get_turf(holder.my_atom)))
+						arcFlash(holder.my_atom, L, min(75000 / count, volume * 1000 / count))
 
 				holder.del_reagent(id)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
**bandaid** fixes permastun infinite use chemicompilers by making less than 1u of voltagen do nothing
NOTE: this is only a bandaid fix and doesnt change the fact voltagen has literally no volume scaling


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad, lets not repeat round 134833 **ever**