### PR TITLE
Fix being able to schedule tealprints over broken Flock floortiles

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -387,9 +387,12 @@
 	targeted = 0
 
 /datum/targetable/flockmindAbility/createStructure/cast()
-	var/turf/T = get_turf(holder.owner)
-	if(!istype(T, /turf/simulated/floor/feather))
+	var/turf/simulated/floor/feather/T = get_turf(holder.owner)
+	if(!istype(T))
 		boutput(holder.get_controlling_mob(), "<span class='alert'>You aren't above a flocktile.</span>")//todo maybe make this flock themed?
+		return TRUE
+	if (T.broken)
+		boutput(holder.get_controlling_mob(), "<span class='alert'>The flocktile you're above is broken!</span>")
 		return TRUE
 	if(locate(/obj/flock_structure/ghost) in T)
 		boutput(holder.get_controlling_mob(), "<span class='alert'>A tealprint has already been scheduled here!</span>")


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where you could make tealprints over broken Flock floortiles.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix