### PR TITLE
Roboticist Defibs

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -633,6 +633,7 @@ ABSTRACT_TYPE(/datum/job/research)
 	slot_ears = list(/obj/item/device/radio/headset/medical)
 	slot_poc1 = list(/obj/item/device/pda2/medical/robotics)
 	slot_poc2 = list(/obj/item/reagent_containers/mender/brute)
+	items_in_backpack = list(/obj/item/robodefibrillator)
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Gives Roboticists a defibrillator in their backpack.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

A few people who play roboticist regularly asked for it on the discord so I figured I could PR it for them. Makes sense that a role that deals regularly with surgery have a tool to help with cardiac arrest.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Munien
(+)Roboticists now start with a defibrillator in their bag.
```
