### PR TITLE
Hotfix for invalid jobs being chosen for traitors

### DIFF
--- a/code/datums/gamemodes/traitor.dm
+++ b/code/datums/gamemodes/traitor.dm
@@ -69,6 +69,8 @@
 	var/list/chosen_traitors = antagWeighter.choose(pool = possible_traitors, role = ROLE_TRAITOR, amount = num_traitors, recordChosen = 1)
 	traitors |= chosen_traitors
 	for (var/datum/mind/traitor in traitors)
+		// although this is assigned by the antagonist datum, we need to do it early in gamemode setup to let the job picker catch it
+		traitor.special_role = ROLE_TRAITOR
 		possible_traitors.Remove(traitor)
 
 	if(num_wraiths)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When making #9366, I removed a small fragment of code that previously prevented jobs like Cyborg and Head of Security from being selected for players that had rolled antagonist. This slipped through my testing, which is my fault. Sorry about that. This hotfix reintroduces the code snippet.

Closes #9683 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I think this should be self-explanatory. :P
