### PR TITLE
Fixes spatial tears being deleted by by meteors (and nanites)

### DIFF
--- a/code/modules/events/spatial_tear.dm
+++ b/code/modules/events/spatial_tear.dm
@@ -66,6 +66,9 @@
 	ex_act(severity)
 		return
 
+	meteorhit()
+		return
+
 	proc/try_pass(mob/user)
 		actions.start(new /datum/action/bar/icon/push_through_tear(user, src), user)
 

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -39,7 +39,7 @@
 	var/smashed_recently = 0
 	var/smash_cooldown = 200
 	var/list/can_smash = list(/obj/window, /obj/grille, /obj/table, /obj/foamedmetal, /obj/rack)
-	var/list/do_not_smash = list(/obj/critter, /obj/machinery/vehicle, /obj/machinery/cruiser, /obj/forcefield)
+	var/list/do_not_smash = list(/obj/critter, /obj/machinery/vehicle, /obj/machinery/cruiser)
 
 	var/projectile_spread = 0
 

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -39,7 +39,7 @@
 	var/smashed_recently = 0
 	var/smash_cooldown = 200
 	var/list/can_smash = list(/obj/window, /obj/grille, /obj/table, /obj/foamedmetal, /obj/rack)
-	var/list/do_not_smash = list(/obj/critter, /obj/machinery/vehicle, /obj/machinery/cruiser)
+	var/list/do_not_smash = list(/obj/critter, /obj/machinery/vehicle, /obj/machinery/cruiser, /obj/forcefield)
 
 	var/projectile_spread = 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Saw drones & nanite swarms can break stuff by bumping into things whilst pathing, usually by calling meteorhit() on it unless specifically coded to do something else. Spatial tears get qdel() on them if they are hit by meteors, and so by extension can be deleted by nanites if they materialise between a nanite and its destination.

This PR overrides meteorhit() on the spatial tear forcefield subtype so they can block meteors (and nanites).

Meteor & energy shields already have overrides on meteorhit(), meaning the only other forcefields that retain the default behaviour of being deleted by a meteor are the wizard, artifact and liquid kinds which seems fair enough - grants protection from 1 hit only.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #2569