### PR TITLE
Make synthorgans' Max Health and Failure Threshold scale by Endurance

### DIFF
--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -1250,9 +1250,12 @@
 					var/obj/critter/C = CROP
 					C.friends = C.friends | src.contributors
 
-				else if(istype(CROP,/obj/item/organ/heart))
-					var/obj/item/organ/heart/H = CROP
-					H.quality = quality_score
+				else if (istype(CROP,/obj/item/organ))
+					var/obj/item/organ/O = CROP
+					if(istype(CROP,/obj/item/organ/heart))
+						O.quality = quality_score
+					O.MAX_DAMAGE += DNA.endurance
+					O.FAIL_DAMAGE += DNA.endurance
 
 				else if(istype(CROP,/obj/item/reagent_containers/balloon))
 					var/obj/item/reagent_containers/balloon/B = CROP


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[ADD TO WIKI][FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a synthplant's Endurance to their synthorgans' Max Health and Failure Threshold.

This increases the power of Botanists who are willing to spend ~30-40 minutes to crank the Endurance of the synthmeat/synthorgans and do self-surgery, because it lets them tank more hot air/TOX damage/etc.

Note: You may wonder why Endurance is added to Failure Threshold instead of scaled `65/100` and then added. This is because at Endurance of ~1000, the organ would fail when it is more than 3 times healthier than a normal liver, which I felt is silly. The code is also simpler this way.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Gives Botanists a more of a reason to grow synthorgans. You can obviously use this to help shrug off chem cocktail organ damage, but I actually view this addition mostly for small gimmicks. Drink the clown under the table! Ride your sugar high! Laugh as your fellow crewmates scramble for internals while you simply tank the pipeburn-heated air!

## Changelog

```changelog
(u)maybeserendipitous
(*)Synthorgan max health and failure threshold increase with Endurance.
```
