### PR TITLE
automender buff

### DIFF
--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -606,7 +606,7 @@
 
 /datum/action/bar/icon/automender_apply
 	duration = 10
-	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_STUNNED | INTERRUPT_ATTACKED
+	interrupt_flags = INTERRUPT_STUNNED
 	id = "automender_apply"
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "mender-active"
@@ -622,6 +622,8 @@
 		M = tool
 		target = targetmob
 		looped = loopcount
+		if (user == target)
+			src.interrupt_flags |= (INTERRUPT_ATTACKED | INTERRUPT_MOVE)
 		..()
 
 	onUpdate()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BALANCE][QOL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
automenders no longer interrupt healing upon being hit or walking unless you are self healing using them


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
automenders are not the best, healing being interrupted by a staffie who help intent swapped positions with you sucks especially as for the first 7 seconds automenders are still ramping up their heal speed
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(*) Automenders no longer interrupt healing upon being hit or walking unless you are self healing using them.
```
