### PR TITLE
Colorful Incantations

### DIFF
--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -212,17 +212,17 @@
 
 /datum/targetable/spell
 	preferred_holder_type = /datum/abilityHolder/wizard
-	var
-		requires_robes = 0
-		offensive = 0
-		cooldown_staff = 0
-		prepared_count = 0
-		casting_time = 0
-		voice_grim = null
-		voice_fem = null
-		voice_other = null
-		maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
-		maptext_colors
+
+	var/requires_robes = 0
+	var/offensive = 0
+	var/cooldown_staff = 0
+	var/prepared_count = 0
+	var/casting_time = 0
+	var/voice_grim = null
+	var/voice_fem = null
+	var/voice_other = null
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = null
 
 	proc/calculate_cooldown()
 		var/cool = src.cooldown

--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -222,6 +222,7 @@
 		voice_fem = null
 		voice_other = null
 		maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+		maptext_colors
 
 	proc/calculate_cooldown()
 		var/cool = src.cooldown

--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -221,6 +221,7 @@
 		voice_grim = null
 		voice_fem = null
 		voice_other = null
+		maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 
 	proc/calculate_cooldown()
 		var/cool = src.cooldown

--- a/code/datums/abilities/wizard/animal.dm
+++ b/code/datums/abilities/wizard/animal.dm
@@ -45,8 +45,7 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 	voice_grim = "sound/voice/wizard/FurryGrim.ogg"
 	voice_fem = "sound/voice/wizard/FurryFem.ogg"
 	voice_other = "sound/voice/wizard/FurryLoud.ogg"
-
-	var/maptext_colors = list("#167935", "#9eee80", "#ee59e3", "#5a1d8a", "#ee59e3", "#9eee80")
+	maptext_colors = list("#167935", "#9eee80", "#ee59e3", "#5a1d8a", "#ee59e3", "#9eee80")
 
 	cast(mob/target)
 		if (!holder)
@@ -101,7 +100,7 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 		..()
 
 		if(!istype(get_area(M), /area/sim/gunsim))
-			M.say("YORAF UHRY", 0, spell.maptext_style, spell.maptext_colors)
+			M.say("YORAF UHRY", FALSE, spell.maptext_style, spell.maptext_colors)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(spell.voice_grim && H && istype(H.wear_suit, /obj/item/clothing/suit/wizrobe/necro) && istype(H.head, /obj/item/clothing/head/wizard/necro))

--- a/code/datums/abilities/wizard/animal.dm
+++ b/code/datums/abilities/wizard/animal.dm
@@ -46,6 +46,8 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 	voice_fem = "sound/voice/wizard/FurryFem.ogg"
 	voice_other = "sound/voice/wizard/FurryLoud.ogg"
 
+	var/maptext_colors = list("#167935", "#9eee80", "#ee59e3", "#5a1d8a", "#ee59e3", "#9eee80")
+
 	cast(mob/target)
 		if (!holder)
 			return 1
@@ -76,9 +78,6 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 	var/datum/abilityHolder/A
 	var/mob/living/M
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
-	var/maptext_colors = list("#167935", "#9eee80", "#ee59e3", "#5a1d8a", "#ee59e3", "#9eee80")
-
 	New(Source, Target, Spell)
 		target = Target
 		spell = Spell
@@ -102,7 +101,7 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 		..()
 
 		if(!istype(get_area(M), /area/sim/gunsim))
-			M.say("YORAF UHRY", 0, spell.maptext_style, maptext_colors)
+			M.say("YORAF UHRY", 0, spell.maptext_style, spell.maptext_colors)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(spell.voice_grim && H && istype(H.wear_suit, /obj/item/clothing/suit/wizrobe/necro) && istype(H.head, /obj/item/clothing/head/wizard/necro))

--- a/code/datums/abilities/wizard/animal.dm
+++ b/code/datums/abilities/wizard/animal.dm
@@ -102,7 +102,7 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 		..()
 
 		if(!istype(get_area(M), /area/sim/gunsim))
-			M.say("YORAF UHRY", unique_maptext_style = maptext_style, maptext_animation_colors = maptext_colors)
+			M.say("YORAF UHRY", 0, spell.maptext_style, maptext_colors)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(spell.voice_grim && H && istype(H.wear_suit, /obj/item/clothing/suit/wizrobe/necro) && istype(H.head, /obj/item/clothing/head/wizard/necro))

--- a/code/datums/abilities/wizard/animal.dm
+++ b/code/datums/abilities/wizard/animal.dm
@@ -76,6 +76,9 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 	var/datum/abilityHolder/A
 	var/mob/living/M
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#167935", "#9eee80", "#ee59e3", "#5a1d8a", "#ee59e3", "#9eee80")
+
 	New(Source, Target, Spell)
 		target = Target
 		spell = Spell
@@ -99,7 +102,7 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 		..()
 
 		if(!istype(get_area(M), /area/sim/gunsim))
-			M.say("YORAF UHRY") // AN EMAL? PAL EMORF? TURAN SPHORM?
+			M.say("YORAF URRY", unique_maptext_style = maptext_style, maptext_animation_colors = maptext_colors)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(spell.voice_grim && H && istype(H.wear_suit, /obj/item/clothing/suit/wizrobe/necro) && istype(H.head, /obj/item/clothing/head/wizard/necro))

--- a/code/datums/abilities/wizard/animal.dm
+++ b/code/datums/abilities/wizard/animal.dm
@@ -102,7 +102,7 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 		..()
 
 		if(!istype(get_area(M), /area/sim/gunsim))
-			M.say("YORAF URRY", unique_maptext_style = maptext_style, maptext_animation_colors = maptext_colors)
+			M.say("YORAF UHRY", unique_maptext_style = maptext_style, maptext_animation_colors = maptext_colors)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(spell.voice_grim && H && istype(H.wear_suit, /obj/item/clothing/suit/wizrobe/necro) && istype(H.head, /obj/item/clothing/head/wizard/necro))

--- a/code/datums/abilities/wizard/animatedead.dm
+++ b/code/datums/abilities/wizard/animatedead.dm
@@ -13,6 +13,9 @@
 	voice_fem = "sound/voice/wizard/AnimateDeadFem.ogg"
 	voice_other = "sound/voice/wizard/AnimateDeadLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#5a1d8a", "#790c4f", "#9f0b2d")
+
 	cast(mob/target)
 		if(!holder)
 			return
@@ -20,7 +23,7 @@
 			boutput(holder.owner, "<span class='alert'>That person is still alive! Find a corpse.</span>")
 			return 1 // No cooldown when it fails.
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("EI NECRIS")
+			holder.owner.say("EI NECRIS", 0, maptext_style, maptext_colors)
 		..()
 
 		var/obj/critter/magiczombie/UMMACTUALLYITSASKELETONNOWFUCKZOMBIESFOREVER = new /obj/critter/magiczombie(get_turf(target)) // what the fuck

--- a/code/datums/abilities/wizard/animatedead.dm
+++ b/code/datums/abilities/wizard/animatedead.dm
@@ -13,7 +13,6 @@
 	voice_fem = "sound/voice/wizard/AnimateDeadFem.ogg"
 	voice_other = "sound/voice/wizard/AnimateDeadLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#5a1d8a", "#790c4f", "#9f0b2d")
 
 	cast(mob/target)

--- a/code/datums/abilities/wizard/animatedead.dm
+++ b/code/datums/abilities/wizard/animatedead.dm
@@ -12,8 +12,7 @@
 	voice_grim = "sound/voice/wizard/AnimateDeadGrim.ogg"
 	voice_fem = "sound/voice/wizard/AnimateDeadFem.ogg"
 	voice_other = "sound/voice/wizard/AnimateDeadLoud.ogg"
-
-	var/maptext_colors = list("#5a1d8a", "#790c4f", "#9f0b2d")
+	maptext_colors = list("#5a1d8a", "#790c4f", "#9f0b2d")
 
 	cast(mob/target)
 		if(!holder)
@@ -22,7 +21,7 @@
 			boutput(holder.owner, "<span class='alert'>That person is still alive! Find a corpse.</span>")
 			return 1 // No cooldown when it fails.
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("EI NECRIS", 0, maptext_style, maptext_colors)
+			holder.owner.say("EI NECRIS", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/obj/critter/magiczombie/UMMACTUALLYITSASKELETONNOWFUCKZOMBIESFOREVER = new /obj/critter/magiczombie(get_turf(target)) // what the fuck

--- a/code/datums/abilities/wizard/blind.dm
+++ b/code/datums/abilities/wizard/blind.dm
@@ -11,11 +11,14 @@
 	voice_fem = "sound/voice/wizard/BlindFem.ogg"
 	voice_other = "sound/voice/wizard/BlindLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#ffffff", "#9c9fa2", "#585c68")
+
 	cast(mob/target)
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("YSTIGG MITAZIM")
+			holder.owner.say("YSTIGG MITAZIM", 0, maptext_style, maptext_colors)
 		..()
 
 		elecflash(target)

--- a/code/datums/abilities/wizard/blind.dm
+++ b/code/datums/abilities/wizard/blind.dm
@@ -11,7 +11,6 @@
 	voice_fem = "sound/voice/wizard/BlindFem.ogg"
 	voice_other = "sound/voice/wizard/BlindLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#ffffff", "#9c9fa2", "#585c68")
 
 	cast(mob/target)

--- a/code/datums/abilities/wizard/blind.dm
+++ b/code/datums/abilities/wizard/blind.dm
@@ -10,14 +10,13 @@
 	voice_grim = "sound/voice/wizard/BlindGrim.ogg"
 	voice_fem = "sound/voice/wizard/BlindFem.ogg"
 	voice_other = "sound/voice/wizard/BlindLoud.ogg"
-
-	var/maptext_colors = list("#ffffff", "#9c9fa2", "#585c68")
+	maptext_colors = list("#ffffff", "#9c9fa2", "#585c68")
 
 	cast(mob/target)
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("YSTIGG MITAZIM", 0, maptext_style, maptext_colors)
+			holder.owner.say("YSTIGG MITAZIM", FALSE, maptext_style, maptext_colors)
 		..()
 
 		elecflash(target)

--- a/code/datums/abilities/wizard/blink.dm
+++ b/code/datums/abilities/wizard/blink.dm
@@ -10,12 +10,15 @@
 	voice_fem = "sound/voice/wizard/BlinkFem.ogg"
 	voice_other = "sound/voice/wizard/BlinkLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
+
 	cast()
 		if(!holder)
 			return
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("SYCAR TYN")
+			holder.owner.say("SYCAR TYN", 0, maptext_style, maptext_colors)
 		..()
 
 		var/accuracy = 3

--- a/code/datums/abilities/wizard/blink.dm
+++ b/code/datums/abilities/wizard/blink.dm
@@ -10,7 +10,6 @@
 	voice_fem = "sound/voice/wizard/BlinkFem.ogg"
 	voice_other = "sound/voice/wizard/BlinkLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
 
 	cast()

--- a/code/datums/abilities/wizard/blink.dm
+++ b/code/datums/abilities/wizard/blink.dm
@@ -9,15 +9,14 @@
 	voice_grim = "sound/voice/wizard/BlinkGrim.ogg"
 	voice_fem = "sound/voice/wizard/BlinkFem.ogg"
 	voice_other = "sound/voice/wizard/BlinkLoud.ogg"
-
-	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
+	maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
 
 	cast()
 		if(!holder)
 			return
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("SYCAR TYN", 0, maptext_style, maptext_colors)
+			holder.owner.say("SYCAR TYN", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/accuracy = 3

--- a/code/datums/abilities/wizard/bullcharge.dm
+++ b/code/datums/abilities/wizard/bullcharge.dm
@@ -10,11 +10,14 @@
 	voice_fem = "sound/voice/wizard/BullChargeFem.ogg"
 	voice_other = "sound/voice/wizard/BullChargeLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
+
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("RAMI TIN")
+			holder.owner.say("RAMI TIN", 0, maptext_style, maptext_colors)
 		..()
 
 		var/list/path = list()

--- a/code/datums/abilities/wizard/bullcharge.dm
+++ b/code/datums/abilities/wizard/bullcharge.dm
@@ -10,7 +10,6 @@
 	voice_fem = "sound/voice/wizard/BullChargeFem.ogg"
 	voice_other = "sound/voice/wizard/BullChargeLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
 
 	cast()

--- a/code/datums/abilities/wizard/bullcharge.dm
+++ b/code/datums/abilities/wizard/bullcharge.dm
@@ -9,14 +9,13 @@
 	voice_grim = "sound/voice/wizard/BullChargeGrim.ogg"
 	voice_fem = "sound/voice/wizard/BullChargeFem.ogg"
 	voice_other = "sound/voice/wizard/BullChargeLoud.ogg"
-
-	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
+	maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
 
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("RAMI TIN", 0, maptext_style, maptext_colors)
+			holder.owner.say("RAMI TIN", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/list/path = list()

--- a/code/datums/abilities/wizard/clairvoyance.dm
+++ b/code/datums/abilities/wizard/clairvoyance.dm
@@ -9,14 +9,13 @@
 	voice_grim = "sound/voice/wizard/ClairvoyanceGrim.ogg"
 	voice_fem = "sound/voice/wizard/ClairvoyanceFem.ogg"
 	voice_other = "sound/voice/wizard/ClairvoyanceLoud.ogg"
-
-	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
+	maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
 
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("HAIDAN SEEHQ", 0, maptext_style, maptext_colors)
+			holder.owner.say("HAIDAN SEEHQ", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/list/mob/targets = list()

--- a/code/datums/abilities/wizard/clairvoyance.dm
+++ b/code/datums/abilities/wizard/clairvoyance.dm
@@ -10,7 +10,6 @@
 	voice_fem = "sound/voice/wizard/ClairvoyanceFem.ogg"
 	voice_other = "sound/voice/wizard/ClairvoyanceLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
 
 	cast()

--- a/code/datums/abilities/wizard/clairvoyance.dm
+++ b/code/datums/abilities/wizard/clairvoyance.dm
@@ -10,11 +10,14 @@
 	voice_fem = "sound/voice/wizard/ClairvoyanceFem.ogg"
 	voice_other = "sound/voice/wizard/ClairvoyanceLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
+
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("HAIDAN SEEHQ")
+			holder.owner.say("HAIDAN SEEHQ", 0, maptext_style, maptext_colors)
 		..()
 
 		var/list/mob/targets = list()

--- a/code/datums/abilities/wizard/cluwne.dm
+++ b/code/datums/abilities/wizard/cluwne.dm
@@ -11,8 +11,7 @@
 	voice_grim = "sound/voice/wizard/CluwneGrim.ogg"
 	voice_fem = "sound/voice/wizard/CluwneFem.ogg"
 	voice_other = "sound/voice/wizard/CluwneLoud.ogg"
-
-	var/maptext_colors = list("#3fb54f", "#9eee80", "#d3cb21", "#b97517")
+	maptext_colors = list("#3fb54f", "#9eee80", "#d3cb21", "#b97517")
 
 	cast(mob/target)
 		if(!holder)

--- a/code/datums/abilities/wizard/cluwne.dm
+++ b/code/datums/abilities/wizard/cluwne.dm
@@ -44,6 +44,9 @@
 	var/datum/abilityHolder/A
 	var/mob/living/M
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#3fb54f", "#9eee80", "#d3cb21", "#b97517")
+
 	New(Source, Target, Spell)
 		target = Target
 		spell = Spell
@@ -67,7 +70,7 @@
 		..()
 
 		if(!istype(get_area(M), /area/sim/gunsim))
-			M.say("NWOLC EGNEVER")
+			M.say("NWOLC EGNEVER", unique_maptext_style = maptext_style, maptext_animation_colors = maptext_colors)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(spell.voice_grim && H && istype(H.wear_suit, /obj/item/clothing/suit/wizrobe/necro) && istype(H.head, /obj/item/clothing/head/wizard/necro))

--- a/code/datums/abilities/wizard/cluwne.dm
+++ b/code/datums/abilities/wizard/cluwne.dm
@@ -12,6 +12,8 @@
 	voice_fem = "sound/voice/wizard/CluwneFem.ogg"
 	voice_other = "sound/voice/wizard/CluwneLoud.ogg"
 
+	var/maptext_colors = list("#3fb54f", "#9eee80", "#d3cb21", "#b97517")
+
 	cast(mob/target)
 		if(!holder)
 			return 1
@@ -44,9 +46,6 @@
 	var/datum/abilityHolder/A
 	var/mob/living/M
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
-	var/maptext_colors = list("#3fb54f", "#9eee80", "#d3cb21", "#b97517")
-
 	New(Source, Target, Spell)
 		target = Target
 		spell = Spell
@@ -70,7 +69,7 @@
 		..()
 
 		if(!istype(get_area(M), /area/sim/gunsim))
-			M.say("NWOLC EGNEVER", unique_maptext_style = maptext_style, maptext_animation_colors = maptext_colors)
+			M.say("NWOLC EGNEVER", spell.maptext_style, spell.maptext_colors)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(spell.voice_grim && H && istype(H.wear_suit, /obj/item/clothing/suit/wizrobe/necro) && istype(H.head, /obj/item/clothing/head/wizard/necro))

--- a/code/datums/abilities/wizard/fireball.dm
+++ b/code/datums/abilities/wizard/fireball.dm
@@ -40,12 +40,15 @@
 
 	var/datum/projectile/fireball/fb_proj = new
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#fcdf74", "#eb9f2b", "#d75015")
+
 	cast(atom/target)
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("MHOL HOTTOV")
+			holder.owner.say("MHOL HOTTOV", 0, maptext_style, maptext_colors)
 		..()
 
-		var/obj/projectile/P = initialize_projectile_ST( holder.owner, fb_proj, target )
+		var/obj/projectile/P = initialize_projectile_ST( holder.owner, fb_proj, target)
 		if (P)
 			P.mob_shooter = holder.owner
 			P.launch()

--- a/code/datums/abilities/wizard/fireball.dm
+++ b/code/datums/abilities/wizard/fireball.dm
@@ -40,7 +40,6 @@
 
 	var/datum/projectile/fireball/fb_proj = new
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#fcdf74", "#eb9f2b", "#d75015")
 
 	cast(atom/target)

--- a/code/datums/abilities/wizard/fireball.dm
+++ b/code/datums/abilities/wizard/fireball.dm
@@ -39,12 +39,11 @@
 	voice_other = "sound/voice/wizard/FireballLoud.ogg"
 
 	var/datum/projectile/fireball/fb_proj = new
-
-	var/maptext_colors = list("#fcdf74", "#eb9f2b", "#d75015")
+	maptext_colors = list("#fcdf74", "#eb9f2b", "#d75015")
 
 	cast(atom/target)
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("MHOL HOTTOV", 0, maptext_style, maptext_colors)
+			holder.owner.say("MHOL HOTTOV", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/obj/projectile/P = initialize_projectile_ST( holder.owner, fb_proj, target)

--- a/code/datums/abilities/wizard/forcewall.dm
+++ b/code/datums/abilities/wizard/forcewall.dm
@@ -9,11 +9,14 @@
 	voice_fem = "sound/voice/wizard/ForcewallFem.ogg"
 	voice_other = "sound/voice/wizard/ForcewallLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF")
+
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("BRIXHUN MOHTYR")
+			holder.owner.say("BRIXHUN MOHTYR", 0, maptext_style, maptext_colors)
 		..()
 		if(!holder.owner.wizard_spellpower(src))
 			boutput(holder.owner, "<span class='alert'>Your spell is weak without a staff to focus it!</span>")

--- a/code/datums/abilities/wizard/forcewall.dm
+++ b/code/datums/abilities/wizard/forcewall.dm
@@ -8,14 +8,13 @@
 	voice_grim = "sound/voice/wizard/ForcewallGrim.ogg"
 	voice_fem = "sound/voice/wizard/ForcewallFem.ogg"
 	voice_other = "sound/voice/wizard/ForcewallLoud.ogg"
-
-	var/maptext_colors = list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF")
+	maptext_colors = list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF")
 
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("BRIXHUN MOHTYR", 0, maptext_style, maptext_colors)
+			holder.owner.say("BRIXHUN MOHTYR", FALSE, maptext_style, maptext_colors)
 		..()
 		if(!holder.owner.wizard_spellpower(src))
 			boutput(holder.owner, "<span class='alert'>Your spell is weak without a staff to focus it!</span>")

--- a/code/datums/abilities/wizard/forcewall.dm
+++ b/code/datums/abilities/wizard/forcewall.dm
@@ -9,7 +9,6 @@
 	voice_fem = "sound/voice/wizard/ForcewallFem.ogg"
 	voice_other = "sound/voice/wizard/ForcewallLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF")
 
 	cast()

--- a/code/datums/abilities/wizard/golem.dm
+++ b/code/datums/abilities/wizard/golem.dm
@@ -11,6 +11,9 @@
 	voice_fem = "sound/voice/wizard/GolemFem.ogg"
 	voice_other = "sound/voice/wizard/GolemLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#fcdf74", "#d75015")
+
 	cast()
 		if(!holder)
 			return
@@ -47,7 +50,7 @@
 
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("CLAE MASHON")
+			holder.owner.say("CLAE MASHON", 0, maptext_style, maptext_colors)
 		..()
 
 		var/obj/critter/golem/TheGolem

--- a/code/datums/abilities/wizard/golem.dm
+++ b/code/datums/abilities/wizard/golem.dm
@@ -11,7 +11,6 @@
 	voice_fem = "sound/voice/wizard/GolemFem.ogg"
 	voice_other = "sound/voice/wizard/GolemLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#fcdf74", "#d75015")
 
 	cast()

--- a/code/datums/abilities/wizard/golem.dm
+++ b/code/datums/abilities/wizard/golem.dm
@@ -10,8 +10,7 @@
 	voice_grim = "sound/voice/wizard/GolemGrim.ogg"
 	voice_fem = "sound/voice/wizard/GolemFem.ogg"
 	voice_other = "sound/voice/wizard/GolemLoud.ogg"
-
-	var/maptext_colors = list("#fcdf74", "#d75015")
+	maptext_colors = list("#fcdf74", "#d75015")
 
 	cast()
 		if(!holder)
@@ -49,7 +48,7 @@
 
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("CLAE MASHON", 0, maptext_style, maptext_colors)
+			holder.owner.say("CLAE MASHON", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/obj/critter/golem/TheGolem

--- a/code/datums/abilities/wizard/iceburst.dm
+++ b/code/datums/abilities/wizard/iceburst.dm
@@ -10,6 +10,9 @@
 	voice_fem = "sound/voice/wizard/IceBurstFem.ogg"
 	voice_other = "sound/voice/wizard/IceBurstLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#55eec2", "#62a5ee", "#3c6dc3", "#12135b", "#3c6dc3", "#62a5ee")
+
 	cast()
 		if(!holder)
 			return
@@ -25,7 +28,7 @@
 			return 1
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("NYTH ERRIN")
+			holder.owner.say("NYTH ERRIN", 0, maptext_style, maptext_colors)
 		..()
 
 		if(!holder.owner.wizard_spellpower(src))

--- a/code/datums/abilities/wizard/iceburst.dm
+++ b/code/datums/abilities/wizard/iceburst.dm
@@ -9,8 +9,7 @@
 	voice_grim = "sound/voice/wizard/IceBurstGrim.ogg"
 	voice_fem = "sound/voice/wizard/IceBurstFem.ogg"
 	voice_other = "sound/voice/wizard/IceBurstLoud.ogg"
-
-	var/maptext_colors = list("#55eec2", "#62a5ee", "#3c6dc3", "#12135b", "#3c6dc3", "#62a5ee")
+	maptext_colors = list("#55eec2", "#62a5ee", "#3c6dc3", "#12135b", "#3c6dc3", "#62a5ee")
 
 	cast()
 		if(!holder)
@@ -27,7 +26,7 @@
 			return 1
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("NYTH ERRIN", 0, maptext_style, maptext_colors)
+			holder.owner.say("NYTH ERRIN", FALSE, maptext_style, maptext_colors)
 		..()
 
 		if(!holder.owner.wizard_spellpower(src))

--- a/code/datums/abilities/wizard/iceburst.dm
+++ b/code/datums/abilities/wizard/iceburst.dm
@@ -10,7 +10,6 @@
 	voice_fem = "sound/voice/wizard/IceBurstFem.ogg"
 	voice_other = "sound/voice/wizard/IceBurstLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#55eec2", "#62a5ee", "#3c6dc3", "#12135b", "#3c6dc3", "#62a5ee")
 
 	cast()

--- a/code/datums/abilities/wizard/kill.dm
+++ b/code/datums/abilities/wizard/kill.dm
@@ -11,8 +11,7 @@
 	voice_grim = "sound/voice/wizard/ShockingGraspGrim.ogg"
 	voice_fem = "sound/voice/wizard/ShockingGraspFem.ogg"
 	voice_other = "sound/voice/wizard/ShockingGraspLoud.ogg"
-
-	var/maptext_colors = list("#ff0000", "#000000")
+	maptext_colors = list("#ff0000", "#000000")
 
 	cast(mob/target)
 		if(!holder)
@@ -21,7 +20,7 @@
 		playsound(holder.owner.loc, "sound/effects/elec_bzzz.ogg", 25, 1, -1)
 		if (do_mob(holder.owner, target, 20))
 			if(!istype(get_area(holder.owner), /area/sim/gunsim))
-				holder.owner.say("EI NATH", 0, maptext_style, maptext_colors)
+				holder.owner.say("EI NATH", FALSE, maptext_style, maptext_colors)
 			..()
 
 			if (ishuman(target))

--- a/code/datums/abilities/wizard/kill.dm
+++ b/code/datums/abilities/wizard/kill.dm
@@ -12,7 +12,6 @@
 	voice_fem = "sound/voice/wizard/ShockingGraspFem.ogg"
 	voice_other = "sound/voice/wizard/ShockingGraspLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 3px black;"
 	var/maptext_colors = list("#ff0000", "#000000")
 
 	cast(mob/target)

--- a/code/datums/abilities/wizard/kill.dm
+++ b/code/datums/abilities/wizard/kill.dm
@@ -12,6 +12,9 @@
 	voice_fem = "sound/voice/wizard/ShockingGraspFem.ogg"
 	voice_other = "sound/voice/wizard/ShockingGraspLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 3px black;"
+	var/maptext_colors = list("#ff0000", "#000000")
+
 	cast(mob/target)
 		if(!holder)
 			return
@@ -19,7 +22,7 @@
 		playsound(holder.owner.loc, "sound/effects/elec_bzzz.ogg", 25, 1, -1)
 		if (do_mob(holder.owner, target, 20))
 			if(!istype(get_area(holder.owner), /area/sim/gunsim))
-				holder.owner.say("EI NATH")
+				holder.owner.say("EI NATH", 0, maptext_style, maptext_colors)
 			..()
 
 			if (ishuman(target))

--- a/code/datums/abilities/wizard/knock.dm
+++ b/code/datums/abilities/wizard/knock.dm
@@ -10,7 +10,6 @@
 	voice_fem = "sound/voice/wizard/KnockFem.ogg"
 	voice_other = "sound/voice/wizard/KnockLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#24639a", "#24bdc6", "#05bd82", "#038463")
 
 	cast()

--- a/code/datums/abilities/wizard/knock.dm
+++ b/code/datums/abilities/wizard/knock.dm
@@ -9,14 +9,13 @@
 	voice_grim = "sound/voice/wizard/KnockGrim.ogg"
 	voice_fem = "sound/voice/wizard/KnockFem.ogg"
 	voice_other = "sound/voice/wizard/KnockLoud.ogg"
-
-	var/maptext_colors = list("#24639a", "#24bdc6", "#05bd82", "#038463")
+	maptext_colors = list("#24639a", "#24bdc6", "#05bd82", "#038463")
 
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("AULIE OXIN FIERA", 0, maptext_style, maptext_colors)
+			holder.owner.say("AULIE OXIN FIERA", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/SPrange = 1

--- a/code/datums/abilities/wizard/knock.dm
+++ b/code/datums/abilities/wizard/knock.dm
@@ -10,11 +10,14 @@
 	voice_fem = "sound/voice/wizard/KnockFem.ogg"
 	voice_other = "sound/voice/wizard/KnockLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#24639a", "#24bdc6", "#05bd82", "#038463")
+
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("AULIE OXIN FIERA")
+			holder.owner.say("AULIE OXIN FIERA", 0, maptext_style, maptext_colors)
 		..()
 
 		var/SPrange = 1

--- a/code/datums/abilities/wizard/magicmissile.dm
+++ b/code/datums/abilities/wizard/magicmissile.dm
@@ -13,8 +13,7 @@
 	var/datum/projectile/big_missile = new/datum/projectile/special/homing/magicmissile
 	var/datum/projectile/lil_missile = new/datum/projectile/special/homing/magicmissile/weak
 	var/datum/projectile/the_missile
-
-	var/maptext_colors = list("#f57382", "#f8aaaa", "#f7e0e3", "#f8aaaa")
+	maptext_colors = list("#f57382", "#f8aaaa", "#f7e0e3", "#f8aaaa")
 
 	cast()
 		if(!holder)
@@ -35,7 +34,7 @@
 			missile_targets += M
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("ICEE BEEYEM", 0, maptext_style, maptext_colors) // EHM-EYEARRVEE
+			holder.owner.say("ICEE BEEYEM", FALSE, maptext_style, maptext_colors) // EHM-EYEARRVEE
 		..()
 
 		var/num_shots = src.base_shots

--- a/code/datums/abilities/wizard/magicmissile.dm
+++ b/code/datums/abilities/wizard/magicmissile.dm
@@ -14,7 +14,6 @@
 	var/datum/projectile/lil_missile = new/datum/projectile/special/homing/magicmissile/weak
 	var/datum/projectile/the_missile
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#f57382", "#f8aaaa", "#f7e0e3", "#f8aaaa")
 
 	cast()

--- a/code/datums/abilities/wizard/magicmissile.dm
+++ b/code/datums/abilities/wizard/magicmissile.dm
@@ -14,6 +14,9 @@
 	var/datum/projectile/lil_missile = new/datum/projectile/special/homing/magicmissile/weak
 	var/datum/projectile/the_missile
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#f57382", "#f8aaaa", "#f7e0e3", "#f8aaaa")
+
 	cast()
 		if(!holder)
 			return
@@ -33,7 +36,7 @@
 			missile_targets += M
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("ICEE BEEYEM") // EHM-EYEARRVEE
+			holder.owner.say("ICEE BEEYEM", 0, maptext_style, maptext_colors) // EHM-EYEARRVEE
 		..()
 
 		var/num_shots = src.base_shots

--- a/code/datums/abilities/wizard/magshield.dm
+++ b/code/datums/abilities/wizard/magshield.dm
@@ -9,8 +9,7 @@
 	voice_grim = "sound/voice/wizard/MagicShieldGrim.ogg"
 	voice_fem = "sound/voice/wizard/MagicShieldFem.ogg"
 	voice_other = "sound/voice/wizard/MagicShieldLoud.ogg"
-
-	var/maptext_colors = list("#24639a", "#24bdc6")
+	maptext_colors = list("#24639a", "#24bdc6")
 
 	cast()
 		if(!holder)
@@ -20,7 +19,7 @@
 			return
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("XYZZYX", 0, maptext_style, maptext_colors)
+			holder.owner.say("XYZZYX", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/image/shield_overlay = null

--- a/code/datums/abilities/wizard/magshield.dm
+++ b/code/datums/abilities/wizard/magshield.dm
@@ -10,7 +10,6 @@
 	voice_fem = "sound/voice/wizard/MagicShieldFem.ogg"
 	voice_other = "sound/voice/wizard/MagicShieldLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#24639a", "#24bdc6")
 
 	cast()

--- a/code/datums/abilities/wizard/magshield.dm
+++ b/code/datums/abilities/wizard/magshield.dm
@@ -10,6 +10,9 @@
 	voice_fem = "sound/voice/wizard/MagicShieldFem.ogg"
 	voice_other = "sound/voice/wizard/MagicShieldLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#24639a", "#24bdc6")
+
 	cast()
 		if(!holder)
 			return
@@ -18,7 +21,7 @@
 			return
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("XYZZYX")
+			holder.owner.say("XYZZYX", 0, maptext_style, maptext_colors)
 		..()
 
 		var/image/shield_overlay = null

--- a/code/datums/abilities/wizard/mutate.dm
+++ b/code/datums/abilities/wizard/mutate.dm
@@ -9,14 +9,13 @@
 	voice_grim = "sound/voice/wizard/MutateGrim.ogg"
 	voice_fem = "sound/voice/wizard/MutateFem.ogg"
 	voice_other = "sound/voice/wizard/MutateLoud.ogg"
-
-	var/maptext_colors = list("#d73715", "#d73715", "#fcf574")
+	maptext_colors = list("#d73715", "#d73715", "#fcf574")
 
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("BIRUZ BENNAR", 0, maptext_style, maptext_colors)
+			holder.owner.say("BIRUZ BENNAR", FALSE, maptext_style, maptext_colors)
 		..()
 
 		boutput(holder.owner, "<span class='notice'>Your muscles are magically empowered and you feel very athletic!</span>")

--- a/code/datums/abilities/wizard/mutate.dm
+++ b/code/datums/abilities/wizard/mutate.dm
@@ -10,11 +10,14 @@
 	voice_fem = "sound/voice/wizard/MutateFem.ogg"
 	voice_other = "sound/voice/wizard/MutateLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#d73715", "#d73715", "#fcf574")
+
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("BIRUZ BENNAR")
+			holder.owner.say("BIRUZ BENNAR", 0, maptext_style, maptext_colors)
 		..()
 
 		boutput(holder.owner, "<span class='notice'>Your muscles are magically empowered and you feel very athletic!</span>")

--- a/code/datums/abilities/wizard/mutate.dm
+++ b/code/datums/abilities/wizard/mutate.dm
@@ -10,7 +10,6 @@
 	voice_fem = "sound/voice/wizard/MutateFem.ogg"
 	voice_other = "sound/voice/wizard/MutateLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#d73715", "#d73715", "#fcf574")
 
 	cast()

--- a/code/datums/abilities/wizard/pandemonium.dm
+++ b/code/datums/abilities/wizard/pandemonium.dm
@@ -10,7 +10,6 @@
 	voice_fem = "sound/voice/wizard/PandemoniumFem.ogg"
 	voice_other = "sound/voice/wizard/PandemoniumLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#FF0000", "#00FF00", "#FFFF00", "#0000FF", "#00FFFF", "#FF00FF")
 
 	cast()

--- a/code/datums/abilities/wizard/pandemonium.dm
+++ b/code/datums/abilities/wizard/pandemonium.dm
@@ -9,14 +9,13 @@
 	voice_grim = "sound/voice/wizard/PandemoniumGrim.ogg"
 	voice_fem = "sound/voice/wizard/PandemoniumFem.ogg"
 	voice_other = "sound/voice/wizard/PandemoniumLoud.ogg"
-
-	var/maptext_colors = list("#FF0000", "#00FF00", "#FFFF00", "#0000FF", "#00FFFF", "#FF00FF")
+	maptext_colors = list("#FF0000", "#00FF00", "#FFFF00", "#0000FF", "#00FFFF", "#FF00FF")
 
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("WARR LEHFUQUE", 0, maptext_style, maptext_colors)
+			holder.owner.say("WARR LEHFUQUE", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/list/available_effects = list("babel", "boost", "roar", "signaljam", "grilles", "meteors")

--- a/code/datums/abilities/wizard/pandemonium.dm
+++ b/code/datums/abilities/wizard/pandemonium.dm
@@ -10,11 +10,14 @@
 	voice_fem = "sound/voice/wizard/PandemoniumFem.ogg"
 	voice_other = "sound/voice/wizard/PandemoniumLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#FF0000", "#00FF00", "#FFFF00", "#0000FF", "#00FFFF", "#FF00FF")
+
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("WATT LEHFUQUE")
+			holder.owner.say("WARR LEHFUQUE", 0, maptext_style, maptext_colors)
 		..()
 
 		var/list/available_effects = list("babel", "boost", "roar", "signaljam", "grilles", "meteors")

--- a/code/datums/abilities/wizard/phaseshift.dm
+++ b/code/datums/abilities/wizard/phaseshift.dm
@@ -11,7 +11,6 @@
 	voice_fem = "sound/voice/wizard/MistFormFem.ogg"
 	voice_other = "sound/voice/wizard/MistFormLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
 
 	cast()

--- a/code/datums/abilities/wizard/phaseshift.dm
+++ b/code/datums/abilities/wizard/phaseshift.dm
@@ -10,8 +10,7 @@
 	voice_grim = "sound/voice/wizard/MistFormGrim.ogg"
 	voice_fem = "sound/voice/wizard/MistFormFem.ogg"
 	voice_other = "sound/voice/wizard/MistFormLoud.ogg"
-
-	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
+	maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
 
 	cast()
 		if(!holder)
@@ -20,7 +19,7 @@
 			return 1
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("PHEE CABUE", 0, maptext_style, maptext_colors)
+			holder.owner.say("PHEE CABUE", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/SPtime = 35

--- a/code/datums/abilities/wizard/phaseshift.dm
+++ b/code/datums/abilities/wizard/phaseshift.dm
@@ -11,6 +11,9 @@
 	voice_fem = "sound/voice/wizard/MistFormFem.ogg"
 	voice_other = "sound/voice/wizard/MistFormLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#24639a", "#24bdc6", "#55eec2", "#24bdc6")
+
 	cast()
 		if(!holder)
 			return
@@ -18,7 +21,7 @@
 			return 1
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("PHEE CABUE")
+			holder.owner.say("PHEE CABUE", 0, maptext_style, maptext_colors)
 		..()
 
 		var/SPtime = 35

--- a/code/datums/abilities/wizard/prismatic_spray.dm
+++ b/code/datums/abilities/wizard/prismatic_spray.dm
@@ -26,7 +26,6 @@
 	//instance projectile datum for non-random usage, randomise() is called on this
 	var/datum/projectile/artifact/prismatic_projectile/ps_proj = new
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF")
 
 	New()

--- a/code/datums/abilities/wizard/prismatic_spray.dm
+++ b/code/datums/abilities/wizard/prismatic_spray.dm
@@ -25,8 +25,7 @@
 	var/list/proj_types = list()
 	//instance projectile datum for non-random usage, randomise() is called on this
 	var/datum/projectile/artifact/prismatic_projectile/ps_proj = new
-
-	var/maptext_colors = list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF")
+	maptext_colors = list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF")
 
 	New()
 		..()
@@ -41,7 +40,7 @@
 	cast(atom/target)
 		if (holder.owner.wizard_spellpower(src) || istype(src, /datum/targetable/spell/prismatic_spray/admin))
 			if(!istype(get_area(holder.owner), /area/sim/gunsim))
-				holder.owner.say("PROJEHK TUL IHNFERNUS", 0, maptext_style, maptext_colors) //incantation credit to Grifflez
+				holder.owner.say("PROJEHK TUL IHNFERNUS", FALSE, maptext_style, maptext_colors) //incantation credit to Grifflez
 			//var/mob/living/carbon/human/O = holder.owner
 			logTheThing("combat", holder.owner, target, "casts Prismatic spray at [constructTarget(target,"combat")].")
 			// Put voice stuff here in the future

--- a/code/datums/abilities/wizard/prismatic_spray.dm
+++ b/code/datums/abilities/wizard/prismatic_spray.dm
@@ -26,6 +26,9 @@
 	//instance projectile datum for non-random usage, randomise() is called on this
 	var/datum/projectile/artifact/prismatic_projectile/ps_proj = new
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF")
+
 	New()
 		..()
 		for (var/X in filtered_concrete_typesof(/datum/projectile, .proc/filter_projectile))
@@ -39,7 +42,7 @@
 	cast(atom/target)
 		if (holder.owner.wizard_spellpower(src) || istype(src, /datum/targetable/spell/prismatic_spray/admin))
 			if(!istype(get_area(holder.owner), /area/sim/gunsim))
-				holder.owner.say("PROJEHK TUL IHNFERNUS") //incantation credit to Grifflez
+				holder.owner.say("PROJEHK TUL IHNFERNUS", 0, maptext_style, maptext_colors) //incantation credit to Grifflez
 			//var/mob/living/carbon/human/O = holder.owner
 			logTheThing("combat", holder.owner, target, "casts Prismatic spray at [constructTarget(target,"combat")].")
 			// Put voice stuff here in the future

--- a/code/datums/abilities/wizard/rathens.dm
+++ b/code/datums/abilities/wizard/rathens.dm
@@ -10,11 +10,14 @@
 	voice_fem = "sound/voice/wizard/RathensSecretFem.ogg"
 	voice_other = "sound/voice/wizard/RathensSecretLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#d73715", "#d73715", "#fcf574")
+
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("ARSE NATH!")
+			holder.owner.say("ARSE NATH", 0, maptext_style, maptext_colors)
 		..()
 
 		playsound(holder.owner, "sound/voice/farts/superfart.ogg", 25, 1)

--- a/code/datums/abilities/wizard/rathens.dm
+++ b/code/datums/abilities/wizard/rathens.dm
@@ -10,7 +10,6 @@
 	voice_fem = "sound/voice/wizard/RathensSecretFem.ogg"
 	voice_other = "sound/voice/wizard/RathensSecretLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#d73715", "#d73715", "#fcf574")
 
 	cast()

--- a/code/datums/abilities/wizard/rathens.dm
+++ b/code/datums/abilities/wizard/rathens.dm
@@ -9,14 +9,13 @@
 	voice_grim = "sound/voice/wizard/RathensSecretGrim.ogg"
 	voice_fem = "sound/voice/wizard/RathensSecretFem.ogg"
 	voice_other = "sound/voice/wizard/RathensSecretLoud.ogg"
-
-	var/maptext_colors = list("#d73715", "#d73715", "#fcf574")
+	maptext_colors = list("#d73715", "#d73715", "#fcf574")
 
 	cast()
 		if(!holder)
 			return
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("ARSE NATH", 0, maptext_style, maptext_colors)
+			holder.owner.say("ARSE NATH", FALSE, maptext_style, maptext_colors)
 		..()
 
 		playsound(holder.owner, "sound/voice/farts/superfart.ogg", 25, 1)

--- a/code/datums/abilities/wizard/shock.dm
+++ b/code/datums/abilities/wizard/shock.dm
@@ -15,8 +15,7 @@
 	var/burn_damage = 100
 	var/target_damage_modifier = 1.95
 	var/arc_range = 3
-
-	var/maptext_colors = list("#ebb02b", "#fcf574", "#ebb02b", "#fcf574", "#ebf0f2")
+	maptext_colors = list("#ebb02b", "#fcf574", "#ebb02b", "#fcf574", "#ebf0f2")
 
 	cast(mob/target)
 		if(!holder)
@@ -27,7 +26,7 @@
 			return 1
 		playsound(holder.owner.loc, "sound/effects/elec_bzzz.ogg", 25, 1, -1)
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("EI NATH", 0, maptext_style, maptext_colors)
+			holder.owner.say("EI NATH", FALSE, maptext_style, maptext_colors)
 		..()
 
 		playsound(holder.owner.loc, "sound/effects/elec_bigzap.ogg", 25, 1, -1)

--- a/code/datums/abilities/wizard/shock.dm
+++ b/code/datums/abilities/wizard/shock.dm
@@ -16,7 +16,6 @@
 	var/target_damage_modifier = 1.95
 	var/arc_range = 3
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#ebb02b", "#fcf574", "#ebb02b", "#fcf574", "#ebf0f2")
 
 	cast(mob/target)

--- a/code/datums/abilities/wizard/shock.dm
+++ b/code/datums/abilities/wizard/shock.dm
@@ -16,6 +16,9 @@
 	var/target_damage_modifier = 1.95
 	var/arc_range = 3
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#ebb02b", "#fcf574", "#ebb02b", "#fcf574", "#ebf0f2")
+
 	cast(mob/target)
 		if(!holder)
 			return
@@ -25,7 +28,7 @@
 			return 1
 		playsound(holder.owner.loc, "sound/effects/elec_bzzz.ogg", 25, 1, -1)
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("EI NATH")
+			holder.owner.say("EI NATH", 0, maptext_style, maptext_colors)
 		..()
 
 		playsound(holder.owner.loc, "sound/effects/elec_bigzap.ogg", 25, 1, -1)

--- a/code/datums/abilities/wizard/stickstosnakes.dm
+++ b/code/datums/abilities/wizard/stickstosnakes.dm
@@ -14,6 +14,9 @@
 	voice_other = "sound/voice/wizard/recordthese.ogg"
 	*/
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#ee59e3", "#ee59e3", "#b320c3", "#e59e3", "#b320c3", "#ee59e3")
+
 	cast(atom/target)
 		if(!holder)
 			return
@@ -62,7 +65,7 @@
 			return 1 // No cooldown when it fails.
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("STYX TUSNEKS")
+			holder.owner.say("STYX TUSNEKS", 0, maptext_style, maptext_colors)
         //..() uncomment this when we have voice files
 
 		var/obj/critter/snake/snake = new(stick.loc, stick)

--- a/code/datums/abilities/wizard/stickstosnakes.dm
+++ b/code/datums/abilities/wizard/stickstosnakes.dm
@@ -14,7 +14,6 @@
 	voice_other = "sound/voice/wizard/recordthese.ogg"
 	*/
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#ee59e3", "#ee59e3", "#b320c3", "#e59e3", "#b320c3", "#ee59e3")
 
 	cast(atom/target)

--- a/code/datums/abilities/wizard/stickstosnakes.dm
+++ b/code/datums/abilities/wizard/stickstosnakes.dm
@@ -13,8 +13,7 @@
 	voice_fem = "sound/voice/wizard/someoneto.ogg"
 	voice_other = "sound/voice/wizard/recordthese.ogg"
 	*/
-
-	var/maptext_colors = list("#ee59e3", "#ee59e3", "#b320c3", "#e59e3", "#b320c3", "#ee59e3")
+	maptext_colors = list("#ee59e3", "#ee59e3", "#b320c3", "#e59e3", "#b320c3", "#ee59e3")
 
 	cast(atom/target)
 		if(!holder)
@@ -64,7 +63,7 @@
 			return 1 // No cooldown when it fails.
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("STYX TUSNEKS", 0, maptext_style, maptext_colors)
+			holder.owner.say("STYX TUSNEKS", FALSE, maptext_style, maptext_colors)
         //..() uncomment this when we have voice files
 
 		var/obj/critter/snake/snake = new(stick.loc, stick)

--- a/code/datums/abilities/wizard/summon_staff.dm
+++ b/code/datums/abilities/wizard/summon_staff.dm
@@ -10,8 +10,7 @@
 	voice_fem = "sound/voice/wizard/StaffFem.ogg"
 	//voice_other = "sound/voice/wizard/notdoneyet.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
-	var/maptext_colors = list("#b320c3", "#5a1d8a", "#170d3c", "#5a1d8a")
+	var/maptext_colors = list("#b320c3", "#5a1d8a")
 
 
 	cast(mob/target)
@@ -104,7 +103,6 @@
 	cooldown = 20 SECONDS
 	requires_robes = 1
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#ebb02b", "#fcf574", "#ebb02b", "#fcf574", "#ebf0f2")
 
 	cast(mob/target)

--- a/code/datums/abilities/wizard/summon_staff.dm
+++ b/code/datums/abilities/wizard/summon_staff.dm
@@ -9,8 +9,7 @@
 	voice_grim = "sound/voice/wizard/StaffGrim.ogg"
 	voice_fem = "sound/voice/wizard/StaffFem.ogg"
 	//voice_other = "sound/voice/wizard/notdoneyet.ogg"
-
-	var/maptext_colors = list("#b320c3", "#5a1d8a")
+	maptext_colors = list("#b320c3", "#5a1d8a")
 
 
 	cast(mob/target)
@@ -102,8 +101,7 @@
 	targeted = 0
 	cooldown = 20 SECONDS
 	requires_robes = 1
-
-	var/maptext_colors = list("#ebb02b", "#fcf574", "#ebb02b", "#fcf574", "#ebf0f2")
+	maptext_colors = list("#ebb02b", "#fcf574", "#ebb02b", "#fcf574", "#ebf0f2")
 
 	cast(mob/target)
 		var/mob/living/M = holder?.owner

--- a/code/datums/abilities/wizard/summon_staff.dm
+++ b/code/datums/abilities/wizard/summon_staff.dm
@@ -27,7 +27,7 @@
 			return 1
 
 		if(!istype(get_area(M), /area/sim/gunsim)) // Avoid dead chat spam
-			M.say("KOHM HEIRE", unique_maptext_style = maptext_style, maptext_animation_colors = maptext_colors)
+			M.say("KOHM HEIRE", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/list/staves = list()
@@ -112,7 +112,7 @@
 			return 1
 
 		if(!istype(get_area(M), /area/sim/gunsim)) // Avoid dead chat spam
-			M.say("KUH, ABAH'RAH", unique_maptext_style = maptext_style, maptext_animation_colors = maptext_colors)
+			M.say("KUH, ABAH'RAH", FALSE, maptext_style, maptext_colors)
 		..()
 
 		var/list/staves = list()

--- a/code/datums/abilities/wizard/summon_staff.dm
+++ b/code/datums/abilities/wizard/summon_staff.dm
@@ -10,6 +10,10 @@
 	voice_fem = "sound/voice/wizard/StaffFem.ogg"
 	//voice_other = "sound/voice/wizard/notdoneyet.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#b320c3", "#5a1d8a", "#170d3c", "#5a1d8a")
+
+
 	cast(mob/target)
 		if (!holder)
 			return 1
@@ -25,7 +29,7 @@
 			return 1
 
 		if(!istype(get_area(M), /area/sim/gunsim)) // Avoid dead chat spam
-			M.say("KOMH HEIRE")
+			M.say("KOHM HEIRE", unique_maptext_style = maptext_style, maptext_animation_colors = maptext_colors)
 		..()
 
 		var/list/staves = list()
@@ -100,6 +104,9 @@
 	cooldown = 20 SECONDS
 	requires_robes = 1
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#ebb02b", "#fcf574", "#ebb02b", "#fcf574", "#ebf0f2")
+
 	cast(mob/target)
 		var/mob/living/M = holder?.owner
 		if (!ismob(M))
@@ -109,7 +116,7 @@
 			return 1
 
 		if(!istype(get_area(M), /area/sim/gunsim)) // Avoid dead chat spam
-			M.say("KUH, ABAH'RAH")
+			M.say("KUH, ABAH'RAH", unique_maptext_style = maptext_style, maptext_animation_colors = maptext_colors)
 		..()
 
 		var/list/staves = list()

--- a/code/datums/abilities/wizard/teleport.dm
+++ b/code/datums/abilities/wizard/teleport.dm
@@ -7,6 +7,7 @@
 	requires_robes = 1
 	cooldown_staff = 1
 	restricted_area_check = 1
+	var/maptext_colors = list("#39ffba", "#05bd82", "#038463", "#05bd82")
 
 	cast()
 		if (!holder)
@@ -22,9 +23,6 @@
 	var/voice_grim = "sound/voice/wizard/TeleportGrim.ogg"
 	var/voice_fem = "sound/voice/wizard/TeleportFem.ogg"
 	var/voice_other = "sound/voice/wizard/TeleportLoud.ogg"
-
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
-	var/maptext_colors = list("#39ffba", "#05bd82", "#038463", "#05bd82")
 
 	if (src.getStatusDuration("paralysis") || !isalive(src))
 		boutput(src, "<span class='alert'>Not when you're incapacitated.</span>")
@@ -142,7 +140,7 @@
 				tele.doCooldown()
 
 		if (3) // Spell-specific stuff.
-			src.say("SCYAR NILA [uppertext(A)]", 0, maptext_style, maptext_colors)
+			src.say("SCYAR NILA [uppertext(A)]", 0, spell.maptext_style, spell.maptext_colors)
 			if(ishuman(src))
 				var/mob/living/carbon/human/O = src
 				if(istype(O.wear_suit, /obj/item/clothing/suit/wizrobe/necro) && istype(O.head, /obj/item/clothing/head/wizard/necro))

--- a/code/datums/abilities/wizard/teleport.dm
+++ b/code/datums/abilities/wizard/teleport.dm
@@ -23,6 +23,9 @@
 	var/voice_fem = "sound/voice/wizard/TeleportFem.ogg"
 	var/voice_other = "sound/voice/wizard/TeleportLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#39ffba", "#05bd82", "#038463", "#05bd82")
+
 	if (src.getStatusDuration("paralysis") || !isalive(src))
 		boutput(src, "<span class='alert'>Not when you're incapacitated.</span>")
 		return 0
@@ -139,7 +142,7 @@
 				tele.doCooldown()
 
 		if (3) // Spell-specific stuff.
-			src.say("SCYAR NILA [uppertext(A)]")
+			src.say("SCYAR NILA [uppertext(A)]", 0, maptext_style, maptext_colors)
 			if(ishuman(src))
 				var/mob/living/carbon/human/O = src
 				if(istype(O.wear_suit, /obj/item/clothing/suit/wizrobe/necro) && istype(O.head, /obj/item/clothing/head/wizard/necro))

--- a/code/datums/abilities/wizard/teleport.dm
+++ b/code/datums/abilities/wizard/teleport.dm
@@ -7,7 +7,7 @@
 	requires_robes = 1
 	cooldown_staff = 1
 	restricted_area_check = 1
-	var/maptext_colors = list("#39ffba", "#05bd82", "#038463", "#05bd82")
+	maptext_colors = list("#39ffba", "#05bd82", "#038463", "#05bd82")
 
 	cast()
 		if (!holder)
@@ -140,7 +140,7 @@
 				tele.doCooldown()
 
 		if (3) // Spell-specific stuff.
-			src.say("SCYAR NILA [uppertext(A)]", 0, spell.maptext_style, spell.maptext_colors)
+			src.say("SCYAR NILA [uppertext(A)]", FALSE, spell.maptext_style, spell.maptext_colors)
 			if(ishuman(src))
 				var/mob/living/carbon/human/O = src
 				if(istype(O.wear_suit, /obj/item/clothing/suit/wizrobe/necro) && istype(O.head, /obj/item/clothing/head/wizard/necro))

--- a/code/datums/abilities/wizard/warp.dm
+++ b/code/datums/abilities/wizard/warp.dm
@@ -12,7 +12,6 @@
 	voice_fem = "sound/voice/wizard/WarpFem.ogg"
 	voice_other = "sound/voice/wizard/WarpLoud.ogg"
 
-	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
 	var/maptext_colors = list("#5cde24", "#167935", "#084623", "#0167935")
 
 	cast(mob/target)

--- a/code/datums/abilities/wizard/warp.dm
+++ b/code/datums/abilities/wizard/warp.dm
@@ -12,6 +12,9 @@
 	voice_fem = "sound/voice/wizard/WarpFem.ogg"
 	voice_other = "sound/voice/wizard/WarpLoud.ogg"
 
+	var/maptext_style = "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;"
+	var/maptext_colors = list("#5cde24", "#167935", "#084623", "#0167935")
+
 	cast(mob/target)
 		if(!holder)
 			return 1
@@ -26,7 +29,7 @@
 			return 1
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("GHEIT AUT")
+			holder.owner.say("GHEIT AUT", 0, maptext_style, maptext_colors)
 		..()
 
 		if (target.traitHolder.hasTrait("training_chaplain"))

--- a/code/datums/abilities/wizard/warp.dm
+++ b/code/datums/abilities/wizard/warp.dm
@@ -11,8 +11,7 @@
 	voice_grim = "sound/voice/wizard/WarpGrim.ogg"
 	voice_fem = "sound/voice/wizard/WarpFem.ogg"
 	voice_other = "sound/voice/wizard/WarpLoud.ogg"
-
-	var/maptext_colors = list("#5cde24", "#167935", "#084623", "#0167935")
+	maptext_colors = list("#5cde24", "#167935", "#084623", "#0167935")
 
 	cast(mob/target)
 		if(!holder)
@@ -28,7 +27,7 @@
 			return 1
 
 		if(!istype(get_area(holder.owner), /area/sim/gunsim))
-			holder.owner.say("GHEIT AUT", 0, maptext_style, maptext_colors)
+			holder.owner.say("GHEIT AUT", FALSE, maptext_style, maptext_colors)
 		..()
 
 		if (target.traitHolder.hasTrait("training_chaplain"))

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -682,7 +682,7 @@
 			return src.eyecam.client.preferences.auto_capitalization
 	. = ..()
 
-/mob/living/say(var/message, ignore_stamina_winded)
+/mob/living/say(var/message, ignore_stamina_winded, unique_maptext_style, maptext_animation_colors)
 	message = strip_html(trim(copytext(sanitize_noencode(message), 1, MAX_MESSAGE_LEN)))
 
 	if (!message)
@@ -1125,7 +1125,15 @@
 				maptext_color ="#D8BFD8"
 		else
 			maptext_color = src.last_chat_color
-		chat_text = make_chat_maptext(say_location, messages[1], "color: [maptext_color];" + src.speechpopupstyle + singing_italics)
+
+		if(unique_maptext_style)
+			chat_text = make_chat_maptext(say_location, messages[1], "color: [maptext_color];" + unique_maptext_style + singing_italics)
+		else
+			chat_text = make_chat_maptext(say_location, messages[1], "color: [maptext_color];" + src.speechpopupstyle + singing_italics)
+
+		if(maptext_animation_colors)
+			oscillate_colors(chat_text, maptext_animation_colors)
+
 		if(chat_text)
 			chat_text.measure(src.client)
 			for(var/image/chat_maptext/I in src.chat_text.lines)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -682,7 +682,7 @@
 			return src.eyecam.client.preferences.auto_capitalization
 	. = ..()
 
-/mob/living/say(var/message, ignore_stamina_winded, unique_maptext_style, maptext_animation_colors)
+/mob/living/say(var/message, ignore_stamina_winded, var/unique_maptext_style, var/maptext_animation_colors)
 	message = strip_html(trim(copytext(sanitize_noencode(message), 1, MAX_MESSAGE_LEN)))
 
 	if (!message)

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1397,7 +1397,7 @@
 
 	return rendered
 
-/mob/living/carbon/human/say(var/message, var/ignore_stamina_winded = 0, unique_maptext_style, maptext_animation_colors)
+/mob/living/carbon/human/say(var/message, var/ignore_stamina_winded = FALSE, var/unique_maptext_style, var/maptext_animation_colors)
 	var/original_language = src.say_language
 	if (mutantrace?.override_language)
 		say_language = mutantrace.override_language

--- a/code/mob/living/carbon/human.dm
+++ b/code/mob/living/carbon/human.dm
@@ -1397,7 +1397,7 @@
 
 	return rendered
 
-/mob/living/carbon/human/say(var/message, var/ignore_stamina_winded = 0)
+/mob/living/carbon/human/say(var/message, var/ignore_stamina_winded = 0, unique_maptext_style, maptext_animation_colors)
 	var/original_language = src.say_language
 	if (mutantrace?.override_language)
 		say_language = mutantrace.override_language
@@ -1453,7 +1453,7 @@
 		var/datum/pathogen/P = src.pathogens[uid]
 		message = P.onsay(message)
 
-	..(message)
+	..(message, unique_maptext_style = unique_maptext_style, maptext_animation_colors = maptext_animation_colors)
 
 	src.say_language = original_language
 

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1518,7 +1518,7 @@
 					else
 						if (iswizard(src) && prob(10))
 							message = pick("<span class='alert'><B>[src]</B> breaks out the most unreal dance move you've ever seen!</span>", "<span class='alert'><B>[src]'s</B> dance move borders on the goddamn diabolical!</span>")
-							src.say("GHEIT DAUN!")
+							src.say("GHEIT DAUN!", 0, "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;", list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF"))
 							animate_flash_color_fill(src,"#5C0E80", 1, 10)
 							animate_levitate(src, 1, 10)
 							SPAWN(0) // some movement to make it look cooler

--- a/code/mob/living/carbon/human/procs/emote.dm
+++ b/code/mob/living/carbon/human/procs/emote.dm
@@ -1518,7 +1518,7 @@
 					else
 						if (iswizard(src) && prob(10))
 							message = pick("<span class='alert'><B>[src]</B> breaks out the most unreal dance move you've ever seen!</span>", "<span class='alert'><B>[src]'s</B> dance move borders on the goddamn diabolical!</span>")
-							src.say("GHEIT DAUN!", 0, "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;", list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF"))
+							src.say("GHEIT DAUN!", FALSE, "color: white !important; text-shadow: 1px 1px 3px white; -dm-text-outline: 1px black;", list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF", "#FF00FF"))
 							animate_flash_color_fill(src,"#5C0E80", 1, 10)
 							animate_levitate(src, 1, 10)
 							SPAWN(0) // some movement to make it look cooler

--- a/code/modules/animation/AnimationLibrary.dm
+++ b/code/modules/animation/AnimationLibrary.dm
@@ -873,7 +873,7 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 	return
 
 /proc/animate_rainbow_glow(var/atom/A)
-	if (!istype(A) && !isclient(A))
+	if (!istype(A) && !isclient(A) && !istype(A, /image/chat_maptext))
 		return
 	animate(A, color = "#FF0000", time = rand(5,10), loop = -1, easing = LINEAR_EASING)
 	animate(color = "#FFFF00", time = rand(5,10), loop = -1, easing = LINEAR_EASING)
@@ -881,6 +881,16 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 	animate(color = "#00FFFF", time = rand(5,10), loop = -1, easing = LINEAR_EASING)
 	animate(color = "#0000FF", time = rand(5,10), loop = -1, easing = LINEAR_EASING)
 	animate(color = "#FF00FF", time = rand(5,10), loop = -1, easing = LINEAR_EASING)
+	return
+
+/proc/oscillate_colors(var/atom/A, var/list/colors_to_swap)
+	if (!istype(A) && !isclient(A) && !istype(A, /image/chat_maptext))
+		return
+	for(var/the_color in colors_to_swap)
+		if(the_color == colors_to_swap[1])
+			animate(A, color = the_color, time = rand(5,10), loop = -1, easing = LINEAR_EASING)
+		else
+			animate(color = the_color, time = rand(5,10), loop = -1, easing = LINEAR_EASING)
 	return
 
 /proc/animate_fade_to_color_fill(var/atom/A,var/the_color,var/time)

--- a/code/modules/animation/AnimationLibrary.dm
+++ b/code/modules/animation/AnimationLibrary.dm
@@ -891,7 +891,6 @@ proc/muzzle_flash_any(var/atom/movable/A, var/firing_angle, var/muzzle_anim, var
 			animate(A, color = the_color, time = rand(5,10), loop = -1, easing = LINEAR_EASING)
 		else
 			animate(color = the_color, time = rand(5,10), loop = -1, easing = LINEAR_EASING)
-	return
 
 /proc/animate_fade_to_color_fill(var/atom/A,var/the_color,var/time)
 	if (!istype(A) || !the_color || !time)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

[FEAT]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR makes it so that when wizards incant their spells, the maptext is all fancy and animated. Each spell gets their own specifically defined colors, but some color sets are used for multiple where it's fitting. They mostly pull from the HUD icons for color choice. I had a recorded video of every single spell, but that was too long for uploading to github so here's a reasonable sample instead. 


https://user-images.githubusercontent.com/53125172/179398106-4e4786b8-05f6-470d-9bc1-5be186e2e2a4.mp4

Note that I didn't set any for doppelgänger, since I thought it would be unbefitting for it to stick out. Luckily, it wouldn't have been shown anyways since you're stored in the phasing-thingy. Same is true for phase shift, so while that one has code to handle pretty text it's never actually visible. If someone found a way to activate phase shift without actually shifting it'd be fancy though.

This works by adding two new args to the say proc, one which sets the maptext styling info stuff for the message and one which chooses what colors to cycle through, accepting a list with an arbitrary length of at least 2. If either of these are null it'll behave as regular. This means you could theoretically make any forced speech have these fancy visual effects without changing *all* the text of the person speaking, so this could be used for future spells or other stuff that we want to look cool.

Also adds a new proc to animationlibrary called 'oscillate_colors', which accepts a target and list of colors, and then cycles through the list of colors. I felt it was much better to implement something like this than to make custom procs for every complicated animation I wanted, and this could be used for whatever probably.

Double note that while I tested this and it works well in-game, this felt like a complicated project for me and I've never messed with some of the stuff touched here, so I don't fully expect it all to be ideally written. So uh, probably not ready to merge without some code review but I wouldn't know if it has issues without being told :sheltersweat:.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It's a pretty nice looking effect to me, adds some nice detail. It's also just... cool! Fun that a visual representation of magical words would, themselves, look kinda magical.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Flaborized
(+)Wizard incantations are now a bit more magical looking.
```
