### PR TITLE
convert wall updating to use signals

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -21,6 +21,8 @@
 	#define COMSIG_ATOM_PRE_UPDATE_ICON "atom_before_update_icon"
 	/// When something calls UpdateIcon, after the icon is updated
 	#define COMSIG_ATOM_POST_UPDATE_ICON "atom_after_update_icon"
+	/// When something's neighboring wall changes
+	#define COMSIG_ATOM_WALLNEIGHBOR_UPDATE "atom_wallneighbor_update"
 	/// When reagents change
 	#define COMSIG_ATOM_REAGENT_CHANGE "atm_reag"
 	/// When an atom is dragged onto something (usr, over_object, src_location, over_location, src_control, over_control, params)

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -51,7 +51,7 @@
 		src.UpdateIcon()
 
 	proc/update_neighbors()
-		for (var/atom/A as anything in neighbors)
+		for (var/atom/A in neighbors)
 			A.UpdateIcon()
 
 	Del()

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -58,6 +58,9 @@
 		src.RL_SetSprite(null)
 		if (floor_underlay)
 			qdel(floor_underlay)
+		for (var/atom/A in neighbors)
+			var/turf/simulated/wall/auto/W = A
+			W.neighbors -= src
 		..()
 
 	proc/setFloorUnderlay(FloorIcon, FloorIcon_State, Floor_Intact, Floor_Health, Floor_Burnt, Floor_Name)

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -18,6 +18,7 @@
 	var/mod = null
 	var/obj/overlay/floor_underlay = null
 	var/dont_follow_map_settings_for_icon_state = 0
+	var/neighbors = list()
 
 	temp
 		var/was_rwall = 0
@@ -32,20 +33,26 @@
 		src.levelupdate()
 		src.gas_impermeable = 1
 		src.layer = src.layer - 0.1
-		SPAWN(0)
+
+		if (src.can_be_auto)
+			for (var/atom/A in orange(1,src))
+				if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/simulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
+					var/turf/simulated/wall/auto/W = A
+					neighbors += A
+					W.neighbors += src
 			src.UpdateIcon()
+			src.update_neighbors()
+
 		SPAWN(1 SECOND)
 			// so that if it's getting created by the map it works, and if it isn't this will just return
 			src.setFloorUnderlay('icons/turf/floors.dmi', "plating", 0, 100, 0, "plating")
-			if (src.can_be_auto)
-				for (var/turf/simulated/wall/auto/W in orange(1,src))
-					W.UpdateIcon()
-				for (var/obj/grille/G in orange(1,src))
-					G.UpdateIcon()
-				for (var/obj/window/auto/W in orange(1,src))
-					W.UpdateIcon()
-				for (var/turf/simulated/wall/false_wall/F in orange(1,src))
-					F.UpdateIcon()
+
+	proc/update()
+		src.UpdateIcon()
+
+	proc/update_neighbors()
+		for (var/atom/A as anything in neighbors)
+			A.UpdateIcon()
 
 	Del()
 		src.RL_SetSprite(null)
@@ -254,9 +261,11 @@
 						s_connect_image = image(src.icon, "connect[overlaydir]")
 					else
 						s_connect_image.icon_state = "connect[overlaydir]"
-					src.UpdateOverlays(s_connect_image, "connect")
+					/// the code here keeps yelling at me if i use updateoverlays and i cant find what is updating it
+					src.overlays = null
+					src.overlays += s_connect_image
 				else
-					src.UpdateOverlays(null, "connect")
+					src.overlays = null
 
 
 	get_desc()

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -35,7 +35,7 @@
 		src.layer = src.layer - 0.1
 
 		if (src.can_be_auto)
-			for (var/atom/A in orange(1,src))
+			for (var/atom/A as anything in orange(1,src))
 				if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/simulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
 					var/turf/simulated/wall/auto/W = A
 					neighbors += A

--- a/code/obj/false_wall.dm
+++ b/code/obj/false_wall.dm
@@ -40,15 +40,13 @@
 					var/turf/simulated/wall/auto/W = A
 					neighbors += A
 					W.neighbors += src
-			src.UpdateIcon()
 			src.update_neighbors()
+			SPAWN(0)
+				src.UpdateIcon()
 
 		SPAWN(1 SECOND)
 			// so that if it's getting created by the map it works, and if it isn't this will just return
 			src.setFloorUnderlay('icons/turf/floors.dmi', "plating", 0, 100, 0, "plating")
-
-	proc/update()
-		src.UpdateIcon()
 
 	proc/update_neighbors()
 		for (var/atom/A in neighbors)

--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -31,13 +31,21 @@
 	///can you use this as a base for a new window?
 	var/can_build_window = TRUE
 
+	var/neighbors = list()
+
 
 	New()
 		..()
 		if(src.auto)
 			SPAWN(0) //fix for sometimes not joining on map load
+				for (var/atom/A in orange(1,src))
+					if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/simulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
+						var/turf/simulated/wall/auto/W = A
+						neighbors += A
+						W.neighbors += src
 				if (map_setting && ticker)
 					src.update_neighbors()
+
 
 				src.UpdateIcon()
 
@@ -510,8 +518,8 @@
 				icon_state = "grille[builtdir]" + "-0"
 
 	proc/update_neighbors()
-		for (var/obj/grille/G in orange(1,src))
-			G.UpdateIcon()
+		for (var/atom/A in neighbors)
+			A.UpdateIcon()
 
 	proc/drop_rods(var/amount)
 		if (!isnum(amount))

--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -50,15 +50,10 @@
 				src.UpdateIcon()
 
 	disposing()
-		var/list/neighbors = null
-		if (src.auto && src.anchored && map_setting)
-			neighbors = list()
-			for (var/obj/grille/O in orange(1,src))
-				neighbors += O //find all of our neighbors before we move
 		..()
-		for (var/obj/grille/O in neighbors)
-			O?.UpdateIcon() //now that we are in nullspace tell them to update
-
+		for(var/atom/A in neighbors)
+			var/turf/simulated/wall/auto/W = A
+			W.neighbors -= src
 	steel
 #ifdef IN_MAP_EDITOR
 		icon_state = "grille0-0"

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -736,7 +736,7 @@
 		explosion_resistance = 3
 	New()
 		..()
-		for (var/atom/A in orange(1,src))
+		for (var/atom/A as anything in orange(1,src))
 			if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/simulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
 				var/turf/simulated/wall/auto/W = A
 				neighbors += A

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -754,9 +754,9 @@
 
 	disposing()
 		..()
-
-		if (map_setting)
-			src.update_neighbors()
+		for (var/atom/A in neighbors)
+			var/turf/simulated/wall/auto/W = A
+			W.neighbors -= src
 
 	update_icon()
 		if (!src.anchored)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -720,7 +720,7 @@
 	//deconstruct_time = 20
 	object_flags = 0 // so they don't inherit the HAS_DIRECTIONAL_BLOCKING flag from thindows
 	flags = FPRINT | USEDELAY | ON_BORDER | ALWAYS_SOLID_FLUID | IS_PERSPECTIVE_FLUID
-
+	var/neighbors = list()
 	var/mod = "W-"
 	var/list/connects_to = list(/turf/simulated/wall/auto/supernorn, /turf/simulated/wall/auto/reinforced/supernorn, /turf/simulated/wall/auto/supernorn/wood, /turf/simulated/wall/auto/marsoutpost,
 		/turf/simulated/shuttle/wall, /turf/unsimulated/wall, /turf/simulated/wall/auto/shuttle, /obj/indestructible/shuttle_corner,
@@ -736,12 +736,21 @@
 		explosion_resistance = 3
 	New()
 		..()
+		for (var/atom/A in orange(1,src))
+			if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/simulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
+				var/turf/simulated/wall/auto/W = A
+				neighbors += A
+				W.neighbors += src
 
 		if (map_setting && ticker)
 			src.update_neighbors()
 
 		SPAWN(0)
 			src.UpdateIcon()
+
+	proc/update_neighbors()
+		for (var/atom/A in neighbors)
+			A.UpdateIcon()
 
 	disposing()
 		..()
@@ -772,14 +781,6 @@
 		if (..(W, user))
 			src.UpdateIcon()
 			src.update_neighbors()
-
-	proc/update_neighbors()
-		for (var/turf/simulated/wall/auto/T in orange(1,src))
-			T.UpdateIcon()
-		for (var/obj/window/auto/O in orange(1,src))
-			O.UpdateIcon()
-		for (var/obj/grille/G in orange(1,src))
-			G.UpdateIcon()
 
 /obj/window/auto/reinforced
 	icon_state = "mapwin_r"

--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -44,6 +44,9 @@
 
 	Del()
 		src.RL_SetSprite(null)
+		for (var/atom/A in neighbors)
+			var/turf/simulated/wall/auto/W = A
+			W.neighbors -= src
 		..()
 
 	the_tuff_stuff

--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -510,7 +510,7 @@ ABSTRACT_TYPE(turf/simulated/wall/auto/hedge)
 		if (current_state > GAME_STATE_WORLD_INIT)
 
 			for (var/atom/A as anything in orange(1,src))
-				if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/simulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
+				if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/unsimulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
 					var/turf/simulated/wall/auto/W = A
 					neighbors += A
 					W.neighbors += src

--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -17,18 +17,27 @@
 	var/connect_diagonal = 0 // 0 = no diagonal sprites, 1 = diagonal only if both adjacent cardinals are present, 2 = always allow diagonals
 	var/d_state = 0
 	var/connect_across_areas = TRUE
+	var/neighbors = list()
 
 	New()
 		..()
-		if (map_setting && ticker)
-			src.update_neighbors()
 
 		if (current_state > GAME_STATE_WORLD_INIT)
-			SPAWN(0) //worldgen overrides ideally
-				src.UpdateIcon()
+
+			for (var/atom/A as anything in orange(1,src))
+				if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/simulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
+					var/turf/simulated/wall/auto/W = A
+					neighbors += A
+					W.neighbors += src
+			src.update_neighbors()
+			src.UpdateIcon()
 
 		else
 			worldgenCandidates[src] = 1
+
+	proc/update_neighbors()
+		for (var/atom/A as anything in neighbors)
+			A.UpdateIcon()
 
 	generate_worldgen()
 		src.UpdateIcon()
@@ -62,11 +71,6 @@
 			else
 				src.UpdateOverlays(null, "connect")
 
-	proc/update_neighbors()
-		for (var/turf/simulated/wall/auto/T in orange(1,src))
-			T.UpdateIcon()
-		for (var/obj/grille/G in orange(1,src))
-			G.UpdateIcon()
 
 /turf/simulated/wall/auto/reinforced
 	name = "reinforced wall"
@@ -202,11 +206,6 @@
 	/turf/simulated/wall/auto/shuttle, /turf/simulated/wall/auto/shuttle, /obj/machinery/door, /obj/window, /obj/wingrille_spawn, /turf/simulated/wall/auto/reinforced/supernorn/yellow, /turf/simulated/wall/auto/reinforced/supernorn/blackred,
 	/turf/simulated/wall/auto/reinforced/jen)
 
-	update_neighbors()
-		..()
-		for (var/obj/window/auto/O in orange(1,src))
-			O.UpdateIcon()
-
 	the_tuff_stuff
 		explosion_resistance = 7
 
@@ -264,11 +263,6 @@
 	the_tuff_stuff
 		explosion_resistance = 3
 
-	update_neighbors()
-		..()
-		for (var/obj/window/auto/O in orange(1,src))
-			O.UpdateIcon()
-
 	dark1
 		color = "#dddddd"
 
@@ -324,11 +318,6 @@
 	the_tuff_stuff
 		explosion_resistance = 7
 
-	update_neighbors()
-		..()
-		for (var/obj/window/auto/O in orange(1,src))
-			O.UpdateIcon()
-
 /turf/simulated/wall/auto/reinforced/supernorn
 	icon = 'icons/turf/walls_supernorn_smooth.dmi'
 	mod = "norn-R-"
@@ -349,11 +338,6 @@
 
 	the_tuff_stuff
 		explosion_resistance = 11
-
-	update_neighbors()
-		..()
-		for (var/obj/window/auto/O in orange(1,src))
-			O.UpdateIcon()
 
 /turf/simulated/wall/auto/reinforced/supernorn/yellow
 	icon = 'icons/turf/walls_manta.dmi'
@@ -411,10 +395,6 @@
 	connects_to = list(/turf/simulated/wall/auto/reinforced/paper, /turf/simulated/wall/auto/reinforced/supernorn, /turf/simulated/wall/auto, /obj/table/reinforced/bar/auto, /obj/window, /obj/wingrille_spawn)
 	connects_with_overlay = list(/obj/table/reinforced/bar/auto)
 
-	update_neighbors()
-		..()
-		for (var/obj/window/auto/O in orange(1,src))
-			O.UpdateIcon()
 /turf/simulated/wall/auto/supernorn/wood
 	icon = 'icons/turf/walls_wood.dmi'
 	connect_diagonal = 0
@@ -441,11 +421,6 @@
 
 	connects_with_overlay = list(/turf/simulated/wall/auto/reinforced/supernorn,
 	/obj/machinery/door, /obj/window)
-
-	update_neighbors()
-		..()
-		for (var/obj/window/auto/O in orange(1,src))
-			O.UpdateIcon()
 
 /turf/simulated/wall/auto/reinforced/gannets
 	icon = 'icons/turf/walls_destiny.dmi'
@@ -528,17 +503,27 @@ ABSTRACT_TYPE(turf/simulated/wall/auto/hedge)
 	var/image/connect_image = null
 	var/d_state = 0
 	var/connect_diagonal = 0 // 0 = no diagonal sprites, 1 = diagonal only if both adjacent cardinals are present, 2 = always allow diagonals
-
+	var/neighbors = list()
 	New()
 		..()
-		if (map_setting && ticker)
-			src.update_neighbors()
+
 		if (current_state > GAME_STATE_WORLD_INIT)
-			SPAWN(0) //worldgen overrides ideally
-				src.UpdateIcon()
+
+			for (var/atom/A as anything in orange(1,src))
+				if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/simulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
+					var/turf/simulated/wall/auto/W = A
+					neighbors += A
+					W.neighbors += src
+			src.update_neighbors()
+			src.UpdateIcon()
 
 		else
 			worldgenCandidates[src] = 1
+
+	proc/update_neighbors()
+		for (var/atom/A as anything in neighbors)
+			A.UpdateIcon()
+
 
 	generate_worldgen()
 		src.UpdateIcon()
@@ -568,12 +553,6 @@ ABSTRACT_TYPE(turf/simulated/wall/auto/hedge)
 				src.UpdateOverlays(src.connect_image, "connect")
 			else
 				src.UpdateOverlays(null, "connect")
-
-	proc/update_neighbors()
-		for (var/turf/unsimulated/wall/auto/T in orange(1,src))
-			T.UpdateIcon()
-		for (var/obj/grille/G in orange(1,src))
-			G.UpdateIcon()
 
 /turf/unsimulated/wall/auto/reinforced
 	name = "reinforced wall"

--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -36,7 +36,7 @@
 			worldgenCandidates[src] = 1
 
 	proc/update_neighbors()
-		for (var/atom/A as anything in neighbors)
+		for (var/atom/A in neighbors)
 			A.UpdateIcon()
 
 	generate_worldgen()
@@ -521,7 +521,7 @@ ABSTRACT_TYPE(turf/simulated/wall/auto/hedge)
 			worldgenCandidates[src] = 1
 
 	proc/update_neighbors()
-		for (var/atom/A as anything in neighbors)
+		for (var/atom/A in neighbors)
 			A.UpdateIcon()
 
 

--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -17,7 +17,6 @@
 	var/connect_diagonal = 0 // 0 = no diagonal sprites, 1 = diagonal only if both adjacent cardinals are present, 2 = always allow diagonals
 	var/d_state = 0
 	var/connect_across_areas = TRUE
-	var/neighbors = list()
 
 	New()
 		..()
@@ -26,27 +25,25 @@
 
 			for (var/atom/A as anything in orange(1,src))
 				if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/simulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
-					var/turf/simulated/wall/auto/W = A
-					neighbors += A
-					W.neighbors += src
-			src.update_neighbors()
+					A.RegisterSignal(src,"atom_wallneighbor_update", /atom/proc/UpdateIcon, override = TRUE)
+			SEND_SIGNAL(src,"atom_wallneighbor_update")
 			src.UpdateIcon()
 
 		else
 			worldgenCandidates[src] = 1
 
+	/// this is here because some procs still expect this to exist.
 	proc/update_neighbors()
-		for (var/atom/A in neighbors)
-			A.UpdateIcon()
+		SEND_SIGNAL(src,"atom_wallneighbor_update")
 
 	generate_worldgen()
 		src.UpdateIcon()
 
 	Del()
 		src.RL_SetSprite(null)
-		for (var/atom/A in neighbors)
-			var/turf/simulated/wall/auto/W = A
-			W.neighbors -= src
+		for (var/atom/A as anything in orange(1,src))
+			if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/simulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
+				A.UnregisterSignal(src,"atom_wallneighbor_update", /atom/proc/UpdateIcon)
 		..()
 
 	the_tuff_stuff
@@ -507,32 +504,32 @@ ABSTRACT_TYPE(turf/simulated/wall/auto/hedge)
 	var/d_state = 0
 	var/connect_diagonal = 0 // 0 = no diagonal sprites, 1 = diagonal only if both adjacent cardinals are present, 2 = always allow diagonals
 	var/neighbors = list()
+
 	New()
 		..()
 
 		if (current_state > GAME_STATE_WORLD_INIT)
-
 			for (var/atom/A as anything in orange(1,src))
 				if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/unsimulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
-					var/turf/simulated/wall/auto/W = A
-					neighbors += A
-					W.neighbors += src
-			src.update_neighbors()
+					A.RegisterSignal(src,"atom_wallneighbor_update", /atom/proc/UpdateIcon, override = TRUE)
+			SEND_SIGNAL(src,"atom_wallneighbor_update")
 			src.UpdateIcon()
 
 		else
 			worldgenCandidates[src] = 1
 
+	/// this is here because some procs still expect this to exist.
 	proc/update_neighbors()
-		for (var/atom/A in neighbors)
-			A.UpdateIcon()
-
+		SEND_SIGNAL(src,"atom_wallneighbor_update")
 
 	generate_worldgen()
 		src.UpdateIcon()
 
 	Del()
 		src.RL_SetSprite(null)
+		for (var/atom/A as anything in orange(1,src))
+			if(istype(A,/obj/window/auto) || istype(A,/obj/grille) || istype(A,/turf/unsimulated/wall/auto) || istype(A,/turf/simulated/wall/false_wall))
+				A.UnregisterSignal(src,"atom_wallneighbor_update", /atom/proc/UpdateIcon)
 		..()
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[PERFORMANCE] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
this PR aims to reduce the amount of times the code for walls, windows, grilles, and false walls have to loop through orange(1,src) to find neighboring walls

due to the change to how walls update neighboring turfs/objs, a false wall bug has been fixed by this
(walls would never loop through to find false walls to update near them)

the 3-4 orange() for loops were replaced with a signal used to update walls, windows, grilles, false walls, etc.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->

wall code and everything copied from it looped through orange(1,src) atleast 3-4 times per wall.
this is probably bad, and using a signal to handle this is most likely better.


