### PR TITLE
Nerfs mousetrap bombs

### DIFF
--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -349,6 +349,13 @@
 		src.icon_state = "mousetrap"
 		src.armed = 0
 
+		var/delay = 0
+		if (type != "feet") //detonate instantly if stepped on, and with a small delay otherwise
+			delay = 0.7 SECONDS
+		SPAWN(delay)
+			src.trigger_payload(target)
+
+	proc/trigger_payload(mob/target)
 		if (src.grenade)
 			logTheThing("bombing", target, null, "triggers [src] (armed with: [src.grenade]) at [log_loc(src)]")
 			src.grenade.explode()
@@ -363,10 +370,9 @@
 
 		else if (src.pipebomb)
 			logTheThing("bombing", target, null, "triggers [src] (armed with: [src.pipebomb]) at [log_loc(src)]")
-			SPAWN(0.7 SECONDS)
-				src.overlays -= image('icons/obj/items/weapons.dmi', "trap-pipebomb")
-				src.pipebomb.do_explode()
-				src.pipebomb = null
+			src.overlays -= image('icons/obj/items/weapons.dmi', "trap-pipebomb")
+			src.pipebomb.do_explode()
+			src.pipebomb = null
 
 		else if (src.signaler)
 			logTheThing("bombing", target, null, "triggers [src] (armed with: [src.signaler]) at [log_loc(src)]")
@@ -398,8 +404,7 @@
 			playsound(src.loc, 'sound/voice/farts/superfart.ogg', 100, 1)
 			qdel(src.buttbomb)
 			src.buttbomb = null
-		clear_armer()
-		return
+		src.clear_armer()
 
 // Added support for old-style grenades and pipe bombs (Convair880).
 /obj/item/mousetrap_roller

--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -363,9 +363,10 @@
 
 		else if (src.pipebomb)
 			logTheThing("bombing", target, null, "triggers [src] (armed with: [src.pipebomb]) at [log_loc(src)]")
-			src.overlays -= image('icons/obj/items/weapons.dmi', "trap-pipebomb")
-			src.pipebomb.do_explode()
-			src.pipebomb = null
+			SPAWN(0.7 SECONDS)
+				src.overlays -= image('icons/obj/items/weapons.dmi', "trap-pipebomb")
+				src.pipebomb.do_explode()
+				src.pipebomb = null
 
 		else if (src.signaler)
 			logTheThing("bombing", target, null, "triggers [src] (armed with: [src.signaler]) at [log_loc(src)]")

--- a/code/obj/item/storage/small_storage_parent.dm
+++ b/code/obj/item/storage/small_storage_parent.dm
@@ -248,8 +248,7 @@
 			if (usr.s_active)
 				usr.detach_hud(usr.s_active)
 				usr.s_active = null
-			if (src.mousetrap_check(usr))
-				return
+			src.mousetrap_check(usr)
 			usr.s_active = src.hud
 			hud.update(usr)
 			usr.attach_hud(src.hud)
@@ -293,8 +292,7 @@
 			if (user.s_active)
 				user.detach_hud(user.s_active)
 				user.s_active = null
-			if (src.mousetrap_check(user))
-				return
+			src.mousetrap_check(user)
 			user.s_active = src.hud
 			hud.update(user)
 			user.attach_hud(src.hud)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes mousetrap bombs have a 0.7 second activation delay when they go off in your hands and makes the inventory they are in still open when activated.
This makes it possible to throw in time to escape the explosion if you're expecting it, but still likely to catch you off guard if you are not.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
![image](https://user-images.githubusercontent.com/20713227/179775077-dfca8642-4b10-470f-b842-9434e18d1fa6.png)
![image](https://user-images.githubusercontent.com/20713227/179775957-15fa345a-6007-4814-8991-41141e5f17e9.png)
![image](https://user-images.githubusercontent.com/20713227/179775510-759f3c2d-724d-4c98-aeec-d81a2e5689eb.png)



## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Mousetrap bombs now have a short activation delay if they are set off in your hands.
```
