### PR TITLE
Fixes a bunch of robotic critter weirdness

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1349,10 +1349,14 @@ ABSTRACT_TYPE(/mob/living/critter/robotic)
 /// Parent for robotic critters. Handles some traits that robots should have- damaged by EMPs, immune to fire and rads
 /mob/living/critter/robotic
 	name = "a fucked up robot"
+	can_bleed = FALSE
+	metabolizes = FALSE
 	var/emp_vuln = 1
+	blood_id = null
 
 	New()
 		..()
+		src.reagents = null
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_RADPROT, src, 100)
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_HEATPROT, src, 100)
 		APPLY_ATOM_PROPERTY(src, PROP_MOB_COLDPROT, src, 100)
@@ -1361,3 +1365,6 @@ ABSTRACT_TYPE(/mob/living/critter/robotic)
 	emp_act()
 		src.emag_act() // heh
 		src.TakeDamage(10 * emp_vuln, 10 * emp_vuln)
+
+	vomit()
+		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #9263
Fixes #9147
Just changes some default values on the `/mob/living/critter/robotic` parent so robots don't vomit/bleed/metabolize etc.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Robots should not vomit.
