### PR TITLE
Fix particpant ribbon transformation

### DIFF
--- a/code/mob/living/object.dm
+++ b/code/mob/living/object.dm
@@ -55,8 +55,10 @@
 				boutput(controller, "<h3 class='alert'>Uh oh, you tried to possess something illegal! Here's a toolbox instead!</h3>")
 				src.possessed_thing = new /obj/item/storage/toolbox/artistic
 
-
-		set_loc(get_turf(src.possessed_thing))
+		if(loc)
+			set_loc(loc)
+		else
+			set_loc(get_turf(src.possessed_thing))
 		possessed_thing.set_loc(src)
 
 		//Appearance Stuff


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #9826 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
You're supposed to spawn where you are, but for some reason the mob/living/object code spawns you at the item location despite having a loc parameter, and a newly spawned item with no loc set spawns at 0,0.
