### PR TITLE
Adds an action bar and time scaling to pill forcefeeding and a harm intent function to syringes

### DIFF
--- a/code/modules/chemistry/tools/pills.dm
+++ b/code/modules/chemistry/tools/pills.dm
@@ -56,30 +56,13 @@
 				user.visible_message("[user] swallows [src].",\
 				"<span class='notice'>You swallow [src].</span>")
 			else if(check_target_immunity(M))
-				user.show_message( "<span class='alert'>You try to force [M] to swallow [src], but fail!</span>")
+				user.show_message( "<span class='alert'>You try to force [M] to swallow [src], but can't!</span>")
 				return
 			else
 				user.visible_message("<span class='alert'>[user] attempts to force [M] to swallow [src].</span>",\
 				"<span class='alert'>You attempt to force [M] to swallow [src].</span>")
 				logTheThing("combat", user, M, "tries to force-feed a [src.name] [log_reagents(src)] to [constructTarget(M,"combat")] at [log_loc(user)].")
-
-				if (!do_mob(user, M))
-					if (user && ismob(user))
-						user.show_text("You were interrupted!", "red")
-					return
-				if (!src.reagents || !src.reagents.total_volume)
-					user.show_text("[src] doesn't contain any reagents.", "red")
-					return
-				user.visible_message("<span class='alert'>[user] forces [M] to swallow [src].</span>",\
-				"<span class='alert'>You force [M] to swallow [src].</span>")
-
-			logTheThing("combat", user, M, "[user == M ? "swallows" : "makes [constructTarget(M,"combat")] swallow"] a [src.name] [log_reagents(src)] at [log_loc(user)].")
-			if (reagents.total_volume)
-				reagents.reaction(M, INGEST)
-				sleep(0.1 SECONDS)
-				reagents.trans_to(M, reagents.total_volume)
-			user.u_equip(src)
-			qdel(src)
+				actions.start(new/datum/action/bar/icon/pill(M, src, src.icon, src.icon_state), user)
 			return 1
 
 		return 0
@@ -122,6 +105,26 @@
 		else
 			return ..()
 
+	proc/pill_action(mob/user, mob/target)
+		if (iscarbon(target) || ismobcritter(target))
+			if (target == user)
+				user.visible_message("[user] swallows [src].",\
+				"<span class='notice'>You swallow [src].</span>")
+			else if(check_target_immunity(target))
+				user.show_message( "<span class='alert'>You try to force [target] to swallow [src], but fail!</span>")
+				return
+			else
+				user.visible_message("<span class='alert'>[user] forces [target] to swallow [src].</span>",\
+				"<span class='alert'>You force [target] to swallow [src].</span>")
+
+		logTheThing("combat", user, target, "[user == target ? "swallows" : "makes [constructTarget(target,"combat")] swallow"] a [src.name] [log_reagents(src)] at [log_loc(user)].")
+		
+		if (reagents.total_volume)
+			reagents.reaction(target, INGEST)
+			sleep(0.1 SECONDS)
+			reagents.trans_to(target, reagents.total_volume)
+		user.u_equip(src)
+		qdel(src)
 
 
 

--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -112,8 +112,11 @@
 							return
 
 					if(target != user)
-						user.visible_message("<span class='alert'><B>[user] is trying to draw blood from [target]!</B></span>")
-						actions.start(new/datum/action/bar/icon/syringe(target, src, src.icon, src.icon_state), user)
+						if (user.a_intent == INTENT_HARM)
+							user.visible_message("<span class='alert'><B>[user] stabs [target] with [src] and starts drawing blood!</B></span>")
+						else
+							user.visible_message("<span class='alert'><B>[user] is trying to draw blood from [target]!</B></span>")
+						actions.start(new/datum/action/bar/icon/syringe(user, target, src, src.icon, src.icon_state), user)
 					else
 						transfer_blood(target, src, src.amount_per_transfer_from_this)
 						boutput(user, "<span class='notice'>You fill [src] with [src.amount_per_transfer_from_this] units of [target]'s blood.</span>")
@@ -169,8 +172,11 @@
 						return
 					if (target != user)
 						logTheThing("combat", user, target, "tries to inject [constructTarget(target,"combat")] with a [src] [log_reagents(src)] at [log_loc(user)].")
-						user.visible_message("<span class='alert'><B>[user] is trying to inject [target] with [src]!</B></span>")
-						actions.start(new/datum/action/bar/icon/syringe(target, src, src.icon, src.icon_state), user)
+						if (user.a_intent == INTENT_HARM)
+							user.visible_message("<span class='alert'><B>[user] stabs [target] with [src] and starts injecting!</B></span>")
+						else
+							user.visible_message("<span class='alert'><B>[user] is trying to inject [target] with [src]!</B></span>")
+						actions.start(new/datum/action/bar/icon/syringe(user, target, src, src.icon, src.icon_state), user)
 						user.update_inhands()
 						return
 					else
@@ -201,14 +207,17 @@
 
 		return
 
-	proc/syringe_action(mob/user, mob/target)
+	proc/syringe_action(mob/user, mob/target, var/dosage = 1)
 		switch(src.mode)
 			if(S_DRAW)
-				transfer_blood(target, src, src.amount_per_transfer_from_this)
-				target.visible_message("<span class='alert'>[user] draws blood from [target]!</span>")
+				if (dosage >= 0.33)
+					transfer_blood(target, src, src.amount_per_transfer_from_this * dosage)
+					target.visible_message("<span class='alert'>[user] draws blood from [target]!</span>")
+				else
+					target.visible_message("<span class='alert'>[user] jabs [target] but fails to draw blood!</span>")
 			if(S_INJECT)
-				src.reagents.reaction(target, INGEST, src.amount_per_transfer_from_this)
-				src.reagents.trans_to(target, src.amount_per_transfer_from_this)
+				src.reagents.reaction(target, INGEST, src.amount_per_transfer_from_this * dosage)
+				src.reagents.trans_to(target, src.amount_per_transfer_from_this * dosage)
 				target.visible_message("<span class='alert'>[user] injects [target] with the [src]!</span>")
 				logTheThing("combat", user, target, "injects [constructTarget(target,"combat")] with a [src.name] [log_reagents(src)] at [log_loc(user)].")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[WIKI][BALANCE][FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
PILLS:
Forcefeeding now has an action bar with some time scaling.
Less than or equal to 10u takes 1.5 seconds to forcefeed, scaling linearly at 0.075 seconds per unit until 6 seconds (70 units).
The current time of 3 seconds matches with 30u, so dosages of <30u are now faster.
10: 1.5 seconds
30: 3.0 seconds
50: 4.5 seconds
70+: 6.0 seconds

SYRINGES:
Harm intent is now a jab that prompts a 6 second action bar - completion administers 7.5 units, most interrupts past 1 second (inject) or 2 seconds (draw) will inject/draw up to 5 units, scaled linearly with time past 1 second.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pills are currently far too good at forcing chems into an enemy, and the act of forcefeeding them can be easily missed.
Meanwhile, syringes have the same time (3 seconds) to add a maximum of 5 units (rather than 100) and prompt an obvious action bar and big alert message.
The pill change makes it easier to get away from 100u pills of instant death, while allowing for potent poisons and typical medical dosages to be administered either faster or at the same speed.
The syringe change gives syringes a use case for harmful actions, allowing certain poisons to be administered in a debilitating dosage more reliably (but very obviously) without forcing a change on doctors who rely on precise 5u dosages.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)MylieDaniels
(*)Forcefeeding pills has an action bar, and time to forcefeed scales with size of pill, from 1.5 seconds at 10u to 6 seconds at 70+ units.
(*)Syringes on harm intent do a longer action bar that injects a partial dose even if interrupted.
```
