### PR TITLE
Gives det holster a unique description

### DIFF
--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -701,6 +701,7 @@
 
 	shoulder_holster
 		name = "shoulder holster"
+		desc = "A holster to hold a gun, and whatever is just a bit too big to put under a hat."
 		icon_state = "shoulder_holster"
 		item_state = "shoulder_holster"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Title.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The detective holster uses the officer description. I feel like it could use it's own flavour since the detective is not exactly an officer, noir trendy.
