### PR TITLE
Minimum rounds played for detective

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -552,6 +552,7 @@ ABSTRACT_TYPE(/datum/job/security)
 	slot_ears = list(/obj/item/device/radio/headset/detective)
 	items_in_backpack = list(/obj/item/clothing/glasses/vr,/obj/item/storage/box/detectivegun)
 	map_can_autooverride = 0
+	rounds_needed_to_play = 15 // Half of sec, please stop shooting people with lethals
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Raises the minimum rounds played for the detective to 15.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While not as powerful as security they have a level of security access, stuns, lethals, handcuffs, flash etc.
New detectives can get themselves into trouble easily. Security assistant already acts as our "security training wheels" job.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(+)Minimum rounds required to play Detective has increased to 15.
```
