### PR TITLE
Synthlimbs can hold roses without gloves

### DIFF
--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -445,11 +445,11 @@
 		var/mob/living/carbon/human/H = user
 		if(src.thorned)
 			if (H.hand)//gets active arm - left arm is 1, right arm is 0
-				if (istype(H.limbs.l_arm,/obj/item/parts/robot_parts))
+				if (istype(H.limbs.l_arm,/obj/item/parts/robot_parts) || istype(H.limbs.l_arm,/obj/item/parts/human_parts/arm/left/synth))
 					..()
 					return
 			else
-				if (istype(H.limbs.r_arm,/obj/item/parts/robot_parts))
+				if (istype(H.limbs.r_arm,/obj/item/parts/robot_parts) || istype(H.limbs.r_arm,/obj/item/parts/human_parts/arm/right/synth))
 					..()
 					return
 			if(istype(H))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[feature]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allow synthetic limb holders to pick up roses without need for gloves (like robot limbs)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Your plant arm is picking up a plant :)