### PR TITLE
Mining cyborgs get appraiser & material analyzer

### DIFF
--- a/code/modules/robotics/robot/module_tool_creator/modules.dm
+++ b/code/modules/robotics/robot/module_tool_creator/modules.dm
@@ -159,7 +159,7 @@
 		/obj/item/reagent_containers/dropper,
 	)
 
-// miner.
+// miner. quartermaster.
 /datum/robot/module_tool_creator/recursive/module/mining
 	definitions = list(
 		// TODO: make versatile satchel (same as civilian module's satchel)
@@ -172,6 +172,7 @@
 		/obj/item/satchel/mining/large,
 		/obj/item/extinguisher, // TODO: make large version
 		/obj/item/device/gps,
+		/obj/item/device/appraisal,
+		/obj/item/device/matanalyzer,
 		// TODO: make barcode machine
-		// TODO: make internal ore processor
 	)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds two tools to the mining cyborg module: The cargo appraiser and material analyzer


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The cargo appraiser is adefault-spawn mining kit, and the material analyzer isn't currently able to be used by cyborgs in any capacity.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(+)The mining cyborg module now includes the cargo appraisal and material analysis tools.
```
