### PR TITLE
Attempting absorb on an NPC will let you copy them

### DIFF
--- a/code/modules/antagonists/changeling/abilities/absorb.dm
+++ b/code/modules/antagonists/changeling/abilities/absorb.dm
@@ -147,17 +147,10 @@
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
-		var/mob/ownerMob = owner
-
 		if (isliving(target))
 			target:was_harmed(owner, special = "ling")
 
-		var/datum/abilityHolder/changeling/C = devour.holder
-		if (istype(C))
-			var/datum/bioHolder/originalBHolder = new/datum/bioHolder(target)
-			originalBHolder.CopyOther(target.bioHolder)
-			C.absorbed_dna[target.real_name] = originalBHolder
-			ownerMob.show_message("<span class='notice'>We can now transform into [target.real_name], we must hold still...</span>", 1)
+		devour.addDNA(target)
 
 	onEnd()
 		..()
@@ -179,7 +172,7 @@
 
 	onInterrupt()
 		..()
-		boutput(owner, "<span class='alert'>Our absorbtion of [target] has been interrupted!</span>")
+		boutput(owner, "<span class='alert'>Our absorption of [target] has been interrupted!</span>")
 
 /datum/targetable/changeling/absorb
 	name = "Absorb DNA"
@@ -209,6 +202,7 @@
 			return 1
 		if (isnpc(T))
 			boutput(C, "<span class='alert'>The DNA of this target seems inferior somehow, you have no desire to feed on it.</span>")
+			addDNA(T)
 			return 1
 		if (T.bioHolder.HasEffect("husk"))
 			boutput(usr, "<span class='alert'>This creature has already been drained...</span>")
@@ -216,3 +210,12 @@
 
 		actions.start(new/datum/action/bar/private/icon/changelingAbsorb(T, src), C)
 		return 0
+
+	proc/addDNA(var/mob/living/T)
+		var/datum/abilityHolder/changeling/C = holder
+		var/mob/ownerMob = holder.owner
+		if (istype(C) && isnull(C.absorbed_dna[T.real_name]))
+			var/datum/bioHolder/originalBHolder = new/datum/bioHolder(T)
+			originalBHolder.CopyOther(T.bioHolder)
+			C.absorbed_dna[T.real_name] = originalBHolder
+			ownerMob.show_message("<span class='notice'>We can now transform into [T.real_name].</span>", 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Absorbing NPCs is now disallowed on lings, preventing you from acquiring the DNA needed to transform.

This PR makes it so attempting to absorb (but failing) an NPC will still grant you their DNA.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pretending to be Shitty Bill as a ling in the diner is a classic move that I thought was worth preserving. 

```changelog
(u)CodeDude
(+)Changelings can copy NPC DNA by attempting to absorb them.
```
