### PR TITLE
Makes stun baton dodgeable (aurora, matrix) and prevents thralls from batoning their master

### DIFF
--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -247,10 +247,6 @@
 	attack(mob/M, mob/user)
 		src.add_fingerprint(user)
 
-		if(check_target_immunity( M ))
-			user.show_message("<span class='alert'>[M] seems to be warded from attacks!</span>")
-			return
-
 		if (!M.melee_attack_test(user, src))
 			logTheThing("combat", user, M, "attacks [constructTarget(M,"combat")] with [src] ([type], object name: [initial(name)]) but the attack is blocked!")
 			return

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -268,6 +268,9 @@
 				if (!src.is_active || (src.is_active && src.can_stun() == 0))
 					src.do_stun(user, M, "failed_stun", 1)
 				else
+					if (user.mind && user.mind.special_role == ROLE_VAMPTHRALL && isvampire(M) && user.is_mentally_dominated_by(M))
+						boutput(user, "<span class='alert'>You cannot harm your master!</span>")
+						return
 					if (M.do_dodge(user, src))
 						return
 					src.do_stun(user, M, "stun", 2)

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -247,8 +247,8 @@
 	attack(mob/M, mob/user)
 		src.add_fingerprint(user)
 
-		if (!M.melee_attack_test(user, src))
-			logTheThing("combat", user, M, "attacks [constructTarget(M,"combat")] with [src] ([type], object name: [initial(name)]) but the attack is blocked!")
+		if(check_target_immunity( M ))
+			user.show_message("<span class='alert'>[M] seems to be warded from attacks!</span>")
 			return
 
 		if (src.can_stun() == 1 && user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50))
@@ -268,6 +268,8 @@
 				if (!src.is_active || (src.is_active && src.can_stun() == 0))
 					src.do_stun(user, M, "failed_stun", 1)
 				else
+					if (M.do_dodge(user, src))
+						return
 					src.do_stun(user, M, "stun", 2)
 
 		return

--- a/code/obj/item/stun_baton.dm
+++ b/code/obj/item/stun_baton.dm
@@ -251,6 +251,10 @@
 			user.show_message("<span class='alert'>[M] seems to be warded from attacks!</span>")
 			return
 
+		if (!M.melee_attack_test(user, src))
+			logTheThing("combat", user, M, "attacks [constructTarget(M,"combat")] with [src] ([type], object name: [initial(name)]) but the attack is blocked!")
+			return
+
 		if (src.can_stun() == 1 && user.bioHolder && user.bioHolder.HasEffect("clumsy") && prob(50))
 			src.do_stun(user, M, "failed", 1)
 			JOB_XP(user, "Clown", 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Major] [Balance]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stun batons on help intent currently ignore some of the melee attack checks, namely dodge chances (ie CE's aurora belt @ 25% or 80% block ), vamp thrall checks and the checks for if the target is doing a matrix flip (from the perk).

This is because stun baton attack code overrides it's parent, but excludes said checks in the override.

This PR re-adds those checks, allowing you to roll a chance with the CE belt to shrug off a stun baton help intent attack or to dodge them with matrix flipout. It also prevents thralls from stun batoning their masters.

Feedback welcome on whether this makes the CE belt too strong.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5375
Thralls shouldn't be able to baton their masters.
Matrix flipout is supposed to let you dodge anything.
Consistency with how the CE belt works in melee.