### PR TITLE
Bolds Time Numbers in Hub Entry

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -747,9 +747,9 @@ var/f_color_selector_handler/F_Color_Selector
 	if(ticker?.round_elapsed_ticks > 0 && current_state == GAME_STATE_PLAYING)
 		statsus += "Time: <b>[round(ticker.round_elapsed_ticks / 36000)]:[add_zero(num2text(ticker.round_elapsed_ticks / 600 % 60), 2)]</b><br>"
 	else if (current_state == GAME_STATE_FINISHED)
-		statsus += "Time: RESTARTING<br>"
+		statsus += "Time: <b>RESTARTING</b><br>"
 	else if(!ticker)
-		statsus += "Time: STARTING<br>"
+		statsus += "Time: <b>STARTING</b><br>"
 
 	if (map_settings)
 		var/map_name = istext(map_settings.display_name) ? "[map_settings.display_name]" : "[map_settings.name]"

--- a/code/world.dm
+++ b/code/world.dm
@@ -745,7 +745,7 @@ var/f_color_selector_handler/F_Color_Selector
 	statsus += "The classic SS13 experience. &#8212; (<a href=\"http://bit.ly/gndscd\">Discord</a>)<br>"
 
 	if(ticker?.round_elapsed_ticks > 0 && current_state == GAME_STATE_PLAYING)
-		statsus += "Time: [round(ticker.round_elapsed_ticks / 36000)]:[add_zero(num2text(ticker.round_elapsed_ticks / 600 % 60), 2)]<br>"
+		statsus += "Time: <b>[round(ticker.round_elapsed_ticks / 36000)]:[add_zero(num2text(ticker.round_elapsed_ticks / 600 % 60), 2)]</b><br>"
 	else if (current_state == GAME_STATE_FINISHED)
 		statsus += "Time: RESTARTING<br>"
 	else if(!ticker)


### PR DESCRIPTION
Thank you to Waka for the previous merge, just a tiiiiny edit, bolded the numbers after Time: to match how both Map: and Mode: have the text after being bold too
Didn't add a changelog because of how minor it is (can add if you want)