### PR TITLE
Changes egg farting to an overdose effect

### DIFF
--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -3074,6 +3074,7 @@ datum
 				if (severity == 1)
 					if(probmult(16))
 						M.emote("fart")
+						
 		fooddrink/beff
 			name = "beff"
 			id = "beff"

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -3070,10 +3070,9 @@ datum
 					M.reagents.add_reagent("cholesterol", rand(1,2) * mult)
 				..()
 				
-			do_overdose(var/severity = 1, var/mob/M, var/mult = 1)
-				if (severity == 1)
-					if(probmult(16))
-						M.emote("fart")
+			do_overdose(var/severity, var/mob/M, var/mult = 1)
+				if(probmult(16))
+					M.emote("fart")
 						
 		fooddrink/beff
 			name = "beff"

--- a/code/modules/chemistry/Reagents-FoodDrink.dm
+++ b/code/modules/chemistry/Reagents-FoodDrink.dm
@@ -3057,6 +3057,7 @@ datum
 			fluid_g = 220
 			fluid_b = 0
 			transparency = 225
+			overdose = 10
 			pathogen_nutrition = list("water", "sugar", "sodium", "iron", "nitrogen")
 			hunger_value = 1
 			viscosity = 0.2
@@ -3065,13 +3066,14 @@ datum
 				if(!M) M = holder.my_atom
 				M.nutrition += 1 * mult
 
-				if(probmult(8))
-					M.emote("fart")
-
 				if(prob(3))
 					M.reagents.add_reagent("cholesterol", rand(1,2) * mult)
 				..()
-
+				
+			do_overdose(var/severity = 1, var/mob/M, var/mult = 1)
+				if (severity == 1)
+					if(probmult(16))
+						M.emote("fart")
 		fooddrink/beff
 			name = "beff"
 			id = "beff"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[QOL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The flat 8% chance of farting per life loop caused by the egg reagent has been replaced by an overdose effect, where farts occur after an overdose threshold of 10u; requiring at least three kitchen eggs to cause an overdose.

To compensate for the increased amount of egg required, a person now has a 16% chance of farting per life loop when overdosing on eggs (compared to fartonium's 66% chance without an overdose threshold).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
i want to be able to eat one egg and not fart, and some people would prefer to be able to continue force-feeding eggs to immobilised people sitting above a bible. this should be a decent compromise.

eggs 🍳