### PR TITLE
Better method for varedited airlock names

### DIFF
--- a/code/obj/machinery/door/airlock.dm
+++ b/code/obj/machinery/door/airlock.dm
@@ -194,8 +194,6 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	var/has_panel = 1
 	var/hackMessage = ""
 	var/net_access_code = null
-        /// Set nameOverride to FALSE to stop New() from overwriting door name with Area name
-	var/nameOverride = TRUE
 
 	var/no_access = 0
 
@@ -206,7 +204,7 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 
 	New()
 		..()
-		if(!isrestrictedz(src.z) && nameOverride)
+		if(!isrestrictedz(src.z) && src.name == initial(src.name)) //The second half prevents varedited names being overwritten
 			var/area/station/A = get_area(src)
 			src.name = A.name
 		src.net_access_code = rand(1, NET_ACCESS_OPTIONS)

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -71028,7 +71028,7 @@
 "del" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "EMERGENCY DISPOSAL";
-	nameOverride = 0
+	
 	},
 /turf/simulated/floor/airless/engine/caution/westeast,
 /area/station/hangar/science)
@@ -76186,7 +76186,7 @@
 "ewr" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Outpost Shuttle Dock";
-	nameOverride = 0
+	
 	},
 /obj/access_spawn/research,
 /turf/simulated/floor/airless/caution/northsouth,
@@ -76336,7 +76336,7 @@
 "fwk" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Outpost Shuttle Dock";
-	nameOverride = 0
+	
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/research,
@@ -77249,7 +77249,7 @@
 "jNM" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Research Outpost Shuttle";
-	nameOverride = 0
+	
 	},
 /obj/access_spawn/research,
 /turf/unsimulated/floor/shuttle,
@@ -77328,7 +77328,7 @@
 "kcO" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Outpost Shuttle Dock";
-	nameOverride = 0
+	
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/research,
@@ -79317,7 +79317,6 @@
 "tFo" = (
 /obj/machinery/door/airlock/pyro/glass{
 	name = "Research Outpost";
-	nameOverride = 0;
 	req_access_txt = "24"
 	},
 /turf/simulated/floor/grey/blackgrime,
@@ -79623,7 +79622,7 @@
 "vuO" = (
 /obj/machinery/door/airlock/pyro/external{
 	name = "Outpost Shuttle Dock";
-	nameOverride = 0
+	
 	},
 /obj/access_spawn/research,
 /turf/simulated/floor/airless/caution/northsouth,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL][cleanliness]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Implements a method of automatically preventing airlocks from overwriting varedited names with the area.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Saves a variable on airlocks and is less clunky to set up.

Will also make a ton of custom airlock names on cog1 show up, I don't know about other maps.