### PR TITLE
Hydroponics Cleanup

### DIFF
--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -470,31 +470,29 @@
 	amount_per_transfer_from_this = 25
 	event_handler_flags = NO_MOUSEDROP_QOL
 
+	// returns whether the inserted item was brewed
 	proc/brew(var/obj/item/W as obj)
-		var/brewable
 		var/list/brew_result
 
 		if(istype(W,/obj/item/reagent_containers/food))
 			var/obj/item/reagent_containers/food/F = W
-			brewable = F.brewable
 			brew_result = F.brew_result
 
 		else if(istype(W, /obj/item/plant))
 			var/obj/item/plant/P = W
-			brewable = P.brewable
 			brew_result = P.brew_result
 
-		if (!brewable || !brew_result)
-			return 0
+		if (!brew_result)
+			return FALSE
 
-		if (islist(brew_result) && length(brew_result))
+		if (islist(brew_result))
 			for (var/i in brew_result)
 				src.reagents.add_reagent(i, 10)
 		else
 			src.reagents.add_reagent(brew_result, 20)
 
 		src.visible_message("<span class='notice'>[src] brews up [W]!</span>")
-		return 1
+		return TRUE
 
 	attackby(obj/item/W, mob/user)
 		if (istype(W,/obj/item/reagent_containers/food) || istype(W, /obj/item/plant))

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -12,7 +12,6 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food)
 	var/food_color = "#FF0000" //Color for various food items
 	var/custom_food = 1 //Can it be used to make custom food like for pizzas
 	var/festivity = 0
-	var/brewable = 0 // will hitting a still with it do anything?
 	var/brew_result = null // what will it make if it's brewable?
 	var/unlock_medal_when_eaten = null // Add medal name here in the format of e.g. "That tasted funny".
 	var/from_emagged_oven = 0 // to prevent re-rolling of food in emagged ovens

--- a/code/modules/food_and_drink/discount_dans.dm
+++ b/code/modules/food_and_drink/discount_dans.dm
@@ -187,7 +187,6 @@
 	var/activated = 0
 	initial_volume = 50
 	initial_reagents = list("msg"=9)
-	brewable = 1
 	brew_result = list("sewage", "ethanol")
 	food_effects = list("food_sweaty")
 
@@ -331,7 +330,6 @@
 	var/color_prob = 100
 	initial_volume = 50
 	initial_reagents = list("badgrease"=3,"VHFCS"=9)
-	brewable = 1
 	brew_result = list("sewage", "yuck")
 	food_effects = list("food_sweaty")
 

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -224,7 +224,6 @@
 	icon = 'icons/obj/foodNdrink/food_produce.dmi'
 	icon_state = "rice-sprig"
 	food_color = "#FFFFAA"
-	brewable = 1
 	brew_result = "ricewine"
 
 /obj/item/reagent_containers/food/snacks/ingredient/rice
@@ -241,7 +240,6 @@
 	custom_food = 1
 	initial_volume = 50
 	initial_reagents = list("sugar"=25)
-	brewable = 1
 	brew_result = "rum"
 
 /obj/item/reagent_containers/food/snacks/ingredient/peanutbutter
@@ -302,7 +300,6 @@
 	doants = 0
 	initial_volume = 50
 	initial_reagents = list("honey"=15)
-	brewable = 1
 	brew_result = "mead"
 	New()
 		..()

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -132,7 +132,6 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	force = 0
 	food_color = "#FFFF00"
 	var/popping = 0
-	brewable = 1
 	brew_result = "bourbon"
 
 	temperature_expose(datum/gas_mixture/air, temperature, volume)
@@ -323,7 +322,6 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	bites_left = 5
 	heal_amt = 1
 	food_color = "#FF00FF"
-	brewable = 1
 	brew_result = "wine"
 	validforhat = 1
 	food_effects = list("food_cold", "food_refreshed")
@@ -385,7 +383,6 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	bites_left = 5
 	heal_amt = 1
 	food_color = "#CC0000"
-	brewable = 1
 	brew_result = "wine"
 	validforhat = 1
 	food_effects = list("food_cold", "food_refreshed")
@@ -743,7 +740,6 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	planttype = /datum/plant/fruit/pear
 	bites_left = 1
 	heal_amt = 2
-	brewable = 1
 	brew_result = "cider" // pear cider is delicious, fuck you.
 	food_color = "#3FB929"
 
@@ -755,7 +751,6 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	//planttype = ///datum/plant/pear
 	bites_left = 1
 	heal_amt = 2
-	brewable = 1
 	brew_result = list("cider","rotting") //bad
 	food_color = "#3FB929"
 	initial_volume = 30
@@ -789,7 +784,6 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	bites_left = 3
 	heal_amt = 1
 	food_color = "#40C100"
-	brewable = 1
 	brew_result = "cider"
 	validforhat = 1
 	food_effects = list("food_cold", "food_refreshed")
@@ -1111,7 +1105,6 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 	bites_left = 1
 	heal_amt = 0
 	food_color = "#F0E68C"
-	brewable = 1
 	brew_result = "vodka"
 
 	attackby(obj/item/W, mob/user)

--- a/code/modules/food_and_drink/sandwiches.dm
+++ b/code/modules/food_and_drink/sandwiches.dm
@@ -339,7 +339,6 @@
 	bites_left = 3
 	heal_amt = 1
 	food_color = "#C8C8C8"
-	brewable = 1
 	brew_result = "beepskybeer"
 	initial_reagents = list("cholesterol"=5,"nanites"=20)
 
@@ -350,7 +349,6 @@
 	bites_left = 3
 	heal_amt = 1
 	food_color = "#C8C8C8"
-	brewable = 1
 	brew_result = "beepskybeer"
 	initial_reagents = list("cholesterol"=5,"nanites"=20)
 

--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -5,7 +5,7 @@
 	var/iconmod = null // name of the sprite files in hydro_mutants.dmi
 	var/harvest_override = 0 // If 1, you can harvest it irregardless of the plant's base harvestability
 	var/harvested_proc_override = 0
-	var/special_proc_override = 0
+	var/special_proc_override = FALSE
 	// If 0, just use the base plant's settings
 	// If 1, use the mutation's special_proc instead
 	// If anything else, use both the base and the mutant procs
@@ -44,7 +44,7 @@
 		if (POT.dead || !POT.current) lasterr = 402
 		if (lasterr)
 			logTheThing("debug", null, null, "<b>Plant HYP</b> [src] in pot [POT] failed with error [.]")
-			special_proc_override = 0
+			special_proc_override = FALSE
 		return lasterr
 
 	proc/HYPattacked_proc_M(var/obj/machinery/plantpot/POT,var/mob/user)
@@ -176,7 +176,7 @@
 	iconmod = "MelonBowling"
 	ENrange = list(12,null)
 	chance = 20
-	special_proc_override = 1
+	special_proc_override = TRUE
 
 	HYPspecial_proc_M(var/obj/machinery/plantpot/POT)
 		..()
@@ -284,7 +284,7 @@
 	iconmod = "SynthButts"
 	dont_rename_crop = true
 	crop = /obj/item/clothing/head/butt/synth
-	special_proc_override = 1
+	special_proc_override = TRUE
 	mutation_sfx = "sound/voice/farts/fart6.ogg"
 
 	HYPspecial_proc_M(var/obj/machinery/plantpot/POT)
@@ -486,7 +486,7 @@
 	name = "Wholetuna Cordata"
 	iconmod = "Wholetuna"
 	crop = /obj/item/fish/random
-	special_proc_override = 1
+	special_proc_override = TRUE
 
 	HYPspecial_proc_M(var/obj/machinery/plantpot/POT)
 		..()
@@ -594,7 +594,7 @@
 	name = "White Radweed"
 	name_prefix = "White "
 	iconmod = "RadweedWhite"
-	special_proc_override = 1
+	special_proc_override = TRUE
 	assoc_reagents = list("penteticacid")
 
 	HYPspecial_proc_M(var/obj/machinery/plantpot/POT)
@@ -689,7 +689,7 @@
 	name = "Dogwood Tree"
 	dont_rename_crop = true
 	iconmod = "TreeDogwood"
-	special_proc_override = 1
+	special_proc_override = TRUE
 	attacked_proc_override = 1
 	mutation_sfx = "sound/voice/animal/dogbark.ogg"
 

--- a/code/modules/hydroponics/plants.dm
+++ b/code/modules/hydroponics/plants.dm
@@ -246,22 +246,26 @@ ABSTRACT_TYPE(/datum/plant)
 	var/endurance = 0
 	var/list/commuts = null // General transferrable mutations
 	var/datum/plantmutation/mutation = null // is it mutated? if so which variation?
-	var/list/alleles = list(0,0,0,0,0,0,0)
-	// Order goes:
-	// Species, Growtime, Harvtime, Cropsize, Harvests, Potency, Endurance
+	// dominant?
+	var/d_species = FALSE
+	var/d_growtime = FALSE
+	var/d_harvtime = FALSE
+	var/d_cropsize = FALSE
+	var/d_harvests = FALSE
+	var/d_potency = FALSE
+	var/d_endurance = FALSE
 	// Species allele controls name, appearance, crop produce and mutations
-	// 1 is dominant, else recessive
 
-	New(var/loc,var/random_alleles = 1)
+	New(var/loc,var/random_alleles = TRUE)
 		..()
 		if (random_alleles)
-			src.alleles[1] = rand(0,1)
-			src.alleles[2] = rand(0,1)
-			src.alleles[3] = rand(0,1)
-			src.alleles[4] = rand(0,1)
-			src.alleles[5] = rand(0,1)
-			src.alleles[6] = rand(0,1)
-			src.alleles[7] = rand(0,1)
+			src.d_species = rand(0,1)
+			src.d_growtime = rand(0,1)
+			src.d_harvtime = rand(0,1)
+			src.d_cropsize = rand(0,1)
+			src.d_harvests = rand(0,1)
+			src.d_potency = rand(0,1)
+			src.d_endurance = rand(0,1)
 			// optimise this later
 
 /datum/action/bar/icon/harvest_plant  //In the words of my forebears, "I really don't know a good spot to put this, so im putting it here, fuck you." Adds a channeled action to harvesting flagged plants.

--- a/code/modules/hydroponics/plants.dm
+++ b/code/modules/hydroponics/plants.dm
@@ -35,9 +35,6 @@ ABSTRACT_TYPE(/datum/plant)
 	var/list/mutations = list() // what mutant variants does this plant have?
 	var/genome = 0 // Used for splicing - how "similar" the plants are = better odds of splice
 	var/stop_size_scaling // Stops the enlarging of sprites based on quality
-	var/list/harvest_tools // For plants that don't harvest normally and need some sort of special tool (mixed list of tool flags and item paths)
-	var/harvest_tool_message // An output message for plants with unique harvest messages (string)
-	var/harvest_tool_fail_message // A helpful output message to players when they attempt to harvest a plant by hand
 	var/no_extract // Stops the extraction of seeds in the PlantMaster
 
 	var/special_proc = 0 // Does this plant do something special when it's in the pot?
@@ -290,9 +287,6 @@ ABSTRACT_TYPE(/datum/plant)
 			source = sourcerelay
 		if(duration2)
 			duration = duration2
-		if(plant_pot.current.harvest_tools && (source.equipped() != null))
-			var/obj/item/I = source.equipped()
-			toolcheck = I
 		..()
 
 	onUpdate()

--- a/code/modules/hydroponics/plants.dm
+++ b/code/modules/hydroponics/plants.dm
@@ -39,7 +39,6 @@ ABSTRACT_TYPE(/datum/plant)
 	var/harvest_tool_message // An output message for plants with unique harvest messages (string)
 	var/harvest_tool_fail_message // A helpful output message to players when they attempt to harvest a plant by hand
 	var/no_extract // Stops the extraction of seeds in the PlantMaster
-	var/list/required_reagents // reagents required for the plant to grow - formated like: list(list(id="poo",amount=100),list(id="thing",amount=number))
 
 	var/special_proc = 0 // Does this plant do something special when it's in the pot?
 	var/attacked_proc = 0 // Does this plant react if you try to attack it?

--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -7,7 +7,6 @@
 	var/crop_prefix = ""
 	desc = "You shouldn't be able to see this item ingame!"
 	icon = 'icons/obj/hydroponics/items_hydroponics.dmi'
-	var/brewable = 0 // will hitting a still with it do anything?
 	var/brew_result = null // what will it make if it's brewable?
 	rand_pos = 1
 
@@ -93,7 +92,6 @@
 	name = "cannabis leaf"
 	desc = "Leafs for reefin'!"
 	icon_state = "cannabisleaf"
-	brewable = 1
 	brew_result = list("THC", "CBD")
 	contraband = 1
 	w_class = W_CLASS_TINY
@@ -179,7 +177,6 @@
 	name = "tobacco leaf"
 	desc = "A leaf from a tobacco plant. This could probably be smoked..."
 	icon_state = "tobacco"
-	brewable = 1
 	brew_result = list("nicotine")
 
 	build_name(obj/item/W)
@@ -189,21 +186,18 @@
 	name = "twobacco leaf"
 	desc = "A leaf from the twobacco plant. This could probably be smoked- wait, is it already smoking?"
 	icon_state = "twobacco"
-	brewable = 1
 	brew_result = list("nicotine2")
 
 /obj/item/plant/wheat
 	name = "wheat"
 	desc = "Never eat shredded wheat."
 	icon_state = "wheat"
-	brewable = 1
 	brew_result = "beer"
 
 /obj/item/plant/wheat/durum
 	name = "durum wheat"
 	desc = "A harder wheat for a harder palate."
 	icon_state = "wheat"
-	brewable = 1
 	brew_result = "beer"
 
 /obj/item/plant/wheat/metal
@@ -231,7 +225,6 @@
 	crop_suffix	= " cane"
 	desc = "Grown lovingly in our space plantations."
 	icon_state = "sugarcane"
-	brewable = 1
 	brew_result = "rum"
 
 /obj/item/plant/herb/grass
@@ -278,7 +271,6 @@
 	crop_suffix	= " bark"
 	desc = "Often regarded as a delicacy when used for tea, Asomna also has stimulant properties."
 	icon_state = "asomna"
-	brewable = 1
 	brew_result = "tea"
 
 /obj/item/plant/herb/asomna/robust
@@ -286,7 +278,6 @@
 	crop_suffix = " bark"
 	desc = "Often regarded as a delicacy when used for tea, Asomna also has stimulant properties. This particular chunk looks extra spicy."
 	icon_state = "asomnarobust"
-	brewable = 1
 	brew_result = "tea"
 
 /obj/item/plant/herb/commol
@@ -318,7 +309,6 @@
 	crop_suffix = " root"
 	desc = "This thick root is covered in abnormal ammounts of bark. A powerful emetic can be extracted from it. This one looks particularly revolting"
 	icon_state = "ipecacuanhabilious"
-	brewable = 1
 	brew_result = "gvomit"
 
 /obj/item/plant/herb/sassafras
@@ -326,7 +316,6 @@
 	crop_suffix	= " root"
 	desc = "Roots from a Sassafras tree. Can be fermented into delicious sarsaparilla."
 	icon_state = "sassafras"
-	brewable = 1
 	brew_result = "sarsaparilla"
 
 /obj/item/plant/herb/venne
@@ -352,7 +341,6 @@
 	crop_suffix	= " leaves"
 	desc = "Aromatic leaves with a clean flavor."
 	icon_state = "mint"
-	brewable = 1
 	brew_result = "menthol"
 
 /obj/item/plant/herb/catnip
@@ -360,7 +348,6 @@
 	crop_suffix	= ""
 	desc = "Otherwise known as catnip or catswort.  Cat drugs."
 	icon_state = "catnip"
-	brewable = 1
 	brew_result = "catdrugs"
 
 /obj/item/plant/herb/poppy
@@ -374,7 +361,6 @@
 	crop_suffix = " leaves"
 	desc = "Leaves from a green tea plant, which can be used to create matcha."
 	icon_state = "tealeaves"
-	brewable = TRUE
 	brew_result = "matcha"
 
 /obj/item/plant/herb/aconite

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1329,6 +1329,8 @@
 
 			// At this point all the harvested items are inside the plant pot, and this is the
 			// part where we decide where they're going and get them out.
+			var/seeds_only = satchelpick == "Seeds Only"
+			var/produce_only = satchelpick == "Produce Only"
 			if(SA)
 				// If we're putting stuff in a satchel, this is where we do it.
 				for(var/obj/item/I in src.contents)
@@ -1336,11 +1338,11 @@
 						boutput(user, "<span class='alert'>Your satchel is full! You dump the rest on the floor.</span>")
 						break
 					if(istype(I,/obj/item/seed/))
-						if(!satchelpick || satchelpick == "Seeds Only")
+						if(!satchelpick || seeds_only)
 							I.set_loc(SA)
 							I.add_fingerprint(user)
 					else
-						if(!satchelpick || satchelpick == "Produce Only")
+						if(!satchelpick || produce_only)
 							I.set_loc(SA)
 							I.add_fingerprint(user)
 				SA.UpdateIcon()

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -416,6 +416,12 @@
 				// If there's no mutation we just use the base special proc, obviously!
 				growing.HYPspecial_proc(src)
 
+		// Have we lost all health or growth, or used up all available harvests? If so, this plant
+		// should now die. Sorry, that's just life! Didn't they teach you the curds and the peas?
+		if((src.health < 1 || src.growth < 0) || (growing.harvestable && src.harvests < 1))
+			HYPkillplant()
+			return
+
 		var/current_growth_level = 0
 		// This is entirely for updating the icon. Check how far the plant has grown and update
 		// if it's gone a level beyond what the tracking says it is.
@@ -447,12 +453,6 @@
 		else if(health_warning && src.health > growing.starthealth / 2)
 			src.health_warning = 0
 			do_update_icon = TRUE
-
-		// Have we lost all health or growth, or used up all available harvests? If so, this plant
-		// should now die. Sorry, that's just life! Didn't they teach you the curds and the peas?
-		if((src.health < 1 || src.growth < 0) || (growing.harvestable && src.harvests < 1))
-			HYPkillplant()
-			return
 
 		if(do_update_icon)
 			UpdateIcon()

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1107,7 +1107,7 @@
 			var/cropcount = getamount
 			var/seedcount = 0
 
-			while (getamount > 0)
+			for (var/_ in 1 to getamount)
 				var/quality_score = base_quality_score
 				quality_score += rand(-2,2)
 				// Just a bit of natural variance to make it interesting
@@ -1332,8 +1332,6 @@
 						S.planttype = hybrid
 
 					seedcount++
-				getamount--
-
 
 			// Give XP based on base quality of crop harvest. Will make better later, like so more plants harvasted and stuff, this is just for testing.
 			// This is only reached if you actually got anything harvested.

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -337,12 +337,6 @@
 		// We obtain the current plant type in the plantpot, and the genes of the individual plant.
 		// We'll be referencing these a lot!
 
-		if(growing.required_reagents)
-			for(var/i=1,i<=growing.required_reagents.len,i++)
-				if(src.reagents.get_reagent_amount(growing.required_reagents[i]["id"]) < growing.required_reagents[i]["amount"])
-					return
-		//Checks to see if the plant requires a reagent to grow, and compares to to the reagents present in the pot.
-
 		// REAGENT PROCESSING
 		var/drink_rate = 1
 		// drink_rate is how much reagent is consumed per tick. This used to be 0.5, but got bumped

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1715,7 +1715,7 @@ proc/HYPgeneticanalysis(var/mob/user as mob,var/obj/scanned,var/datum/plant/P,va
 		<table style='border-collapse: collapse; border: 1px solid black; margin: 0 0.25em; width: 100%;'>
 			<caption>Analysis of \the <b>[scanned.name]</b></caption>
 			<tr>
-				<th style='white-space: nowrap;' width=0>Species</th><td colspan='3'>[P.name] ([DNA.alleles[1] ? "D" : "r"])</td>
+				<th style='white-space: nowrap;' width=0>Species</th><td colspan='3'>[P.name] ([DNA.d_species ? "D" : "r"])</td>
 			</tr>
 			<tr>
 				<th style='white-space: nowrap;' width=0>Generation</th><td style='text-align: right; white-space: nowrap;'>[generation]</td><td colspan=2 width=100%>&nbsp;</td>
@@ -1723,37 +1723,37 @@ proc/HYPgeneticanalysis(var/mob/user as mob,var/obj/scanned,var/datum/plant/P,va
 			<tr>
 				<th style='white-space: nowrap;' width=0>Maturation Rate</th>
 				<td width=0 style='text-align: right; white-space: nowrap;'>[DNA.growtime]</td>
-				<td width=0 style='text-align: center;'>[DNA.alleles[2] ? "D" : "r"]</td>
+				<td width=0 style='text-align: center;'>[DNA.d_growtime ? "D" : "r"]</td>
 				<td width=100%><span style='display: inline-block; border-right: 1px solid black; height: 1em; width: [clamp(abs(DNA.growtime), 0, 100)]%; background-color: [DNA.growtime > 0 ? "#2f2" : "#a55"];'></span></td>
 				</tr>
 			<tr>
 				<th style='white-space: nowrap;' width=0>Production Rate</th>
 				<td width=0 style='text-align: right; white-space: nowrap;'>[DNA.harvtime]</td>
-				<td width=0 style='text-align: center;'>[DNA.alleles[3] ? "D" : "r"]</td>
+				<td width=0 style='text-align: center;'>[DNA.d_harvtime ? "D" : "r"]</td>
 				<td width=100%><span style='display: inline-block; border-right: 1px solid black; height: 1em; width: [clamp(abs(DNA.harvtime), 0, 100)]%; background-color: [DNA.harvtime > 0 ? "#2f2" : "#a55"];'></span></td>
 				</tr>
 			<tr>
 				<th style='white-space: nowrap;' width=0>Lifespan</th>
 				<td width=0 style='text-align: right; white-space: nowrap;'>[DNA.harvests]</td>
-				<td width=0 style='text-align: center;'>[DNA.alleles[4] ? "D" : "r"]</td>
+				<td width=0 style='text-align: center;'>[DNA.d_harvests ? "D" : "r"]</td>
 				<td width=100%><span style='display: inline-block; border-right: 1px solid black; height: 1em; width: [clamp(abs(DNA.harvests), 0, 100)]%; background-color: [DNA.harvests > 0 ? "#2f2" : "#a55"];'></span></td>
 				</tr>
 			<tr>
 				<th style='white-space: nowrap;' width=0>Yield</th>
 				<td width=0 style='text-align: right; white-space: nowrap;'>[DNA.cropsize]</td>
-				<td width=0 style='text-align: center;'>[DNA.alleles[5] ? "D" : "r"]</td>
+				<td width=0 style='text-align: center;'>[DNA.d_cropsize ? "D" : "r"]</td>
 				<td width=100%><span style='display: inline-block; border-right: 1px solid black; height: 1em; width: [clamp(abs(DNA.cropsize), 0, 100)]%; background-color: [DNA.cropsize > 0 ? "#2f2" : "#a55"];'></span></td>
 				</tr>
 			<tr>
 				<th style='white-space: nowrap;' width=0>Potency</th>
 				<td width=0 style='text-align: right; white-space: nowrap;'>[DNA.potency]</td>
-				<td width=0 style='text-align: center;'>[DNA.alleles[6] ? "D" : "r"]</td>
+				<td width=0 style='text-align: center;'>[DNA.d_potency ? "D" : "r"]</td>
 				<td width=100%><span style='display: inline-block; border-right: 1px solid black; height: 1em; width: [clamp(abs(DNA.potency), 0, 100)]%; background-color: [DNA.potency > 0 ? "#2f2" : "#a55"];'></span></td>
 				</tr>
 			<tr>
 				<th style='white-space: nowrap;' width=0>Endurance</th>
 				<td width=0 style='text-align: right; white-space: nowrap;'>[DNA.endurance]</td>
-				<td width=0 style='text-align: center;'>[DNA.alleles[7] ? "D" : "r"]</td>
+				<td width=0 style='text-align: center;'>[DNA.d_endurance ? "D" : "r"]</td>
 				<td width=100%><span style='display: inline-block; border-right: 1px solid black; height: 1em; width: [clamp(abs(DNA.endurance), 0, 100)]%; background-color: [DNA.endurance > 0 ? "#2f2" : "#a55"];'></span></td>
 				</tr>
 		</table>

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1088,8 +1088,8 @@
 		var/extra_harvest_chance = 0
 
 		if(getamount > harvest_cap)
-			getamount = harvest_cap
 			extra_harvest_chance += getamount - harvest_cap
+			getamount = harvest_cap
 			// Max harvest amount for all plants is capped. If we've got higher output
 			// than the cap it's probably through gene manipulation, so reward the player
 			// with greater chances for an extra harvest if this is the case.

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -387,39 +387,6 @@
 					if(current_reagent)
 						current_reagent.on_plant_life(src)
 
-			/* DEPRECATED, IN COMMENTS FOR THE MOMENT FOR TESTING
-			// Now we do a similar thing for gene strains, except with these we do a hard-coded
-			// thing right here since the gene strains themselves are just text strings.
-			for (var/X in DNA.commuts)
-				switch(X)
-					if("Unstable")
-						if(prob(18))
-							HYPmutateplant(1)
-						// Unstable causes the plant to mutate on its own every so often.
-						// Players might want this or might not, so it's neither good nor bad.
-					if("Accelerator")
-						if(prob(10))
-							DNA.growtime--
-							DNA.harvtime--
-						// This gene strain should be kept rare. It boosts the growth rate genes
-						// which makes the plant grow faster permanently. As of the time of writing
-						// I don't think anyone's discovered it so if it needs a downside, we can
-						// figure it out later.
-					if("Poor Health")
-						if(prob(24))
-							HYPdamageplant("frailty",1)
-						// Poor Health is a bad strain to have that causes the plant to slowly take
-						// damage for sod all reason. It's basically a weak wuss plant strain.
-					if("Rapid Growth")
-						src.growth += 2
-						// Basically like rapid metabolism with no downsides.
-					if("Stunted Growth")
-						if(src.growth > 1)
-							src.growth--
-						// Slow down growth. We don't want this to reduce src.growth to zero in
-						// any case, because that means the plant would die.
-			*/
-
 			if(DNA.commuts)
 				for (var/datum/plant_gene_strain/X in DNA.commuts)
 					X.on_process(src)

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -934,16 +934,16 @@
 		// Pretty much figure out if we can harvest the plant yet or not. This is used for
 		// updating the sprite and obviously handling harvesting when a player clicks
 		// on the plant pot.
-		if(!current || !plantgenes || health < 1 || harvests < 1 || recently_harvested) return 0
+		if(!current || !plantgenes || health < 1 || harvests < 1 || recently_harvested) return FALSE
 		if(plantgenes.mutation)
 			var/datum/plantmutation/MUT = plantgenes.mutation
 			if(MUT.harvest_override && MUT.crop)
-				if(src.growth >= current.harvtime - plantgenes.harvtime) return 1
-				else return 0
-		if(!current.crop || !current.harvestable) return 0
+				if(src.growth >= current.harvtime - plantgenes.harvtime) return TRUE
+				else return FALSE
+		if(!current.crop || !current.harvestable) return FALSE
 
-		if(src.growth >= current.harvtime - plantgenes.harvtime) return 1
-		else return 0
+		if(src.growth >= current.harvtime - plantgenes.harvtime) return TRUE
+		else return FALSE
 
 	proc/HYPharvesting(var/mob/living/user,var/obj/item/satchel/SA)
 		// This proc is where the harvesting actually happens. Again it shouldn't need tweaking

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1047,16 +1047,6 @@
 			base_quality_score -= 12
 			// And this is if you've neglected the plant!
 
-
-		if(DNA.commuts)
-			for(var/datum/plant_gene_strain/quality/Q in DNA.commuts)
-				if(Q.negative)
-					base_quality_score -= Q.quality_mod
-				else
-					base_quality_score += Q.quality_mod
-		// And ones that mess with the quality of crops.
-		// Unstable isn't here because it'd be less random outside the loop.
-
 		var/getitem = null
 		var/dont_rename_crop = false
 		// Figure out what crop we use - the base crop or a mutation crop.
@@ -1072,7 +1062,14 @@
 				getitem = growing.crop
 				dont_rename_crop = growing.dont_rename_crop
 
-		var/extra_harvest_chance = 0
+		if(DNA.commuts)
+			for(var/datum/plant_gene_strain/quality/Q in DNA.commuts)
+				if(Q.negative)
+					base_quality_score -= Q.quality_mod
+				else
+					base_quality_score += Q.quality_mod
+		// And ones that mess with the quality of crops.
+		// Unstable isn't here because it'd be less random outside the loop.
 
 		if(DNA.commuts)
 			for(var/datum/plant_gene_strain/yield/Y in DNA.commuts)
@@ -1086,6 +1083,8 @@
 					harvest_cap *= Y.yield_mult
 					harvest_cap += Y.yield_mod
 		// Gene strains that boost or penalize the cap.
+
+		var/extra_harvest_chance = 0
 
 		if(getamount > harvest_cap)
 			getamount = harvest_cap

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -237,7 +237,6 @@
 	var/image/water_meter = null
 	var/image/plant_sprite = null
 	var/grow_level = 1 // Same as the above except for current plant growth
-	var/do_update_icon = FALSE // this is now a var on the pot itself so you can actually call it outside of process()
 	var/do_update_water_icon = 1 // this handles the water overlays specifically (water and water level) It's set to 1 by default so it'll update on spawn
 	var/growth_rate = 2
 		// We have this here as a check for whether or not the plant needs to update its sprite.
@@ -430,23 +429,24 @@
 		else
 			current_growth_level = 1
 
+		var/do_update_icon = FALSE
 		if(current_growth_level != src.grow_level)
 			src.grow_level = current_growth_level
-			src.do_update_icon = TRUE
+			do_update_icon = TRUE
 
 		if(!harvest_warning && HYPcheck_if_harvestable())
 			src.harvest_warning = 1
-			src.do_update_icon = TRUE
+			do_update_icon = TRUE
 		else if(harvest_warning && !HYPcheck_if_harvestable())
 			src.harvest_warning = 0
-			src.do_update_icon = TRUE
+			do_update_icon = TRUE
 
 		if(!health_warning && src.health <= growing.starthealth / 2)
 			src.health_warning = 1
-			src.do_update_icon = TRUE
+			do_update_icon = TRUE
 		else if(health_warning && src.health > growing.starthealth / 2)
 			src.health_warning = 0
-			src.do_update_icon = TRUE
+			do_update_icon = TRUE
 
 		// Have we lost all health or growth, or used up all available harvests? If so, this plant
 		// should now die. Sorry, that's just life! Didn't they teach you the curds and the peas?
@@ -454,7 +454,7 @@
 			HYPkillplant()
 			return
 
-		if(src.do_update_icon)
+		if(do_update_icon)
 			UpdateIcon()
 			update_name()
 

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -345,7 +345,7 @@
 			// icon on the plant pot needs to change.
 
 			if(current_water_level)
-				if(current_water_level < 200) // max water limit!!
+				if(current_water_level <= 200) // max water limit!!
 					if(HYPCheckCommut(DNA,/datum/plant_gene_strain/metabolism_slow) && prob(50))
 						src.growth++
 						drink_rate /= 2

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1063,26 +1063,27 @@
 				dont_rename_crop = growing.dont_rename_crop
 
 		if(DNA.commuts)
-			for(var/datum/plant_gene_strain/quality/Q in DNA.commuts)
-				if(Q.negative)
-					base_quality_score -= Q.quality_mod
-				else
-					base_quality_score += Q.quality_mod
-		// And ones that mess with the quality of crops.
-		// Unstable isn't here because it'd be less random outside the loop.
-
-		if(DNA.commuts)
-			for(var/datum/plant_gene_strain/yield/Y in DNA.commuts)
-				if(Y.negative)
-					if(harvest_cap == 0 || Y.yield_mult == 0)
-						continue
+			for(var/datum/plant_gene_strain/G in DNA.commuts)
+				// And ones that mess with the quality of crops.
+				// Unstable isn't here because it'd be less random outside the loop.
+				if (istype(G, /datum/plant_gene_strain/quality))
+					var/datum/plant_gene_strain/quality/Q = G
+					if(Q.negative)
+						base_quality_score -= Q.quality_mod
 					else
-						harvest_cap /= Y.yield_mult
-						harvest_cap -= Y.yield_mod
-				else
-					harvest_cap *= Y.yield_mult
-					harvest_cap += Y.yield_mod
-		// Gene strains that boost or penalize the cap.
+						base_quality_score += Q.quality_mod
+				// Gene strains that boost or penalize the cap.
+				else if (istype(G, /datum/plant_gene_strain/yield))
+					var/datum/plant_gene_strain/yield/Y = G
+					if(Y.negative)
+						if(harvest_cap == 0 || Y.yield_mult == 0)
+							continue
+						else
+							harvest_cap /= Y.yield_mult
+							harvest_cap -= Y.yield_mod
+					else
+						harvest_cap *= Y.yield_mult
+						harvest_cap += Y.yield_mod
 
 		var/extra_harvest_chance = 0
 

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -155,21 +155,14 @@
 		if(isAI(user) || isobserver(user)) return // naughty AIs used to be able to harvest plants
 		src.add_fingerprint(user)
 		if(src.current)
-			var/datum/plant/growing = src.current
-
 			if(src.dead)
 				boutput(user, "<span class='notice'>You clear the dead plant.</span>")
 				HYPdestroyplant()
 				return
 
 			if(HYPcheck_if_harvestable())
-				if(!growing.harvest_tools) //if the plant needs a specific tool or set of tools to harvest
-					HYPharvesting(user,null)
-				else
-					if(!growing.harvest_tool_fail_message)
-						boutput(user, "<span><b>You don't have the right tool to harvest this plant!</b></span>")
-					else
-						boutput(user,growing.harvest_tool_fail_message)
+				HYPharvesting(user,null)
+
 
 	HYPdestroyplant()
 		..()
@@ -522,23 +515,6 @@
 					qdel (W)
 					if(!(user in src.contributors))
 						src.contributors += user
-			if(src.current.harvest_tools)
-			//checks to see if the plant requires a specific tool to harvest, rather than an empty hand.
-				var/passed
-				for(var/i=1,i<=src.current.harvest_tools.len,i++)
-					if(ispath(src.current.harvest_tools[i]))
-						if(istype(W,src.current.harvest_tools[i]))
-							passed = 1
-							break
-					else if(istool(W,src.current.harvest_tools[i]))
-						passed = 1
-						break
-				if(passed)
-					if(src.current.harvest_tool_message)
-						boutput(user,src.current.harvest_tool_message)
-					HYPharvesting(user,null)
-					return
-
 
 		// From here on out we handle item reacions of the plantpot itself rather than specific
 		// special kinds of plant.
@@ -707,8 +683,6 @@
 			if(src.dead)
 				boutput(user, "<span class='alert'>The plant is dead and cannot be harvested!</span>")
 				return
-			if (src.current.harvest_tools)
-				return
 			var/datum/plant/growing = src.current
 			if(!growing.harvestable)
 				boutput(user, "<span class='alert'>You doubt this plant is going to grow anything worth harvesting...</span>")
@@ -739,13 +713,8 @@
 				return
 
 			if(HYPcheck_if_harvestable())
-				if(!growing.harvest_tools) //if the plant needs a specific tool or set of tools to harvest
-					HYPharvesting(user,null)
-				else
-					if(!growing.harvest_tool_fail_message)
-						boutput(user, "<span><b>You don't have the right tool to harvest this plant!</b></span>")
-					else
-						boutput(user,growing.harvest_tool_fail_message)
+				HYPharvesting(user,null)
+
 				// If the plant is ready for harvest, do that. Otherwise, check it's condition.
 			else
 				boutput(user, "You check [src.name] and the tray.")

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -348,8 +348,7 @@
 				if(current_water_level < 200) // max water limit!!
 					if(HYPCheckCommut(DNA,/datum/plant_gene_strain/metabolism_slow) && prob(50))
 						src.growth++
-						if(drink_rate)
-							drink_rate /= 2
+						drink_rate /= 2
 						// If our plant has a slow metabolism, it will only gain growth 50% of
 						// the time compared to usual. It consumes reagents a lot slower though.
 						// This is essentially like putting the plant on slow-mo overall.

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -403,10 +403,10 @@
 				// proc that overrides the regular one.
 				var/datum/plantmutation/MUT = plantgenes.mutation
 				switch (MUT.special_proc_override)
-					if(0)
+					if(FALSE)
 						// There's no special proc for this mutation, so just use the regular one.
 						growing.HYPspecial_proc(src)
-					if(1)
+					if(TRUE)
 						// The mutation overrides the base proc to use its own.
 						MUT.HYPspecial_proc_M(src)
 					else

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1319,14 +1319,7 @@
 				else
 					JOB_XP(user, "Botanist", 1)
 
-			var/list/harvest_string = list("You harvest [cropcount] item")
-			if (cropcount > 1)
-				harvest_string += "s"
-			if(seedcount)
-				harvest_string += " and [seedcount] seed"
-				if (seedcount > 1)
-					harvest_string += "s"
-			boutput(user, "<span class='notice'>[harvest_string.Join()].</span>")
+			boutput(user, "<span class='notice'>You harvest [cropcount] item[s_es(cropcount)][seedcount ? " and [seedcount] seed[s_es(seedcount)]" : ""].</span>")
 
 			// Mostly for dangerous produce (explosive tomatoes etc) that should show up somewhere in the logs (Convair880).
 			if(istype(MUT,/datum/plantmutation/))

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -193,11 +193,7 @@
 				var/datum/plant/P1 = src.splicing1.planttype
 				var/datum/plant/P2 = src.splicing2.planttype
 
-				var/genome_difference = 0
-				if (P1.genome > P2.genome)
-					genome_difference = P1.genome - P2.genome
-				else
-					genome_difference = P2.genome - P1.genome
+				var/genome_difference = abs(P1.genome - P2.genome)
 				splice_chance -= genome_difference * 10
 
 				splice_chance -= src.splicing1.seeddamage
@@ -340,10 +336,11 @@
 
 				if (!stored || !DNA)
 					give = 0
-				if (HYPCheckCommut(DNA,/datum/plant_gene_strain/seedless))
+				else if (HYPCheckCommut(DNA,/datum/plant_gene_strain/seedless))
 					give = 0
-				if(stored.no_extract)
+				else if(stored.no_extract)
 					give = 0
+
 				if (!give)
 					boutput(usr, "<span class='alert'>No viable seeds found in [I].</span>")
 				else
@@ -472,11 +469,7 @@
 			if (!P1 || !P2) splice_chance = 0
 			else
 				// Seeds from different families aren't easy to splice
-				var/genome_difference = 0
-				if (P1.genome > P2.genome)
-					genome_difference = P1.genome - P2.genome
-				else
-					genome_difference = P2.genome - P1.genome
+				var/genome_difference = abs(P1.genome - P2.genome)
 				splice_chance -= genome_difference * 10
 
 				// Deduct chances if the seeds are damaged from infusing or w/e else
@@ -510,28 +503,17 @@
 				var/datum/plantgenes/submissiveDNA = null
 
 				// Establish which species allele is dominant
-				if (dominance > 0)
+				// If neither, we pick randomly unlike the rest of the allele resolutions
+				if (dominance > 0 || (dominance == 0 && prob(50)))
 					dominantspecies = P1
 					submissivespecies = P2
 					dominantDNA = P1DNA
 					submissiveDNA = P2DNA
-				else if (dominance < 0)
+				else
 					dominantspecies = P2
 					submissivespecies = P1
 					dominantDNA = P2DNA
 					submissiveDNA = P1DNA
-				else
-					// If neither, we pick randomly unlike the rest of the allele resolutions
-					if (prob(50))
-						dominantspecies = P1
-						submissivespecies = P2
-						dominantDNA = P1DNA
-						submissiveDNA = P2DNA
-					else
-						dominantspecies = P2
-						submissivespecies = P1
-						dominantDNA = P2DNA
-						submissiveDNA = P1DNA
 
 				// Create the new seed
 				var/obj/item/seed/S = new /obj/item/seed
@@ -718,12 +700,7 @@
 		else if (dominance < 0)
 			return value2
 		else
-			var/average = (value1 + value2)
-			if (average != 0) average /= 2
-			return round(average)
-
-
-
+			return round((value1 + value2)/2)
 
 	proc/QuickAnalysisRow(var/obj/scanned, var/datum/plant/P, var/datum/plantgenes/DNA)
 		// Largely copied from plantpot.dm

--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -496,7 +496,7 @@
 				var/datum/plantgenes/P1DNA = seed1.plantgenes
 				var/datum/plantgenes/P2DNA = seed2.plantgenes
 
-				var/dominance = P1DNA.alleles[1] - P2DNA.alleles[1]
+				var/dominance = P1DNA.d_species - P2DNA.d_species
 				var/datum/plant/dominantspecies = null
 				var/datum/plant/submissivespecies = null
 				var/datum/plantgenes/dominantDNA = null
@@ -582,22 +582,22 @@
 				// If one is dominant and the other recessive, use the dominant value
 				// If both are dominant or recessive, average the values out
 
-				P.growtime = SpliceMK2(P1DNA.alleles[2],P2DNA.alleles[2],P1.vars["growtime"],P2.vars["growtime"])
-				DNA.growtime = SpliceMK2(P1DNA.alleles[2],P2DNA.alleles[2],P1DNA.vars["growtime"],P2DNA.vars["growtime"])
+				P.growtime = SpliceMK2(P1DNA.d_growtime,P2DNA.d_growtime,P1.vars["growtime"],P2.vars["growtime"])
+				DNA.growtime = SpliceMK2(P1DNA.d_growtime,P2DNA.d_growtime,P1DNA.vars["growtime"],P2DNA.vars["growtime"])
 
-				P.harvtime = SpliceMK2(P1DNA.alleles[3],P2DNA.alleles[3],P1.vars["harvtime"],P2.vars["harvtime"])
-				DNA.harvtime = SpliceMK2(P1DNA.alleles[3],P2DNA.alleles[3],P1DNA.vars["harvtime"],P2DNA.vars["harvtime"])
+				P.harvtime = SpliceMK2(P1DNA.d_harvtime,P2DNA.d_harvtime,P1.vars["harvtime"],P2.vars["harvtime"])
+				DNA.harvtime = SpliceMK2(P1DNA.d_harvtime,P2DNA.d_harvtime,P1DNA.vars["harvtime"],P2DNA.vars["harvtime"])
 
-				P.cropsize = SpliceMK2(P1DNA.alleles[4],P2DNA.alleles[4],P1.vars["cropsize"],P2.vars["cropsize"])
-				DNA.cropsize = SpliceMK2(P1DNA.alleles[4],P2DNA.alleles[4],P1DNA.vars["cropsize"],P2DNA.vars["cropsize"])
+				P.cropsize = SpliceMK2(P1DNA.d_cropsize,P2DNA.d_cropsize,P1.vars["cropsize"],P2.vars["cropsize"])
+				DNA.cropsize = SpliceMK2(P1DNA.d_cropsize,P2DNA.d_cropsize,P1DNA.vars["cropsize"],P2DNA.vars["cropsize"])
 
-				P.harvests = SpliceMK2(P1DNA.alleles[5],P2DNA.alleles[5],P1.vars["harvests"],P2.vars["harvests"])
-				DNA.harvests = SpliceMK2(P1DNA.alleles[5],P2DNA.alleles[5],P1DNA.vars["harvests"],P2DNA.vars["harvests"])
+				P.harvests = SpliceMK2(P1DNA.d_harvests,P2DNA.d_harvests,P1.vars["harvests"],P2.vars["harvests"])
+				DNA.harvests = SpliceMK2(P1DNA.d_harvests,P2DNA.d_harvests,P1DNA.vars["harvests"],P2DNA.vars["harvests"])
 
-				DNA.potency = SpliceMK2(P1DNA.alleles[6],P2DNA.alleles[6],P1DNA.vars["potency"],P2DNA.vars["potency"])
+				DNA.potency = SpliceMK2(P1DNA.d_potency,P2DNA.d_potency,P1DNA.vars["potency"],P2DNA.vars["potency"])
 
-				P.endurance = SpliceMK2(P1DNA.alleles[7],P2DNA.alleles[7],P1.vars["endurance"],P2.vars["endurance"])
-				DNA.endurance = SpliceMK2(P1DNA.alleles[7],P2DNA.alleles[7],P1DNA.vars["endurance"],P2DNA.vars["endurance"])
+				P.endurance = SpliceMK2(P1DNA.d_endurance,P2DNA.d_endurance,P1.vars["endurance"],P2.vars["endurance"])
+				DNA.endurance = SpliceMK2(P1DNA.d_endurance,P2DNA.d_endurance,P1DNA.vars["endurance"],P2DNA.vars["endurance"])
 
 				boutput(usr, "<span class='notice'>Splice successful.</span>")
 				playsound(src, "sound/machines/ping.ogg", 50, 1)
@@ -719,15 +719,15 @@
 			generation = F.generation
 
 		return {"
-		<td class='l [DNA.alleles[1] ? "hyp-dominant" : ""]'>[P.name]</td>
+		<td class='l [DNA.d_species ? "hyp-dominant" : ""]'>[P.name]</td>
 		<td class='r'>[P.genome]</td>
 		<td class='r'>[generation]</td>
-		<td class='r [DNA.alleles[2] ? "hyp-dominant" : ""]'>[DNA.growtime]</td>
-		<td class='r [DNA.alleles[3] ? "hyp-dominant" : ""]'>[DNA.harvtime]</td>
-		<td class='r [DNA.alleles[4] ? "hyp-dominant" : ""]'>[DNA.harvests]</td>
-		<td class='r [DNA.alleles[5] ? "hyp-dominant" : ""]'>[DNA.cropsize]</td>
-		<td class='r [DNA.alleles[6] ? "hyp-dominant" : ""]'>[DNA.potency]</td>
-		<td class='r [DNA.alleles[7] ? "hyp-dominant" : ""]'>[DNA.endurance]</td>
+		<td class='r [DNA.d_growtime ? "hyp-dominant" : ""]'>[DNA.growtime]</td>
+		<td class='r [DNA.d_harvtime ? "hyp-dominant" : ""]'>[DNA.harvtime]</td>
+		<td class='r [DNA.d_cropsize ? "hyp-dominant" : ""]'>[DNA.harvests]</td>
+		<td class='r [DNA.d_harvests ? "hyp-dominant" : ""]'>[DNA.cropsize]</td>
+		<td class='r [DNA.d_potency ? "hyp-dominant" : ""]'>[DNA.potency]</td>
+		<td class='r [DNA.d_endurance ? "hyp-dominant" : ""]'>[DNA.endurance]</td>
 		"}
 
 	Exited(Obj, newloc)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS][BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This cleans up some hydroponics related code, mainly the tray, seed manipulator, and plants in general.
It also includes some very minor bug fixes.

This also removes `harvest_tools`, `harvest_tool_message`, `harvest_tool_fail_message`, `required_reagents`, and related code.
In the interest of searchability, I will list the original excised fields and their associated comments here.

```
	var/list/harvest_tools // For plants that don't harvest normally and need some sort of special tool (mixed list of tool flags and item paths)
	var/harvest_tool_message // An output message for plants with unique harvest messages (string)
	var/harvest_tool_fail_message // A helpful output message to players when they attempt to harvest a plant by hand

	var/list/required_reagents // reagents required for the plant to grow - formated like: list(list(id="poo",amount=100),list(id="thing",amount=number))
```

Supersedes #9524 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Code cleanliness, possible performance improvements due to excising unneeded code.