### PR TITLE
Removes spare id purchase from random merchants.

### DIFF
--- a/code/modules/economy/shady_robot.dm
+++ b/code/modules/economy/shady_robot.dm
@@ -91,7 +91,7 @@
 
 	var/num_common_products = 13 //how many of these to pick for sale
 
-	var/list/rare_products = list(/datum/commodity/contraband/radiojammer,/datum/commodity/contraband/stealthstorage,/datum/commodity/medical/injectorbelt,/datum/commodity/medical/injectormask,/datum/commodity/junk/voltron,/datum/commodity/laser_gun,/datum/commodity/relics/crown,/datum/commodity/contraband/egun,/datum/commodity/relics/armor,/datum/commodity/contraband/spareid,/datum/commodity/contraband/voicechanger,/datum/commodity/contraband/chamsuit,/datum/commodity/contraband/dnascram)
+	var/list/rare_products = list(/datum/commodity/contraband/radiojammer,/datum/commodity/contraband/stealthstorage,/datum/commodity/medical/injectorbelt,/datum/commodity/medical/injectormask,/datum/commodity/junk/voltron,/datum/commodity/laser_gun,/datum/commodity/relics/crown,/datum/commodity/contraband/egun,/datum/commodity/relics/armor,/datum/commodity/contraband/voicechanger,/datum/commodity/contraband/chamsuit,/datum/commodity/contraband/dnascram)
 	var/num_rare_products = 2 //how many of these to pick for sale
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the spare ID purchase from random merchants that appear on the station. This should lower the amount of times that all access spreads like a plague while nobody gave it/stole it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
All access is really kinda silly to be able to buy for a plethora of reasons. For example, you can steal from the budgets and salaries of crewmembers thus being able to circumvent limitations on funds (pretty bad for a something to buy from a merchant!). You could also make a bajillion more all access IDs, and we all know how that usually goes. 
