### PR TITLE
remove random chance for dwarf mutation

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -781,8 +781,6 @@ ABSTRACT_TYPE(/datum/job/engineering)
 		if (!M)
 			return
 		M.bioHolder.AddEffect("training_miner")
-		if(prob(20))
-			M.bioHolder.AddEffect("dwarf", magical=1)
 
 /datum/job/engineering/mechanic
 	name = "Mechanic"


### PR DESCRIPTION
[qol]

## About the PR 
removes the random chance for miners to be dwarves roundstart


## Why's this needed? 
in my experience it's just annoying. i get it's a DF reference, but having less control over character appearance roundstart bothers some people. i can also just cut the chance from 20% to something less, like 5%, but it's tough to roundstart with this thing you don't want and then genetics is just starting out in their research and can't fix it yet.
