### PR TITLE
Prevents typing indicators on mute players

### DIFF
--- a/code/procs/mobprocs/typing_indicator.dm
+++ b/code/procs/mobprocs/typing_indicator.dm
@@ -75,7 +75,7 @@ The say/whisper/me wrappers and cancel_typing remove the typing indicator.
 
 // -- Human Typing Indicators -- //
 /mob/living/create_typing_indicator()
-	if(!src.has_typing_indicator && isalive(src)) //Prevents sticky overlays and typing while in any state besides conscious
+	if(!src.has_typing_indicator && isalive(src) && !src.bioHolder?.HasEffect("mute")) //Prevents sticky overlays and typing while in any state besides conscious
 		src.UpdateOverlays(living_typing_bubble, TYPING_OVERLAY_KEY)
 		src.has_typing_indicator = TRUE
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Anyone with the mute gene no longer generates typing indicators.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Having the typing indicator pop up when you're just trying to type out an emote as mime is annoying.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)People with the mute gene no longer have typing indicators
```
