### PR TITLE
Counterrev implants no longer convert players. the amount of counterrev implants in vending machines and cargo has been upped by roughly half.

### DIFF
--- a/code/modules/economy/supply_packs.dm
+++ b/code/modules/economy/supply_packs.dm
@@ -1034,8 +1034,8 @@ ABSTRACT_TYPE(/datum/supply_packs)
 	name = "Counter-Revolutionary Kit"
 	desc = "Implanters and counter-revolutionary implants to supress rebellion against Nanotrasen."
 	category = "Security Department"
-	contains = list(/obj/item/implantcase/counterrev = 4,
-					/obj/item/implanter = 2)
+	contains = list(/obj/item/implantcase/counterrev = 6,
+					/obj/item/implanter = 3)
 	cost = 6000
 	containertype = /obj/storage/crate
 	containername = "Counter-Revolutionary Kit"

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1283,8 +1283,8 @@
 		product_list += new/datum/data/vending_product(/obj/item/device/pda2/security, 2)
 		product_list += new/datum/data/vending_product(/obj/item/sec_tape/vended, 3)
 		product_list += new/datum/data/vending_product(/obj/item/ammo/bullets/a38/stun, 2)
-		product_list += new/datum/data/vending_product(/obj/item/implantcase/counterrev, 3)
-		product_list += new/datum/data/vending_product(/obj/item/implanter, 1)
+		product_list += new/datum/data/vending_product(/obj/item/implantcase/counterrev, 5)
+		product_list += new/datum/data/vending_product(/obj/item/implanter, 2)
 #ifdef RP_MODE
 		product_list += new/datum/data/vending_product(/obj/item/paper/book/from_file/space_law, 1)
 #endif

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -460,36 +460,6 @@ THROWING DARTS
 				//src.on_remove(H)
 				//H.implant.Remove(src)
 				//src.set_loc(get_turf(H))
-			else if (H.mind in ticker.mode:revolutionaries)
-				H.TakeDamage("chest", 1, 1, 0)
-				H.changeStatus("weakened", 1 SECOND)
-				H.force_laydown_standup()
-				H.emote("scream")
-				playsound(H.loc, "sound/effects/electric_shock.ogg", 60, 0,0,pitch = 1.6)
-
-	do_process(var/mult = 1)
-		if (ticker?.mode && istype(ticker.mode, /datum/game_mode/revolution))
-			if (!ishuman(src.owner))
-				return
-			var/mob/living/carbon/human/H = src.owner
-			if (H.mind in ticker.mode:revolutionaries)
-				H.TakeDamage("chest", 1.5*mult, 1.5*mult, 0)
-				if (H.health < 0)
-					H.changeStatus("paralysis", 5 SECONDS)
-					H.force_laydown_standup()
-					H.show_text("<B>The [src] has successfuly deprogrammed your revolutionary spirit!</B>", "blue")
-
-					//heal a small amount for the trouble of bein critted via this thing
-					H.HealDamage("All", max(30 - H.health,0), 0)
-					H.HealDamage("All", 0, max(30 - H.health,0))
-
-					ticker.mode:remove_revolutionary(H.mind)
-				else
-					if (prob(30))
-						H.show_text("<B>The [src] burns and rattles inside your chest! It's attempting to force your loyalty to the heads of staff!</B>", "blue")
-						playsound(H.loc, "sound/effects/electric_shock_short.ogg", 60, 0,0,pitch = 0.8)
-						H.emote("twitch_v")
-
 		..()
 
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This is a pr that Id like to see test merged for a week and then feedback collected. While I think this would fix a lot of issues with revs, it will probably introduce some more. The ability for counterrev implants to convert people has been removed, they still show peoples rev status and prevent them from being converted to rev. This prs sister pr is #9835 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This forces combat escalation when it comes to derevving people, this not only offers emotional incentive to not get derevved by sec (afterall you dont want to get beat up), this also communicates to players that beating up converts people. I think this change should make revs way more active and will make action way more common, not to mention, help make the rev gamemode a bit more balanced compared to the overwhelming chance of security curbstomping victory currently. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Ikea
(*)Counterrev implants no longer automatically convert revolutionaries. 
```
