### PR TITLE
Gives the radio show host headphones 20% ear disorient resistance

### DIFF
--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -139,6 +139,10 @@
 	icon_override = "rh"
 	icon_tooltip = "Radio Show Host"
 
+	set_Properties()
+		..()
+		setProperty("disorient_resist_ear", 20)
+
 /obj/item/device/radio/headset/command/comm_officer
 	name = "communications officer's headset"
 	desc = "Used by the communications officer, this headset can communicate over multiple secure frequencies. These things have been a rare sight as of late."

--- a/code/obj/item/device/radios/headsets.dm
+++ b/code/obj/item/device/radios/headsets.dm
@@ -139,7 +139,7 @@
 	icon_override = "rh"
 	icon_tooltip = "Radio Show Host"
 
-	set_Properties()
+	setupProperties()
 		..()
 		setProperty("disorient_resist_ear", 20)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Grants the radio show host 20% resistance to ear disorient. This should give the radio show host a bit more flavour on their headphones and make them more headphone-like.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It makes a bit of sense. Headphones block out noise, but not all of it.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)Made the radio show host headphones more protective against loud noises.
```
