### PR TITLE
Ignore Temperature Expose on Circulators when Hatched Closed 

### DIFF
--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -308,7 +308,7 @@
 		if(src.is_open_container())
 			. = ..()
 		else
-			src.material?.triggerTemp(src, temp)
+			src.material?.triggerTemp(src, exposed_temperature)
 
 	proc/circulate_gas(datum/gas_mixture/gas)
 		var/datum/gas_mixture/gas_input = air1

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -303,6 +303,13 @@
 	proc/is_circulator_active()
 		return last_pressure_delta > src.min_circ_pressure
 
+	temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+		// Protect if hatch is closed
+		if(src.is_open_container())
+			. = ..()
+		else
+			src.material?.triggerTemp(src, temp)
+
 	proc/circulate_gas(datum/gas_mixture/gas)
 		var/datum/gas_mixture/gas_input = air1
 		var/datum/gas_mixture/gas_output = air2


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Having the panel closed will cause the TEG Circulators to ignore `temperature_expose()` on the contained reagents.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Allows for increased variety of reagents used when the temperature can be controlled.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Azrun
(+)TEG Circulator maintenance panel now protected with aerogel.  Less likely to be impacted by environmental temperatures when panel is closed.
```
