### PR TITLE
Fixes Kudzu race being removable via GeneTek

### DIFF
--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1905,6 +1905,7 @@ TYPEINFO(/datum/mutantrace)
 	needs_oxy = 0 //get their nutrients from the kudzu
 	understood_languages = list("english", "kudzu")
 	movement_modifier = /datum/movement_modifier/kudzu
+	genetics_removable = FALSE
 	mutant_folder = 'icons/mob/human.dmi' // vOv
 	mutant_organs = list(\
 		"left_eye"=/obj/item/organ/eye/synth,\


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Kudzu mutant race can be removed at a genetics terminal. This causes various issues not currently documented on GH, but I saw someone mention it on the forums.

Applies the flag from #6769 to the Kudzu mutant race so you can't do that anymore.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Removing the kudzu MR shouldn't take 5 seconds in a genetic lab, it's not a free respawn.

Via forums:
![image](https://user-images.githubusercontent.com/86617057/178492986-343ce408-7673-41c5-92f5-2ebf05479d9e.png)
