### PR TITLE
Fixed a runtime when setting time with nukeman

### DIFF
--- a/code/modules/networks/computer3/mainframe2/os_drivers.dm
+++ b/code/modules/networks/computer3/mainframe2/os_drivers.dm
@@ -1064,7 +1064,7 @@
 				if (!isnum(data["time"]))
 					return ESIG_GENERIC
 
-				var/newtime = clamp("time", 0, MAX_NUKE_TIME)
+				var/newtime = clamp(data["time"], MIN_NUKE_TIME, MAX_NUKE_TIME)
 
 				var/sessionid = "[world.timeofday%100][rand(0,9)]"
 				message_device("command=settime&time=[newtime]&session=[sessionid]")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When using nukeman setting the time of the nuclear charge would cause an in-game driver error and a runtime on the server. Tested fix on a local server.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Runtimes are bad.