### PR TITLE
Requisition tuneup batch (feat. aid contract handling, returns behavior)

### DIFF
--- a/code/modules/economy/requisition/rc_aid.dm
+++ b/code/modules/economy/requisition/rc_aid.dm
@@ -1,13 +1,17 @@
 ABSTRACT_TYPE(/datum/req_contract/aid)
 /**
  * Aid contracts are a class of standard (market-listed) contract.
- * Uniquely among contracts, aid contracts can't be pinned due to their urgency. Requirements and flavor text should convey this urgency.
+ * Uniquely among contracts, aid contracts can't be pinned due to their urgency,
+ * and will leave after a certain number of market cycles instead of at random.
+ * Requirements and flavor text should convey this urgency.
  *
  * These should -usually- be fairly ordinary supplies that a fast-moving Quartermasters' office can scrounge up with relatively little aid.
  * Anything more difficult to respond to in short order, or prepare in advance, should yield significantly more cash.
  */
 /datum/req_contract/aid //in your final hour, astral wolf...
 	req_class = AID_CONTRACT
+	///Number of cycles changes that the contract will survive. Defaults to one, which allows contract to be present in two cycles.
+	var/cycles_remaining = 1
 
 /datum/req_contract/aid/wrecked
 	//name = "Breach Recovery"
@@ -21,6 +25,7 @@ ABSTRACT_TYPE(/datum/req_contract/aid)
 
 	New()
 		src.name = pick(namevary)
+		src.cycles_remaining = rand(0,2)
 		src.flavor_desc = "An affiliated [pick(desc_placejob)] [pick(desc_placetype)] has [pick(desc_enhancer1)] a [pick(desc_enhancer2)] [pick(desc_whatborked)]"
 		src.flavor_desc += " and requires repair supplies as soon as possible."
 		src.payout += rand(0,80) * 10
@@ -83,7 +88,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/basictool)
 /datum/req_contract/aid/triage
 	//name = "Medical Aid"
 	payout = 5000
-	var/list/namevary = list("Medical Aid","Medical Emergency","Triage Support","Aid Request","Critical Condition")
+	var/list/namevary = list("Medical Aid","Medical Emergency","Triage Support","Aid Request","Critical Condition","Vital Support")
 	var/list/desc_helpsite = list("A medical facility","An affiliated station's medical bay","A triage center","A medical outpost","Our nearest station")
 	var/list/desc_tense = list("to assist with","after heavy load due to","to restock after")
 	var/list/desc_crisis = list(
@@ -105,6 +110,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/basictool)
 
 	New()
 		src.name = pick(namevary)
+		src.cycles_remaining = rand(1,2)
 		src.flavor_desc = "[pick(desc_helpsite)] requires additional supplies [pick(desc_tense)] [pick(desc_crisis)]. [pick(desc_emphasis)]"
 		src.payout += rand(0,60) * 10
 
@@ -189,7 +195,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 /datum/req_contract/aid/geeksquad
 	//name = "Computer Failure"
 	payout = 4800
-	var/list/namevary = list("Systems Failure","Short Circuit","Computer Overload","Electronics Failure","Systems Breakdown")
+	var/list/namevary = list("Systems Failure","Short Circuit","Computer Overload","Electronics Failure","Systems Breakdown","Crucial Repair")
 	var/list/desc_wherebork = list("research","mining","security","cargo transfer","communications","deep-space survey")
 	var/list/desc_whobork = list("vessel","ship","station","outpost")
 	var/list/desc_whybork = list("experienced","lost systems control due to","ceased operation after","suffered a power surge resulting in")
@@ -219,6 +225,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 
 	New()
 		src.name = pick(namevary)
+		src.cycles_remaining = rand(1,3)
 		src.flavor_desc = "An affiliated [pick(desc_wherebork)] [pick(desc_whobork)] has [pick(desc_whybork)] [pick(desc_howmuchbork)] its [pick(desc_sys)]. [pick(desc_emphasis)]"
 		src.payout += rand(0,60) * 10
 
@@ -311,6 +318,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/surgical)
 
 	New()
 		src.name = pick(namevary)
+		src.cycles_remaining = rand(1,2)
 		var/tilter = pick(desc_shortage)
 		src.flavor_desc = "An affiliated [pick(desc_placejob)] [pick(desc_place)] is experiencing"
 		src.flavor_desc += " a severe shortage of [tilter] [pick(desc_after)] [pick(desc_whybork)].[pick(desc_emphasis)]"

--- a/code/modules/economy/requisition/rc_civilian.dm
+++ b/code/modules/economy/requisition/rc_civilian.dm
@@ -441,7 +441,7 @@ ABSTRACT_TYPE(/datum/rc_entry/reagent/caterdrink)
 /datum/req_contract/civilian/architecture
 	//name = "Architecture Deluxe"
 	payout = 5200
-	var/list/namevary = list("Structural Setup","Brick by Brick","New Construction","Building Supply","Structure Fabrication")
+	var/list/namevary = list("Structural Setup","Brick by Brick","New Construction","Building Supply","Structure Fabrication","Asset Development")
 	var/list/desc_thingbuilt = list("A planetary habitation site","A new deluxe retreat","A new station wing","An affiliated construction project")
 	var/list/desc_progress = list("currently underway","delayed by supply difficulties","planned for near-term assembly","commissioned by a third party")
 	var/list/desc_resource = list("stone","turf seed","window treatment","wood","solvent","detailing metal")

--- a/code/modules/economy/requisition/rc_scientific.dm
+++ b/code/modules/economy/requisition/rc_scientific.dm
@@ -11,7 +11,7 @@ ABSTRACT_TYPE(/datum/req_contract/scientific)
 	//name = "Don't Ask Too Many Questions"
 	payout = 5000
 	weight = 80
-	var/list/namevary = list("Organ Analysis","Organ Research","Biolab Supply","Biolab Partnership","ERROR: CANNOT VERIFY ORIGIN")
+	var/list/namevary = list("Organ Analysis","Organ Research","Biolab Supply","Biolab Partnership","ERROR: CANNOT VERIFY ORIGIN","Organ Study")
 	var/list/desc_begins = list("conducting","performing","beginning","initiating","seeking supplies for","organizing")
 	var/list/desc_whatstudy = list("long-term study","intensive trialing","in-depth analysis","study","regulatory assessment")
 	var/list/desc_whystudy = list("decay","function","robustness","response to a new medication","atrophy in harsh conditions","therapies","bounciness")
@@ -55,7 +55,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 /datum/req_contract/scientific/spectrometry
 	//name = "Totally Will Not Result In A Resonance Cascade"
 	payout = 3300
-	var/list/namevary = list("Beamline Calibration","Spectral Analysis","Chromatic Analysis","Refraction Survey")
+	var/list/namevary = list("Beamline Calibration","Spectral Analysis","Chromatic Analysis","Refraction Survey","Component Restock","Photonics Project")
 	var/list/desc_wherestudy = list(
 		"Optics calibration laboratory",
 		"Field laboratory at crystal excavation site",
@@ -121,7 +121,7 @@ ABSTRACT_TYPE(/datum/rc_entry/item/organ)
 /datum/req_contract/scientific/botanical
 	//name = "Feed Me, Seymour (Butz)"
 	payout = 2500
-	var/list/namevary = list("Botanical Prototyping","Hydroponic Acclimation","Cultivar Propagation","Plant Genotype Study")
+	var/list/namevary = list("Botanical Prototyping","Hydroponic Acclimation","Cultivar Propagation","Plant Genotype Study","Botanical Advancement")
 	var/list/desc_wherestudy = list(
 		"An affiliated hydroponics lab",
 		"A cultivation analysis project",

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -433,7 +433,7 @@
 				qdel(sell_crate)
 				if(return_handling == RET_VOID) return
 			else
-				handle_returns(sell_crate,return_handling)
+				handle_returns(sell_crate, return_handling)
 				if(return_handling == RET_INSUFFICIENT)
 					var/datum/signal/pdaSignal = get_free_signal()
 					var/returnmsg = "Notification: No contract fulfilled by Requisition crate. Returning as sent."

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -83,17 +83,23 @@
 		if(length(req_contracts) >= max_req_contracts)
 			return
 		var/contract2make //picking path from which to generate the newly-added contract
-		if(src.civ_contracts_active == 0)
+		if(src.civ_contracts_active == 0) //guarantee presence of at least one contract of each type
 			contract2make = pick_req_contract(/datum/req_contract/civilian)
 		else if(src.aid_contracts_active == 0)
 			contract2make = pick_req_contract(/datum/req_contract/aid)
 		else if(src.sci_contracts_active == 0)
 			contract2make = pick_req_contract(/datum/req_contract/scientific)
-		else
-			switch(rand(1,10)) //civ weighted slightly higher
-				if(1 to 4) contract2make = pick_req_contract(/datum/req_contract/civilian)
-				if(5 to 7) contract2make = pick_req_contract(/datum/req_contract/aid)
-				if(8 to 10) contract2make = pick_req_contract(/datum/req_contract/scientific)
+		else //do random gen, slightly higher weighting to civilian; don't make too many aid contracts
+			if(src.aid_contracts_active > 1)
+				if(prob(55))
+					contract2make = pick_req_contract(/datum/req_contract/civilian)
+				else
+					contract2make = pick_req_contract(/datum/req_contract/scientific)
+			else
+				switch(rand(1,10))
+					if(1 to 4) contract2make = pick_req_contract(/datum/req_contract/civilian)
+					if(5 to 7) contract2make = pick_req_contract(/datum/req_contract/aid)
+					if(8 to 10) contract2make = pick_req_contract(/datum/req_contract/scientific)
 		var/datum/req_contract/contractmade = new contract2make
 		switch(contractmade.req_class)
 			if(CIV_CONTRACT) src.civ_contracts_active++
@@ -206,16 +212,29 @@
 				if (prob(T.chance_leave))
 					T.hidden = 1
 
-		// Thin out and re-generate unpinned contracts
+		// Thin out and time out contracts by variant...
 		for(var/datum/req_contract/RC in src.req_contracts)
-			if(!RC.pinned && prob(80))
-				switch(RC.req_class)
-					if(CIV_CONTRACT) src.civ_contracts_active--
-					if(AID_CONTRACT) src.aid_contracts_active--
-					if(SCI_CONTRACT) src.sci_contracts_active--
-				src.req_contracts -= RC
-				qdel(RC)
+			switch(RC.req_class)
+				if(CIV_CONTRACT)
+					if(!RC.pinned && prob(80))
+						src.civ_contracts_active--
+						src.req_contracts -= RC
+						qdel(RC)
+				if(SCI_CONTRACT)
+					if(!RC.pinned && prob(70))
+						src.sci_contracts_active--
+						src.req_contracts -= RC
+						qdel(RC)
+				if(AID_CONTRACT)
+					var/datum/req_contract/aid/RCAID = RC
+					if(RCAID.cycles_remaining)
+						RCAID.cycles_remaining--
+					else
+						src.aid_contracts_active--
+						src.req_contracts -= RC
+						qdel(RC)
 
+		//... and repopulate afterwards.
 		while(length(src.req_contracts) < src.max_req_contracts)
 			src.add_req_contract()
 
@@ -348,8 +367,11 @@
 
 		return duckets
 
-	proc/handle_returns(obj/storage/crate/sold_crate)
-		sold_crate.name = "Returned Requisitions Crate"
+	proc/handle_returns(obj/storage/crate/sold_crate,var/return_code)
+		if(return_code == RET_INSUFFICIENT) //clarifies purpose for crate return
+			sold_crate.name = "Returned Requisitions Crate"
+		else
+			sold_crate.name = "Reimbursed Requisitions Crate"
 		SPAWN(rand(18,24) SECONDS)
 			shippingmarket.receive_crate(sold_crate)
 
@@ -411,7 +433,7 @@
 				qdel(sell_crate)
 				if(return_handling == RET_VOID) return
 			else
-				handle_returns(sell_crate)
+				handle_returns(sell_crate,return_handling)
 				if(return_handling == RET_INSUFFICIENT)
 					var/datum/signal/pdaSignal = get_free_signal()
 					var/returnmsg = "Notification: No contract fulfilled by Requisition crate. Returning as sent."

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -227,7 +227,7 @@
 						qdel(RC)
 				if(AID_CONTRACT)
 					var/datum/req_contract/aid/RCAID = RC
-					if(RCAID.cycles_remaining)
+					if(RCAID.cycles_remaining > 0)
 						RCAID.cycles_remaining--
 					else
 						src.aid_contracts_active--

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -1069,7 +1069,13 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 		if(RC.flavor_desc) src.temp += "[RC.flavor_desc]<br><br>"
 		src.temp += "[RC.requis_desc]"
 		if(RC.req_class == AID_CONTRACT && !RC.pinned) // Cannot ordinarily be pinned. Unpin support included for contract testing.
+			var/datum/req_contract/aid/RCAID = RC
 			src.temp += "URGENT - Cannot Be Reserved<br>"
+			if(RCAID.cycles_remaining)
+				var/formatted_cycles_remaining = RCAID.cycles_remaining + 1
+				src.temp += "Contract leaves market in [formatted_cycles_remaining] cycles<br>"
+			else
+				src.temp += "Contract leaves market with next cycle<br>"
 		else
 			src.temp += "<A href='[topicLink("pin_contract","\ref[RC]")]'>[RC.pinned ? "Unpin Contract" : "Pin Contract"]</A><br>"
 		src.temp += "<A href='[topicLink("print_req","\ref[RC]")]'>Print List</A>"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Batch of improvements to the QM requisitions system, primarily focused on a change to aid contract behavior.

- Aid contracts now have a "cycles_remaining" variable, defaulting to 1. Existing contracts now have random ranges for this.
- Market cycle shifts will now check this variable, decrementing it if it's above zero or removing the contract otherwise.
- This variable is also shown on the front-end, allowing quartermasters to take it into account when choosing which contracts to try and fulfill.
- Contract removal and reintroduction have been adjusted slightly, notably preventing more than two Aid contracts from appearing on the markets at once due to their new increased persistence.
- Requisitions crates sent back after an attempted contract fulfillment will now be "Returned" if the contract was not fulfilled, or "Reimbursed" if it was (addresses #9544 by way of improved clarity).
- Added additional name variants to select existing contracts to reduce the chances of name collision.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Improves the usability and readability of the QM requisitions system.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(*)Aid contracts in the quartermasters' requisitions market now last for a fixed amount of cycles, instead of having a chance to rotate out.
```
