### PR TITLE
Fix typo in disease controls

### DIFF
--- a/code/datums/controllers/disease_controls.dm
+++ b/code/datums/controllers/disease_controls.dm
@@ -27,7 +27,7 @@ var/datum/disease_controller/disease_controls
 
 /proc/get_disease_from_name(var/disease_name)
 	if (!istext(disease_name))
-		logTheThing("debug", null, null, "<b>Disease:</b> Attempt to find disase with non-string")
+		logTheThing("debug", null, null, "<b>Disease:</b> Attempt to find disease with non-string")
 		return null
 	if (!disease_controls.standard_diseases.len && !length(disease_controls.custom_diseases))
 		logTheThing("debug", null, null, "<b>Disease:</b> Cant find schematic due to empty disease lists")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes 'disase' to 'disease'.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Found it while working on patho/microbiology. Might as well fix it.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

