### PR TITLE
makes certain vamp powers work in containers

### DIFF
--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -434,7 +434,7 @@
 	preferred_holder_type = /datum/abilityHolder/vampire
 	var/when_stunned = 0 // 0: Never | 1: Ignore mob.stunned and mob.weakened | 2: Ignore all incapacitation vars
 	var/not_when_handcuffed = 0
-	var/not_when_in_an_object = 1 // 0: Anywhere | 1: Only on turfs | 2: Anywhere but the port a brig
+	var/not_when_in_an_object = 1
 	var/unlock_message = null
 
 	New()
@@ -506,10 +506,7 @@
 
 		if(isobj(M)) //Exception for VampTEG and Sentient Objects...
 			return 1
-		if (src.not_when_in_an_object == 1 && !isturf(M.loc))
-			boutput(M, "<span class='alert'>You can't use this ability here.</span>")
-			return 0
-		if (src.not_when_in_an_object == 2 && istype(M.loc,/obj/machinery/port_a_brig))
+		if (src.not_when_in_an_object && !isturf(M.loc))
 			boutput(M, "<span class='alert'>You can't use this ability here.</span>")
 			return 0
 		if (!(iscarbon(M) || ismobcritter(M)))

--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -434,7 +434,7 @@
 	preferred_holder_type = /datum/abilityHolder/vampire
 	var/when_stunned = 0 // 0: Never | 1: Ignore mob.stunned and mob.weakened | 2: Ignore all incapacitation vars
 	var/not_when_handcuffed = 0
-	var/not_when_in_an_object = 1
+	var/not_when_in_an_object = 1 // 0: Anywhere | 1: Only on turfs | 2: Anywhere but the port a brig
 	var/unlock_message = null
 
 	New()
@@ -506,7 +506,10 @@
 
 		if(isobj(M)) //Exception for VampTEG and Sentient Objects...
 			return 1
-		if (src.not_when_in_an_object && !isturf(M.loc))
+		if (src.not_when_in_an_object == 1 && !isturf(M.loc))
+			boutput(M, "<span class='alert'>You can't use this ability here.</span>")
+			return 0
+		if (src.not_when_in_an_object == 2 && istype(M.loc,/obj/machinery/port_a_brig))
 			boutput(M, "<span class='alert'>You can't use this ability here.</span>")
 			return 0
 		if (!(iscarbon(M) || ismobcritter(M)))

--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -136,10 +136,6 @@
 				src.UpdateIcon()
 				boutput(usr, "<span class='notice'>Please press a number to bind this ability to...</span>")
 				return
-
-		if (!isturf(owner.holder.owner.loc))
-			boutput(owner.holder.owner, "<span class='alert'>You can't use this spell here.</span>")
-			return
 		if (spell.targeted && usr.targeting_ability == owner)
 			usr.targeting_ability = null
 			usr.update_cursor()
@@ -438,6 +434,7 @@
 	preferred_holder_type = /datum/abilityHolder/vampire
 	var/when_stunned = 0 // 0: Never | 1: Ignore mob.stunned and mob.weakened | 2: Ignore all incapacitation vars
 	var/not_when_handcuffed = 0
+	var/not_when_in_an_object = 1
 	var/unlock_message = null
 
 	New()
@@ -509,7 +506,9 @@
 
 		if(isobj(M)) //Exception for VampTEG and Sentient Objects...
 			return 1
-
+		if (src.not_when_in_an_object && !isturf(M.loc))
+			boutput(M, "<span class='alert'>You can't use this ability here.</span>")
+			return 0
 		if (!(iscarbon(M) || ismobcritter(M)))
 			boutput(M, "<span class='alert'>You cannot use any powers in your current form.</span>")
 			return 0

--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -434,7 +434,7 @@
 	preferred_holder_type = /datum/abilityHolder/vampire
 	var/when_stunned = 0 // 0: Never | 1: Ignore mob.stunned and mob.weakened | 2: Ignore all incapacitation vars
 	var/not_when_handcuffed = 0
-	var/not_when_in_an_object = 1
+	var/not_when_in_an_object = TRUE
 	var/unlock_message = null
 
 	New()

--- a/code/datums/abilities/vampire/blood_tracking.dm
+++ b/code/datums/abilities/vampire/blood_tracking.dm
@@ -7,6 +7,7 @@
 	max_range = 0
 	cooldown = 0
 	pointCost = 0
+	not_when_in_an_object = 0
 	when_stunned = 2
 	not_when_handcuffed = 0
 	dont_lock_holder = 1

--- a/code/datums/abilities/vampire/blood_tracking.dm
+++ b/code/datums/abilities/vampire/blood_tracking.dm
@@ -7,7 +7,7 @@
 	max_range = 0
 	cooldown = 0
 	pointCost = 0
-	not_when_in_an_object = 0
+	not_when_in_an_object = FALSE
 	when_stunned = 2
 	not_when_handcuffed = 0
 	dont_lock_holder = 1

--- a/code/datums/abilities/vampire/cancel_stun.dm
+++ b/code/datums/abilities/vampire/cancel_stun.dm
@@ -7,7 +7,7 @@
 	max_range = 0
 	cooldown = 10
 	pointCost = 0
-	not_when_in_an_object = 0
+	not_when_in_an_object = FALSE
 	when_stunned = 2
 	not_when_handcuffed = 0
 

--- a/code/datums/abilities/vampire/cancel_stun.dm
+++ b/code/datums/abilities/vampire/cancel_stun.dm
@@ -7,6 +7,7 @@
 	max_range = 0
 	cooldown = 10
 	pointCost = 0
+	not_when_in_an_object = 0
 	when_stunned = 2
 	not_when_handcuffed = 0
 

--- a/code/datums/abilities/vampire/coffin.dm
+++ b/code/datums/abilities/vampire/coffin.dm
@@ -90,7 +90,6 @@
 	max_range = 999
 	cooldown = 600
 	pointCost = 400
-	not_when_in_an_object = 0
 	when_stunned = 1
 	not_when_handcuffed = 0
 	sticky = 1

--- a/code/datums/abilities/vampire/coffin.dm
+++ b/code/datums/abilities/vampire/coffin.dm
@@ -50,7 +50,7 @@
 	max_range = 999
 	cooldown = 600
 	pointCost = 0
-	not_when_in_an_object = 0
+	not_when_in_an_object = FALSE
 	when_stunned = 1
 	not_when_handcuffed = 0
 	sticky = 1

--- a/code/datums/abilities/vampire/coffin.dm
+++ b/code/datums/abilities/vampire/coffin.dm
@@ -90,7 +90,7 @@
 	max_range = 999
 	cooldown = 600
 	pointCost = 400
-	not_when_in_an_object = 0
+	not_when_in_an_object = 2
 	when_stunned = 1
 	not_when_handcuffed = 0
 	sticky = 1

--- a/code/datums/abilities/vampire/coffin.dm
+++ b/code/datums/abilities/vampire/coffin.dm
@@ -90,7 +90,7 @@
 	max_range = 999
 	cooldown = 600
 	pointCost = 400
-	not_when_in_an_object = 2
+	not_when_in_an_object = 0
 	when_stunned = 1
 	not_when_handcuffed = 0
 	sticky = 1

--- a/code/datums/abilities/vampire/coffin.dm
+++ b/code/datums/abilities/vampire/coffin.dm
@@ -50,6 +50,7 @@
 	max_range = 999
 	cooldown = 600
 	pointCost = 0
+	not_when_in_an_object = 0
 	when_stunned = 1
 	not_when_handcuffed = 0
 	sticky = 1
@@ -89,6 +90,7 @@
 	max_range = 999
 	cooldown = 600
 	pointCost = 400
+	not_when_in_an_object = 0
 	when_stunned = 1
 	not_when_handcuffed = 0
 	sticky = 1
@@ -107,8 +109,8 @@
 		var/turf/spawnturf = V.coffin_turf
 		if (istype(spawnturf,/turf/space))
 			spawnturf = get_turf(M)
-
-		if (spawnturf.z != M.z)
+		var/turf/owner_turf = get_turf(M)
+		if (spawnturf.z != owner_turf?.z)
 			boutput(M, "<span class='alert'>You cannot escape to a different Z-level.</span>")
 			return 1
 

--- a/code/datums/abilities/vampire/coffin.dm
+++ b/code/datums/abilities/vampire/coffin.dm
@@ -50,7 +50,6 @@
 	max_range = 999
 	cooldown = 600
 	pointCost = 0
-	not_when_in_an_object = FALSE
 	when_stunned = 1
 	not_when_handcuffed = 0
 	sticky = 1

--- a/code/datums/abilities/vampire/enthrall.dm
+++ b/code/datums/abilities/vampire/enthrall.dm
@@ -45,6 +45,7 @@
 	max_range = 1
 	cooldown = 1
 	pointCost = 0
+	not_when_in_an_object = 0
 	when_stunned = 1
 	not_when_handcuffed = 0
 	restricted_area_check = 0

--- a/code/datums/abilities/vampire/enthrall.dm
+++ b/code/datums/abilities/vampire/enthrall.dm
@@ -45,7 +45,7 @@
 	max_range = 1
 	cooldown = 1
 	pointCost = 0
-	not_when_in_an_object = 0
+	not_when_in_an_object = FALSE
 	when_stunned = 1
 	not_when_handcuffed = 0
 	restricted_area_check = 0

--- a/code/datums/abilities/vampire/radio_jammer.dm
+++ b/code/datums/abilities/vampire/radio_jammer.dm
@@ -5,6 +5,7 @@
 	targeted = 0
 	cooldown = 1800
 	pointCost = 50
+	not_when_in_an_object = 0
 	when_stunned = 0
 	not_when_handcuffed = 0
 	var/duration = 300

--- a/code/datums/abilities/vampire/radio_jammer.dm
+++ b/code/datums/abilities/vampire/radio_jammer.dm
@@ -5,7 +5,7 @@
 	targeted = 0
 	cooldown = 1800
 	pointCost = 50
-	not_when_in_an_object = 0
+	not_when_in_an_object = FALSE
 	when_stunned = 0
 	not_when_handcuffed = 0
 	var/duration = 300

--- a/code/datums/abilities/vampire/screech.dm
+++ b/code/datums/abilities/vampire/screech.dm
@@ -7,6 +7,7 @@
 	max_range = 0
 	cooldown = 300
 	pointCost = 60
+	not_when_in_an_object = 0
 	when_stunned = 1
 	var/duration = 10 SECONDS
 	not_when_handcuffed = 0

--- a/code/datums/abilities/vampire/screech.dm
+++ b/code/datums/abilities/vampire/screech.dm
@@ -7,7 +7,7 @@
 	max_range = 0
 	cooldown = 300
 	pointCost = 60
-	not_when_in_an_object = 0
+	not_when_in_an_object = 2
 	when_stunned = 1
 	var/duration = 10 SECONDS
 	not_when_handcuffed = 0

--- a/code/datums/abilities/vampire/screech.dm
+++ b/code/datums/abilities/vampire/screech.dm
@@ -7,7 +7,7 @@
 	max_range = 0
 	cooldown = 300
 	pointCost = 60
-	not_when_in_an_object = 0
+	not_when_in_an_object = FALSE
 	when_stunned = 1
 	var/duration = 10 SECONDS
 	not_when_handcuffed = 0

--- a/code/datums/abilities/vampire/screech.dm
+++ b/code/datums/abilities/vampire/screech.dm
@@ -7,7 +7,7 @@
 	max_range = 0
 	cooldown = 300
 	pointCost = 60
-	not_when_in_an_object = 2
+	not_when_in_an_object = 0
 	when_stunned = 1
 	var/duration = 10 SECONDS
 	not_when_handcuffed = 0

--- a/code/datums/abilities/vampire/thrall_abilities.dm
+++ b/code/datums/abilities/vampire/thrall_abilities.dm
@@ -7,7 +7,7 @@
 	max_range = 1
 	cooldown = 0
 	pointCost = 0
-	not_when_in_an_object = 0
+	not_when_in_an_object = FALSE
 	when_stunned = 1
 	not_when_handcuffed = 0
 	restricted_area_check = 0

--- a/code/datums/abilities/vampire/thrall_abilities.dm
+++ b/code/datums/abilities/vampire/thrall_abilities.dm
@@ -7,6 +7,7 @@
 	max_range = 1
 	cooldown = 0
 	pointCost = 0
+	not_when_in_an_object = 0
 	when_stunned = 1
 	not_when_handcuffed = 0
 	restricted_area_check = 0

--- a/code/datums/abilities/vampiric_thrall.dm
+++ b/code/datums/abilities/vampiric_thrall.dm
@@ -123,7 +123,7 @@
 	preferred_holder_type = /datum/abilityHolder/vampiric_thrall
 	var/when_stunned = 1 // 0: Never | 1: Ignore mob.stunned and mob.weakened | 2: Ignore all incapacitation vars
 	var/not_when_handcuffed = 0
-	var/not_when_in_an_object = 1
+	var/not_when_in_an_object = 1 // 0: Anywhere | 1: Only on turfs | 2: Anywhere but the port a brig
 	var/unlock_message = null
 
 	New()

--- a/code/datums/abilities/vampiric_thrall.dm
+++ b/code/datums/abilities/vampiric_thrall.dm
@@ -123,7 +123,7 @@
 	preferred_holder_type = /datum/abilityHolder/vampiric_thrall
 	var/when_stunned = 1 // 0: Never | 1: Ignore mob.stunned and mob.weakened | 2: Ignore all incapacitation vars
 	var/not_when_handcuffed = 0
-	var/not_when_in_an_object = 1
+	var/not_when_in_an_object = TRUE
 	var/unlock_message = null
 
 	New()

--- a/code/datums/abilities/vampiric_thrall.dm
+++ b/code/datums/abilities/vampiric_thrall.dm
@@ -123,6 +123,7 @@
 	preferred_holder_type = /datum/abilityHolder/vampiric_thrall
 	var/when_stunned = 1 // 0: Never | 1: Ignore mob.stunned and mob.weakened | 2: Ignore all incapacitation vars
 	var/not_when_handcuffed = 0
+	var/not_when_in_an_object = 1
 	var/unlock_message = null
 
 	New()

--- a/code/datums/abilities/vampiric_thrall.dm
+++ b/code/datums/abilities/vampiric_thrall.dm
@@ -123,7 +123,7 @@
 	preferred_holder_type = /datum/abilityHolder/vampiric_thrall
 	var/when_stunned = 1 // 0: Never | 1: Ignore mob.stunned and mob.weakened | 2: Ignore all incapacitation vars
 	var/not_when_handcuffed = 0
-	var/not_when_in_an_object = 1 // 0: Anywhere | 1: Only on turfs | 2: Anywhere but the port a brig
+	var/not_when_in_an_object = 1
 	var/unlock_message = null
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
makes some vamp powers such as cancel stuns and thrallspeak work in containers


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #9441, allows for vampires to use certain powers which shouldnt be restricted for being in a container such as cancel stuns

(not i am not aware of the balance implications of this and the port a brig)
