### PR TITLE
Fixes Soulguard and other respawns removing abilitys

### DIFF
--- a/code/datums/abilities/ability_parent.dm
+++ b/code/datums/abilities/ability_parent.dm
@@ -1316,7 +1316,7 @@
 	transferOwnership(var/newbody)
 		for (var/datum/abilityHolder/H in holders)
 			H.transferOwnership(newbody)
-		owner = newbody
+		..()
 
 	remove_unlocks()
 		for (var/datum/abilityHolder/H in holders)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
abilityHolder/composite now properly calls the parent proc in proc/transferOwnership, which mostly handles transferring the HUD for the abilities to the new owner.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9708
Fixes #9698
