### PR TITLE
Inventory pockets are hidden

### DIFF
--- a/code/datums/inventory.dm
+++ b/code/datums/inventory.dm
@@ -14,7 +14,7 @@
 /datum/humanInventory/ui_status(mob/user)
 	return min(
 		tgui_physical_state.can_use_topic(src.human, user),
-	tgui_not_incapacitated_state.can_use_topic(src.human, user)
+		tgui_not_incapacitated_state.can_use_topic(src.human, user)
 	)
 
 /datum/humanInventory/ui_interact(mob/user, datum/tgui/ui)

--- a/code/datums/inventory.dm
+++ b/code/datums/inventory.dm
@@ -1,4 +1,5 @@
 #define MAKE_SLOT(slot, item) list("id" = slot, "item" = item?.name)
+#define MAKE_SLOT_CUSTOM(slot, item, name) list("id" = slot, "item" = item ? name : null)
 
 /datum/humanInventory
 	var/mob/living/carbon/human/human = null
@@ -13,7 +14,7 @@
 /datum/humanInventory/ui_status(mob/user)
 	return min(
 		tgui_physical_state.can_use_topic(src.human, user),
-		tgui_not_incapacitated_state.can_use_topic(src.human, user)
+	tgui_not_incapacitated_state.can_use_topic(src.human, user)
 	)
 
 /datum/humanInventory/ui_interact(mob/user, datum/tgui/ui)
@@ -38,8 +39,8 @@
 		MAKE_SLOT("slot_wear_suit", src.human.wear_suit),
 		MAKE_SLOT("slot_back", src.human.back),
 		MAKE_SLOT("slot_wear_id", src.human.wear_id),
-		MAKE_SLOT("slot_l_store", src.human.l_store),
-		MAKE_SLOT("slot_r_store", src.human.r_store),
+		MAKE_SLOT_CUSTOM("slot_l_store", src.human.l_store, "Something"),
+		MAKE_SLOT_CUSTOM("slot_r_store", src.human.r_store, "Something"),
 	)
 
 	. = list(
@@ -110,3 +111,4 @@
 			return
 
 #undef MAKE_SLOT
+#undef MAKE_SLOT_CUSTOM


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Hides inventory pockets like they used to.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

bug bad and I completely missed this when moving it to tgui

Fixes #9494

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Luxizzle
(+)People can no longer see what are in your pockets like they used to. Finally some privacy again.
```
