### PR TITLE
Lets flockminds use the flockpanel from drones

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -64,9 +64,15 @@ var/flock_signal_unleashed = FALSE
 /datum/flock/ui_act(action, list/params, datum/tgui/ui)
 	var/mob/user = ui.user;
 	if (!istype(user, /mob/living/intangible/flock/flockmind))
-		return
+		var/mob/living/critter/flock/drone/F = user
+		if (!istype(F) || !istype(F.controller, /mob/living/intangible/flock/flockmind))
+			return
 	switch(action)
 		if("jump_to")
+			if (istype(user, /mob/living/critter/flock/drone/))
+				var/mob/living/critter/flock/drone/F = user
+				user = F.controller
+				F.release_control()
 			var/atom/movable/origin = locate(params["origin"])
 			if(!QDELETED(origin))
 				var/turf/T = get_turf(origin)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Flockminds can now use the flock while possessing a drone, using jump will kick them out to do so.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
QOL stuff I noticed while trying to replicate #9592