### PR TITLE
Flammable Polaroids

### DIFF
--- a/code/obj/item/cameras.dm
+++ b/code/obj/item/cameras.dm
@@ -198,6 +198,9 @@
 	var/written = null
 	var/image/my_writing = null
 	tooltip_flags = REBUILD_DIST
+	burn_point = 220
+	burn_output = 900
+	burn_possible = 2
 
 	New(location, var/image/IM, var/icon/IC, var/nname, var/ndesc)
 		..(location)


### PR DESCRIPTION
[QoL]


## About the PR:
Sets the `burn_point`, `burn_output`, and `burn_possible` vars on `/obj/item/photo` to the same value as that of the corresponding vars on `obj/item/paper`.



## Why's this needed? 
Polaroids shouldn't be oddly resistant to fire, and burning evidence is a fun addition to RP scenarios.