### PR TITLE
Renames corrosion resistance material prop to chemical resistance, merges permability with chemical resistance

### DIFF
--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -262,8 +262,8 @@ ABSTRACT_TYPE(/datum/material/metal)
 		material_flags |= MATERIAL_METAL
 		setProperty("electrical", 5)
 		setProperty("thermal", 6)
-		setProperty("permeable", 3)
 		setProperty("density", 4)
+		setProperty("chemical", 6)
 
 /datum/material/metal/rock
 	mat_id = "rock"
@@ -340,6 +340,7 @@ ABSTRACT_TYPE(/datum/material/metal)
 		value = 175
 		setProperty("density", 4)
 		setProperty("hard", 2)
+		setProperty("chemical", 8)
 
 
 
@@ -352,6 +353,7 @@ ABSTRACT_TYPE(/datum/material/metal)
 		..()
 		setProperty("density", 6)
 		setProperty("hard", 5)
+		setProperty("chemical", 7)
 
 
 /datum/material/metal/mauxite
@@ -513,6 +515,7 @@ ABSTRACT_TYPE(/datum/material/metal)
 		material_flags |= MATERIAL_CRYSTAL
 		setProperty("density", 8)
 		setProperty("hard", 8)
+		setProperty("chemical", 9)
 
 
 /datum/material/metal/negativematter
@@ -552,9 +555,8 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		material_flags |= MATERIAL_CRYSTAL
 		setProperty("hard", 3)
 		setProperty("electrical", 3)
-		setProperty("permeable", 1)
 		setProperty("thermal", 3)
-		setProperty("corrosion", 5)
+		setProperty("chemical", 5)
 
 /datum/material/crystal/glass
 	mat_id = "glass"
@@ -828,7 +830,7 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		..()
 		setProperty("density", 8)
 		setProperty("hard", 4)
-		setProperty("corrosion", 6)
+		setProperty("chemical", 9)
 
 
 // hi it me cirr im doing dumb
@@ -889,8 +891,7 @@ ABSTRACT_TYPE(/datum/material/crystal)
 		setProperty("density", rand(1, 8))
 		setProperty("hard", rand(1, 8))
 		setProperty("reflective", rand(1, 9))
-		setProperty("corrosion", rand(1, 8))
-		setProperty("permeable", rand(3, 9))
+		setProperty("chemical", rand(1, 8))
 		addTrigger(triggersTemp, new /datum/materialProc/temp_miraclium())
 
 
@@ -1006,7 +1007,7 @@ ABSTRACT_TYPE(/datum/material/organic)
 	New()
 		..()
 		material_flags |= MATERIAL_CRYSTAL | MATERIAL_CLOTH
-		setProperty("corrosion", 3)
+		setProperty("chemical", 3)
 		setProperty("density", 5)
 		setProperty("hard", 1)
 		setProperty("flammable", 9)
@@ -1079,8 +1080,7 @@ ABSTRACT_TYPE(/datum/material/organic)
 		material_flags |= MATERIAL_CLOTH
 		setProperty("density", 4)
 		setProperty("hard", 1)
-		setProperty("corrosion", 7)
-		setProperty("permeable", 9)
+		setProperty("chemical", 6)
 		setProperty("flammable", 2)
 		addTrigger(triggersOnEat, new /datum/materialProc/oneat_viscerite())
 
@@ -1209,8 +1209,7 @@ ABSTRACT_TYPE(/datum/material/organic)
 	New()
 		..()
 		setProperty("density", 5)
-		setProperty("corrosion", 7)
-		setProperty("permeable", 3)
+		setProperty("chemical", 7)
 		setProperty("thermal", 2)
 		setProperty("flammable", 1)
 		addTrigger(triggersOnLife, new /datum/materialProc/generic_reagent_onlife("cholesterol", 1))
@@ -1230,7 +1229,6 @@ ABSTRACT_TYPE(/datum/material/organic)
 	New()
 		..()
 		setProperty("hard", 1)
-		setProperty("permeable", 9)
 
 
 /datum/material/organic/coral
@@ -1358,7 +1356,6 @@ ABSTRACT_TYPE(/datum/material/fabric)
 		setProperty("hard", 2)
 		setProperty("thermal", 1)
 		setProperty("flammable", 1)
-		setProperty("permeable", 2)
 
 
 	New()
@@ -1392,7 +1389,6 @@ ABSTRACT_TYPE(/datum/material/fabric)
 		setProperty("hard", 4)
 		setProperty("thermal", 9)
 		setProperty("stability", 4)
-		setProperty("permeable", 8)
 		setProperty("electrical", 7)
 
 
@@ -1410,7 +1406,6 @@ ABSTRACT_TYPE(/datum/material/fabric)
 		setProperty("hard", 1)
 		setProperty("stability", 9)
 		setProperty("electrical", 1)
-		setProperty("permeable", 1)
 		addTrigger(triggersOnAdd, new /datum/materialProc/ethereal_add())
 		addTrigger(triggersOnEntered, new /datum/materialProc/soulsteel_entered())
 
@@ -1444,7 +1439,7 @@ ABSTRACT_TYPE(/datum/material/fabric)
 		..()
 		setProperty("density", 8)
 		setProperty("hard", 4)
-		setProperty("corrosion", 7)
+		setProperty("chemical", 9)
 		setProperty("stability", 8)
 		setProperty("electrical", 7)
 

--- a/code/modules/materials/Mat_Properties.dm
+++ b/code/modules/materials/Mat_Properties.dm
@@ -171,9 +171,9 @@ ABSTRACT_TYPE(/datum/material_property)
 			if(8 to INFINITY)
 				return "very flammable"
 
-/datum/material_property/corrosion
-	name = "Corrosion resistance"
-	id = "corrosion"
+/datum/material_property/chemical
+	name = "Chemical resistance"
+	id = "chemical"
 	default_value = 3
 
 	prefix_high_min = 5
@@ -188,11 +188,11 @@ ABSTRACT_TYPE(/datum/material_property)
 			if(2 to 4)
 				return "slightly corroded"
 			if(4 to 6)
-				return "slightly corrosion-resistant"
+				return "slightly chemical-resistant"
 			if(6 to 8)
-				return "corrosion-resistant"
+				return "chemical-resistant"
 			if(8 to INFINITY)
-				return "highly corrosion-resistant"
+				return "highly chemical-resistant"
 
 /datum/material_property/stability
 	name = "Stability"
@@ -213,26 +213,6 @@ ABSTRACT_TYPE(/datum/material_property)
 			if(8 to INFINITY)
 				return "very solid"
 
-/datum/material_property/permeability
-	name = "Permeability"
-	id = "permeable"
-
-	default_value = 6
-
-	getAdjective(var/datum/material/M)
-		switch(M.getProperty(id))
-			if(0 to 1)
-				return "very impermeable"
-			if(1 to 2)
-				return "impermeable"
-			if(2 to 4)
-				return "slightly impermeable"
-			if(4 to 6)
-				return "slightly permeable"
-			if(6 to 8)
-				return "permeable"
-			if(8 to INFINITY)
-				return "very permeable"
 
 /datum/material_property/radioactivity
 	name = "Radioactivity"

--- a/code/obj/grille.dm
+++ b/code/obj/grille.dm
@@ -184,7 +184,7 @@
 
 			cut_resist = material.getProperty("hard") * 10
 			blunt_resist = material.getProperty("density") * 10
-			corrode_resist = material.getProperty("corrosion") * 10
+			corrode_resist = material.getProperty("chemical") * 10
 			if (blunt_resist != 0) blunt_resist /= 2
 
 	damage_blunt(var/amount)

--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -150,8 +150,8 @@
 			setProperty("coldprot", 10+prot)
 			setProperty("heatprot", 2+round(prot/2))
 
-			prot =  max(0, (7 - visr_material.getProperty("permeable")) * 5)
-			setProperty("viralprot", prot)
+			prot =  clamp(((visr_material.getProperty("chemical") - 4) * 10), 10, 35) // All crystals (assuming default chem value) will give 20 chemprot, same as normal helm.
+			setProperty("chemprot", prot)
 
 			prot = max(0, visr_material.getProperty("density") - 3) / 2
 			setProperty("meleeprot_head", 3 + prot) // even if soft visor, still gives some value

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1291,8 +1291,8 @@
 			setProperty("coldprot", 10+prot)
 			setProperty("heatprot", 2+round(prot/2))
 
-			prot =  max(0, (7 - src.material.getProperty("permeable")) * 10)
-			setProperty("viralprot", prot)
+			prot =  max(10, (src.material.getProperty("chemical") - 4) * 15) // 30 would be default for metal.
+			setProperty("chemprot", prot)
 
 			prot = max(0, renf.getProperty("density") - 3) / 2
 			setProperty("meleeprot", 3 + prot)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -124,7 +124,7 @@
 			cut_resist 		= material.getProperty("hard") * 10
 			blunt_resist 	= material.getProperty("density") * 5
 			stab_resist 	= material.getProperty("hard") * 10
-			corrode_resist 	= material.getProperty("corrosion") * 10
+			corrode_resist 	= material.getProperty("chemical") * 10
 
 			if (material.alpha > 220)
 				opacity = 1 // useless opaque window
@@ -139,7 +139,7 @@
 			cut_resist 		+= round(reinforcement.getProperty("hard") * 5)
 			blunt_resist 	+= round(reinforcement.getProperty("density") * 5)
 			stab_resist 	+= round(reinforcement.getProperty("hard") * 5)
-			corrode_resist 	+= round(reinforcement.getProperty("corrosion") * 5)
+			corrode_resist 	+= round(reinforcement.getProperty("chemical") * 5)
 
 			name = "[reinforcement.name]-reinforced " + name
 

--- a/code/turf/turf.dm
+++ b/code/turf/turf.dm
@@ -67,8 +67,6 @@
 		if(istype(src.material))
 			if(initial(src.opacity))
 				src.RL_SetOpacity(src.material.alpha <= MATERIAL_ALPHA_OPACITY ? 0 : 1)
-
-			gas_impermeable = (src.density && material.hasProperty("permeable")) ? material.getProperty("permeable") >= 7 : gas_impermeable
 		return
 
 	serialize(var/savefile/F, var/path, var/datum/sandbox/sandbox)

--- a/strings/books/matsci_guide_new.txt
+++ b/strings/books/matsci_guide_new.txt
@@ -940,14 +940,6 @@ Thank you for your service to Nanotrasen.</i></p>
 			<li>51 to 75 --  Slightly corrosion-resistant</li>
 			<li>76 to 90 --  Corrosion-resistant</li>
 			<li>90+      --  Very corrosion-resistant</li></ul>
-		<p style="margin-right:10%; margin-left:1%"><b>Permeability</b></p>
-			<ul style='list-style-type:circle'>
-			<li>1 to 10  --  Very impermeable</li>
-			<li>11 to 25 --  Impermeable</li>
-			<li>26 to 50 --  Slightly impermeable</li>
-			<li>51 to 75 --  Slightly permeable</li>
-			<li>76 to 90 --  Permeable</li>
-			<li>90+      --  Very permeable</li></ul>
 		<p style="margin-right:10%; margin-left:1%"><b>Reflectivity</b></p>
 			<ul style='list-style-type:circle'>
 			<li>1 to 10  --  Very dull (low reflectivity)</li>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The corrosion resistance material property has been renamed to chemical resistance. All applications of permability has been completely merged with chemical resistance and permability property has been removed. This also rebalances several materials corrosion resistance stat + rebalances the matsci spacesuits, replacing the viral prot variability with chemprot variability.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having both a permability and a corrosion resistance stat has always struck me as needlessly redundant. This should make this property feel much more distinct and defined.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)The corrosion resistance material property has been renamed to chemical resistance. All applications of permeability has been completely merged with chemical resistance and the permeability material property has been removed.
```
