### PR TITLE
QM Shipping Market Tweaks

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -73,8 +73,8 @@
 
 		update_shipping_data()
 
-		time_between_shifts = 6000 // 10 minutes
-		time_until_shift = time_between_shifts + rand(-900,1200)
+		time_between_shifts = 4500 // 7.5 minutes base.
+		time_until_shift = time_between_shifts + rand(-1500,1500)
 
 	proc/add_commodity(var/datum/commodity/new_c)
 		src.commodities["[new_c.comtype]"] = new_c
@@ -258,7 +258,7 @@
 		// send artifact resupply
 		if(src.artifact_resupply_amount > 1 && !src.artifacts_on_the_way)
 			src.artifacts_on_the_way = TRUE
-			SPAWN(rand(1,5) MINUTES)
+			SPAWN(1 MINUTES)
 				// handle the artifact amount
 				var/art_amount = round(artifact_resupply_amount)
 				artifact_resupply_amount -= art_amount


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][BALANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes the shipping market timer from 12-9 minutes to 10-5 minutes, and changes the rand(1,5) on the artifact resupply crate to a flat 1 minute.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A lot of people complain about the dead time on rolling a bad market, as it's essentially 1/4th of the shift you'll be waiting. Generally I want to spice this up by making them move faster and have a quicker market shift, to make QM faster paced. Hopefully this will make players more interested in garnering money throughout the shift instead of spending twelve minutes smashing through as many crates as possible to make all the money they need immediately on a decent shift, as that gameplay kind of sucks. This won't stop that entirely, just make more avenues to sell on, though.

The resupply changes are to remove the randomness on receiving your reward, as they've already "done" all the hard parts of the artifact selling. I think making it a flat time will help players be punctual and waste less time just tapping their foot waiting, which i don't think many enjoy.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Moberry
(*)Changes the shipping market timer from 12-9 minutes to 10-5 minutes.
(+)Artifact Resupply is now a flat one minute delay.
```
