### PR TITLE
edge case handling for ghostdrone spawns

### DIFF
--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -150,6 +150,9 @@
 			ghost.name = (src.oldname ? src.oldname : src.real_name)
 			ghost.real_name = (src.oldname ? src.oldname : src.real_name)
 
+		//Don't be on the list of available drones
+		available_ghostdrones -= src
+
 		//So the drone cant pick up an item and then die, sending the item ~to the void~
 		var/obj/item/magtractor/mag = locate(/obj/item/magtractor) in src.tools
 		var/obj/item/magHeld = mag.holding ? mag.holding : null

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -1271,7 +1271,7 @@
 	var/mob/living/silicon/ghostdrone/G
 	if (pickNew && islist(available_ghostdrones) && length(available_ghostdrones))
 		for (var/mob/living/silicon/ghostdrone/T in available_ghostdrones)
-			if (T.newDrone)
+			if (T.newDrone && !isdead(T))
 				G = T
 				break
 			else // why are you in this list

--- a/code/obj/machinery/drone_factory.dm
+++ b/code/obj/machinery/drone_factory.dm
@@ -60,7 +60,9 @@
 					if(istype(D))
 						D.visible_message("[src] scoops up [D]!",\
 						"You feel yourself being torn away from the afterlife and into [src]!")
-						droneize(D, 1)
+						if(!droneize(D, TRUE))
+							D.visible_message("There are no ghost drones available! Your soul is added back to the queue.")
+							ghostdrone_candidates += M
 
 		else
 			src.icon_state = "ghostcatcher0"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #2148 by adding detection of dead drones to the drone queue handling, preventing players from being put into dead drones regardless of the cause.