### PR TITLE
Add circuitboard for announcement computer 

### DIFF
--- a/code/obj/machinery/computer/announcement.dm
+++ b/code/obj/machinery/computer/announcement.dm
@@ -4,6 +4,7 @@
 	name = "Announcement Computer"
 	icon_state = "comm"
 	machine_registry_idx = MACHINES_ANNOUNCEMENTS
+	circuit_type = /obj/item/circuitboard/announcement
 	var/last_announcement = 0
 	var/announcement_delay = 1200
 	var/obj/item/card/id/ID = null

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -142,6 +142,9 @@ ABSTRACT_TYPE(/obj/item/circuitboard)
 /obj/item/circuitboard/telescope
 	name = "Circuit board (Quantum Telescope)"
 	computertype = "/obj/machinery/computer/telescope"
+/obj/item/circuitboard/announcement
+	name = "Circuit board (Announcement Computer)"
+	computertype = "/obj/machinery/computer/announcement"
 
 /obj/computerframe/meteorhit(obj/O as obj)
 	qdel(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Makes announcement computers constructable/deconstructable by adding a circuit for them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9258 
Seems weird that you couldn't do that before.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Announcement computers are now constructable.
```
