### PR TITLE
Ingesting acid scars your vocal chords and makes your voice appear as unknown

### DIFF
--- a/code/mob.dm
+++ b/code/mob.dm
@@ -70,6 +70,7 @@
 	var/real_name = null
 	var/blinded = null
 	var/disfigured = FALSE
+	var/vdisfigured = FALSE
 	var/druggy = 0
 	var/sleeping = 0.0
 	var/lying = 0.0

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1385,11 +1385,13 @@
 		rendered = "<span class='name'>"
 	else
 		rendered = "<span class='name' data-ctx='\ref[src.mind]'>"
-	if (src.wear_mask && src.wear_mask.vchange || src.vdisfigured)//(istype(src.wear_mask, /obj/item/clothing/mask/gas/voice))
+	if (src.wear_mask && src.wear_mask.vchange)//(istype(src.wear_mask, /obj/item/clothing/mask/gas/voice))
 		if (src.wear_id)
 			rendered += "[src.wear_id:registered]</span>"
 		else
 			rendered += "Unknown</span>"
+	else if (src.vdisfigured)
+		rendered += "Unknown</span>"
 	else
 		rendered += "[src.real_name]</span>[alt_name]"
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1650,8 +1650,6 @@
 						rendered = "<span class='game say'><span class='name'>[src.wear_id:registered]</span> whispers, <span class='message'>\"[message_c]\"</span></span>"
 					else
 						rendered = "<span class='game say'><span class='name'>Unknown</span> whispers, <span class='message'>\"[message_c]\"</span></span>"
-				else if (src.vdisfigured)
-					rendered = "<span class='game say'><span class='name'>Unknown</span> whispers, <span class='message'>\"[message_c]\"</span></span>"
 				else
 					rendered = "<span class='game say'><span class='name'>[src.real_name]</span>[alt_name] whispers, <span class='message'>\"[message_c]\"</span></span>"
 
@@ -1671,8 +1669,6 @@
 				rendered = "<span class='game say'><span class='name'>[src.wear_id:registered]</span> whispers, <span class='message'>[message]</span></span>"
 			else
 				rendered = "<span class='game say'><span class='name'>Unknown</span> whispers, <span class='message'>[message]</span></span>"
-		else if (src.vdisfigured)
-			rendered = "<span class='game say'><span class='name'>Unknown</span> whispers, <span class='message'>[message]</span></span>"
 		else
 			rendered = "<span class='game say'><span class='name'>[src.real_name]</span>[alt_name] whispers, <span class='message'>[message]</span></span>"
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1390,6 +1390,8 @@
 			rendered += "[src.wear_id:registered]</span>"
 		else
 			rendered += "Unknown</span>"
+	else if (src.vdisfigured)
+		rendered += "Unknown</span>"
 	else
 		rendered += "[src.real_name]</span>[alt_name]"
 
@@ -1648,6 +1650,8 @@
 						rendered = "<span class='game say'><span class='name'>[src.wear_id:registered]</span> whispers, <span class='message'>\"[message_c]\"</span></span>"
 					else
 						rendered = "<span class='game say'><span class='name'>Unknown</span> whispers, <span class='message'>\"[message_c]\"</span></span>"
+				else if (src.vdisfigured)
+					rendered = "<span class='game say'><span class='name'>Unknown</span> whispers, <span class='message'>\"[message_c]\"</span></span>"
 				else
 					rendered = "<span class='game say'><span class='name'>[src.real_name]</span>[alt_name] whispers, <span class='message'>\"[message_c]\"</span></span>"
 
@@ -1667,6 +1671,8 @@
 				rendered = "<span class='game say'><span class='name'>[src.wear_id:registered]</span> whispers, <span class='message'>[message]</span></span>"
 			else
 				rendered = "<span class='game say'><span class='name'>Unknown</span> whispers, <span class='message'>[message]</span></span>"
+		else if (src.vdisfigured)
+			rendered = "<span class='game say'><span class='name'>Unknown</span> whispers, <span class='message'>[message]</span></span>"
 		else
 			rendered = "<span class='game say'><span class='name'>[src.real_name]</span>[alt_name] whispers, <span class='message'>[message]</span></span>"
 

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1385,13 +1385,11 @@
 		rendered = "<span class='name'>"
 	else
 		rendered = "<span class='name' data-ctx='\ref[src.mind]'>"
-	if (src.wear_mask && src.wear_mask.vchange)//(istype(src.wear_mask, /obj/item/clothing/mask/gas/voice))
+	if (src.wear_mask && src.wear_mask.vchange || src.vdisfigured)//(istype(src.wear_mask, /obj/item/clothing/mask/gas/voice))
 		if (src.wear_id)
 			rendered += "[src.wear_id:registered]</span>"
 		else
 			rendered += "Unknown</span>"
-	else if (src.vdisfigured)
-		rendered += "Unknown</span>"
 	else
 		rendered += "[src.real_name]</span>[alt_name]"
 

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -417,7 +417,7 @@ datum
 				else if(method == INGEST)
 					if (isliving(M))
 						if (M.vdisfigured)
-							boutput(M, "<span class='notice'>You feel the ache in your vocal chords dissipate as you awkwardly swallow the synthflesh.</span>")
+							boutput(M, "<span class='notice'>You feel the ache in your vocal chords dissipate as you ingest the synthflesh.</span>")
 							M.vdisfigured = FALSE
 
 			reaction_turf(var/turf/T, var/volume)

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -414,6 +414,13 @@ datum
 
 					M.UpdateDamageIcon()
 
+				else if(method == INGEST)
+					if (isliving(M))
+						var/mob/living/H = M
+						if (H.vdisfigured)
+							boutput(H, "<span class='notice'>You feel the ache in your vocal chords dissipate as you awkwardly swallow the synthflesh.</span>")
+							H.vdisfigured = FALSE
+
 			reaction_turf(var/turf/T, var/volume)
 				var/list/covered = holder.covered_turf()
 				if (covered.len > 9)

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -416,10 +416,9 @@ datum
 
 				else if(method == INGEST)
 					if (isliving(M))
-						var/mob/living/H = M
-						if (H.vdisfigured)
-							boutput(H, "<span class='notice'>You feel the ache in your vocal chords dissipate as you awkwardly swallow the synthflesh.</span>")
-							H.vdisfigured = FALSE
+						if (M.vdisfigured)
+							boutput(M, "<span class='notice'>You feel the ache in your vocal chords dissipate as you awkwardly swallow the synthflesh.</span>")
+							M.vdisfigured = FALSE
 
 			reaction_turf(var/turf/T, var/volume)
 				var/list/covered = holder.covered_turf()

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -896,7 +896,6 @@ datum
 								return
 					else
 						random_brute_damage(M, min(15,volume))
-
 				else if (method == TOUCH && volume <= 10 && prob(20))
 					if (ishuman(M))
 						var/mob/living/carbon/human/H = M

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -95,19 +95,16 @@ datum
 					else
 
 						M.TakeDamage("All", 0, min(5, volume * 0.5) * stack_mult, 0, DAMAGE_BURN)
-				else if (method == INGEST)
-					if (ishuman(M))
-						var/mob/living/carbon/human/H = M
-						H.TakeDamage("chest", 0, 5, 0, DAMAGE_BURN)
-						H.emote("scream")
-						if (!H.vdisfigured)
-							boutput(H,"<span class='alert'>Your vocal chords become scarred from ingesting acid!</span>")
-							H.vdisfigured = TRUE
 				else
 					boutput(M, "<span class='alert'>The greenish acidic substance stings[volume < 10 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
 					if (volume >= 10)
 						M.TakeDamage("All", 0, clamp((volume - 10) * 2, 4, 20), 0, DAMAGE_BURN)
 						M.emote("scream")
+						if (ishuman(M))
+							var/mob/living/carbon/human/H = M
+							if (!H.vdisfigured)
+								boutput(H,"<span class='alert'>Your vocal chords become scarred from ingesting acid!</span>")
+								H.vdisfigured = TRUE
 
 			reaction_obj(var/obj/O, var/volume)
 				if (istype(O,/obj/fluid))
@@ -174,14 +171,6 @@ datum
 						M.unlock_medal("Red Hood", 1)
 					else
 						random_burn_damage(M, min(5, volume * 0.25))
-				else if (method == INGEST)
-					if (ishuman(M))
-						var/mob/living/carbon/human/H = M
-						H.TakeDamage("chest", 0, 5, 0, DAMAGE_BURN)
-						H.emote("scream")
-						if (!H.vdisfigured)
-							boutput(H,"<span class='alert'>Your vocal chords become scarred from ingesting acid!</span>")
-							H.vdisfigured = TRUE
 				else
 					boutput(M, "<span class='alert'>The transparent acidic substance stings[volume < 25 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
 					if (volume >= 25)
@@ -908,15 +897,6 @@ datum
 					else
 						random_brute_damage(M, min(15,volume))
 
-				else if (method == INGEST)
-					if (ishuman(M))
-						var/mob/living/carbon/human/H = M
-						H.TakeDamage("chest", 0, 5, 0, DAMAGE_BURN)
-						H.emote("scream")
-						if (!H.vdisfigured)
-							boutput(H,"<span class='alert'>Your vocal chords become scarred from ingesting acid!</span>")
-							H.vdisfigured = TRUE
-
 				else if (method == TOUCH && volume <= 10 && prob(20))
 					if (ishuman(M))
 						var/mob/living/carbon/human/H = M
@@ -948,6 +928,11 @@ datum
 				else if (volume >= 5)
 					M.emote("scream")
 					M.TakeDamage("All", 0, clamp((volume - 5) * 3, 8, 75), 0, DAMAGE_BURN)
+					if (ishuman(M))
+						var/mob/living/carbon/human/H = M
+						if (!H.vdisfigured)
+							boutput(H,"<span class='alert'>Your vocal chords become scarred from ingesting acid!</span>")
+							H.vdisfigured = TRUE
 
 				boutput(M, "<span class='alert'>The blueish acidic substance stings[volume < 5 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
 				return

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -95,6 +95,14 @@ datum
 					else
 
 						M.TakeDamage("All", 0, min(5, volume * 0.5) * stack_mult, 0, DAMAGE_BURN)
+				else if (method == INGEST)
+					if (ishuman(M))
+						var/mob/living/carbon/human/H = M
+						H.TakeDamage("chest", 0, 5, 0, DAMAGE_BURN)
+						H.emote("scream")
+						if (!H.vdisfigured)
+							boutput(H,"<span class='alert'>Your vocal chords become scarred from ingesting acid!</span>")
+							H.vdisfigured = TRUE
 				else
 					boutput(M, "<span class='alert'>The greenish acidic substance stings[volume < 10 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
 					if (volume >= 10)
@@ -166,6 +174,14 @@ datum
 						M.unlock_medal("Red Hood", 1)
 					else
 						random_burn_damage(M, min(5, volume * 0.25))
+				else if (method == INGEST)
+					if (ishuman(M))
+						var/mob/living/carbon/human/H = M
+						H.TakeDamage("chest", 0, 5, 0, DAMAGE_BURN)
+						H.emote("scream")
+						if (!H.vdisfigured)
+							boutput(H,"<span class='alert'>Your vocal chords become scarred from ingesting acid!</span>")
+							H.vdisfigured = TRUE
 				else
 					boutput(M, "<span class='alert'>The transparent acidic substance stings[volume < 25 ? " you, but isn't concentrated enough to harm you" : null]!</span>")
 					if (volume >= 25)
@@ -891,6 +907,16 @@ datum
 								return
 					else
 						random_brute_damage(M, min(15,volume))
+
+				else if (method == INGEST)
+					if (ishuman(M))
+						var/mob/living/carbon/human/H = M
+						H.TakeDamage("chest", 0, 5, 0, DAMAGE_BURN)
+						H.emote("scream")
+						if (!H.vdisfigured)
+							boutput(H,"<span class='alert'>Your vocal chords become scarred from ingesting acid!</span>")
+							H.vdisfigured = TRUE
+
 				else if (method == TOUCH && volume <= 10 && prob(20))
 					if (ishuman(M))
 						var/mob/living/carbon/human/H = M

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -896,6 +896,7 @@ datum
 								return
 					else
 						random_brute_damage(M, min(15,volume))
+
 				else if (method == TOUCH && volume <= 10 && prob(20))
 					if (ishuman(M))
 						var/mob/living/carbon/human/H = M

--- a/code/modules/mechanics/MechanicMadness.dm
+++ b/code/modules/mechanics/MechanicMadness.dm
@@ -2535,6 +2535,8 @@
 						heardname = ID.registered
 					else
 						heardname = "Unknown"
+				else if (H.vdisfigured)
+					heardname = "Unknown"
 
 		SEND_SIGNAL(src,COMSIG_MECHCOMP_TRANSMIT_SIGNAL,"name=[heardname]&message=[message]")
 		animate_flash_color_fill(src,"#00FF00",2, 2)

--- a/code/modules/transport/pods/communications.dm
+++ b/code/modules/transport/pods/communications.dm
@@ -105,6 +105,9 @@
 			var/mob/living/carbon/human/H = usr
 			if (H.wear_mask && H.wear_mask.vchange && H.wear_id)
 				. = H.wear_id:registered
+			else if (H.vdisfigured)
+				. = "Unknown"
+
 			else
 				. = usr.name
 		else

--- a/code/obj/item/device/audio_log.dm
+++ b/code/obj/item/device/audio_log.dm
@@ -287,6 +287,9 @@
 		if (real_name)
 			speaker_name = real_name
 
+		else if (speaker.vdisfigured)
+			speaker_name = "Unknown"
+
 		if(ishuman(speaker) && speaker.wear_mask && speaker.wear_mask.vchange)//istype(speaker.wear_mask, /obj/item/clothing/mask/gas/voice))
 			if(speaker:wear_id)
 				speaker_name = speaker:wear_id:registered

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -478,7 +478,7 @@ var/list/headset_channel_lookup
 			var/prep_name = "[real_name ? real_name : M.real_name]"
 			if(M.vdisfigured)
 				prep_name = "Unknown"
-			rendered = "[part_a][prep_name][part_b][M.say_quote(messages[1])][part_c]" //delete if no work
+			rendered = "[part_a][prep_name][part_b][M.say_quote(messages[1])][part_c]"
 			for (var/mob/R in heard_normal)
 				var/thisR = rendered
 				if (R.isAIControlled())

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -475,7 +475,11 @@ var/list/headset_channel_lookup
 				R.show_message(thisR, 2)
 
 		if (length(heard_normal))
-			rendered = "[part_a][real_name ? real_name : M.real_name][part_b][M.say_quote(messages[1])][part_c]"
+			var/prep_name = "[real_name ? real_name : M.real_name]"
+			if(ishuman(M))
+				if (M:vdisfigured)
+					prep_name = "Unknown"
+			rendered = "[part_a][prep_name][part_b][M.say_quote(messages[1])][part_c]" //delete if no work
 			for (var/mob/R in heard_normal)
 				var/thisR = rendered
 				if (R.isAIControlled())

--- a/code/obj/item/device/radio.dm
+++ b/code/obj/item/device/radio.dm
@@ -476,9 +476,8 @@ var/list/headset_channel_lookup
 
 		if (length(heard_normal))
 			var/prep_name = "[real_name ? real_name : M.real_name]"
-			if(ishuman(M))
-				if (M:vdisfigured)
-					prep_name = "Unknown"
+			if(M.vdisfigured)
+				prep_name = "Unknown"
 			rendered = "[part_a][prep_name][part_b][M.say_quote(messages[1])][part_c]" //delete if no work
 			for (var/mob/R in heard_normal)
 				var/thisR = rendered


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that all forms of acid IE: Sulphric, Fluorosulphuric etc. will scar your characters vocal chords if ingested, and make it so that your voice appears as unknown when talking. Also adds in a method of healing the damage done to your vocal chords by ingesting synthflesh, making your voice appear normal again. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The recent PR #9433 made it so that disfiguring one's face no longer makes your voice appear as unknown, which is something a few of us from the RP server have been sorely missing since the change. It was a very useful supplementary tool to support the RP of some of the more shady characters that some of us like to play, and I think it would be good to have a new method of making your voice appear as unknown. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)HauntedAngel
(+) Ingesting acid now scars your vocal chords and makes your voice appear as unknown.
(+) Ingesting Synthflesh can repair the damage done from ingesting acid. 
```
