### PR TITLE
Replaces the golden skull in the hop prefab

### DIFF
--- a/assets/maps/prefabs/prefab_customs_shuttle.dmm
+++ b/assets/maps/prefabs/prefab_customs_shuttle.dmm
@@ -126,7 +126,7 @@
 	pixel_x = 4;
 	pixel_y = 11
 	},
-/obj/item/skull/gold,
+/obj/item/device/light/zippo/gold,
 /turf/simulated/floor/carpet{
 	dir = 8;
 	icon_state = "fgreen2"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the golden skull in this prefab with a zippo. This should make less instant wins for antags out and about.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This thing is worth 7 hunter points. That's not a good idea to keep a near instant win for an antag in a prefab.
