### PR TITLE
Renames proc addDNA() to addBHData()

### DIFF
--- a/code/modules/antagonists/changeling/abilities/absorb.dm
+++ b/code/modules/antagonists/changeling/abilities/absorb.dm
@@ -150,7 +150,7 @@
 		if (isliving(target))
 			target:was_harmed(owner, special = "ling")
 
-		devour.addDNA(target)
+		devour.addBData(target)
 
 	onEnd()
 		..()
@@ -202,7 +202,7 @@
 			return 1
 		if (isnpc(T))
 			boutput(C, "<span class='alert'>The DNA of this target seems inferior somehow, you have no desire to feed on it.</span>")
-			addDNA(T)
+			addBData(T)
 			return 1
 		if (T.bioHolder.HasEffect("husk"))
 			boutput(usr, "<span class='alert'>This creature has already been drained...</span>")
@@ -211,7 +211,7 @@
 		actions.start(new/datum/action/bar/private/icon/changelingAbsorb(T, src), C)
 		return 0
 
-	proc/addDNA(var/mob/living/T)
+	proc/addBData(var/mob/living/T)
 		var/datum/abilityHolder/changeling/C = holder
 		var/mob/ownerMob = holder.owner
 		if (istype(C) && isnull(C.absorbed_dna[T.real_name]))

--- a/code/modules/antagonists/changeling/abilities/absorb.dm
+++ b/code/modules/antagonists/changeling/abilities/absorb.dm
@@ -150,7 +150,7 @@
 		if (isliving(target))
 			target:was_harmed(owner, special = "ling")
 
-		devour.addBData(target)
+		devour.addBHData(target)
 
 	onEnd()
 		..()
@@ -202,7 +202,7 @@
 			return 1
 		if (isnpc(T))
 			boutput(C, "<span class='alert'>The DNA of this target seems inferior somehow, you have no desire to feed on it.</span>")
-			addBData(T)
+			addBHData(T)
 			return 1
 		if (T.bioHolder.HasEffect("husk"))
 			boutput(usr, "<span class='alert'>This creature has already been drained...</span>")
@@ -211,7 +211,7 @@
 		actions.start(new/datum/action/bar/private/icon/changelingAbsorb(T, src), C)
 		return 0
 
-	proc/addBData(var/mob/living/T)
+	proc/addBHData(var/mob/living/T)
 		var/datum/abilityHolder/changeling/C = holder
 		var/mob/ownerMob = holder.owner
 		if (istype(C) && isnull(C.absorbed_dna[T.real_name]))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
In #9611 I made a proc call addDNA(), putting it in a file which already contained a proc called addDna().

This PR renames addDNA to addBHData so we don't have two near identical proc names in the same file.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Code readability, I'm an idiot