### PR TITLE
Adds sterile masks to the janitor vendor

### DIFF
--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2726,6 +2726,7 @@ ABSTRACT_TYPE(/obj/machinery/vending/cola)
 		product_list += new/datum/data/vending_product(/obj/item/storage/box/mousetraps, 4)
 		product_list += new/datum/data/vending_product(/obj/item/caution, 10)
 		product_list += new/datum/data/vending_product(/obj/item/clothing/gloves/long, 2)
+		product_list += new/datum/data/vending_product(/obj/item/clothing/mask/sterile, 4)
 
 		product_list += new/datum/data/vending_product(/obj/item/sponge/cheese, 2, hidden=1)
 

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -2726,7 +2726,7 @@ ABSTRACT_TYPE(/obj/machinery/vending/cola)
 		product_list += new/datum/data/vending_product(/obj/item/storage/box/mousetraps, 4)
 		product_list += new/datum/data/vending_product(/obj/item/caution, 10)
 		product_list += new/datum/data/vending_product(/obj/item/clothing/gloves/long, 2)
-		product_list += new/datum/data/vending_product(/obj/item/clothing/mask/sterile, 4)
+		product_list += new/datum/data/vending_product(/obj/item/clothing/mask/surgical, 4)
 
 		product_list += new/datum/data/vending_product(/obj/item/sponge/cheese, 2, hidden=1)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds sterile masks to the janitor vendor so janitors can have easy access to them. This should let janitors get sterile masks easier, which isn't really a problem since a lot of full boxes of them spawn everywhere.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I see people that get really into nasty places, to clean them, wear these things to prevent inhaling a bunch of mold and stuff. Makes sense for a janitor to have.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)Added sterile masks to the JaniTech vendor
```
