### PR TITLE
Buffs syndicate laser designator

### DIFF
--- a/code/obj/item/nuclear_operative/designator.dm
+++ b/code/obj/item/nuclear_operative/designator.dm
@@ -162,7 +162,7 @@
 	var/image/target_overlay = null
 
 	/// Override this for the child of `/obj/machinery/broadside_gun` to determine what happens on-firing
-	proc/bombard(var/atom/target, var/mob/user)
+	proc/bombard(atom/target, mob/user)
 		return
 
 	New()

--- a/code/obj/item/nuclear_operative/designator.dm
+++ b/code/obj/item/nuclear_operative/designator.dm
@@ -201,7 +201,7 @@
 		playsound(sound_turf, "sound/weapons/energy/howitzer_firing.ogg", 50, 1)
 		sleep(2.5 SECONDS)
 		var/area/designated_area = get_area(target_turf)
-		command_alert("Heavy ordinace has been detected launching from the Cairngorm towards the [initial(designated_area.name)], ETA 10 seconds.","Central Command Alert")
+		command_alert("Heavy ordinace has been detected launching from the Cairngorm towards the [initial(designated_area.name)], ETA 5 seconds.","Central Command Alert")
 		flick("152mm_firing", src)
 		firing_turf = get_step(firing_turf, WEST)
 		firing_turf = get_step(firing_turf, WEST)
@@ -213,10 +213,10 @@
 			sleep(1.2 SECONDS)
 			qdel(animation)
 		playsound(sound_turf, "sound/weapons/energy/howitzer_shot.ogg", 50, 1)
-		sleep(rand(60, 110))
+		sleep(rand(3 SECONDS, 7 SECONDS))
 		if(!isnull(src.target_overlay))
 			target_turf.overlays -= src.target_overlay
-		explosion_new(user, target_turf, 75)
+		explosion_new(user, target_turf, 100)
 		sound_turf = get_turf(src)
 		sound_offset_length = initial(sound_offset_length)
 		return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Decreases the time from 6-11 seconds to 3-7 to land once the announcement happens, in addition to a 33% increase in power


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This thing is... abundantly obvious and isn't that powerful, making it a cool-but-questionable choice as opposed to buying more gunbots


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Nukeop laser designator now fires faster and has a more powerful explosion
```
