### PR TITLE
Nerfs Some of The Fire Elementals Loot

### DIFF
--- a/code/WorkInProgress/GerhazoStuff.dm
+++ b/code/WorkInProgress/GerhazoStuff.dm
@@ -750,8 +750,7 @@
 
 	New()
 		. = ..()
-		mutations_to_add = list(new /datum/mutation_orb_mutdata(id = "fire_resist", magical = 1),
-		new /datum/mutation_orb_mutdata(id = "aura_fire", magical = 1),
+		mutations_to_add = list(new /datum/mutation_orb_mutdata(id = "aura_fire", magical = 1),
 		new /datum/mutation_orb_mutdata(id = "fire_breath", stabilized = 1)
 		//new /datum/mutation_orb_mutdata(id = "immolate", stabilized = 1, powerboosted = 1)
 		)
@@ -902,7 +901,7 @@
 
 	New()
 		. = ..()
-		properties_to_set = list(new /datum/property_setter_property(incrementative = 0, cap = 100, property_name = "heatprot", property_value = 100))
+		properties_to_set = list(new /datum/property_setter_property(incrementative = 0, cap = 100, property_name = "heatprot", property_value = 50))
 
 
 /obj/item/property_setter/reinforce


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE] [INPUT WANTED]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr nerfs the fire orb and the fire jewel by removing the fire gene that the orb gives, and reducing the heat protection the jewel gives down to 50%, from 100%


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fire elementals can have a difficult time if one of them gets isolated and beat to death, considering there's currently a 2/3 chance that the beaten fire elemental will drop an item that makes their offensive abilities practically useless. this aims to still make the loot somewhat desirable, while not making it full fire immunity.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)The fire orb no longer gives fire damage immunity.
(+)The fire jewel's heat protection has been reduced to 50%, down from 100%.
```
