### PR TITLE
Give television variants their own circuit boards

### DIFF
--- a/code/obj/machinery/computer/buildandrepair.dm
+++ b/code/obj/machinery/computer/buildandrepair.dm
@@ -31,8 +31,14 @@ ABSTRACT_TYPE(/obj/item/circuitboard)
 	mats = 6
 
 /obj/item/circuitboard/security
-	name = "Circuit board (Security)"
+	name = "Circuit board (Security Cameras)"
 	computertype = "/obj/machinery/computer/security"
+/obj/item/circuitboard/security_tv
+	name = "Circuit board (Security Television)"
+	computertype = "/obj/machinery/computer/security/wooden_tv"
+/obj/item/circuitboard/small_tv
+	name = "Circuit board (Television)"
+	computertype = "/obj/machinery/computer/security/wooden_tv/small"
 
 //obj/item/circuitboard/med_data
 //	name = "Circuit board (Medical)"

--- a/code/obj/machinery/computer/security.dm
+++ b/code/obj/machinery/computer/security.dm
@@ -101,12 +101,14 @@
 /obj/machinery/computer/security/wooden_tv
 	name = "Security Cameras"
 	icon_state = "security_det"
+	circuit_type = /obj/item/circuitboard/security_tv
 
 	small
 		name = "Television"
 		desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?"
 		network = "Zeta"
 		icon_state = "security_tv"
+		circuit_type = /obj/item/circuitboard/small_tv
 
 		power_change()
 			return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Renames the old circuit board for clarity, and adds a circuit board for the Security Television (found in Detective's office) and the normal Television (found in various Crew areas)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #5791
Closes #9618 (duplicate)

