### PR TITLE
fixes public camera viewers turning into security camera viewers

### DIFF
--- a/code/WorkInProgress/ud5/backup/z7_urs_dungeon_5.dmm
+++ b/code/WorkInProgress/ud5/backup/z7_urs_dungeon_5.dmm
@@ -7538,7 +7538,7 @@
 /area/adventure/urs_dungeon)
 "os" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/item/clothing/glasses/vr{

--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -33,7 +33,9 @@ ABSTRACT_TYPE(/obj/item/circuitboard)
 /obj/item/circuitboard/security
 	name = "Circuit board (Security)"
 	computertype = "/obj/machinery/computer/security"
-
+/obj/item/circuitboard/television
+    name = "Circuit board (Television)"
+    computertype = "/obj/machinery/computer/security/small"
 //obj/item/circuitboard/med_data
 //	name = "Circuit board (Medical)"
 //	computertype = "/obj/machinery/computer/med_data"

--- a/code/obj/machinery/computer/security.dm
+++ b/code/obj/machinery/computer/security.dm
@@ -102,17 +102,16 @@
 	name = "Security Cameras"
 	icon_state = "security_det"
 
-	small
-		name = "Television"
-		desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?"
-		network = "Zeta"
-		icon_state = "security_tv"
+/obj/machinery/computer/security/small
+        name = "Television"
+        desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?"
+        circuit_type = "/obj/item/circuitboard/television"
+        network = "Zeta"
+        icon_state = "security_tv"
 
-		power_change()
-			return
 
 // -------------------- VR --------------------
-/obj/machinery/computer/security/wooden_tv/small/virtual
+/obj/machinery/computer/security/small/virtual
 	desc = "It's making you feel kinda twitchy for some reason."
 	icon = 'icons/effects/VR.dmi'
 // --------------------------------------------

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -5821,7 +5821,7 @@
 /area/station/hallway/primary/north)
 "oy" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "oz" = (

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -7332,7 +7332,7 @@
 	dir = 4
 	},
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet{
@@ -12947,7 +12947,7 @@
 	pixel_x = -10
 	},
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/wood,
@@ -16856,7 +16856,7 @@
 /area/station/crew_quarters/bar)
 "aIA" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
@@ -17955,7 +17955,7 @@
 	pixel_x = 10
 	},
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet{
@@ -23442,7 +23442,7 @@
 	dir = 4
 	},
 /obj/table/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/disposal/small/east{
@@ -30236,7 +30236,7 @@
 	icon_state = "4-8"
 	},
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/disposalpipe/segment/brig{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -2134,7 +2134,7 @@
 	pixel_x = 14;
 	pixel_y = 3
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_x = -3;
 	pixel_y = 9
 	},
@@ -4196,7 +4196,7 @@
 /area/station/crew_quarters/showers)
 "amJ" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/machinery/light{
 	dir = 8;
 	tag = ""
@@ -4651,7 +4651,7 @@
 /area/station/security/brig)
 "anJ" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/decal/poster/wallsign/cdnp{
@@ -8577,7 +8577,7 @@
 /obj/window/reinforced{
 	dir = 2
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 7
 	},
 /turf/simulated/floor/carpet{
@@ -9047,7 +9047,7 @@
 "azY" = (
 /obj/table/auto,
 /obj/deskclutter,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/bar,
@@ -26053,7 +26053,7 @@
 /area/space)
 "bpy" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/delivery,
@@ -39838,7 +39838,7 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/purple,
@@ -42650,7 +42650,7 @@
 /area/station/science/lobby)
 "chY" = (
 /obj/table/glass/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/wood,
@@ -42815,7 +42815,7 @@
 /area/station/hallway/secondary/exit)
 "cix" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/greenwhite/other{

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -6667,7 +6667,7 @@
 /area/station/crew_quarters/fitness)
 "aqa" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor,
@@ -10803,7 +10803,7 @@
 /area/station/crew_quarters/kitchen)
 "azz" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/white,
@@ -13232,7 +13232,7 @@
 /area/station/crew_quarters/cafeteria)
 "aER" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet{
@@ -13528,7 +13528,7 @@
 /area/station/hydroponics/bay)
 "aFF" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/carpet{
 	dir = 5;
 	icon_state = "fgreen5"
@@ -15936,7 +15936,7 @@
 /area/station/crew_quarters/cafeteria)
 "aLX" = (
 /obj/table/glass/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor{
@@ -17525,7 +17525,7 @@
 "aPE" = (
 /obj/item/game_kit,
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet,
@@ -22257,7 +22257,7 @@
 /area/station/hallway/secondary/entry)
 "baE" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/neutral/side,
@@ -28522,7 +28522,7 @@
 /area/station/engine/engineering)
 "bpI" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/camera{
@@ -30731,7 +30731,7 @@
 /area/station/security/main)
 "buq" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/item/clothing/glasses/vr{
@@ -35155,7 +35155,7 @@
 /area/station/hallway/primary/east)
 "bDp" = (
 /obj/table/wood/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/black,
@@ -35801,7 +35801,7 @@
 	pixel_y = 21
 	},
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/blueblack,
 /area/station/engine/power{
 	name = "Engineering Control Room"
@@ -38742,7 +38742,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/item/device/radio/intercom/bridge,
@@ -41524,7 +41524,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/black,
@@ -46182,7 +46182,7 @@
 "bYK" = (
 /obj/disposalpipe/segment/mail/vertical,
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/camera{
@@ -49080,7 +49080,7 @@
 /area/station/storage/tech)
 "cgg" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/power/apc{
@@ -50296,7 +50296,7 @@
 /area/station/science/teleporter)
 "cjz" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/door_control{
@@ -51014,7 +51014,7 @@
 "cle" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/intercom/science,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light{
@@ -54430,7 +54430,7 @@
 /area/station/catwalk/south)
 "csV" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/arrival,
@@ -55697,7 +55697,7 @@
 /area/station/science/lobby)
 "cvU" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet{
@@ -57803,7 +57803,7 @@
 /area/station/medical/medbay/lobby)
 "cAB" = (
 /obj/table/glass/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet,
@@ -58344,7 +58344,7 @@
 /area/station/science/lab)
 "cBM" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light_switch/north{
@@ -62747,7 +62747,7 @@
 /area/station/science/chemistry)
 "cMn" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/white,
@@ -64480,7 +64480,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/yellow/side{
@@ -71094,7 +71094,7 @@
 /area/station/medical/medbay)
 "dey" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/bot/white,
@@ -72937,7 +72937,7 @@
 /area/research_outpost)
 "diK" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/cable{

--- a/maps/density.dmm
+++ b/maps/density.dmm
@@ -579,7 +579,7 @@
 /area/station/security/main)
 "bp" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/item/clothing/glasses/vr{
@@ -3123,7 +3123,7 @@
 /area/station/crew_quarters/bar)
 "ha" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/bar,

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -6541,7 +6541,7 @@
 /area/station/medical/medbay/lobby)
 "aAV" = (
 /obj/table/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light/incandescent{

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -613,7 +613,7 @@
 /area/station/security/brig/north_side)
 "abc" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light/incandescent/warm,
@@ -20603,7 +20603,7 @@
 /area/station/crew_quarters/courtroom)
 "fEt" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 7
 	},
 /turf/simulated/floor/specialroom/bar,
@@ -23913,7 +23913,7 @@
 /obj/machinery/light/incandescent/cool{
 	dir = 1
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/item/decoration/ashtray{
@@ -37338,7 +37338,7 @@
 /area/station/science/artifact)
 "kEK" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/purple/standard/edge{
@@ -54675,7 +54675,7 @@
 /area/station/hangar/science)
 "pEL" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/arcade,
@@ -60725,7 +60725,7 @@
 /area/station/science/lobby)
 "rll" = (
 /obj/table/glass/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light/emergency,

--- a/maps/fleet.dmm
+++ b/maps/fleet.dmm
@@ -1691,7 +1691,7 @@
 /area/station/science/teleporter)
 "dK" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/purplewhite{
@@ -11287,7 +11287,7 @@
 	})
 "wB" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/bar/edge{

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -22744,7 +22744,7 @@
 	})
 "bfM" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/grime,
@@ -34621,7 +34621,7 @@
 /area/station/crew_quarters/kitchen)
 "bKc" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},
@@ -51858,7 +51858,7 @@
 /area/station/science/testchamber)
 "cDp" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 7
 	},
 /obj/item/clothing/head/helmet/camera{

--- a/maps/icarus.dmm
+++ b/maps/icarus.dmm
@@ -5640,7 +5640,7 @@
 /area/station/crew_quarters/cafeteria)
 "amP" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/bar/edge{
@@ -17827,7 +17827,7 @@
 /area/station/medical/medbay/lobby)
 "aMC" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/medbay,
@@ -21246,7 +21246,7 @@
 /area/station/science/teleporter)
 "aTF" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/door_control{
@@ -26905,7 +26905,7 @@
 /area/station/crew_quarters/quarters_west)
 "ldu" = (
 /obj/table/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor,

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -838,7 +838,7 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/item/paper{
@@ -20467,7 +20467,7 @@
 /area/station/crew_quarters/kitchen)
 "bjo" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/bar,
@@ -22032,7 +22032,7 @@
 /area/station/crew_quarters/cafeteria)
 "boy" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/green/standard/narrow/northsouth,
@@ -27674,7 +27674,7 @@
 /area/station/hallway/secondary/south)
 "bHA" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/camera{
@@ -28979,7 +28979,7 @@
 	})
 "bKW" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/darkblue/checker/other,
@@ -29373,7 +29373,7 @@
 /area/station/quartermaster/office)
 "bLV" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/orangeblack/side{
@@ -29634,7 +29634,7 @@
 /area/station/science/teleporter)
 "bMJ" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/power/apc/autoname_north,
@@ -42410,7 +42410,7 @@
 /area/station/maintenance/central)
 "fsR" = (
 /obj/table/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/neutral/side{
@@ -43167,7 +43167,7 @@
 /area/station/crew_quarters/courtroom)
 "ggc" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor,
@@ -43727,7 +43727,7 @@
 /area/station/crew_quarters/pool)
 "gFU" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/orangeblack/corner{
@@ -45821,7 +45821,7 @@
 /area/station/security/main)
 "iQf" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light{
@@ -46207,7 +46207,7 @@
 /area/station/hydroponics/bay)
 "jnz" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light/emergency{
@@ -47626,7 +47626,7 @@
 /area/station/security/interrogation)
 "kQv" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/blue,
@@ -47656,7 +47656,7 @@
 /area/station/garden/aviary)
 "kSA" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/white,
@@ -51553,7 +51553,7 @@
 /area/station/crew_quarters/quarters_south)
 "oIR" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/item/device/radio/beacon{
@@ -51958,7 +51958,7 @@
 /area/station/bridge)
 "phF" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/disposalpipe/segment/vertical,
@@ -52538,7 +52538,7 @@
 /area/station/crew_quarters/showers)
 "pKm" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "pKK" = (

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -13139,7 +13139,7 @@
 /area/station/crew_quarters/quarters)
 "aLi" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
@@ -15434,7 +15434,7 @@
 /area/station/security/brig)
 "aSo" = (
 /obj/table/wood/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 5
 	},
 /obj/item_dispenser/handcuffs,
@@ -22977,7 +22977,7 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 5
 	},
 /turf/simulated/floor/wood/seven,
@@ -24185,7 +24185,7 @@
 /area/station/medical/medbay/lobby)
 "boB" = (
 /obj/table/glass/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 5
 	},
 /turf/simulated/floor/blue,
@@ -34035,7 +34035,7 @@
 /area/station/maintenance/upperstarboard)
 "dUV" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/decoration/clock{

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -41465,7 +41465,7 @@
 /area/tech_outpost)
 "cdx" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/grime,

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -1093,7 +1093,7 @@
 	})
 "aqo" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/nw_se,
@@ -2916,7 +2916,7 @@
 /area/station/quartermaster/cargooffice)
 "aSt" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor,
@@ -4802,7 +4802,7 @@
 /area/station/medical/staff)
 "bwl" = (
 /obj/table/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light{
@@ -7074,7 +7074,7 @@
 /area/shuttle/merchant_shuttle/right_station/cogmap)
 "cem" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/item/reagent_containers/food/drinks/mug{
 	pixel_x = -15
 	},
@@ -12500,7 +12500,7 @@
 /area/station/crew_quarters/barber_shop)
 "dAy" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/engine/caution/west,
@@ -13083,7 +13083,7 @@
 /area/station/crew_quarters/arcade)
 "dHz" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor,
@@ -16143,7 +16143,7 @@
 /area/station/crew_quarters/bar)
 "ewO" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/purple,
@@ -16700,7 +16700,7 @@
 /area/station/hangar/medical)
 "eFH" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/bar/edge{
@@ -18100,7 +18100,7 @@
 /area/station/medical/staff)
 "eZI" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor,
@@ -23539,7 +23539,7 @@
 /area/station/hangar/qm)
 "gwz" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light_switch/west,
@@ -29562,7 +29562,7 @@
 /area/station/medical/staff)
 "hYd" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/neutral,
@@ -30819,7 +30819,7 @@
 /area/station/bridge)
 "itB" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/bar/edge{
@@ -32065,7 +32065,7 @@
 /area/station/ai_monitored/armory)
 "iIM" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/grime,
@@ -35902,7 +35902,7 @@
 /area/station/mining/refinery)
 "jKg" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/item/decoration/ashtray{
@@ -44293,7 +44293,7 @@
 /area/station/engine/elect)
 "lOD" = (
 /obj/table/wood/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/firealarm{
@@ -48420,7 +48420,7 @@
 /area/station/hallway/primary/east)
 "mSI" = (
 /obj/table/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/firealarm{
@@ -50136,7 +50136,7 @@
 /area/station/medical/medbay/surgery)
 "ntt" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor,
@@ -60062,7 +60062,7 @@
 /area/station/security/processing)
 "pWs" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/wood,
@@ -60362,7 +60362,7 @@
 /obj/table/reinforced/chemistry/auto{
 	name = "prep counter"
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/cafeteria,
@@ -68921,7 +68921,7 @@
 	})
 "skL" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/camera{
@@ -72749,7 +72749,7 @@
 /area/station/maintenance/disposal)
 "teE" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/grey,
@@ -74424,7 +74424,7 @@
 /area/station/hallway/primary/south)
 "tzz" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/bar,
@@ -75577,7 +75577,7 @@
 /area/space)
 "tOD" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor,
@@ -76258,7 +76258,7 @@
 /area/station/storage/emergency2)
 "tXm" = (
 /obj/table/glass/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/blue/standard/edge/west,
@@ -77033,7 +77033,7 @@
 /area/station/science/gen_storage)
 "uhk" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/purple/fancy/innercorner/nw,
@@ -77768,7 +77768,7 @@
 /area/station/turret_protected/ai_upload)
 "urd" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light/small{
@@ -81970,7 +81970,7 @@
 /area/station/hallway/primary/east)
 "vox" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor,

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -57779,7 +57779,7 @@
 "chb" = (
 /obj/table/auto,
 /obj/deskclutter,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/specialroom/bar,
@@ -57810,7 +57810,7 @@
 /obj/disposalpipe/segment/transport{
 	dir = 8
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/purple,
@@ -60910,7 +60910,7 @@
 /area/station/medical/robotics)
 "cku" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/decal/poster/wallsign/cdnp{
@@ -60928,7 +60928,7 @@
 	pixel_x = -14;
 	pixel_y = 3
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_x = 3;
 	pixel_y = 9
 	},
@@ -60936,7 +60936,7 @@
 /area/station/crew_quarters/quarters)
 "ckw" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/greenwhite/other{
@@ -61365,7 +61365,7 @@
 /area/station/hallway/secondary/entry)
 "cli" = (
 /obj/table/glass/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/wood,
@@ -61839,7 +61839,7 @@
 /area/station/science/bot_storage)
 "cmd" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/delivery,
@@ -62442,7 +62442,7 @@
 /obj/window/reinforced{
 	dir = 2
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 7
 	},
 /turf/simulated/floor/carpet{
@@ -63206,7 +63206,7 @@
 /area/listeningpost)
 "cob" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/machinery/light{
 	dir = 4;
 	tag = ""

--- a/maps/unused/atlas_old.dmm
+++ b/maps/unused/atlas_old.dmm
@@ -16189,7 +16189,7 @@
 /area/station/maintenance/southwest)
 "Mf" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/cafeteria)
 "Mg" = (

--- a/maps/unused/chiron.dmm
+++ b/maps/unused/chiron.dmm
@@ -1717,7 +1717,7 @@
 "adc" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/radio,
@@ -11093,7 +11093,7 @@
 	pixel_x = 6
 	},
 /obj/item/device/radio/intercom/catering{
-	
+
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
@@ -12577,7 +12577,7 @@
 /area/station/crew_quarters/cafeteria)
 "ayl" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light,
@@ -15921,7 +15921,7 @@
 /area/station/solar/west)
 "aFD" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -20211,7 +20211,7 @@
 /area/station/security/brig)
 "aOy" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/grime,
@@ -32309,7 +32309,7 @@
 /area/station/hallway/secondary/exit)
 "blR" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/table/auto,
 /obj/item/decoration/ashtray,

--- a/maps/unused/crash_gimmick.dmm
+++ b/maps/unused/crash_gimmick.dmm
@@ -23115,7 +23115,7 @@
 /area/russian/radiation)
 "czv" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 7
 	},
 /obj/item/clothing/head/helmet/camera{
@@ -34585,7 +34585,7 @@
 /area/russian/radiation)
 "dfC" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/grime{
@@ -50463,7 +50463,7 @@
 /area/russian/radiation)
 "jCQ" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/disposalpipe/segment/food{
 	dir = 4
 	},

--- a/maps/unused/donut2.dmm
+++ b/maps/unused/donut2.dmm
@@ -13878,7 +13878,7 @@
 /area/station/crew_quarters/quarters)
 "aCr" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/storage/crate,
 /obj/item/clothing/under/gimmick/princess,
@@ -24637,7 +24637,7 @@
 /area/station/medical/medbay)
 "aXD" = (
 /obj/table/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet{
@@ -38389,7 +38389,7 @@
 /area/station/crew_quarters/juryroom)
 "byI" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/juryroom)
@@ -38944,7 +38944,7 @@
 /area/station/janitor/office)
 "bzI" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/storage/secure/closet/civilian/janitor,
 /turf/simulated/floor/specialroom/arcade,
@@ -43457,7 +43457,7 @@
 /obj/table/auto,
 /obj/item/device/radio/signaler,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/item/device/radio/signaler{
 	pixel_x = 2;

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -4724,7 +4724,7 @@
 /area/station/medical/cdc)
 "alj" = (
 /obj/table/reinforced/chemistry/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
 "alk" = (
@@ -19387,7 +19387,7 @@
 "aUy" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9;
-	level = 2 
+	level = 2
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4

--- a/maps/unused/hainemap.dmm
+++ b/maps/unused/hainemap.dmm
@@ -2414,7 +2414,7 @@
 "gU" = (
 /obj/table/reinforced,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/radio,
@@ -6572,7 +6572,7 @@
 /area/space)
 "sO" = (
 /obj/table/wood/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/wood,
@@ -7052,7 +7052,7 @@
 /area/space)
 "ui" = (
 /turf/simulated/floor/black/side{
-	
+
 	},
 /area/space)
 "uj" = (

--- a/maps/unused/halloween14.dmm
+++ b/maps/unused/halloween14.dmm
@@ -67443,7 +67443,7 @@
 /area/crypt/sigma/crew)
 "cId" = (
 /obj/table/woodentable/single,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/decal/glow{
@@ -71021,7 +71021,7 @@
 	name = "old oak table";
 	tag = "icon-bar (SOUTHEAST)"
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/decal/glow{
@@ -74752,7 +74752,7 @@
 	icon_state = "tabledir";
 	dir = 10
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/floor/delivery,
@@ -75358,7 +75358,7 @@
 	})
 "dap" = (
 /obj/table,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/floor{
@@ -76989,7 +76989,7 @@
 	},
 /obj/item/pen,
 /obj/item/pen,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/floor{
@@ -77111,7 +77111,7 @@
 /area/sim/racing_entry)
 "ddN" = (
 /obj/table,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/floor/specialroom/bar,

--- a/maps/unused/horizon_2019.dmm
+++ b/maps/unused/horizon_2019.dmm
@@ -23278,7 +23278,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/purpleblack{
 	dir = 9
 	},
@@ -25221,7 +25221,7 @@
 	})
 "bfK" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/disposalpipe/segment/brig{
@@ -38668,7 +38668,7 @@
 /area/station/crew_quarters/kitchen)
 "bIK" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/disposalpipe/segment/brig{
 	dir = 4
 	},
@@ -46316,7 +46316,7 @@
 /area/station/security/brig)
 "bYM" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	name = "Authorised Entertainment";
 	pixel_y = 12
 	},
@@ -49600,7 +49600,7 @@
 /area/space)
 "cfQ" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	name = "Authorised Entertainment";
 	pixel_y = 12
 	},

--- a/maps/unused/mushroom.dmm
+++ b/maps/unused/mushroom.dmm
@@ -1646,7 +1646,7 @@
 /area/station/maintenance/solar/west)
 "adU" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/computer/stockexchange{
 	icon_state = "QMreq";
@@ -1938,7 +1938,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -2684,7 +2684,7 @@
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor,
 /area/station/janitor/office)
@@ -2729,7 +2729,7 @@
 /area/station/maintenance/northeast)
 "age" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -3271,7 +3271,7 @@
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/box/mousetraps,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/grime,
 /area/station/janitor/office)
@@ -4692,7 +4692,7 @@
 /area/station/quartermaster/storage)
 "akJ" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/light,
 /turf/simulated/floor,
@@ -7369,7 +7369,7 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aqC" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/light/small{
 	tag = "icon-bulb1 (WEST)";
@@ -9192,7 +9192,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/light/small{
 	tag = "icon-bulb1 (WEST)";
@@ -16014,7 +16014,7 @@
 /area/station/science/lobby)
 "aJl" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor,
 /area/station/science/lobby)
 "aJm" = (

--- a/maps/unused/mushroom_new_walls.dmm
+++ b/maps/unused/mushroom_new_walls.dmm
@@ -27147,7 +27147,7 @@
 /area/station/security/detectives_office)
 "lul" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "lvd" = (

--- a/maps/unused/mushroom_new_xmas.dmm
+++ b/maps/unused/mushroom_new_xmas.dmm
@@ -1675,7 +1675,7 @@
 /area/station/maintenance/solar/west)
 "adU" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/computer/stockexchange{
 	icon_state = "QMreq";
@@ -1966,7 +1966,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -2716,7 +2716,7 @@
 /obj/stool/bed,
 /obj/item/clothing/suit/bedsheet,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor,
 /area/station/janitor/office)
@@ -2771,7 +2771,7 @@
 /area/station/hallway/primary/north)
 "age" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -3337,7 +3337,7 @@
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/box/mousetraps,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/grime,
 /area/station/janitor/office)
@@ -7346,7 +7346,7 @@
 /area/station/turret_protected/ai_upload_foyer)
 "aqb" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/light/small{
 	tag = "icon-bulb1 (WEST)";
@@ -9437,7 +9437,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/light/small{
 	tag = "icon-bulb1 (WEST)";
@@ -16596,7 +16596,7 @@
 /area/station/science/lobby)
 "aJl" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/purple,
 /area/station/science/lobby)
 "aJm" = (
@@ -32712,7 +32712,7 @@
 /area/station/quartermaster/office)
 "bqX" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/machinery/light,
 /turf/simulated/floor/orangeblack/side,

--- a/maps/unused/samedi.dmm
+++ b/maps/unused/samedi.dmm
@@ -3917,7 +3917,7 @@
 /area/station/crew_quarters/locker)
 "aif" = (
 /obj/table/wood/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/wood/two,
@@ -14587,7 +14587,7 @@
 "aGa" = (
 /obj/table/reinforced/auto,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/radio,
@@ -20784,7 +20784,7 @@
 /area/station/crew_quarters/bar)
 "aUc" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/green/fancy/edge/ne,
@@ -26990,7 +26990,7 @@
 /area/station/hallway/secondary/exit)
 "bhj" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/escape,
@@ -31219,7 +31219,7 @@
 /area/station/crew_quarters/fitness)
 "bqw" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor,
@@ -35109,7 +35109,7 @@
 /area/station/crew_quarters/quartersA)
 "bzJ" = (
 /obj/table/wood/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/wood,
@@ -38337,7 +38337,7 @@
 /area/station/science/teleporter)
 "bHi" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light{
@@ -40158,7 +40158,7 @@
 /area/station/science/lobby)
 "bLc" = (
 /obj/table/wood/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light{
@@ -41644,7 +41644,7 @@
 /area/station/science/lab)
 "bNP" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light_switch/north{
@@ -42378,7 +42378,7 @@
 /area/station/crew_quarters/quarters_south)
 "bPn" = (
 /obj/table/wood/round/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/wood,
@@ -42483,7 +42483,7 @@
 	pixel_y = 1
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/black,
 /area/research_outpost)
@@ -42948,7 +42948,7 @@
 /area/research_outpost)
 "bQy" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/cable{
@@ -43025,7 +43025,7 @@
 	pixel_y = 21
 	},
 /obj/item/device/radio/intercom{
-	
+
 	},
 /obj/storage/crate/furnacefuel,
 /turf/simulated/floor/plating,
@@ -44791,7 +44791,7 @@
 /area/research_outpost/hangar)
 "bUk" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/shuttlebay,
 /area/research_outpost/hangar)
@@ -44843,7 +44843,7 @@
 /area/research_outpost)
 "bUp" = (
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/purple/side{
 	dir = 9
@@ -46166,7 +46166,7 @@
 /obj/table/auto,
 /obj/random_item_spawner/tools,
 /obj/item/device/radio/intercom{
-	
+
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost)

--- a/maps/unused/setpieces/SHARED_biodomeExpanded.dmm
+++ b/maps/unused/setpieces/SHARED_biodomeExpanded.dmm
@@ -4737,7 +4737,7 @@
 /turf/unsimulated/floor/caution/west,
 /area/crater/biodome/entry)
 "fBE" = (
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/map/light/screen,
@@ -9626,7 +9626,7 @@
 /area/swampzone/interiors/bonktek/lounge)
 "ltN" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/map/light/screen,

--- a/maps/unused/setpieces/gokart_full.dmm
+++ b/maps/unused/setpieces/gokart_full.dmm
@@ -1550,7 +1550,7 @@
 	icon_state = "tabledir";
 	dir = 10
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/floor/delivery,
@@ -1726,7 +1726,7 @@
 	})
 "el" = (
 /obj/table,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/floor{
@@ -2342,7 +2342,7 @@
 	},
 /obj/item/pen,
 /obj/item/pen,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/floor{
@@ -2383,7 +2383,7 @@
 /area/racing_entry)
 "fx" = (
 /obj/table,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/floor/specialroom/bar,

--- a/maps/wrestlemap.dmm
+++ b/maps/wrestlemap.dmm
@@ -1810,7 +1810,7 @@
 /area/station/janitor/office)
 "aIp" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/carpet/grime,
 /area/station/mining/cargo_staff_room)
 "aIE" = (
@@ -7530,7 +7530,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/carpet/purple/standard/edge/se,
 /area/station/crew_quarters/stockex)
 "dfG" = (
@@ -8295,7 +8295,7 @@
 /area/station/security/checkpoint/arrivals)
 "duF" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
@@ -8755,7 +8755,7 @@
 "dDs" = (
 /obj/disposalpipe/segment,
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
@@ -13751,7 +13751,7 @@
 /area/station/chapel/sanctuary)
 "fIa" = (
 /obj/table/glass/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
 /area/station/hallway/secondary/entry)
@@ -13760,7 +13760,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/neutral/side,
 /area/station/crew_quarters/jazz)
 "fIz" = (
@@ -18990,7 +18990,7 @@
 /area/station/medical/medbay)
 "hWN" = (
 /obj/table/glass/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 26;
@@ -25957,7 +25957,7 @@
 	dir = 4
 	},
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/cable{
 	icon_state = "4-8"
 	},
@@ -27756,7 +27756,7 @@
 /area/station/hallway/secondary/exit)
 "lJV" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/black,
 /area/station/security/brig)
 "lKj" = (
@@ -29067,7 +29067,7 @@
 /area/station/maintenance/inner/the_cage)
 "mnw" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/plating/airless/asteroid,
 /area/space)
 "mnG" = (
@@ -32691,7 +32691,7 @@
 /area/station/chapel/sanctuary)
 "nTv" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/carpet/red/fancy,
 /area/station/crew_quarters/lounge)
 "nTz" = (
@@ -35506,7 +35506,7 @@
 	})
 "pjp" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /obj/disposalpipe/segment/mail/horizontal,
 /turf/simulated/floor/black,
 /area/station/security/secwing{
@@ -45070,7 +45070,7 @@
 /area/station/quartermaster/office)
 "tku" = (
 /obj/table/glass/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "tkv" = (
@@ -46346,7 +46346,7 @@
 /obj/item/reagent_containers/food/drinks/milk{
 	pixel_x = -8
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_x = 7;
 	pixel_y = 4
 	},
@@ -51728,7 +51728,7 @@
 /area/station/crew_quarters/observatory)
 "wgv" = (
 /obj/table/glass,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/purple/side{
 	dir = 8
 	},
@@ -55113,7 +55113,7 @@
 /area/station/maintenance/inner/the_cage)
 "xzp" = (
 /obj/table/glass/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/simulated/floor/green/checker,
 /area/station/hallway/primary/central)
 "xzx" = (

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -30174,7 +30174,7 @@
 /area/crypt/sigma/crew)
 "bOe" = (
 /obj/table/wood/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/map/light/screen,
@@ -31932,7 +31932,7 @@
 /obj/table/virtual{
 	icon_state = "tabledir"
 	},
-/obj/machinery/computer/security/wooden_tv/small/virtual,
+/obj/machinery/computer/security/small/virtual,
 /turf/unsimulated/floor/setpieces/gauntlet,
 /area/gauntlet/viewing)
 "bTF" = (
@@ -35779,7 +35779,7 @@
 	})
 "cgp" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/floor/delivery,
@@ -36326,7 +36326,7 @@
 	})
 "chE" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/floor/carpet{
@@ -37244,7 +37244,7 @@
 /area/sim/racing_entry)
 "ckb" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/floor/wood,
@@ -37576,7 +37576,7 @@
 	pixel_x = 13;
 	pixel_y = 4
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_x = -3;
 	pixel_y = 8
 	},
@@ -42629,7 +42629,7 @@
 /area/owlery/staffhall)
 "czj" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	network = "Owlery"
 	},
 /turf/unsimulated/floor/white,
@@ -43072,7 +43072,7 @@
 /area/owlery/staffhall)
 "cAk" = (
 /obj/table/reinforced/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	network = "Owlery"
 	},
 /turf/unsimulated/floor/carpet{
@@ -49058,7 +49058,7 @@
 /obj/decal/fakeobjects/lightbulb_broken{
 	dir = 8
 	},
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	network = "Owlery";
 	pixel_y = 3
 	},
@@ -63711,7 +63711,7 @@
 /area/crypt/sigma/morgue)
 "dGG" = (
 /obj/table/wood/round/auto,
-/obj/machinery/computer/security/wooden_tv/small,
+/obj/machinery/computer/security/small,
 /turf/unsimulated/floor/carpet{
 	icon_state = "fpurple1";
 	tag = "icon-fpurple1"
@@ -68588,7 +68588,7 @@
 /turf/unsimulated/floor/carpet/grime,
 /area/crypt/sigma/rd)
 "dUk" = (
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/map/light/screen,
@@ -77578,7 +77578,7 @@
 /area/iomoon)
 "xCw" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/unsimulated/outdoors/grass,

--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -8357,7 +8357,7 @@
 /area/tech_outpost)
 "awJ" = (
 /obj/table/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /obj/machinery/light/small,

--- a/maps/z5.dmm
+++ b/maps/z5.dmm
@@ -3669,7 +3669,7 @@
 /area/diner/dining)
 "ke" = (
 /obj/table/reinforced/bar/auto,
-/obj/machinery/computer/security/wooden_tv/small{
+/obj/machinery/computer/security/small{
 	pixel_y = 8
 	},
 /turf/simulated/floor/delivery,


### PR DESCRIPTION
[help wanted][bugfix]
## About the PR 
makes public camera viewers their own subtype of security cameras (instead of a child of detective cameras) to force it to remain only on the zeta network when the screen is disconnected and reconnected. also preserves the original public viewer type when reconnected; only erroneous sprite now is the disconnected state


## Why's this needed? 
bug bad

