### PR TITLE
Componentizes analyzeable objects + general device analyzer improvements

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -35,6 +35,8 @@
 	#define COMSIG_ATOM_PROJECTILE_REFLECTED "atom_reflect_projectile"
 	/// When something enters the contents of this atom (i.e. Entered())
 	#define COMSIG_ATOM_ENTERED "atom_entered"
+	/// When this atom is analyzed with a device analyzer (item, user)
+	#define COMSIG_ATOM_ANALYZE "atom_analyze"
 	/// Attacking with an item in-hand (item, attacker, params, is_special)
 	#define COMSIG_ATTACKBY "attackby"
 	/// Attacking without an item in-hand (attacker)
@@ -65,8 +67,6 @@
 	#define XSIG_OUTERMOST_MOVABLE_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_outermost_changed")
 	/// when the z-level of a movable changes (works in nested contents) (thing, old_z_level, new_z_level)
 	#define XSIG_MOVABLE_Z_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_z-level_changed")
-
-// ---- obj signals ----
 
 // ---- obj/critter signals ----
 
@@ -105,6 +105,8 @@
 	#define COMSIG_ITEM_CONSUMED_PARTIAL "itm_atk_consumed_partial"
 	/// After we've consumed an item
 	#define COMSIG_ITEM_CONSUMED_ALL "itm_atk_consumed_all"
+	/// Called before an attackby that uses this item (target, user)
+	#define COMSIG_ITEM_ATTACKBY_PRE "itm_atkby_pre"
 	/// When an item is used to attack a mob before it actually hurts the mob
 	#define COMSIG_ITEM_ATTACK_PRE "itm_atk_pre"
 	/// When an item is used in-hand

--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -68,6 +68,8 @@
 	/// when the z-level of a movable changes (works in nested contents) (thing, old_z_level, new_z_level)
 	#define XSIG_MOVABLE_Z_CHANGED list(/datum/component/complexsignal/outermost_movable, "mov_z-level_changed")
 
+// ---- obj signals ----
+
 // ---- obj/critter signals ----
 
 	// When an obj/critter dies

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -91,7 +91,7 @@
 	attackby(var/obj/item/I, var/mob/user)
 		if(status & BROKEN)
 			return
-		if (istype(I,/obj/item/electronics/scanner) || istype(I,/obj/item/deconstructor))
+		if (istype(I,/obj/item/deconstructor))
 			user.visible_message("<span class='alert'><B>[user] hits [src] with [I]!</B></span>")
 			return
 		if (istype(I, /obj/item/handheld_vacuum))

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -700,6 +700,8 @@
 	SHOULD_NOT_OVERRIDE(1)
 	if(SEND_SIGNAL(src,COMSIG_ATTACKBY,W,user, params, is_special))
 		return
+	if(SEND_SIGNAL(W, COMSIG_ITEM_ATTACKBY_PRE, src, user))
+		return
 	src.attackby(W, user, params, is_special)
 
 //mbc : sorry, i added a 'is_special' arg to this proc to avoid race conditions.

--- a/code/atom.dm
+++ b/code/atom.dm
@@ -698,9 +698,9 @@
 ///wrapper proc for /atom/proc/attackby so that signals are always sent. Call this, but do not override it.
 /atom/proc/Attackby(obj/item/W, mob/user, params, is_special = 0)
 	SHOULD_NOT_OVERRIDE(1)
-	if(SEND_SIGNAL(src,COMSIG_ATTACKBY,W,user, params, is_special))
-		return
 	if(SEND_SIGNAL(W, COMSIG_ITEM_ATTACKBY_PRE, src, user))
+		return
+	if(SEND_SIGNAL(src,COMSIG_ATTACKBY,W,user, params, is_special))
 		return
 	src.attackby(W, user, params, is_special)
 

--- a/code/datums/components/analyzable.dm
+++ b/code/datums/components/analyzable.dm
@@ -1,0 +1,46 @@
+/**
+  * Makes an object scannable by the device analyzer.
+  * The result type is drawn from either the parent's typepath or its mechanics_type_override.
+  * Syndicate objects can't be scanned by non-Syndicate scanners.
+  */
+/datum/component/analyzable
+	var/final_type
+
+TYPEINFO(/datum/component/analyzable)
+	initialization_args = list(
+		ARG_INFO("result_type", DATA_INPUT_TYPE, "the typepath that scanning this object will provide")
+	)
+
+/datum/component/analyzable/Initialize(result_type)
+	if (!isobj(parent))
+		return COMPONENT_INCOMPATIBLE
+	var/obj/O = parent
+	if (O.mechanics_blacklist)
+		return COMPONENT_INCOMPATIBLE
+	src.final_type = result_type
+	RegisterSignal(parent, list(COMSIG_ATTACKBY), .proc/attempt_analysis)
+
+/datum/component/analyzable/proc/attempt_analysis(atom/A, obj/item/I, mob/user)
+	PRIVATE_PROC(TRUE)
+	if (A.disposed || user.a_intent == INTENT_HARM || !istype(I, /obj/item/electronics/scanner))
+		return
+	var/obj/item/electronics/scanner/S = I
+	var/obj/O = A
+	if(O.mechanics_blacklist || isnull(O.mats) || O.mats == 0 || (O.is_syndicate && !S.is_syndicate))
+		// if this item doesn't have mats defined or was constructed or
+		// attempting to scan a syndicate item and this is a normal scanner
+		boutput(user, "<span class='alert'>The structure of this object is not compatible with [S].</span>")
+		return TRUE
+	user.visible_message("<span class='notice'>[user] scans [O].</span>", "<span class='notice'>You run [S] over [O]...</span>")
+	animate_scanning(O, "#FFFF00")
+	if (S.scanned.Find(src.final_type))
+		boutput(user, "<span class='alert'>You have already scanned that object.</span>")
+		return TRUE
+	S.scanned += src.final_type
+	boutput(user, "<span class='notice'>Item scan successful.</span>")
+	playsound(O.loc, "sound/machines/tone_beep.ogg", 30, FALSE)
+	return TRUE
+
+/datum/component/analyzer/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_ATTACKBY)
+	. = ..()

--- a/code/datums/components/analyzable.dm
+++ b/code/datums/components/analyzable.dm
@@ -9,7 +9,7 @@
 
 TYPEINFO(/datum/component/analyzable)
 	initialization_args = list(
-		ARG_INFO("result_type", DATA_INPUT_TYPE, "the typepath that scanning this object will provide")
+		ARG_INFO("type_override", DATA_INPUT_TYPE, "the typepath that scanning this object will provide")
 	)
 
 /datum/component/analyzable/Initialize(type_override)
@@ -24,8 +24,9 @@ TYPEINFO(/datum/component/analyzable)
 /datum/component/analyzable/proc/attempt_analysis(atom/parent_atom, obj/item/I, mob/user)
 	PRIVATE_PROC(TRUE)
 	var/obj/O = parent_atom
-	if (O.disposed || user.a_intent == INTENT_HARM || !istype(I, /obj/item/electronics/scanner))
+	if (O.disposed || !istype(I, /obj/item/electronics/scanner))
 		return
+	// in the future, this could be replaced with a component for analyzers themselves, too
 	var/obj/item/electronics/scanner/S = I
 	S.do_scan_effects(O, user)
 	if (isnull(O.mats) || O.mats == 0 || (O.is_syndicate && !S.is_syndicate))

--- a/code/datums/components/analyzable.dm
+++ b/code/datums/components/analyzable.dm
@@ -28,7 +28,6 @@ TYPEINFO(/datum/component/analyzable)
 		return
 	// in the future, this could be replaced with a component for analyzers themselves, too
 	var/obj/item/electronics/scanner/S = I
-	S.do_scan_effects(parent_atom, user)
 	if (isnull(parent_atom.mats) || parent_atom.mats == 0 || (parent_atom.is_syndicate && !S.is_syndicate))
 		// if this item doesn't have mats defined or was constructed or
 		// attempting to scan a syndicate item and this is a normal scanner

--- a/code/datums/components/analyzable.dm
+++ b/code/datums/components/analyzable.dm
@@ -18,23 +18,22 @@ TYPEINFO(/datum/component/analyzable)
 	if (O.mechanics_blacklist)
 		return COMPONENT_INCOMPATIBLE
 	src.final_type = result_type
-	RegisterSignal(parent, list(COMSIG_ATTACKBY), .proc/attempt_analysis)
+	RegisterSignal(parent, list(COMSIG_ATOM_ANALYZE), .proc/attempt_analysis)
 
-/datum/component/analyzable/proc/attempt_analysis(atom/A, obj/item/I, mob/user)
+/datum/component/analyzable/proc/attempt_analysis(atom/parent_atom, obj/item/I, mob/user)
 	PRIVATE_PROC(TRUE)
-	if (A.disposed || user.a_intent == INTENT_HARM || !istype(I, /obj/item/electronics/scanner))
+	var/obj/O = parent_atom
+	if (O.disposed || user.a_intent == INTENT_HARM || !istype(I, /obj/item/electronics/scanner))
 		return
 	var/obj/item/electronics/scanner/S = I
-	var/obj/O = A
-	if(O.mechanics_blacklist || isnull(O.mats) || O.mats == 0 || (O.is_syndicate && !S.is_syndicate))
+	S.do_scan_effects(O, user)
+	if (isnull(O.mats) || O.mats == 0 || (O.is_syndicate && !S.is_syndicate))
 		// if this item doesn't have mats defined or was constructed or
 		// attempting to scan a syndicate item and this is a normal scanner
-		boutput(user, "<span class='alert'>The structure of this object is not compatible with [S].</span>")
+		boutput(user, "<span class='alert'>The structure of [O] is not compatible with [S].</span>")
 		return TRUE
-	user.visible_message("<span class='notice'>[user] scans [O].</span>", "<span class='notice'>You run [S] over [O]...</span>")
-	animate_scanning(O, "#FFFF00")
 	if (S.scanned.Find(src.final_type))
-		boutput(user, "<span class='alert'>You have already scanned that object.</span>")
+		boutput(user, "<span class='alert'>You have already scanned this type of object.</span>")
 		return TRUE
 	S.scanned += src.final_type
 	boutput(user, "<span class='notice'>Item scan successful.</span>")
@@ -42,5 +41,5 @@ TYPEINFO(/datum/component/analyzable)
 	return TRUE
 
 /datum/component/analyzer/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_ATTACKBY)
+	UnregisterSignal(parent, COMSIG_ATOM_ANALYZE)
 	. = ..()

--- a/code/datums/components/analyzable.dm
+++ b/code/datums/components/analyzable.dm
@@ -4,20 +4,21 @@
   * Syndicate objects can't be scanned by non-Syndicate scanners.
   */
 /datum/component/analyzable
-	var/final_type
+	/// When this component is scanned, it will add the following typepath to the device analyzer's database
+	var/result_type
 
 TYPEINFO(/datum/component/analyzable)
 	initialization_args = list(
 		ARG_INFO("result_type", DATA_INPUT_TYPE, "the typepath that scanning this object will provide")
 	)
 
-/datum/component/analyzable/Initialize(result_type)
+/datum/component/analyzable/Initialize(type_override)
 	if (!isobj(parent))
 		return COMPONENT_INCOMPATIBLE
 	var/obj/O = parent
 	if (O.mechanics_blacklist)
 		return COMPONENT_INCOMPATIBLE
-	src.final_type = result_type
+	src.result_type = type_override
 	RegisterSignal(parent, list(COMSIG_ATOM_ANALYZE), .proc/attempt_analysis)
 
 /datum/component/analyzable/proc/attempt_analysis(atom/parent_atom, obj/item/I, mob/user)
@@ -32,10 +33,10 @@ TYPEINFO(/datum/component/analyzable)
 		// attempting to scan a syndicate item and this is a normal scanner
 		boutput(user, "<span class='alert'>The structure of [O] is not compatible with [S].</span>")
 		return TRUE
-	if (S.scanned.Find(src.final_type))
+	if (S.scanned.Find(src.result_type))
 		boutput(user, "<span class='alert'>You have already scanned this type of object.</span>")
 		return TRUE
-	S.scanned += src.final_type
+	S.scanned += src.result_type
 	boutput(user, "<span class='notice'>Item scan successful.</span>")
 	playsound(O.loc, "sound/machines/tone_beep.ogg", 30, FALSE)
 	return TRUE

--- a/code/datums/components/analyzable.dm
+++ b/code/datums/components/analyzable.dm
@@ -21,25 +21,25 @@ TYPEINFO(/datum/component/analyzable)
 	src.result_type = type_override
 	RegisterSignal(parent, list(COMSIG_ATOM_ANALYZE), .proc/attempt_analysis)
 
-/datum/component/analyzable/proc/attempt_analysis(atom/parent_atom, obj/item/I, mob/user)
+/datum/component/analyzable/proc/attempt_analysis(obj/parent_atom, obj/item/I, mob/user)
 	PRIVATE_PROC(TRUE)
-	var/obj/O = parent_atom
-	if (O.disposed || !istype(I, /obj/item/electronics/scanner))
+	// parent_atom can be safely cast as an obj in arguments without other checks because the component can only be applied to objs
+	if (parent_atom.disposed || !istype(I, /obj/item/electronics/scanner))
 		return
 	// in the future, this could be replaced with a component for analyzers themselves, too
 	var/obj/item/electronics/scanner/S = I
-	S.do_scan_effects(O, user)
-	if (isnull(O.mats) || O.mats == 0 || (O.is_syndicate && !S.is_syndicate))
+	S.do_scan_effects(parent_atom, user)
+	if (isnull(parent_atom.mats) || parent_atom.mats == 0 || (parent_atom.is_syndicate && !S.is_syndicate))
 		// if this item doesn't have mats defined or was constructed or
 		// attempting to scan a syndicate item and this is a normal scanner
-		boutput(user, "<span class='alert'>The structure of [O] is not compatible with [S].</span>")
+		boutput(user, "<span class='alert'>The structure of [parent_atom] is not compatible with [S].</span>")
 		return TRUE
 	if (S.scanned.Find(src.result_type))
 		boutput(user, "<span class='alert'>You have already scanned this type of object.</span>")
 		return TRUE
 	S.scanned += src.result_type
 	boutput(user, "<span class='notice'>Item scan successful.</span>")
-	playsound(O.loc, "sound/machines/tone_beep.ogg", 30, FALSE)
+	playsound(parent_atom.loc, 'sound/machines/tone_beep.ogg', 30, FALSE)
 	return TRUE
 
 /datum/component/analyzer/UnregisterFromParent()

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -11,6 +11,7 @@
 	var/list/mats = 0 // either a number or a list of the form list("MET-1"=5, "erebite"=3)
 	var/deconstruct_flags = DECON_NONE
 
+	var/mechanics_blacklist = FALSE // If true, this object can't be scanned by device analyzers
 	var/mechanics_type_override = null //Fix for children of scannable items being reproduced in mechanics
 	var/artifact = null
 	var/move_triggered = 0
@@ -28,6 +29,8 @@
 		if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
 			var/turf/T = get_turf(src)
 			T?.UpdateDirBlocks()
+		if (!isnull(src.mats) && src.mats != 0 && !src.mechanics_blacklist)
+			src.AddComponent(/datum/component/analyzable, !isnull(src.mechanics_type_override) ? src.mechanics_type_override : src.type)
 		src.update_access_from_txt()
 
 	Move(NewLoc, direct)

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -11,8 +11,10 @@
 	var/list/mats = 0 // either a number or a list of the form list("MET-1"=5, "erebite"=3)
 	var/deconstruct_flags = DECON_NONE
 
-	var/mechanics_blacklist = FALSE // If true, this object can't be scanned by device analyzers
-	var/mechanics_type_override = null //Fix for children of scannable items being reproduced in mechanics
+	/// If TRUE, this object can't be scanned at all by device analyzers
+	var/mechanics_blacklist = FALSE
+	/// If defined, device analyzer scans will yield this typepath (instead of the default, which is just the object's type itself)
+	var/mechanics_type_override = null
 	var/artifact = null
 	var/move_triggered = 0
 	var/object_flags = 0

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -120,6 +120,7 @@
 /obj/item/electronics/frame
 	name = "frame"
 	icon_state = "frame"
+	mechanics_blacklist = TRUE
 	var/store_type = null
 	var/secured = 0
 	var/viewstat = 0
@@ -417,29 +418,6 @@
 	syndicate
 		is_syndicate = 1
 
-/obj/item/electronics/scanner/afterattack(var/obj/O, mob/user as mob)
-	if(istype(O,/obj/machinery/rkit) || istype(O, /obj/item/electronics/frame))
-		return
-	if(istype(O,/obj/))
-		if(O.mats == 0 || isnull(O.mats) || O.disposed || (O.is_syndicate != 0 && src.is_syndicate == 0))
-			// if this item doesn't have mats defined or was constructed or
-			// attempting to scan a syndicate item and this is a normal scanner
-			boutput(user, "<span class='alert'>The structure of this object is not compatible with the scanner.</span>")
-			return
-
-		user.visible_message("<B>[user.name]</B> scans [O].")
-
-		var/final_type = O.mechanics_type_override ? O.mechanics_type_override : O.type
-
-		for (var/X in src.scanned)
-			if (final_type == X)
-				boutput(user, "<span class='alert'>You have already scanned that object.</span>")
-				return
-
-		animate_scanning(O, "#FFFF00")
-		src.scanned += final_type
-		boutput(user, "<span class='notice'>Item scan successful.</span>")
-
 ////////////////////////////////////////////////////////////////no
 /obj/machinery/rkit
 	name = "ruckingenur kit"
@@ -448,6 +426,7 @@
 	icon_state = "rkit"
 	anchored = 1
 	density = 1
+	mechanics_blacklist = TRUE
 	//var/datum/electronics/electronics_items/link = null
 	req_access = list(access_captain, access_head_of_personnel, access_maxsec, access_engineering_chief)
 

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -416,7 +416,7 @@
 	var/viewstat = 0
 
 	syndicate
-		is_syndicate = 1
+		is_syndicate = TRUE
 	
 	New()
 		. = ..()
@@ -436,7 +436,11 @@
 		return TRUE
 	
 	proc/do_scan_effects(atom/target, mob/user)
-		user.visible_message("<span class='notice'>[user] scans [target].</span>", "<span class='notice'>You run [src] over [target]...</span>")
+		user.tri_message(target,
+			"<span class='notice'>[user] scans [target].</span>", \
+			"<span class='notice'>You run [src] over [target]...</span>", \
+			"<span class='notice'>[user] waves [src] in your face. You feel [pick("funny", "weird", "odd", "strange", "off")].</span>"
+		)
 		animate_scanning(target, "#FFFF00")
 
 ////////////////////////////////////////////////////////////////no

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -438,7 +438,7 @@
 	proc/do_scan_effects(atom/target, mob/user)
 		// more often than not, this will display for objects, but we include a message to scanned mobs just for consistency's sake
 		user.tri_message(target,
-			"<span class='notice'>[user] scans [target].</span>", \
+			"<span class='notice'>[user] scans [user == target ? himself_or_herself(user) : target] with [src].</span>", \
 			"<span class='notice'>You run [src] over [user == target ? "yourself" : target]...</span>", \
 			"<span class='notice'>[user] waves [src] at you. You feel [pick("funny", "weird", "odd", "strange", "off")].</span>"
 		)

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -422,6 +422,11 @@
 		. = ..()
 		RegisterSignal(src, list(COMSIG_ITEM_ATTACKBY_PRE), .proc/pre_attackby)
 	
+	get_desc()
+		// We display this on a separate line and with a different color to show emphasis
+		. = ..()
+		. += "<br><span class='notice'>Use the Help, Disarm, or Grab intents to scan objects when you click them. Switch to Harm intent to place it on tables, store it in backpacks, and so on.</span>"
+
 	proc/pre_attackby(obj/item/parent_item, atom/A, mob/user)
 		if (user.a_intent == INTENT_HARM)
 			return

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -429,9 +429,9 @@
 			var/obj/O = A
 			if (O.mechanics_blacklist)
 				return
+		do_scan_effects(A, user)
 		if (SEND_SIGNAL(A, COMSIG_ATOM_ANALYZE, parent_item, user))
 			return TRUE
-		do_scan_effects(A, user)
 		boutput(user, "<span class='alert'>The structure of [A] is not compatible with [parent_item].</span>")
 		return TRUE
 	

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -436,10 +436,11 @@
 		return TRUE
 	
 	proc/do_scan_effects(atom/target, mob/user)
+		// more often than not, this will display for objects, but we include a message to scanned mobs just for consistency's sake
 		user.tri_message(target,
 			"<span class='notice'>[user] scans [target].</span>", \
-			"<span class='notice'>You run [src] over [target]...</span>", \
-			"<span class='notice'>[user] waves [src] in your face. You feel [pick("funny", "weird", "odd", "strange", "off")].</span>"
+			"<span class='notice'>You run [src] over [user == target ? "yourself" : target]...</span>", \
+			"<span class='notice'>[user] waves [src] at you. You feel [pick("funny", "weird", "odd", "strange", "off")].</span>"
 		)
 		animate_scanning(target, "#FFFF00")
 

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -417,6 +417,27 @@
 
 	syndicate
 		is_syndicate = 1
+	
+	New()
+		. = ..()
+		RegisterSignal(src, list(COMSIG_ITEM_ATTACKBY_PRE), .proc/pre_attackby)
+	
+	proc/pre_attackby(obj/item/parent_item, atom/A, mob/user)
+		if (user.a_intent == INTENT_HARM)
+			return
+		if (isobj(A))
+			var/obj/O = A
+			if (O.mechanics_blacklist)
+				return
+		if (SEND_SIGNAL(A, COMSIG_ATOM_ANALYZE, parent_item, user))
+			return TRUE
+		do_scan_effects(A, user)
+		boutput(user, "<span class='alert'>The structure of [A] is not compatible with [parent_item].</span>")
+		return TRUE
+	
+	proc/do_scan_effects(atom/target, mob/user)
+		user.visible_message("<span class='notice'>[user] scans [target].</span>", "<span class='notice'>You run [src] over [target]...</span>")
+		animate_scanning(target, "#FFFF00")
 
 ////////////////////////////////////////////////////////////////no
 /obj/machinery/rkit

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -945,7 +945,7 @@
  * blind_message (optional) is what blind people will hear, e.g. "You hear something!"
  * Observers in range of either target will see the message, so the proc can be called on either target
  */
-/atom/proc/tri_message(mob/second_target, viewer_message, first_message, second_message, blind_message)
+/atom/proc/tri_message(atom/second_target, viewer_message, first_message, second_message, blind_message)
 	var/list/source_viewers = AIviewers(Center = src)
 	var/list/target_viewers = AIviewers(Center = second_target)
 	// get a list of all viewers within range of either target, discarding duplicates

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -249,6 +249,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\datums\components\_holdertargeting.dm"
 #include "code\datums\components\_loctargeting.dm"
 #include "code\datums\components\_wearertargeting.dm"
+#include "code\datums\components\analyzable.dm"
 #include "code\datums\components\arable.dm"
 #include "code\datums\components\barber.dm"
 #include "code\datums\components\baseball_bat_reflect.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

* Introduces the `analyzeable` component. when a device analyzer is used on an atom, rather than doing a typecheck followed by a materials check, it will instead check to see if that atom has this component, and if so, attempt to analyze it.
  * This component is currently added to any new `/obj` instance that previously filled the requisite triggers for being analyzeable, but it could be expanded to any other atom types in the future.
* Introduces the `COMSIG_ATOM_ANALYZE` signature, which is sent when a device analyzer is used on an object. The analyzeable component registers a handler for this.
* Introduces the `COMSIG_ITEM_ATTACKBY_PRE` signature, which is sent just before `attackby` is triggered. If a registered handler returns a positive value, the `attackby` will be canceled.
* Moved device analyzer logic from `afterattack`; instead, the analyzers have a listener for `ATTACKBY_PRE` that activates when someone uses the analyzer on something. This prevents the analyzer from doing things like angering Beepsky if a mechanic tries to scan him.
* Adds a `mechanics_blacklist` variable to `/obj` that prevents that object from holding the `analyzeable` component and causes device analyzers to not attempt to scan them. Replaced the analyzer's strict type checks for the ruckingneur kit (probably misspelled that) and object frame by setting this variable to `TRUE` for those objects.
* The device analyzer can \*attempt\* to scan anything, not just `/obj`s. Right now it'll still only give actual results for `/obj` atoms, but it will display the scanning effect on any atom and show silly messages to people who get targeted by the scan.
* A player on harm intent will use the device analyzer to hit things instead of scanning them. This serves a few purposes, like letting you put them into lockers and disposals, onto tables and racks, etc.
* Some general feedback improvements for device analyzer - a beeping sound, message improvements, etc.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

this all started as an attempt to make device analyzers not smack things in the process of scanning them, but I gradually broadened the scope into a more expandable and modular form over the course of developing the PR. making analysis component-based allows it to be expanded to any atom that could benefit from it, with minimal overhead required (via use of things like component subtypes) as well as axing some very janky logic that device analyzers used to use.

one of my concerns here would be if it's unclean to add a component to every atom that could technically be scannable, but my knowledge of the system's inner workings isn't sufficient to say if that would be a real problem or not, so I'd love to hear some second opinions.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ilysen
(+)Device analyzers will no longer attack an object when you scan it, meaning you can scan things without potentially smacking fragile objects, angering Beepsky, etc.
(+)Using a device analyzer on Harm intent will skip the scan and make it function like any other item, meaning you can hit people with it, put it into disposals or on tables, and so on.
(+)Note that due to the above change, you'll need to be on Harm intent to put device analyzers into your bag.
```
