### PR TITLE
Fixes wraith being able to emag shuttle

### DIFF
--- a/code/datums/abilities/wraith.dm
+++ b/code/datums/abilities/wraith.dm
@@ -270,7 +270,7 @@
 
 	cast(atom/T)
 		if (..())
-			return 1
+			return TRUE
 
 		//If you targeted a turf for some reason, find a valid target on it
 		var/atom/target = null
@@ -290,7 +290,7 @@
 			var/mob/living/carbon/H = T
 			if (H.traitHolder.hasTrait("training_chaplain"))
 				boutput(usr, "<span class='alert'>Some mysterious force protects [T] from your influence.</span>")
-				return 1
+				return TRUE
 			else
 				boutput(usr, "<span class='notice'>[pick("You sap [T]'s energy.", "You suck the breath out of [T].")]</span>")
 				boutput(T, "<span class='alert'>You feel really tired all of a sudden!</span>")
@@ -298,22 +298,22 @@
 				H.emote("pale")
 				H.remove_stamina( rand(100, 120) )//might be nice if decay was useful.
 				H.changeStatus("stunned", 4 SECONDS)
-				return 0
+				return FALSE
 		else if (isobj(T))
 			var/obj/O = T
-			if(istype(O, /obj/machinery/computer/shuttle/embedded))
+			if(istype(O, /obj/machinery/computer/shuttle))
 				boutput(usr, "<span class='alert'>You cannot seem to alter the energy of [O].</span>" )
-				return 0
+				return TRUE
 			// go to jail, do not pass src, do not collect pushed messages
 			if (O.emag_act(null, null))
 				boutput(usr, "<span class='notice'>You alter the energy of [O].</span>")
-				return 0
+				return FALSE
 			else
 				boutput(usr, "<span class='alert'>You fail to alter the energy of the [O].</span>")
-				return 1
+				return TRUE
 		else
 			boutput(usr, "<span class='alert'>There is nothing to decay here!</span>")
-			return 1
+			return FALSE
 
 /datum/targetable/wraithAbility/command
 	name = "Command"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Turns out there was already a check to prevent wraith emagging shuttle, it just seems to use the wrong subtype?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Wraith emagging shuttle within seconds of it arriving is becoming a regular occurrence, there is no counterplay other than running on and hoping server load delays the shuttle takeoff long enough.
Also with #8542 possibly being merged in the nearish future wraith should have a much more realistic shot at achieving its objectives of stopping humans from escaping without relying on people being slow to get on the shuttle.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(*)Fixes wraith being able to emag the escape shuttle console
```
