### PR TITLE
makes pod wars cloners impossible to sabotage

### DIFF
--- a/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
+++ b/code/datums/gamemodes/pod_wars/pw_misc_objects.dm
@@ -187,6 +187,9 @@
 	ex_act(severity)
 		return
 
+	powered()
+		return TRUE
+
 	disposing()
 		..()
 		UnsubscribeProcess()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

makes it impossible to fuck up cloners on pod wars

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

last round when i tried to sabotage syndicate medical chem dispenser by cutting the wires it killed the cloning too which is bad this send syndies on a 10 minute death loop