### PR TITLE
blobs now trigger INTERRUPT_ATTACKED, mild refactoring

### DIFF
--- a/code/modules/antagonists/blob/blob_abilities.dm
+++ b/code/modules/antagonists/blob/blob_abilities.dm
@@ -579,7 +579,7 @@
 
 
 //The owner is the blob tile object...
-/datum/action/bar/blob_absorb //This is used when you try to set someones internals
+/datum/action/bar/blob_absorb
 	bar_icon_state = "bar-blob"
 	border_icon_state = "border-blob"
 	color_active = "#d73715"
@@ -587,11 +587,8 @@
 	color_failure = "#8d1422"
 	duration = 10 SECONDS
 
-	// interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	interrupt_flags = 0
-	id = "internalsother"
-	// icon = 'icons/obj/clothing/item_masks.dmi'
-	// icon_state = "breath"
+	id = "blobabsorb"
 	var/mob/living/target
 	var/mob/living/intangible/blob_overmind/blob_o
 
@@ -604,11 +601,16 @@
 			return
 		src.blob_o = blob_o
 
-	onInterrupt(var/flag)
+	onStart()
 		..()
+		if(!target || !owner || GET_DIST(owner, target) > 0 || !blob_o)
+			interrupt(INTERRUPT_ALWAYS)
+			return
+		actions.interrupt(target, INTERRUPT_ATTACKED)
+
 	onUpdate()
 		..()
-		if(!target || !owner || get_dist(owner, target) > 0 || !blob_o)
+		if(!target || !owner || GET_DIST(owner, target) > 0 || !blob_o)
 			interrupt(INTERRUPT_ALWAYS)
 			return
 		if (ishuman(target) && target:decomp_stage == 4)
@@ -621,7 +623,7 @@
 	onEnd()
 		..()
 		//owner type actually matters here. But it should never not be this anyway...
-		if(!target || !owner || get_dist(owner, target) > 0 || !istype (blob_o, /mob/living/intangible/blob_overmind))
+		if(!target || !owner || GET_DIST(owner, target) > 0 || !istype (blob_o, /mob/living/intangible/blob_overmind))
 			return
 
 		//This whole first bit is all still pretty ugly cause this ability works on both critters and humans. I didn't have it in me to rewrite the whole thing - kyle


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BALANCE][BUG][CLEANLINESS] -->
fixes #9788 (the blobs not triggering INTERRUPT_ATTACKED part is the bug being fixed, pod entering doesnt have INTERRUPT_ATTACKED as one of its interrupt flags)
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
blob absorb now triggers INTERRUPT_ATTACKED
slightly refactors the blob of the absorb actionbar


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad