### PR TITLE
Blacklists implants from electroplater

### DIFF
--- a/code/obj/machinery/arc_electroplater.dm
+++ b/code/obj/machinery/arc_electroplater.dm
@@ -81,6 +81,10 @@
 			boutput(user, "<span class='alert'>That wouldn't possibly fit!</span>")
 			return
 
+		if (istype(W, /obj/item/implant))
+			boutput(user, "<span class='alert'>Despite your best efforts, you can't seem to make it enter the electroplater somehow.</span>")
+			return
+
 		if (W.w_class > src.max_wclass || istype(W, /obj/item/storage/secure))
 			boutput(user, "<span class='alert'>There is no way that could fit!</span>")
 			return

--- a/code/obj/machinery/arc_electroplater.dm
+++ b/code/obj/machinery/arc_electroplater.dm
@@ -82,7 +82,7 @@
 			return
 
 		if (istype(W, /obj/item/implant))
-			boutput(user, "<span class='alert'>Despite your best efforts, you can't seem to make it enter the electroplater somehow.</span>")
+			boutput(user, "<span class='alert'>You can't plate something this tiny!</span>")
 			return
 
 		if (W.w_class > src.max_wclass || istype(W, /obj/item/storage/secure))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When trying to insert an implant into the electroplater, you will get a message that you cant put it into the electroplater.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Matsci implants are a strategy that isnt fun or easy to deal with nor are they new player friendly. Removing them while keeping the rest of electroplaters gimmick functionality seems for the best.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(+)You can no longer plate implants with the arc electroplater.
```
