### PR TITLE
Convert artifact_paper_dispenser to a subtype of paper_bin

### DIFF
--- a/code/obj/artifacts/artifactanalysis.dm
+++ b/code/obj/artifacts/artifactanalysis.dm
@@ -171,12 +171,3 @@
 			var/obj/O = src.attached
 			O.remove_suffixes("\[[src.artifactType]\]")
 			O.UpdateName()
-
-/obj/artifact_paper_dispenser
-	name = "artifact analysis form tray"
-	icon = 'icons/obj/writing.dmi'
-	icon_state = "artifact_form_tray"
-	desc = "A tray full of forms for classifying alien artifacts."
-
-	attack_hand(mob/user)
-		user.put_in_hand_or_drop(new /obj/item/sticker/postit/artifact_paper())

--- a/code/obj/item/paper.dm
+++ b/code/obj/item/paper.dm
@@ -1163,10 +1163,23 @@ as it may become compromised.
 	burn_output = 800
 	burn_possible = 1
 
+	/// the item type this bin contains, should always be a subtype for /obj/item for reasons...
+	var/bin_type = /obj/item/paper
+
+/obj/item/paper_bin/artifact_paper
+	name = "artifact analysis form tray"
+	desc = "A tray full of forms for classifying alien artifacts."
+	icon = 'icons/obj/writing.dmi'
+	icon_state = "artifact_form_tray"
+	amount = INFINITY
+	bin_type = /obj/item/sticker/postit/artifact_paper
+
+	update()
+		tooltip_rebuild = 1
 
 /obj/item/paper_bin/proc/update()
 	tooltip_rebuild = 1
-	src.icon_state = "paper_bin[(src.amount || locate(/obj/item/paper, src)) ? "1" : null]"
+	src.icon_state = "paper_bin[(src.amount || locate(bin_type, src)) ? "1" : null]"
 	return
 
 /obj/item/paper_bin/mouse_drop(mob/user as mob)
@@ -1176,17 +1189,18 @@ as it may become compromised.
 
 /obj/item/paper_bin/attack_hand(mob/user)
 	src.add_fingerprint(user)
-	var/obj/item/paper = locate(/obj/item/paper) in src
+	var/obj/item/paper = locate(bin_type) in src
 	if (paper)
 		user.put_in_hand_or_drop(paper)
 	else
 		if (src.amount >= 1 && user) //Wire: Fix for Cannot read null.loc (&& user)
 			src.amount--
-			var/obj/item/paper/P = new /obj/item/paper
+			var/obj/item/P = new bin_type
 			P.set_loc(src)
 			user.put_in_hand_or_drop(P)
-			if (rand(1,100) == 13)
-				P.info = "Help me! I am being forced to code SS13 and It won't let me leave."
+			if (rand(1,100) == 13 && istype(P, /obj/item/paper))
+				var/obj/item/paper/PA = P
+				PA.info = "Help me! I am being forced to code SS13 and It won't let me leave."
 	src.update()
 	return
 
@@ -1194,8 +1208,8 @@ as it may become compromised.
 	..()
 	src.Attackhand(user)
 
-/obj/item/paper_bin/attackby(obj/item/paper/P, mob/user) // finally you can write on all the paper AND put it back in the bin to mess with whoever shows up after you ha ha
-	if (istype(P))
+/obj/item/paper_bin/attackby(obj/item/P, mob/user) // finally you can write on all the paper AND put it back in the bin to mess with whoever shows up after you ha ha
+	if (istype(P, bin_type))
 		user.drop_item()
 		P.set_loc(src)
 		boutput(user, "You place [P] into [src].")
@@ -1213,7 +1227,7 @@ as it may become compromised.
 	var/next_generate = 0
 
 	attack_self(mob/user as mob)
-		if (src.amount < 1 && isnull(locate(/obj/item/paper) in src))
+		if (src.amount < 1 && isnull(locate(bin_type) in src))
 			if (src.next_generate < ticker.round_elapsed_ticks)
 				boutput(user, "The [src] generates another sheet of paper using the power of [pick("technology","science","computers","nanomachines",5;"magic",5;"extremely tiny clowns")].")
 				src.amount++

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -18540,7 +18540,7 @@
 /obj/item/disk/data/tape{
 	pixel_y = -5
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = 10
 	},
 /turf/simulated/floor/purple,

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -49966,7 +49966,7 @@
 	name = "autoname  - SS13";
 	pixel_x = 10
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = -8;
 	pixel_y = 9
 	},

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -65025,7 +65025,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = 6;
 	pixel_y = 9
 	},

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -69487,7 +69487,7 @@
 /obj/item/device/matanalyzer,
 /obj/item/device/matanalyzer,
 /obj/machinery/light,
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = -6;
 	pixel_y = 10
 	},

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -24142,7 +24142,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = 6;
 	pixel_y = 9
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -74380,7 +74380,7 @@
 /obj/item/hand_labeler{
 	pixel_x = 15
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = 3;
 	pixel_y = 3
 	},

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -61833,7 +61833,7 @@
 	pixel_x = 5;
 	pixel_y = -2
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = -6;
 	pixel_y = 8
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -30693,7 +30693,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = -6;
 	pixel_y = 8
 	},

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -31557,7 +31557,7 @@
 /obj/disposalpipe/segment/mail{
 	dir = 4
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = 8;
 	pixel_y = 6
 	},

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -9649,7 +9649,7 @@
 	layer = 3.5
 	},
 /obj/machinery/light_switch/auto,
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = 15
 	},
 /turf/simulated/floor/black,

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -82322,7 +82322,7 @@
 	dir = 1;
 	name = "autoname - SS13"
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = 8;
 	pixel_y = 3
 	},
@@ -85887,7 +85887,7 @@
 /obj/item/clipboard{
 	pixel_x = -4
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = 13
 	},
 /turf/simulated/floor/engine/caution/west,

--- a/maps/pamgoc.dmm
+++ b/maps/pamgoc.dmm
@@ -58913,7 +58913,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = -6;
 	pixel_y = 9
 	},

--- a/maps/unused/crash_gimmick.dmm
+++ b/maps/unused/crash_gimmick.dmm
@@ -17656,7 +17656,7 @@
 	pixel_x = 5;
 	pixel_y = -2
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = -6;
 	pixel_y = 8
 	},

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -2875,7 +2875,7 @@
 	pixel_x = -7;
 	pixel_y = 3
 	},
-/obj/artifact_paper_dispenser{
+/obj/item/paper_bin/artifact_paper{
 	pixel_x = 6;
 	pixel_y = 4
 	},
@@ -19369,7 +19369,7 @@
 "aUy" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9;
-	level = 2 
+	level = 2
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 4


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL][bug][cleanliness] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Converts the artifact_paper_dispenser to a subtype of paper_bin.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Allows you to put forms back in the bin and allows you to pick up the whole bin by click dragging it to your character, for example when a gravity well has moved it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Luxizzle
(+)Artifact paper dispensers now act like paper bins. You can pick them up and put artifact papers back in.
```
