### PR TITLE
Disables kudzu people

### DIFF
--- a/code/datums/controllers/process/kudzu.dm
+++ b/code/datums/controllers/process/kudzu.dm
@@ -33,8 +33,9 @@
 				stats += "[thing] processed [count] times. Total kudzu: [kudzu.len]<br>"
 			boutput(usr, "<br>[stats]")
 
-
+/*
 /mob/living/carbon/human/proc/infect_kudzu()
 	var/obj/icecube/kudzu/cube = new /obj/icecube/kudzu(get_turf(src), src)
 	src.set_loc(cube)
 	cube.visible_message("<span class='alert'><B>[src] is covered by the vines!</span>")
+*/

--- a/code/mob/living/life/decomposition.dm
+++ b/code/mob/living/life/decomposition.dm
@@ -10,10 +10,10 @@
 				return ..()
 
 			var/mult = get_multiplier()
-
+			/*
 			if (!isrestrictedz(T.z) && H.loc == T && T.temp_flags & HAS_KUDZU) //only infect if on the floor
 				H.infect_kudzu()
-
+			*/
 			if (H.mutantrace && !H.mutantrace.decomposes)
 				return ..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr comments out the code for kudzu infection occurring, all the code involved is maintained. Any death on kudzu will no longer transform people into kudzu people.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently kudzu people are both awkward and not fun for all parties involved. Frequently kudzu people log out due to the boredom of the role, and it can often lead to toxicity and self antagging when it comes to people dealing with kudzu. While many of these issues could be fixed with a very significant revamp of kudzu people, currently kudzu people have little to no benefit to the game, and until such a revamp comes it feels unfair to leave them in the game.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Kudzu people have been disabled, kudzu will no longer convert dead bodies into kudzu people.
```
