### PR TITLE
Makes synthmeat mutations infusion based only.

### DIFF
--- a/code/modules/hydroponics/plant_mutations.dm
+++ b/code/modules/hydroponics/plant_mutations.dm
@@ -309,28 +309,24 @@
 	            /obj/item/parts/human_parts/leg/left/synth, /obj/item/parts/human_parts/leg/right/synth,
 	            /obj/item/parts/human_parts/arm/left/synth/bloom, /obj/item/parts/human_parts/arm/right/synth/bloom,
 	            /obj/item/parts/human_parts/leg/left/synth/bloom, /obj/item/parts/human_parts/leg/right/synth/bloom)
-	chance = 15
 
 /datum/plantmutation/synthmeat/heart
 	name = "Synthheart"
 	dont_rename_crop = true
 	iconmod = "SynthHearts"
 	crop = /obj/item/organ/heart/synth
-	chance = 10
 
 /datum/plantmutation/synthmeat/eye
 	name = "Syntheye"
 	dont_rename_crop = true
 	iconmod = "SynthEyes"
 	crop = /obj/item/organ/eye/synth
-	chance = 8
 
 /datum/plantmutation/synthmeat/brain
 	name = "Synthbrain"
 	dont_rename_crop = true
 	iconmod = "SynthBrains"
 	crop = /obj/item/organ/brain/synth
-	chance = 4
 
 /datum/plantmutation/synthmeat/butt/buttbot
 	name = "Synthbuttbot"
@@ -344,49 +340,42 @@
 	dont_rename_crop = true
 	iconmod = "SynthLungs"
 	crop = list(/obj/item/organ/lung/synth/left, /obj/item/organ/lung/synth/right)
-	chance = 6
 
 /datum/plantmutation/synthmeat/appendix
 	name = "Synthappendix"
 	dont_rename_crop = true
 	iconmod = "SynthAppendixes"
 	crop = /obj/item/organ/appendix/synth
-	chance = 6
 
 /datum/plantmutation/synthmeat/pancreas
 	name = "Synthpancreas"
 	dont_rename_crop = true
 	iconmod = "SynthPancreata"
 	crop = /obj/item/organ/pancreas/synth
-	chance = 4
 
 /datum/plantmutation/synthmeat/liver
 	name = "Synthliver"
 	dont_rename_crop = true
 	iconmod = "SynthLivers"
 	crop = /obj/item/organ/liver/synth
-	chance = 6
 
 /datum/plantmutation/synthmeat/kidney
 	name = "Synthkidney"
 	dont_rename_crop = true
 	iconmod = "SynthKidneys"
 	crop = list(/obj/item/organ/kidney/synth/left, /obj/item/organ/kidney/synth/right)
-	chance = 7
 
 /datum/plantmutation/synthmeat/spleen
 	name = "Synthspleen"
 	dont_rename_crop = true
 	iconmod = "SynthSpleens"
 	crop = /obj/item/organ/spleen/synth
-	chance = 5
 
 /datum/plantmutation/synthmeat/stomach
 	name = "Synthstomach"
 	dont_rename_crop = true
 	iconmod = "SynthStomachs"
 	crop = list(/obj/item/organ/stomach/synth, /obj/item/organ/intestines/synth)
-	chance = 5
 
 // Soy Mutations
 

--- a/code/modules/hydroponics/plants_crop.dm
+++ b/code/modules/hydroponics/plants_crop.dm
@@ -135,12 +135,6 @@ ABSTRACT_TYPE(/datum/plant/crop)
 	genome = 7
 	special_proc = 1
 	assoc_reagents = list("synthflesh")
-	mutations = list(/datum/plantmutation/synthmeat/butt,/datum/plantmutation/synthmeat/limb,
-	/datum/plantmutation/synthmeat/brain,/datum/plantmutation/synthmeat/heart,
-	/datum/plantmutation/synthmeat/eye,/datum/plantmutation/synthmeat/lung,
-	/datum/plantmutation/synthmeat/appendix,/datum/plantmutation/synthmeat/pancreas,
-	/datum/plantmutation/synthmeat/liver,/datum/plantmutation/synthmeat/kidney,
-	/datum/plantmutation/synthmeat/spleen, /datum/plantmutation/synthmeat/stomach,)
 	commuts = list(/datum/plant_gene_strain/yield,/datum/plant_gene_strain/unstable)
 
 	HYPinfusionP(var/obj/item/seed/S,var/reagent)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL] [removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes random chance mutation for synthmeat plants, makes it so people can only do infusions to get the mutations. There's no chance regarding if you'll get the mutation via infusion but I can easily add in the chance if wanted! All chemicals needed for the infusions are easily available for botanists, except for proconvertin and simethicone, both of which you can easily get by asking a doctor or scientist!
(I also went ahead and removed the chance code from synthmeat's plant_mutations since it wasn't actually doing anything when it's not applied in plants_crop.)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Synthmeat is probably one of the more annoying plants to grow because it'll just randomly mutate when say you just want limbs, meat, etc. This is a quality of life change for any botanist looking to grow a specific synthmeat mutation or just synthmeat in general.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)avimour
(+)Synthmeat plant mutations are now only infusion based.
```
