### PR TITLE
Add monospace say decoration for silicons

### DIFF
--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -363,6 +363,7 @@ h1.alert, h2.alert {color: #000000;}
 .adminHearing .name[data-ctx] {border-bottom: 1px dotted black;}
 .blobalert {color: #4c00ff; font-size: 1.5em; font-weight: bold;}
 .lawupdate {color: #6464ff}
+.monospace {font-family: monospace;}
 
 .rstandard {color: #008000;}
 .rintercom {color: #006080;}

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1199,7 +1199,7 @@
 			else
 				M.show_message(thisR, 2, assoc_maptext = chat_text)
 
-/mob/living/proc/say_decorate(var/message)
+/mob/living/proc/say_decorate(message)
 	return message
 
 // helper proooocs

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -769,6 +769,8 @@
 	// check for singing prefix before radio prefix
 	message = check_singing_prefix(message)
 
+	message = say_decorate(message)
+
 	var/italics = 0
 	var/forced_language = null
 	var/message_range = null
@@ -1196,6 +1198,9 @@
 					M.show_message(thisR, 2, assoc_maptext = chat_text)
 			else
 				M.show_message(thisR, 2, assoc_maptext = chat_text)
+
+/mob/living/proc/say_decorate(var/message)
+	return message
 
 // helper proooocs
 

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -23,6 +23,8 @@
 
 	var/obj/item/cell/cell = null
 
+	var/static/regex/monospace_say_regex = new(@"`([^`]+)`", "g")
+
 	can_bleed = 0
 	blood_id = "oil"
 	use_stamina = 0
@@ -236,8 +238,6 @@
 			return ..(message)
 	else
 		return ..(message)
-
-/mob/living/silicon/var/regex/monospace_say_regex = new(@"`([^`]+)`", "g")
 
 /mob/living/silicon/say_decorate(message)
 	. = monospace_say_regex.Replace(message, "<span class='monospace'>$1</span>")

--- a/code/mob/living/silicon.dm
+++ b/code/mob/living/silicon.dm
@@ -211,7 +211,6 @@
 			src.set_cursor('icons/cursors/shock.dmi')
 			return
 	return ..()
-
 /mob/living/silicon/say(var/message)
 	if (!message)
 		return
@@ -237,6 +236,11 @@
 			return ..(message)
 	else
 		return ..(message)
+
+/mob/living/silicon/var/regex/monospace_say_regex = new(@"`([^`]+)`", "g")
+
+/mob/living/silicon/say_decorate(message)
+	. = monospace_say_regex.Replace(message, "<span class='monospace'>$1</span>")
 
 /mob/living/proc/process_killswitch()
 	return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][feature] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Allows you to surround text with \` as a silicon to display the text in a monospace font kind of `like this`

![dreamseeker_UysdomyTIn](https://user-images.githubusercontent.com/14966486/179838064-21dc65a6-8a9d-4460-9f9e-60acefe3f307.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I thought it would be neat. Makes robots more robotic feeling by letting them add flair to their messages.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Luxizzle
(+)Silicons can now surround parts of their messages with ` to display it in a monospace font.
```
