### PR TITLE
Table painting.

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -247,6 +247,9 @@
 			else
 				boutput(user, "<span class='notice'>\The [src] is too weak to be modified!</span>")
 
+		else if (istype(W, /obj/item/paint_can))
+			return
+
 		else if (isscrewingtool(W))
 			if (istype(src.desk_drawer) && src.desk_drawer.locked)
 				actions.start(new /datum/action/bar/icon/table_tool_interact(src, W, TABLE_LOCKPICK), user)
@@ -859,6 +862,9 @@
 					smashprob += 15
 				else
 					return
+
+		else if(istype(W, /obj/item/paint_can))
+			return
 
 		else if (istype(W)) // determine smash chance via item size and user clumsiness  :v
 			if (user.bioHolder.HasEffect("clumsy"))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] --> [SIZE/XS] [QoL]

## About the PR 

Clicking on a table with a paint can will now paint the table, instead of placing the paint can on top. You must now throw a paint can to place it on a table.


## Why's this needed?

Creative freedom. Previously you would need to pray for an admin to help you paint tables.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)CalliopeSoups
(+)Crew no longer need divine help to paint tables.
```
