### PR TITLE
Makes Masquerade masks actually hide your face

### DIFF
--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -618,9 +618,11 @@
 	desc = "A mask. Specifically for masquerades."
 	icon_state = "cherryblossom"
 	item_state = "cherryblossom"
+	see_face = 0
 
 /obj/item/clothing/mask/peacockmask
 	name = "peacock mask"
 	desc = "A mask. Specifically for masquerades."
 	icon_state = "peacock"
 	item_state = "peacock"
+	see_face = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Simply added "see_face = 0" to the two masquerade masks (Cherryblossom and Peacock), hiding the faces of the wearer


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The whole point of masquerade masks was to hide your face, so the ones in-game should reflect this quality