### PR TITLE
Small coffeeberry bug fix!

### DIFF
--- a/code/modules/hydroponics/plants_crop.dm
+++ b/code/modules/hydroponics/plants_crop.dm
@@ -272,5 +272,6 @@ ABSTRACT_TYPE(/datum/plant/crop)
 	harvests = 5
 	endurance = 0
 	genome = 6
+	assoc_reagents = list("coffee")
 	commuts = list(/datum/plant_gene_strain/immunity_toxin,/datum/plant_gene_strain/metabolism_slow)
 	mutations = list(/datum/plantmutation/coffee/mocha, /datum/plantmutation/coffee/latte)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just adds associated reagent to coffeeberry, letting the coffee it produces to scale with potency + be able to make fun splices!
Without it, it's mutations were a bit funky! Mochaberries would have 200u chocolate and 10u coffee, ie the same for latte berries with milk and coffee. Drink splices like Laura Palmer would only work if the coffee berry was the dominant plant.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Most other crops with reagents have this line, however coffee berries didn't which causes some issues regarding splices and even it's mutations! Also fixes #9464 
