### PR TITLE
Removes the chance of receiving the Noir mutation when playing Mime.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1384,8 +1384,6 @@ ABSTRACT_TYPE(/datum/job/civilian)
 			return
 		M.bioHolder.AddEffect("mute", magical=1)
 		M.bioHolder.AddEffect("blankman", magical=1)
-		if(prob(20))
-			M.bioHolder.AddEffect("noir", magical=1)
 
 /datum/job/special/musician
 	name = "Musician"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
As the title says, just removes the mutation chance to roll noir.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Most mime players tend to say noir just isn't enjoyable to roll, as it detracts from the aesthetic of the mime palette and just makes fashion unfun. I honestly agree.


