### PR TITLE
Reintroduces antag captains on RP

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -154,9 +154,6 @@ ABSTRACT_TYPE(/datum/job/command)
 	wages = PAY_EXECUTIVE
 	high_priority_job = 1
 	receives_miranda = 1
-#ifdef RP_MODE
-	allow_traitors = 0
-#endif
 	cant_spawn_as_rev = 1
 	announce_on_join = 1
 	allow_spy_theft = 0


### PR DESCRIPTION
[Balance][input wanted]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

removes rpmode ifdef for no antag caps

## Why's this needed?
thought about this one a lot after patching and in the recent months especially. original patch was to hopefully establish another meta-reliable command role on RP, which...I cant honestly say I think has panned out as strongly as hoped; there's still a LOT of distrust of captains
After watching more of classic and how antag HoPs play, I can't say I have any gear concerns for antag captains either.

What this DOES have the potential to re-add is a unique dynamic and memorable antagonist role for some serious and creative RP, the suspense of and core idea that no one is totally trustworthy (almost no one, anyways), and a potentially larger threat for stations to unify against when I think I've observed a real need for something that does that.
Additionally, parity with classic servers which I think preserves some of the intuitive knowledge of the game that newer players develop. It's weird and clunky to explain to people that Captains can be antag, but only on classic, and not RP, unless they're conspirators, but you can only be conspirator on RP, and so on.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)nefarious6th
(*)Captains are able to be antags on RP again
```
