### PR TITLE
Lings can slash at blobs now

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -444,7 +444,7 @@
 			return
 
 		if (isobj(target))
-			switch (user.smash_through(target, list("window", "grille")))
+			switch (user.smash_through(target, list("window", "grille", "blob")))
 				if (0)
 					if (isitem(target))
 						boutput(user, "<span class='alert'>You try to pick [target] up but it wiggles out of your hand. Opposable thumbs would be nice.</span>")
@@ -688,7 +688,7 @@
 			return
 
 		if (isobj(target))
-			switch (user.smash_through(target, list("window", "grille", "door")))
+			switch (user.smash_through(target, list("window", "grille", "door", "blob")))
 				if (0)
 					if (istype(target, /obj/item/reagent_containers))
 						if (prob(50 * quality))
@@ -896,7 +896,7 @@
 			return
 
 		if (isobj(target))
-			switch (user.smash_through(target, list("window", "grille", "door")))
+			switch (user.smash_through(target, list("window", "grille", "door", "blob")))
 				if (0)
 					target.Attackhand(user, params, location, control)
 					return
@@ -1203,7 +1203,7 @@
 			return
 
 		if (isobj(target))
-			switch (user.smash_through(target, list("grille")))
+			switch (user.smash_through(target, list("grille","blob")))
 				if (0)
 					if (isitem(target))
 						if (prob(60))

--- a/code/mob/living/critter/aquatic.dm
+++ b/code/mob/living/critter/aquatic.dm
@@ -577,7 +577,7 @@ ABSTRACT_TYPE(/mob/living/critter/aquatic)
 		return
 
 	if (isobj(target))
-		switch (user.smash_through(target, list("window", "grille", "table")))
+		switch (user.smash_through(target, list("window", "grille", "table", "blob"))) //crab vs blob when
 			if (0)
 				if (isitem(target))
 					if (prob(33))

--- a/code/procs/mob_procs.dm
+++ b/code/procs/mob_procs.dm
@@ -1035,10 +1035,10 @@
 // Avoids some C&P since multiple procs make use of this ability (Convair880).
 /mob/proc/smash_through(var/obj/target, var/list/can_smash, var/show_message = 1)
 	if (!src || !ismob(src) || !target || !isobj(target))
-		return 0
+		return FALSE
 
 	if (!islist(can_smash) || !length(can_smash))
-		return 0
+		return FALSE
 
 	for (var/S in can_smash)
 		if (S == "window" && istype(target, /obj/window))
@@ -1047,7 +1047,7 @@
 				src.visible_message("<span class='alert'>[src] smashes through the window.</span>", "<span class='notice'>You smash through the window.</span>")
 			W.health = 0
 			W.smash()
-			return 1
+			return TRUE
 
 		if (S == "grille" && istype(target, /obj/grille))
 			var/obj/grille/G = target
@@ -1056,21 +1056,28 @@
 					G.visible_message("<span class='alert'><b>[src]</b> violently slashes [G]!</span>")
 				playsound(G.loc, "sound/impact_sounds/Metal_Hit_Light_1.ogg", 80, 1)
 				G.damage_slashing(15)
-				return 1
+				return TRUE
 
 		if (S == "door" && istype(target, /obj/machinery/door))
 			var/obj/machinery/door/door = target
 			SPAWN(0)
 				door.tear_apart(src)
-			return 1
+			return TRUE
 
 		if (S == "table" && istype(target, /obj/table))
 			var/obj/table/table = target
 			playsound(table.loc, "sound/impact_sounds/Generic_Hit_Heavy_1.ogg", 40, 1)
 			table.deconstruct()
-			return 1
+			return TRUE
 
-	return 0
+		if (S == "blob" && istype(target, /obj/blob))
+			var/obj/blob/B = target
+			if(show_message)
+				src.visible_message("<span class='alert'><B>[src] savagely slashes [B]!</span>", "<span class='notice'>You savagely slash at \the [B]</span>")
+			B.take_damage(rand(6,10),1,DAMAGE_CUT)
+			playsound(src.loc, "sound/voice/blob/blobdamaged[rand(1, 3)].ogg", 75, 1)
+			return TRUE
+	return FALSE
 
 /mob/proc/saylist(var/message, var/list/heard, var/list/olocs, var/thickness, var/italics, var/list/processed, var/use_voice_name = 0, var/image/chat_maptext/assoc_maptext = null)
 	var/message_a


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
So can a few other mob arms like bears. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #1889 and also enables KING CRAB vs BLOB


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Ling horror form can now slash at blob flesh. So can bear, brullbar, claw, and KING CRAB arms
```
