### PR TITLE
Clarifies the description of the loyalty implant box.

### DIFF
--- a/code/obj/item/storage/implant.dm
+++ b/code/obj/item/storage/implant.dm
@@ -27,7 +27,7 @@
 /obj/item/storage/box/revimp_kit
 	name = "counter-revolutionary implant kit"
 	icon_state = "implant"
-	desc = "A box containing an implanting tool and six counter-revolutionary implant cases. The implanter can remove the implants from their cases and inject them in a person, supressing their will to rebel against the Captain and crew."
+	desc = "A box containing an implanting tool and six counter-revolutionary implant cases. The implanter can remove the implants from their cases and inject them in a person, supressing their will to commit large scale revolution, as the name implies."
 	spawn_contents = list(/obj/item/implantcase/counterrev = 6,\
 	/obj/item/implanter)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Slightly edits the description of the loyalty implant box. This should lead to less confusion from players unfamiliar with their mechanical use.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some players interpreted this bit as the implanter making you "loyal" and no longer an antag instead of being for the revolution game mode. That's not what these things do as all and killing confusion
