### PR TITLE
Add access check for Donut 3 armory turret

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -84421,6 +84421,7 @@
 	dir = 4;
 	icon_state = "line1"
 	},
+/obj/access_spawn/security,
 /obj/machinery/turret{
 	dir = 8
 	},


### PR DESCRIPTION
[QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds a security access spawner for the Donut 3 armory turret.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The turret would fire at everyone, including security members, which would make it so that you need to turn off the turret whenever you went into the armory. Also, the turret was in such a position that if you set it on lethal, its shots could hit you even if you were standing in front of the turret control panel. 

Also, more in-line with the Oshan armory turret which does have an access spawn.