### PR TITLE
Adds vampire clothing to geoff honkington

### DIFF
--- a/code/modules/economy/commodity.dm
+++ b/code/modules/economy/commodity.dm
@@ -2174,6 +2174,15 @@
 	upperfluc = 150
 	lowerfluc = -100
 
+/datum/commodity/costume/vampire
+	comname = "Vampire Costume"
+	comtype = /obj/item/storage/box/costume/vampire
+	desc = "A bunch of clothing that kinda resembles a vampire from some old piece of cienema."
+	price = 600
+	baseprice = 100
+	upperfluc = 150
+	lowerfluc = -100
+
 /datum/commodity/costume/abomination
 	comname = "Abomination Costume"
 	comtype = /obj/item/storage/box/costume/abomination

--- a/code/modules/economy/trader.dm
+++ b/code/modules/economy/trader.dm
@@ -1076,6 +1076,7 @@
 		src.goods_sell += new /datum/commodity/costume/utena(src)
 		src.goods_sell += new /datum/commodity/costume/roller_disco(src)
 		src.goods_sell += new /datum/commodity/costume/werewolf(src)
+		src.goods_sell += new /datum/commodity/costume/vampire(src)
 		src.goods_sell += new /datum/commodity/costume/abomination(src)
 		src.goods_sell += new /datum/commodity/costume/hotdog(src)
 		src.goods_sell += new /datum/commodity/costume/purpwitch(src)

--- a/code/obj/item/storage/clothing.dm
+++ b/code/obj/item/storage/clothing.dm
@@ -392,6 +392,12 @@
 		var/obj/item/clothing/head/H = new /obj/item/clothing/head/werewolf/odd(src)
 		H.color = my_color
 
+/obj/item/storage/box/costume/vampire
+	name = "vampire costume set"
+	desc = "Blah blah blah."
+	spawn_contents = list(/obj/item/clothing/under/gimmick/vampire,
+	/obj/item/clothing/suit/gimmick/vampire)
+
 /obj/item/storage/box/costume/abomination
 	name = "abomination costume set"
 	spawn_contents = list(/obj/item/clothing/suit/gimmick/abomination,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the vampire gimmick clothing to geoff honkington's wares. This should let people really get their dracula on as a vampire, among other gimmicks.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Vampire clothing is only able to be gotten during halloween, i kinda feel like it should be a bit more common considering several other halloween costumes are part of the wares of geoff.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)Added a vampire costume to Geoff Honkington's shop.
```
