### PR TITLE
Removes penlight flash effect.

### DIFF
--- a/code/modules/medical/surgery_tools.dm
+++ b/code/modules/medical/surgery_tools.dm
@@ -1413,9 +1413,6 @@ CONTAINS:
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
 
-			if (!H.blinded) // can't see the light if you can't see shit else!!
-				H.vision.flash(src.anim_duration)
-
 			if (istype(H.glasses) && !istype(H.glasses, /obj/item/clothing/glasses/regular) && H.glasses.c_flags & COVERSEYES) // check all the normal things that could cover eyes
 				results_msg = "&emsp;<span class='alert'>It's hard to accurately judge how [H]'s eyes reacted through [his_or_her(H)] [H.glasses.name]!</span>"
 			else if (istype(H.wear_mask) && H.wear_mask.c_flags & COVERSEYES)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the grody and old code flash effect from pen lights. Did you know it only checked if the mob was blind and nothing else for the flash effect?


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The effect is not blocked by eyewear nor is there a limit on how many times you can do it. On top of that it purely serves as a punishment to a player that a doctor decides to do things the old fashioned way. Instead of using an objectively superior medical scanner.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)Removed the penlight flash effect
```
