### PR TITLE
Dropping An Item Will Drop Grabs First

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -1222,6 +1222,11 @@
 				W = held
 		if (!istype(W) || W.cant_drop) return
 
+		if (W.special_grab != null)
+			if (W.chokehold != null)
+				W.drop_grab()
+				return
+
 		if (W && !W.qdeled)
 			if (istype(src.loc, /obj/vehicle))
 				var/obj/vehicle/V = src.loc


### PR DESCRIPTION
[QoL]


## About the PR:
Attempting to drop an item will now drop any grabs made with it first.



## Why's this needed?
Quality of life.
No more releasing a hostage that you are holding at gunpoint only for them to take your firearm and turn you into Swiss cheese.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Attempting to drop an item will now drop any grabs made with it first.
```
