### PR TITLE
Alternate harm intent mode for syringes

### DIFF
--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -112,8 +112,11 @@
 							return
 
 					if(target != user)
-						user.visible_message("<span class='alert'><B>[user] is trying to draw blood from [target]!</B></span>")
-						actions.start(new/datum/action/bar/icon/syringe(target, src, src.icon, src.icon_state), user)
+						if (user.a_intent == INTENT_HARM)
+							user.visible_message("<span class='alert'><B>[user] stabs [target] with [src] and starts drawing blood!</B></span>")
+						else
+							user.visible_message("<span class='alert'><B>[user] is trying to draw blood from [target]!</B></span>")
+						actions.start(new/datum/action/bar/icon/syringe(user, target, src, src.icon, src.icon_state), user)
 					else
 						transfer_blood(target, src, src.amount_per_transfer_from_this)
 						boutput(user, "<span class='notice'>You fill [src] with [src.amount_per_transfer_from_this] units of [target]'s blood.</span>")
@@ -169,8 +172,11 @@
 						return
 					if (target != user)
 						logTheThing("combat", user, target, "tries to inject [constructTarget(target,"combat")] with a [src] [log_reagents(src)] at [log_loc(user)].")
-						user.visible_message("<span class='alert'><B>[user] is trying to inject [target] with [src]!</B></span>")
-						actions.start(new/datum/action/bar/icon/syringe(target, src, src.icon, src.icon_state), user)
+						if (user.a_intent == INTENT_HARM)
+							user.visible_message("<span class='alert'><B>[user] stabs [target] with [src] and starts injecting!</B></span>")
+						else
+							user.visible_message("<span class='alert'><B>[user] is trying to inject [target] with [src]!</B></span>")
+						actions.start(new/datum/action/bar/icon/syringe(user, target, src, src.icon, src.icon_state), user)
 						user.update_inhands()
 						return
 					else
@@ -201,14 +207,17 @@
 
 		return
 
-	proc/syringe_action(mob/user, mob/target)
+	proc/syringe_action(mob/user, mob/target, var/dosage = 1)
 		switch(src.mode)
 			if(S_DRAW)
-				transfer_blood(target, src, src.amount_per_transfer_from_this)
-				target.visible_message("<span class='alert'>[user] draws blood from [target]!</span>")
+				if (dosage >= 0.33)
+					transfer_blood(target, src, src.amount_per_transfer_from_this * dosage)
+					target.visible_message("<span class='alert'>[user] draws blood from [target]!</span>")
+				else
+					target.visible_message("<span class='alert'>[user] jabs [target] but fails to draw blood!</span>")
 			if(S_INJECT)
-				src.reagents.reaction(target, INGEST, src.amount_per_transfer_from_this)
-				src.reagents.trans_to(target, src.amount_per_transfer_from_this)
+				src.reagents.reaction(target, INGEST, src.amount_per_transfer_from_this * dosage)
+				src.reagents.trans_to(target, src.amount_per_transfer_from_this * dosage)
 				target.visible_message("<span class='alert'>[user] injects [target] with the [src]!</span>")
 				logTheThing("combat", user, target, "injects [constructTarget(target,"combat")] with a [src.name] [log_reagents(src)] at [log_loc(user)].")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[WIKI][BALANCE][FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
SYRINGES:
Harm intent is now a jab that prompts a 6 second action bar - completion administers 7.5 units, most interrupts past 1 second (inject) or 2 seconds (draw) will inject/draw up to 5 units, scaled linearly with time past 1 second.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gives syringes a use case for harmful actions, allowing certain poisons to be administered in a small dosage more reliably (but very obviously) without forcing a change on doctors who rely on precise 5u dosages.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)MylieDaniels
(*)Syringes on harm intent do a longer action bar that injects a partial dose even if interrupted.
```
