### PR TITLE
Enables flock in both mixed and random event spawns

### DIFF
--- a/code/datums/gamemodes/arcfiend.dm
+++ b/code/datums/gamemodes/arcfiend.dm
@@ -8,7 +8,7 @@
 
 	has_wizards = 0
 	has_werewolves = 0
-	has_blobs = 0
+	major_threats = list(ROLE_WRAITH)
 
 	num_enemies_divisor = 20
 

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -251,7 +251,7 @@
 						stuff_to_output += "<B>[traitor_name] was a [string]!</B>"
 		catch(var/exception/e)
 			logTheThing("debug", null, null, "kyle|former-antag-runtime: [e.file]:[e.line] - [e.name] - [e.desc]")
-	
+
 	// Display all antagonist datums. We arrange them like this so that each antagonist is bundled together by type
 	for (var/V in concrete_typesof(/datum/antagonist))
 		var/datum/antagonist/dummy = V
@@ -389,6 +389,9 @@
 					antag.current.real_name = newname
 					antag.current.name = newname
 
+		if (ROLE_FLOCKMIND)
+			bestow_objective(antag, /datum/objective/specialist/flock)
+			antag.current.make_flockmind()
 		if (ROLE_SPY_THIEF)
 			objective_set_path = /datum/objective_set/spy_theft
 			SPAWN(1 SECOND) //dumb delay to avoid race condition where spy assignment bugs

--- a/code/datums/gamemodes/mixed.dm
+++ b/code/datums/gamemodes/mixed.dm
@@ -57,7 +57,8 @@
 	src.latejoin_antag_roles[ROLE_GRINCH] = 1;
 #endif
 
-	if ((num_enemies >= 4 && prob(30)) || debug_mixed_forced_wraith || debug_mixed_forced_blob || debug_mixed_forced_flock)
+	var/major_threat_chance = length(src.major_threats) * 10
+	if ((num_enemies >= 4 && prob(major_threat_chance)) || debug_mixed_forced_wraith || debug_mixed_forced_blob || debug_mixed_forced_flock)
 		var/chosen = weighted_pick(src.major_threats)
 		if (chosen == ROLE_WRAITH || debug_mixed_forced_wraith)
 			num_enemies = max(num_enemies - 2, 1)

--- a/code/datums/gamemodes/mixed.dm
+++ b/code/datums/gamemodes/mixed.dm
@@ -7,11 +7,11 @@
 	var/const/traitors_possible = 8 // cogwerks - lowered from 10
 	var/const/werewolf_players_req = 15
 
-	var/has_wizards = 1
-	var/has_werewolves = 1
-	var/has_blobs = 1
+	var/has_wizards = TRUE
+	var/has_werewolves = TRUE
 
 	var/list/traitor_types = list(ROLE_TRAITOR = 1, ROLE_CHANGELING = 1, ROLE_VAMPIRE = 1 , ROLE_SPY_THIEF = 1, ROLE_WEREWOLF = 1, ROLE_ARCFIEND = 1)
+	var/list/major_threats = list(ROLE_BLOB = 1, ROLE_WRAITH = 1, ROLE_FLOCKMIND = 1)
 
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
@@ -51,18 +51,23 @@
 	var/num_spy_thiefs = 0
 	var/num_werewolves = 0
 	var/num_arcfiends = 0
+	var/num_flockminds = 0
 #if defined(XMAS) && !defined(RP_MODE)
 	src.traitor_types[ROLE_GRINCH] = 1;
 	src.latejoin_antag_roles[ROLE_GRINCH] = 1;
 #endif
 
-	if ((num_enemies >= 4 && prob(20)) || debug_mixed_forced_wraith || debug_mixed_forced_blob)
-		if (prob(50) || debug_mixed_forced_wraith)
+	if ((num_enemies >= 4 && prob(30)) || debug_mixed_forced_wraith || debug_mixed_forced_blob || debug_mixed_forced_flock)
+		var/chosen = weighted_pick(src.major_threats)
+		if (chosen == ROLE_WRAITH || debug_mixed_forced_wraith)
 			num_enemies = max(num_enemies - 2, 1)
 			num_wraiths = 1
-		else if (has_blobs)
+		else if (chosen == ROLE_BLOB || debug_mixed_forced_blob)
 			num_enemies = max(num_enemies - 4, 1)
 			num_blobs = 1
+		else if (chosen == ROLE_FLOCKMIND || debug_mixed_forced_flock)
+			num_enemies = max(num_enemies - 3, 1)
+			num_flockminds = 1
 	for(var/j = 0, j < num_enemies, j++)
 		if(has_wizards && prob(10)) // powerful combat roles
 			num_wizards++
@@ -181,6 +186,14 @@
 			traitors += blob
 			blob.special_role = ROLE_BLOB
 			possible_blobs.Remove(blob)
+
+	if(num_flockminds)
+		var/list/possible_flockminds = get_possible_enemies(ROLE_FLOCKMIND,num_flockminds)
+		var/list/chosen_flockminds = antagWeighter.choose(pool = possible_flockminds, role = ROLE_FLOCKMIND, amount = num_flockminds, recordChosen = 1)
+		for (var/datum/mind/flockmind in chosen_flockminds)
+			traitors += flockmind
+			flockmind.special_role = ROLE_FLOCKMIND
+			possible_flockminds.Remove(flockmind)
 
 	if(num_grinches)
 		var/list/possible_grinches = get_possible_enemies(ROLE_MISC,num_grinches)

--- a/code/datums/gamemodes/mixed_rp.dm
+++ b/code/datums/gamemodes/mixed_rp.dm
@@ -10,7 +10,7 @@
 
 	has_wizards = 0
 	has_werewolves = 0
-	has_blobs = 0
+	major_threats = list(ROLE_WRAITH)
 
 	num_enemies_divisor = 12
 

--- a/code/datums/gamemodes/vampire.dm
+++ b/code/datums/gamemodes/vampire.dm
@@ -8,7 +8,7 @@
 
 	has_wizards = 0
 	has_werewolves = 0
-	has_blobs = 0
+	major_threats = list(ROLE_WRAITH)
 
 	num_enemies_divisor = 20
 

--- a/code/global.dm
+++ b/code/global.dm
@@ -271,6 +271,7 @@ var/global
 	deadchat_allowed = 1
 	debug_mixed_forced_wraith = 0
 	debug_mixed_forced_blob = 0
+	debug_mixed_forced_flock = 0
 	farting_allowed = 1
 	blood_system = 1
 	bone_system = 0

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -43,7 +43,7 @@
 				message_admins("Antagonist Spawn (non-admin) is disabled in this game mode, aborting.")
 				return
 
-			src.antagonist_type = pick(list("Blob", "Hunter", "Werewolf", "Wizard", "Wraith", "Wrestler", "Wrestler_Doodle", "Vampire", "Changeling"))
+			src.antagonist_type = pick(list("Blob", "Hunter", "Werewolf", "Wizard", "Wraith", "Wrestler", "Wrestler_Doodle", "Vampire", "Changeling", "Flockmind"))
 
 		switch (src.antagonist_type)
 			if ("Blob", "Blob (AI)")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [FEATURE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR enables flockminds to spawn both as a roundstart antag in (non RP) mixed rounds and as a random event antag spawn. Chances are the same as blob and wraith for mixed, and the same as any other random event antag for the event.
Refactors mixed slightly to allow for another major threat type antag, behaviour should be mostly unchanged.
I've credited all the main flock devs in the changelog since I think this is the first major flock public changelog since the rework. Let me know if that makes sense or not.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flock seems to finally be at a point where it can be enabled without direct admin supervision, and Katzen said do it.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech, Amylizzle, FlameArrow57, Stonepillar
(*)Flockminds can now spawn in the (non RP) mixed gamemode and as random event antags.
```
