### PR TITLE
Add thinktape to cogmap2 artifact lab

### DIFF
--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -67998,8 +67998,15 @@
 "cXA" = (
 /obj/table/reinforced/auto,
 /obj/deskclutter,
-/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -4;
+	pixel_y = -2
+	},
 /obj/machinery/light_switch/north,
+/obj/item/disk/data/tape{
+	pixel_x = 5;
+	pixel_y = 8
+	},
 /turf/simulated/floor/purplewhite{
 	dir = 1
 	},
@@ -71027,8 +71034,7 @@
 /area/station/maintenance/solar/south)
 "del" = (
 /obj/machinery/door/airlock/pyro/glass{
-	name = "EMERGENCY DISPOSAL";
-	
+	name = "EMERGENCY DISPOSAL"
 	},
 /turf/simulated/floor/airless/engine/caution/westeast,
 /area/station/hangar/science)
@@ -76185,8 +76191,7 @@
 /area/station/hallway/secondary/exit)
 "ewr" = (
 /obj/machinery/door/airlock/pyro/external{
-	name = "Outpost Shuttle Dock";
-	
+	name = "Outpost Shuttle Dock"
 	},
 /obj/access_spawn/research,
 /turf/simulated/floor/airless/caution/northsouth,
@@ -76335,8 +76340,7 @@
 /area/station/security/checkpoint/podbay)
 "fwk" = (
 /obj/machinery/door/airlock/pyro/external{
-	name = "Outpost Shuttle Dock";
-	
+	name = "Outpost Shuttle Dock"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/research,
@@ -77248,8 +77252,7 @@
 /area/station/maintenance/central)
 "jNM" = (
 /obj/machinery/door/airlock/pyro/external{
-	name = "Research Outpost Shuttle";
-	
+	name = "Research Outpost Shuttle"
 	},
 /obj/access_spawn/research,
 /turf/unsimulated/floor/shuttle,
@@ -77327,8 +77330,7 @@
 /area/station/hangar/science)
 "kcO" = (
 /obj/machinery/door/airlock/pyro/external{
-	name = "Outpost Shuttle Dock";
-	
+	name = "Outpost Shuttle Dock"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/research,
@@ -79621,8 +79623,7 @@
 /area/shuttle/research/outpost)
 "vuO" = (
 /obj/machinery/door/airlock/pyro/external{
-	name = "Outpost Shuttle Dock";
-	
+	name = "Outpost Shuttle Dock"
 	},
 /obj/access_spawn/research,
 /turf/simulated/floor/airless/caution/northsouth,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][bug] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds a thinktape to cogmap2's artifact lab.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

No thinktape means you either can't activate artifacts or you have to keep asking for the backup mainframe tape.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Luxizzle
(+)Cogmap2's Artifact Lab now includes a thinktape.
```
