### PR TITLE
Comsig item consume fix

### DIFF
--- a/_std/defines/component_defines/component_defines_atom.dm
+++ b/_std/defines/component_defines/component_defines_atom.dm
@@ -99,13 +99,13 @@
 	#define COMSIG_ITEM_DROPPED "itm_drop"
 	/// When an item is used to attack a mob
 	#define COMSIG_ITEM_ATTACK_POST "itm_atk_post"
-	/// Just before an item is eaten
+	/// Just before an item is eaten (eater,item)
 	#define COMSIG_ITEM_CONSUMED_PRE "itm_atk_consumed_pre"
-	/// When an item is eaten
+	/// When an item is eaten (eater,item)
 	#define COMSIG_ITEM_CONSUMED "itm_atk_consumed"
-	/// After an item's been eaten, but there's still some left
+	/// After an item's been eaten, but there's still some left (eater,item)
 	#define COMSIG_ITEM_CONSUMED_PARTIAL "itm_atk_consumed_partial"
-	/// After we've consumed an item
+	/// After we've consumed an item (eater,item)
 	#define COMSIG_ITEM_CONSUMED_ALL "itm_atk_consumed_all"
 	/// Called before an attackby that uses this item (target, user)
 	#define COMSIG_ITEM_ATTACKBY_PRE "itm_atkby_pre"
@@ -157,6 +157,10 @@
 	#define COMSIG_MOB_PICKUP "mob_pickup"
 	/// When a mob drops an item
 	#define COMSIG_MOB_DROPPED "mob_drop"
+	/// Just before an item is eaten (feeder,item)
+	#define COMSIG_MOB_ITEM_CONSUMED_PRE "mob_itm_atk_consumed_pre"
+	/// When an item is eaten (feeder,item)
+	#define COMSIG_MOB_ITEM_CONSUMED "mob_itm_atk_consumed"
 	/// Sent when a mob throws something (target, params)
 	#define COMSIG_MOB_THROW_ITEM "throw_item"
 	/// Sent when a mob throws something that lands nearby

--- a/code/datums/components/food_stuff.dm
+++ b/code/datums/components/food_stuff.dm
@@ -20,7 +20,7 @@ TYPEINFO(/datum/component/consume/can_eat_inedible_organs)
 /datum/component/consume/can_eat_inedible_organs/Initialize(var/can_eat_heads)
 	..()
 	src.can_eat_heads = can_eat_heads
-	RegisterSignal(parent, list(COMSIG_ITEM_CONSUMED_PRE), .proc/is_it_organs)
+	RegisterSignal(parent, list(COMSIG_MOB_ITEM_CONSUMED_PRE), .proc/is_it_organs)
 
 /datum/component/consume/can_eat_inedible_organs/proc/is_it_organs(var/mob/M, var/mob/user, var/obj/item/I)
 	if (istype(I, /obj/item/skull) || (istype(I, /obj/item/organ/head) && can_eat_heads)) // skulls, heads
@@ -29,7 +29,7 @@ TYPEINFO(/datum/component/consume/can_eat_inedible_organs)
 		return 0
 
 /datum/component/consume/can_eat_inedible_organs/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_ITEM_CONSUMED_PRE)
+	UnregisterSignal(parent, COMSIG_MOB_ITEM_CONSUMED_PRE)
 	. = ..()
 
 /datum/component/consume/organpoints
@@ -43,7 +43,7 @@ TYPEINFO(/datum/component/consume/organpoints)
 /datum/component/consume/organpoints/Initialize(var/target_abilityholder)
 	..()
 	src.target_abilityholder = target_abilityholder
-	RegisterSignal(parent, list(COMSIG_ITEM_CONSUMED), .proc/eat_organ_get_points)
+	RegisterSignal(parent, list(COMSIG_MOB_ITEM_CONSUMED), .proc/eat_organ_get_points)
 
 /datum/component/consume/organpoints/proc/eat_organ_get_points(var/mob/M, var/mob/user, var/obj/item/I)
 	if (!I || !M || !ishuman(M) || !user)
@@ -145,7 +145,7 @@ TYPEINFO(/datum/component/consume/organpoints)
 		L.abilityHolder.addPoints(add_these_points, target_abilityholder)
 
 /datum/component/consume/organpoints/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_ITEM_CONSUMED)
+	UnregisterSignal(parent, COMSIG_MOB_ITEM_CONSUMED)
 	. = ..()
 
 
@@ -161,7 +161,7 @@ TYPEINFO(/datum/component/consume/organheal)
 /datum/component/consume/organheal/Initialize(var/mod_mult)
 	..()
 	src.mod_mult = mod_mult
-	RegisterSignal(parent, list(COMSIG_ITEM_CONSUMED), .proc/eat_organ_get_heal)
+	RegisterSignal(parent, list(COMSIG_MOB_ITEM_CONSUMED), .proc/eat_organ_get_heal)
 
 /datum/component/consume/organheal/proc/eat_organ_get_heal(var/mob/M, var/mob/user, var/obj/item/I)
 	if (!I || !M || !user)
@@ -254,7 +254,7 @@ TYPEINFO(/datum/component/consume/organheal)
 
 
 /datum/component/consume/organheal/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_ITEM_CONSUMED)
+	UnregisterSignal(parent, COMSIG_MOB_ITEM_CONSUMED)
 	. = ..()
 
 

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -378,7 +378,7 @@
 	if (M?.bioHolder && !M.bioHolder.HasEffect("mattereater"))
 		if(ON_COOLDOWN(M, "eat", EAT_COOLDOWN))
 			return 0
-	var/edibility_override = SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED_PRE, user, src)
+	var/edibility_override = SEND_SIGNAL(M, COMSIG_MOB_ITEM_CONSUMED_PRE, user, src)
 	var/can_matter_eat = by_matter_eater && (M == user) && M.bioHolder.HasEffect("mattereater")
 	var/edible_check = src.edible || (src.material?.edible) || (edibility_override & FORCE_EDIBILITY)
 	if (!edible_check && !can_matter_eat)
@@ -401,7 +401,8 @@
 		SPAWN(0.6 SECOND)
 			if (!src || !M || !user)
 				return
-			SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED, user, src)
+			SEND_SIGNAL(M, COMSIG_MOB_ITEM_CONSUMED, user, src) //one to the mob
+			SEND_SIGNAL(src, COMSIG_ITEM_CONSUMED, M, src) //one to the item
 			user.u_equip(src)
 			qdel(src)
 		return 1
@@ -435,7 +436,8 @@
 		SPAWN(1 SECOND)
 			if (!src || !M || !user)
 				return
-			SEND_SIGNAL(M, COMSIG_ITEM_CONSUMED, user, src)
+			SEND_SIGNAL(M, COMSIG_MOB_ITEM_CONSUMED, user, src) //one to the mob
+			SEND_SIGNAL(src, COMSIG_ITEM_CONSUMED, M, src) //one to the item
 			user.u_equip(src)
 			qdel(src)
 		return 1

--- a/code/obj/item.dm
+++ b/code/obj/item.dm
@@ -378,7 +378,7 @@
 	if (M?.bioHolder && !M.bioHolder.HasEffect("mattereater"))
 		if(ON_COOLDOWN(M, "eat", EAT_COOLDOWN))
 			return 0
-	var/edibility_override = SEND_SIGNAL(M, COMSIG_MOB_ITEM_CONSUMED_PRE, user, src)
+	var/edibility_override = SEND_SIGNAL(M, COMSIG_MOB_ITEM_CONSUMED_PRE, user, src) || SEND_SIGNAL(src, COMSIG_ITEM_CONSUMED_PRE, M, user)
 	var/can_matter_eat = by_matter_eater && (M == user) && M.bioHolder.HasEffect("mattereater")
 	var/edible_check = src.edible || (src.material?.edible) || (edibility_override & FORCE_EDIBILITY)
 	if (!edible_check && !can_matter_eat)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a few signals which were confusingly defined. The `COMSIG_ITEM_CONSUMED` signals operated on mobs, while all other `ITEM` signals operate on items. I added new signals `COMSIG_MOB_ITEM_CONSUMED` and redefined the behaviour of `COMSIG_ITEM_CONSUMED` as appropriate. 
This was only used in one place anyway, but the radiation component makes use of the behaviour and it ought to work right.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
#9741 
