### PR TITLE
Gives forensic scanners an option to print the report of the last scan they did.

### DIFF
--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -183,15 +183,15 @@ that cannot be itched
 
 				user.show_text("No match found in security records.", "red")
 				return
-		if("Print last scan")
-			if(!ON_COOLDOWN(src, "print", 2 SECOND))
-				playsound(src, "sound/machines/printer_thermal.ogg", 50, 1)
-				SPAWN(1 SECONDS)
-					var/obj/item/paper/P = new /obj/item/paper
-					P.set_loc(get_turf(src))
+			if("Print last scan")
+				if(!ON_COOLDOWN(src, "print", 2 SECOND))
+					playsound(src, "sound/machines/printer_thermal.ogg", 50, 1)
+					SPAWN(1 SECONDS)
+						var/obj/item/paper/P = new /obj/item/paper
+						P.set_loc(get_turf(src))
 
-					P.info = last_scan
-					P.name = "Forensic readout"
+						P.info = last_scan
+						P.name = "Forensic readout"
 
 
 	pixelaction(atom/target, params, mob/user, reach)

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -152,6 +152,9 @@ that cannot be itched
 	var/active = 0
 	var/distancescan = 0
 	var/target = null
+	var/last_scan = "No scans have been done yet."
+	var/printing = null
+
 
 	attack_self(mob/user as mob)
 
@@ -183,7 +186,8 @@ that cannot be itched
 		if(distancescan)
 			if(!(BOUNDS_DIST(user, target) == 0) && IN_RANGE(user, target, 3))
 				user.visible_message("<span class='notice'><b>[user]</b> takes a distant forensic scan of [target].</span>")
-				boutput(user, scan_forensic(target, visible = 1))
+				last_scan = scan_forensic(target, visible = 1)
+				boutput(user, last_scan)
 				src.add_fingerprint(user)
 
 	afterattack(atom/A as mob|obj|turf|area, mob/user as mob)
@@ -192,7 +196,8 @@ that cannot be itched
 			return
 
 		user.visible_message("<span class='alert'><b>[user]</b> has scanned [A].</span>")
-		boutput(user, scan_forensic(A, visible = 1)) // Moved to scanprocs.dm to cut down on code duplication (Convair880).
+		last_scan = scan_forensic(A, visible = 1) // Moved to scanprocs.dm to cut down on code duplication (Convair880).
+		boutput(user, last_scan)
 		src.add_fingerprint(user)
 
 		if(!active && istype(A, /obj/decal/cleanable/blood))
@@ -232,6 +237,21 @@ that cannot be itched
 				icon_state = "fs_pinfar"
 		SPAWN(0.5 SECONDS)
 			.(T)
+	verb/set_phrase()
+		set name = "Print last report"
+		set category = "Local"
+
+		if (!src.printing )
+			src.printing = 1
+			playsound(src, "sound/machines/printer_thermal.ogg", 50, 1)
+			SPAWN(1 SECONDS)
+				var/obj/item/paper/P = new /obj/item/paper
+				P.set_loc(get_turf(src))
+
+				P.info = last_scan
+				P.name = "Forensic readout"
+			src.printing = null
+
 
 /obj/item/device/detective_scanner/detective
 	name = "cool forensic scanner"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives forensic scanners an option to print the report of the last scan they did via a verb. If no scans have been made yet, prints a paper with a corresponding message.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
To make courts easier, more interesting and more realistic.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Chatauscours
(+)Forensic scanners can now print the copy of the last report.
```
