### PR TITLE
Makes inspector clothes able to be claimed multiple times.

### DIFF
--- a/code/WorkInProgress/rewardsLocker.dm
+++ b/code/WorkInProgress/rewardsLocker.dm
@@ -863,6 +863,7 @@
 	title = "(Skin set) Inspector's Clothes"
 	desc = "Will change the skin of a detective's coat, hats, gloves, shoes, jumpsuit, and holster."
 	required_medal = "Neither fashionable noir stylish"
+	once_per_round = FALSE
 
 	rewardActivate(var/mob/activator)
 		if (ishuman(activator))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
title. Should effect very little due to how limited the inspector medal is.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A detective may lose their current hat and need to get the spare hat from the locker, they shouldn't have to deal with poor fashion tastes after losing their precious hat.
