### PR TITLE
Removes electronics commodity from the general trader pool

### DIFF
--- a/code/modules/economy/traders/generic.dm
+++ b/code/modules/economy/traders/generic.dm
@@ -10,7 +10,6 @@
 
 	base_goods_buy = list(/datum/commodity/trader/generic/anyore,
 	/datum/commodity/trader/generic/herbs,
-	/datum/commodity/trader/generic/electronics,
 	/datum/commodity/trader/generic/anyfood,
 	/datum/commodity/trader/generic/shipcomponents,
 	/datum/commodity/trader/generic/jumpsuits,

--- a/code/modules/economy/traders/generic.dm
+++ b/code/modules/economy/traders/generic.dm
@@ -197,13 +197,6 @@
 	possible_names = list("I'll buy any medical herbs you may have.",
 	"I need to restock on medical herbs. I'm willing to buy them from you for a good price.")
 
-/datum/commodity/trader/generic/electronics
-	comname = "Electrical Components"
-	comtype = /obj/item/electronics/
-	price_boundary = list(20,100)
-	possible_names = list("I need to buy electrical components for a project.",
-	"We're rather short on electrical components needed for repairs. We're willing to pay well.")
-
 /datum/commodity/trader/generic/shipcomponents
 	comname = "Ship/Pod Components"
 	comtype = /obj/item/shipcomponent/


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? --> 
This just removes the Electronics commdity from the general trader pool to match with the removal from the shipping market.



## Why's this needed? <!-- Describe why you think this should be added to the game. --> 
Cleans up the trader pool as electronics was an unused commodity and was removed from the shipping market but not removed from the trader commodity pool.
