### PR TITLE
Added two random rooms: "tomato" and "plushbridge" 

### DIFF
--- a/assets/maps/random_rooms/3x3/tomato.dmm
+++ b/assets/maps/random_rooms/3x3/tomato.dmm
@@ -1,0 +1,86 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/decal/cleanable/blood/tracks,
+/turf/simulated/floor/airless/plating,
+/area/dmm_suite/clear_area)
+"n" = (
+/obj/item/skull{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/decal/cleanable/blood/gibs,
+/turf/simulated/floor/airless/plating,
+/area/dmm_suite/clear_area)
+"s" = (
+/obj/decal/fakeobjects/skeleton{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/decal/cleanable/blood,
+/turf/simulated/floor/airless/plating,
+/area/dmm_suite/clear_area)
+"t" = (
+/obj/item/seed/grass{
+	auxillary_datum = /datum/plant/vegetable/tomato;
+	name = "tomato seed";
+	pixel_x = 3;
+	pixel_y = 35
+	},
+/turf/simulated/floor/airless/plating,
+/area/dmm_suite/clear_area)
+"u" = (
+/obj/item/seed/grass{
+	auxillary_datum = /datum/plant/vegetable/tomato;
+	name = "tomato seed";
+	pixel_x = 3;
+	pixel_y = -32
+	},
+/turf/simulated/floor/airless/plating,
+/area/dmm_suite/clear_area)
+"F" = (
+/obj/decal/cleanable/tomatosplat,
+/obj/item/reagent_containers/food/snacks/plant/tomato{
+	pixel_y = 8
+	},
+/obj/item/kitchen/utensil/knife/plastic{
+	pixel_x = 6;
+	layer = 1
+	},
+/obj/decal/cleanable/blood/tracks,
+/obj/item/paper{
+	layer = 0;
+	pixel_x = 7;
+	pixel_y = -7;
+	info = ">:(";
+	name = "tomato-soaked paper"
+	},
+/turf/simulated/floor/airless/plating,
+/area/dmm_suite/clear_area)
+"M" = (
+/obj/item/seed/grass{
+	auxillary_datum = /datum/plant/vegetable/tomato;
+	name = "tomato seed";
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/turf/simulated/floor/airless/plating,
+/area/dmm_suite/clear_area)
+"W" = (
+/turf/simulated/floor/airless/plating,
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+M
+u
+s
+"}
+(2,1,1) = {"
+a
+F
+W
+"}
+(3,1,1) = {"
+n
+t
+W
+"}

--- a/assets/maps/random_rooms/5x3/plushbridge.dmm
+++ b/assets/maps/random_rooms/5x3/plushbridge.dmm
@@ -40,7 +40,7 @@
 /area/dmm_suite/clear_area)
 "m" = (
 /obj/item/toy/plush/small{
-	name = "Dr.Fluffikins";
+	name = "Isabelle Bearnadotte";
 	rand_pos = 0
 	},
 /obj/item/clothing/head/nursehat{

--- a/assets/maps/random_rooms/5x3/plushbridge.dmm
+++ b/assets/maps/random_rooms/5x3/plushbridge.dmm
@@ -40,7 +40,7 @@
 /area/dmm_suite/clear_area)
 "m" = (
 /obj/item/toy/plush/small{
-	name = "Isabelle Bearnadotte";
+	name = "Doctor Isabear";
 	rand_pos = 0
 	},
 /obj/item/clothing/head/nursehat{

--- a/assets/maps/random_rooms/5x3/plushbridge.dmm
+++ b/assets/maps/random_rooms/5x3/plushbridge.dmm
@@ -1,79 +1,87 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/decoration/decorativeplant/plant3,
+/obj/decoration/decorativeplant/plant3{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/decal/cleanable/leaves{
+	pixel_y = -1;
+	pixel_x = -3
+	},
 /turf/simulated/floor/airless/blue/corner{
 	dir = 4
 	},
 /area/dmm_suite/clear_area)
 "c" = (
 /obj/table/wood/round/auto,
-/obj/item/reagent_containers/food/drinks/bottle/champagne/breakaway_glass{
-	pixel_y = 12;
-	pixel_x = 4;
-	reagents = apple_juice
+/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
+	pixel_y = 7;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/flute{
+	pixel_y = 8;
+	pixel_x = -7
 	},
 /turf/simulated/floor/carpet/blue/fancy/innercorner/west,
 /area/dmm_suite/clear_area)
 "g" = (
-/obj/stool/chair/green{
-	dir = 8
-	},
 /obj/item/toy/plush/small/bunny{
-	pixel_y = 3
+	name = "Hop";
+	rand_pos = 0
 	},
 /obj/item/pen/crayon/random{
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -5;
+	rand_pos = 0
 	},
+/obj/stool/bench/green/auto,
+/obj/decal/cleanable/paper,
 /turf/simulated/floor/carpet/blue/fancy/edge/nw,
 /area/dmm_suite/clear_area)
 "m" = (
-/obj/stool/chair/blue{
-	dir = 8
-	},
 /obj/item/toy/plush/small{
-	pixel_y = 6
+	name = "Dr.Fluffikins";
+	rand_pos = 0
 	},
 /obj/item/clothing/head/nursehat{
-	pixel_y = 16
+	pixel_y = 11
 	},
+/obj/stool/bench/blue/auto,
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/dmm_suite/clear_area)
 "n" = (
-/obj/stool/chair/red{
-	dir = 8
-	},
 /obj/item/toy/plush/small/buddy{
-	pixel_x = -2;
-	pixel_y = 1
+	name = "D'aww Bringer";
+	rand_pos = 0
 	},
 /obj/item/clothing/head/NTberet{
-	pixel_y = 8;
-	pixel_x = -1
+	pixel_y = 7;
+	pixel_x = 1
 	},
+/obj/stool/bench/red/auto,
 /turf/simulated/floor/carpet/blue,
 /area/dmm_suite/clear_area)
 "t" = (
-/obj/stool/chair/yellow{
-	dir = 8
-	},
 /obj/item/toy/plush/small/singuloose{
-	pixel_x = -1;
-	pixel_y = 1
+	pixel_y = -1;
+	name = "Singuloose the Engineer";
+	rand_pos = 0
 	},
 /obj/item/clothing/head/helmet/hardhat{
-	pixel_x = -1;
-	pixel_y = 6
+	pixel_y = 3
 	},
+/obj/stool/bench/yellow/auto,
+/obj/decal/cleanable/oil,
 /turf/simulated/floor/carpet/blue/fancy/edge/sw,
 /area/dmm_suite/clear_area)
 "x" = (
-/obj/machinery/light/incandescent/cool{
-	dir = 1;
-	pixel_y = 12
-	},
 /obj/table/wood,
 /obj/machinery/computer/security/wooden_tv/small{
 	pixel_y = 8
+	},
+/obj/decal/poster/wallsign/poster_nt{
+	pixel_y = 34;
+	pixel_x = -7
 	},
 /turf/simulated/floor/airless/blue/side,
 /area/dmm_suite/clear_area)
@@ -84,6 +92,13 @@
 	pixel_x = -2
 	},
 /obj/decal/cleanable/dirt/dirt3,
+/obj/decal/poster/wallsign/no_smoking{
+	pixel_y = 26;
+	pixel_x = 7
+	},
+/obj/decal/cleanable/cobweb{
+	layer = 14
+	},
 /turf/simulated/floor/airless/blue/corner,
 /area/dmm_suite/clear_area)
 "N" = (
@@ -108,33 +123,36 @@
 /area/dmm_suite/clear_area)
 "P" = (
 /obj/stool/bee_bed{
-	pixel_y = 8
+	pixel_y = 4
 	},
 /obj/item/toy/plush/small/bee/cute{
-	pixel_y = 5;
-	dir = 3
+	dir = 3;
+	name = "Captain Buzz";
+	rand_pos = 0
 	},
 /obj/item/clothing/head/fancy/captain{
 	pixel_x = -1;
-	pixel_y = 10
+	pixel_y = 5
 	},
 /turf/simulated/floor/carpet/blue/fancy/narrow/west,
 /area/dmm_suite/clear_area)
 "Q" = (
+/obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/floor/carpet/blue/fancy/edge/east,
 /area/dmm_suite/clear_area)
 "R" = (
 /obj/decal/cleanable/dirt/dirt2,
+/obj/item/clothing/suit/cardboard_box/ai,
 /turf/simulated/floor/carpet/blue/fancy/edge/ne,
 /area/dmm_suite/clear_area)
 "T" = (
-/obj/stool/chair{
-	dir = 8
+/obj/item/toy/plush/small/monkey{
+	name = "Dr.Monke";
+	rand_pos = 0
 	},
-/obj/item/toy/plush/small/monkey,
-/obj/item/reagent_containers/vending/vial/random{
-	pixel_x = 7;
-	pixel_y = -2
+/obj/stool/bench/auto,
+/obj/item/reagent_containers/dropper{
+	pixel_y = -4
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge/south,
 /area/dmm_suite/clear_area)
@@ -145,8 +163,8 @@
 /area/dmm_suite/clear_area)
 "Z" = (
 /obj/decal/cleanable/dirt/jen,
-/obj/machinery/light/incandescent/cool{
-	pixel_y = -12
+/obj/machinery/light/small{
+	pixel_y = -5
 	},
 /turf/simulated/floor/airless/blue/side{
 	dir = 1

--- a/assets/maps/random_rooms/5x3/plushbridge.dmm
+++ b/assets/maps/random_rooms/5x3/plushbridge.dmm
@@ -1,0 +1,180 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/decoration/decorativeplant/plant3,
+/turf/simulated/floor/airless/blue/corner{
+	dir = 4
+	},
+/area/dmm_suite/clear_area)
+"c" = (
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/drinks/bottle/champagne/breakaway_glass{
+	pixel_y = 12;
+	pixel_x = 4;
+	reagents = apple_juice
+	},
+/turf/simulated/floor/carpet/blue/fancy/innercorner/west,
+/area/dmm_suite/clear_area)
+"g" = (
+/obj/stool/chair/green{
+	dir = 8
+	},
+/obj/item/toy/plush/small/bunny{
+	pixel_y = 3
+	},
+/obj/item/pen/crayon/random{
+	pixel_x = -6
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/nw,
+/area/dmm_suite/clear_area)
+"m" = (
+/obj/stool/chair/blue{
+	dir = 8
+	},
+/obj/item/toy/plush/small{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/nursehat{
+	pixel_y = 16
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/north,
+/area/dmm_suite/clear_area)
+"n" = (
+/obj/stool/chair/red{
+	dir = 8
+	},
+/obj/item/toy/plush/small/buddy{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/clothing/head/NTberet{
+	pixel_y = 8;
+	pixel_x = -1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/dmm_suite/clear_area)
+"t" = (
+/obj/stool/chair/yellow{
+	dir = 8
+	},
+/obj/item/toy/plush/small/singuloose{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/clothing/head/helmet/hardhat{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/sw,
+/area/dmm_suite/clear_area)
+"x" = (
+/obj/machinery/light/incandescent/cool{
+	dir = 1;
+	pixel_y = 12
+	},
+/obj/table/wood,
+/obj/machinery/computer/security/wooden_tv/small{
+	pixel_y = 8
+	},
+/turf/simulated/floor/airless/blue/side,
+/area/dmm_suite/clear_area)
+"J" = (
+/obj/table/wood,
+/obj/item/item_box/medical_patches{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor/airless/blue/corner,
+/area/dmm_suite/clear_area)
+"N" = (
+/obj/table/wood,
+/obj/item/folder{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/paper{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/paper{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/pen/pencil{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/se,
+/area/dmm_suite/clear_area)
+"P" = (
+/obj/stool/bee_bed{
+	pixel_y = 8
+	},
+/obj/item/toy/plush/small/bee/cute{
+	pixel_y = 5;
+	dir = 3
+	},
+/obj/item/clothing/head/fancy/captain{
+	pixel_x = -1;
+	pixel_y = 10
+	},
+/turf/simulated/floor/carpet/blue/fancy/narrow/west,
+/area/dmm_suite/clear_area)
+"Q" = (
+/turf/simulated/floor/carpet/blue/fancy/edge/east,
+/area/dmm_suite/clear_area)
+"R" = (
+/obj/decal/cleanable/dirt/dirt2,
+/turf/simulated/floor/carpet/blue/fancy/edge/ne,
+/area/dmm_suite/clear_area)
+"T" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/item/toy/plush/small/monkey,
+/obj/item/reagent_containers/vending/vial/random{
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge/south,
+/area/dmm_suite/clear_area)
+"X" = (
+/turf/simulated/floor/airless/blue/side{
+	dir = 4
+	},
+/area/dmm_suite/clear_area)
+"Z" = (
+/obj/decal/cleanable/dirt/jen,
+/obj/machinery/light/incandescent/cool{
+	pixel_y = -12
+	},
+/turf/simulated/floor/airless/blue/side{
+	dir = 1
+	},
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+J
+X
+a
+"}
+(2,1,1) = {"
+x
+P
+Z
+"}
+(3,1,1) = {"
+g
+c
+t
+"}
+(4,1,1) = {"
+m
+n
+T
+"}
+(5,1,1) = {"
+R
+Q
+N
+"}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds two new random rooms to the pool of existing random rooms. The "tomato" room is a 3x3 prefab and "plushbridge" is a 5x3 prefab. The new rooms use existing assets, so I doubt too much will be impacted. (unless I made some huge mistake i'm new aaaa)

**Plush Bridge**
![image](https://user-images.githubusercontent.com/11701889/180143898-005381d3-f9ac-411b-89ff-861a0d82b2a9.png)

**Tomato**
![image](https://user-images.githubusercontent.com/11701889/180143971-8c5e0b0b-df92-45cf-a3d6-daa64ec83d54.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More random room variety is always fun!
