### PR TITLE
monkeys drop items when meatspiked

### DIFF
--- a/code/obj/kitchenspike.dm
+++ b/code/obj/kitchenspike.dm
@@ -35,6 +35,7 @@
 			src.visible_message("<span class='alert'>[user] forces [victim] onto the spike, killing [him_or_her(victim)] instantly!</span>")
 		else
 			src.visible_message("<span class='alert'>[victim] is impaled on the spikes, instantly killing [him_or_her(victim)]!")
+		victim.unequip_all()
 		qdel(victim)
 		JOB_XP(user, "Chef", 2)
 		return TRUE


### PR DESCRIPTION
## About the PR
monkeys and meatspikes are both older than the concept of monkeys having an inventory. the meatspike will now correctly drop the monkeys inventory on spike



## Why's this needed? 
its a bug


## Changelog
```changelog
(u)singh
(+)Monkeys will now drop their inventory when meat spiked
```

