### PR TITLE
Fixes fingerprints not updating when copying someone's appearance

### DIFF
--- a/code/modules/medical/genetics/bioHolder.dm
+++ b/code/modules/medical/genetics/bioHolder.dm
@@ -605,6 +605,7 @@ var/list/datum/bioEffect/mutini_effects = list()
 			ownerName = toCopy.ownerName
 			Uid = toCopy.Uid
 			uid_hash = md5(Uid)
+			build_fingerprints()
 
 		if (copyPool)
 			src.RemoveAllPoolEffects()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When copying someone's appearance via the CopyOther() proc, such as via mutagen or ling abilities, DNA copies over but fingerprints do not. This is because fingerprints are generated from the md5 UID (aka DNA) via their own dedicated proc, which currently only gets called for new bioHolders.

This PR adds the build_fingerprints() proc to CopyOther() so it updates the fingerprints properly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8997
Fixes #9458
Doesn't affect Law bringers as they bypassed the issue by working off of DNA now

