### PR TITLE
chems no longer interact with intangible mobs

### DIFF
--- a/code/modules/chemistry/Chemistry-Holder.dm
+++ b/code/modules/chemistry/Chemistry-Holder.dm
@@ -626,6 +626,8 @@ datum
 		proc/reaction(var/atom/A, var/method=TOUCH, var/react_volume, var/can_spawn_fluid = 1, var/minimum_react = 0.01, var/can_burn = 1, var/list/paramslist = 0)
 			if (src.total_volume <= 0)
 				return
+			if (isintangible(A))
+				return
 			if (isobserver(A)) // errrr
 				return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
chemicals can no longer cause touch reactions to intangible mobs using smoke powder
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad (fixes #9909)