### PR TITLE
Fixes welding mask vision tint being toggleable

### DIFF
--- a/code/mob/living/life/hud.dm
+++ b/code/mob/living/life/hud.dm
@@ -33,19 +33,19 @@
 			var/color_mod_r = 255
 			var/color_mod_g = 255
 			var/color_mod_b = 255
-			if ( human_owner.client.view_tint )
-				if (istype(human_owner.glasses))
-					color_mod_r *= human_owner.glasses.color_r
-					color_mod_g *= human_owner.glasses.color_g
-					color_mod_b *= human_owner.glasses.color_b
-				if (istype(human_owner.wear_mask))
-					color_mod_r *= human_owner.wear_mask.color_r
-					color_mod_g *= human_owner.wear_mask.color_g
-					color_mod_b *= human_owner.wear_mask.color_b
-				if (istype(human_owner.head))
-					color_mod_r *= human_owner.head.color_r
-					color_mod_g *= human_owner.head.color_g
-					color_mod_b *= human_owner.head.color_b
+			if (istype(human_owner.glasses) && (human_owner.client.view_tint || human_owner.glasses.bypass_view_tint))
+				color_mod_r *= human_owner.glasses.color_r
+				color_mod_g *= human_owner.glasses.color_g
+				color_mod_b *= human_owner.glasses.color_b
+			if (istype(human_owner.wear_mask) && (human_owner.client.view_tint || human_owner.wear_mask.bypass_view_tint))
+				color_mod_r *= human_owner.wear_mask.color_r
+				color_mod_g *= human_owner.wear_mask.color_g
+				color_mod_b *= human_owner.wear_mask.color_b
+			if (istype(human_owner.head) && (human_owner.client.view_tint || human_owner.head.bypass_view_tint))
+				color_mod_r *= human_owner.head.color_r
+				color_mod_g *= human_owner.head.color_g
+				color_mod_b *= human_owner.head.color_b
+			if (human_owner.client.view_tint)
 				var/obj/item/organ/eye/L_E = human_owner.get_organ("left_eye")
 				if (istype(L_E))
 					color_mod_r *= L_E.color_r

--- a/code/obj/item/clothing.dm
+++ b/code/obj/item/clothing.dm
@@ -9,6 +9,9 @@
 	//var/c_flags = null // these don't need to be in the general flags when they only apply to clothes  :I
 	// mbc moived c flags up to item bewcause some wearaables things are items and not clothign :)
 
+	///Bypass client view tint settings, for things like welding masks
+	var/bypass_view_tint = FALSE
+
 	var/color_r = 1 // used for vision stuff, see human/handle_regular_hud_updates()
 	var/color_g = 1 // (why were these only on crafted glasses?  they could have just been used on the parent like this from the start  :V)
 	var/color_b = 1

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -659,6 +659,7 @@
 	m_amt = 3000
 	g_amt = 1000
 	var/up = FALSE // The helmet's current position
+	bypass_view_tint = TRUE
 	color_r = 0.3 // darken
 	color_g = 0.3
 	color_b = 0.3


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the welding mask screen tint override client settings on screen tint.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The setting is there to prevent the slight colour tints from obscuring your vision, the welding mask is very much supposed to obscure your vision, therefore shouldn't be included.
Also this is basically a direct revs buff.