### PR TITLE
Prevents sentinels hiding in walls

### DIFF
--- a/code/obj/flock/structure/rift.dm
+++ b/code/obj/flock/structure/rift.dm
@@ -42,7 +42,7 @@
 				if(prob(25))
 					if (src.flock)
 						src.flock.claimTurf(flock_convert_turf(S))
-						if (sentinel_count > 0)
+						if (sentinel_count > 0 && !flock_is_blocked_turf(S))
 							new /obj/flock_structure/sentinel(S, src.flock)
 							sentinel_count--
 					else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes rift spawned sentinels spawning in walls.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Arcflash turrets are spooky enough, they don't need to hide in the walls