### PR TITLE
No blood, feasts or DNA from NPC Humans

### DIFF
--- a/_std/macros/ismob.dm
+++ b/_std/macros/ismob.dm
@@ -14,7 +14,7 @@
 
 #define iscarbon(x) istype(x, /mob/living/carbon)
 #define ismonkey(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/monkey))
-#define isnpc(x) istype(x, /mob/living/carbon/human/npc)
+#define isnpc(x) (istype(x, /mob/living/carbon/human/npc) || (istype(x, /mob/living/carbon/human) && x:is_npc))
 #define isnpcmonkey(x) (istype(x,/mob/living/carbon/human/npc/monkey) && istype(x:mutantrace, /datum/mutantrace/monkey))
 #define ishuman(x) istype(x, /mob/living/carbon/human)
 #define iscow(x) (istype(x, /mob/living/carbon/human) && istype(x:mutantrace, /datum/mutantrace/cow))

--- a/code/datums/abilities/vampire/blood_steal.dm
+++ b/code/datums/abilities/vampire/blood_steal.dm
@@ -22,6 +22,10 @@
 			boutput(M, "<span class='alert'>You are already performing a Bite action and cannot start a Blood Steal.</span>")
 			return 1
 
+		if (isnpc(target))
+			boutput(M, "<span class='alert'>The blood of this target would provide you with no sustenance.</span>")
+			return 1
+
 		actions.start(new/datum/action/bar/private/icon/vamp_ranged_blood_suc(M,V,target, src), M)
 
 		return 0

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -345,6 +345,10 @@
 			boutput(M, "<span class='alert'>You are already performing a Blood action and cannot start a Bite.</span>")
 			return 1
 
+		if (isnpc(target))
+			boutput(M, "<span class='alert'>The blood of this target would provide you with no sustenance.</span>")
+			return 1
+
 		var/mob/living/carbon/human/HH = target
 
 

--- a/code/datums/abilities/werewolf/werewolf_feast.dm
+++ b/code/datums/abilities/werewolf/werewolf_feast.dm
@@ -33,6 +33,10 @@
 			boutput(M, "<span class='alert'>[target] probably wouldn't taste very good.</span>")
 			return 1
 
+		if (npc(target)) // Critter mobs include robots and combat drones. There's not a lot of meat on them.
+			boutput(M, "<span class='alert'>Something about [target]'s smell puts you off feasting on them.</span>")
+			return 1
+
 		if (!target.lying)
 			boutput(M, "<span class='alert'>[target] needs to be lying on the ground first.</span>")
 			return 1

--- a/code/datums/abilities/werewolf/werewolf_feast.dm
+++ b/code/datums/abilities/werewolf/werewolf_feast.dm
@@ -33,7 +33,7 @@
 			boutput(M, "<span class='alert'>[target] probably wouldn't taste very good.</span>")
 			return 1
 
-		if (npc(target)) // Critter mobs include robots and combat drones. There's not a lot of meat on them.
+		if (isnpc(target)) // Critter mobs include robots and combat drones. There's not a lot of meat on them.
 			boutput(M, "<span class='alert'>Something about [target]'s smell puts you off feasting on them.</span>")
 			return 1
 

--- a/code/mob/living/carbon/human/gimmick.dm
+++ b/code/mob/living/carbon/human/gimmick.dm
@@ -208,6 +208,10 @@ mob/living/carbon/human/cluwne/satan/megasatan //someone can totally use this fo
 		src.real_name = "Father Ted"
 
 /mob/living/carbon/human/fatherjack
+	real_name = "Father Jack"
+	gender = MALE
+	is_npc = TRUE
+
 	New()
 		..()
 		src.equip_new_if_possible(/obj/item/clothing/shoes/red, slot_shoes)
@@ -216,8 +220,6 @@ mob/living/carbon/human/cluwne/satan/megasatan //someone can totally use this fo
 
 	initializeBioholder()
 		. = ..()
-		bioHolder.mobAppearance.gender = "male"
-		src.real_name = "Father Jack"
 		bioHolder.bloodType = "B+"
 
 	Life(datum/controller/process/mobs/parent)
@@ -347,6 +349,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 /mob/living/carbon/human/biker
 	real_name = "Shitty Bill"
 	gender = MALE
+	is_npc = 1
 	var/talk_prob = 5
 	var/greeted_murray = 0
 
@@ -704,6 +707,8 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 // merchant
 
 /mob/living/carbon/human/merchant
+	is_npc = TRUE
+
 	New()
 		..()
 		SPAWN(0)
@@ -806,6 +811,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 /mob/living/carbon/human/don_glab
 	real_name = "Donald \"Don\" Glabs"
 	gender = MALE
+	is_npc = TRUE
 
 	New()
 		..()
@@ -928,7 +934,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 
 
 /mob/living/carbon/human/spacer
-	is_npc = 1
+	is_npc = TRUE
 	uses_mobai = 1
 	New()
 		..()
@@ -963,7 +969,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 // This is Big Yank, one of John Bill's old buds. Yank owes John a favor. He's a Juicer.
 /mob/living/carbon/human/big_yank
 	gender = MALE
-	is_npc = 1
+	is_npc = TRUE
 	uses_mobai = 1
 
 	New()

--- a/code/mob/living/carbon/human/gimmick.dm
+++ b/code/mob/living/carbon/human/gimmick.dm
@@ -349,7 +349,7 @@ proc/empty_mouse_params()//TODO MOVE THIS!!!
 /mob/living/carbon/human/biker
 	real_name = "Shitty Bill"
 	gender = MALE
-	is_npc = 1
+	is_npc = TRUE
 	var/talk_prob = 5
 	var/greeted_murray = 0
 

--- a/code/modules/antagonists/changeling/abilities/absorb.dm
+++ b/code/modules/antagonists/changeling/abilities/absorb.dm
@@ -207,6 +207,9 @@
 		if (isnpcmonkey(T))
 			boutput(C, "<span class='alert'>Our hunger will not be satisfied by this lesser being.</span>")
 			return 1
+		if (isnpc(T))
+			boutput(C, "<span class='alert'>The DNA of this target seems inferior somehow, you have no desire to feed on it.</span>")
+			return 1
 		if (T.bioHolder.HasEffect("husk"))
 			boutput(usr, "<span class='alert'>This creature has already been drained...</span>")
 			return 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[WIKI][BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Prevents targeting NPC humans for Changeling absorb, Werewolf feast or Vampire blood abilities.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Robust players will start the round by killing 4+ NPCs.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flappybat
(*)Human NPCs are no longer valid targets for Changeling's DNA absorb, Werewolf feast and Vampire blood abilities.
```
