### PR TITLE
Fixes sheltestfrogs brains being unrecoverable

### DIFF
--- a/code/modules/medical/diseases/frog_flu.dm
+++ b/code/modules/medical/diseases/frog_flu.dm
@@ -33,4 +33,5 @@
 			affected_mob.visible_message("<span class='alert'><b>[affected_mob] transforms!</b></span>")
 			affected_mob.unequip_all()
 			logTheThing("combat", affected_mob, null, "is transformed into a critter frog by the [name] reagent at [log_loc(affected_mob)].")
-			affected_mob.make_critter(/mob/living/critter/small_animal/frog, affected_mob)
+			var/mob/living/critter/C = affected_mob.make_critter(/mob/living/critter/small_animal/frog, affected_mob)
+			C.butcherable = 1 //So the brain is recoverable

--- a/code/modules/medical/diseases/frog_flu.dm
+++ b/code/modules/medical/diseases/frog_flu.dm
@@ -34,4 +34,4 @@
 			affected_mob.unequip_all()
 			logTheThing("combat", affected_mob, null, "is transformed into a critter frog by the [name] reagent at [log_loc(affected_mob)].")
 			var/mob/living/critter/C = affected_mob.make_critter(/mob/living/critter/small_animal/frog, affected_mob)
-			C.butcherable = 1 //So the brain is recoverable
+			C.butcherable = TRUE //So the brain is recoverable


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Players turned into frog critters via frog flu (aka sheltestgrog) cannot have their brain recovered. Using a sharp object on the critter corpse merely produces leather.

This PR applies the same treatment that the polymorph spell does to transformed critters: sets the butcherable variable to 1, allowing the brain to be recovered.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9118, I think - the issue describes being turned into a frog by a wizard, but frog is not a valid polymorph target & the spell would handle this anyway. This was the only explanation that made sense to me
Fixes #8807