### PR TITLE
removes co2 canisters from battle royale

### DIFF
--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -106,6 +106,8 @@ var/global/area/current_battle_spawn = null
 				qdel(MAC)
 			if (/obj/machinery/portable_atmospherics/canister/toxins)
 				qdel(MAC)
+			if (/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
+				qdel(MAC)
 			if (/obj/machinery/teleport/portal_generator)
 				qdel(MAC)
 			if (/obj/machinery/bot/secbot)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BALANCE] -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes co2 canisters from battle royale


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
practically the same reason plasma was removed from BR, people dont even spawn with internals on that gamemode
