### PR TITLE
Werewolves enjoy dog biscuits too.

### DIFF
--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -412,7 +412,6 @@
 			if (ispug(M) || iswerewolf(M))
 				..()
 				boutput(M, "<span class='notice'>That tasted delicious!</span>")
-
 			else
 				src.heal_amt = 0
 				..()

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -412,6 +412,10 @@
 			if (ispug(M))
 				..()
 				boutput(M, "<span class='notice'>That tasted delicious!</span>")
+			if (iswerewolf(M))
+				..()
+				boutput(M, "<span class='notice'>That tasted delicious!</span>")
+				src.heal_amt = 0
 			else
 				src.heal_amt = 0
 				..()

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -409,10 +409,7 @@
 		food_effects = list("food_hp_up_big", "food_energized_big")
 
 		heal(var/mob/M)
-			if (ispug(M))
-				..()
-				boutput(M, "<span class='notice'>That tasted delicious!</span>")
-			if (iswerewolf(M))
+			if (ispug(M) || iswerewolf(M))
 				..()
 				boutput(M, "<span class='notice'>That tasted delicious!</span>")
 
@@ -424,11 +421,7 @@
 
 		on_bite(var/mob/M)
 			var/list/food_effects_pre = src.food_effects //would just use initial() but it was nulling the list. whatever
-			if (!ispug(M))
-				src.food_effects = list()
-			..()
-			src.food_effects = food_effects_pre
-			if (!iswerewolf(M))
+			if (!ispug(M) && !iswerewolf(M))
 				src.food_effects = list()
 			..()
 			src.food_effects = food_effects_pre

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -415,7 +415,7 @@
 			if (iswerewolf(M))
 				..()
 				boutput(M, "<span class='notice'>That tasted delicious!</span>")
-				src.heal_amt = 0
+
 			else
 				src.heal_amt = 0
 				..()
@@ -425,6 +425,10 @@
 		on_bite(var/mob/M)
 			var/list/food_effects_pre = src.food_effects //would just use initial() but it was nulling the list. whatever
 			if (!ispug(M))
+				src.food_effects = list()
+			..()
+			src.food_effects = food_effects_pre
+			if (!iswerewolf(M))
 				src.food_effects = list()
 			..()
 			src.food_effects = food_effects_pre


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Werewolves can eat dog biscuits without getting the "That tasted awful! Why would you eat it!?" message, instead they get the same message as pugs, just without the healing buff.
![werewolf](https://user-images.githubusercontent.com/99692679/177753747-9784dd28-2ab6-4d43-8b4d-79144ea2cbc9.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Big dogs deserve to enjoy treats just as much as little ones.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Munien
(+)Werewolves can now happily enjoy dog treats!
```
