### PR TITLE
Fixes #1673 - check if arms are attached before severing them

### DIFF
--- a/code/obj/item/mob_parts.dm
+++ b/code/obj/item/mob_parts.dm
@@ -179,6 +179,8 @@ ABSTRACT_TYPE(/obj/item/parts)
 		else if(remove_object)
 			src.remove_object = null
 			qdel(src)
+		if(!QDELETED(src))
+			src.holder = null
 		return object
 
 	proc/sever(var/mob/user)
@@ -255,7 +257,8 @@ ABSTRACT_TYPE(/obj/item/parts)
 			src.remove_object = null
 			holder = null
 			qdel(src)
-
+		if(!QDELETED(src))
+			src.holder = null
 		return object
 
 	//for humans

--- a/code/obj/item/uplinks.dm
+++ b/code/obj/item/uplinks.dm
@@ -815,15 +815,16 @@ Note: Add new traitor items to syndicate_buylist.dm, not here.
 						var/mob/living/carbon/human/H = M
 						var/obj/item/parts/HP = delivery
 					//	var/limb_name = HP.holder.real_name + "'s " + HP.name
-						if(HP == B.item) //Uhh idk if this will work
+						if(HP == B.item && HP.holder == M) //Is this the right limb and is it attached?
 							HP.remove()
 							take_bleeding_damage(H, null, 10)
 							H.changeStatus("weakened", 3 SECONDS)
 							playsound(H.loc, 'sound/impact_sounds/Flesh_Break_2.ogg', 50, 1)
 							H.emote("scream")
 							logTheThing("combat", user, null, "spy thief claimed [constructTarget(H)]'s [HP] at [log_loc(user)]")
-						else
+						else if(HP != B.item)
 							user.show_text("That isn't the right limb!", "red")
+							return 0
 					else
 						M.drop_from_slot(delivery,get_turf(M))
 				if (!istype(delivery,/obj/item/parts))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #1673 by first making limbs that have been remove have a null holder, and then checking that limbs are attached before inflicting damage on the mob with the spy thief pda limb steal.
