### PR TITLE
Makes ability buttons and grabs unscannable by the chameleon projector

### DIFF
--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -122,7 +122,7 @@
 			if (user && ismob(user))
 				user.show_text("You are too far away to do that.", "red")
 			return
-		if (istype(target, /obj/ability_button) || istype(target, /obj/item/grab)) //just don't scan ability buttons or grabs
+		if (plane == PLANE_HUD || istype(target, /obj/item/grab)) //just don't scan ability buttons or grabs
 			return
 		//Okay, enough scanning shit without actual icons yo.
 		if (!isnull(initial(target.icon)) && !isnull(initial(target.icon_state)) && target.icon && target.icon_state && isobj(target)) // please blame flourish

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -122,6 +122,8 @@
 			if (user && ismob(user))
 				user.show_text("You are too far away to do that.", "red")
 			return
+		if (istype(target, /obj/ability_button)) //just don't scan ability buttons.
+			return
 		//Okay, enough scanning shit without actual icons yo.
 		if (!isnull(initial(target.icon)) && !isnull(initial(target.icon_state)) && target.icon && target.icon_state && isobj(target)) // please blame flourish
 			if (!cham)
@@ -235,6 +237,8 @@
 		if (BOUNDS_DIST(src, target) > 0)
 			if (user && ismob(user))
 				user.show_text("You are too far away to do that.", "red")
+			return
+		if (!istype(target, /obj/ability_button)) //just don't scan ability buttons.
 			return
 		if (!isnull(initial(target.icon)) && !isnull(initial(target.icon_state)) && target.icon && target.icon_state && (isitem(target) || istype(target, /obj/shrub) || istype(target, /obj/critter) || istype(target, /obj/machinery/bot))) // cogwerks - added more fun
 			playsound(src, "sound/weapons/flash.ogg", 100, 1, 1)

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -122,7 +122,7 @@
 			if (user && ismob(user))
 				user.show_text("You are too far away to do that.", "red")
 			return
-		if (plane == PLANE_HUD || istype(target, /obj/item/grab)) //just don't scan hud stuff or grabs
+		if (plane == PLANE_HUD || isgrab(target)) //just don't scan hud stuff or grabs
 			return
 		//Okay, enough scanning shit without actual icons yo.
 		if (!isnull(initial(target.icon)) && !isnull(initial(target.icon_state)) && target.icon && target.icon_state && isobj(target)) // please blame flourish
@@ -238,7 +238,7 @@
 			if (user && ismob(user))
 				user.show_text("You are too far away to do that.", "red")
 			return
-		if (plane == PLANE_HUD  || istype(target, /obj/item/grab)) //just don't scan hud stuff and grabs
+		if (plane == PLANE_HUD  || isgrab(target)) //just don't scan hud stuff and grabs
 			return
 		if (!isnull(initial(target.icon)) && !isnull(initial(target.icon_state)) && target.icon && target.icon_state && (isitem(target) || istype(target, /obj/shrub) || istype(target, /obj/critter) || istype(target, /obj/machinery/bot))) // cogwerks - added more fun
 			playsound(src, "sound/weapons/flash.ogg", 100, 1, 1)

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -122,7 +122,7 @@
 			if (user && ismob(user))
 				user.show_text("You are too far away to do that.", "red")
 			return
-		if (istype(target, /obj/ability_button)) //just don't scan ability buttons.
+		if (istype(target, /obj/ability_button) || istype(target, /obj/item/grab)) //just don't scan ability buttons or grabs
 			return
 		//Okay, enough scanning shit without actual icons yo.
 		if (!isnull(initial(target.icon)) && !isnull(initial(target.icon_state)) && target.icon && target.icon_state && isobj(target)) // please blame flourish
@@ -238,7 +238,7 @@
 			if (user && ismob(user))
 				user.show_text("You are too far away to do that.", "red")
 			return
-		if (!istype(target, /obj/ability_button)) //just don't scan ability buttons.
+		if (istype(target, /obj/ability_button) || istype(target, /obj/item/grab)) //just don't scan ability buttons.
 			return
 		if (!isnull(initial(target.icon)) && !isnull(initial(target.icon_state)) && target.icon && target.icon_state && (isitem(target) || istype(target, /obj/shrub) || istype(target, /obj/critter) || istype(target, /obj/machinery/bot))) // cogwerks - added more fun
 			playsound(src, "sound/weapons/flash.ogg", 100, 1, 1)

--- a/code/obj/item/device/chameleon.dm
+++ b/code/obj/item/device/chameleon.dm
@@ -122,7 +122,7 @@
 			if (user && ismob(user))
 				user.show_text("You are too far away to do that.", "red")
 			return
-		if (plane == PLANE_HUD || istype(target, /obj/item/grab)) //just don't scan ability buttons or grabs
+		if (plane == PLANE_HUD || istype(target, /obj/item/grab)) //just don't scan hud stuff or grabs
 			return
 		//Okay, enough scanning shit without actual icons yo.
 		if (!isnull(initial(target.icon)) && !isnull(initial(target.icon_state)) && target.icon && target.icon_state && isobj(target)) // please blame flourish
@@ -238,7 +238,7 @@
 			if (user && ismob(user))
 				user.show_text("You are too far away to do that.", "red")
 			return
-		if (istype(target, /obj/ability_button) || istype(target, /obj/item/grab)) //just don't scan ability buttons.
+		if (plane == PLANE_HUD  || istype(target, /obj/item/grab)) //just don't scan hud stuff and grabs
 			return
 		if (!isnull(initial(target.icon)) && !isnull(initial(target.icon_state)) && target.icon && target.icon_state && (isitem(target) || istype(target, /obj/shrub) || istype(target, /obj/critter) || istype(target, /obj/machinery/bot))) // cogwerks - added more fun
 			playsound(src, "sound/weapons/flash.ogg", 100, 1, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #9184, fixes #9186, and fixes #9381. Should let players stop scanning some ui elements and being them.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
While amusing to some, seeing UI stuff outside of the UI is really jarring.
