### PR TITLE
moves confiscated items locker on horizon

### DIFF
--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -19088,6 +19088,9 @@
 	pixel_x = -10
 	},
 /obj/storage/secure/closet/medical/medkit,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -20596,9 +20599,6 @@
 "baE" = (
 /obj/stool/chair/comfy/wheelchair{
 	dir = 4
-	},
-/obj/machinery/status_display{
-	pixel_x = -32
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 8
@@ -35997,6 +35997,9 @@
 /area/station/security/equipment)
 "bNP" = (
 /obj/machinery/vending/medical_public,
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
 /turf/simulated/floor/red,
 /area/station/security/main)
 "bNR" = (
@@ -38164,9 +38167,6 @@
 /obj/machinery/disposal/small/east,
 /obj/disposalpipe/trunk{
 	dir = 4
-	},
-/obj/machinery/status_display{
-	pixel_x = -32
 	},
 /turf/simulated/floor/red/side{
 	dir = 8
@@ -53938,7 +53938,6 @@
 /area/station/hallway/primary/central)
 "gYJ" = (
 /obj/disposalpipe/junction/right/east,
-/obj/storage/secure/closet/brig,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "gZC" = (
@@ -60333,6 +60332,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
+/obj/storage/secure/closet/brig,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "veP" = (


### PR DESCRIPTION
## About the PR 
slightly moves the confiscated items locker on horizon (and moves a few status displays nearby for aesthetics)

## Why's this needed? 
most confiscated items lockers are only a wall or two away from getting broken into; horizon's was weirdly very internal to the department making heists really unlikely. moving it to the other side of the door from where it was can offer some interesting counterplay to try and get contraband again