### PR TITLE
removes loose forensic scanners

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -44143,10 +44143,6 @@
 /obj/window/reinforced{
 	dir = 2
 	},
-/obj/item/device/detective_scanner{
-	pixel_x = 10;
-	pixel_y = 10
-	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "dxC" = (
@@ -47188,9 +47184,6 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
-/obj/item/device/detective_scanner{
-	pixel_x = 12
-	},
 /obj/disposalpipe/segment/food,
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -47655,10 +47648,6 @@
 	dir = 2
 	},
 /obj/item/paper_bin,
-/obj/item/device/detective_scanner{
-	pixel_x = -10;
-	pixel_y = 9
-	},
 /obj/item/pen,
 /obj/item/storage/box/evidence{
 	pixel_x = 5;

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -8955,10 +8955,6 @@
 /obj/window/reinforced{
 	dir = 2
 	},
-/obj/item/device/detective_scanner{
-	pixel_x = -6;
-	pixel_y = 4
-	},
 /turf/simulated/floor/black,
 /area/station/security/main)
 "azM" = (
@@ -13764,10 +13760,6 @@
 /area/station/security/main)
 "aLw" = (
 /obj/table/auto,
-/obj/item/device/detective_scanner{
-	pixel_x = -9;
-	pixel_y = 2
-	},
 /obj/item/hand_labeler{
 	pixel_x = 7;
 	pixel_y = 10

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -29892,18 +29892,6 @@
 	name = "Robust Donuts";
 	pixel_y = 10
 	},
-/obj/item/device/detective_scanner{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/item/device/detective_scanner{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/item/device/detective_scanner{
-	pixel_x = -5;
-	pixel_y = -5
-	},
 /obj/cable{
 	d1 = 4;
 	d2 = 8;

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -4252,7 +4252,6 @@
 "are" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/toolbox/emergency,
-/obj/item/device/detective_scanner,
 /obj/decal/tile_edge/line/white{
 	dir = 1;
 	icon_state = "line1"
@@ -19615,7 +19614,6 @@
 	},
 /obj/item/device/radio/headset/security,
 /obj/item/device/prisoner_scanner,
-/obj/item/device/detective_scanner,
 /obj/machinery/light/incandescent/warm,
 /obj/machinery/firealarm{
 	dir = 8;
@@ -60793,7 +60791,6 @@
 	dir = 1;
 	pixel_y = 21
 	},
-/obj/item/device/detective_scanner,
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
 "xZr" = (
@@ -61102,7 +61099,6 @@
 	},
 /obj/table/wood/auto,
 /obj/item/device/camera_viewer,
-/obj/item/device/detective_scanner,
 /turf/simulated/floor/red/checker{
 	dir = 4
 	},

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -14957,7 +14957,6 @@
 	pixel_x = 9;
 	pixel_y = -1
 	},
-/obj/item/device/detective_scanner,
 /obj/item/pen{
 	pixel_x = -7;
 	pixel_y = -2
@@ -75475,9 +75474,6 @@
 /obj/item/chem_grenade/pepper{
 	pixel_x = -5;
 	pixel_y = 13
-	},
-/obj/item/device/detective_scanner{
-	pixel_x = 6
 	},
 /obj/disposalpipe/segment/ejection{
 	dir = 2

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -39254,7 +39254,6 @@
 	pixel_x = 5;
 	pixel_y = 7
 	},
-/obj/item/device/detective_scanner,
 /turf/simulated/floor/red/side{
 	dir = 4
 	},

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -46616,17 +46616,11 @@
 /obj/item/hand_labeler{
 	pixel_y = 8
 	},
-/obj/item/device/detective_scanner{
-	pixel_x = 7
-	},
 /obj/machinery/recharger/wall/sticky{
 	dir = 1;
 	pixel_y = 26
 	},
 /obj/blind_switch/area/east,
-/obj/item/device/detective_scanner{
-	pixel_x = 7
-	},
 /turf/simulated/floor/redblack{
 	dir = 8
 	},
@@ -47634,9 +47628,6 @@
 /obj/table/reinforced/auto,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/item/device/detective_scanner{
-	pixel_x = 15
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -48412,14 +48403,12 @@
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical,
 /obj/item/device/audio_log,
-/obj/item/device/detective_scanner,
 /obj/item/body_bag,
 /obj/item/body_bag,
 /obj/item/body_bag,
 /obj/storage/cart/forensic{
 	req_access_txt = "1"
 	},
-/obj/item/device/detective_scanner,
 /obj/disposalpipe/segment/brig{
 	dir = 8
 	},

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -498,7 +498,7 @@
 /area/station/bridge)
 "abw" = (
 /obj/displaycase{
-	displayed = new /obj/item/captaingun;
+	displayed = new/obj/item/captaingun;
 	pixel_y = 8
 	},
 /obj/table/wood/auto,
@@ -17445,16 +17445,6 @@
 	pixel_x = -7;
 	pixel_y = 6
 	},
-/obj/item/device/detective_scanner{
-	pixel_x = 6;
-	pixel_y = -3;
-	rand_pos = 0
-	},
-/obj/item/device/detective_scanner{
-	pixel_x = 6;
-	pixel_y = 11;
-	rand_pos = 0
-	},
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/sec_foyer)
 "aXP" = (
@@ -18883,10 +18873,6 @@
 /obj/item/ammo/bullets/smoke,
 /obj/item/ammo/bullets/smoke,
 /obj/item/gun/kinetic/riot40mm,
-/obj/item/device/detective_scanner{
-	pixel_x = 6;
-	pixel_y = 6
-	},
 /turf/simulated/floor/redblack{
 	dir = 6
 	},
@@ -41515,9 +41501,6 @@
 	pixel_y = 20
 	},
 /obj/machinery/phone,
-/obj/item/device/detective_scanner{
-	rand_pos = 0
-	},
 /obj/noticeboard/persistent{
 	name = "Security persistent notice board";
 	persistent_id = "security"

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -28747,15 +28747,9 @@
 	pixel_x = -7;
 	pixel_y = 6
 	},
-/obj/item/device/detective_scanner{
-	pixel_x = -6
-	},
 /obj/item/hand_labeler{
 	pixel_x = 8;
 	pixel_y = 10
-	},
-/obj/item/device/detective_scanner{
-	pixel_x = -3
 	},
 /obj/disposalpipe/junction/right/west,
 /obj/cable{
@@ -38772,7 +38766,6 @@
 /obj/table/reinforced/auto,
 /obj/item/storage/box/evidence,
 /obj/item/storage/box/evidence,
-/obj/item/device/detective_scanner,
 /obj/machinery/light/incandescent/cool/very,
 /turf/simulated/floor/black,
 /area/station/security/interrogation)


### PR DESCRIPTION
[balance]

## About the PR 
removes all the free-floating forensic scanners from maps in rotation (and manta)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
oddly enough, i discovered when doing this there's a lot of variance between which maps offer what kind of availability of some scanners, with like most maps not giving hos offices any but then destiny giving the hos office three; so it standardizes that teensy bit of the puzzle

increases the value of detectives and sec assistants

increases the value of security PDAs and recordtrak computers 

increases the value of forensic scanners as a requisition token purchase, which is the primary thing i wanted to do here.

i think it's redundant and sort of self-defeating to offer scanners as a token purchase but then also have 4+ in a department for officers to pick up. limiting forensic scanners to just one or two free-floating ones just makes a mad dash, which feels unfair because then suddenly someone is getting their two utility token purchases plus a freebie scanner, and the next officer after them can only get 2/3 the same sort of value. 