### PR TITLE
Removes stability material property from the game

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -276,7 +276,6 @@ ABSTRACT_TYPE(/datum/material/metal)
 		..()
 		setProperty("density", 2)
 		setProperty("hard", 2)
-		setProperty("stability", 2)
 		setProperty("electrical", 4)
 		setProperty("thermal", 4)
 
@@ -311,7 +310,6 @@ ABSTRACT_TYPE(/datum/material/metal)
 	color = "#B87333" //the hex value known as copper in RGB colorspace
 	New()
 		..()
-		setProperty("stability", 3)
 		setProperty("electrical", 6)
 		setProperty("density", 2)
 		setProperty("hard", 1)
@@ -324,7 +322,6 @@ ABSTRACT_TYPE(/datum/material/metal)
 	color = "#E39362"
 	New()
 		..()
-		setProperty("stability", 6)
 		setProperty("electrical", 7)
 		setProperty("density", 2)
 		setProperty("hard", 2)
@@ -377,7 +374,6 @@ ABSTRACT_TYPE(/datum/material/metal)
 
 		material_flags |= MATERIAL_ENERGY
 		setProperty("electrical", 6)
-		setProperty("stability", 3)
 		setProperty("radioactive", 5)
 		setProperty("hard", 2)
 
@@ -463,7 +459,6 @@ ABSTRACT_TYPE(/datum/material/metal)
 		setProperty("density", 9)
 		setProperty("hard", 3)
 		setProperty("electrical", 7)
-		setProperty("stability", 2)
 		setProperty("n_radioactive", 8)
 
 
@@ -483,7 +478,6 @@ ABSTRACT_TYPE(/datum/material/metal)
 
 		setProperty("density", 2) //fucked up values for fucked up material but not silly putty
 		setProperty("hard", 2)
-		setProperty("stability", 1)
 		setProperty("electrical", 2)
 
 
@@ -495,7 +489,6 @@ ABSTRACT_TYPE(/datum/material/metal)
 
 	New()
 		..()
-		setProperty("stability", 9)
 		setProperty("density", 8)
 		setProperty("hard", 1)
 
@@ -623,7 +616,6 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		setProperty("hard", 3)
 		setProperty("electrical", 6)
 		setProperty("radioactive", 8)
-		setProperty("stability", 1)
 
 		addTrigger(triggersOnAdd, new /datum/materialProc/erebite_flash())
 		addTrigger(triggersTemp, new /datum/materialProc/erebite_temp())
@@ -852,7 +844,6 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		setProperty("density", 2) //light
 		setProperty("hard", 5) // very hard
 		setProperty("reflective", 9) // shiny
-		setProperty("stability", 4) // constantly fluctuating
 		setProperty("electrical", 7) // good conductor
 
 
@@ -908,7 +899,6 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		setProperty("reflective", 9)
 		setProperty("density", 9)
 		setProperty("hard", 9)
-		setProperty("stability", 7)
 		setProperty("electrical", 1)
 		addTrigger(triggersOnAdd, new /datum/materialProc/gold_add())
 
@@ -1259,7 +1249,6 @@ ABSTRACT_TYPE(/datum/material/organic)
 		material_flags |= MATERIAL_ENERGY
 		setProperty("density", 1)
 		setProperty("hard", 1)
-		setProperty("stability", 2)
 		addTrigger(triggersOnAdd, new /datum/materialProc/ethereal_add())
 // Fabrics
 
@@ -1391,7 +1380,6 @@ ABSTRACT_TYPE(/datum/material/fabric)
 		setProperty("density", 4)
 		setProperty("hard", 4)
 		setProperty("thermal", 9)
-		setProperty("stability", 4)
 		setProperty("permeable", 8)
 		setProperty("electrical", 7)
 
@@ -1408,7 +1396,6 @@ ABSTRACT_TYPE(/datum/material/fabric)
 		material_flags |= MATERIAL_METAL | MATERIAL_ENERGY
 		setProperty("density", 1)
 		setProperty("hard", 1)
-		setProperty("stability", 9)
 		setProperty("electrical", 1)
 		setProperty("permeable", 1)
 		addTrigger(triggersOnAdd, new /datum/materialProc/ethereal_add())
@@ -1428,7 +1415,6 @@ ABSTRACT_TYPE(/datum/material/fabric)
 		setProperty("density", 6)
 		setProperty("hard", 1)
 		setProperty("thermal", 9)
-		setProperty("stability", 8)
 		setProperty("radioactive", 3)
 		setProperty("electrical", 7)
 		addTrigger(triggersOnLife, new /datum/materialProc/generic_itchy_onlife())
@@ -1445,7 +1431,6 @@ ABSTRACT_TYPE(/datum/material/fabric)
 		setProperty("density", 8)
 		setProperty("hard", 4)
 		setProperty("corrosion", 7)
-		setProperty("stability", 8)
 		setProperty("electrical", 7)
 
 

--- a/code/modules/materials/Mat_Properties.dm
+++ b/code/modules/materials/Mat_Properties.dm
@@ -194,25 +194,6 @@ ABSTRACT_TYPE(/datum/material_property)
 			if(8 to INFINITY)
 				return "highly corrosion-resistant"
 
-/datum/material_property/stability
-	name = "Stability"
-	id = "stability"
-
-	getAdjective(var/datum/material/M)
-		switch(M.getProperty(id))
-			if(0 to 1)
-				return "very unstable"
-			if(1 to 2)
-				return "unstable"
-			if(2 to 4)
-				return "slightly unstable"
-			if(4 to 6)
-				return "slightly solid"
-			if(6 to 8)
-				return "solid"
-			if(8 to INFINITY)
-				return "very solid"
-
 /datum/material_property/permeability
 	name = "Permeability"
 	id = "permeable"

--- a/code/modules/power/TEG.dm
+++ b/code/modules/power/TEG.dm
@@ -1351,7 +1351,7 @@ Present 	Unscrewed  Connected 	Unconnected		Missing
 /** Thermoelectric Generator Semiconductor - A beautiful array of thermopiles */
 /obj/item/teg_semiconductor
 	name = "Prototype Semiconductor"
-	desc = "A large rectangulr plate stamped with 'Prototype Thermo-Electric Generator Semiconductor.  If found please return to NanoTrasen.'"
+	desc = "A large rectangular plate stamped with 'Prototype Thermo-Electric Generator Semiconductor.  If found please return to NanoTrasen.'"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "semi"
 

--- a/code/obj/item/gun/ammo.dm
+++ b/code/obj/item/gun/ammo.dm
@@ -1177,15 +1177,6 @@
 	max_charge = 40.0
 	recharge_rate = 5.0
 
-	process()
-		if(src.material)
-			if(src.material.hasProperty("stability"))
-				if(src.material.getProperty("stability") <= 1)
-					if(prob(1))
-						var/turf/T = get_turf(src)
-						explosion_new(src, T, 1)
-						src.visible_message("<span class='alert'>\the [src] detonates.</span>")
-
 
 /obj/item/ammo/power_cell/self_charging/custom
 	name = "Power Cell"

--- a/code/turf/turf_autoalign.dm
+++ b/code/turf/turf_autoalign.dm
@@ -175,18 +175,6 @@
 			else
 				return
 
-		if (src.material)
-			var/fail = 0
-			if (src.material.getProperty("stability") <= 2)
-				fail = 1
-			if (src.material.quality < 0) if(prob(abs(src.material.quality)))
-				fail = 1
-			if (fail)
-				user.visible_message("<span class='alert'>You hit the wall and it [getMatFailString(src.material.material_flags)]!</span>","<span class='alert'>[user] hits the wall and it [getMatFailString(src.material.material_flags)]!</span>")
-				playsound(src.loc, "sound/impact_sounds/Generic_Stab_1.ogg", 25, 1)
-				del(src)
-				return
-
 		src.visible_message("<span class='alert'>[usr ? usr : "Someone"] uselessly hits [src] with [W].</span>", "<span class='alert'>You uselessly hit [src] with [W].</span>")
 
 /turf/simulated/wall/auto/jen

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -281,17 +281,6 @@
 				boutput(user, text("<span class='notice'>You punch the [src.name].</span>"))
 				return
 
-	if(src.material)
-		var/fail = 0
-		if(src.material.hasProperty("stability") && src.material.getProperty("stability") <= 2) fail = 1
-		if(src.material.quality < 0) if(prob(abs(src.material.quality))) fail = 1
-
-		if(fail)
-			user.visible_message("<span class='alert'>You punch the wall and it [getMatFailString(src.material.material_flags)]!</span>","<span class='alert'>[user] punches the wall and it [getMatFailString(src.material.material_flags)]!</span>")
-			playsound(src, "sound/impact_sounds/Generic_Stab_1.ogg", 25, 1)
-			dismantle_wall(1)
-			return
-
 	boutput(user, "<span class='notice'>You hit the [src.name] but nothing happens!</span>")
 	playsound(src, "sound/impact_sounds/Generic_Stab_1.ogg", 25, 1)
 	interact_particle(user,src)
@@ -342,18 +331,6 @@
 		else return
 
 	else
-		if(src.material)
-			src.material.triggerOnHit(src, W, user, 1)
-			var/fail = 0
-			if(src.material.hasProperty("stability") && src.material.getProperty("stability") <= 2) fail = 1
-			if(src.material.quality < 0) if(prob(abs(src.material.quality))) fail = 1
-
-			if(fail)
-				user.visible_message("<span class='alert'>You hit the wall and it [getMatFailString(src.material.material_flags)]!</span>","<span class='alert'>[user] hits the wall and it [getMatFailString(src.material.material_flags)]!</span>")
-				playsound(src, "sound/impact_sounds/Generic_Stab_1.ogg", 25, 1)
-				del(src)
-				return
-
 		src.visible_message("<span class='alert'>[usr ? usr : "Someone"] uselessly hits [src] with [W].</span>", "<span class='alert'>You uselessly hit [src] with [W].</span>")
 		//return attack_hand(user)
 
@@ -535,18 +512,6 @@
 
 	if(istype(src, /turf/simulated/wall/r_wall) && src.d_state > 0)
 		src.icon_state = "r_wall-[d_state]"
-
-	if(src.material)
-		src.material.triggerOnHit(src, W, user, 1)
-		var/fail = 0
-		if(src.material.hasProperty("stability") && src.material.getProperty("stability") <= 2) fail = 1
-		if(src.material.quality < 0) if(prob(abs(src.material.quality))) fail = 1
-
-		if(fail)
-			user.visible_message("<span class='alert'>You hit the wall and it [getMatFailString(src.material.material_flags)]!</span>","<span class='alert'>[user] hits the wall and it [getMatFailString(src.material.material_flags)]!</span>")
-			playsound(src.loc, "sound/impact_sounds/Generic_Stab_1.ogg", 25, 1)
-			del(src)
-			return
 
 	src.visible_message("<span class='alert'>[usr ? usr : "Someone"] uselessly hits [src] with [W].</span>", "<span class='alert'>You uselessly hit [src] with [W].</span>")
 	//return attack_hand(user)

--- a/code/turf/walls.dm
+++ b/code/turf/walls.dm
@@ -331,6 +331,8 @@
 		else return
 
 	else
+		if(src.material)
+			src.material.triggerOnHit(src, W, user, 1)
 		src.visible_message("<span class='alert'>[usr ? usr : "Someone"] uselessly hits [src] with [W].</span>", "<span class='alert'>You uselessly hit [src] with [W].</span>")
 		//return attack_hand(user)
 
@@ -512,6 +514,9 @@
 
 	if(istype(src, /turf/simulated/wall/r_wall) && src.d_state > 0)
 		src.icon_state = "r_wall-[d_state]"
+
+	if(src.material)
+		src.material.triggerOnHit(src, W, user, 1)
 
 	src.visible_message("<span class='alert'>[usr ? usr : "Someone"] uselessly hits [src] with [W].</span>", "<span class='alert'>You uselessly hit [src] with [W].</span>")
 	//return attack_hand(user)

--- a/strings/books/matsci_guide_new.txt
+++ b/strings/books/matsci_guide_new.txt
@@ -40,7 +40,7 @@ An aspiring metallurgist requires a suitable workshop in which they can create a
 <ul><li>Nano-Fabricator schematics describe needing either metal alloys, fabrics, rubber, or crystals, but it is possible for a single bar of alloyed material to possess all the properties needed for a schematic to begin working
 <li> You can store and view your stored materials under the “Storage” tab</li><br>
 <li>You can automatically store projects you make in the Nano-Fabricator by setting output to the Nano-Fabricator under the “Settings” tab</li><br>
-</li></ul><li><b>Material Analyzer</b> - a green handheld device that reports information of a material including electrical conductivity, thermal conductivity, hardness, density, stability, and others. See "An Index of Properties and Their Effects" section below.
+</li></ul><li><b>Material Analyzer</b> - a green handheld device that reports information of a material including electrical conductivity, thermal conductivity, hardness, density, and others. See "An Index of Properties and Their Effects" section below.
 </ul>
 <ul><li><b>Arc Electroplater</b> - a machine that allows for you to place a material in an electrolyte bath and then place an object into the bath to transfer the electrolyzed material to the surface of the object.
 <ul><li>This allows for transfer of material properties to objects you cannot make through the Nano-Fabricator. Particularly of interest in thermo-electric systems.</li></ul>
@@ -62,7 +62,6 @@ This section shows the different properties or materials that are of interest to
 </p><ul><li>(ex.: Copper, Claretine, Electrum)</ul></li>
 <p style="margin-right:10%; margin-left:1%"><b>Thermal Conductivity</b> - ability of material to transfer heat through it with little loss of energy; <b>more insulating materials do better at keeping heat within which can be advantageous for creating temperature differentials.</b></p>
 <ul><li>(ex.: Carbon Nanofiber, Fibrilith, Space spider silk)</ul></li>
-<p style="margin-right:10%; margin-left:1%"><b>Stability</b> - how prone a material is to degradation; important for rechargable power cells, as lower stability means that with each recharge, there is a chance for the cell to explode.
 </p><ul><li>(ex.: Starstone, Carbon Nanofiber, Hauntium)</ul></li>
 <p style="margin-right:10%; margin-left:1%"><b>Density</b> -  sturdiness of the material when used in things like wearables.</p>
 <ul><li>(ex.: Viscerite, Plasmasteel, Starstone)</ul></li>
@@ -79,7 +78,7 @@ This section shows the different properties or materials that are of interest to
 <section id="Basic-Mats"><h3>Basic Ores and Their Properties</h3></section>
 <hr>
 Below is a list of all the basic ores that are common to asteroids in this sector, as well as their particular properties that are of interest for Materials Science. See Appendix II for material classifications.
-The properties in full and in order are Radioactivity, Electrical Conductivity, Stability, Hardness, Density, Flammability, Corrosion Resistance, Permeability, and Reflectivity.
+The properties in full and in order are Radioactivity, Electrical Conductivity, Hardness, Density, Flammability, Corrosion Resistance, Permeability, and Reflectivity.
 <br><br>
 <table>
 <tr><th align="right">ORE</th>
@@ -262,7 +261,7 @@ The properties in full and in order are Radioactivity, Electrical Conductivity, 
 <section id="Advanced-Mats"><h3>Advanced Materials and Their Properties</h3></section>
 <hr>
 These are additional useful materials and their relative properties.
-The properties in full and in order are Radioactivity, Electrical Conductivity, Thermal Conductivity, Stability, Hardness, Density, Flammability, Corrosion Resistance, Permeability, and Reflectivity.
+The properties in full and in order are Radioactivity, Electrical Conductivity, Thermal Conductivity, Hardness, Density, Flammability, Corrosion Resistance, Permeability, and Reflectivity.
 <br><br>
 <table>
 <tr><th align="right">ORGANIC MAT</th>
@@ -718,7 +717,7 @@ The properties in full and in order are Radioactivity, Electrical Conductivity, 
 <section id="Alloyed-Mats"><h3>Alloyed Materials and Their Properties</h3></section>
 <hr>
 This section contains different common and particular alloyed materials and the properties they possess that are of interest for Materials Science. The exact manner by which most of these can be made can be found at the references in the footnote.
-The properties in full and in order are Radioactivity, Neutron Radiation, Electrical Conductivity, Thermal Conductivity, Stability, Hardness, Density, Flammability, Corrosion Resistance, Permeability, and Reflectivity.
+The properties in full and in order are Radioactivity, Neutron Radiation, Electrical Conductivity, Thermal Conductivity, Hardness, Density, Flammability, Corrosion Resistance, Permeability, and Reflectivity.
 <br><br>
 <table>
 <tr><th align="right">ALLOY</th>
@@ -900,14 +899,6 @@ Thank you for your service to Nanotrasen.</i></p>
 			<li>66 to 76 --  Thermally-conductive</li>
 			<li>77 to 85 --  Highly thermally-conductive</li>
 			<li>86+      --  Extremely thermally-conductive</li></ul>
-		<p style="margin-right:10%; margin-left:1%"><b>Stability</b></p>
-			<ul style='list-style-type:circle'>
-			<li>1 to 10  --  Very unstable</li>
-			<li>11 to 25 --  Unstable</li>
-			<li>26 to 50 --  Slightly unstable</li>
-			<li>51 to 75 --  Slightly solid</li>
-			<li>76 to 90 --  Solid</li>
-			<li>90+      --  Very solid (stable)</li></ul>
 		<p style="margin-right:10%; margin-left:1%"><b>Hardness</b></p>
 			<ul style='list-style-type:circle'>
 			<li>1 to 10  --  Very soft (low hardness)</li>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
All uses of stability (used only for custom small cells and custom walls) and the related property have been removed.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Previously, the stability property served to encourage null alloying low stability materials with high stability materials. With the removal of null alloying, stability no longer has much of a point outside of rng cell exploding. This also helps to trim up matsci in order to help with further expansion.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)The stability material property has been removed from the game.
```
