### PR TITLE
Changes Capsaicin On-Touch Protection Requirements

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2043,20 +2043,21 @@ datum
 
 
 				else if (method == TOUCH)
-					if(iscarbon(M) || ismobcritter(M))
+					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
-						var/mob/living/critter/C = M
-						if((issmokeimmune(H) && H.glasses?.c_flags & COVERSEYES) || isrobocritter(C) || istype(C, /mob/living/critter/fire_elemental)) // robotic critters and fire elementals will be immune, but not organic critters.
+						if((issmokeimmune(H) && H.glasses?.c_flags & COVERSEYES))
 							return
-						else
-							M.reagents.add_reagent("capsaicin",round(volume_passed/5))
-							if(prob(50))
-								M.emote("scream")
-								boutput(M, "<span class='alert'><b>Your eyes hurt!</b></span>")
-								M.take_eye_damage(1, 1)
-							M.change_eye_blurry(3)
-							M.changeStatus("stunned", 2 SECONDS)
-							M.change_misstep_chance(10)
+					if(isrobocritter(M) || istype(M, /mob/living/critter/fire_elemental)) // robotic critters and fire elementals will be immune, but not organic critters.
+						return
+					else
+						M.reagents.add_reagent("capsaicin",round(volume_passed/5))
+						if(prob(50))
+							M.emote("scream")
+							boutput(M, "<span class='alert'><b>Your eyes hurt!</b></span>")
+							M.take_eye_damage(1, 1)
+						M.change_eye_blurry(3)
+						M.changeStatus("stunned", 2 SECONDS)
+						M.change_misstep_chance(10)
 
 
 		fooddrink/el_diablo

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2045,7 +2045,8 @@ datum
 				else if (method == TOUCH)
 					if(iscarbon(M) || ismobcritter(M))
 						var/mob/living/carbon/human/H = M
-						if((issmokeimmune(H) && H.glasses?.c_flags & COVERSEYES) || isrobocritter(M) || /mob/living/critter/fire_elemental) // robotic critters and fire elementals will be immune, but not organic critters.
+						var/mob/living/critter/C = M
+						if((issmokeimmune(H) && H.glasses?.c_flags & COVERSEYES) || isrobocritter(C) || istype(C, /mob/living/critter/fire_elemental)) // robotic critters and fire elementals will be immune, but not organic critters.
 							return
 						else
 							M.reagents.add_reagent("capsaicin",round(volume_passed/5))

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -2043,8 +2043,11 @@ datum
 
 
 				else if (method == TOUCH)
-					if(iscarbon(M))
-						if(!M.wear_mask)
+					if(iscarbon(M) || ismobcritter(M))
+						var/mob/living/carbon/human/H = M
+						if((issmokeimmune(H) && H.glasses?.c_flags & COVERSEYES) || isrobocritter(M) || /mob/living/critter/fire_elemental) // robotic critters and fire elementals will be immune, but not organic critters.
+							return
+						else
 							M.reagents.add_reagent("capsaicin",round(volume_passed/5))
 							if(prob(50))
 								M.emote("scream")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This changes the protection requirements of capsaicin to require both smoke cloud protection and eye wear in order to protect from it's on-touch effects.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently, it only checks if a carbon entity is wearing a mask. Considering the only entities that are susceptible to it all spawn with a box that contains a mask (I.E. everyone), it currently is useless when it comes to using the crowd dispersal grenades. This makes it so that the grenades are now a viable choice in the sec loadout vendor.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(*)Capsaicin (the stuff in crowd dispersal grenades and peppers) now requires chem smoke protection (or internals) and glasses to be protected from it.
```
