### PR TITLE
Makes inspector clothing reward work with shoulder holsters

### DIFF
--- a/code/WorkInProgress/rewardsLocker.dm
+++ b/code/WorkInProgress/rewardsLocker.dm
@@ -861,13 +861,13 @@
 
 /datum/achievementReward/inspectorscloths
 	title = "(Skin set) Inspector's Clothes"
-	desc = "Requires that you wear something in your suit and jumpsuit slots."
+	desc = "Will change the skin of your suit, jumpsuit, and shoulder holster."
 	required_medal = "Neither fashionable noir stylish"
 
 	rewardActivate(var/mob/activator)
 		if (ishuman(activator))
 			var/mob/living/carbon/human/H = activator
-			var/succ = 0
+			var/succ = FALSE
 			if (H.wear_suit)
 				var/obj/item/clothing/M = H.wear_suit
 				if (istype(M, /obj/item/clothing/suit/wizrobe))
@@ -910,6 +910,17 @@
 				M.desc = "A uniform for the modern detective. (Base Item: [prev2])"
 				H.set_clothing_icon_dirty()
 				succ = TRUE
+
+			if (H.belt)
+				var/obj/item/storage/belt/security/shoulder_holster/M = H.belt
+				if (istype(M))
+					M.icon_state = "inspector_holster"
+					M.item_state = "inspector_holster"
+					M.name = "inspector holster"
+					M.real_name = "inspector holster"
+					M.desc = "A shoulder holster for the modern detective"
+					H.set_clothing_icon_dirty()
+					succ = TRUE
 
 			if (!succ)
 				boutput(activator, "<span class='alert'>Unable to redeem... you need to be wearing something in your suit/exosuit slots.</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Let's the inspector clothing reward work on the detective shoulder holster. This should make this reward look a little better on a detective.
![image](https://user-images.githubusercontent.com/40079883/175238362-6fa8f93a-48d9-4729-aafc-09cef0bad230.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
We have it, why not use it?


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)The inspector clothing reward now works with shoulder holsters.
```
