### PR TITLE
3x3 Peel of Legend Random Room

### DIFF
--- a/assets/maps/random_rooms/3x3/legendofclown_65.dmm
+++ b/assets/maps/random_rooms/3x3/legendofclown_65.dmm
@@ -1,0 +1,94 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 10
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 5
+	},
+/area/dmm_suite/clear_area)
+"e" = (
+/obj/table/clothred/auto,
+/obj/machinery/light/small/floor/cool/very,
+/obj/item/bananapeel{
+	pixel_y = 4;
+	name = "Peel of Legend";
+	desc = "Go forth, and slip them all.";
+	burn_possible = 0
+	},
+/obj/decal/lightshaft{
+	pixel_y = 1;
+	pixel_x = -11;
+	desc = "A spotlight, probably shining on something important.";
+	name = "Spotlight"
+	},
+/turf/simulated/grass,
+/area/dmm_suite/clear_area)
+"r" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 9
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 6
+	},
+/area/dmm_suite/clear_area)
+"z" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 6
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 9
+	},
+/area/dmm_suite/clear_area)
+"I" = (
+/obj/decal/tile_edge/stripe/extra_big,
+/turf/simulated/floor/grasstodirt{
+	dir = 1
+	},
+/area/dmm_suite/clear_area)
+"L" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 8
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 4
+	},
+/area/dmm_suite/clear_area)
+"M" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/grasstodirt,
+/area/dmm_suite/clear_area)
+"N" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 4
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 8
+	},
+/area/dmm_suite/clear_area)
+"S" = (
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 5
+	},
+/turf/simulated/floor/grasstodirt{
+	dir = 10
+	},
+/area/dmm_suite/clear_area)
+
+(1,1,1) = {"
+r
+L
+a
+"}
+(2,1,1) = {"
+M
+e
+I
+"}
+(3,1,1) = {"
+S
+N
+z
+"}


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a random room containing a fancy banana peel and equally fancy table for it to rest on.
Claim this legendary artifact (A normal banana peel) and go forth on your quest for comedy!

![legendclowntest](https://user-images.githubusercontent.com/106848385/181115047-e4118cb1-b80b-4b9f-a4db-f0a620ae30ca.PNG)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Random rooms are fun, banana peels are fun, and this one shouldn't show up to often to make sure the joke doesn't get old.
