### PR TITLE
Fix anti-tamper devices spawning within crates

### DIFF
--- a/code/obj/storage/loot_crates.dm
+++ b/code/obj/storage/loot_crates.dm
@@ -72,7 +72,10 @@ var/global/datum/loot_crate_manager/loot_crate_manager = new /datum/loot_crate_m
 	New()
 		..()
 		src.light = image('icons/obj/large_storage.dmi',"lootcratelocklight")
-		new /obj/item/antitamper(src)
+		new /obj/item/antitamper(
+			src,
+			TRUE, // Attach it to crate being spawned
+		)
 
 		var/list/loot = list()
 		loot.Add(pick(loot_crate_manager.aesthetic), pick(loot_crate_manager.department), pick(loot_crate_manager.player))
@@ -416,9 +419,10 @@ var/global/datum/loot_crate_manager/loot_crate_manager = new /datum/loot_crate_m
 	throwforce = 2
 	var/obj/storage/crate/attached = null
 
-	New(var/obj/storage/crate/C)
+	New(var/obj/storage/crate/C, var/attach_to_crate = FALSE)
 		..()
-		attach_to(C)
+		if (attach_to_crate)
+			attach_to(C)
 
 	disposing()
 		. = ..()
@@ -438,9 +442,11 @@ var/global/datum/loot_crate_manager/loot_crate_manager = new /datum/loot_crate_m
 		add_fingerprint(user)
 		detach_from(attached)
 
-	proc/attach_to(var/obj/storage/crate/C)
+	proc/attach_to(var/obj/storage/crate/C, var/mob/user)
 		if (!C || !istype(C))
 			return
+		if (user != null)
+			user.u_equip(src)
 		set_loc(C)
 		attached = C
 		attached.vis_contents += src


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a couple of bugs with the anti-tamper devices added as a part of the debris field loot rework:
1. Anti-tamper devices that spawned in the crates would attach themselves to the spawned crate, making them unusable
2. Anti-tamper devices slapped on the crate after being picked up would still be in the character's hand, leading to a buggy state

https://user-images.githubusercontent.com/84296283/179382536-0b88c97d-1211-4e1c-b32a-545201d87fb0.mp4

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bugs bad, loot good. Fixes #9693.