### PR TITLE
Make chemprot apply consistently to touch reactions

### DIFF
--- a/code/mob/living/life/skin.dm
+++ b/code/mob/living/life/skin.dm
@@ -18,7 +18,7 @@
 					continue
 
 				if (A.reagents && A.reagents.total_volume)
-					A.reagents.reaction(owner, TOUCH, react_volume = use_volume, paramslist = (A.reagents.total_volume == A.reagents.maximum_volume) ? 0 : list("silent", "nopenetrate"))
+					A.reagents.reaction(owner, TOUCH, react_volume = use_volume, paramslist = (A.reagents.total_volume == A.reagents.maximum_volume) ? 0 : list("silent", "nopenetrate", "ignore_chemprot"))
 					A.reagents.trans_to(owner, waste_volume/2)
 					A.reagents.remove_any(waste_volume/2)
 				else

--- a/code/modules/admin/buildmodes/reagents.dm
+++ b/code/modules/admin/buildmodes/reagents.dm
@@ -29,7 +29,7 @@ Right Mouse Button on buildmode    = Select reagent<br>
 			return
 		var/datum/reagent/reagent = reagent_holder.reagent_list[reagent_id]
 		blink(get_turf(object))
-		if(ismob(object)) reagent.reaction_mob(object, 1, 20)
+		if(ismob(object)) reagent.reaction_mob_chemprot_layer(object, 1, 20)
 		if(isobj(object)) reagent.reaction_obj(object, 20)
 		if(isturf(object)) reagent.reaction_turf(object, 20)
 

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -681,7 +681,7 @@ datum
 						//mbc : I put in a check to stop extremely distilled things in fluids from reacting
 						if(current_reagent != null && current_reagent.volume > minimum_react) // Don't put spawn(0) in the below three lines it breaks foam! - IM
 							if(ismob(A) && !isobserver(A))
-								if (!current_reagent.reaction_mob(A, TOUCH, current_reagent.volume*volume_fraction, paramslist))
+								if (!current_reagent.reaction_mob_chemprot_layer(A, TOUCH, current_reagent.volume*volume_fraction, paramslist))
 									.+= current_id
 							if(isturf(A))
 								if (!current_reagent.reaction_turf(A, current_reagent.volume*volume_fraction))
@@ -736,7 +736,7 @@ datum
 							if(ismob(A) && !isobserver(A))
 								//SPAWN(0)
 									//if (current_reagent) //This is in a spawn. Between our first check and the execution, this may be bad.
-								if (!current_reagent.reaction_mob(A, INGEST, current_reagent.volume*volume_fraction))
+								if (!current_reagent.reaction_mob_chemprot_layer(A, INGEST, current_reagent.volume*volume_fraction))
 									.+= current_id
 							if(isturf(A))
 								//SPAWN(0)

--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -736,7 +736,7 @@ datum
 							if(ismob(A) && !isobserver(A))
 								//SPAWN(0)
 									//if (current_reagent) //This is in a spawn. Between our first check and the execution, this may be bad.
-								if (!current_reagent.reaction_mob_chemprot_layer(A, INGEST, current_reagent.volume*volume_fraction))
+								if (!current_reagent.reaction_mob(A, INGEST, current_reagent.volume*volume_fraction))
 									.+= current_id
 							if(isturf(A))
 								//SPAWN(0)

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -139,6 +139,8 @@ datum
 			SHOULD_CALL_PARENT(TRUE)
 			var/datum/reagent/self = src					  //of the reagent to the mob on TOUCHING it.
 			var/did_not_react = 1
+			if(!raw_volume) //this should literally never matter but I dare not assume
+				raw_volume = volume
 			switch(method)
 				if(TOUCH)
 					if (penetrates_skin && !("nopenetrate" in paramslist))

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -127,12 +127,13 @@ datum
 		//Modifies the effective volume applied to the mob, but preserves the raw volume so it can be accessed for special behaviors.
 		proc/reaction_mob_chemprot_layer(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0)
 			var/raw_volume = volume
-			if(method == TOUCH && !src.pierces_outerwear)
+			if(method == TOUCH && !src.pierces_outerwear && !("ignore_chemprot" in paramslist))
 				var/percent_protection = clamp(GET_ATOM_PROPERTY(M, PROP_MOB_CHEMPROT), 0, 100)
 				if(percent_protection)
 					percent_protection = 1 - (percent_protection/100)
 					volume *= percent_protection
 			. = reaction_mob(M, method, volume, paramslist, raw_volume)
+			return
 
 		proc/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume) //By default we have a chance to transfer some
 			SHOULD_CALL_PARENT(TRUE)

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -130,7 +130,7 @@ datum
 			if(method == TOUCH && !src.pierces_outerwear && !("ignore_chemprot" in paramslist))
 				var/percent_protection = clamp(GET_ATOM_PROPERTY(M, PROP_MOB_CHEMPROT), 0, 100)
 				if(percent_protection)
-					percent_protection = 1 - (percent_protection/100)
+					percent_protection = 1 - (percent_protection/100) //inverts the percentage to get the multiplier on effective reagents
 					volume *= percent_protection
 			. = reaction_mob(M, method, volume, paramslist, raw_volume)
 			return
@@ -139,8 +139,6 @@ datum
 			SHOULD_CALL_PARENT(TRUE)
 			var/datum/reagent/self = src					  //of the reagent to the mob on TOUCHING it.
 			var/did_not_react = 1
-			if(!raw_volume) //this should literally never matter but I dare not assume
-				raw_volume = volume
 			switch(method)
 				if(TOUCH)
 					if (penetrates_skin && !("nopenetrate" in paramslist))

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -142,7 +142,7 @@ datum
 				if(TOUCH)
 					if (penetrates_skin && !("nopenetrate" in paramslist))
 						if(M.reagents)
-							M.reagents.add_reagent(self.id,volume*modifier,self.data)
+							M.reagents.add_reagent(self.id,volume*touch_modifier,self.data)
 							did_not_react = 0
 					if (ishuman(M) && hygiene_value && method == TOUCH)
 						var/mob/living/carbon/human/H = M

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -123,7 +123,7 @@ datum
 			B.take_damage(blob_damage, volume, "poison")
 			return 1
 
-		//Proc to process a mob's chemical protection in advance of reaction.
+		//Proc to check a mob's chemical protection in advance of reaction.
 		//Modifies the effective volume applied to the mob, but preserves the raw volume so it can be accessed for special behaviors.
 		proc/reaction_mob_chemprot_layer(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0)
 			var/raw_volume = volume

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -123,7 +123,18 @@ datum
 			B.take_damage(blob_damage, volume, "poison")
 			return 1
 
-		proc/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0) //By default we have a chance to transfer some
+		//Proc to process a mob's chemical protection in advance of reaction.
+		//Modifies the effective volume applied to the mob, but preserves the raw volume so it can be accessed for special behaviors.
+		proc/reaction_mob_chemprot_layer(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0)
+			var/raw_volume = volume
+			if(method == TOUCH)
+				var/percent_protection = clamp(GET_ATOM_PROPERTY(M, PROP_MOB_CHEMPROT), 0, 100)
+				if(percent_protection)
+					percent_protection = 1 - (percent_protection/100)
+					volume *= percent_protection
+			. = reaction_mob(M, method, volume, paramslist, raw_volume)
+
+		proc/reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume) //By default we have a chance to transfer some
 			SHOULD_CALL_PARENT(TRUE)
 			var/datum/reagent/self = src					  //of the reagent to the mob on TOUCHING it.
 			var/did_not_react = 1

--- a/code/modules/chemistry/Chemistry-Reagents.dm
+++ b/code/modules/chemistry/Chemistry-Reagents.dm
@@ -127,7 +127,7 @@ datum
 		//Modifies the effective volume applied to the mob, but preserves the raw volume so it can be accessed for special behaviors.
 		proc/reaction_mob_chemprot_layer(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0)
 			var/raw_volume = volume
-			if(method == TOUCH)
+			if(method == TOUCH && !src.pierces_outerwear)
 				var/percent_protection = clamp(GET_ATOM_PROPERTY(M, PROP_MOB_CHEMPROT), 0, 100)
 				if(percent_protection)
 					percent_protection = 1 - (percent_protection/100)
@@ -141,12 +141,6 @@ datum
 			switch(method)
 				if(TOUCH)
 					if (penetrates_skin && !("nopenetrate" in paramslist))
-						var/percent_protection = clamp(GET_ATOM_PROPERTY(M, PROP_MOB_CHEMPROT), 0, 100)
-						var/modifier = 1
-						if(!src.pierces_outerwear)
-							modifier -= (percent_protection/100)
-						modifier *= touch_modifier
-
 						if(M.reagents)
 							M.reagents.add_reagent(self.id,volume*modifier,self.data)
 							did_not_react = 0

--- a/code/modules/chemistry/Reagents-Base.dm
+++ b/code/modules/chemistry/Reagents-Base.dm
@@ -800,14 +800,14 @@ datum
 						var/obj/item/toy/sponge_capsule/S = O
 						S.add_water()
 
-			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
+			reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
 				. = ..()
-				if(!volume)
-					volume = 10
+				if(!raw_volume)
+					raw_volume = 10
 				if(method == TOUCH)
 					var/mob/living/L = M
 					if(istype(L) && L.getStatusDuration("burning"))
-						L.changeStatus("burning", -1 * volume SECONDS)
+						L.changeStatus("burning", -1 * raw_volume SECONDS)
 						playsound(L, "sound/impact_sounds/burn_sizzle.ogg", 50, 1, pitch = 0.8)
 						. = 0
 
@@ -819,7 +819,7 @@ datum
 			hygiene_value = 2
 			value = 3 // 1 1 1
 
-			reaction_mob(var/mob/target, var/method=TOUCH, var/volume)
+			reaction_mob(var/mob/target, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
 				..()
 				var/reacted = 0
 				var/mob/living/M = target
@@ -836,7 +836,7 @@ datum
 						for(var/mob/O in AIviewers(M, null))
 							O.show_message(text("<span class='alert'><b>[] begins to crisp and burn!</b></span>", M), 1)
 						boutput(M, "<span class='alert'>Holy Water! It burns!</span>")
-						var/burndmg = volume * 1.25
+						var/burndmg = raw_volume * 1.25 //the sanctification inflicts the pain, not the water that carries it.
 						burndmg = min(burndmg, 80) //cap burn at 110(80 now >:) so we can't instant-kill vampires. just crit em ok.
 						M.TakeDamage("chest", 0, burndmg, 0, DAMAGE_BURN)
 						M.change_vampire_blood(-burndmg)

--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -142,8 +142,8 @@ datum
 						var/datum/statusEffect/simpledot/burning/burn = L.hasStatus("burning")
 						L.changeStatus("slowed", 4 SECONDS, optional = 4)
 						if(istype(L) && burn) //double up on the extra burny, not blockable by biosuits/etc either
-							L.changeStatus("burning", src.raw_volume SECONDS)
-							burn.counter += 5 * src.raw_volume
+							L.changeStatus("burning", src.volume SECONDS)
+							burn.counter += 5 * src.volume
 
 		combustible/kerosene
 			name = "kerosene"
@@ -778,7 +778,7 @@ datum
 						if(!D.reagents) D.create_reagents(10)
 						D.reagents.add_reagent("blackpowder", 5, null)
 				return
-			reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
+			reaction_mob(var/mob/living/carbon/human/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
 				. = ..()
 				if (ishuman(M) && raw_volume >= 10)
 					M.gunshot_residue = 1

--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -105,13 +105,13 @@ datum
 				holder?.del_reagent(id)
 				return
 
-			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
+			reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
 				. = ..()
 				if(method == TOUCH)
 					var/mob/living/L = M
 					var/datum/statusEffect/simpledot/burning/burn = L.hasStatus("burning")
 					if(istype(L) && burn)
-						L.TakeDamage("All", 0, (1 - L.get_heat_protection()/100) * clamp(3 * volume * (burn.getStage()-1.25), 0, 35), 0, DAMAGE_BURN)
+						L.TakeDamage("All", 0, (1 - L.get_heat_protection()/100) * clamp(3 * raw_volume * (burn.getStage()-1.25), 0, 35), 0, DAMAGE_BURN)
 						if(!M.stat && !ON_COOLDOWN(M, "napalm_scream", 1 SECOND))
 							M.emote("scream")
 					return 0
@@ -135,15 +135,15 @@ datum
 				id = "syndicate_napalm"
 				description = "Extra sticky, extra burny"
 
-				reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
+				reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
 					. = ..()
 					if(method == TOUCH)
 						var/mob/living/L = M
 						var/datum/statusEffect/simpledot/burning/burn = L.hasStatus("burning")
 						L.changeStatus("slowed", 4 SECONDS, optional = 4)
 						if(istype(L) && burn) //double up on the extra burny, not blockable by biosuits/etc either
-							L.changeStatus("burning", src.volume SECONDS)
-							burn.counter += 5 * src.volume
+							L.changeStatus("burning", src.raw_volume SECONDS)
+							burn.counter += 5 * src.raw_volume
 
 		combustible/kerosene
 			name = "kerosene"
@@ -401,10 +401,12 @@ datum
 					var/radius = min((volume - 3) * 0.15, 3)
 					fireflash_sm(T, radius, 4500 + volume * 500, 350)
 
-			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
+			reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
 				. = ..()
 				if(method == TOUCH || method == INGEST)
 					var/mob/living/L = M
+					if(method == TOUCH)
+						volume = raw_volume
 					if(istype(L))
 						if (volume <= 1)
 							L.update_burning(10)
@@ -776,9 +778,9 @@ datum
 						if(!D.reagents) D.create_reagents(10)
 						D.reagents.add_reagent("blackpowder", 5, null)
 				return
-			reaction_mob(var/mob/living/carbon/human/M, var/method=TOUCH, var/volume)
+			reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
 				. = ..()
-				if (ishuman(M) && volume >= 10)
+				if (ishuman(M) && raw_volume >= 10)
 					M.gunshot_residue = 1
 				return
 

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -64,9 +64,9 @@ datum
 				if(reagent_state == LIQUID || prob(2 * volume - min(14 + T0C - holder.total_temperature, 100) * 0.1))
 					explode(list(T), "splash on turf")
 
-			reaction_mob(var/mob/M, var/volume)
+			reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
 				. = ..()
-				if(reagent_state == LIQUID || prob(2 * volume - min(14 + T0C - holder.total_temperature, 100) * 0.1))
+				if(reagent_state == LIQUID || prob(2 * raw_volume - min(14 + T0C - holder.total_temperature, 100) * 0.1))
 					explode(list(get_turf(M)), "splash on [key_name(M)]")
 
 			reaction_obj(var/obj/O, var/volume)
@@ -864,18 +864,18 @@ datum
 			block_slippy = 1
 			var/counter
 
-			reaction_mob(var/mob/M, var/method=TOUCH, var/volume_passed)
+			reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
 				. = ..()
 				if(method == TOUCH)
 					var/mob/living/L = M
 					. = 0
 
 					if(L.getStatusDuration("slowed")>=10 SECONDS)
-						L.setStatusMin("staggered", (0.3 SECONDS)*volume_passed)
+						L.setStatusMin("staggered", (0.3 SECONDS)*raw_volume)
 						if(!ON_COOLDOWN(M, "stuck in glue", 15 SECOND))
 							boutput(M, "<span class='notice'>You get stuck in the glue!</span>")
 					else
-						L.changeStatus("slowed", min((0.4 SECONDS)*volume_passed, 10 SECONDS))
+						L.changeStatus("slowed", min((0.4 SECONDS)*raw_volume, 10 SECONDS))
 				return
 
 			reaction_turf(var/turf/target, var/volume)
@@ -1009,10 +1009,10 @@ datum
 					if(glued_comp?.glued_to == A)
 						qdel(glued_comp)
 
-			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
+			reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
 				. = ..()
 				if (method == TOUCH)
-					remove_stickers(M, volume)
+					remove_stickers(M, raw_volume)
 				unglue_attached_to(M)
 
 			reaction_obj(var/obj/O, var/volume)

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1719,7 +1719,7 @@ datum
 						var/amt = min(volume/100,1)
 						src.holder.remove_reagent("sewage",amt)
 						M.reagents.add_reagent("sewage",amt)
-						src.reaction_mob(M,INGEST,amt)
+						src.reaction_mob_chemprot_layer(M,INGEST,amt)
 				return
 
 			on_mob_life(var/mob/M, var/mult = 1)

--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -1719,7 +1719,7 @@ datum
 						var/amt = min(volume/100,1)
 						src.holder.remove_reagent("sewage",amt)
 						M.reagents.add_reagent("sewage",amt)
-						src.reaction_mob_chemprot_layer(M,INGEST,amt)
+						src.reaction_mob(M,INGEST,amt)
 				return
 
 			on_mob_life(var/mob/M, var/mult = 1)

--- a/code/modules/chemistry/Reagents-PoisonEtc.dm
+++ b/code/modules/chemistry/Reagents-PoisonEtc.dm
@@ -854,16 +854,16 @@ datum
 				..()
 				return
 
-			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
+			reaction_mob(var/mob/M, var/method=TOUCH, var/volume, var/paramslist = 0, var/raw_volume)
 				. = ..()
 				if(method == TOUCH)
 					. = 0
-				if (method == TOUCH && volume >= 10)
+				if (method == TOUCH && raw_volume >= 10)
 					if (ishuman(M))
 						var/mob/living/carbon/human/H = M
 						var/blocked = 0
 						if (!H.wear_mask && !H.head)
-							H.TakeDamage("head", 0, clamp((volume - 5) * 2, 8, 50), 0, DAMAGE_BURN)
+							H.TakeDamage("head", 0, clamp((raw_volume - 5) * 2, 8, 50), 0, DAMAGE_BURN)
 							H.emote("scream")
 							if(!H.disfigured)
 								boutput(H, "<span class='alert'>Your face has become disfigured!</span>")
@@ -874,7 +874,7 @@ datum
 						else
 							if (H.head)
 								var/obj/item/clothing/head/D = H.head
-								if (!(D.item_function_flags & IMMUNE_TO_ACID))
+								if (!(D.item_function_flags & IMMUNE_TO_ACID) && D.getProperty("chemprot") * 2 < raw_volume)
 									if(!D.hasStatus("acid"))
 										boutput(M, "<span class='alert'>Your [H.head] begins to melt!</span>")
 										D.changeStatus("acid", 5 SECONDS, list("mob_owner" = M))
@@ -884,7 +884,7 @@ datum
 							if (!(H.head?.c_flags & SPACEWEAR) || !(H.head?.item_function_flags & IMMUNE_TO_ACID))
 								if (H.wear_mask)
 									var/obj/item/clothing/mask/K = H.wear_mask
-									if (!(K.item_function_flags & IMMUNE_TO_ACID))
+									if (!(K.item_function_flags & IMMUNE_TO_ACID) && K.getProperty("chemprot") * 3 < raw_volume)
 										if(!K.hasStatus("acid"))
 											boutput(M, "<span class='alert'>Your [H.wear_mask] begins to melt away!</span>")
 											K.changeStatus("acid", 5 SECONDS, list("mob_owner" = M))
@@ -896,37 +896,9 @@ datum
 								return
 					else
 						random_brute_damage(M, min(15,volume))
-				else if (method == TOUCH && volume <= 10 && prob(20))
-					if (ishuman(M))
-						var/mob/living/carbon/human/H = M
-						var/blocked = 0
-						if (H.wear_mask || H.head)
-							if (H.head)
-								var/obj/item/clothing/head/D = H.head
-								if (!(D.item_function_flags & IMMUNE_TO_ACID))
-									if(!D.hasStatus("acid"))
-										boutput(M, "<span class='alert'>Your [H.head] begins to melt!</span>")
-										D.changeStatus("acid", 5 SECONDS, list("mob_owner" = M))
-								else
-									H.visible_message("<span class='alert>The blueish acidic substance slides off \the [D] harmlessly.</span>", "<span class='alert'>Your [H.head] protects you from the acid!</span>")
-								blocked = 1
-							if (!(H.head?.c_flags & SPACEWEAR))
-								if (H.wear_mask)
-									var/obj/item/clothing/mask/K = H.wear_mask
-									if (!(K.item_function_flags & IMMUNE_TO_ACID))
-										if(!K.hasStatus("acid"))
-											boutput(M, "<span class='alert'>Your [H.wear_mask] begins to melt away!</span>")
-											K.changeStatus("acid", 5 SECONDS, list("mob_owner" = M))
-									else
-										H.visible_message("<span class='alert'>The blueish acidic substance slides off \the [K] harmlessly.</span>", "<span class='alert'>Your [H.wear_mask] protects you from the acid!</span>")
-									blocked = 1
-
-							if (blocked)
-								return
-						M.TakeDamage("head", 0, clamp((volume - 5) * 2, 8, 50), 0, DAMAGE_BURN)
 				else if (volume >= 5)
 					M.emote("scream")
-					M.TakeDamage("All", 0, clamp((volume - 5) * 3, 8, 75), 0, DAMAGE_BURN)
+					M.TakeDamage("All", 0, clamp((volume - 5) * 2, 8, 75), 0, DAMAGE_BURN)
 					if (ishuman(M))
 						var/mob/living/carbon/human/H = M
 						if (!H.vdisfigured)

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -198,7 +198,7 @@
 					var/mob/living/L = M
 					L.skin_process += src
 			else
-				reagents.reaction(M, TOUCH, paramslist = list("nopenetrate"))
+				reagents.reaction(M, TOUCH, paramslist = list("nopenetrate","ignore_chemprot"))
 
 				var/datum/reagents/R = new
 				reagents.copy_to(R)
@@ -563,7 +563,7 @@
 		var/use_volume_adjusted = use_volume * mult
 
 		if (reagents?.total_volume)
-			var/list/params = list("nopenetrate")
+			var/list/params = list("nopenetrate","ignore_chemprot")
 			if (silent)
 				params.Add("silent")
 

--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -832,7 +832,7 @@ var/mutable_appearance/fluid_ma
 		if (!(src.wear_suit && src.wear_suit.hasProperty ("chemprot") && (src.wear_suit.getProperty("chemprot") >= 40)) && (src.head && src.head.seal_hair))
 			do_reagent_reaction = 1
 */
-	if (do_reagent_reaction && entered_group) //if entered_group == 1, it may not have been set yet
+	if (entered_group) //if entered_group == 1, it may not have been set yet
 		if (isturf(oldloc))
 			if (T.active_liquid)
 				entered_group = 0

--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -810,28 +810,6 @@ var/mutable_appearance/fluid_ma
 			//	if (!M.anchored)
 			//		F.add_tracked_blood(M)
 
-/*
-	var/do_reagent_reaction = 1
-
-	if (F.my_depth_level == 1)
-		if(src.shoes && src.shoes.hasProperty ("chemprot") && (src.shoes.getProperty("chemprot") >= 5)) //sandals do not help
-			do_reagent_reaction = 0
-
-	if (F.my_depth_level == 2 || F.my_depth_level == 3)
-		if (src.wear_suit && src.wear_suit.hasProperty ("chemprot") && (src.wear_suit.getProperty("chemprot") >= 40))
-			do_reagent_reaction = 0
-
-	if (F.my_depth_level >= 4)
-		if ((src.wear_suit && src.wear_suit.hasProperty ("chemprot") && (src.wear_suit.getProperty("chemprot") >= 40)) && (src.head && src.head.seal_hair))
-			do_reagent_reaction = 0
-
-	if (!shoes)
-		do_reagent_reaction = 1
-
-	if (src.lying)
-		if (!(src.wear_suit && src.wear_suit.hasProperty ("chemprot") && (src.wear_suit.getProperty("chemprot") >= 40)) && (src.head && src.head.seal_hair))
-			do_reagent_reaction = 1
-*/
 	if (entered_group) //if entered_group == 1, it may not have been set yet
 		if (isturf(oldloc))
 			if (T.active_liquid)

--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -810,7 +810,7 @@ var/mutable_appearance/fluid_ma
 			//	if (!M.anchored)
 			//		F.add_tracked_blood(M)
 
-
+/*
 	var/do_reagent_reaction = 1
 
 	if (F.my_depth_level == 1)
@@ -831,10 +831,10 @@ var/mutable_appearance/fluid_ma
 	if (src.lying)
 		if (!(src.wear_suit && src.wear_suit.hasProperty ("chemprot") && (src.wear_suit.getProperty("chemprot") >= 40)) && (src.head && src.head.seal_hair))
 			do_reagent_reaction = 1
-
+*/
 	if (do_reagent_reaction && entered_group) //if entered_group == 1, it may not have been set yet
 		if (isturf(oldloc))
 			if (T.active_liquid)
 				entered_group = 0
 
-	..(F, oldloc, do_reagent_reaction)
+	..(F, oldloc)

--- a/code/modules/status_system/statusFoodBuffs.dm
+++ b/code/modules/status_system/statusFoodBuffs.dm
@@ -67,7 +67,7 @@
 				continue
 
 			if (A.reagents && A.reagents.total_volume)
-				A.reagents.reaction(src, TOUCH, react_volume = use_volume, paramslist = (A.reagents.total_volume == A.reagents.maximum_volume) ? 0 : list("silent", "nopenetrate"))
+				A.reagents.reaction(src, TOUCH, react_volume = use_volume, paramslist = (A.reagents.total_volume == A.reagents.maximum_volume) ? 0 : list("silent", "nopenetrate", "ignore_chemprot"))
 				A.reagents.trans_to(src, use_volume/2)
 				A.reagents.remove_any(use_volume/2)
 			else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAJOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Implements the following set of changes with the aim of making chemprot consistently factor into all touch applications of chemicals (as opposed to only factoring into the extent of skin penetration for skin penetrating chems).

**Main Implementation**

- Adds a reaction_mob_chemprot_layer proc that handles the application of chemprot to the practical volume of a reagent that's applied to a mob, also providing the pre-mitigation volume (raw_volume) so reactions can use it if they logically shouldn't care about hitting a mob's suit instead of the skin itself.
- Places aforementioned proc in other locations where reaction_mob was called without a specified non-touch method.
- Removes the separate chemprot check for skin-penetrating chemicals, since the blocking factor by that point is now your skin instead of your clothing.
- Removes a set of checks in /mob/living/carbon/human/EnteredFluid that would cause reactions to simply not happen at all if specific pieces of gear met certain criteria, meaning general chemprot never even factored in.

**Accommodation Changes**

- Adds an "ignore_chemprot" reaction parameter, causing the chemprot check to be entirely skipped.
- Introduces the "ignore_chemprot" reaction parameter to patches, auto-menders and skin processes, so their efficacy isn't affected by this change.
- Water splashed on a mob now uses raw_volume to determine its effectiveness at extinguishing fires.
- Holy water applied to vampires uses raw_volume to determine its damage, in accordance with the principles of sanctification.
- Glue now uses raw_volume for its determination of stickiness.
- Nitroglycerin now uses raw_volume for its explosion strength as applied to mobs.
- Acetone now uses raw_volume for sticker removal.
- Napalm, chlorine trifluoride and black powder now use raw_volume for contact effect strength / thresholds.
- Fluorosulfuric acid now bases its exposed-to-face damage on raw_volume when 10 or more units are applied, and additionally won't melt face gear whose chemprot exceeds 1/3 of the applied volume. Roughly preserves current behavior; a more in-depth rework would probably be cool, but that's getting into scope creep.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Chemprot currently has no bearing on topical effects from chems, which is a major lapse in coverage; this fixes that in a way that shouldn't reduce design space for reagent reactions.

Should not change the behavior of *most* individual chemicals in the strictest sense; the change to the applied amount may have other consequences, but I think I've accounted for the most crucial ones (I inspected every reaction_mob for usage of volume).

Whether patches and automenders should be able to go through chemically-protective attire is debatable, but leaving them operational seems like the better option for gameplay purposes.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Kubius
(*)Chem protection on gear now properly factors into most chemical touch effects. Menders and patches are exempt. 
```