### PR TITLE
changes on scorpions and rattlesnakes

### DIFF
--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1253,21 +1253,24 @@ datum
 
 			on_mob_life(var/mob/M, var/mult = 1)
 				if (!M) M = holder.my_atom
-				M.take_toxin_damage(1*mult)
-				random_brute_damage(M, 1*mult, FALSE)
-				bleed(M, rand(4,5) * mult, 3 * mult)
+				M.take_toxin_damage(0.5*mult)
+				take_bleeding_damage(M, null, 2 * mult, DAMAGE_CUT, 1, get_turf(M))
+				if (probmult(6))
+					M.visible_message(pick("<span class='alert'><B>[M]</B>'s [pick("eyes", "arms", "legs")] bleed!</span>",\
+											"<span class='alert'><B>[M]</B> bleeds [pick("profusely", "from every wound")]!</span>",\
+											"<span class='alert'><B>[M]</B>'s [pick("chest", "face", "whole body")] bleeds!</span>"))
 
-				if (prob(25))
-					M.reagents.add_reagent("histamine", rand(5,10) * mult)
+				if (prob(15))
+					M.reagents.add_reagent("histamine", rand(8,10) * mult)
 
 				if (probmult(10))
-					M.setStatus("stunned", max(M.getStatusDuration("stunned"), 5 SECONDS))
+					M.setStatus("staggered", max(M.getStatusDuration("staggered"), 5 SECONDS))
 					boutput(M, "<span class='alert'><b>Your body hurts so much.</b></span>")
 					if (!isdead(M))
 						M.emote(pick("cry", "tremble", "scream"))
 
 				if (probmult(10))
-					M.setStatus("slowed", max(M.getStatusDuration("slowed"), 10 SECONDS))
+					M.setStatus("slowed", max(M.getStatusDuration("slowed"), 8 SECONDS))
 					boutput(M, "<span class='alert'><b>Everything starts hurting.</b></span>")
 					M.take_toxin_damage(8)
 					if (!isdead(M))

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -1255,6 +1255,7 @@ datum
 				if (!M) M = holder.my_atom
 				M.take_toxin_damage(1*mult)
 				random_brute_damage(M, 1*mult, FALSE)
+				bleed(M, rand(4,5) * mult, 3 * mult)
 
 				if (prob(25))
 					M.reagents.add_reagent("histamine", rand(5,10) * mult)
@@ -1262,7 +1263,6 @@ datum
 				if (probmult(10))
 					M.setStatus("stunned", max(M.getStatusDuration("stunned"), 5 SECONDS))
 					boutput(M, "<span class='alert'><b>Your body hurts so much.</b></span>")
-					bleed(M, rand(30,60), rand(3,9))
 					if (!isdead(M))
 						M.emote(pick("cry", "tremble", "scream"))
 

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -1505,7 +1505,7 @@
 
 	CritterDeath()
 		..()
-		src.reagents.add_reagent("viper_venom", 100, null)
+		src.reagents.add_reagent("viper_venom", 40, null)
 		return
 
 	seek_target()

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -468,7 +468,7 @@
 
 	ChaseAttack(mob/M)
 		..()
-		if(!ON_COOLDOWN(src, "scorpion_ability", 10 SECONDS))
+		if(!ON_COOLDOWN(src, "scorpion_ability", 15 SECONDS))
 			if(prob(50))
 				M.visible_message("<span class='combat'><B>[src]</B> stings [src.target]!</span>")
 				M.reagents?.add_reagent("neurotoxin", 15)
@@ -484,9 +484,23 @@
 
 
 	CritterAttack(mob/M)
-		take_bleeding_damage(M, M, rand(3,6), DAMAGE_STAB, 1)
-		M.visible_message("<span class='combat'><B>[src]</B> snips [src.target] with its pincers!</span>")
-		playsound(src.loc, "sound/items/Wirecutter.ogg", 50, 0)
+		if(!ON_COOLDOWN(src, "scorpion_ability", 15 SECONDS))
+			if(prob(50))
+				M.visible_message("<span class='combat'><B>[src]</B> stings [src.target]!</span>")
+				M.reagents?.add_reagent("neurotoxin", 15)
+				M.reagents?.add_reagent("toxin", 6)
+				playsound(src.loc, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
+				M.emote("scream")
+			else
+				random_brute_damage(M, rand(5,10),1)
+				M.visible_message("<span class='combat'><B>[src]</B> tackles [src.target] with its pincers!</span>")
+				playsound(src.loc, "sound/items/Wirecutter.ogg", 50, 0)
+				M.changeStatus("weakened", 4 SECONDS)
+				M.force_laydown_standup()
+		else
+			take_bleeding_damage(M, M, rand(3,6), DAMAGE_STAB, 1)
+			M.visible_message("<span class='combat'><B>[src]</B> snips [src.target] with its pincers!</span>")
+			playsound(src.loc, "sound/items/Wirecutter.ogg", 50, 0)
 
 
 
@@ -1474,7 +1488,7 @@
 	desc = "A rattlesnake in space."
 	icon_state = "rattlesnake"
 	dead_state = "rattlesnake_dead"
-	density = 0
+	density = 1
 	health = 20
 	aggressive = 1
 	defensive = 1

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -1505,7 +1505,7 @@
 
 	CritterDeath()
 		..()
-		src.reagents.add_reagent("viper_venom", 40, null)
+		src.reagents.add_reagent("viper_venom", 100, null)
 		return
 
 	seek_target()
@@ -1527,7 +1527,7 @@
 						if (issilicon(C) && src.atksilicon) src.attack = 1
 						if(!ON_COOLDOWN(src, "snake bite", 15 SECONDS))
 							C.visible_message("<span class='combat'><B>[src]</B> bites [C.name]!</span>")
-							C.reagents?.add_reagent("viper_venom", rand(15,25))
+							C.reagents?.add_reagent("viper_venom", rand(25,35))
 							playsound(src.loc, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
 							C.emote("scream")
 					if (1 to 2)
@@ -1558,7 +1558,7 @@
 		..()
 		if(!ON_COOLDOWN(src, "snake bite", 15 SECONDS))
 			M.visible_message("<span class='combat'><B>[src]</B> bites [src.target]!</span>")
-			M.reagents?.add_reagent("viper_venom", rand(10,15))
+			M.reagents?.add_reagent("viper_venom", rand(15,30))
 			playsound(src.loc, "sound/impact_sounds/Generic_Stab_1.ogg", 50, 1)
 			M.emote("scream")
 		src.task = "chasing"


### PR DESCRIPTION
[LABEL][balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Some changes i'd like to do on scorpion and rattlesnake behaviour, mainly increasing the delay between stings and tackles on scorpions a bit, while also preventing them to be stuck on just snipping at you forever, making it so you are able to shoot rattlesnakes again and changing their venom behavior from a 10% chance of a lot of bleeding to a smaller amount of constant bleeding.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I've been wanting to change these behaviors in a bit, and make these critters a bit more consistent. Now you are able to effectively get rid of snakes without putting yourself in danger, which is good, their venom is nowhere near as much RNG based, since you can't roll the massive bleeding twice in a row and go into semi instant lethal hypotension, and scorpions have a bigger delay on their attacks, but don't get stuck infinitely using their snip attack on you.



```changelog
(u)Hans
(+)You can now shoot Rattlesnakes, scorpions have a longer special ability delay and , and viper venom's bleeding isn't as RNG dependant and can't hit as hard as fast now.
```