### PR TITLE
Remove the plasmafart symptom from pathology

### DIFF
--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -1721,35 +1721,6 @@ datum/pathogeneffects/malevolent/farts/smoke
 		var/datum/reagent/RE = H.get_reagent(R)
 		return "The [RE.name] violently explodes into a puff of smoke when coming into contact with the pathogen."
 
-datum/pathogeneffects/malevolent/farts/plasma
-	name = "Plasma Farts"
-	desc = "The infected individual occasionally farts. Plasma."
-	rarity = RARITY_RARE
-	cooldown = 600
-
-	fart(var/mob/M, var/datum/pathogen/origin, var/voluntary)
-		..()
-		var/turf/T = get_turf(M)
-		var/datum/gas_mixture/gas = new /datum/gas_mixture
-		gas.zero()
-		gas.toxins = origin.stage * (voluntary ? 0.6 : 3) // only a fifth for voluntary farts
-		gas.temperature = T20C
-		gas.volume = R_IDEAL_GAS_EQUATION * T20C / 1000
-		if (T)
-			T.assume_air(gas)
-
-	disease_act(var/mob/M, var/datum/pathogen/origin)
-		if (!origin.symptomatic)
-			return
-		..()
-		if (origin.stage > 2 && prob(origin.stage * 3))
-			M.take_toxin_damage(1)
-			M.take_oxygen_deprivation(4)
-
-	react_to(var/R, var/zoom)
-		if (R == "infernite" || R == "phlogiston")
-			return "The gas lights up in a puff of flame."
-
 datum/pathogeneffects/malevolent/farts/co2
 	name = "CO2 Farts"
 	desc = "The infected individual occasionally farts. Carbon dioxide."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Deletes the plasma fart symptom from pathology.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Plasma farts (and the other fart symptoms) are derivatives.
Plasma farts are a source of grief and disproportional harm and do not have a place in a redesign.
I do not want a successor to pathology to have this method of gas production.
If gas production becomes a consideration, it would be handled through canisters/objects instead of mobs.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->
