### PR TITLE
Decouple peripheral uses of pathology

### DIFF
--- a/code/datums/sims.dm
+++ b/code/datums/sims.dm
@@ -234,10 +234,6 @@
 
 		onDeplete()
 			holder.owner.contract_disease(/datum/ailment/disease/space_madness, null, null, 1)
-			if (ishuman(holder.owner))
-				var/mob/living/carbon/human/H = holder.owner
-				if (!H.pathogens.len)
-					holder.owner.infected(ez_pathogen(/datum/pathogeneffects/malevolent/serious_paranoia))
 
 		onLife()
 			if (value < 10 && prob((10 - value) * 10))

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -557,11 +557,7 @@
 
 	heal(var/mob/M)
 		if(prob(15))
-			#ifdef CREATE_PATHOGENS //PATHOLOGY REMOVAL
-			wrap_pathogen(M.reagents, generate_indigestion_pathogen(), 15)
-			#else
 			M.reagents.add_reagent("salmonella",15)
-			#endif
 			boutput(M, "<span class='alert'>That tasted a little bit...off.</span>")
 		..()
 

--- a/code/modules/food_and_drink/sandwiches.dm
+++ b/code/modules/food_and_drink/sandwiches.dm
@@ -286,26 +286,13 @@
 	icon_state ="moldyburger"
 	bites_left = 1
 	heal_amt = 1
-	initial_volume = 15
-	initial_reagents = null
 	food_effects = list("food_bad_breath")
 
-	New()
-		..()
-		#ifdef CREATE_PATHOGENS // PATHOLOGY REMOVAL
-		wrap_pathogen(reagents, generate_flu_pathogen(), 7)
-		wrap_pathogen(reagents, generate_cold_pathogen(), 8)
-		#endif
-
 	heal(var/mob/M)
-		#ifdef CREATE_PATHOGENS //PATHOLOGY REMOVAL
-		..()
-		#else
-		boutput(M, "<span class='alert'>Oof, how old was that?.</span>")
+		boutput(M, "<span class='alert'>Oof, how old was that?</span>")
 		if(prob(66))
 			M.reagents.add_reagent("salmonella",15)
 		..()
-		#endif
 
 /obj/item/reagent_containers/food/snacks/burger/plague
 	name = "burgle"

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1692,13 +1692,6 @@
 		L.take_toxin_damage(tox * mult)
 		if(weighted_average > 4)
 			weighted_average = 0
-			#ifdef CREATE_PATHOGENS
-			if(!isdead(L))
-				var/datum/pathogen/P = new /datum/pathogen
-				P.create_weak()
-				P.spread = 0
-				wrap_pathogen(L.reagents, P, 10)
-			#endif
 		if(probmult(puke_prob))
 			L.visible_message("<span class='alert'>[L] pukes all over [himself_or_herself(L)].</span>", "<span class='alert'>You puke all over yourself!</span>")
 			L.vomit()
@@ -1728,10 +1721,6 @@
 				. += " Your ghostly essence makes you immune to its poison."
 			else
 				. += " You will take toxic damage."
-				#ifdef CREATE_PATHOGENS
-				if(how_miasma > 4)
-					. += " You might get sick."
-				#endif
 
 /datum/statusEffect/dripping_paint
 	id = "marker_painted"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[DNM][removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes some code encapsulated by ifdef CREATE_PATHOGENS.
To specify:
Depletion of sanity only gives space madness.
Raw cookie dough only gives salmonella.
Moldy burgers only give salmonella (by chance).
Miasma exposure will no longer give pathogens.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
In either case where pathology is removed or reworked as microbiology, these portions of code would be removed.
This is a PR atomizing this change.
I don't think these changes need a changelog entry, correct me if I am wrong here.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

