### PR TITLE
Fixes thrall names not updating

### DIFF
--- a/code/datums/abilities/vampire.dm
+++ b/code/datums/abilities/vampire.dm
@@ -354,7 +354,6 @@
 
 			var/mob/living/M = victim
 
-
 			if (!M.mind && !M.client)
 				if (M.ghost && M.ghost.client && !(M.ghost.mind && M.ghost.mind.dnr))
 					var/mob/dead/ghost = M.ghost
@@ -373,7 +372,6 @@
 								C.mob.mind.transfer_to(M)
 							else
 								M.client = C
-
 							break
 
 			if (!M.client)
@@ -390,8 +388,6 @@
 					owner.TakeDamage("chest", 0, 30)
 					return
 
-
-			M.real_name = "thrall [M.real_name]"
 			if (M.mind)
 				M.mind.special_role = ROLE_VAMPTHRALL
 				if(ismob(owner))

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1059,7 +1059,7 @@ TYPEINFO(/datum/mutantrace)
 			M.add_stam_mod_max("vampiric_thrall", 100)
 			//APPLY_ATOM_PROPERTY(M, PROP_MOB_STAMINA_REGEN_BONUS, "vampiric_thrall", 15)
 			src.original_name = src.mob.real_name
-			src.mob.real_name = "thrall [mob.real_name]"
+			src.mob.real_name = "thrall [src.mob.real_name]"
 			src.mob.UpdateName()
 
 	disposing()

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1050,6 +1050,7 @@ TYPEINFO(/datum/mutantrace)
 	var/const/blood_decay = 0.5
 	var/cleanable_tally = 0
 	var/const/blood_to_health_scalar = 0.5 //200 blood = 100 health
+	var/original_name
 
 	New(var/mob/living/carbon/human/M)
 		..()
@@ -1057,11 +1058,17 @@ TYPEINFO(/datum/mutantrace)
 			src.add_ability(src.mob)
 			M.add_stam_mod_max("vampiric_thrall", 100)
 			//APPLY_ATOM_PROPERTY(M, PROP_MOB_STAMINA_REGEN_BONUS, "vampiric_thrall", 15)
+			src.original_name = src.mob.real_name
+			src.mob.real_name = "thrall [mob.real_name]"
+			src.mob.UpdateName()
 
 	disposing()
 		if (ishuman(src.mob))
 			src.mob.remove_stam_mod_max("vampiric_thrall")
 			//REMOVE_ATOM_PROPERTY(src.mob, PROP_MOB_STAMINA_REGEN_BONUS, "vampiric_thrall")
+			if (!isnull(src.original_name))
+				src.mob.real_name = src.original_name
+				src.mob.UpdateName()
 		..()
 
 	proc/add_ability(var/mob/living/carbon/human/H)
@@ -1102,7 +1109,6 @@ TYPEINFO(/datum/mutantrace)
 		if (abil)
 			if (abil.master)
 				abil.master.remove_thrall(src.mob)
-				abil.master = null
 			else
 				remove_mindslave_status(src.mob)
 		..()

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1102,6 +1102,7 @@ TYPEINFO(/datum/mutantrace)
 		if (abil)
 			if (abil.master)
 				abil.master.remove_thrall(src.mob)
+				abil.master = null
 			else
 				remove_mindslave_status(src.mob)
 		..()

--- a/code/datums/mutantraces.dm
+++ b/code/datums/mutantraces.dm
@@ -1052,11 +1052,11 @@ TYPEINFO(/datum/mutantrace)
 	var/const/blood_to_health_scalar = 0.5 //200 blood = 100 health
 	var/original_name
 
-	New(var/mob/living/carbon/human/M)
+	New()
 		..()
 		if(ishuman(src.mob))
 			src.add_ability(src.mob)
-			M.add_stam_mod_max("vampiric_thrall", 100)
+			src.mob.add_stam_mod_max("vampiric_thrall", 100)
 			//APPLY_ATOM_PROPERTY(M, PROP_MOB_STAMINA_REGEN_BONUS, "vampiric_thrall", 15)
 			src.original_name = src.mob.real_name
 			src.mob.real_name = "thrall [src.mob.real_name]"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Thralls have their names set as "Thrall - whatever" when they are originally created. However, the prefix never gets removed, meaning that even if cloned for the rest of the round they will be labelled a thrall.

This PR moves the name setting and resetting to the thrall mutant race New() and Dispose(), so if a player manages to get rid of their thraldom their name is properly restored.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8640