### PR TITLE
removes sarin grenades from BR

### DIFF
--- a/code/datums/syndicate_buylist.dm
+++ b/code/datums/syndicate_buylist.dm
@@ -1098,7 +1098,6 @@ ABSTRACT_TYPE(/datum/syndicate_buylist/surplus)
 	item = /obj/item/chem_grenade/sarin
 	cost = 1
 	desc = "A terrifying grenade containing a potent nerve gas. Try not to get caught in the smoke."
-	br_allowed = TRUE
 	can_buy = UPLINK_TRAITOR | UPLINK_SPY_THIEF | UPLINK_NUKE_OP
 
 /////////////////////////////////////////// Irregular Items //////////////////////////////////////////////////


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes sarin grenades from the battle royale item pool


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
sarin grenades are horrid for actual combat usually they just doom anyone that touches it

the times i saw it used on shuttle turned into nearly stunlocked people dying to a poison without even being capable of combat

their other use is dooming a whole safezone during a storm

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+) Removed sarin grenades from BR
```
