### PR TITLE
Vampires and arcfiends replenish hunger and thirst when feeding

### DIFF
--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -234,6 +234,12 @@
 			else
 				src.points = max(src.points + change, 0)
 
+			if (change > 0 && ishuman(src.owner))
+				var/mob/living/carbon/human/H = src.owner
+				if (H.sims)
+					H.sims.affectMotive("Thirst", change * 0.5)
+					H.sims.affectMotive("Hunger", change * 0.5)
+
 	proc/get_vampire_blood(var/total_blood = 0)
 		if (total_blood)
 			return src.vamp_blood

--- a/code/modules/antagonists/arcfiend/arcfiend.dm
+++ b/code/modules/antagonists/arcfiend/arcfiend.dm
@@ -45,6 +45,11 @@
 	addPoints(add_points, target_ah_type = src.type)
 		src.lifetime_energy += add_points
 		var/points = min((MAX_ARCFIEND_POINTS - src.points), add_points)
+		if (points > 0 && ishuman(src.owner))
+			var/mob/living/carbon/human/H = src.owner
+			if (H.sims)
+				H.sims.affectMotive("Thirst", points * 0.1)
+				H.sims.affectMotive("Hunger", points * 0.1)
 		. = ..(points, target_ah_type)
 
 ABSTRACT_TYPE(/datum/targetable/arcfiend)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When motives are enabled, vampires and arcfiends can replenish them by feeding on blood or power respectively. They're replenished at a rate of 1% per two units of blood for vampires, and 1% per ten units of power for arcfiends.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

As they're creatures that feed on blood and electricity, I always thought it was silly that the actual representations of their hunger/thirst needs were unaffected by doing the thing they're characterized for, so you'd still need to have a salad or something even after draining half a dozen people. Replenishing the needs by feeding (imo) makes 'em feel more immersive, since you're actually feeling less hungry after a feeding.