### PR TITLE
Fix #1431 - abusing flock code for mining scans

### DIFF
--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -2103,9 +2103,7 @@ obj/item/clothing/gloves/concussive
 	if(!user || !T || !decalicon) return
 	var/image/O = image('icons/obj/items/mining.dmi',T,decalicon,ASTEROID_MINING_SCAN_DECAL_LAYER)
 	var/datum/client_image_group/cig = get_image_group(T)
-	if(!cig.subscribed_mobs_with_subcount[user])
-		cig.add_mob(user)
-
+	cig.add_mob(user) //we can add this multiple times so if the user refreshes the scan, it times properly and uses the sub count to handle remove
 	cig.add_image(O)
 
 	SPAWN(2 MINUTES)

--- a/code/obj/mining.dm
+++ b/code/obj/mining.dm
@@ -640,6 +640,9 @@
 			if (!(O.type in mining_controls.magnet_do_not_erase))
 				qdel(O)
 		for (var/turf/simulated/T in mining_controls.magnet_area.contents)
+			var/datum/client_image_group/cig = get_image_group(T) //clear out scan results
+			for(var/image/i in cig.images)
+				cig.remove_image(i)
 			if (!istype(T,/turf/simulated/floor/airless/plating/catwalk/))
 				T.ReplaceWithSpace()
 				//qdel(T)
@@ -2063,6 +2066,10 @@ obj/item/clothing/gloves/concussive
 	var/datum/ore/O
 	var/datum/ore/event/E
 	for (var/turf/simulated/wall/auto/asteroid/AST in range(T,range))
+		//clear out any scanning images if there are any
+		var/datum/client_image_group/cig = get_image_group(T)
+		for(var/image/i in cig.images)
+			cig.remove_image(i)
 		stone++
 		O = AST.ore
 		E = AST.event
@@ -2095,13 +2102,14 @@ obj/item/clothing/gloves/concussive
 /proc/mining_scandecal(var/mob/living/user, var/turf/T, var/decalicon)
 	if(!user || !T || !decalicon) return
 	var/image/O = image('icons/obj/items/mining.dmi',T,decalicon,ASTEROID_MINING_SCAN_DECAL_LAYER)
-	user << O
+	var/datum/client_image_group/cig = get_image_group(T)
+	if(!cig.subscribed_mobs_with_subcount[user])
+		cig.add_mob(user)
+
+	cig.add_image(O)
+
 	SPAWN(2 MINUTES)
-		if (user?.client)
-			user.client.images -= O
-			user.client.screen -= O
-		qdel (O)
-		O = null
+		cig.remove_mob(user)
 
 ///// MINER TRAITOR ITEM /////
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #1431 by redoing the image overlays using the flock annotation system. Scans are refreshed when a new thing is pulled into the mining area, plus all the benefits of the client_image_group system (ie, when the mob dies or whatever, the mining scans are removed appropriately).