### PR TITLE
Bartender's "don't lose your shotgun" crew objective can be completed again

### DIFF
--- a/code/datums/crew_objective.dm
+++ b/code/datums/crew_objective.dm
@@ -392,7 +392,7 @@ ABSTRACT_TYPE(/datum/objective/crew/bartender)
 /datum/objective/crew/bartender/shotgun
 	explanation_text = "Don't lose your shotgun!"
 	check_completion()
-		if(owner.current?.check_contents_for(/obj/item/gun/kinetic/riotgun))
+		if(owner.current?.check_contents_for(/obj/item/gun/kinetic/sawnoff))
 			return TRUE
 		else
 			return FALSE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When the bartender's gun was changed away from a riot shotgun, the crew objective not to lose your shotgun did not have its typepath changed, meaning that it will fail unless you get a riot shotgun from somewhere else. This PR just changes the typepath to the sawn-off shotgun that the bartender now starts with, making the objective possible to complete.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Bugs are no bueno.

## Testing
Spawned in as a bartender 'til I got the objective, then ended the round using the game panel and shuttle calls. The objective was successfully completed when I had the double-barreled shotgun in my inventory.

![image](https://user-images.githubusercontent.com/47678781/178774958-738c5b33-8bee-465c-9c28-1d77519467dc.png)


## Changelog
N/A
