### PR TITLE
Modernises Space Rhinovirus

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -63,8 +63,6 @@
 	var/develop_resist = 0
 	var/associated_reagent = null // associated reagent, duh
 
-	var/list/disease_data = list() // A list of things for people to research about the disease to make it
-	var/list/strain_data = list()  // Used for Rhinovirus
 
 // IMPLEMENT PROPER CURE PROC
 
@@ -153,6 +151,7 @@
 	var/virulence = 100    // how likely is this disease to spread
 	var/develop_resist = 0 // can you develop a resistance to this?
 	var/cycles = 0         // does this disease have a cyclical nature? if so, how many cycles have elapsed?
+	var/list/strain_data = list()  // Used for Rhinovirus, basically arbitrary data storage
 
 	stage_act(var/mult)
 		if (!affected_mob || disposed)
@@ -228,6 +227,10 @@
 				master.stage_act(affected_mob, src, mult)
 
 		return 0
+
+	disposing()
+		strain_data = null
+		..()
 
 /datum/ailment_data/addiction
 	var/associated_reagent = null
@@ -383,9 +386,11 @@
 			AD.detectability = strain.detectability
 			AD.develop_resist = strain.develop_resist
 			AD.cure = strain.cure
+			AD.spread = strain.spread
 			AD.info = strain.info
 			AD.resistance_prob = strain.resistance_prob
 			AD.temperature_cure = strain.temperature_cure
+			AD.strain_data = strain.strain_data.Copy()
 		else
 			AD.name = D.name
 			AD.stage_prob = D.stage_prob
@@ -395,6 +400,7 @@
 			AD.detectability = D.detectability
 			AD.develop_resist = D.develop_resist
 			AD.cure = D.cure
+			AD.spread = D.spread
 			AD.info = D.info
 			AD.resistance_prob = D.resistance_prob
 			AD.temperature_cure = D.temperature_cure

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -962,6 +962,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\modules\medical\diseases\cluwneing_around.dm"
 #include "code\modules\medical\diseases\cold.dm"
 #include "code\modules\medical\diseases\corrupt_robotic_transformation.dm"
+#include "code\modules\medical\diseases\dna_spread.dm"
 #include "code\modules\medical\diseases\edisons_disease.dm"
 #include "code\modules\medical\diseases\fake_gbs.dm"
 #include "code\modules\medical\diseases\flu.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feat][cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Modernises Space Rhinovirus, the disease that turns patients into copies of patient zero (until cured), to current systems and code.

-Removes unused disease_data from disease datums, moves strain_data from /datum/ailment to datum/ailment_data/disease

-Fixes diseases not propagating their method of spreading (at the moment this has no round effect since AFAICT no contagious diseases occur normally)

-Makes Space Rhinovirus work again, since it was both unticked and referenced ancient-ass mob systems that I've never even experienced.

Like every other contagious disease there's no mechanism for Space Rhinovirus to occur within a round, but I'd encourage admins to infect people with it. :3 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sounds like a fun thing to have to me
Improves disease code a bit, and there's at least one other disease that looks like it should use strain_data to function properly (lycantrophy)


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)BatElite
(+)Space Rhinovirus roams the stars again, stay true to yourself in the face of such adversity!
```
