### PR TITLE
Improves freedom implant

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -337,14 +337,14 @@ THROWING DARTS
 /obj/item/implant/freedom
 	name = "freedom implant"
 	icon_state = "implant-r"
-	var/uses = 1.0
+	var/uses = 1
 	impcolor = "r"
 	scan_category = "syndicate"
-	var/activation_emote = "chuckle"
+	var/activation_emote = "shrug"
 
 	New()
-		src.activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
-		src.uses = rand(1, 5)
+		src.activation_emote = pick("eyebrow", "nod", "shrug", "smile", "yawn", "flex", "snap")
+		src.uses = rand(3, 5)
 		..()
 		return
 
@@ -353,22 +353,27 @@ THROWING DARTS
 			return 0
 
 		if (emote == src.activation_emote)
-			src.uses--
-			boutput(source, "You feel a faint click.")
+			var/activated = FALSE
 
 			if (source.hasStatus("handcuffed"))
 				source.handcuffs.drop_handcuffs(source)
+				activated = TRUE
 
 			// Added shackles here (Convair880).
 			if (ishuman(source))
 				var/mob/living/carbon/human/H = source
 				if (H.shoes && H.shoes.chained)
+					activated = TRUE
 					var/obj/item/clothing/shoes/SH = H.shoes
 					H.u_equip(SH)
 					SH.set_loc(H.loc)
 					H.update_clothing()
 					if (SH)
 						SH.layer = initial(SH.layer)
+
+			if (activated)
+				src.uses--
+				boutput(source, "You feel a faint click.")
 
 	implanted(mob/source as mob)
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Freedom implants now have 3-5 uses instead of 1-5, they only activate when actually removing cuffs, and the pool of emotes has been reduced to only include those that have hotkeys.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Randomly getting only a single use felt awful, I've left a bit of RNG so it's still not quite possible to know if someone's out of charges.
Since the emote could be something as common as nodding or involuntary like giggle or smile (yes it does work like that), using charges when not cuffed seems bad.
Having to type out "twitch_s" to activate an ability isn't great, I also removed wink so it doesn't conflict with the derringer.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(*)Made freedom implants more reliable.
```
