### PR TITLE
Vocal chord acid scarring audio log bugfix

### DIFF
--- a/code/obj/item/device/audio_log.dm
+++ b/code/obj/item/device/audio_log.dm
@@ -287,7 +287,7 @@
 		if (real_name)
 			speaker_name = real_name
 
-		else if (speaker.vdisfigured)
+		if (speaker.vdisfigured)
 			speaker_name = "Unknown"
 
 		if(ishuman(speaker) && speaker.wear_mask && speaker.wear_mask.vchange)//istype(speaker.wear_mask, /obj/item/clothing/mask/gas/voice))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Should fix issue #9923. Scarring your voice with acid should now properly make your voice show up as "unknown" on an audio log.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

I had intended to make it so that your voice should also show up as "Unknown" on audio logs, I just did it improperly back when I added in the code for acid vocal scarring.

