### PR TITLE
Meson goggles and welding masks immediately update their wearer's sprite when toggled

### DIFF
--- a/code/obj/item/clothing/glasses.dm
+++ b/code/obj/item/clothing/glasses.dm
@@ -60,7 +60,7 @@
 		..() //if not selecting the head of a human or monkey, just do normal attack.
 
 /obj/item/clothing/glasses/meson
-	name = "Meson Goggles"
+	name = "meson goggles"
 	icon_state = "meson"
 	var/base_state = "meson"
 	item_state = "glasses"
@@ -82,8 +82,8 @@
 	proc/toggle(var/mob/toggler)
 		src.on = !src.on
 		src.item_state = "[src.base_state][src.on ? null : "-off"]"
-		toggler.set_clothing_icon_dirty()
 		set_icon_state("[src.base_state][src.on ? null : "-off"]")
+		toggler.update_clothing()
 		playsound(src, "sound/items/mesonactivate.ogg", 30, 1)
 		if (ishuman(toggler))
 			var/mob/living/carbon/human/H = toggler

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -676,7 +676,7 @@
 		color_r = initial(color_r) // darken
 		color_g = initial(color_g)
 		color_b = initial(color_b)
-		user.set_clothing_icon_dirty()
+		user.update_clothing()
 
 		src.c_flags |= (COVERSEYES | BLOCKCHOKE)
 		setProperty("meleeprot_head", 1)
@@ -690,7 +690,7 @@
 		color_r = 1 // no effect
 		color_g = 1
 		color_b = 1
-		user.set_clothing_icon_dirty()
+		user.update_clothing()
 
 		src.c_flags &= ~(COVERSEYES | BLOCKCHOKE)
 		setProperty("meleeprot_head", 4)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

See title. Also lowercases the name of meson goggles, since I'm a rebel. I was also going to do this with some medal rewards like Fish, only to discover that it was a giant if-else chain that manually changed names and such (WHHYYY???) so I held off.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The icon state updates instantly for the item's sprite itself, but the wearer's actual appearance only updates on the next life cycle. The delay looks a bit strange, and I'm hoping that making it immediate will bring it in line with other stuff.

