### PR TITLE
Fixes sawdrones & nanite swarms committing friendly-fire

### DIFF
--- a/code/modules/telescience/telescope/telescopeMisc.dm
+++ b/code/modules/telescience/telescope/telescopeMisc.dm
@@ -239,6 +239,7 @@ var/list/magnet_locations = list()
 			attacking = 1
 			//playsound(src.loc, "sound/machines/whistlebeep.ogg", 55, 1)
 			src.visible_message("<span class='alert'><b>[src]</b> shreds [M]!</span>")
+
 			var/tturf = get_turf(M)
 			Shoot(tturf, src.loc, src)
 			SPAWN(attack_cooldown)

--- a/code/modules/telescience/telescope/telescopeMisc.dm
+++ b/code/modules/telescience/telescope/telescopeMisc.dm
@@ -239,7 +239,6 @@ var/list/magnet_locations = list()
 			attacking = 1
 			//playsound(src.loc, "sound/machines/whistlebeep.ogg", 55, 1)
 			src.visible_message("<span class='alert'><b>[src]</b> shreds [M]!</span>")
-
 			var/tturf = get_turf(M)
 			Shoot(tturf, src.loc, src)
 			SPAWN(attack_cooldown)
@@ -263,11 +262,4 @@ var/list/magnet_locations = list()
 		if(prob(1) && alive)
 			new/obj/item/material_piece/iridiumalloy(src.loc)
 
-		..()
-
-	bullet_act(var/obj/projectile/P)
-		if (isobj(P.shooter))
-			var/obj/O = P.shooter
-			if(istype(O, /obj/critter/gunbot/drone/buzzdrone/naniteswarm)) //No more friendly fire
-				return
 		..()

--- a/code/modules/telescience/telescope/telescopeMisc.dm
+++ b/code/modules/telescience/telescope/telescopeMisc.dm
@@ -264,3 +264,10 @@ var/list/magnet_locations = list()
 			new/obj/item/material_piece/iridiumalloy(src.loc)
 
 		..()
+
+	bullet_act(var/obj/projectile/P)
+		if (isobj(P.shooter))
+			var/obj/O = P.shooter
+			if(istype(O, /obj/critter/gunbot/drone/buzzdrone/naniteswarm)) //No more friendly fire
+				return
+		..()

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -678,6 +678,13 @@
 			name = "Drone CR-[rand(1,999)]"
 			return
 
+		bullet_act(var/obj/projectile/P)
+			if (isobj(P.shooter))
+				var/obj/O = P.shooter
+				if(istype(O, /obj/critter/gunbot/drone/buzzdrone)) //No more friendly fire at melee range
+					return
+			..()
+
 		fish
 			name = "Syndicate FishDrone"
 			desc = "A Syndicate robo-fish. This appears to be a continuation of the scrap cutter production line made for underwater use."

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -16,6 +16,7 @@
 	firevuln = 0.5
 	brutevuln = 1
 	miscvuln = 0
+	attack_range = 7
 	luminosity = 5
 	seekrange = 15
 	flying = 1
@@ -362,7 +363,7 @@
 					src.task = "thinking"
 					walk_to(src,0)
 				if (target)
-					if (get_dist(src, src.target) <= 7)
+					if (get_dist(src, src.target) <= src.attack_range)
 						var/mob/living/carbon/M = src.target
 						if (M)
 							if(!src.attacking) ChaseAttack(M)
@@ -646,6 +647,7 @@
 		projectile_type = /datum/projectile/laser/drill/cutter
 		current_projectile = new/datum/projectile/laser/drill/cutter
 		smashes_shit = 1
+		attack_range = 1
 		mats = 	list("POW-2" = 19, "MET-2" = 12, "CON-2" = 14, "DEN-2" =26)
 
 		ChaseAttack(atom/M)

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -676,6 +676,13 @@
 			name = "Drone CR-[rand(1,999)]"
 			return
 
+		bullet_act(var/obj/projectile/P)
+			if (isobj(P.shooter))
+				var/obj/O = P.shooter
+				if(istype(O, /obj/critter/gunbot/drone/buzzdrone)) //No more friendly fire at melee range
+					return
+			..()
+
 		fish
 			name = "Syndicate FishDrone"
 			desc = "A Syndicate robo-fish. This appears to be a continuation of the scrap cutter production line made for underwater use."

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -676,13 +676,6 @@
 			name = "Drone CR-[rand(1,999)]"
 			return
 
-		bullet_act(var/obj/projectile/P)
-			if (isobj(P.shooter))
-				var/obj/O = P.shooter
-				if(istype(O, /obj/critter/gunbot/drone/buzzdrone)) //No more friendly fire at melee range
-					return
-			..()
-
 		fish
 			name = "Syndicate FishDrone"
 			desc = "A Syndicate robo-fish. This appears to be a continuation of the scrap cutter production line made for underwater use."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Sawdrones & their subtype nanites fight in melee by "shooting" /projectile/laser/drill/cutter towards the player. They will shoot even if they are not directly adjacent to the player: as they tend to move in packs, this often leads to friendly fire resulting in the drones / nanite swarms decimating their allies.

This PR reimplements the attack_range variable from critter_parent for drones: most drones have a range of 7, which is what they were hardcoded as previously, but saw drones & their subtype nanitesswarms now have an attack_range of 1. It also adds a check making sawdrones & nanites immune to their own projectiles if fired from a fellow sawdrone/nanite.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9096
