### PR TITLE
removes stimulants from battle royale

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -675,7 +675,6 @@ This is basically useless for anyone but miners.
 	item = /obj/item/storage/box/stimulants
 	cost = 6
 	desc = "When top agents need energy, they turn to our new line of X-Cite 500 stimulants. This 3-pack of all-natural* and worry-free** blend accelerates perception, endurance, and reaction time to superhuman levels! Shrug off even the cruelest of blows without a scratch! <br><br><font size=-1>*Contains less than 0.5 grams unnatural material per 0.49 gram serving.<br>**May cause dizziness, blurred vision, heart failure, renal compaction, adenoid calcification, or death. Users are recommended to take only a single dose at a time, and let withdrawl symptoms play out naturally.</font>"
-	br_allowed = TRUE
 	job = list("Medical Doctor","Medical Director","Scientist","Geneticist","Pathologist","Research Director")
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes stimulants from the battle royale gamemode


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stimulants are basically impossible to fight. and reduce shuttle combat to whose stims run out last in rounds where several boxes of them are found if only one box is found with any remotely decent gear its basically a free win

Other items that can nearly singlehandedly lead to a win such as katana, c saber and red chainsaw were removed.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+) Removed stimulants from battle royale.
```
