### PR TITLE
Syringe chem implant buffs

### DIFF
--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -337,14 +337,14 @@ THROWING DARTS
 /obj/item/implant/freedom
 	name = "freedom implant"
 	icon_state = "implant-r"
-	var/uses = 1.0
+	var/uses = 1
 	impcolor = "r"
 	scan_category = "syndicate"
-	var/activation_emote = "chuckle"
+	var/activation_emote = "shrug"
 
 	New()
-		src.activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
-		src.uses = rand(1, 5)
+		src.activation_emote = pick("eyebrow", "nod", "shrug", "smile", "yawn", "flex", "snap")
+		src.uses = rand(3, 5)
 		..()
 		return
 
@@ -353,22 +353,27 @@ THROWING DARTS
 			return 0
 
 		if (emote == src.activation_emote)
-			src.uses--
-			boutput(source, "You feel a faint click.")
+			var/activated = FALSE
 
 			if (source.hasStatus("handcuffed"))
 				source.handcuffs.drop_handcuffs(source)
+				activated = TRUE
 
 			// Added shackles here (Convair880).
 			if (ishuman(source))
 				var/mob/living/carbon/human/H = source
 				if (H.shoes && H.shoes.chained)
+					activated = TRUE
 					var/obj/item/clothing/shoes/SH = H.shoes
 					H.u_equip(SH)
 					SH.set_loc(H.loc)
 					H.update_clothing()
 					if (SH)
 						SH.layer = initial(SH.layer)
+
+			if (activated)
+				src.uses--
+				boutput(source, "You feel a faint click.")
 
 	implanted(mob/source as mob)
 		..()

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -903,16 +903,17 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			..()
 			implant_overlay = null
 
-	body_visible
+		body_visible
 		bleed_time = 0
 		leaves_wound = FALSE
 		var/barbed = FALSE
 		var/pull_out_name = ""
+		var/chemmult = 1
 
 		on_life(mult)
 			. = ..()
 			if (src.reagents?.total_volume)
-				src.reagents.trans_to(owner, 1 * mult)
+				src.reagents.trans_to(owner, chemmult * mult)
 
 		dart
 			name = "dart"
@@ -955,6 +956,12 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			desc = "A syringe round, of the type that is fired from a syringe gun. Whatever was inside is completely gone."
 			icon = 'icons/obj/chemical.dmi'
 			icon_state = "syringeproj"
+			chemmult = 2.5 //faster for medical purposes
+
+			on_life(mult)
+				. = ..()
+				if (src.reagents?.total_volume)
+					src.reagents.trans_to(owner, chemmult * mult)
 
 			New()
 				..()
@@ -965,6 +972,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 				desc = "An empty syringe round, of the type that is fired from a syringe gun. It has a barbed tip. Nasty!"
 				icon_state = "syringeproj_barbed"
 				barbed = TRUE
+				chemmult = 2 //5 life loops for all chems to be transferred
 
 	blowdart
 		name = "blowdart"

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -337,14 +337,14 @@ THROWING DARTS
 /obj/item/implant/freedom
 	name = "freedom implant"
 	icon_state = "implant-r"
-	var/uses = 1
+	var/uses = 1.0
 	impcolor = "r"
 	scan_category = "syndicate"
-	var/activation_emote = "shrug"
+	var/activation_emote = "chuckle"
 
 	New()
-		src.activation_emote = pick("eyebrow", "nod", "shrug", "smile", "yawn", "flex", "snap")
-		src.uses = rand(3, 5)
+		src.activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
+		src.uses = rand(1, 5)
 		..()
 		return
 
@@ -353,27 +353,22 @@ THROWING DARTS
 			return 0
 
 		if (emote == src.activation_emote)
-			var/activated = FALSE
+			src.uses--
+			boutput(source, "You feel a faint click.")
 
 			if (source.hasStatus("handcuffed"))
 				source.handcuffs.drop_handcuffs(source)
-				activated = TRUE
 
 			// Added shackles here (Convair880).
 			if (ishuman(source))
 				var/mob/living/carbon/human/H = source
 				if (H.shoes && H.shoes.chained)
-					activated = TRUE
 					var/obj/item/clothing/shoes/SH = H.shoes
 					H.u_equip(SH)
 					SH.set_loc(H.loc)
 					H.update_clothing()
 					if (SH)
 						SH.layer = initial(SH.layer)
-
-			if (activated)
-				src.uses--
-				boutput(source, "You feel a faint click.")
 
 	implanted(mob/source as mob)
 		..()
@@ -903,7 +898,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			..()
 			implant_overlay = null
 
-		body_visible
+	body_visible
 		bleed_time = 0
 		leaves_wound = FALSE
 		var/barbed = FALSE
@@ -956,7 +951,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 			desc = "A syringe round, of the type that is fired from a syringe gun. Whatever was inside is completely gone."
 			icon = 'icons/obj/chemical.dmi'
 			icon_state = "syringeproj"
-			chemmult = 2.5 //faster for medical purposes
+			chemmult = 2 //faster for medical purposes
 
 			on_life(mult)
 				. = ..()
@@ -972,7 +967,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 				desc = "An empty syringe round, of the type that is fired from a syringe gun. It has a barbed tip. Nasty!"
 				icon_state = "syringeproj_barbed"
 				barbed = TRUE
-				chemmult = 2 //5 life loops for all chems to be transferred
+				chemmult = 1.5 //5 life loops for all chems to be transferred
 
 	blowdart
 		name = "blowdart"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR buffs the chem transfer rate of the syndicate and nanotrasen syringe gun syringes to be better. Syndicate syringes now add around 3 units every life loop, and normal ones add around 4 units, as opposed to the ~1u baseline. Other chemical implants have been unchanged

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Syringe guns after the syringe implant refractor have been really, really slow, and that makes them pretty useless, both in terms of as a meaningful way of getting any amount of medicine into someone or poisoning them.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)NightmarechaMillian
(+)Syringe gun syringes should transfer reagents faster now.
```
