### PR TITLE
clown cars now force a laydown standup

### DIFF
--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -1175,6 +1175,7 @@ ABSTRACT_TYPE(/obj/vehicle)
 			C.show_message("<span class='alert'><B>[rider] crashes into [M] with the [src]!</B></span>", 1)
 		M.changeStatus("stunned", 8 SECONDS)
 		M.changeStatus("weakened", 5 SECONDS)
+		M.force_laydown_standup()
 		playsound(src.loc, "sound/impact_sounds/Generic_Hit_Heavy_1.ogg", 40, 1)
 
 /obj/vehicle/clowncar/bullet_act(flag, A as obj)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BALANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
clown cars now make people they run over the moment they hit them instead of the next life cycle
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
its very easy to stop a clown car with one click having to wait several seconds for the people you hit to fall down doesnt help that at all.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+)Clown cars now make people who they run over fall to the ground instantly.
```
