### PR TITLE
Gives people being converted through counterrevs and beatings now gives you temporary melee prot

### DIFF
--- a/code/mob/melee_attack_procs.dm
+++ b/code/mob/melee_attack_procs.dm
@@ -1074,10 +1074,16 @@
 				if(target.client && target.health < 0 && ishuman(target)) //Only do rev stuff if they have a client and are low health
 					if ((owner.mind in R.revolutionaries) || (owner.mind in R.head_revolutionaries))
 						if (R.add_revolutionary(target.mind))
+							for (var/datum/mind/M in target)
+								if (M.current)
+									M.current.changeStatus("newcause", 5 SECONDS)
 							target.HealDamage("All", max(30 - target.health,0), 0)
 							target.HealDamage("All", 0, max(30 - target.health,0))
 					else
 						if (R.remove_revolutionary(target.mind))
+							for (var/datum/mind/M in target)
+								if (M.current)
+									M.current.changeStatus("newcause", 5 SECONDS)
 							target.HealDamage("All", max(30 - target.health,0), 0)
 							target.HealDamage("All", 0, max(30 - target.health,0))
 		clear(null)

--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -1431,6 +1431,27 @@
 		getTooltip()
 			. = "Your max stamina and stamina regen have been increased slightly."
 
+	newcause
+		id = "newcause"
+		name = "Newfound cause"
+		desc = "Your newfound purpose in life has encouraged you to toughen up a little!"
+		icon_state = "revspirit"
+		unique = 1
+		maxDuration = 5 SECONDS
+		onAdd(optional = 8)
+			. = ..()
+			if(ismob(owner))
+				var/mob/M = owner
+				APPLY_ATOM_PROPERTY(M, PROP_MOB_MELEEPROT_BODY, src, optional)
+				APPLY_ATOM_PROPERTY(M, PROP_MOB_MELEEPROT_HEAD, src, optional)
+
+	onRemove()
+		. = ..()
+		if(ismob(owner))
+			var/mob/M = owner
+			REMOVE_ATOM_PROPERTY(M, PROP_MOB_MELEEPROT_BODY, src)
+			REMOVE_ATOM_PROPERTY(M, PROP_MOB_MELEEPROT_HEAD, src)
+
 	patho_oxy_speed
 		id = "patho_oxy_speed"
 		name = "Oxygen Storage"

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -476,6 +476,7 @@ THROWING DARTS
 				H.TakeDamage("chest", 1.5*mult, 1.5*mult, 0)
 				if (H.health < 0)
 					H.changeStatus("paralysis", 5 SECONDS)
+					H.changeStatus("newcause", 5 SECONDS)
 					H.force_laydown_standup()
 					H.show_text("<B>The [src] has successfuly deprogrammed your revolutionary spirit!</B>", "blue")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Upon being converted through counterrev implants and beatings, you gain a status (Newfound cause) that gives you 5 seconds of 8 head and body melee protection. Sister pr of #9836


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This should help prevent the mob mass beating one guy from killing the person they just converted and give them time to react. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Upon being converted through counterrev implants or beatings, you now gain 5 seconds of additional melee protection.
```
