### PR TITLE
Remove the detonation symptom from pathology

### DIFF
--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -2189,21 +2189,3 @@ datum/pathogeneffects/malevolent/snaps/wild
 				return "The individual microbodies appear to be playing some form of freeform jazz. They are clearly off-key."
 			else
 				return "The pathogen appears to be using the powder granules to make microscopic... saxophones???"
-
-
-datum/pathogeneffects/malevolent/detonation
-	name = "Necrotic Detonation"
-	desc = "The pathogen will cause you to violently explode upon death."
-	rarity = RARITY_VERY_RARE
-
-	may_react_to()
-		return "Some of the pathogen's dead cells seem to remain active."
-
-	ondeath(mob/M as mob, var/datum/pathogen/origin)
-		if (!origin.symptomatic)
-			return
-		explosion_new(M, get_turf(M), origin.stage*5, origin.stage/2.5)
-
-	react_to(var/R, var/zoom)
-		if (R == "synthflesh")
-			return "There are stray synthflesh pieces all over the dish."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the detonation symptom from pathology.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
There is no place for gib-equivalent symptoms in pathology or its potential successor.
This PR atomizes a necessary step in both cases of total removal and redesign.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
