### PR TITLE
Changes the value of several ores, and also shortens the shipping market rollover time and resupply time.

### DIFF
--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -35,14 +35,6 @@
 	upperfluc = 10
 	lowerfluc = 10 */
 
-/datum/commodity/electronics
-	comname = "Electronic Parts"
-	comtype = /obj/item/electronics
-	price = 25
-	baseprice = 25
-	upperfluc = 15
-	lowerfluc = -15
-	onmarket = 1
 
 /datum/commodity/robotics
 	comname = "Robot Parts"

--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -376,7 +376,14 @@
 	baseprice = 3500
 	upperfluc = 5000
 	lowerfluc = -2500
-	onmarket = 1
+/datum/commodity/mat_bar/gold
+	comname = "Gold Bar"
+	comtype = /obj/item/material_piece/gold
+	onmarket = 0
+	price = 3500
+	baseprice = 3500
+	upperfluc = 5000
+	lowerfluc = -2550
 
 /datum/commodity/goldbar
 	comname = "Gold Bullion"

--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -103,6 +103,18 @@
 	lowerfluc = -3
 /// pathology
 
+/datum/commodity/mat_bar
+	comname = "Material Bar"
+	comtype = /obj/item/material_piece
+	desc = "A Material Bar of some type."
+	desc_buy = "The Promethus Consortium is currently gathering resources for a research project and is willing to buy this item"
+	desc_buy_demand = "The colony on Regus X has had their main power reactor break down and need this item for repairs"
+	onmarket = 1
+	price = 70
+	baseprice = 70
+	upperfluc = 30
+	lowerfluc = -30
+
 /datum/commodity/ore // because QMs keep scamming the system, I am lowering the base price of ore way down - cogwerks
 	comname = "Rock"
 	comtype = /obj/item/raw_material
@@ -123,11 +135,27 @@
 	baseprice = 40
 	upperfluc = 60
 	lowerfluc = -20
+/datum/commodity/mat_bar/mauxite
+	comname = "Mauxite Bar"
+	comtype = /obj/item/material_piece/mauxite
+	onmarket = 0
+	price = 40
+	baseprice = 40
+	upperfluc = 60
+	lowerfluc = -20
 
 /datum/commodity/ore/pharosium
 	comname = "Pharosium"
 	comtype = /obj/item/raw_material/pharosium
 	onmarket = 1
+	price = 50
+	baseprice = 50
+	upperfluc = 50
+	lowerfluc = -25
+/datum/commodity/mat_bar/pharosium
+	comname = "Pharosium Bar"
+	comtype = /obj/item/material_piece/pharosium
+	onmarket = 0
 	price = 50
 	baseprice = 50
 	upperfluc = 50
@@ -141,11 +169,27 @@
 	baseprice = 35
 	upperfluc = 50
 	lowerfluc = -25
+/datum/commodity/mat_bar/char
+	comname = "Char Bar"
+	comtype = /obj/item/material_piece/char
+	onmarket = 0
+	price = 35
+	baseprice = 35
+	upperfluc = 50
+	lowerfluc = -25
 
 /datum/commodity/ore/molitz
 	comname = "Molitz"
 	comtype = /obj/item/raw_material/molitz
 	onmarket = 1
+	price = 90
+	baseprice = 90
+	upperfluc = 75
+	lowerfluc = -45
+/datum/commodity/mat_bar/molitz
+	comname = "Molitz Bar"
+	comtype = /obj/item/material_piece/molitz
+	onmarket = 0
 	price = 90
 	baseprice = 90
 	upperfluc = 75
@@ -157,8 +201,16 @@
 	onmarket = 1
 	price = 225
 	baseprice = 225
-	upperfluc = 200
-	lowerfluc = -100
+	upperfluc = 250
+	lowerfluc = -120
+/datum/commodity/mat_bar/cobryl
+	comname = "Cobryl Bar"
+	comtype = /obj/item/material_piece/cobryl
+	onmarket = 0
+	price = 225
+	baseprice = 225
+	upperfluc = 250
+	lowerfluc = -120
 
 /datum/commodity/ore/uqill
 	comname = "Uqill"
@@ -168,14 +220,12 @@
 	baseprice = 750
 	upperfluc = 1000
 	lowerfluc = -500
-
-/datum/commodity/ore/telecrystal
-	comname = "Telecrystal"
-	comtype = /obj/item/raw_material/telecrystal
-	desc = "A large unprocessed telecrystal, a gemstone with space-warping properties."
-	onmarket = 1
-	price = 1000
-	baseprice = 1000
+/datum/commodity/mat_bar/uqill
+	comname = "Uqill Bar"
+	comtype = /obj/item/material_piece/uqill
+	onmarket = 0
+	price = 750
+	baseprice = 750
 	upperfluc = 1000
 	lowerfluc = -500
 
@@ -187,20 +237,27 @@
 	baseprice = 60
 	upperfluc = 50
 	lowerfluc = -30
-
-/datum/commodity/ore/koshmarite
-	comname = "Koshmarite"
-	comtype = /obj/item/raw_material/eldritch
-	onmarket = 1
-	price = 175
-	baseprice = 175
-	upperfluc = 125
-	lowerfluc = -75
+/datum/commodity/mat_bar/fibrilith
+	comname = "Fibrilith Block"
+	comtype = /obj/item/material_piece/fibrilith
+	onmarket = 0
+	price = 60
+	baseprice = 60
+	upperfluc = 50
+	lowerfluc = -30
 
 /datum/commodity/ore/viscerite
 	comname = "Viscerite"
 	comtype = /obj/item/raw_material/martian
 	onmarket = 1
+	price = 150
+	baseprice = 150
+	upperfluc = 100
+	lowerfluc = -50
+/datum/commodity/mat_bar/viscerite
+	comname = "Viscerite Block"
+	comtype = /obj/item/material_piece/viscerite
+	onmarket = 0
 	price = 150
 	baseprice = 150
 	upperfluc = 100
@@ -214,6 +271,14 @@
 	baseprice = 200
 	upperfluc = 200
 	lowerfluc = -100
+/datum/commodity/mat_bar/bohrum
+	comname = "Bohrum Bar"
+	comtype = /obj/item/material_piece/bohrum
+	onmarket = 0
+	price = 200
+	baseprice = 200
+	upperfluc = 200
+	lowerfluc = -100
 
 /datum/commodity/ore/claretine
 	comname = "Claretine"
@@ -222,6 +287,48 @@
 	price = 350
 	baseprice = 350
 	upperfluc = 200
+	lowerfluc = -200
+/datum/commodity/mat_bar/claretine
+	comname = "Claretine Bar"
+	comtype = /obj/item/material_piece/claretine
+	onmarket = 0
+	price = 350
+	baseprice = 350
+	upperfluc = 200
+	lowerfluc = -200
+
+/datum/commodity/ore/koshmarite
+	comname = "Koshmarite"
+	comtype = /obj/item/raw_material/eldritch
+	onmarket = 1
+	price = 175
+	baseprice = 175
+	upperfluc = 125
+	lowerfluc = -75
+/datum/commodity/mat_bar/koshmarite
+	comname = "Koshmarite Block"
+	comtype = /obj/item/material_piece/koshmarite
+	onmarket = 0
+	price = 175
+	baseprice = 175
+	upperfluc = 125
+	lowerfluc = -75
+
+/datum/commodity/ore/cerenkite
+	comname = "Cerenkite"
+	comtype = /obj/item/raw_material/cerenkite
+	onmarket = 1
+	price = 500
+	baseprice = 500
+	upperfluc = 250
+	lowerfluc = -200
+/datum/commodity/mat_bar/cerenkite
+	comname = "Cerenkite Bar"
+	comtype = /obj/item/material_piece/cerenkite
+	onmarket = 0
+	price = 500
+	baseprice = 500
+	upperfluc = 250
 	lowerfluc = -200
 
 /datum/commodity/ore/erebite
@@ -232,13 +339,12 @@
 	baseprice = 650
 	upperfluc = 200
 	lowerfluc = -200
-
-/datum/commodity/ore/cerenkite
-	comname = "Cerenkite"
-	comtype = /obj/item/raw_material/cerenkite
-	onmarket = 1
-	price = 480
-	baseprice = 480
+/datum/commodity/mat_bar/erebite
+	comname = "Erebite Bar"
+	comtype = /obj/item/material_piece/erebite
+	onmarket = 0
+	price = 650
+	baseprice = 650
 	upperfluc = 200
 	lowerfluc = -200
 
@@ -250,11 +356,45 @@
 	baseprice = 550
 	upperfluc = 200
 	lowerfluc = -200
+/datum/commodity/mat_bar/plasmastone
+	comname = "Plasmastone Bar"
+	comtype = /obj/item/material_piece/plasmastone
+	onmarket = 0
+	price = 550
+	baseprice = 550
+	upperfluc = 200
+	lowerfluc = -200
+
+/datum/commodity/ore/telecrystal
+	comname = "Telecrystal"
+	comtype = /obj/item/raw_material/telecrystal
+	desc = "A large unprocessed telecrystal, a gemstone with space-warping properties."
+	onmarket = 1
+	price = 1000
+	baseprice = 1000
+	upperfluc = 1000
+	lowerfluc = -500
+/datum/commodity/mat_bar/telecrystal
+	comname = "Telecrystal Block"
+	comtype = /obj/item/material_piece/telecrystal
+	onmarket = 0
+	price = 1000
+	baseprice = 1000
+	upperfluc = 1000
+	lowerfluc = -500
 
 /datum/commodity/ore/syreline
 	comname = "Syreline"
 	comtype = /obj/item/raw_material/syreline
 	onmarket = 1
+	price = 800
+	baseprice = 800
+	upperfluc = 1000
+	lowerfluc = -300
+/datum/commodity/mat_bar/syreline
+	comname = "Syreline Bar"
+	comtype = /obj/item/material_piece/syreline
+	onmarket = 0
 	price = 800
 	baseprice = 800
 	upperfluc = 1000

--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -103,18 +103,6 @@
 	lowerfluc = -3
 /// pathology
 
-/datum/commodity/mat_bar
-	comname = "Material Bar"
-	comtype = /obj/item/material_piece
-	desc = "A Material Bar of some type."
-	desc_buy = "The Promethus Consortium is currently gathering resources for a research project and is willing to buy this item"
-	desc_buy_demand = "The colony on Regus X has had their main power reactor break down and need this item for repairs"
-	onmarket = 1
-	price = 70
-	baseprice = 70
-	upperfluc = 30
-	lowerfluc = -30
-
 /datum/commodity/ore // because QMs keep scamming the system, I am lowering the base price of ore way down - cogwerks
 	comname = "Rock"
 	comtype = /obj/item/raw_material
@@ -131,19 +119,19 @@
 	comname = "Mauxite"
 	comtype = /obj/item/raw_material/mauxite
 	onmarket = 1
-/datum/commodity/mat_bar/mauxite
-	comname = "Mauxite Bar"
-	comtype = /obj/item/material_piece/mauxite
-	onmarket = 0
+	price = 40
+	baseprice = 40
+	upperfluc = 60
+	lowerfluc = -20
 
 /datum/commodity/ore/pharosium
 	comname = "Pharosium"
 	comtype = /obj/item/raw_material/pharosium
 	onmarket = 1
-/datum/commodity/mat_bar/pharosium
-	comname = "Pharosium Bar"
-	comtype = /obj/item/material_piece/pharosium
-	onmarket = 0
+	price = 50
+	baseprice = 50
+	upperfluc = 50
+	lowerfluc = -25
 
 /datum/commodity/ore/char
 	comname = "Char"
@@ -153,38 +141,22 @@
 	baseprice = 35
 	upperfluc = 50
 	lowerfluc = -25
-/datum/commodity/mat_bar/char
-	comname = "Char Bar"
-	comtype = /obj/item/material_piece/char
-	onmarket = 0
-	price = 35
-	baseprice = 35
-	upperfluc = 50
-	lowerfluc = -25
 
 /datum/commodity/ore/molitz
 	comname = "Molitz"
 	comtype = /obj/item/raw_material/molitz
 	onmarket = 1
-/datum/commodity/mat_bar/molitz
-	comname = "Molitz Bar"
-	comtype = /obj/item/material_piece/molitz
-	onmarket = 0
+	price = 90
+	baseprice = 90
+	upperfluc = 75
+	lowerfluc = -45
 
 /datum/commodity/ore/cobryl
 	comname = "Cobryl"
 	comtype = /obj/item/raw_material/cobryl
 	onmarket = 1
-	price = 200
-	baseprice = 200
-	upperfluc = 200
-	lowerfluc = -100
-/datum/commodity/mat_bar/cobryl
-	comname = "Cobryl Bar"
-	comtype = /obj/item/material_piece/cobryl
-	onmarket = 0
-	price = 200
-	baseprice = 200
+	price = 225
+	baseprice = 225
 	upperfluc = 200
 	lowerfluc = -100
 
@@ -192,14 +164,6 @@
 	comname = "Uqill"
 	comtype = /obj/item/raw_material/uqill
 	onmarket = 1
-	price = 750
-	baseprice = 750
-	upperfluc = 1000
-	lowerfluc = -500
-/datum/commodity/mat_bar/uqill
-	comname = "Uqill Bar"
-	comtype = /obj/item/material_piece/uqill
-	onmarket = 0
 	price = 750
 	baseprice = 750
 	upperfluc = 1000
@@ -214,55 +178,31 @@
 	baseprice = 1000
 	upperfluc = 1000
 	lowerfluc = -500
-/datum/commodity/mat_bar/telecrystal
-	comname = "Telecrystal Block"
-	comtype = /obj/item/material_piece/telecrystal
-	onmarket = 0
-	price = 1000
-	baseprice = 1000
-	upperfluc = 1000
-	lowerfluc = -500
 
 /datum/commodity/ore/fibrilith // why is this worth a ton of money?? dropping the value to further upset QMs
 	comname = "Fibrilith"
 	comtype = /obj/item/raw_material/fibrilith
 	onmarket = 1
-/datum/commodity/mat_bar/fibrilith
-	comname = "Fibrilith Block"
-	comtype = /obj/item/material_piece/fibrilith
-	onmarket = 0
+	price = 60
+	baseprice = 60
+	upperfluc = 50
+	lowerfluc = -30
 
 /datum/commodity/ore/koshmarite
 	comname = "Koshmarite"
 	comtype = /obj/item/raw_material/eldritch
 	onmarket = 1
-	price = 100
-	baseprice = 100
-	upperfluc = 100
-	lowerfluc = -50
-/datum/commodity/mat_bar/koshmarite
-	comname = "Koshmarite Block"
-	comtype = /obj/item/material_piece/koshmarite
-	onmarket = 0
-	price = 100
-	baseprice = 100
-	upperfluc = 100
-	lowerfluc = -50
+	price = 175
+	baseprice = 175
+	upperfluc = 125
+	lowerfluc = -75
 
 /datum/commodity/ore/viscerite
 	comname = "Viscerite"
 	comtype = /obj/item/raw_material/martian
 	onmarket = 1
-	price = 100
-	baseprice = 100
-	upperfluc = 100
-	lowerfluc = -50
-/datum/commodity/mat_bar/viscerite
-	comname = "Viscerite Block"
-	comtype = /obj/item/material_piece/viscerite
-	onmarket = 0
-	price = 100
-	baseprice = 100
+	price = 150
+	baseprice = 150
 	upperfluc = 100
 	lowerfluc = -50
 
@@ -270,14 +210,6 @@
 	comname = "Bohrum"
 	comtype = /obj/item/raw_material/bohrum
 	onmarket = 1
-	price = 200
-	baseprice = 200
-	upperfluc = 200
-	lowerfluc = -100
-/datum/commodity/mat_bar/bohrum
-	comname = "Bohrum Bar"
-	comtype = /obj/item/material_piece/bohrum
-	onmarket = 0
 	price = 200
 	baseprice = 200
 	upperfluc = 200
@@ -291,27 +223,11 @@
 	baseprice = 350
 	upperfluc = 200
 	lowerfluc = -200
-/datum/commodity/mat_bar/claretine
-	comname = "Claretine Bar"
-	comtype = /obj/item/material_piece/claretine
-	onmarket = 0
-	price = 350
-	baseprice = 350
-	upperfluc = 200
-	lowerfluc = -200
 
 /datum/commodity/ore/erebite
 	comname = "Erebite"
 	comtype = /obj/item/raw_material/erebite
 	onmarket = 1
-	price = 650
-	baseprice = 650
-	upperfluc = 200
-	lowerfluc = -200
-/datum/commodity/mat_bar/erebite
-	comname = "Erebite Bar"
-	comtype = /obj/item/material_piece/erebite
-	onmarket = 0
 	price = 650
 	baseprice = 650
 	upperfluc = 200
@@ -325,27 +241,11 @@
 	baseprice = 480
 	upperfluc = 200
 	lowerfluc = -200
-/datum/commodity/mat_bar/cerenkite
-	comname = "Cerenkite Bar"
-	comtype = /obj/item/material_piece/cerenkite
-	onmarket = 0
-	price = 650
-	baseprice = 650
-	upperfluc = 200
-	lowerfluc = -200
 
 /datum/commodity/ore/plasmastone
 	comname = "Plasmastone"
 	comtype = /obj/item/raw_material/plasmastone
 	onmarket = 1
-	price = 550
-	baseprice = 550
-	upperfluc = 200
-	lowerfluc = -200
-/datum/commodity/mat_bar/plasmastone
-	comname = "Plasmastone Bar"
-	comtype = /obj/item/material_piece/plasmastone
-	onmarket = 0
 	price = 550
 	baseprice = 550
 	upperfluc = 200
@@ -359,14 +259,6 @@
 	baseprice = 800
 	upperfluc = 1000
 	lowerfluc = -300
-/datum/commodity/mat_bar/syreline
-	comname = "Syreline Bar"
-	comtype = /obj/item/material_piece/syreline
-	onmarket = 0
-	price = 800
-	baseprice = 800
-	upperfluc = 1000
-	lowerfluc = -300
 
 /datum/commodity/ore/gold
 	comname = "Gold Nugget"
@@ -376,14 +268,6 @@
 	baseprice = 3500
 	upperfluc = 5000
 	lowerfluc = -2500
-/datum/commodity/mat_bar/gold
-	comname = "Gold Bar"
-	comtype = /obj/item/material_piece/gold
-	onmarket = 0
-	price = 3500
-	baseprice = 3500
-	upperfluc = 5000
-	lowerfluc = -2550
 
 /datum/commodity/goldbar
 	comname = "Gold Bullion"

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -73,8 +73,8 @@
 
 		update_shipping_data()
 
-		time_between_shifts = 6000 // 10 minutes
-		time_until_shift = time_between_shifts + rand(-900,1200)
+		time_between_shifts = 4500 // 7.5 minutes base.
+		time_until_shift = time_between_shifts + rand(-1500,1500)
 
 	proc/add_commodity(var/datum/commodity/new_c)
 		src.commodities["[new_c.comtype]"] = new_c
@@ -258,7 +258,7 @@
 		// send artifact resupply
 		if(src.artifact_resupply_amount > 1 && !src.artifacts_on_the_way)
 			src.artifacts_on_the_way = TRUE
-			SPAWN(rand(1,5) MINUTES)
+			SPAWN(1 MINUTES)
 				// handle the artifact amount
 				var/art_amount = round(artifact_resupply_amount)
 				artifact_resupply_amount -= art_amount

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -258,7 +258,7 @@
 		// send artifact resupply
 		if(src.artifact_resupply_amount > 1 && !src.artifacts_on_the_way)
 			src.artifacts_on_the_way = TRUE
-			SPAWN(1 MINUTES)
+			SPAWN(30 SECONDS)
 				// handle the artifact amount
 				var/art_amount = round(artifact_resupply_amount)
 				artifact_resupply_amount -= art_amount

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -258,7 +258,7 @@
 		// send artifact resupply
 		if(src.artifact_resupply_amount > 1 && !src.artifacts_on_the_way)
 			src.artifacts_on_the_way = TRUE
-			SPAWN(30 SECONDS)
+			SPAWN(1 MINUTES)
 				// handle the artifact amount
 				var/art_amount = round(artifact_resupply_amount)
 				artifact_resupply_amount -= art_amount


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] [QOL][BALANCE]-->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes several of the ore commodity values so they are more unique instead of using a standard value of 70, and slightly buffs some of the preexisting values to create a bit more interest in them. It also lowers the artifact resupply from rand(1,5) to a flat 1 minute, and changes the shipping market rollover to 7.5 minutes with a variable 2 and a half minutes. 

Oh, also removes the electronics commodity because literally nobody ever used it and it's kind of a holdover from old good, from what I'm told.

Planning to do some more significant changes to cargo, but unfortunately I'm not particularly good at coding and honestly it's kind of hard to figure out how to fix some of the issues I'd like to fix. Until I figure those out, I figured I'd PR the existing changes i have since they're fairly simple and don't affect gameplay terribly.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The ore changes were because having several ores at a default value just didn't look very nice visually and didn't feel great gameplay wise either, and i think this gives just a little bit more interest in actually selling spare ores if they're hot. The changes to the shipping market time were based off of a lot of complaints about how long the market can be on an unfavourable roll, and how it can be pretty boring just waiting for another shift. 

I had planned to make it so the market has a shift immediately upon a round start, but uh, haven't figured out how to actually do that yet, nor have I figured out how to make material bars sell as the material. 🐝 

The resupply time was changed just because I think it's not a great idea to have a random time on something that somebody relies on to do their job, especially when they've already fulfilled all the requirements to actually receive their resupply. It's not instant because there are some advantages to having a small window of time to put out several artifacts at once to rack up the artifact resupply value, though.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Moberry
(*)The Shipping Market uptime has been reduced from 12-9 minutes to 10-5 minutes.
(+)Rebalances some commodity values, and removes the electronics commodity from the shipping market. Changes the artifact resupply timer to a flat one minute.
```
