### PR TITLE
Red oxygen grenade fabrication capability for gas extractors

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -661,6 +661,15 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Machinery"
 
+/datum/manufacture/red_o2_grenade
+	name = "Red Oxygen Grenade"
+	item_paths = list("MET-2","CON-1","molitz","char")
+	item_amounts = list(2,2,10,1)
+	item_outputs = list(/obj/item/old_grenade/oxygen)
+	time = 10 SECONDS
+	create = 1
+	category = "Tool"
+
 ////////////////////////////////
 
 /datum/manufacture/player_module

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2405,7 +2405,8 @@
 		/datum/manufacture/o2_can,
 		/datum/manufacture/co2_can,
 		/datum/manufacture/n2_can,
-		/datum/manufacture/plasma_can)
+		/datum/manufacture/plasma_can,
+		/datum/manufacture/red_o2_grenade)
 
 // a blank manufacturer for mechanics
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a manufacture datum for red oxygen grenades with the same cost as mech-scanned reproduction, and installs it into the gas extractor. Does not remove the existing mech-scan compatibility.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

More tools at Engineering's disposal without requiring Mechanics, and another cool use for the gas extractor.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(+)Gas extractors are now capable of producing red oxygen grenades.
```
