### PR TITLE
Antagonist datumization: mixed traitors, admin tools

### DIFF
--- a/_std/defines/antagonists.dm
+++ b/_std/defines/antagonists.dm
@@ -3,4 +3,4 @@
 #define ANTAGONIST_SOURCE_ROUND_START null
 #define ANTAGONIST_SOURCE_LATE_JOIN "late-joining "
 #define ANTAGONIST_SOURCE_RANDOM_EVENT "random event "
-#define ANTAGONIST_SOURCE_ADMIN null
+#define ANTAGONIST_SOURCE_ADMIN "admin-created "

--- a/browserassets/html/traitorTips/traitorTips.html
+++ b/browserassets/html/traitorTips/traitorTips.html
@@ -3,7 +3,7 @@
 	<h1 class="center">You are a traitor!</h1>
 	<img src="{{resource("images/antagTips/traitor-image.png")}}" class="center" />
 
-	<p>1. The Syndicate has provided you with a disguised uplink. It can either be your <em>PDA</em> or <em>headset</em>.</p>
+	<p>1. The Syndicate has provided you with a disguised uplink. It should be your <em>PDA</em> or <em>headset</em>, but it might be a <em>standalone unit</em> if nothing else is available.</p>
 
 	<p>2. The details and your objectives will always be stored in your notes. To access them, use the <em>Notes</em> verb.</p>
 
@@ -23,6 +23,13 @@
 			2. Dial in the frequency assigned to you.<br>
 			3. Press the 'Lock' button after you're done buying the items.<br>
 			4. It will now function as a regular headset again.
+		</span>
+	</p>
+	<p>
+		4. To unlock a <em>standalone uplink</em>:<br>
+		<span class="small indent">
+			1. Put the uplink into an empty hand and click on it.<br>
+			2. Enter the password.
 		</span>
 	</p>
 

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -312,7 +312,7 @@
 		return candidates
 
 /// Set up an antag with default equipment, objectives etc as they would be in mixed
-/datum/game_mode/proc/equip_antag(var/datum/mind/antag)
+/datum/game_mode/proc/equip_antag(datum/mind/antag)
 	var/objective_set_path = null
 
 	if (antag.assigned_role == "Chaplain" && antag.special_role == ROLE_VAMPIRE)
@@ -324,12 +324,7 @@
 
 	switch (antag.special_role)
 		if (ROLE_TRAITOR)
-		#ifdef RP_MODE
-			objective_set_path = pick(typesof(/datum/objective_set/traitor/rp_friendly))
-		#else
-			objective_set_path = pick(typesof(/datum/objective_set/traitor))
-		#endif
-			equip_traitor(antag.current)
+			antag.add_antagonist(ROLE_TRAITOR)
 
 		if (ROLE_CHANGELING)
 			objective_set_path = /datum/objective_set/changeling

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -240,7 +240,7 @@ datum/mind
 			if (initial(A.id) == role_id)
 				src.antagonists.Add(new A(src, do_equip, do_objectives, do_relocate, silent, source))
 				src.current.antagonist_overlay_refresh(TRUE, FALSE)
-				return TRUE
+				return !isnull(src.get_antagonist(role_id))
 		return FALSE
 
 	/// Attempts to remove existing antagonist datums of ID role_id from this mind.
@@ -248,7 +248,10 @@ datum/mind
 		for (var/datum/antagonist/A as anything in src.antagonists)
 			if (A.id == role_id)
 				A.remove_self(TRUE, FALSE)
-				antagonists.Remove(A)
+				src.antagonists.Remove(A)
+				if (!length(src.antagonists) && src.special_role == A.id)
+					src.special_role = null
+					ticker.mode.traitors.Remove(src)
 				qdel(A)
 				return TRUE
 		return FALSE
@@ -259,6 +262,8 @@ datum/mind
 			A.remove_self(TRUE, FALSE)
 			src.antagonists.Remove(A)
 			qdel(A)
+		src.special_role = null
+		ticker.mode.traitors.Remove(src)
 		return length(src.antagonists) <= 0
 
 	disposing()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -2218,6 +2218,76 @@ var/global/noir = 0
 			else
 				tgui_alert(usr,"Cannot make this mob a traitor")
 
+		if ("add_antagonist")
+			if (src.level < LEVEL_PA)
+				tgui_alert(usr, "You must be at least a Primary Administrator to change someone's antagonist status.")
+				return
+			var/mob/M = locate(href_list["targetmob"])
+			if (!M?.mind)
+				return
+			var/list/antag_options = list()
+			for (var/V as anything in concrete_typesof(/datum/antagonist))
+				var/datum/antagonist/A = V
+				if (!M.mind.get_antagonist(initial(A.id)))
+					antag_options[initial(A.display_name)] = initial(A.id)
+			if (!length(antag_options))
+				boutput(usr, "<span class='alert'>Antagonist assignment failed - no valid antagonist roles exist.</span>")
+				return
+			for (var/V as anything in M.mind.antagonists)
+				var/datum/antagonist/A = V
+				if (A.mutually_exclusive)
+					if (tgui_alert(usr, "[M.real_name] (ckey [M.ckey]) has an antagonist role that will not naturally occur with others. Proceed anyway? This might cause !!FUN!! interactions.", "Force Antagonist", list("Yes", "Cancel")) != "Yes")
+						return
+				break
+			var/selected_keyvalue = tgui_input_list(usr, "Choose an antagonist role to assign.", "Add Antagonist", antag_options)
+			var/do_equipment = tgui_alert(usr, "Equip the antagonist with uplinks, special abilities, etc.?", "Add Antagonist", list("Yes", "No", "Cancel"))
+			if (do_equipment == "Cancel")
+				return
+			var/do_objectives = tgui_alert(usr, "Assign randomly-generated objectives?", "Add Antagonist", list("Yes", "No", "Cancel"))
+			if (do_objectives == "Cancel" || !M?.mind || !selected_keyvalue)
+				return
+			if (tgui_alert(usr, "[M.real_name] (ckey [M.ckey]) will immediately become \a [selected_keyvalue]. Equipment and abilities will[do_equipment == "Yes" ? "" : " NOT"] be added. Objectives will [do_objectives == "Yes" ? "be generated automatically" : "not be present"]. Is this what you want?", "Add Antagonist", list("Make it so.", "Cancel.")) != "Make it so.") // This is definitely not ideal, but it's what we have for now
+				return
+			boutput(usr, "<span class='notice'>Adding antagonist of type \"[selected_keyvalue]\" to mob [M.real_name] (ckey [M.ckey])...</span>")
+			var/success = M.mind.add_antagonist(antag_options[selected_keyvalue], do_equipment == "Yes", do_objectives == "Yes", source = ANTAGONIST_SOURCE_ADMIN, respect_mutual_exclusives = FALSE)
+			if (success)
+				boutput(usr, "<span class='notice'>Addition successful. [M.real_name] (ckey [M.ckey]) is now \a [selected_keyvalue].</span>")
+			else
+				boutput(usr, "<span class='alert'>Addition failed with return code [success]. The mob may be incompatible. Report this to a coder.</span>")
+
+		if ("remove_antagonist")
+			if (src.level < LEVEL_PA)
+				tgui_alert(usr, "You must be at least a Primary Administrator to change someone's antagonist status.")
+				return
+			var/datum/antagonist/antag = locate(href_list["target_antagonist"])
+			var/mob/M = locate(href_list["targetmob"])
+			if (!antag || !M?.mind)
+				return
+			if (tgui_alert(usr, "Remove the [antag.display_name] antagonist from [M.real_name] (ckey [M.ckey])?", "antagonist", list("Yes", "Cancel")) != "Yes")
+				return
+			boutput(usr, "<span class='notice'>Removing antagonist of type \"[antag.id]\" from mob [M.real_name] (ckey [M.ckey])...</span>")
+			var/success = M.mind.remove_antagonist(antag.id)
+			if (success)
+				boutput(usr, "<span class='notice'>Removal successful.[length(M.mind.antagonists) ? "" : " As this was [M.real_name] (ckey [M.ckey])'s only antagonist role, their antagonist status is now fully removed."]</span>")
+			else
+				boutput(usr, "<span class='alert'>Removal failed with return code [success]; report this to a coder.</span>")
+		
+		if ("wipe_antagonists")
+			if (src.level < LEVEL_PA)
+				tgui_alert(usr, "You must be at least a Primary Administrator to change someone's antagonist status.")
+				return
+			var/mob/M = locate(href_list["targetmob"])
+			if (!M?.mind)
+				return
+			if (tgui_alert(usr, "Really remove all antagonists from [M.real_name] (ckey [M.ckey])?", "antagonist", list("Yes", "Cancel")) != "Yes")
+				return
+			boutput(usr, "<span class='notice'>Removing all antagonist statuses from [M.real_name] (ckey [M.ckey])...</span>")
+			var/success = M.mind.wipe_antagonists()
+			if (success)
+				boutput(usr, "<span class='notice'>Removal successful. [M.real_name] (ckey [M.ckey]) is no longer an antagonist.")
+			else
+				boutput(usr, "<span class='alert'>Removal failed with return code [success]; report this to a coder.</span>")
+
 		if ("create_object")
 			if (src.level >= LEVEL_SA)
 				create_object(usr)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -2240,7 +2240,9 @@ var/global/noir = 0
 						return
 				break
 			var/selected_keyvalue = tgui_input_list(usr, "Choose an antagonist role to assign.", "Add Antagonist", antag_options)
-			var/do_equipment = tgui_alert(usr, "Equip the antagonist with uplinks, special abilities, etc.?", "Add Antagonist", list("Yes", "No", "Cancel"))
+			if (!selected_keyvalue)
+				return
+			var/do_equipment = tgui_alert(usr, "Give the antagonist its default equipment? (Uplinks, clothing, special abilities, etc.)", "Add Antagonist", list("Yes", "No", "Cancel"))
 			if (do_equipment == "Cancel")
 				return
 			var/do_objectives = tgui_alert(usr, "Assign randomly-generated objectives?", "Add Antagonist", list("Yes", "No", "Cancel"))

--- a/code/modules/admin/player_options.dm
+++ b/code/modules/admin/player_options.dm
@@ -76,15 +76,24 @@
 
 	//Antag roles (yes i said antag jeez shut up about it already)
 	var/antag
-	if (M.mind && M.mind.special_role != null)
-		antag = {"
-		<a href='[playeropt_link(M, "traitor")]' class='antag'>[M.mind.special_role]</a> &mdash;
-		<a href='[playeropt_link(M, "remove_traitor")]' class='antag'>Remove</a>
-		"}
-	else if (!isobserver(M))
-		antag = "<a href='[playeropt_link(M, "traitor")]'>Make Antagonist</a>"
-	else
-		antag = "Observer"
+	if (M.mind)
+		var/antag_len = length(M.mind.antagonists)
+		if (antag_len)
+			antag = "<b>[antag_len] antagonist role\s present.</b><br>"
+			for (var/datum/antagonist/this_antag as anything in M.mind.antagonists)
+				antag += "[this_antag.display_name] &mdash; <a href='?src=\ref[src];action=remove_antagonist;targetmob=\ref[M];target_antagonist=\ref[this_antag]'>Remove</a><br>"
+			antag += "<a href='?src=\ref[src];targetmob=\ref[M];action=add_antagonist'>Add Antagonist Role</a><br>"
+			antag += "<a href='?src=\ref[src];targetmob=\ref[M];action=wipe_antagonists'>Remove All Antagonist Roles</a><br>"
+		else if (M.mind.special_role != null)
+			antag = {"
+			<a href='[playeropt_link(M, "traitor")]' class='antag'>[M.mind.special_role]</a> &mdash;
+			<a href='[playeropt_link(M, "remove_traitor")]' class='antag'>Remove</a>
+			"}
+		else if (!isobserver(M))
+			antag = "<a href='[playeropt_link(M, "traitor")]'>Make Antagonist</a>"
+			antag += "<br><a href='?src=\ref[src];targetmob=\ref[M];action=add_antagonist'>Add Antagonist Role (New system, WIP)</a><br>"
+		else
+			antag = "Observer"
 
 	//General info
 	//  Logs link:

--- a/code/modules/antagonists/__antagonist.dm
+++ b/code/modules/antagonists/__antagonist.dm
@@ -25,6 +25,9 @@ ABSTRACT_TYPE(/datum/antagonist)
 			message_admins("Antagonist datum of type [src.type] and usr [usr] attempted to spawn without a mind. This should never happen!!")
 			qdel(src)
 			return FALSE
+		if (!src.is_compatible_with(new_owner))
+			qdel(src)
+			return FALSE
 		owner = new_owner
 		new_owner.special_role = id
 		src.setup_antagonist(do_equip, do_objectives, do_relocate, silent, source)
@@ -41,7 +44,7 @@ ABSTRACT_TYPE(/datum/antagonist)
 			owner.former_antagonist_roles.Add(owner.special_role)
 			owner.special_role = null
 
-	/// Returns TRUE if this antagonist can be assigned to the given mind, and FALSE otherwise. This is intended to be overriden by subtypes; mutual exclusivity and other selection logic is not performed here. 
+	/// Returns TRUE if this antagonist can be assigned to the given mind, and FALSE otherwise. This is intended to be special logic, overriden by subtypes; mutual exclusivity and other selection logic is not performed here. 
 	proc/is_compatible_with(datum/mind/mind)
 		return TRUE
 

--- a/code/modules/antagonists/traitor/traitor.dm
+++ b/code/modules/antagonists/traitor/traitor.dm
@@ -21,6 +21,9 @@
 		if (istype(H.belt, /obj/item/device/pda2) || istype(H.belt, /obj/item/device/radio))
 			uplink_source = H.belt
 			loc_string = "on your belt"
+		else if (istype(H.wear_id, /obj/item/device/pda2))
+			uplink_source = H.wear_id
+			loc_string = "in your ID slot"
 		else if (istype(H.r_store, /obj/item/device/pda2))
 			uplink_source = H.r_store
 			loc_string = "in your pocket"
@@ -45,7 +48,10 @@
 			src.uplink = S
 			uplink_source = S
 			S.lock_code_autogenerate = TRUE
-			loc_string = "on the ground beneath you"
+			if (!(H.equip_if_possible(S, H.slot_in_backpack)))
+				loc_string = "on the ground beneath you"
+			else
+				loc_string = "in [H.back] on your back"
 		uplink.setup(src.owner, uplink_source)
 
 		// step 3 of uplinkification: inform the player about it and store the code in their memory
@@ -73,12 +79,8 @@
 		if (!override) // Display a different popup depending on the type of uplink we got
 			if (!uplink)
 				override = "traitorhard"
-			else if (istype(uplink, /obj/item/uplink/integrated/pda))
-				override = "traitorpda"
-			else if (istype(uplink, /obj/item/uplink/integrated/radio))
-				override = "traitorradio"
 			else
-				override = "traitorgeneric"
+				override = "traitorpda"
 		..(override)
 
 	handle_round_end(log_data)

--- a/strings/admin_changelog.txt
+++ b/strings/admin_changelog.txt
@@ -1,3 +1,6 @@
+(t)tue jul 19 22
+(u)Ilysen
+(*)Started integrating the new antagonist system with the player panel. Development is still ongoing, but at bare minimum admins should be able to add and remove traitor status from people now.
 (t)tue jun 14 22
 (u)LeahTheTech
 (*)Added flockgib verb and player option


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR further expands the system introduced in #9366. After an initial hiccup (see #9684), I haven't heard any more issue reports about the system, so I felt it was time to cast a wider net.
* Roundstart traitors in the mixed gametypes will now use antagonists datums. **Mid-round traitors still use the old system.**
* Partially implemented manipulation of antagonist datums to the player panel. Admins can add or remove antagonists from a player, with our without their equipment and objectives.
  * Admin-created antagonists appear differently in the end-round summary.
* Refined the traitor datum a bit; standalone uplinks will try to appear in your backpack instead of on the ground, and the popups displayed are now more astute (the names were misleading, oops!)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

The antag datumization system *seems* to be working more or less smoothly so far, and I'd like to keep expanding it. The rationale of the system is the same as it was in the original PR: compartmentalization and updating of antagonist logic is sorely needed.

In spite of that, I still want to be super sure that the system is working before I migrate more involved antagonists over, like changeling and vampire, so I wanted to do a smaller expansion of the existing one. Traitors should now be datum antagonists far more often, but are still not as likely to break something as a more expansive inclusion like another antagonist type.

## Testing

I used admin tools to add and remove antagonists to myself with several different combinations of objectives and equipment, as well as readying up for intrigue rounds on the local server. When rolling traitor, I'd get the datum; for other things like arcfiend, it used the old system.

I'm sure there's gonna be stuff I missed. Hopefully it's nothing too bad. :P

![dreamseeker_7TPiLjHW9p](https://user-images.githubusercontent.com/47678781/179860077-b10c0e93-0df5-412e-a16b-9a47ed88f287.png)
![dreamseeker_HtkbER0a3l](https://user-images.githubusercontent.com/47678781/179860078-a87e8754-c3c7-485c-92af-f646e6f2e0c5.png)

## Changelog
N/A