### PR TITLE
Separate armor penetration from D_PIERCING

### DIFF
--- a/code/WorkInProgress/VirvaStuff.dm
+++ b/code/WorkInProgress/VirvaStuff.dm
@@ -106,6 +106,7 @@ obj/item/ammo/bullets/flechette_mag
 	ks_ratio = 1.0
 	hit_ground_chance = 100
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_type = DAMAGE_STAB
 	shot_number = 2
 	shot_delay = 0.07 SECONDS
@@ -205,6 +206,7 @@ obj/item/ammo/bullets/flechette_mag
 	shot_sound = 'sound/weapons/9x19NATO.ogg'
 	power = 15
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_type = DAMAGE_STAB
 	hit_ground_chance = 50
 	projectile_speed = 60

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1870,6 +1870,12 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 	var/rangedprot_base = get_ranged_protection() //will be 1 unless overridden
 	if (P.proj_data) //Wire: Fix for: Cannot read null.damage_type
 		var/rangedprot_mod = max(rangedprot_base*(1-P.proj_data.armor_ignored),1)
+
+		if (rangedprot_mod > 1)
+			armor_msg = ", but your armor softens the hit!"
+		else
+			armor_msg = ", but [P] pierces through your armor!"
+
 		switch(P.proj_data.damage_type)
 			if (D_KINETIC)
 				if (stun > 0)
@@ -1879,8 +1885,6 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 				src.TakeDamage("chest", (damage/rangedprot_mod), 0, 0, P.proj_data.hit_type)
 				if (isalive(src))
 					lastgasp()
-				if(rangedprot_base > 1)
-					armor_msg = ", but your armor softens the hit!"
 
 			if (D_PIERCING)
 				if (stun > 0)
@@ -1890,17 +1894,14 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 				src.TakeDamage("chest", damage/rangedprot_mod, 0, 0, P.proj_data.hit_type)
 				if (isalive(src))
 					lastgasp()
-				if (rangedprot_base > 1)
-					armor_msg = ", but [P] pierces through your armor!"
 
 			if (D_SLASHING)
 				if (stun > 0)
 					src.remove_stamina(min(round(stun/rangedprot_mod) * 30, 125)) //thanks to the odd scaling i have to cap this.
 					src.stamina_stun()
 
-				if (rangedprot_base > 1)
+				if (rangedprot_mod > 1)
 					src.TakeDamage("chest", (damage/rangedprot_mod), 0, 0, P.proj_data.hit_type)
-					armor_msg = ", but your armor softens the hit!"
 				else
 					src.TakeDamage("chest", (damage*2), 0, 0, P.proj_data.hit_type)
 
@@ -1914,8 +1915,6 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 				if (src.stuttering < stun)
 					src.stuttering = stun
 				src.TakeDamage("chest", 0, (damage/rangedprot_mod), 0, P.proj_data.hit_type)
-				if(rangedprot_base > 1)
-					armor_msg = ", but your armor softens the hit!"
 
 			if (D_BURNING)
 				if (stun > 0)
@@ -1928,8 +1927,6 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 					return 0
 				src.TakeDamage("chest", 0, (damage/rangedprot_mod), 0, P.proj_data.hit_type)
 				src.update_burning(damage/rangedprot_mod)
-				if(rangedprot_base > 1)
-					armor_msg = ", but your armor softens the hit!"
 
 			if (D_RADIOACTIVE)
 				if (stun > 0)
@@ -1942,8 +1939,6 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 				if(GET_ATOM_PROPERTY(src, PROP_MOB_STAMINA_REGEN_BONUS) != orig_val)
 					SPAWN(30 SECONDS)
 						REMOVE_ATOM_PROPERTY(src, PROP_MOB_STAMINA_REGEN_BONUS, "projectile")
-				if(rangedprot_base > 1)
-					armor_msg = ", but your armor softens the hit!"
 
 			if (D_TOXIC)
 				if (stun > 0)
@@ -1952,8 +1947,6 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 
 				if (!P.reagents)
 					src.take_toxin_damage(damage)
-				if(rangedprot_base > 1)
-					armor_msg = ", but your armor softens the hit!"
 
 	if (!P.proj_data.silentshot)
 		src.visible_message("<span class='alert'>[src] is hit by the [P.name]!</span>", "<span class='alert'>You are hit by the [P.name][armor_msg]!</span>")

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1873,7 +1873,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 
 		if (rangedprot_mod > 1)
 			armor_msg = ", but your armor softens the hit!"
-		else
+		else if(rangedprot_base > 1)
 			armor_msg = ", but [P] pierces through your armor!"
 
 		switch(P.proj_data.damage_type)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1867,39 +1867,39 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 		damage = round((P.power*P.proj_data.ks_ratio), 1.0)
 		stun = round((P.power*(1.0-P.proj_data.ks_ratio)), 1.0)
 	var/armor_msg = ""
-	var/rangedprot = get_ranged_protection() //will be 1 unless overridden
+	var/rangedprot_base = get_ranged_protection() //will be 1 unless overridden
 	if (P.proj_data) //Wire: Fix for: Cannot read null.damage_type
-		rangedprot = max(rangedprot-P.proj_data.armor_ignored,1)
+		var/rangedprot_mod = max(rangedprot_base*(1-P.proj_data.armor_ignored),1)
 		switch(P.proj_data.damage_type)
 			if (D_KINETIC)
 				if (stun > 0)
-					src.remove_stamina(min(round(stun/rangedprot, 0.5) * 30, 125)) //thanks to the odd scaling i have to cap this.
+					src.remove_stamina(min(round(stun/rangedprot_mod, 0.5) * 30, 125)) //thanks to the odd scaling i have to cap this.
 					src.stamina_stun()
 
-				src.TakeDamage("chest", (damage/rangedprot), 0, 0, P.proj_data.hit_type)
+				src.TakeDamage("chest", (damage/rangedprot_mod), 0, 0, P.proj_data.hit_type)
 				if (isalive(src))
 					lastgasp()
-				if(rangedprot > 1)
+				if(rangedprot_base > 1)
 					armor_msg = ", but your armor softens the hit!"
 
 			if (D_PIERCING)
 				if (stun > 0)
-					src.remove_stamina(min(round(stun/rangedprot) * 30, 125)) //thanks to the odd scaling i have to cap this.
+					src.remove_stamina(min(round(stun/rangedprot_mod) * 30, 125)) //thanks to the odd scaling i have to cap this.
 					src.stamina_stun()
 
-				src.TakeDamage("chest", damage/max((rangedprot/3), 1), 0, 0, P.proj_data.hit_type)
+				src.TakeDamage("chest", damage/rangedprot_mod, 0, 0, P.proj_data.hit_type)
 				if (isalive(src))
 					lastgasp()
-				if (rangedprot > 1)
+				if (rangedprot_base > 1)
 					armor_msg = ", but [P] pierces through your armor!"
 
 			if (D_SLASHING)
 				if (stun > 0)
-					src.remove_stamina(min(round(stun/rangedprot) * 30, 125)) //thanks to the odd scaling i have to cap this.
+					src.remove_stamina(min(round(stun/rangedprot_mod) * 30, 125)) //thanks to the odd scaling i have to cap this.
 					src.stamina_stun()
 
-				if (rangedprot > 1)
-					src.TakeDamage("chest", (damage/rangedprot), 0, 0, P.proj_data.hit_type)
+				if (rangedprot_base > 1)
+					src.TakeDamage("chest", (damage/rangedprot_mod), 0, 0, P.proj_data.hit_type)
 					armor_msg = ", but your armor softens the hit!"
 				else
 					src.TakeDamage("chest", (damage*2), 0, 0, P.proj_data.hit_type)
@@ -1913,27 +1913,27 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 
 				if (src.stuttering < stun)
 					src.stuttering = stun
-				src.TakeDamage("chest", 0, (damage/rangedprot), 0, P.proj_data.hit_type)
-				if(rangedprot > 1)
+				src.TakeDamage("chest", 0, (damage/rangedprot_mod), 0, P.proj_data.hit_type)
+				if(rangedprot_base > 1)
 					armor_msg = ", but your armor softens the hit!"
 
 			if (D_BURNING)
 				if (stun > 0)
-					src.remove_stamina(min(round(stun/rangedprot) * 30, 125)) //thanks to the odd scaling i have to cap this.
+					src.remove_stamina(min(round(stun/rangedprot_mod) * 30, 125)) //thanks to the odd scaling i have to cap this.
 					src.stamina_stun()
 
 				if (src.is_heat_resistant())
 					// fire resistance should probably not let you get hurt by welders
 					src.visible_message("<span class='alert'><b>[src] seems unaffected by fire!</b></span>")
 					return 0
-				src.TakeDamage("chest", 0, (damage/rangedprot), 0, P.proj_data.hit_type)
-				src.update_burning(damage/rangedprot)
-				if(rangedprot > 1)
+				src.TakeDamage("chest", 0, (damage/rangedprot_mod), 0, P.proj_data.hit_type)
+				src.update_burning(damage/rangedprot_mod)
+				if(rangedprot_base > 1)
 					armor_msg = ", but your armor softens the hit!"
 
 			if (D_RADIOACTIVE)
 				if (stun > 0)
-					src.remove_stamina(min(round(stun/rangedprot) * 30, 125)) //thanks to the odd scaling i have to cap this.
+					src.remove_stamina(min(round(stun/rangedprot_mod) * 30, 125)) //thanks to the odd scaling i have to cap this.
 					src.stamina_stun()
 
 				src.changeStatus("radiation", damage SECONDS)
@@ -1942,17 +1942,17 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 				if(GET_ATOM_PROPERTY(src, PROP_MOB_STAMINA_REGEN_BONUS) != orig_val)
 					SPAWN(30 SECONDS)
 						REMOVE_ATOM_PROPERTY(src, PROP_MOB_STAMINA_REGEN_BONUS, "projectile")
-				if(rangedprot > 1)
+				if(rangedprot_base > 1)
 					armor_msg = ", but your armor softens the hit!"
 
 			if (D_TOXIC)
 				if (stun > 0)
-					src.remove_stamina(min(round(stun/rangedprot) * 30, 125)) //thanks to the odd scaling i have to cap this.
+					src.remove_stamina(min(round(stun/rangedprot_mod) * 30, 125)) //thanks to the odd scaling i have to cap this.
 					src.stamina_stun()
 
 				if (!P.reagents)
 					src.take_toxin_damage(damage)
-				if(rangedprot > 1)
+				if(rangedprot_base > 1)
 					armor_msg = ", but your armor softens the hit!"
 
 	if (!P.proj_data.silentshot)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1869,6 +1869,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 	var/armor_msg = ""
 	var/rangedprot = get_ranged_protection() //will be 1 unless overridden
 	if (P.proj_data) //Wire: Fix for: Cannot read null.damage_type
+		rangedprot = max(rangedprot-P.proj_data.armor_ignored,1)
 		switch(P.proj_data.damage_type)
 			if (D_KINETIC)
 				if (stun > 0)

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -7,11 +7,12 @@
 	if(istype(/atom, .))
 		return . //meatshielded
 
+	var/armor_value_bullet = get_ranged_protection()
+
 	var/damage = 0
 	if (P.proj_data)  //ZeWaka: Fix for null.ks_ratio
 		damage = round((P.power*P.proj_data.ks_ratio), 1.0)
-
-	var/armor_value_bullet = get_ranged_protection()
+		armor_value_bullet = max(armor_value_bullet-P.proj_data.armor_ignored,1)
 
 	var/target_organ = pick("left_lung", "right_lung", "left_kidney", "right_kidney", "liver", "stomach", "intestines", "spleen", "pancreas", "appendix", "tail")
 	if (P.proj_data) //Wire: Fix for: Cannot read null.damage_type

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -12,7 +12,7 @@
 	var/damage = 0
 	if (P.proj_data)  //ZeWaka: Fix for null.ks_ratio
 		damage = round((P.power*P.proj_data.ks_ratio), 1.0)
-		armor_value_bullet = max(rangedprot*(1-P.proj_data.armor_ignored),1)
+		armor_value_bullet = max(armor_value_bullet*(1-P.proj_data.armor_ignored),1)
 
 	var/target_organ = pick("left_lung", "right_lung", "left_kidney", "right_kidney", "liver", "stomach", "intestines", "spleen", "pancreas", "appendix", "tail")
 	if (P.proj_data) //Wire: Fix for: Cannot read null.damage_type

--- a/code/mob/living/carbon/human/procs/damage.dm
+++ b/code/mob/living/carbon/human/procs/damage.dm
@@ -12,7 +12,7 @@
 	var/damage = 0
 	if (P.proj_data)  //ZeWaka: Fix for null.ks_ratio
 		damage = round((P.power*P.proj_data.ks_ratio), 1.0)
-		armor_value_bullet = max(armor_value_bullet-P.proj_data.armor_ignored,1)
+		armor_value_bullet = max(rangedprot*(1-P.proj_data.armor_ignored),1)
 
 	var/target_organ = pick("left_lung", "right_lung", "left_kidney", "right_kidney", "liver", "stomach", "intestines", "spleen", "pancreas", "appendix", "tail")
 	if (P.proj_data) //Wire: Fix for: Cannot read null.damage_type

--- a/code/modules/projectiles/40mm.dm
+++ b/code/modules/projectiles/40mm.dm
@@ -29,6 +29,7 @@ radioactive - rips apart cells or some shit
 toxic - poisons
 */
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	//With what % do we hit mobs laying down
 	hit_ground_chance = 90
 	//Can we pass windows

--- a/code/modules/projectiles/bullet.dm
+++ b/code/modules/projectiles/bullet.dm
@@ -132,6 +132,7 @@ toxic - poisons
 	armor_piercing
 		damage_type = D_PIERCING
 		hit_type = DAMAGE_STAB
+		armor_ignored = 0.66
 
 /datum/projectile/bullet/assault_rifle/burst
 	sname = "burst fire"
@@ -142,6 +143,7 @@ toxic - poisons
 	armor_piercing
 		damage_type = D_PIERCING
 		hit_type = DAMAGE_STAB
+		armor_ignored = 0.66
 
 //0.308
 /datum/projectile/bullet/minigun
@@ -180,6 +182,7 @@ toxic - poisons
 	name = "bullet"
 	power = 85
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_type = DAMAGE_STAB
 	implanted = /obj/item/implant/projectile/bullet_308
 	shot_sound = 'sound/weapons/railgun.ogg'
@@ -207,6 +210,7 @@ toxic - poisons
 	power = 70
 	icon_state = "sniper_bullet"
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_type = DAMAGE_STAB
 	implanted = /obj/item/implant/projectile/bullet_308
 	shot_sound = 'sound/weapons/railgun.ogg'
@@ -372,6 +376,7 @@ toxic - poisons
 /datum/projectile/bullet/revolver_357/AP
 	power = 50
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_type = DAMAGE_STAB
 	implanted = /obj/item/implant/projectile/bullet_357AP
 
@@ -379,6 +384,7 @@ toxic - poisons
 /datum/projectile/bullet/revolver_357/AP
 	power = 50
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_type = DAMAGE_STAB
 	implanted = /obj/item/implant/projectile/bullet_357AP
 */
@@ -399,6 +405,7 @@ toxic - poisons
 	power = 35
 	implanted = /obj/item/implant/projectile/bullet_38AP
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_type = DAMAGE_STAB
 
 /datum/projectile/bullet/revolver_38/stunners//energy bullet things so he can actually stun something
@@ -484,6 +491,7 @@ toxic - poisons
 	dissipation_delay = 1
 	dissipation_rate = 50
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_type = DAMAGE_STAB
 	hit_ground_chance = 100
 	implanted = /obj/item/implant/projectile/bullet_41
@@ -506,6 +514,7 @@ toxic - poisons
 	name = "bullet"
 	power = 100
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_type = DAMAGE_STAB
 	implanted = /obj/item/implant/projectile/flintlock
 	shot_sound = 'sound/weapons/flintlock.ogg'
@@ -780,6 +789,7 @@ toxic - poisons
 	window_pass = 0
 	icon_state = "20mmAPHE"
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_type = DAMAGE_CUT
 	power = 150
 	dissipation_delay = 1
@@ -1380,6 +1390,7 @@ datum/projectile/bullet/autocannon
 	name = "shrapnel"
 	power = 10
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_type = DAMAGE_CUT
 	window_pass = 0
 	icon = 'icons/obj/scrap.dmi'

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -470,7 +470,7 @@ datum/projectile
 	var/ks_ratio = 1.0           /* Kill/Stun ratio, when it hits a mob the damage/stun is based upon this and the power
 	                                eg 1.0 will cause damage = to power while 0.0 would cause just stun = to power */
 
-	var/armor_ignored = 0		 // Percentage of armor to ignore
+	var/armor_ignored = 0		 // Percentage of armor to ignore. Old-style AP is 0.66 = ignore 66% of target's armor
 
 	var/sname = "stun"           // name of the projectile setting, used when you change a guns setting
 	var/shot_sound = 'sound/weapons/Taser.ogg' // file location for the sound you want it to play

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -469,7 +469,8 @@ datum/projectile
 									// When firing in a straight line, I was getting doubled falloff values on the fourth tile from the shooter, as well as others further along. -Tarm
 	var/ks_ratio = 1.0           /* Kill/Stun ratio, when it hits a mob the damage/stun is based upon this and the power
 	                                eg 1.0 will cause damage = to power while 0.0 would cause just stun = to power */
-  var/armor_ignored = 0				 // How much flat ranged protection will be ignored
+
+	var/armor_ignored = 0		 // How much flat ranged protection will be ignored
 									// (Sec vests have 1 prot, so 1 armor_ignored or greater will ignore all armor)
 
 	var/sname = "stun"           // name of the projectile setting, used when you change a guns setting

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -470,7 +470,7 @@ datum/projectile
 	var/ks_ratio = 1.0           /* Kill/Stun ratio, when it hits a mob the damage/stun is based upon this and the power
 	                                eg 1.0 will cause damage = to power while 0.0 would cause just stun = to power */
   var/armor_ignored = 0				 // How much flat ranged protection will be ignored
-									// (Ranged prot is a multiplier. Sec vests have 1.5 prot, so 0.5 armor_ignored or greater will ignore all armor)
+									// (Sec vests have 1 prot, so 1 armor_ignored or greater will ignore all armor)
 
 	var/sname = "stun"           // name of the projectile setting, used when you change a guns setting
 	var/shot_sound = 'sound/weapons/Taser.ogg' // file location for the sound you want it to play

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -470,8 +470,7 @@ datum/projectile
 	var/ks_ratio = 1.0           /* Kill/Stun ratio, when it hits a mob the damage/stun is based upon this and the power
 	                                eg 1.0 will cause damage = to power while 0.0 would cause just stun = to power */
 
-	var/armor_ignored = 0		 // How much flat ranged protection will be ignored
-									// (Sec vests have 1 prot, so 1 armor_ignored or greater will ignore all armor)
+	var/armor_ignored = 0		 // Percentage of armor to ignore
 
 	var/sname = "stun"           // name of the projectile setting, used when you change a guns setting
 	var/shot_sound = 'sound/weapons/Taser.ogg' // file location for the sound you want it to play

--- a/code/modules/projectiles/projectile_parent.dm
+++ b/code/modules/projectiles/projectile_parent.dm
@@ -18,6 +18,7 @@
 	//var/obj/o_shooter = null
 	var/list/targets = list()
 	var/power = 20 // temp var to store what the current power of the projectile should be when it hits something
+	var/armor_ignored = 0
 	var/max_range = PROJ_INFINITE_RANGE //max range
 	var/initial_power = 20 // local copy of power for determining power when hitting things
 	var/implanted = null
@@ -468,6 +469,8 @@ datum/projectile
 									// When firing in a straight line, I was getting doubled falloff values on the fourth tile from the shooter, as well as others further along. -Tarm
 	var/ks_ratio = 1.0           /* Kill/Stun ratio, when it hits a mob the damage/stun is based upon this and the power
 	                                eg 1.0 will cause damage = to power while 0.0 would cause just stun = to power */
+  var/armor_ignored = 0				 // How much flat ranged protection will be ignored
+									// (Ranged prot is a multiplier. Sec vests have 1.5 prot, so 0.5 armor_ignored or greater will ignore all armor)
 
 	var/sname = "stun"           // name of the projectile setting, used when you change a guns setting
 	var/shot_sound = 'sound/weapons/Taser.ogg' // file location for the sound you want it to play

--- a/code/obj/artifacts/artifactdatums.dm
+++ b/code/obj/artifacts/artifactdatums.dm
@@ -221,6 +221,7 @@ ABSTRACT_TYPE(/datum/artifact/art)
 	shot_sound = 'sound/weapons/Taser.ogg'
 	shot_number = 1
 	damage_type = D_PIERCING
+	armor_ignored = 0.66
 	hit_ground_chance = 90
 	window_pass = 0
 	var/obj/machinery/artifact/turret/turretArt = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a new variable to projectiles that allows coders to manually adjust how much ranged protection to ignore.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the only method to reduce effective armor is with piercing damage, which currently makes security vests 100% useless.

For example, you want a gun that can crit an armored security guard in 2 hits. Right now your only options are:

**A:** Set the damage to the appropriate value to crit them in 2 hits 
Since secvests have 1 ranged prot, this is 100 damage, an instant crit to unarmored personnel.

**B:** Set piercing on, and make it do 50 damage, where there is no benefit security, naked or not.

Having this merged will mean certain weapons could do slightly more balanced spreads of damage, or completely ignore light armor.