### PR TITLE
Chameleon backpacks and belts are now quiet

### DIFF
--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -1299,6 +1299,7 @@
 	inhand_image_icon = 'icons/mob/inhand/hand_storage.dmi'
 	wear_image_icon = 'icons/mob/clothing/belt.dmi'
 	uses_multiple_icon_states = 1
+	sneaky = TRUE
 	var/list/clothing_choices = list()
 
 	New()

--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -1422,6 +1422,7 @@
 	spawn_contents = list()
 	in_list_or_max = TRUE
 	can_hold = list(/obj/item/storage/belt/chameleon)
+	sneaky = TRUE
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
No longer do chameleon backpacks and belts put the message in chat along with the rustle noise when you put things in it


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
So you can pull out/put away contraband quietly, so you aren't forced to use pockets for fear of "Joe Badman has put away the cyalume saber"


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Zonespace
(+)Chameleon backpacks and belts no longer show a message when putting away/pulling out items
```
