### PR TITLE
Makes wigs layer the same as hair.

### DIFF
--- a/code/obj/ToSplit/barber_shop.dm
+++ b/code/obj/ToSplit/barber_shop.dm
@@ -17,6 +17,7 @@
 	name = "toupée"
 	desc = "You can't tell the difference, Honest!"
 	icon_state= "wig"
+	wear_layer = MOB_HAIR_LAYER2 //it IS hair afterall
 
 	///Takes a list of style ids to colors and generates a wig from it
 	proc/setup_wig(var/style_list)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It changes the wear layer of wigs to be the exact same as normal hair, this should make it so when you wear a wig it'll be under gas masks and radios.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It looks much prettier and a few people requested it!
