### PR TITLE
Stops ghostdrones tracking blood

### DIFF
--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -35,7 +35,6 @@
 
 	New()
 		..()
-		APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOATING, src)
 		START_TRACKING
 		hud = new(src)
 		src.attach_hud(hud)
@@ -102,6 +101,9 @@
 		/*SPAWN(0)
 			out(src, "<b>Use \"say ; (message)\" to speak to fellow drones through the spooky power of spirits within machines.</b>")
 			src.show_laws_drone()*/
+
+	track_blood()
+		return
 
 	update_canmove() // this is called on Life() and also by force_laydown_standup() btw
 		..()

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -35,6 +35,7 @@
 
 	New()
 		..()
+		APPLY_ATOM_PROPERTY(src, PROP_ATOM_FLOATING, src)
 		START_TRACKING
 		hud = new(src)
 		src.attach_hud(hud)

--- a/code/obj/machinery/mass_driver.dm
+++ b/code/obj/machinery/mass_driver.dm
@@ -19,7 +19,7 @@
 	var/O_limit
 	var/atom/target = get_edge_target_turf(src, src.dir)
 	for(var/atom/movable/O in src.loc)
-		if(O.anchored || isobserver(O) || isintangible(O) || (HAS_ATOM_PROPERTY(O, PROP_ATOM_FLOATING) && !isghostdrone(O))) continue
+		if(O.anchored || isobserver(O) || isintangible(O) || HAS_ATOM_PROPERTY(O, PROP_ATOM_FLOATING)) continue
 		O_limit++
 		if(O_limit >= 20)
 			for(var/mob/M in hearers(src, null))

--- a/code/obj/machinery/mass_driver.dm
+++ b/code/obj/machinery/mass_driver.dm
@@ -19,7 +19,7 @@
 	var/O_limit
 	var/atom/target = get_edge_target_turf(src, src.dir)
 	for(var/atom/movable/O in src.loc)
-		if(O.anchored || isobserver(O) || isintangible(O) || HAS_ATOM_PROPERTY(O, PROP_ATOM_FLOATING)) continue
+		if(O.anchored || isobserver(O) || isintangible(O) || (HAS_ATOM_PROPERTY(O, PROP_ATOM_FLOATING) && !isghostdrone(O))) continue
 		O_limit++
 		if(O_limit >= 20)
 			for(var/mob/M in hearers(src, null))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stops ghostdrones tracking blood. Doesn't use PROP_ATOM_FLOATING because that messes with mass drivers.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Ghostdrones currently leave bloody footprints behind them, despite having no feet.