### PR TITLE
Kondaru Red Floor Crosses to Blue 

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -18624,7 +18624,7 @@
 	icon_state = "on";
 	on = 1
 	},
-/turf/simulated/floor/red,
+/turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "bcR" = (
 /obj/disposalpipe/segment/vertical,
@@ -19232,7 +19232,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /obj/machinery/light/small/floor/netural,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/bluewhite{
 	dir = 1
 	},
 /area/station/medical/medbay)
@@ -24150,7 +24150,7 @@
 /area/station/storage/eva)
 "bwe" = (
 /obj/disposalpipe/segment/mail/vertical,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/bluewhite{
 	dir = 10
 	},
 /area/station/medical/medbooth)
@@ -24164,7 +24164,7 @@
 	dir = 8;
 	pixel_x = 8
 	},
-/turf/simulated/floor/redwhite/corner{
+/turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
 /area/station/medical/medbooth)
@@ -24416,7 +24416,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/bluewhite{
 	dir = 8
 	},
 /area/station/medical/medbooth)
@@ -24851,7 +24851,7 @@
 /turf/simulated/floor/darkblue,
 /area/station/medical/medbay/pharmacy)
 "byz" = (
-/turf/simulated/floor/redwhite,
+/turf/simulated/floor/bluewhite,
 /area/station/medical/medbooth)
 "byB" = (
 /obj/landmark/magnet_center,
@@ -33256,7 +33256,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/device/radio/beacon,
-/turf/simulated/floor/red,
+/turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "bZl" = (
 /obj/table/auto,
@@ -40726,7 +40726,7 @@
 /turf/simulated/floor/engine,
 /area/station/security/secwing)
 "dOy" = (
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/bluewhite{
 	dir = 8
 	},
 /area/station/medical/medbay)
@@ -44763,7 +44763,7 @@
 	name = "Medical Doctor"
 	},
 /obj/disposalpipe/segment/morgue,
-/turf/simulated/floor/redwhite{
+/turf/simulated/floor/bluewhite{
 	dir = 4
 	},
 /area/station/medical/medbay)
@@ -44965,7 +44965,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/redwhite,
+/turf/simulated/floor/bluewhite,
 /area/station/medical/medbay)
 "hQg" = (
 /obj/table/auto,
@@ -48561,7 +48561,7 @@
 "lGK" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/disposalpipe/segment/horizontal,
-/turf/simulated/floor/redwhite/corner{
+/turf/simulated/floor/bluewhite/corner{
 	dir = 4
 	},
 /area/station/medical/medbooth)
@@ -57285,7 +57285,7 @@
 /turf/simulated/floor/grey,
 /area/station/crew_quarters/catering)
 "urd" = (
-/turf/simulated/floor/red,
+/turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "ury" = (
 /obj/grille/catwalk{
@@ -60974,7 +60974,7 @@
 /area/station/mining/magnet)
 "xQE" = (
 /obj/machinery/atmospherics/pipe/simple,
-/turf/simulated/floor/red,
+/turf/simulated/floor/blue,
 /area/station/medical/medbay)
 "xQK" = (
 /obj/table/reinforced/bar/auto,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the red floor crosses in Kondaru to blue versions, keeping in line with other changes we are doing in regards to red crosses. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Please do not violate the Geneva Conventions.

![unknown (9)](https://user-images.githubusercontent.com/105123457/176003269-82d1ea00-4957-418b-b45c-0ab18d6c9dcd.png)
![unknown (10)](https://user-images.githubusercontent.com/105123457/176003300-e5b769e9-cbd1-4814-ba6c-6c2345234308.png)

