### PR TITLE
Moved Horizon arrivals podbay hangar button so it wouldn't be floating in space

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -6750,13 +6750,7 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quartersB)
 "asL" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/obj/machinery/r_door_control/podbay/mainpod1/new_walls/west{
-	pixel_x = 0
-	},
+/obj/machinery/r_door_control/podbay/mainpod1/new_walls/south,
 /turf/space,
 /area/space)
 "asM" = (
@@ -94888,8 +94882,8 @@ aaa
 aaa
 aaa
 aaa
+aal
 asL
-aaa
 arQ
 ash
 bBY


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the hangar bay door control button slightly lower at the arrivals pod bay in Horizon so it wouldn't be floating in space
Fixes #9282

Before:
![Before](https://user-images.githubusercontent.com/97562733/175607165-a67a8998-711b-473c-9035-27b36b0ee570.PNG)

After:
![After](https://user-images.githubusercontent.com/97562733/175607212-ba7bdf1f-0c9d-4e74-a6f0-a0a867f5e3a7.PNG)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes very little sense why the hangar door button should be floating in space, so I moved it onto the wall next to the hangar door

