### PR TITLE
Fixes #1061 - the eye-spider's mark ability

### DIFF
--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -392,11 +392,11 @@
 		if(src.marked_target && src.client)
 			var/image/arrow = image(icon = 'icons/mob/screen1.dmi', icon_state = "arrow", loc = src, layer = HUD_LAYER)
 			arrow.color = "#ff0000ff"
-			arrow.pixel_y = 20
-			arrow.transform = matrix(arrow.transform, 2,2, MATRIX_SCALE)
-			var/angle = 180 + get_angle(src, src.marked_target)
+			arrow.transform = matrix(arrow.transform, -2, -2, MATRIX_SCALE)
+			var/angle = get_angle(src, src.marked_target)
 			arrow.transform = matrix(arrow.transform, angle, MATRIX_ROTATE)
-			src.client?.images += arrow
+			arrow.transform = matrix(arrow.transform, sin(angle)*40, cos(angle)*40, MATRIX_TRANSLATE)
+			src.client.images += arrow
 			animate(arrow, time = 3 SECONDS, alpha = 0)
 			SPAWN(3 SECONDS)
 				src.client?.images -= arrow

--- a/code/mob/living/critter/changeling_critters.dm
+++ b/code/mob/living/critter/changeling_critters.dm
@@ -387,6 +387,21 @@
 		hivemind_owner.insert_into_hivemind(src)
 		qdel(src)
 
+	Life(datum/controller/process/mobs/parent)
+		. = ..()
+		if(src.marked_target && src.client)
+			var/image/arrow = image(icon = 'icons/mob/screen1.dmi', icon_state = "arrow", loc = src, layer = HUD_LAYER)
+			arrow.color = "#ff0000ff"
+			arrow.pixel_y = 20
+			arrow.transform = matrix(arrow.transform, 2,2, MATRIX_SCALE)
+			var/angle = 180 + get_angle(src, src.marked_target)
+			arrow.transform = matrix(arrow.transform, angle, MATRIX_ROTATE)
+			src.client?.images += arrow
+			animate(arrow, time = 3 SECONDS, alpha = 0)
+			SPAWN(3 SECONDS)
+				src.client?.images -= arrow
+				qdel(arrow)
+
 ///////////////////////////
 // LEGWORM
 ///////////////////////////


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #1061 - The original bug is not present, but the mark ability doesn't actually currently work because stat panel text clipping I think?
Anyway, this changes how it works to instead create an arrow pointing to the marked target every life tick, like so:
![image](https://user-images.githubusercontent.com/3855802/181995485-cda05903-7417-42f6-9c8b-a7637a61e9bb.png)

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Eyespider mark ability is now more accurate, and points at the marked target.
```
