### PR TITLE
changeling regenerative statis changes

### DIFF
--- a/code/modules/antagonists/changeling/abilities/regeneration.dm
+++ b/code/modules/antagonists/changeling/abilities/regeneration.dm
@@ -50,7 +50,8 @@
 					C.change_misstep_chance(-INFINITY)
 					C.take_oxygen_deprivation(-INFINITY)
 					C.delStatus("drowsy")
-					c.delStatus("n_radiation")
+					C.delStatus("passing_out")
+					C.delStatus("n_radiation")
 					C.delStatus("paralysis")
 					C.delStatus("slowed")
 					C.delStatus("stunned")
@@ -71,6 +72,11 @@
 							C.implant.Remove(I)
 							I.set_loc(C.loc)
 							continue
+					if(C.bioHolder?.effects && length(C.bioHolder.effects))
+						for(var/bioEffectId in C.bioHolder.effects)
+							var/datum/bioEffect/gene = C.bioHolder.GetEffect(bioEffectId)
+							if (gene.curable_by_mutadone && gene.effectType == EFFECT_TYPE_DISABILITY)
+								C.bioHolder.RemoveEffect(gene.id)
 
 				C.set_clothing_icon_dirty()
 				H.in_fakedeath = 0

--- a/code/modules/antagonists/changeling/abilities/regeneration.dm
+++ b/code/modules/antagonists/changeling/abilities/regeneration.dm
@@ -47,11 +47,16 @@
 					C.HealDamage("All", 1000, 1000)
 					C.take_brain_damage(-INFINITY)
 					C.take_toxin_damage(-INFINITY)
+					C.change_misstep_chance(-INFINITY)
 					C.take_oxygen_deprivation(-INFINITY)
+					C.delStatus("drowsy")
+					c.delStatus("n_radiation")
 					C.delStatus("paralysis")
+					C.delStatus("slowed")
 					C.delStatus("stunned")
 					C.delStatus("weakened")
 					C.delStatus("radiation")
+					C.delStatus("disorient")
 					C.health = 100
 					C.reagents.clear_reagents()
 					C.lying = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
adds certain harmful status effects that were missed to the cleared ones, removes all misstep and bad genes


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
a big portion of the now deleted status effects not being deleted felt like an oversight eg. n_radiation staying but radiation being deleted, misstep is also something that can be common when dying or stung 2 very common uses of stasis.

the removal of bad genes is mainly due to the radiation removal and also the fact that one of your forms having a lot of bad mutations eg. rad storm victims or victims of the neurosting + epi autoinjector combo victims makes it basically useless for disguise as no one wants to look like the captain with the radioactive and blind gene


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+)Changeling regenerative statis now removes more negative status effects and bad genes.
```
