### PR TITLE
Makes strange vampire clothing only claimable with the vampire cape.

### DIFF
--- a/code/WorkInProgress/rewardsLocker.dm
+++ b/code/WorkInProgress/rewardsLocker.dm
@@ -814,23 +814,13 @@
 			var/mob/living/carbon/human/H = activator
 			if (H.wear_suit)
 				var/obj/item/clothing/M = H.wear_suit
-				if (istype(M, /obj/item/clothing/suit/wizrobe))
-					boutput(activator, "Your magic-infused robes resist the meta-telelogical energies!")
-					return
-				if (istype(M, /obj/item/clothing/suit/space/industrial/syndicate) || istype(M, /obj/item/clothing/suit/space/syndicate))
-					boutput(activator, "Nyet, comrade.")
-					return
+				if (istype(M, /obj/item/clothing/suit/gimmick/vampire))
 				var/prev = M.name
 				M.icon = 'icons/obj/clothing/overcoats/item_suit.dmi'
 				M.inhand_image_icon = 'icons/mob/inhand/hand_cl_suit.dmi'
-				if (M.inhand_image) M.inhand_image.icon = 'icons/mob/inhand/hand_cl_suit.dmi'
 				M.wear_image_icon = 'icons/mob/clothing/overcoats/worn_suit.dmi'
-				if (M.wear_image) M.wear_image.icon = 'icons/mob/clothing/overcoats/worn_suit.dmi'
 				M.icon_state = "vclothes"
 				M.item_state = "vclothes"
-				if (istype(M, /obj/item/clothing/suit/labcoat))
-					var/obj/item/clothing/suit/labcoat/L = M
-					L.coat_style = null
 				M.name = "strange vampire outfit"
 				M.real_name = "strange vampire outfit"
 				M.desc = "How many breads <i>have</i> you eaten in your life? It's a good question. (Base Item: [prev])"

--- a/code/WorkInProgress/rewardsLocker.dm
+++ b/code/WorkInProgress/rewardsLocker.dm
@@ -806,7 +806,7 @@
 
 /datum/achievementReward/dioclothes
 	title = "(Skin) Strange Vampire Outfit"
-	desc = "Requires that you wear something in your suit slot."
+	desc = "Requires that you wear a vampire cape."
 	required_medal = "Dracula Jr."
 
 	rewardActivate(var/mob/activator)
@@ -815,19 +815,19 @@
 			if (H.wear_suit)
 				var/obj/item/clothing/M = H.wear_suit
 				if (istype(M, /obj/item/clothing/suit/gimmick/vampire))
-				var/prev = M.name
-				M.icon = 'icons/obj/clothing/overcoats/item_suit.dmi'
-				M.inhand_image_icon = 'icons/mob/inhand/hand_cl_suit.dmi'
-				M.wear_image_icon = 'icons/mob/clothing/overcoats/worn_suit.dmi'
-				M.icon_state = "vclothes"
-				M.item_state = "vclothes"
-				M.name = "strange vampire outfit"
-				M.real_name = "strange vampire outfit"
-				M.desc = "How many breads <i>have</i> you eaten in your life? It's a good question. (Base Item: [prev])"
-				H.set_clothing_icon_dirty()
+					var/prev = M.name
+					M.icon = 'icons/obj/clothing/overcoats/item_suit.dmi'
+					M.inhand_image_icon = 'icons/mob/inhand/hand_cl_suit.dmi'
+					M.wear_image_icon = 'icons/mob/clothing/overcoats/worn_suit.dmi'
+					M.icon_state = "vclothes"
+					M.item_state = "vclothes"
+					M.name = "strange vampire outfit"
+					M.real_name = "strange vampire outfit"
+					M.desc = "How many breads <i>have</i> you eaten in your life? It's a good question. (Base Item: [prev])"
+					H.set_clothing_icon_dirty()
 				return 1
 
-		boutput(activator, "<span class='alert'>Unable to redeem... Only humans can redeem this.</span>")
+		boutput(activator, "<span class='alert'>Unable to redeem... you must be wearing a vampire cape. Guess it's the thought that <i>counts<i>. </span>")
 		return
 
 /datum/achievementReward/clown_college


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the strange vampire clothing only claimable with the vampire cape, as the title says. This should kill off all the invisibility bugs from claiming medals. Preferably would be added after #9589 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Well the invisible clothing bug is really bad. Plain and simple.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)The strange vampire clothing can now only be claimed with the vampire cape
```
