### PR TITLE
3x5 "Beach" Random Room

### DIFF
--- a/assets/maps/random_rooms/3x5/beachroom.dmm
+++ b/assets/maps/random_rooms/3x5/beachroom.dmm
@@ -1,0 +1,87 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/light/incandescent/harsh{
+	dir = 8
+	},
+/turf/simulated/floor/darkblue,
+/area/dmm_suite/clear_area)
+"c" = (
+/obj/item/clothing/under/towel,
+/turf/simulated/floor/orange,
+/area/dmm_suite/clear_area)
+"f" = (
+/obj/stool/chair{
+	desc = "";
+	foldable = 0;
+	icon_state = "chair_pool"
+	},
+/turf/simulated/floor/green,
+/area/dmm_suite/clear_area)
+"i" = (
+/turf/simulated/floor/bluewhite,
+/area/dmm_suite/clear_area)
+"I" = (
+/obj/machinery/light/incandescent/harsh{
+	dir = 4
+	},
+/turf/simulated/floor/darkblue,
+/area/dmm_suite/clear_area)
+"K" = (
+/turf/simulated/floor/bluewhite{
+	dir = 10
+	},
+/area/dmm_suite/clear_area)
+"P" = (
+/turf/simulated/floor/orange,
+/area/dmm_suite/clear_area)
+"R" = (
+/obj/machinery/drainage,
+/obj/item/fish/herring{
+	pixel_x = -14;
+	pixel_y = 13
+	},
+/turf/simulated/floor/darkblue,
+/area/dmm_suite/clear_area)
+"S" = (
+/turf/simulated/floor/bluewhite/corner{
+	dir = 4
+	},
+/area/dmm_suite/clear_area)
+"V" = (
+/turf/simulated/floor/green,
+/area/dmm_suite/clear_area)
+"Z" = (
+/obj/machinery/light/small/floor/harsh/very,
+/obj/table/folding,
+/obj/item/cocktail_stuff/drink_umbrella{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/coconut{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/simulated/floor/orange,
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+P
+P
+S
+K
+a
+"}
+(2,1,1) = {"
+V
+Z
+c
+i
+R
+"}
+(3,1,1) = {"
+V
+f
+P
+i
+I
+"}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a beach theme random room, perfect for the hard-working employee in need of a break.
Drinks are not provided (Budget Cuts).
NT cannot be held responsible from any injuries that result from diving into the "Realistic Water".

![Beachroom](https://user-images.githubusercontent.com/106848385/181059661-8db44241-ce23-41cf-ba60-a6ab646df519.PNG)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More random rooms is fun, plus employees can always use a new location for some R&R.
