### PR TITLE
Replaces Old Security Records Computers With ThinkDOS SecMate Computers

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -4854,7 +4854,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/arrivals)
 "aon" = (
-/obj/machinery/computer/secure_data,
+/obj/machinery/computer3/generic/secure_data,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/red/side{
 	dir = 10
 	},
@@ -4865,6 +4869,9 @@
 	},
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/cable{
+	icon_state = "1-8"
 	},
 /obj/submachine/weapon_vendor/security,
 /turf/simulated/floor/red/side,
@@ -55951,8 +55958,8 @@
 	pixel_y = 11
 	},
 /obj/item/clipboard{
-	pixel_y = 4;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 4
 	},
 /obj/item/pen{
 	pixel_x = 6;
@@ -59013,8 +59020,8 @@
 	pixel_x = 19
 	},
 /obj/item/reagent_containers/food/snacks/candy/butterscotch{
-	pixel_y = -4;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -4
 	},
 /turf/simulated/floor/wood/two,
 /area/station/medical/staff)
@@ -62305,12 +62312,12 @@
 /obj/item/storage/wall/office,
 /obj/rack,
 /obj/item/robodefibrillator{
-	pixel_y = 6;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 6
 	},
 /obj/item/reagent_containers/hypospray{
-	pixel_y = 2;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 2
 	},
 /obj/item/storage/box/health_upgrade_kit{
 	pixel_x = 9;
@@ -63765,8 +63772,8 @@
 "vMs" = (
 /obj/table/auto,
 /obj/item/cigpacket/propuffs{
-	pixel_y = -2;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = -2
 	},
 /obj/item/clothing/mask/cigarette/propuffs{
 	pixel_x = -2;

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -20953,7 +20953,7 @@
 	dir = 8;
 	pixel_y = 6
 	},
-/obj/machinery/computer/secure_data{
+/obj/machinery/computer3/generic/secure_data{
 	dir = 4
 	},
 /obj/cable{
@@ -25353,7 +25353,7 @@
 /turf/simulated/floor/black,
 /area/station/ranch)
 "fAh" = (
-/obj/machinery/computer/secure_data,
+/obj/machinery/computer3/generic/secure_data,
 /obj/decal/tile_edge/line/white{
 	icon_state = "line1"
 	},
@@ -38725,10 +38725,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/decal/tile_edge/line/black{
-	icon_state = "line1"
-	},
-/obj/machinery/computer/secure_data{
+/obj/machinery/computer3/generic/secure_data{
 	dir = 8
 	},
 /obj/machinery/power/data_terminal,
@@ -47811,7 +47808,7 @@
 	dir = 5;
 	icon_state = "line2"
 	},
-/obj/machinery/computer/secure_data,
+/obj/machinery/computer3/generic/secure_data,
 /obj/decal/poster/wallsign/poster_nt{
 	pixel_y = 28
 	},

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -38735,6 +38735,9 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
 /turf/simulated/floor/red,
 /area/station/security/checkpoint{
 	name = "Security Checkpoint"

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -903,7 +903,7 @@
 /area/station/turret_protected/AIsat)
 "abL" = (
 /obj/machinery/power/data_terminal,
-/obj/machinery/computer/secure_data,
+/obj/machinery/computer3/generic/secure_data,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -26535,8 +26535,8 @@
 /area/station/crew_quarters/garden)
 "hvd" = (
 /obj/decal/tile_edge/line/blue{
-	icon_state = "line1";
-	dir = 1
+	dir = 1;
+	icon_state = "line1"
 	},
 /obj/cable{
 	d1 = 1;
@@ -36577,7 +36577,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/ranch)
 "kwK" = (
-/obj/machinery/computer/secure_data{
+/obj/machinery/computer3/generic/secure_data{
 	dir = 8
 	},
 /obj/decoration/vent{
@@ -64978,7 +64978,7 @@
 	icon_state = "1-10"
 	},
 /obj/cable,
-/obj/machinery/computer/secure_data{
+/obj/machinery/computer3/generic/secure_data{
 	dir = 8
 	},
 /obj/machinery/power/data_terminal,
@@ -71425,7 +71425,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/west)
 "uzE" = (
-/obj/machinery/computer/secure_data{
+/obj/machinery/computer3/generic/secure_data{
 	dir = 4
 	},
 /obj/item/reagent_containers/food/drinks/mug/random_color{

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -25196,6 +25196,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/red/checker{
 	dir = 4
 	},
@@ -25681,14 +25686,19 @@
 	},
 /area/station/maintenance/southwest)
 "bmz" = (
-/obj/machinery/computer/secure_data{
+/obj/machinery/computer3/generic/secure_data{
 	dir = 8
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/machinery/recharger/wall/sticky,
 /turf/simulated/floor/red/checker{
 	dir = 4
 	},
-/area/station/security/checkpoint/arrivals)
+/area/space)
 "bmA" = (
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)
@@ -25848,7 +25858,12 @@
 /area/station/hangar/qm)
 "bmT" = (
 /obj/machinery/light_switch/north,
-/obj/machinery/computer/secure_data,
+/obj/machinery/computer3/generic/secure_data,
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /obj/decal/cleanable/dirt,
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -32072,11 +32087,21 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment,
+/obj/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
 "bDC" = (
 /obj/disposalpipe/segment/mineral{
 	dir = 4
+	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
@@ -32090,6 +32115,11 @@
 	dir = 4
 	},
 /obj/disposalpipe/segment/transport,
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/courtroom)
 "bDE" = (
@@ -54233,6 +54263,11 @@
 /obj/disposalpipe/segment/transport{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/red/checker{
 	dir = 4

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -25698,7 +25698,7 @@
 /turf/simulated/floor/red/checker{
 	dir = 4
 	},
-/area/space)
+/area/station/security/checkpoint/arrivals)
 "bmA" = (
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/east)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -31079,7 +31079,7 @@
 	},
 /area/station/security/secwing)
 "bQK" = (
-/obj/machinery/computer/secure_data{
+/obj/machinery/computer3/generic/secure_data{
 	dir = 4
 	},
 /obj/cable{


### PR DESCRIPTION
[QoL]


## About the PR:
Replaces all instances of `/obj/machinery/computer/secure_data` with `/obj/machinery/computer3/generic/secure_data` and adds data terminals where necessary in the following maps: Cogmap, Destiny, Donut3, Horizon, and Kondaru.



## Why's this needed?
`/obj/machinery/computer3/generic/secure_data` has largely superseded `/obj/machinery/computer/secure_data` due to superior UI and inbuilt functions. If I am not mistaken, the old computers were meant to be removed from maps anyway.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Replaced old Security Records computers with ThinkDOS SecMate computers.
```
