### PR TITLE
Face Disfiguration Retool

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -2425,6 +2425,7 @@
 	src.take_brain_damage(-INFINITY)
 	src.health = src.max_health
 	src.buckled = null
+	src.disfigured = FALSE
 	if (src.hasStatus("handcuffed"))
 		src.handcuffs.destroy_handcuffs(src)
 	src.bodytemperature = src.base_body_temp

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -69,6 +69,7 @@
 	var/stuttering = null
 	var/real_name = null
 	var/blinded = null
+	var/disfigured = FALSE
 	var/druggy = 0
 	var/sleeping = 0.0
 	var/lying = 0.0

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1218,14 +1218,14 @@
 			src.update_name_tag("")
 	else
 		if (id_name != src.real_name)
-			if (src.decomp_stage > 2)
+			if (src.decomp_stage > 2 || src.disfigured)
 				src.name = "[src.name_prefix(null, 1)]Unknown[id_name ? " (as [id_name])" : ""][src.name_suffix(null, 1)]"
 				src.update_name_tag(id_name)
 			else
 				src.name = "[src.name_prefix(null, 1)][src.real_name][id_name ? " (as [id_name])" : ""][src.name_suffix(null, 1)]"
 				src.update_name_tag(src.real_name)
 		else
-			if (src.decomp_stage > 2)
+			if (src.decomp_stage > 2 || src.disfigured)
 				src.name = "[src.name_prefix(null, 1)]Unknown[src.wear_id ? " (as [id_name])" : ""][src.name_suffix(null, 1)]"
 				src.update_name_tag(id_name)
 			else

--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2202,8 +2202,10 @@ datum
 							boutput(H, "<span class='alert'>Your face comes into contact with the acidic vapors!</span>")
 							H.TakeDamage("head", 0, created_volume * 3, 0, DAMAGE_BURN) // IT'S ACID IT BURNS
 							H.emote("scream")
-							boutput(H, "<span class='alert'>Your face has become disfigured!</span>")
-							H.real_name = "Unknown"
+							if(!H.disfigured)
+								boutput(H, "<span class='alert'>Your face has become disfigured!</span>")
+								H.disfigured = TRUE
+								H.UpdateName()
 							H.changeStatus("weakened", 8 SECONDS)
 							H:unlock_medal("Red Hood", 1)
 				return

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -635,8 +635,10 @@ datum
 					else if (prob(75))
 						M.TakeDamage("head", 25, 0, 0, DAMAGE_BLUNT) // this does brute for some reason, whateverrrr
 						M.emote("scream")
-						boutput(M, "<span class='alert'>Your face has become disfigured!</span>")
-						M.real_name = "Unknown"
+						if(!H.disfigured)
+							boutput(H, "<span class='alert'>Your face has become disfigured!</span>")
+							H.disfigured = TRUE
+							H.UpdateName()
 						M.unlock_medal("Red Hood", 1)
 					else
 						M.TakeDamage("All", 5, 0, 0, DAMAGE_BLUNT)

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -395,6 +395,10 @@ datum
 					M.HealDamage("All", volume_passed * 1.5, volume_passed * 1.5)
 					if (isliving(M))
 						var/mob/living/H = M
+						if (H.disfigured)
+							boutput(H, "<span class='notice'>You feel the synthflesh seeping into your face.</span>")
+							H.disfigured = FALSE
+							H.UpdateName()
 						if (H.bleeding)
 							repair_bleeding_damage(H, 80, 2)
 						if (ishuman(M))

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -85,8 +85,10 @@ datum
 						if (prob(75))
 							M.TakeDamage("head", 0, 10 * stack_mult, 0, DAMAGE_BURN)
 							M.emote("scream")
-							boutput(M, "<span class='alert'>Your face has become disfigured!</span>")
-							M.real_name = "Unknown"
+							if(!M.disfigured)
+								boutput(M, "<span class='alert'>Your face has become disfigured!</span>")
+								M.disfigured = TRUE
+								M.UpdateName()
 							M.unlock_medal("Red Hood", 1)
 						else
 							M.TakeDamage("All", 0, 10 * stack_mult, 0, DAMAGE_BURN)
@@ -157,8 +159,10 @@ datum
 					if (volume >= 50 && prob(75))
 						M.TakeDamage("head", 0, 10, 0, DAMAGE_BURN)
 						M.emote("scream")
-						boutput(M, "<span class='alert'>Your face has become disfigured!</span>")
-						M.real_name = "Unknown"
+						if(!M.disfigured)
+							boutput(M, "<span class='alert'>Your face has become disfigured!</span>")
+							M.disfigured = TRUE
+							M.UpdateName()
 						M.unlock_medal("Red Hood", 1)
 					else
 						random_burn_damage(M, min(5, volume * 0.25))
@@ -856,8 +860,10 @@ datum
 						if (!H.wear_mask && !H.head)
 							H.TakeDamage("head", 0, clamp((volume - 5) * 2, 8, 50), 0, DAMAGE_BURN)
 							H.emote("scream")
-							boutput(H, "<span class='alert'>Your face has become disfigured!</span>")
-							H.real_name = "Unknown"
+							if(!H.disfigured)
+								boutput(H, "<span class='alert'>Your face has become disfigured!</span>")
+								H.disfigured = TRUE
+								H.UpdateName()
 							H.unlock_medal("Red Hood", 1)
 							return
 						else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT][REWORK]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes the way face disfiguration (from acid, currently) affects your name:

- Mobs now have a "disfigured" variable, used for the below changes.
- Instead of setting your real_name to Unknown, face melting will now set the disfigured variable to true.
- The disfigured variable is now checked in UpdateName(), causing your visual name to be Unknown in circumstances where your face is visible.
- Synthflesh can be used on a disfigured individual to restore their face.
- Fully healing a mob also removes disfigured.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Makes facemelting interact better with systems that use real_name (prominently ghosting), and reversible so it's not a permanent hindrance, given treatment.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(+)Disfigured faces can now be mended with synthflesh, and no longer persist with you into the ethereal plane.
```
