### PR TITLE
pod wars blasters can no longer be dual wielded

### DIFF
--- a/code/datums/gamemodes/pod_wars/pw_weapons.dm
+++ b/code/datums/gamemodes/pod_wars/pw_weapons.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/items/gun.dmi'
 	icon_state = "pw_pistol"
 	item_state = "pw_pistol_nt"
+	can_dual_wield = FALSE
 	w_class = 3.0
 	force = 8.0
 	mats = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

makes pod wars blasters undualwieldable

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

if i did the math right dual blasters have 198 dmg per 1,2 seconds
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+)Made pod wars blasters undualwieldable.
```
