### PR TITLE
Better disposal chute/storage interactions

### DIFF
--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -115,29 +115,26 @@
 				S.UpdateIcon()
 				user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
 				return
+		//first time they click with a storage, it gets dumped. second time container itself is added
 		if (istype(I,/obj/item/storage/) && I.contents.len)
-			var/action
-			if (istype(I, /obj/item/storage/mechanics/housing_handheld))
-				action = input(user, "What do you want to do with [I]?") as null|anything in list("Place it in the Chute","Never Mind")
-			else
-				action = input(user, "What do you want to do with [I]?") as null|anything in list("Place it in the Chute","Empty it into the chute","Never Mind")
-			if (!action || action == "Never Mind")
-				return
-			if (!in_interact_range(src, user))
-				boutput(user, "<span class='alert'>You need to be closer to the chute to do that.</span>")
-				return
-			if (action == "Empty it into the chute")
-				var/obj/item/storage/S = I
-				if(istype(S, /obj/item/storage/secure))
-					var/obj/item/storage/secure/secS = S
-					if(secS.locked)
-						boutput("<span class='alert'>You need to unlock the container first.</span>")
-						return
-				for(var/obj/item/O in S)
-					O.set_loc(src)
-					S.hud.remove_object(O)
-				user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
-				return
+			var/obj/item/storage/S = I
+			if(istype(S, /obj/item/storage/secure))
+				var/obj/item/storage/secure/secS = S
+				if(secS.locked)
+					boutput("<span class='alert'>You need to unlock the container first.</span>")
+					return
+			for(var/obj/item/O in S)
+				O.set_loc(src)
+				S.hud.remove_object(O)
+			user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
+			actions.interrupt(user, INTERRUPT_ACT)
+			return
+
+		if (istype(I, /obj/item/storage/mechanics/housing_handheld)) //override to normal activity
+			user.visible_message("[user.name] places \the [I] into \the [src].",\
+			"You place \the [I] into \the [src].")
+			actions.interrupt(user, INTERRUPT_ACT)
+
 		var/obj/item/magtractor/mag
 		if (istype(I.loc, /obj/item/magtractor))
 			mag = I.loc

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -118,10 +118,17 @@
 		//first time they click with a storage, it gets dumped. second time container itself is added
 		if (istype(I,/obj/item/storage/) && I.contents.len)
 			var/obj/item/storage/S = I
+			if(user.a_intent != INTENT_HELP) //place the full thing in
+				user.visible_message("[user.name] dunks \the [I] into \the [src].",\
+				"You dunk \the [I] into \the [src].")
+				actions.interrupt(user, INTERRUPT_ACT)
+				return
 			if(istype(S, /obj/item/storage/secure))
 				var/obj/item/storage/secure/secS = S
 				if(secS.locked)
-					boutput("<span class='alert'>You need to unlock the container first.</span>")
+					boutput("<span class='alert'> Unable to open it, you place the whole [secS] into the container.</span>")
+					I.set_loc(src)
+					actions.interrupt(user, INTERRUPT_ACT)
 					return
 			for(var/obj/item/O in S)
 				O.set_loc(src)
@@ -131,6 +138,7 @@
 			return
 
 		if (istype(I, /obj/item/storage/mechanics/housing_handheld)) //override to normal activity
+			I.set_loc(src)
 			user.visible_message("[user.name] places \the [I] into \the [src].",\
 			"You place \the [I] into \the [src].")
 			actions.interrupt(user, INTERRUPT_ACT)

--- a/code/WorkInProgress/recycling/disposal_chute.dm
+++ b/code/WorkInProgress/recycling/disposal_chute.dm
@@ -116,13 +116,9 @@
 				user.visible_message("<b>[user.name]</b> dumps out [S] into [src].")
 				return
 		//first time they click with a storage, it gets dumped. second time container itself is added
-		if (istype(I,/obj/item/storage/) && I.contents.len)
+		if ((istype(I,/obj/item/storage/) && I.contents.len) && user.a_intent == INTENT_HELP) //if they're not on help intent it'll default to placing it in while full
 			var/obj/item/storage/S = I
-			if(user.a_intent != INTENT_HELP) //place the full thing in
-				user.visible_message("[user.name] dunks \the [I] into \the [src].",\
-				"You dunk \the [I] into \the [src].")
-				actions.interrupt(user, INTERRUPT_ACT)
-				return
+
 			if(istype(S, /obj/item/storage/secure))
 				var/obj/item/storage/secure/secS = S
 				if(secS.locked)
@@ -142,6 +138,7 @@
 			user.visible_message("[user.name] places \the [I] into \the [src].",\
 			"You place \the [I] into \the [src].")
 			actions.interrupt(user, INTERRUPT_ACT)
+			return
 
 		var/obj/item/magtractor/mag
 		if (istype(I.loc, /obj/item/magtractor))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QoL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so that the first time you click a disposal chute with a container, it'll dump the container, and only if it's empty will you place the container in. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having a UI popup is really unpleasant and disrupts gameplay when you're trying to throw away a single medkit with 1 health scanner in it. I left it in for botany/mining satchels, however, as you want to be able to make a choice for those.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)NightmarechaMillian
(*)Clicking a disposal chute with a storage object (toolbox, backpack, boxes, etc) will now place the object in if it's empty and dump contents if it's full. To place the full object in, use non-help intent.
```
