### PR TITLE
Use radioGarbleText for glitchy AI modules

### DIFF
--- a/code/obj/item/ai_modules.dm
+++ b/code/obj/item/ai_modules.dm
@@ -75,11 +75,7 @@ ABSTRACT_TYPE(/obj/item/aiModule)
 
 	proc/get_law_name()
 		if(src.glitched)
-			var/pos = rand(1,length(src.name)-1)
-			var/pos2 = rand(pos,length(src.name))
-			var/part1 = copytext( src.name , 1 , pos)
-			var/part2 = copytext( src.name , pos2)
-			return part1+pick("^^vv<><>BA","AAAAAAAAAAAAAAAAAA","ID10-T ERROR","%FUDGE%","CRASH()","BEEES",":) :) :)","~#@@@#~","\\x00\\x00\\x00\\xDE\\xAD\\xBE\\xEF","\\x00\\x00\\x00\\x00","#BADREF#","OH NO IONS","FFFFBABAFFFBA","?","*?!","$var","001011001111011001","ERR0R")+part2
+			return radioGarbleText(src.name, 7)
 		else
 			return src.name
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just uses the existing `radioGarbleText()` proc to mess up ion'd ai modules, instead of the hacky string replacement thing I did before. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Looks better IMO
![image](https://user-images.githubusercontent.com/3855802/175293985-2123c9b5-d2b5-43fe-9179-5b691b54cdd4.png)



