### PR TITLE
fixes fire wallclip

### DIFF
--- a/code/WorkInProgress/previouslyKeelinsStuff.dm
+++ b/code/WorkInProgress/previouslyKeelinsStuff.dm
@@ -292,9 +292,7 @@ var/reverse_mode = 0
 		return 1
 	var/list/line = getline(A,B)
 	for (var/turf/T in line)
-		if (T == AT || T == BT)
-			break
-		if (T.density)
+		if (!T.gas_cross(T))
 			return 0
 		var/obj/blob/BL = locate() in T
 		if (istype(BL, /obj/blob/wall) || istype(BL, /obj/blob/firewall) || istype(BL, /obj/blob/reflective))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG][BALANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes the proc responsible for handling where fire can go as of now it always returns true, ties it to gas_cross instead of density as being density based had weird effects

NOTE: it has a bit of issues related to spreading around corners due to the way its done, fixing that would require recoding fire spreading fully

**balance implications:**

certain blob tiles now actually block fire as intended

the fact fire no longer goes trough walls

fire doesnt spread over space tiles as they block gas, this may need changing

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
this was probably the intended behavior all along it just had an oversight and always returned true, the only change other than the fix itself is it being tied to gas_cross instead of turf density
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(*)Fire no longer clips trough walls
```
