### PR TITLE
Make Molitz Beta form N2O through catalysis

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -376,7 +376,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 	execute(var/atom/owner)
 		owner.material.triggerTemp(locate(owner))
 
-#define MAX_PLASMA_TO_NITROGEN_RATIO 4
+#define MAX_PLASMA_TO_NITROGEN_RATIO 1
 /datum/materialProc/molitz_temp
 	var/unresonant = 1
 	var/iterations = 4 // big issue I had was that with the strat that Im designing this for (teleporting crystals in and out of engine) one crystal could last you for like, 50 minutes, I didnt want to keep on reducing total amount as itd nerf agent b collection hard. So instead I drastically reduced amount and drastically upped output. This would speed up farming agent b to 3 minutes per crystal, which Im fine with

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -376,7 +376,6 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 	execute(var/atom/owner)
 		owner.material.triggerTemp(locate(owner))
 
-#define MAX_PLASMA_TO_NITROGEN_RATIO 1
 /datum/materialProc/molitz_temp
 	var/unresonant = 1
 	var/iterations = 4 // big issue I had was that with the strat that Im designing this for (teleporting crystals in and out of engine) one crystal could last you for like, 50 minutes, I didnt want to keep on reducing total amount as itd nerf agent b collection hard. So instead I drastically reduced amount and drastically upped output. This would speed up farming agent b to 3 minutes per crystal, which Im fine with
@@ -397,18 +396,8 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		payload.volume = R_IDEAL_GAS_EQUATION * T20C / 1000
 
 		if(agent_b && air.temperature > 500 && air.toxins > MINIMUM_REACT_QUANTITY )
-			// if there is enough nitrogen and oxygen, make sleeping gas and do nothing else
-			if (air.nitrogen > MINIMUM_REACT_QUANTITY && air.oxygen > MINIMUM_REACT_QUANTITY && air.nitrogen * MAX_PLASMA_TO_NITROGEN_RATIO > air.toxins)
-				var reaction_rate = min(air.nitrogen / 2, air.oxygen)
-				reaction_rate = QUANTIZE(reaction_rate)
-
-				air.nitrogen -= reaction_rate * 2
-				air.oxygen -= reaction_rate
-				var/datum/gas/sleeping_agent/trace_gas = payload.get_or_add_trace_gas_by_type(/datum/gas/sleeping_agent)
-				trace_gas.moles += reaction_rate * 2
-				payload.temperature = air.temperature
-
-				target.assume_air(payload)
+			// excess nitrogen prevents oxygen B from being created
+			if (air.nitrogen > air.toxins)
 				return
 
 			var/datum/gas/oxygen_agent_b/trace_gas = payload.get_or_add_trace_gas_by_type(/datum/gas/oxygen_agent_b)
@@ -431,7 +420,6 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 			iterations -= 1
 
 			target.assume_air(payload)
-#undef MAX_PLASMA_TO_NITROGEN_RATIO
 
 /datum/materialProc/molitz_temp/agent_b
 	execute(var/atom/location, var/temp)

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -376,6 +376,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 	execute(var/atom/owner)
 		owner.material.triggerTemp(locate(owner))
 
+#define MAX_PLASMA_TO_NITROGEN_RATIO 4
 /datum/materialProc/molitz_temp
 	var/unresonant = 1
 	var/iterations = 4 // big issue I had was that with the strat that Im designing this for (teleporting crystals in and out of engine) one crystal could last you for like, 50 minutes, I didnt want to keep on reducing total amount as itd nerf agent b collection hard. So instead I drastically reduced amount and drastically upped output. This would speed up farming agent b to 3 minutes per crystal, which Im fine with
@@ -396,8 +397,8 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		payload.volume = R_IDEAL_GAS_EQUATION * T20C / 1000
 
 		if(agent_b && air.temperature > 500 && air.toxins > MINIMUM_REACT_QUANTITY )
-			// if there is nitrogen and oxygen, make sleeping gas and do nothing else
-			if (air.nitrogen > MINIMUM_REACT_QUANTITY && air.oxygen > MINIMUM_REACT_QUANTITY)
+			// if there is enough nitrogen and oxygen, make sleeping gas and do nothing else
+			if (air.nitrogen > MINIMUM_REACT_QUANTITY && air.oxygen > MINIMUM_REACT_QUANTITY && air.nitrogen * MAX_PLASMA_TO_NITROGEN_RATIO > air.toxins)
 				var reaction_rate = min(air.nitrogen / 2, air.oxygen)
 				reaction_rate = QUANTIZE(reaction_rate)
 
@@ -430,6 +431,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 			iterations -= 1
 
 			target.assume_air(payload)
+#undef MAX_PLASMA_TO_NITROGEN_RATIO
 
 /datum/materialProc/molitz_temp/agent_b
 	execute(var/atom/location, var/temp)

--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -396,6 +396,20 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 		payload.volume = R_IDEAL_GAS_EQUATION * T20C / 1000
 
 		if(agent_b && air.temperature > 500 && air.toxins > MINIMUM_REACT_QUANTITY )
+			// if there is nitrogen and oxygen, make sleeping gas and do nothing else
+			if (air.nitrogen > MINIMUM_REACT_QUANTITY && air.oxygen > MINIMUM_REACT_QUANTITY)
+				var reaction_rate = min(air.nitrogen / 2, air.oxygen)
+				reaction_rate = QUANTIZE(reaction_rate)
+
+				air.nitrogen -= reaction_rate * 2
+				air.oxygen -= reaction_rate
+				var/datum/gas/sleeping_agent/trace_gas = payload.get_or_add_trace_gas_by_type(/datum/gas/sleeping_agent)
+				trace_gas.moles += reaction_rate * 2
+				payload.temperature = air.temperature
+
+				target.assume_air(payload)
+				return
+
 			var/datum/gas/oxygen_agent_b/trace_gas = payload.get_or_add_trace_gas_by_type(/datum/gas/oxygen_agent_b)
 			payload.temperature = T0C // Greatly reduce temperature to simulate an endothermic reaction
 			// Itr: .18 Agent B, 20 oxy, 1.3 minutes per iteration, realisticly around 7-8 minutes per crystal.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[INPUT WANTED][FEATURE][ADD TO WIKI]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes:
- Nitrogen suppress Molitz Beta's Oxygen Beta production and beta cycle consumption
- Oxygen Beta preferentially catalyze N2O production over reacting with plasma

This gives Nitrogen a role in the betaburn. As a side effect, this makes it easier to acquire N2O.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Betaburns can be difficult to control. If an engineer needs to attend other duties, like repairing the station, it is very easy for a betaburn to choke itself in oxygen if the crystal is left in the chamber, or die down if the crystal is removed, or otherwise have its Oxygen Beta be wasted. In any case, excepting the CE (who has access to the Mechanics' Lab), the engineer must run into the chamber and grab the crystal, which is funny but dangerous.

This PR adds a way to control the behavior of Molitz Beta from the gas mixer, allowing engineers to put a "pause" on the burn without running in and physically grabbing it. I personally find gas interactions to be the most interesting part of chamberburns, and since this PR enhances Molitz Beta's gas interactions, I think it would make betaburns more appealing.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)maybeserendipitous
(*)Molitz Beta can be suppressed with Nitrogen
(*)Oxygen Beta preferentially catalyzes N2O creation over reacting with Plasma
```