### PR TITLE
Adds Round Time to Hub Entry, Removes Image

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -735,24 +735,26 @@ var/f_color_selector_handler/F_Color_Selector
 /world/proc/update_status()
 	Z_LOG_DEBUG("World/Status", "Updating status")
 
-	var/s = ""
+	var/list/statsus = list()
 
 	if (config?.server_name)
-		s += "<b><a href=\"https://goonhub.com\">[config.server_name]</a></b> &#8212; "
+		statsus += "<b><a href=\"https://goonhub.com\">[config.server_name]</a></b> &#8212; "
 	else
-		s += "<b>SERVER NAME HERE</b> &#8212; "
+		statsus += "<b>SERVER NAME HERE</b> &#8212; "
 
-	s += "The classic SS13 experience. &#8212; (<a href=\"http://bit.ly/gndscd\">Discord</a>)<br>"
+	statsus += "The classic SS13 experience. &#8212; (<a href=\"http://bit.ly/gndscd\">Discord</a>)<br>"
 
-	if(ticker && ticker.round_elapsed_ticks > 0 && current_state == GAME_STATE_PLAYING)
-		s += "Time: [round(ticker.round_elapsed_ticks / 36000)]:[add_zero(num2text(ticker.round_elapsed_ticks / 600 % 60), 2)]<br>"
+	if(ticker?.round_elapsed_ticks > 0 && current_state == GAME_STATE_PLAYING)
+		statsus += "Time: [round(ticker.round_elapsed_ticks / 36000)]:[add_zero(num2text(ticker.round_elapsed_ticks / 600 % 60), 2)]<br>"
+	else if (current_state == GAME_STATE_FINISHED)
+		statsus += "Time: RESTARTING<br>"
 	else if(!ticker)
-		s += "<b>STARTING</b><br>"
+		statsus += "Time: STARTING<br>"
 
 	if (map_settings)
 		var/map_name = istext(map_settings.display_name) ? "[map_settings.display_name]" : "[map_settings.name]"
 		//var/map_link_str = map_settings.goonhub_map ? "<a href=\"[map_settings.goonhub_map]\">[map_name]</a>" : "[map_name]"
-		s += "Map: <b>[map_name]</b><br>"
+		statsus += "Map: <b>[map_name]</b><br>"
 
 	var/list/features = list()
 
@@ -769,11 +771,12 @@ var/f_color_selector_handler/F_Color_Selector
 		features += "respawn allowed"
 
 	if(features)
-		s += "[jointext(features, ", ")]"
+		statsus += "[jointext(features, ", ")]"
 
 	/* does this help? I do not know */
-	if (src.status != s)
-		src.status = s
+	statsus = statsus.Join()
+	if (src.status != statsus)
+		src.status = statsus
 
 	Z_LOG_DEBUG("World/Status", "Status update complete")
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -745,6 +745,11 @@ var/f_color_selector_handler/F_Color_Selector
 
 	s += "The classic SS13 experience. &#8212; (<a href=\"http://bit.ly/gndscd\">Discord</a>)<br>"
 
+	if(ticker && ticker.round_elapsed_ticks > 0 && current_state == GAME_STATE_PLAYING)
+		s += "Round time: [round(ticker.round_elapsed_ticks / 36000)]:[add_zero(num2text(ticker.round_elapsed_ticks / 600 % 60), 2)]<br>"
+	else if(!ticker)
+		s += "<b>STARTING</b><br>"
+
 	if (map_settings)
 		var/map_name = istext(map_settings.display_name) ? "[map_settings.display_name]" : "[map_settings.name]"
 		//var/map_link_str = map_settings.goonhub_map ? "<a href=\"[map_settings.goonhub_map]\">[map_name]</a>" : "[map_name]"
@@ -752,9 +757,7 @@ var/f_color_selector_handler/F_Color_Selector
 
 	var/list/features = list()
 
-	if (!ticker)
-		features += "<b>STARTING</b>"
-	else if (ticker && master_mode)
+	if(ticker && master_mode)
 		if (ticker.hide_mode)
 			features += "Mode: <b>secret</b>"
 		else

--- a/code/world.dm
+++ b/code/world.dm
@@ -735,8 +735,7 @@ var/f_color_selector_handler/F_Color_Selector
 /world/proc/update_status()
 	Z_LOG_DEBUG("World/Status", "Updating status")
 
-	//we start off with an animated bee gif because, well, this is who we are.
-	var/s = "<img src=\"http://goonhub.com/bee.gif\"/>"
+	var/s = ""
 
 	if (config?.server_name)
 		s += "<b><a href=\"https://goonhub.com\">[config.server_name]</a></b> &#8212; "
@@ -746,7 +745,7 @@ var/f_color_selector_handler/F_Color_Selector
 	s += "The classic SS13 experience. &#8212; (<a href=\"http://bit.ly/gndscd\">Discord</a>)<br>"
 
 	if(ticker && ticker.round_elapsed_ticks > 0 && current_state == GAME_STATE_PLAYING)
-		s += "Round time: [round(ticker.round_elapsed_ticks / 36000)]:[add_zero(num2text(ticker.round_elapsed_ticks / 600 % 60), 2)]<br>"
+		s += "Time: [round(ticker.round_elapsed_ticks / 36000)]:[add_zero(num2text(ticker.round_elapsed_ticks / 600 % 60), 2)]<br>"
 	else if(!ticker)
 		s += "<b>STARTING</b><br>"
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Displays the round time in the hub entry above the Map, removes the tiny goon bee gif before the server name, images seem to count a lot towards the byond hub entry char limit and also they don't even show in the byond launcher which is how most people launch the game (or bookmarks)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Knowing the round time is useful and helps players make informed decisions about whether to join the server or not

## Notes

This is my first time with goon code so I probably made mistakes somewhere,