### PR TITLE
Refines the analyzable component some more

### DIFF
--- a/_std/__std.dme
+++ b/_std/__std.dme
@@ -55,6 +55,7 @@
 #include "defines\logging.dm"
 #include "defines\logic.dm"
 #include "defines\materials.dm"
+#include "defines\mechanics.dm"
 #include "defines\medals.dm"
 #include "defines\message_lengths.dm"
 #include "defines\mob.dm"

--- a/_std/defines/mechanics.dm
+++ b/_std/defines/mechanics.dm
@@ -1,0 +1,13 @@
+/// This atom can be scanned normally with a device analyzer.
+#define MECHANICS_INTERACTION_ALLOWED 0
+/// This atom can be scanned, but if scanning would fail, it does the normal attackby logic. Used for putting things on tables, etc.
+#define MECHANICS_INTERACTION_SKIP_IF_FAIL 1
+/// This atom cannot be scanned at all.
+#define MECHANICS_INTERACTION_BLACKLISTED 2
+
+/// The scan attempt succeeded.
+#define MECHANICS_ANALYSIS_SUCCESS 1
+/// The atom cannot be scanned by the scanner, probably due to lacking materials.
+#define MECHANICS_ANALYSIS_INCOMPATIBLE 2
+/// The atom has already been scanned by the device analyzer being used on it.
+#define MECHANICS_ANALYSIS_ALREADY_SCANNED 3

--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -797,6 +797,7 @@
 	plane = PLANE_HUD
 	anchored = 1
 	flags = NOSPLASH
+	mechanics_interaction = MECHANICS_INTERACTION_BLACKLISTED
 
 	var/cooldown = 0
 	var/last_use_time = 0

--- a/code/datums/components/analyzable.dm
+++ b/code/datums/components/analyzable.dm
@@ -16,7 +16,7 @@ TYPEINFO(/datum/component/analyzable)
 	if (!isobj(parent))
 		return COMPONENT_INCOMPATIBLE
 	var/obj/O = parent
-	if (O.mechanics_blacklist)
+	if (O.mechanics_interaction == MECHANICS_INTERACTION_BLACKLISTED)
 		return COMPONENT_INCOMPATIBLE
 	src.result_type = type_override
 	RegisterSignal(parent, list(COMSIG_ATOM_ANALYZE), .proc/attempt_analysis)
@@ -24,22 +24,18 @@ TYPEINFO(/datum/component/analyzable)
 /datum/component/analyzable/proc/attempt_analysis(obj/parent_atom, obj/item/I, mob/user)
 	PRIVATE_PROC(TRUE)
 	// parent_atom can be safely cast as an obj in arguments without other checks because the component can only be applied to objs
-	if (parent_atom.disposed || !istype(I, /obj/item/electronics/scanner))
+	if (parent_atom.disposed)
 		return
-	// in the future, this could be replaced with a component for analyzers themselves, too
+	// if this item doesn't have mats defined or was constructed or
+	// attempting to scan a syndicate item and this is a normal scanner
+	if (isnull(parent_atom.mats) || parent_atom.mats == 0 || (parent_atom.is_syndicate && !I.is_syndicate))
+		return MECHANICS_ANALYSIS_INCOMPATIBLE
 	var/obj/item/electronics/scanner/S = I
-	if (isnull(parent_atom.mats) || parent_atom.mats == 0 || (parent_atom.is_syndicate && !S.is_syndicate))
-		// if this item doesn't have mats defined or was constructed or
-		// attempting to scan a syndicate item and this is a normal scanner
-		boutput(user, "<span class='alert'>The structure of [parent_atom] is not compatible with [S].</span>")
-		return TRUE
-	if (S.scanned.Find(src.result_type))
-		boutput(user, "<span class='alert'>You have already scanned this type of object.</span>")
-		return TRUE
-	S.scanned += src.result_type
-	boutput(user, "<span class='notice'>Item scan successful.</span>")
-	playsound(parent_atom.loc, 'sound/machines/tone_beep.ogg', 30, FALSE)
-	return TRUE
+	if (istype(S))
+		if (S.scanned.Find(src.result_type))
+			return MECHANICS_ANALYSIS_ALREADY_SCANNED
+		S.scanned += src.result_type
+	return MECHANICS_ANALYSIS_SUCCESS
 
 /datum/component/analyzer/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_ATOM_ANALYZE)

--- a/code/obj.dm
+++ b/code/obj.dm
@@ -11,8 +11,8 @@
 	var/list/mats = 0 // either a number or a list of the form list("MET-1"=5, "erebite"=3)
 	var/deconstruct_flags = DECON_NONE
 
-	/// If TRUE, this object can't be scanned at all by device analyzers
-	var/mechanics_blacklist = FALSE
+	/// Dictates how this object behaves when scanned with a device analyzer or equivalent - see "_std/defines/mechanics.dm" for docs
+	var/mechanics_interaction = MECHANICS_INTERACTION_ALLOWED
 	/// If defined, device analyzer scans will yield this typepath (instead of the default, which is just the object's type itself)
 	var/mechanics_type_override = null
 	var/artifact = null
@@ -31,7 +31,7 @@
 		if (HAS_FLAG(object_flags, HAS_DIRECTIONAL_BLOCKING))
 			var/turf/T = get_turf(src)
 			T?.UpdateDirBlocks()
-		if (!isnull(src.mats) && src.mats != 0 && !src.mechanics_blacklist)
+		if (!isnull(src.mats) && src.mats != 0 && !src.mechanics_interaction != MECHANICS_INTERACTION_BLACKLISTED)
 			src.AddComponent(/datum/component/analyzable, !isnull(src.mechanics_type_override) ? src.mechanics_type_override : src.type)
 		src.update_access_from_txt()
 

--- a/code/obj/item/device/pda2/scanners.dm
+++ b/code/obj/item/device/pda2/scanners.dm
@@ -113,7 +113,7 @@
 			if (scan_result != MECHANICS_ANALYSIS_SUCCESS && O.mechanics_interaction == MECHANICS_INTERACTION_SKIP_IF_FAIL)
 				return
 			animate_scanning(A, "#FFFF00")
-			if (scan_result == MECHANICS_ANALYSIS_INCOMPATIBLE)
+			if (!scan_result || scan_result == MECHANICS_ANALYSIS_INCOMPATIBLE)
 				return "<span class='alert'>Unable to scan.</span>"
 
 			var/datum/computer/file/electronics_scan/theScan = new

--- a/code/obj/item/device/pda2/scanners.dm
+++ b/code/obj/item/device/pda2/scanners.dm
@@ -100,21 +100,21 @@
 		on_unset_scan(obj/item/device/pda2/pda)
 			qdel(get_radio_connection_by_id(pda, "ruckkit"))
 
-		scan_atom(atom/A as obj)
-			if (..() || !istype(A, /obj))
+		scan_atom(atom/A)
+			if (..() || !isobj(A) || !ismob(usr))
 				return
-
-			var/obj/O = A
-			if(istype(O,/obj/machinery/rkit) || istype(O, /obj/item/electronics/frame))
-				return
-
-			if(O.mats == 0 || isnull(O.mats) || O.disposed || O.is_syndicate != 0)
-				return "<span class='alert'>Unable to scan.</span>"
-
 			if (!istype(master.host_program, /datum/computer/file/pda_program/os/main_os) || !master.host_program:message_on)
-				return "<span class='alert'>Messaging must be on to communicate with engineering kit.</span>"
-
-			animate_scanning(O, "#FFFF00")
+				return "<span class='alert'>Messaging must be enabled to communicate with engineering kit.</span>"
+			var/obj/O = A
+			var/mob/user = usr
+			if (O.mechanics_interaction == MECHANICS_INTERACTION_BLACKLISTED)
+				return
+			var/scan_result = SEND_SIGNAL(A, COMSIG_ATOM_ANALYZE, src.master, user)
+			if (scan_result != MECHANICS_ANALYSIS_SUCCESS && O.mechanics_interaction == MECHANICS_INTERACTION_SKIP_IF_FAIL)
+				return
+			animate_scanning(A, "#FFFF00")
+			if (scan_result == MECHANICS_ANALYSIS_INCOMPATIBLE)
+				return "<span class='alert'>Unable to scan.</span>"
 
 			var/datum/computer/file/electronics_scan/theScan = new
 			theScan.scannedName = initial(O.name)

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -28,6 +28,7 @@
 	move_triggered = 1
 	flags = FPRINT | TABLEPASS | NOSPLASH
 	w_class = W_CLASS_NORMAL
+	mechanics_interaction = MECHANICS_INTERACTION_SKIP_IF_FAIL
 
 		//cogwerks - burn vars
 	burn_point = 2500

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -470,7 +470,7 @@
 			if (MECHANICS_ANALYSIS_SUCCESS)
 				scan_output = "<span class='notice'>Item scan successful.</span>"
 				playsound(A.loc, 'sound/machines/tone_beep.ogg', 30, FALSE)
-			if (MECHANICS_ANALYSIS_INCOMPATIBLE)
+			if (MECHANICS_ANALYSIS_INCOMPATIBLE, 0) // 0 is returned by SEND_SIGNAL if the component is not present, so we use it here too
 				scan_output = "<span class='alert'>The structure of [A] is not compatible with [parent_item].</span>"
 			if (MECHANICS_ANALYSIS_ALREADY_SCANNED)
 				scan_output = "<span class='alert'>You have already scanned this type of object.</span>"

--- a/code/obj/item/tool/electronics.dm
+++ b/code/obj/item/tool/electronics.dm
@@ -120,7 +120,7 @@
 /obj/item/electronics/frame
 	name = "frame"
 	icon_state = "frame"
-	mechanics_blacklist = TRUE
+	mechanics_interaction = MECHANICS_INTERACTION_BLACKLISTED
 	var/store_type = null
 	var/secured = 0
 	var/viewstat = 0
@@ -451,19 +451,34 @@
 	get_desc()
 		// We display this on a separate line and with a different color to show emphasis
 		. = ..()
-		. += "<br><span class='notice'>Use the Help, Disarm, or Grab intents to scan objects when you click them. Switch to Harm intent to place it on tables, store it in backpacks, and so on.</span>"
+		. += "<br><span class='notice'>Use the Help, Disarm, or Grab intents to scan objects when you click them. Switch to Harm intent do other things.</span>"
 
 	proc/pre_attackby(obj/item/parent_item, atom/A, mob/user)
 		if (user.a_intent == INTENT_HARM)
 			return
+		var/skip_if_fail = FALSE
 		if (isobj(A))
 			var/obj/O = A
-			if (O.mechanics_blacklist)
+			if (O.mechanics_interaction == MECHANICS_INTERACTION_BLACKLISTED)
 				return
-		do_scan_effects(A, user)
-		if (SEND_SIGNAL(A, COMSIG_ATOM_ANALYZE, parent_item, user))
-			return TRUE
-		boutput(user, "<span class='alert'>The structure of [A] is not compatible with [parent_item].</span>")
+			skip_if_fail = O.mechanics_interaction == MECHANICS_INTERACTION_SKIP_IF_FAIL
+		var/scan_result = SEND_SIGNAL(A, COMSIG_ATOM_ANALYZE, parent_item, user)
+		if (scan_result != MECHANICS_ANALYSIS_SUCCESS && skip_if_fail)
+			return
+		var/scan_output = null
+		switch (scan_result)
+			if (MECHANICS_ANALYSIS_SUCCESS)
+				scan_output = "<span class='notice'>Item scan successful.</span>"
+				playsound(A.loc, 'sound/machines/tone_beep.ogg', 30, FALSE)
+			if (MECHANICS_ANALYSIS_INCOMPATIBLE)
+				scan_output = "<span class='alert'>The structure of [A] is not compatible with [parent_item].</span>"
+			if (MECHANICS_ANALYSIS_ALREADY_SCANNED)
+				scan_output = "<span class='alert'>You have already scanned this type of object.</span>"
+		if (!isnull(scan_output))
+			// this is technically sleight of hand, since the effects of scanning are only shown after the scan is actually done
+			// doing this is a lot cleaner, though, than displaying some or all of the messages if the target has MECHANICS_INTERACTION_SKIP_IF_FAIL
+			do_scan_effects(A, user)
+			boutput(user, scan_output)
 		return TRUE
 	
 	proc/do_scan_effects(atom/target, mob/user)
@@ -483,7 +498,7 @@
 	icon_state = "rkit"
 	anchored = 1
 	density = 1
-	mechanics_blacklist = TRUE
+	mechanics_interaction = MECHANICS_INTERACTION_BLACKLISTED
 	//var/datum/electronics/electronics_items/link = null
 	req_access = list(access_captain, access_head_of_personnel, access_maxsec, access_engineering_chief)
 

--- a/code/obj/rack.dm
+++ b/code/obj/rack.dm
@@ -8,6 +8,7 @@
 	anchored = 1.0
 	desc = "A metal frame used to hold objects. Can be wrenched and made portable."
 	event_handler_flags = USE_FLUID_ENTER
+	mechanics_interaction = MECHANICS_INTERACTION_SKIP_IF_FAIL
 
 	proc/rackbreak()
 		icon_state += "-broken"

--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -10,6 +10,7 @@
 	layer = OBJ_LAYER-0.1
 	stops_space_move = TRUE
 	mat_changename = 1
+	mechanics_interaction = MECHANICS_INTERACTION_SKIP_IF_FAIL
 	var/auto_type = /obj/table/auto
 	var/parts_type = /obj/item/furniture_parts/table
 	var/auto = 0

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -30,6 +30,7 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // BEGIN_INCLUDE
+#include "_std\defines\mechanics.dm"
 #include "code\area.dm"
 #include "code\atom.dm"
 #include "code\client.dm"

--- a/goonstation.dme
+++ b/goonstation.dme
@@ -30,7 +30,6 @@ var/datum/preMapLoad/preMapLoad = new
 #include "code\__secret_public.dme"
 
 // BEGIN_INCLUDE
-#include "_std\defines\mechanics.dm"
 #include "code\area.dm"
 #include "code\atom.dm"
 #include "code\client.dm"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS][QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This is a follow-up PR to #9317, which made mechanics analysis component-based, and it does the following things:
1. Expanded `mechanics_blacklist` into `mechanics_interaction`; instead of being a true/false, it now accepts several possible values that determine what happens when the analyzer scans something.
2. Objects can now have their mechanics interaction set to `MECHANICS_SKIP_IF_FAIL`, which causes normal attackby() logic to take place if the object can't be scanned. This lets players put analyzers into backpacks, onto tables, etc. without having to switch intents, as long as those things can't be scanned normally. A few things have this set by default.
4. The analyzable component no longer provides any feedback on its own (i.e. messaging, sound, etc); the feedback is instead handled by the objects themselves. This is so that different items can have varying outputs when scanning objects.
5. The PDA device analyzer now uses the analyzable component too. It still uses afterattack() like other PDA scanners, because PDA code terrifies me and I just wanted to get it roughly on the same page.

Note - PDAs still do the "old" logic of checking for override type directly, instead of getting the `result_type` of the component. If I don't end up having time to fix this here (via making the analyzable component return a list, or some other thing), then I'll do it in the near future.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I like to think the initial PR was good from a code perspective, but it resulted in several usability hindrances in regular play - most notably that you have to switch intents to put it in your backpack. Since backpacks, tables, and so on already can't be scanned, I think this lets us have our cake and eat it too by letting these objects be scanned if they can be, and having them function normally if they can't.

## Testing

I spawned myself in as a mechanic and scanned a ton of different things with both the PDA and device analyzer, to make sure they were working as normal. Analyzers could be placed onto and into things without incident. When varedit was used to make a backpack analyzable and adjust vars accordingly, the analyzer instead scanned the object, and then further clicks caused it to be put into the backpack.

I might have missed something, so I encourage y'all to test too if you think it'd be beneficial!

## Changelog
fixes #9738
N/A