### PR TITLE
Prevents camera monitors from seeing AI only cams

### DIFF
--- a/code/obj/item/device/camera_viewer.dm
+++ b/code/obj/item/device/camera_viewer.dm
@@ -22,7 +22,7 @@
 		var/list/D = list()
 
 		for (var/obj/machinery/camera/C in L)
-			if (C.network == src.network)
+			if (C.network == src.network && !C.ai_only)
 				D[text("[][]", C.c_tag, (C.camera_status ? null : " (Deactivated)"))] = C
 			LAGCHECK(LAG_LOW)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #9730, I missed this thing when updating the sec camera computers.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad, do not spy on the AI