### PR TITLE
Fixes #9755 - Crushed can size changed to tiny

### DIFF
--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -359,6 +359,7 @@
 	desc = "This can's been totally crushed!"
 	icon = 'icons/obj/foodNdrink/can.dmi'
 	w_class = W_CLASS_TINY
+
 	proc/crush_can(var/name, var/icon_state)
 		src.name = "crushed [name]"
 		switch(icon_state)

--- a/code/modules/food_and_drink/drinks.dm
+++ b/code/modules/food_and_drink/drinks.dm
@@ -358,7 +358,7 @@
 	name = "crushed can"
 	desc = "This can's been totally crushed!"
 	icon = 'icons/obj/foodNdrink/can.dmi'
-
+	w_class = W_CLASS_TINY
 	proc/crush_can(var/name, var/icon_state)
 		src.name = "crushed [name]"
 		switch(icon_state)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG - MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #9755 by changing the size of crushed cans from normal to tiny.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This allows janitor vac-guns to pick up crushed cans, where they could only pick up regular/uncrushed cans before.