### PR TITLE
blocks some wiz spells when not on turf

### DIFF
--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -268,10 +268,10 @@
 		if (!istype(src, /datum/targetable/spell/prismatic_spray/admin) && !H.owner.wizard_castcheck(src)) // oh god this is ugly but it's technically not duplicating code so it fixes to problem with the move to ability buttons
 			src.holder.locked = 0
 			return 999
-		var/turf/T = get_turf(holder.owner)
 		if (src.requires_being_on_turf && !isturf(holder.owner.loc))
 			boutput(holder.owner, "<span class='alert'>That ability doesn't seem to work here.</span>")
 			return 999
+		var/turf/T = get_turf(holder.owner)
 		if( offensive && T.loc:sanctuary )
 			boutput(holder.owner, "<span class='alert'>You cannot cast offensive spells on someone in a sanctuary.</span>")
 		if (src.restricted_area_check)

--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -212,7 +212,7 @@
 
 /datum/targetable/spell
 	preferred_holder_type = /datum/abilityHolder/wizard
-
+	var/requires_being_on_turf = FALSE
 	var/requires_robes = 0
 	var/offensive = 0
 	var/cooldown_staff = 0
@@ -269,6 +269,9 @@
 			src.holder.locked = 0
 			return 999
 		var/turf/T = get_turf(holder.owner)
+		if (src.requires_being_on_turf && !isturf(holder.owner.loc))
+			boutput(holder.owner, "<span class='alert'>That ability doesn't seem to work here.</span>")
+			return 999
 		if( offensive && T.loc:sanctuary )
 			boutput(holder.owner, "<span class='alert'>You cannot cast offensive spells on someone in a sanctuary.</span>")
 		if (src.restricted_area_check)

--- a/code/datums/abilities/wizard/animal.dm
+++ b/code/datums/abilities/wizard/animal.dm
@@ -40,6 +40,7 @@ var/list/animal_spell_critter_paths = list(/mob/living/critter/small_animal/cat,
 	max_range = 1
 	cooldown = 1350
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	sticky = 1
 	voice_grim = "sound/voice/wizard/FurryGrim.ogg"

--- a/code/datums/abilities/wizard/animatedead.dm
+++ b/code/datums/abilities/wizard/animatedead.dm
@@ -6,6 +6,7 @@
 	max_range = 1
 	cooldown = 850
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	cooldown_staff = 1
 	sticky = 1

--- a/code/datums/abilities/wizard/blind.dm
+++ b/code/datums/abilities/wizard/blind.dm
@@ -5,6 +5,7 @@
 	targeted = 1
 	cooldown = 100
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	sticky = 1
 	voice_grim = "sound/voice/wizard/BlindGrim.ogg"

--- a/code/datums/abilities/wizard/bullcharge.dm
+++ b/code/datums/abilities/wizard/bullcharge.dm
@@ -5,6 +5,7 @@
 	targeted = 0
 	cooldown = 150
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	voice_grim = "sound/voice/wizard/BullChargeGrim.ogg"
 	voice_fem = "sound/voice/wizard/BullChargeFem.ogg"

--- a/code/datums/abilities/wizard/cluwne.dm
+++ b/code/datums/abilities/wizard/cluwne.dm
@@ -6,6 +6,7 @@
 	max_range = 1
 	cooldown = 1350
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	sticky = 1
 	voice_grim = "sound/voice/wizard/CluwneGrim.ogg"

--- a/code/datums/abilities/wizard/fireball.dm
+++ b/code/datums/abilities/wizard/fireball.dm
@@ -32,6 +32,7 @@
 	target_anything = 1
 	cooldown = 350
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	sticky = 1
 	voice_grim = "sound/voice/wizard/FireballGrim.ogg"

--- a/code/datums/abilities/wizard/forcewall.dm
+++ b/code/datums/abilities/wizard/forcewall.dm
@@ -5,6 +5,7 @@
 	targeted = 0
 	cooldown = 20 SECONDS
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	voice_grim = "sound/voice/wizard/ForcewallGrim.ogg"
 	voice_fem = "sound/voice/wizard/ForcewallFem.ogg"
 	voice_other = "sound/voice/wizard/ForcewallLoud.ogg"

--- a/code/datums/abilities/wizard/golem.dm
+++ b/code/datums/abilities/wizard/golem.dm
@@ -5,6 +5,7 @@
 	targeted = 0
 	cooldown = 500
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	cooldown_staff = 1
 	voice_grim = "sound/voice/wizard/GolemGrim.ogg"

--- a/code/datums/abilities/wizard/iceburst.dm
+++ b/code/datums/abilities/wizard/iceburst.dm
@@ -5,6 +5,7 @@
 	targeted = 0
 	cooldown = 200
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	voice_grim = "sound/voice/wizard/IceBurstGrim.ogg"
 	voice_fem = "sound/voice/wizard/IceBurstFem.ogg"

--- a/code/datums/abilities/wizard/kill.dm
+++ b/code/datums/abilities/wizard/kill.dm
@@ -6,6 +6,7 @@
 	max_range = 1
 	cooldown = 600
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	sticky = 1
 	voice_grim = "sound/voice/wizard/ShockingGraspGrim.ogg"

--- a/code/datums/abilities/wizard/magicmissile.dm
+++ b/code/datums/abilities/wizard/magicmissile.dm
@@ -5,6 +5,7 @@
 	targeted = 0
 	cooldown = 200
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	voice_grim = "sound/voice/wizard/MagicMissileGrim.ogg"
 	voice_fem = "sound/voice/wizard/MagicMissileFem.ogg"

--- a/code/datums/abilities/wizard/prismatic_spray.dm
+++ b/code/datums/abilities/wizard/prismatic_spray.dm
@@ -6,6 +6,7 @@
 	target_anything = 1
 	cooldown = 250 //10 seconds shorter than the cooldown for fireball in modern code
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	sticky = 1
 	/*

--- a/code/datums/abilities/wizard/shock.dm
+++ b/code/datums/abilities/wizard/shock.dm
@@ -6,6 +6,7 @@
 	max_range = 2
 	cooldown = 450
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	sticky = 1
 	voice_grim = "sound/voice/wizard/ShockingGraspGrim.ogg"

--- a/code/datums/abilities/wizard/warp.dm
+++ b/code/datums/abilities/wizard/warp.dm
@@ -5,6 +5,7 @@
 	targeted = 1
 	cooldown = 100
 	requires_robes = 1
+	requires_being_on_turf = TRUE
 	offensive = 1
 	restricted_area_check = 1
 	sticky = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG][BALANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
fixes #2880, blocks most spells while in objects
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad, the balance implications of being polymorhed by a wiz you dont even see are not good either

note: feel free to change which spells work while in objects i simply disabled the ones which had balance issues or were straight up not working in objects
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+)Most wizard spells have no longer work while phase shifting.
```
