### PR TITLE
Rebalances janitor gloves to be chemresistant

### DIFF
--- a/code/obj/item/clothing/gloves.dm
+++ b/code/obj/item/clothing/gloves.dm
@@ -208,8 +208,9 @@ ABSTRACT_TYPE(/obj/item/clothing/gloves)
 	material_prints = "synthetic silicone rubber fibers"
 	setupProperties()
 		..()
-		setProperty("conductivity", 0.3)
+		setProperty("conductivity", 0.6)
 		setProperty("heatprot", 5)
+		setProperty("chemprot", 15)
 
 /obj/item/clothing/gloves/fingerless
 	desc = "These gloves lack fingers. Good for a space biker look, but not so good for concealing your fingerprints."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Increases the chemprot and increases the conductivity on cleaning gloves. This should make janitors more resistant to chemicals which makes sense since they are usually getting down and dirty.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
With the addition of chemical resistance it feels like these gloves should be better at stopping chemicals than electricity.  Keeping these slightly better than latex gloves since they are rarer.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)Janitor gloves are now much more chemically resistant instead of insulating
```
