### PR TITLE
Adds several new recipes to the sci fab.

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1647,15 +1647,41 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Clothing"
 
-/datum/manufacture/mechdropper
-	name ="Mechanical Dropper"
-	item_paths = list("MET-1", "CON-1")
-	item_amounts = list(3, 3)
-	item_outputs = list(/obj/item/reagent_containers/dropper/mechanical)
-	time = 3 SECONDS
+/datum/manufacture/dropper
+	name ="Dropper"
+	item_paths = list("INS-1", "CRY-1")
+	item_amounts = list(1,2)
+	item_outputs = list(/obj/item/reagent_containers/dropper)
+	time = 5 SECONDS
 	create = 1
 	category = "Tool"
 
+/datum/manufacture/mechdropper
+	name ="Mechanical Dropper"
+	item_paths = list("MET-1", "CON-1")
+	item_amounts = list(3,3)
+	item_outputs = list(/obj/item/reagent_containers/dropper/mechanical)
+	time = 5 SECONDS
+	create = 1
+	category = "Tool"
+
+/datum/manufacture/gps
+	name ="Space GPS"
+	item_paths = list("MET-1", "CON-1")
+	item_amounts = list(1,1)
+	item_outputs = list(/obj/item/device/gps)
+	time = 5 SECONDS
+	create = 1
+	category = "Tool"
+
+/datum/manufacture/reagentscanner
+	name ="Reagent Scanner"
+	item_paths = list("MET-1", "CON-1", "CRY-1")
+	item_amounts = list(2,2,1)
+	item_outputs = list(/obj/item/device/reagentscanner)
+	time = 5 SECONDS
+	create = 1
+	category = "Tool"
 // Mining Gear
 #ifndef UNDERWATER_MAP
 /datum/manufacture/mining_magnet

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2187,9 +2187,15 @@
 		/obj/item/material_piece/cloth/cottonfabric)
 	available = list(
 		/datum/manufacture/flashlight,
+		/datum/manufacture/gps,
 		/datum/manufacture/welder,
 		/datum/manufacture/patch,
 		/datum/manufacture/atmos_can,
+		/datum/manufacture/fluidcanister,
+		/datum/manufacture/spectrogoggles,
+		/datum/manufacture/reagentscanner,
+		/datum/manufacture/dropper,
+		/datum/manufacture/mechdropper,
 		/datum/manufacture/biosuit,
 		/datum/manufacture/labcoat,
 		/datum/manufacture/jumpsuit_white,
@@ -2202,6 +2208,15 @@
 		/datum/manufacture/rods2,
 		/datum/manufacture/metal,
 		/datum/manufacture/glass)
+
+	hidden = list(/datum/manufacture/scalpel,
+		/datum/manufacture/circular_saw,
+		/datum/manufacture/surgical_scissors,
+		/datum/manufacture/hemostat,
+		/datum/manufacture/suture,
+		/datum/manufacture/stapler,
+		/datum/manufacture/surgical_spoon
+	)
 
 /obj/machinery/manufacturer/mining
 	name = "mining fabricator"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds droppers, reagent scanners, fluid canisters, GPS and more to the primary recipes and surgical tools to the hidden ones. Also adds a few recipes I forgot to actually put into the fab. Should let scientists do more science easier without running out of supplies.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some sci players suggested these and I decided to go with it.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)Added a few more scientific equipment to the science fabricator
```
