### PR TITLE
Makes mops mop on self attack

### DIFF
--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -377,6 +377,12 @@ WET FLOOR SIGN
 		else // Lances up!
 			user.visible_message("[user] raises a mop as a lance!", "You raise the mop into jousting position.")
 			S.joustingTool = src
+	else
+		for (var/obj/fluid/fluid in user.loc)
+			src.AfterAttack(fluid, user)
+			return
+		if (isturf(user.loc))
+			src.AfterAttack(user.loc, user)
 
 /obj/item/mop/attack(mob/living/M, mob/user)
 	if (user.a_intent == INTENT_HELP)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just makes mop self attack call AfterAttack on the turf or fluid you're standing on.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pressing the use key to mop repeatedly is less stressful on fingers than spam clicking.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Using a mop in hand will now mop the turf you're standing on, mopping now comes with 13% less RSI!
```
