### PR TITLE
Fixes diner safe not initialising properly on Oshan

### DIFF
--- a/code/WorkInProgress/ud5/urs_dungeon.dm
+++ b/code/WorkInProgress/ud5/urs_dungeon.dm
@@ -628,7 +628,7 @@
 		src.injest(M)
 */
 
-var/johnbill_ursdungeon_code = 0420
+var/johnbill_ursdungeon_code = "0420"
 
 /area/diner/arcade/New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The safe in the diner containing VR goggles does not properly set a code on initialisation on Oshan, meaning that it cannot be opened.

The safe usually generates a random 4 digit code as the map loads in on `new area/diner/arcade`. However, on maps that don't have that area (like Oshan) it defaults to the number 0420. When stored as a number, 0420 becomes 272 for some reason; I don't know why it doesn't become 420 as I would expect. The safe code being set to a 3 digit number breaks the safe unlocking minigame, rendering it unopenable.

This PR sets the default code to a string "0420", which is stored properly and allows the minigame to work and the safe to unlock.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8949
