### PR TITLE
Adds a warning when destroying data with the photocopier

### DIFF
--- a/code/obj/machinery/photocopier.dm
+++ b/code/obj/machinery/photocopier.dm
@@ -128,6 +128,9 @@
 				if (src.paper_amount >= 30.0)
 					boutput(user, "<span class='alert'>You can't fit any more paper into \the [src].</span>")
 					return
+				var/obj/item/paper/P = w
+				if (P.info != "" && tgui_alert(user, "This paper has writing on it, are you sure you want to put it in the inlet tray?", "Warning", list("Yes", "No")) == "No")
+					return
 				boutput(user, "You load the sheet of paper into \the [src].")
 				src.paper_amount++
 				qdel(w)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a warning when you try to insert a piece of paper with writing on it into a photocopier with the lid down.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Quote-unquote fixes #9210 and reduces overall photocopier based rage by 75%

```changelog
(u)LeahTheTech
(+)The photocopier will now warn you before eating your manuscript.
```
