### PR TITLE
Vending machines now will always fall over when someone is tossed at them.

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -495,7 +495,7 @@
 			src.fall(user)
 
 /obj/machinery/vending/hitby(atom/movable/M, datum/thrown_thing/thr)
-	if (iscarbon(M) && M.throwing && prob(25))
+	if (iscarbon(M) && M.throwing)
 		src.fall(M)
 		return
 
@@ -804,7 +804,7 @@
 //		SPAWN(2 SECONDS)
 //			src.icon_state = "[initial(icon_state)]-fallen"
 	if (istype(victim) && vicTurf && (BOUNDS_DIST(vicTurf, src) == 0))
-		victim.changeStatus("weakened", 30 SECONDS)
+		victim.changeStatus("weakened", 10 SECONDS)
 		src.visible_message("<b><font color=red>[src.name] tips over onto [victim]!</font></b>")
 		victim.force_laydown_standup()
 		victim.set_loc(vicTurf)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The chance of vending machines not falling over when having people thrown at them is gone, and the stun of vending machines has been reduced from 30 seconds to 10.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Vending machines are currently high risk with very little reward, thus leading to them basically never being used for combat. This should make them more attractive targets in combat. In order to make this change not insanely strong the stun time was reduced to ten seconds from thirty. I wont be suprised if further changes after this are needed (things like requiring aggressive grabs for throws), but in the meantime removing this rng seems good.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Vending machines will always fall down on people tossed at them. Vending machine stun has been reduced to ten seconds.
```
