### PR TITLE
Give flock relay sensible amounts of health

### DIFF
--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -9,7 +9,7 @@
 	flock_desc = "Your goal and purpose. Defend it until it can broadcast the Signal."
 	flock_id = "Signal Relay Broadcast Amplifier"
 	build_time = 30
-	health = 5000
+	health = 600 //same as a nukie nuke * 4 because nuke has /4 damage resist
 	resourcecost = 1000
 	bound_width = 160
 	bound_height = 160


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Oh god it was 5000 who let this through code review?!

This drops the relay health from 5000 (?!?!) to 600, which is 4x the health of a nuclear bomb. However, the nuclear bomb has all incoming damage divided by 4 to 8 depending on amount, so it works out about the same. Also the relay takes 20% bonus brute damage, so it's actually less robust than a nuke, which is fine because it takes less time to go off.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Someone donked up. Possibly me.
