### PR TITLE
Matter eater now eats things

### DIFF
--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -205,8 +205,8 @@
 					if (ishuman(owner))
 						var/mob/living/carbon/human/H = owner
 						if (istype(the_object, /obj/item/organ))
-							var/obj/item/organ/O = the_object
-							if (O.donor)
+							var/obj/item/organ/organ_obj = the_object
+							if (organ_obj.donor)
 								H.organHolder.drop_organ(the_object,H) //hide it inside self so it doesn't hang around until the eating is finished
 						else if (istype(the_object, /obj/item/parts))
 							var/obj/item/parts/part = the_object

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -179,8 +179,6 @@
 			the_server.eaten(owner)
 			using = FALSE
 			return
-		owner.visible_message("<span class='alert'>[owner] eats [the_object].</span>")
-		playsound(owner.loc, "sound/items/eatfood.ogg", 50, FALSE)
 
 		if (ishuman(owner))
 			var/mob/living/carbon/human/H = owner
@@ -199,19 +197,27 @@
 					affecting.heal_damage(4, 0)
 				owner.UpdateDamageIcon()
 
-			// Then delete the actual item itself
-			// Organs and body parts have special behaviors we need to account for
-			if (istype(the_object, /obj/item/organ))
-				var/obj/item/organ/O = the_object
-				if (O.donor)
-					H.organHolder.drop_organ(the_object)
-			else if (istype(the_object, /obj/item/parts))
-				var/obj/item/parts/part = the_object
-				part.delete()
-				H.hud.update_hands()
-
 		if (!QDELETED(the_object)) // Finally, ensure that the item is deleted regardless of what it is
-			qdel(the_object)
+			var/obj/item/I = the_object
+			if(I)
+				if(I.Eat(owner, owner, TRUE)) //eating can return false to indicate it failed
+					// Organs and body parts have special behaviors we need to account for
+					if (ishuman(owner))
+						var/mob/living/carbon/human/H = owner
+						if (istype(the_object, /obj/item/organ))
+							var/obj/item/organ/O = the_object
+							if (O.donor)
+								H.organHolder.drop_organ(the_object,H) //hide it inside self so it doesn't hang around until the eating is finished
+						else if (istype(the_object, /obj/item/parts))
+							var/obj/item/parts/part = the_object
+							part.delete()
+							H.hud.update_hands()
+			else //Eat() handles qdel, visible message and sound playing, so only do that when we don't have Eat()
+				owner.visible_message("<span class='alert'>[owner] eats [the_object].</span>")
+				playsound(owner.loc, "sound/items/eatfood.ogg", 50, FALSE)
+				qdel(the_object)
+
+
 
 		using = FALSE
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -372,14 +372,16 @@
 
 
 //disgusting proc. merge with foods later. PLEASE
-/obj/item/proc/Eat(var/mob/M as mob, var/mob/user)
+/obj/item/proc/Eat(var/mob/M as mob, var/mob/user, var/by_matter_eater=FALSE)
 	if (!iscarbon(M) && !ismobcritter(M))
 		return 0
 	if (M?.bioHolder && !M.bioHolder.HasEffect("mattereater"))
 		if(ON_COOLDOWN(M, "eat", EAT_COOLDOWN))
 			return 0
 	var/edibility_override = SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED_PRE, user, src)
-	if (!src.edible && !(src.material && src.material.edible) && !(edibility_override & FORCE_EDIBILITY))
+	var/can_matter_eat = by_matter_eater && M == user && M.bioHolder.HasEffect("mattereater")
+	var/edible_check = src.edible || (src.material && src.material.edible) || (edibility_override & FORCE_EDIBILITY)
+	if (!edible_check && !can_matter_eat)
 		return 0
 
 	if (M == user)
@@ -396,7 +398,7 @@
 
 		playsound(M.loc,"sound/items/eatfood.ogg", rand(10, 50), 1)
 		eat_twitch(M)
-		SPAWN(1 SECOND)
+		SPAWN(0.6 SECOND)
 			if (!src || !M || !user)
 				return
 			SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED, user, src)

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -379,7 +379,7 @@
 		if(ON_COOLDOWN(M, "eat", EAT_COOLDOWN))
 			return 0
 	var/edibility_override = SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED_PRE, user, src)
-	var/can_matter_eat = by_matter_eater && M == user && M.bioHolder.HasEffect("mattereater")
+	var/can_matter_eat = by_matter_eater && (M == user) && M.bioHolder.HasEffect("mattereater")
 	var/edible_check = src.edible || (src.material?.edible) || (edibility_override & FORCE_EDIBILITY)
 	if (!edible_check && !can_matter_eat)
 		return 0

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -380,7 +380,7 @@
 			return 0
 	var/edibility_override = SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED_PRE, user, src)
 	var/can_matter_eat = by_matter_eater && M == user && M.bioHolder.HasEffect("mattereater")
-	var/edible_check = src.edible || (src.material && src.material.edible) || (edibility_override & FORCE_EDIBILITY)
+	var/edible_check = src.edible || (src.material?.edible) || (edibility_override & FORCE_EDIBILITY)
 	if (!edible_check && !can_matter_eat)
 		return 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes matter eater call `Eat()` on stuff. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9358 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Matter eater now lets you eat food properly, and also transfers reagents. Eat big bottles of whiskey all at once!
```
