### PR TITLE
fixes ling DNA sting making target into unknown

### DIFF
--- a/code/modules/antagonists/changeling/abilities/absorb.dm
+++ b/code/modules/antagonists/changeling/abilities/absorb.dm
@@ -166,7 +166,8 @@
 
 			target.dna_to_absorb = 0
 			target.death(FALSE)
-			target.real_name = "Unknown"
+			target.disfigured = TRUE
+			target.UpdateName()
 			target.bioHolder.AddEffect("husk")
 			target.bioHolder.mobAppearance.flavor_text = "A desiccated husk."
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #5081
fixes dna sting not applying proper names due to how absorbing someone changes their name. 
now absorbing someone will disfigure their face instead. still results in the husk being unknown (think of it as the lack of dna and such making their face look all weird)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
having dna sting work properly is good
