### PR TITLE
Refactors flock antigrab to use COMSIG_MOB_GRABBED

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -73,7 +73,7 @@
 
 /mob/living/critter/flock/drone/proc/do_antigrab(source, var/obj/item/grab/grab)
 	SPAWN(1.5 SECONDS)
-		if (!grab || !grab.affecting || !grab.assailant)
+		if (QDELETED(src) || !isalive(src) || QDELETED(grab) || !grab.affecting || !grab.assailant)
 			return
 		playsound(src, "sound/effects/electric_shock.ogg", 40, 1, -3)
 		boutput(src, "<span class='flocksay'><b>\[SYSTEM: Anti-grapple countermeasures deployed.\]</b></span>")

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -71,7 +71,7 @@
 	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, FALSE, FALSE)
 	src.RegisterSignal(src, COMSIG_MOB_GRABBED, .proc/do_antigrab)
 
-/mob/living/critter/flock/drone/proc/do_antigrab(source, var/obj/item/grab/grab)
+/mob/living/critter/flock/drone/proc/do_antigrab(source, obj/item/grab/grab)
 	SPAWN(1.5 SECONDS)
 		if (QDELETED(src) || !isalive(src) || QDELETED(grab) || !grab.affecting || !grab.assailant)
 			return

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -31,10 +31,6 @@
 	var/floorrunning = FALSE
 	var/can_floorrun = TRUE
 
-	// antigrab powers
-	var/antigrab_counter = 0
-	var/antigrab_fires_at = 2
-
 	var/glow_color = "#26ffe6a2"
 
 /mob/living/critter/flock/drone/New(var/atom/location, var/datum/flock/F=null)
@@ -73,6 +69,17 @@
 		src.contexts += new type
 	APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOCK_THING, src)
 	src.AddComponent(/datum/component/flock_protection, FALSE, FALSE, FALSE, FALSE)
+	src.RegisterSignal(src, COMSIG_MOB_GRABBED, .proc/do_antigrab)
+
+/mob/living/critter/flock/drone/proc/do_antigrab(source, var/obj/item/grab/grab)
+	SPAWN(1.5 SECONDS)
+		if (!grab || !grab.affecting || !grab.assailant)
+			return
+		playsound(src, "sound/effects/electric_shock.ogg", 40, 1, -3)
+		boutput(src, "<span class='flocksay'><b>\[SYSTEM: Anti-grapple countermeasures deployed.\]</b></span>")
+		var/mob/living/L = grab.assailant
+		L.shock(src, 5000)
+		qdel(grab) //in case they don't fall over from our shock
 
 /mob/living/critter/flock/drone/disposing()
 	if (src.flock)
@@ -251,7 +258,7 @@
 	src.is_npc = TRUE // to ensure right flock_speak message
 	flock_speak(src, "Error: Out of signal range. Disconnecting.", src.flock)
 	src.is_npc = FALSE // turns off ai
-
+	src.UnregisterSignal(src, COMSIG_MOB_GRABBED)
 	..()
 
 /mob/living/critter/flock/drone/proc/move_controller_to_station()
@@ -272,6 +279,7 @@
 	src.visible_message("<span class='notice'><b>[src]</b> begins to glow and hover.</span>")
 	src.set_a_intent(INTENT_HELP)
 	src.add_simple_light("drone_light", rgb2num(glow_color))
+	src.RegisterSignal(src, COMSIG_MOB_GRABBED, .proc/do_antigrab)
 	if(src.client)
 		controller = new/mob/living/intangible/flock/trace(src, src.flock)
 		src.is_npc = FALSE
@@ -429,20 +437,6 @@
 		return
 	if (src.dormant)
 		return
-
-	//if we're blocking that means we're not grabbed
-	if (!length(src.grabbed_by) || src.find_type_in_hand(/obj/item/grab/block))
-		src.antigrab_counter = 0
-	else
-		src.antigrab_counter++
-		if (src.antigrab_counter >= src.antigrab_fires_at)
-			playsound(src, "sound/effects/electric_shock.ogg", 40, 1, -3)
-			boutput(src, "<span class='flocksay'><b>\[SYSTEM: Anti-grapple countermeasures deployed.\]</b></span>")
-			for(var/obj/item/grab/G in src.grabbed_by)
-				var/mob/living/L = G.assailant
-				L.shock(src, 5000)
-				qdel(G) //in case they don't fall over from our shock
-			src.antigrab_counter = 0
 
 /mob/living/critter/flock/drone/process_move(keys)
 	if(keys & KEY_RUN && src.resources >= 1)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -73,8 +73,12 @@
 
 /mob/living/critter/flock/drone/proc/do_antigrab(source, obj/item/grab/grab)
 	SPAWN(1.5 SECONDS)
-		if (QDELETED(src) || !isalive(src) || QDELETED(grab) || !grab.affecting || !grab.assailant)
+		if (QDELETED(src) || !isalive(src) || src.dormant || QDELETED(grab) || !grab.affecting || !grab.assailant)
 			return
+		if (istype(grab.assailant, /mob/living/critter/flock/drone))
+			var/mob/living/critter/flock/drone/F = grab.assailant
+			if (F.flock == src.flock)
+				return
 		playsound(src, "sound/effects/electric_shock.ogg", 40, 1, -3)
 		boutput(src, "<span class='flocksay'><b>\[SYSTEM: Anti-grapple countermeasures deployed.\]</b></span>")
 		var/mob/living/L = grab.assailant
@@ -669,6 +673,7 @@
 	src.set_density(FALSE)
 	src.desc = "[initial(desc)]<br><span class='alert'>\The [src] is a dead, broken heap.</span>"
 	src.remove_simple_light("drone_light")
+	src.UnregisterSignal(src, COMSIG_MOB_GRABBED)
 
 /mob/living/critter/flock/drone/ghostize()
 	if(src.controller)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I added a grab signal #8852 and then forgot to add the code that actually uses it, so here is that code.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes flock antigrab not dependant on lifeprocess speed.