### PR TITLE
Renames the NASSA suit to Donk suit

### DIFF
--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -418,7 +418,7 @@ proc/equip_battler(mob/living/carbon/human/battler)
 		/obj/item/clothing/under/gimmick/fake_waldo,
 		/obj/item/clothing/under/gimmick/johnny,
 		/obj/item/clothing/under/gimmick/police,
-		/obj/item/clothing/under/gimmick/blackstronaut,
+		/obj/item/clothing/under/gimmick/donk,
 		/obj/item/clothing/under/gimmick/duke,
 		/obj/item/clothing/under/gimmick/mj_clothes,
 		/obj/item/clothing/under/gimmick/viking,

--- a/code/obj/item/clothing/gimmick.dm
+++ b/code/obj/item/clothing/gimmick.dm
@@ -264,33 +264,35 @@
 	icon_state = "devil"
 	item_state = "devil"
 
-// NASSA
+// Donk clothes
 
-/obj/item/clothing/head/helmet/space/blackstronaut
-	name = "NASSA space helmet"
+/obj/item/clothing/head/helmet/space/donk
+	name = "\improper Donk space helmet"
 	desc = "A helmet with a self-contained pressurized environment. Kinda resembles a motorcycle helmet."
 	icon_state = "EOD"
 
-/obj/item/clothing/under/gimmick/blackstronaut
-	name = "NASSA space suit"
-	desc = "A space activity suit embroidered with the NASSA logo. Space is one cold muthafucka."
-	icon_state = "nassa"
-	item_state = "nassa"
+/obj/item/clothing/under/gimmick/donk
+	name = "\improper Donk space suit"
+	desc = "Some Donk brand spacewear. It's uncomfortable and made out of some really crinkly, metallic materials. Amazingly, this seems to be vacuum sealed."
+	icon_state = "donk"
+	item_state = "donk"
 	c_flags = SPACEWEAR
 	body_parts_covered = TORSO|LEGS|ARMS
 	protective_temperature = 1000
 
 	setupProperties()
 		..()
+		setProperty("heatprot", -20)//it's made out of foil, that would make fire a LOT worse
 		setProperty("coldprot", 20)
+		setProperty("radprot", 5)
 
-// SNAZZA
+// Donkini
 
-/obj/item/clothing/under/gimmick/snazza
-	name = "SNAZZA suit"
-	desc = "A NASSA Suit that appears to have been gussied and repurposed as a space bikini. Snazzy, but utterly useless for space travel."
-	icon_state = "snazza"
-	item_state = "snazza"
+/obj/item/clothing/under/gimmick/donkini
+	name = "\improper Donkini"
+	desc = "A Donk suit that appears to have been gussied and repurposed as a space bikini. Snazzy, but utterly useless for space travel."
+	icon_state = "donk"
+	item_state = "donkini"
 
 // Duke Nukem
 

--- a/code/obj/random_spawners.dm
+++ b/code/obj/random_spawners.dm
@@ -1340,7 +1340,7 @@
 		/obj/item/clothing/under/gimmick/fake_waldo,
 		/obj/item/clothing/under/gimmick/johnny,
 		/obj/item/clothing/under/gimmick/police,
-		/obj/item/clothing/under/gimmick/blackstronaut,
+		/obj/item/clothing/under/gimmick/donk,
 		/obj/item/clothing/under/gimmick/duke,
 		/obj/item/clothing/under/gimmick/mj_clothes,
 		/obj/item/clothing/under/gimmick/viking,

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -731,7 +731,7 @@
 		/obj/item/shipcomponent/sensor/mining)
 
 	clothes
-		spawn_contents = list(/obj/item/clothing/under/gimmick/blackstronaut,
+		spawn_contents = list(/obj/item/clothing/under/gimmick/donk,
 		/obj/item/clothing/shoes/cleats,
 		/obj/item/clothing/mask/balaclava,
 		/obj/item/reagent_containers/glass/beaker/burn)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -33879,7 +33879,7 @@
 	desc = "Smells vaguely of cabbage and diesel."
 	},
 /obj/item/clothing/head/helmet/space/donk{
-	desc = "This was cheaply spray-painted with flames at some point, but only a few flecks remain. There's a little tag on the back that says 'Donk™'.";
+	desc = "This was cheaply spray-painted with flames at some point, but only a few flecks remain. There's a little tag on the back that says 'Donk Co.'.";
 	name = "dented motorbike helm"
 	},
 /obj/machinery/light{

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -33878,8 +33878,8 @@
 /obj/item/clothing/suit/hoodie{
 	desc = "Smells vaguely of cabbage and diesel."
 	},
-/obj/item/clothing/head/helmet/space/blackstronaut{
-	desc = "This was cheaply spray-painted with flames at some point, but only a few flecks remain. There's a little tag on the back that says 'NASSA'.";
+/obj/item/clothing/head/helmet/space/donk{
+	desc = "This was cheaply spray-painted with flames at some point, but only a few flecks remain. There's a little tag on the back that says 'Donk™'.";
 	name = "dented motorbike helm"
 	},
 /obj/machinery/light{

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -1471,8 +1471,8 @@
 /area/abandonedmedicalship/robot_trader)
 "aeR" = (
 /obj/stool/bed,
-/obj/item/clothing/under/gimmick/snazza,
-/obj/item/clothing/head/helmet/space/blackstronaut,
+/obj/item/clothing/under/gimmick/donkini,
+/obj/item/clothing/head/helmet/space/donk,
 /obj/item/clothing/suit/bedsheet,
 /turf/simulated/floor/grime,
 /area/abandonedmedicalship/robot_trader)

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -19289,8 +19289,8 @@
 /area/iss)
 "aVj" = (
 /obj/rack,
-/obj/item/clothing/head/helmet/space/blackstronaut,
-/obj/item/clothing/under/gimmick/snazza,
+/obj/item/clothing/head/helmet/space/donk,
+/obj/item/clothing/under/gimmick/donkini,
 /turf/simulated/floor/grime,
 /area/iss)
 "aVk" = (

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -29729,7 +29729,7 @@
 "bID" = (
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet,
-/obj/item/clothing/under/gimmick/snazza,
+/obj/item/clothing/under/gimmick/donkini,
 /turf/unsimulated/floor/carpet{
 	dir = 10;
 	icon_state = "fred2"
@@ -30075,7 +30075,7 @@
 "bJG" = (
 /obj/storage/crate,
 /obj/item/shipcomponent/engine/helios,
-/obj/item/clothing/under/gimmick/blackstronaut,
+/obj/item/clothing/under/gimmick/donk,
 /turf/unsimulated/floor,
 /area/solarium)
 "bJH" = (
@@ -35422,7 +35422,7 @@
 /turf/unsimulated/floor,
 /area/meat_derelict/entry)
 "caY" = (
-/obj/item/clothing/under/gimmick/blackstronaut,
+/obj/item/clothing/under/gimmick/donk,
 /turf/unsimulated/floor,
 /area/meat_derelict/entry)
 "caZ" = (

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -9401,7 +9401,7 @@
 /turf/simulated/floor/plating,
 /area/helldrone)
 "aFu" = (
-/obj/item/clothing/under/gimmick/blackstronaut,
+/obj/item/clothing/under/gimmick/donk,
 /turf/simulated/floor/sanitary,
 /area/abandonedoutpostthing)
 "aFv" = (
@@ -15403,7 +15403,7 @@
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
 "aVL" = (
-/obj/item/clothing/head/helmet/space/blackstronaut,
+/obj/item/clothing/head/helmet/space/donk,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
 "aVM" = (
@@ -15537,7 +15537,7 @@
 	icon_state = "body2";
 	name = "corpse"
 	},
-/obj/item/clothing/under/gimmick/snazza,
+/obj/item/clothing/under/gimmick/donkini,
 /turf/simulated/floor/white/grime,
 /area/abandonedmedicalship/robot_trader)
 "aWc" = (
@@ -20365,7 +20365,7 @@
 /turf/space,
 /area/abandonedship)
 "blq" = (
-/obj/item/clothing/under/gimmick/snazza,
+/obj/item/clothing/under/gimmick/donkini,
 /obj/item/reagent_containers/glass/bottle/ammonia/large,
 /obj/storage/crate/bloody,
 /turf/simulated/floor/airless/damaged2,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives some nice flavour to Donk Co. by making them behind the jumpsuit slot space suit. Also makes the suit susceptible to fire by making it have -20% fire res and giving it 5% rad resist to make it seem like it's made of foil.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Feels like a bit of cool flavour cogs and I talked about, also opens the door to more products brought to you by Donk Co.

