### PR TITLE
floor / wall planner QoL improvements

### DIFF
--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -462,35 +462,35 @@
 	// var/pod_turf = 0
 	var/turf_op = 0
 
-	var/list/wallicons = list(\
-	"diner" = 'icons/turf/walls_derelict.dmi',\
-	"martian" = 'icons/turf/walls_martian.dmi',\
-	"shuttle blue" = 'icons/turf/walls_shuttle.dmi',\
-	"shuttle white" = 'icons/turf/walls_shuttle-debris.dmi',\
-	"shuttle dark" = 'icons/turf/walls_shuttle-debris.dmi',\
-	"overgrown" = 'icons/turf/walls_overgrown.dmi',\
-	"meat" = 'icons/turf/walls_meat.dmi',\
-	"ancient" = 'icons/turf/walls_ancient.dmi',\
-	"cave" = 'icons/turf/walls_cave.dmi',\
-	"lead blue" = 'icons/turf/walls_lead.dmi',\
-	"lead gray" = 'icons/turf/walls_lead.dmi',\
-	"lead white" = 'icons/turf/walls_lead.dmi',\
-	"ancient smooth" = 'icons/turf/walls_iomoon.dmi',\
+	var/list/wallicons = list(
+		"diner" = 'icons/turf/walls_derelict.dmi',
+		"martian" = 'icons/turf/walls_martian.dmi',
+		"shuttle blue" = 'icons/turf/walls_shuttle.dmi',
+		"shuttle white" = 'icons/turf/walls_shuttle-debris.dmi',
+		"shuttle dark" = 'icons/turf/walls_shuttle-debris.dmi',
+		"overgrown" = 'icons/turf/walls_overgrown.dmi',
+		"meat" = 'icons/turf/walls_meat.dmi',
+		"ancient" = 'icons/turf/walls_ancient.dmi',
+		"cave" = 'icons/turf/walls_cave.dmi',
+		"lead blue" = 'icons/turf/walls_lead.dmi',
+		"lead gray" = 'icons/turf/walls_lead.dmi',
+		"lead white" = 'icons/turf/walls_lead.dmi',
+		"ancient smooth" = 'icons/turf/walls_iomoon.dmi',
 	)
-	var/list/wallmods = list(\
-	"diner" = "oldr-",\
-	"martian" = "martian-",\
-	"shuttle blue" = "",\
-	"shuttle white" = "shuttle-",\
-	"shuttle dark" = "dshuttle-",\
-	"overgrown" = "root-",\
-	"meat" = "meatier-",\
-	"ancient" = "ancient-",\
-	"cave" = "cave-",\
-	"lead blue" = "leadb-",\
-	"lead gray" = "leadg-",\
-	"lead white" = "leadw-",\
-	"ancient smooth" = "interior-",\
+	var/list/wallmods = list(
+		"diner" = "oldr-",
+		"martian" = "martian-",
+		"shuttle blue" = "",
+		"shuttle white" = "shuttle-",
+		"shuttle dark" = "dshuttle-",
+		"overgrown" = "root-",
+		"meat" = "meatier-",
+		"ancient" = "ancient-",
+		"cave" = "cave-",
+		"lead blue" = "leadb-",
+		"lead gray" = "leadg-",
+		"lead white" = "leadw-",
+		"ancient smooth" = "interior-",
 	)
 
 	attack_self(mob/user as mob)

--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -501,7 +501,7 @@
 
 		selecting = 1
 
-		/// mode selection for floor planner
+		// mode selection for floor planner
 		mode = tgui_input_list(message="What to mark?", title="Marking", buttons=icons)
 		if(!mode)
 			mode = "floors"
@@ -512,9 +512,9 @@
 			selecting = 0
 			return
 
-		/// icon selection
-		/// selectedicon is the file we selected
-		/// selectedtype gets used as our iconstate for floors or the key to the lists for walls
+		// icon selection
+		// selectedicon is the file we selected
+		// selectedtype gets used as our iconstate for floors or the key to the lists for walls
 		if (mode == "floors")
 			states += icon_states('icons/turf/construction_floors.dmi')
 			selectedtype = tgui_input_list(message="What kind?", title="Marking", buttons=states)
@@ -817,7 +817,7 @@
 		// Originally worked only on this type specifically.
 		// Which meant it didn't work with the fancy new auto-walls
 
-		/// this has been reworked to use auto walls that i resprited a while back.
+		// this has been reworked to use auto walls that i resprited a while back.
 		if (istype(T, /turf/simulated/wall/auto))
 			var/turf/simulated/wall/auto/AT = T
 			var/connectdir = get_connected_directions_bitflag(AT.connects_to, AT.connects_to_exceptions, TRUE, AT.connect_diagonal)

--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -545,10 +545,6 @@
 			T = get_turf(T)
 		if (!T || !mode)
 			return 0
-		if (mode == "floors" && !isfloor(T))
-			return 0
-		if (mode == "walls" && isfloor(T))
-			return 0
 
 		if (mode == "restore original") //For those who want to undo the carnage
 			if (istype(T, /turf/simulated/floor))

--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -450,12 +450,46 @@
 	click_delay = 1
 
 	var/selecting = 0
-	var/mode = "floors"
-	var/icons = list("floors" = 'icons/turf/construction_floors.dmi', "walls" = 'icons/turf/construction_walls.dmi', "restore original")
+	var/mode = null
+	var/icons = list("floors", "walls", "restore original")
 	var/marker_class = list("floors" = /obj/plan_marker/floor, "walls" = /obj/plan_marker/wall)
-	var/selected = "floor"
+	var/selectedicon = "floor"
+	var/selectedtype
+	var/selectedmod
+	var/selected = null
 	// var/pod_turf = 0
 	var/turf_op = 0
+
+	var/list/wallicons = list(\
+	"diner" = 'icons/turf/walls_derelict.dmi',\
+	"martian" = 'icons/turf/walls_martian.dmi',\
+	"shuttle blue" = 'icons/turf/walls_shuttle.dmi',\
+	"shuttle white" = 'icons/turf/walls_shuttle-debris.dmi',\
+	"shuttle dark" = 'icons/turf/walls_shuttle-debris.dmi',\
+	"overgrown" = 'icons/turf/walls_overgrown.dmi',\
+	"meat" = 'icons/turf/walls_meat.dmi',\
+	"ancient" = 'icons/turf/walls_ancient.dmi',\
+	"cave" = 'icons/turf/walls_cave.dmi',\
+	"lead blue" = 'icons/turf/walls_lead.dmi',\
+	"lead gray" = 'icons/turf/walls_lead.dmi',\
+	"lead white" = 'icons/turf/walls_lead.dmi',\
+	"ancient smooth" = 'icons/turf/walls_iomoon.dmi',\
+	)
+	var/list/wallmods = list(\
+	"diner" = "oldr-",\
+	"martian" = "martian-",\
+	"shuttle blue" = "",\
+	"shuttle white" = "shuttle-",\
+	"shuttle dark" = "dshuttle-",\
+	"overgrown" = "root-",\
+	"meat" = "meatier-",\
+	"ancient" = "ancient-",\
+	"cave" = "cave-",\
+	"lead blue" = "leadb-",\
+	"lead gray" = "leadg-",\
+	"lead white" = "leadw-",\
+	"ancient smooth" = "interior-",\
+	)
 
 	attack_self(mob/user as mob)
 		// This seems to not actually stop anything from working so just axing it.
@@ -466,33 +500,54 @@
 			return
 
 		selecting = 1
-		mode = input("What to mark?", "Marking", mode) in icons
+
+		/// mode selection for floor planner
+		mode = tgui_input_list(message="What to mark?", title="Marking", buttons=icons)
+		if(!mode)
+			mode = "floors"
 		selected = null
 		var/states = list()
 		if (mode == "restore original")
 			boutput(user, "<span class='notice'>Now set for restoring appearance.</span>")
 			selecting = 0
 			return
+
+		/// icon selection
+		/// selectedicon is the file we selected
+		/// selectedtype gets used as our iconstate for floors or the key to the lists for walls
+		if (mode == "floors")
+			states += icon_states('icons/turf/construction_floors.dmi')
+			selectedtype = tgui_input_list(message="What kind?", title="Marking", buttons=states)
+			if(!selectedtype)
+				selectedtype = states[1]
+			selectedicon = 'icons/turf/construction_floors.dmi'
 		if (mode == "walls")
-			states += "* AUTO *"
-		states += icon_states(icons[mode])
-		selected = input("What kind?", "Marking", states[1]) in states
-		// if (mode == "floors" && findtext(selected, "catwalk") != 0)
-		// 	pod_turf = 1
-		// else
-		// 	pod_turf = 0
-		if (mode == "floors" || (mode == "walls" && findtext(selected, "window") != 0))
+			states += wallicons
+			selectedtype = tgui_input_list(message="What kind?", title="Marking", buttons=states)
+			if(!selectedtype)
+				selectedtype = states[1]
+			selectedicon = wallicons[selectedtype]
+			selectedmod = wallmods[selectedtype]
+
+
+
+		if (mode == "floors" || (mode == "walls" && findtext(selectedtype, "window") != 0))
 			turf_op = 0
 		else
 			turf_op = 1
-		boutput(user, "<span class='notice'>Now marking plan for [mode] of type [selected].</span>")
+
+		boutput(user, "<span class='notice'>Now marking plan for [mode] of type '[selectedtype]'.</span>")
 		selecting = 0
 
 	pixelaction(atom/target, params, mob/user)
 		var/turf/T = target
 		if (!istype(T))
 			T = get_turf(T)
-		if (!T)
+		if (!T || !mode)
+			return 0
+		if (mode == "floors" && !isfloor(T))
+			return 0
+		if (mode == "walls" && isfloor(T))
 			return 0
 
 		if (mode == "restore original") //For those who want to undo the carnage
@@ -520,12 +575,13 @@
 			old.Attackby(src, user)
 		else
 			var/class = marker_class[mode]
-			old = new class(T, selected)
+			old = new class(T, selectedicon, selectedtype, mode)
+
 			old.set_dir(get_dir(user, T))
 			// if (pod_turf)
 			// 	old:allows_vehicles = 1
 			old.turf_op = turf_op
-			old:check()
+			old:check(selectedmod)
 		boutput(user, "<span class='notice'>Done.</span>")
 
 		return 1
@@ -543,10 +599,12 @@
 
 	alpha = 128
 
-	New(var/initial_loc, var/initial_state)
+	New(var/initial_loc, var/initial_icon, var/selectedtype, var/mode)
 		..()
 		color = rgb(0, 255, 0)
-		icon_state = initial_state
+		icon = initial_icon
+		if(mode == "floors")
+			icon_state = selectedtype
 
 	attackby(obj/item/W, mob/user)
 		if (istype(W, /obj/item/room_planner))
@@ -758,25 +816,18 @@
 	name = "\improper Wall Plan Marker"
 	desc = "Build a wall here to complete the plan."
 
-	proc/check()
+	proc/check(var/selectedmod)
 		var/turf/T = get_turf(src)
 		// Originally worked only on this type specifically.
 		// Which meant it didn't work with the fancy new auto-walls
-		if (istype(T, /turf/simulated/wall))
-			// Only update if the wall should have a different type
-			if (src.icon_state != "* AUTO *")
-				T.icon = src.icon
-				T.icon_state = src.icon_state
-				T.set_dir(src.dir)
-				T:allows_vehicles = src.allows_vehicles
-			else if (istype(T, /turf/simulated/wall/auto))
-				var/turf/simulated/wall/auto/AT = T
-				AT.icon = initial(AT.icon)
-				AT.icon_state = initial(AT.icon_state)
-				AT.set_dir(initial(AT.dir))
-				AT:allows_vehicles = initial(AT.allows_vehicles)
-				AT.UpdateIcon()
-				AT.update_neighbors()
+
+		/// this has been reworked to use auto walls that i resprited a while back.
+		if (istype(T, /turf/simulated/wall/auto))
+			var/turf/simulated/wall/auto/AT = T
+			var/connectdir = get_connected_directions_bitflag(AT.connects_to, AT.connects_to_exceptions, TRUE, AT.connect_diagonal)
+			AT.icon = src.icon
+			AT.icon_state = "[selectedmod][connectdir]"
+
 			qdel(src)
 
 /obj/plan_marker/floor

--- a/code/WorkInProgress/construction/tools.dm
+++ b/code/WorkInProgress/construction/tools.dm
@@ -453,10 +453,12 @@
 	var/mode = null
 	var/icons = list("floors", "walls", "restore original")
 	var/marker_class = list("floors" = /obj/plan_marker/floor, "walls" = /obj/plan_marker/wall)
-	var/selectedicon = "floor"
+	/// icon file selected
+	var/selectedicon
+	/// iconstate selected
 	var/selectedtype
+	/// mod to use for generating smoothwalls
 	var/selectedmod
-	var/selected = null
 	// var/pod_turf = 0
 	var/turf_op = 0
 
@@ -505,7 +507,6 @@
 		mode = tgui_input_list(message="What to mark?", title="Marking", buttons=icons)
 		if(!mode)
 			mode = "floors"
-		selected = null
 		var/states = list()
 		if (mode == "restore original")
 			boutput(user, "<span class='notice'>Now set for restoring appearance.</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR aims to add some improvements to the floor/wall planner

perspective walls are used instead of the old walls,
tgui input lists are used now,
and the tool will nolonger say "Done" if it doesn't have the mode set

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

floor/wall planner currently uses non perspective wall sprites

also tgui good

![image](https://user-images.githubusercontent.com/64938519/174505637-2fbbbd63-adc0-4ed8-99ac-e8bae61f432e.png)


