### PR TITLE
nukie gas mask fully blocks skinpen

### DIFF
--- a/code/obj/item/clothing/masks.dm
+++ b/code/obj/item/clothing/masks.dm
@@ -213,6 +213,7 @@
 
 		New()
 			..()
+			setProperty("chemprot", 100) // this makes no sense but balance > logic
 			START_TRACKING_CAT(TR_CAT_NUKE_OP_STYLE)
 
 		disposing()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
nukies were meant to be chemproof but the replacement of permability with chemprot fucked it up, this fixes it
## Why's this needed? <!-- Describe why you think this should be added to the game. -->

sarin grenade friendly fire now happens even with internals on this is very bad and you dont want chemnerds hellmixing nukies either

i also **think** the removal of full skinpen protection from nukies was not intended and therefore its likely a bug fix too

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+) The Syndicate has somehow upgraded the gas masks of nuclear operatives to fully block skin penetration of chemicals.
```
