### PR TITLE
Kondaru catering upgrade batch

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -20902,13 +20902,15 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "bkE" = (
-/obj/table/reinforced/chemistry/auto{
-	name = "prep counter"
-	},
 /obj/machinery/light{
 	dir = 8;
 	layer = 9.1;
 	pixel_x = -10
+	},
+/obj/table/reinforced/auto,
+/obj/machinery/glass_recycler{
+	glass_amt = 5;
+	pixel_y = 4
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)
@@ -51662,14 +51664,12 @@
 /turf/simulated/floor/carpet/purple/fancy/edge/south,
 /area/station/crew_quarters/quarters_east)
 "oRT" = (
-/obj/table/reinforced/auto,
-/obj/machinery/glass_recycler{
-	glass_amt = 5;
-	pixel_y = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
+	},
+/obj/table/reinforced/chemistry/auto{
+	name = "prep counter"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/cafeteria)

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -6536,6 +6536,10 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/sanitary/white,
 /area/station/medical/crematorium)
+"arZ" = (
+/obj/machinery/light,
+/turf/simulated/floor/specialroom/bar,
+/area/station/crew_quarters/cafeteria)
 "asa" = (
 /obj/machinery/door/airlock/pyro/external{
 	dir = 4
@@ -20377,6 +20381,9 @@
 "biN" = (
 /obj/table/reinforced/auto,
 /obj/submachine/mixer,
+/obj/item/reagent_containers/food/drinks/drinkingglass/icing{
+	pixel_x = -14
+	},
 /turf/simulated/floor/specialroom/cafeteria{
 	dir = 1
 	},
@@ -38485,10 +38492,11 @@
 	},
 /obj/disposalpipe/segment/mail/horizontal,
 /obj/firedoor_spawn,
+/obj/access_spawn/kitchen,
 /obj/machinery/door/airlock/pyro/glass/windoor{
+	autoclose = 0;
 	dir = 4
 	},
-/obj/access_spawn/kitchen,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "cov" = (
@@ -40041,6 +40049,9 @@
 /obj/item/reagent_containers/food/snacks/breadloaf,
 /obj/item/kitchen/utensil/knife,
 /obj/machinery/light_switch/east,
+/obj/item/kitchen/rollingpin{
+	pixel_y = -15
+	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "dlp" = (
@@ -40606,8 +40617,14 @@
 /area/station/security/main)
 "dLh" = (
 /obj/table/auto,
-/obj/item/storage/box/plates,
-/obj/item/storage/box/cutlery,
+/obj/item/storage/box/plates{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/item/storage/box/cutlery{
+	pixel_x = -3;
+	pixel_y = 4
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "dMh" = (
@@ -41803,6 +41820,9 @@
 /obj/item/shaker/ketchup{
 	pixel_x = 6
 	},
+/obj/item/matchbook{
+	pixel_y = 12
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "eRJ" = (
@@ -42899,7 +42919,7 @@
 	},
 /area/station/hallway/primary/south)
 "fTm" = (
-/obj/wingrille_spawn/auto,
+/obj/table/reinforced/auto,
 /obj/machinery/door/poddoor/pyro/shutters{
 	density = 0;
 	dir = 4;
@@ -42910,7 +42930,13 @@
 	opacity = 0;
 	p_open = 1
 	},
-/turf/simulated/floor/plating,
+/obj/firedoor_spawn,
+/obj/access_spawn/kitchen,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	autoclose = 0;
+	dir = 4
+	},
+/turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "fUz" = (
 /obj/wingrille_spawn/auto,
@@ -44938,9 +44964,15 @@
 /turf/simulated/floor/grey/blackgrime,
 /area/station/security/brig)
 "hSG" = (
-/obj/table/auto,
-/obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/food/drinks/drinkingglass/icing,
+/obj/stove,
+/obj/item/soup_pot{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/ladle{
+	pixel_x = -2;
+	pixel_y = 11
+	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "hTE" = (
@@ -46189,15 +46221,7 @@
 	layer = 9.1;
 	pixel_y = 21
 	},
-/obj/stove,
-/obj/item/soup_pot{
-	pixel_x = 4;
-	pixel_y = 10
-	},
-/obj/item/ladle{
-	pixel_x = -2;
-	pixel_y = 11
-	},
+/obj/submachine/chef_oven,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "jna" = (
@@ -51792,6 +51816,7 @@
 /obj/machinery/cashreg,
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass/windoor{
+	autoclose = 0;
 	dir = 4
 	},
 /obj/access_spawn/kitchen,
@@ -56476,11 +56501,24 @@
 /area/station/crewquarters/cryotron)
 "tCI" = (
 /obj/table/auto,
-/obj/item/storage/box/glassbox,
-/obj/item/storage/box/glassbox,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine,
+/obj/item/storage/box/glassbox{
+	pixel_y = 5
+	},
+/obj/item/storage/box/glassbox{
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine{
+	pixel_x = 14;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine{
+	pixel_x = 14;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine{
+	pixel_x = 14;
+	pixel_y = -4
+	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "tCN" = (
@@ -56636,7 +56674,7 @@
 "tIt" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/drinks/eggnog{
-	pixel_y = 8
+	pixel_x = -1
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -120214,7 +120252,7 @@ bsk
 bkM
 cdF
 czr
-beD
+arZ
 xrb
 bow
 qYM


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEAT]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Small set of upgrades to Kondaru's catering complex, mainly kitchen.

- An additional oven has been provided, taking the previous position of the stove. The stove has been moved southeast to compensate, with table contents rearranged to make room.
- The front serving area for the Kitchen has been expanded to take up the full space of the Cafeteria/Kitchen border.
- The windoors for the Kitchen front serving area will no longer automatically close, to facilitate easy crew pickup of prepared food items.
- The prep counter and glass recycler table in front of house have been swapped with each other.
- Contents of the central table in catering storage have been rearranged for ease of selection, and a matchbook has been introduced for easier lighting of the stove.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Improves the catering gameplay experience on Kondaru. Probably.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(+)Kondaru's kitchen has been upgraded with a second oven and a more robust serving area.
```
