### PR TITLE
Splits The Lawbringer And Antique Lawbringer Job Reward Back Into Two Distinct Rewards

### DIFF
--- a/code/modules/jobxp/JobXPRewards.dm
+++ b/code/modules/jobxp/JobXPRewards.dm
@@ -307,8 +307,7 @@ mob/verb/checkrewards()
 			src.claimedNumbers[usr.key] --
 			return
 
-		var/actual_reward_path = prob(1) ? /obj/item/gun/energy/lawbringer/old : src.reward_path
-		var/obj/item/gun/energy/lawbringer/LG = new actual_reward_path()
+		var/obj/item/gun/energy/lawbringer/LG = new reward_path()
 		var/obj/item/paper/lawbringer_pamphlet/LGP = new/obj/item/paper/lawbringer_pamphlet()
 		if (!istype(LG))
 			boutput(C.mob, "Something terribly went wrong. The reward path got screwed up somehow. call 1-800-CODER. But you're an HoS! You don't need no stinkin' guns anyway!")
@@ -323,6 +322,23 @@ mob/verb/checkrewards()
 		C.mob.put_in_hand_or_drop(LGP)
 		boutput(C.mob, "<span class='emote'>A pamphlet flutters out.</span>")
 		return
+
+/datum/jobXpReward/head_of_security_LG_old
+	name = "The Antique Lawbringer"
+	desc = "Gain access to a voice activated weapon of the past-future-past by sacrificing your gun of the future-past. I.E. The Lawbringer."
+	required_levels = list("Head of Security"=0)
+	claimable = 1
+	claimPerRound = 1
+
+	activate(var/client/C)
+		var/obj/item/gun/energy/lawbringer/I = C.mob.find_type_in_hand(/obj/item/gun/energy/lawbringer)
+
+		if (I)
+			I.make_antique()
+			boutput(C.mob, "Your Lawbringer becomes a little more antique!")
+		else
+			boutput(C.mob, "You need to be holding your Lawbringer in order to claim this reward.")
+			src.claimedNumbers[usr.key] --
 
 //Captain
 


### PR DESCRIPTION
[QoL]

## About the PR:
Just as before the HoS XP removal, the Lawbringer and Antique Lawbringer now have independant job rewards, just without any level requirements.



## Why's this needed?
Players who want the Antique Lawbringer will rarely ever receive it, being a 1% chance to recieve it when redeeming a Lawbringer, and for those who dislike the look of it, it will be a minor annoyance if they do manage to roll it.