### PR TITLE
Replaces nicotine patches with patch-boxes.

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1131,12 +1131,12 @@
 		product_list += new/datum/data/vending_product(/obj/item/cigpacket/propuffs, 10, cost=PAY_TRADESMAN/5)
 		product_list += new/datum/data/vending_product(/obj/item/cigpacket/cigarillo, 10, cost=PAY_TRADESMAN/5)
 		product_list += new/datum/data/vending_product(/obj/item/cigarbox, 1, cost=PAY_TRADESMAN)
-		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/patch/nicotine, 10, cost=PAY_TRADESMAN/10)
 		product_list += new/datum/data/vending_product(/obj/item/matchbook, 10, cost=PAY_UNTRAINED/20)
 		product_list += new/datum/data/vending_product(/obj/item/device/light/zippo, 5, cost=PAY_TRADESMAN/10)
 		product_list += new/datum/data/vending_product(/obj/item/decoration/ashtray, 5, cost=PAY_TRADESMAN/10)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/vape, 10, cost=PAY_TRADESMAN/2)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/ecig_refill_cartridge, 20, cost=PAY_TRADESMAN/5)
+		product_list += new/datum/data/vending_product(/obj/item/item_box/medical_patches/nicotine, 5, cost=PAY_TRADESMAN/5)
 
 		product_list += new/datum/data/vending_product(/obj/item/device/igniter, rand(1, 6), hidden=1, cost=PAY_UNTRAINED/5)
 		product_list += new/datum/data/vending_product(/obj/item/cigpacket/random, rand(0, 1), hidden=1, cost=420)

--- a/code/obj/item/generic_box.dm
+++ b/code/obj/item/generic_box.dm
@@ -287,6 +287,11 @@
 			contained_item = /obj/item/reagent_containers/patch/synthflesh
 			item_amount = 10
 			max_item_amount = 10
+		nicotine
+			name = "box of nicotine patches"
+			contained_item = /obj/item/reagent_containers/patch/nicotine
+			item_amount = 5
+			max_item_amount = 10
 
 		mini_styptic
 			name = "box of mini healing patches"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Replaces nicotine patches in cigarette vendors with nicotine patch-boxes.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

For the maybe 3 people who actually use nicotine patches (one of whom is me), buying individual patches is a pain, a waste of inventory space, and is inconvenient to make your own patch-boxes with extracted nicotine. This makes it easier to purchase a nice convenient box of 5, instead of having to go find an empty patchbox or making your own the long way.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Munien
(+)Nicotine patch boxes are now available for purchase in cigarette vending machines,
```
