### PR TITLE
Fixes #9988 - Typo in mindhack status effect description is now fixed.

### DIFF
--- a/code/modules/status_system/statusEffects.dm
+++ b/code/modules/status_system/statusEffects.dm
@@ -2216,7 +2216,7 @@
 
 	onAdd(mob/hacker, custom_orders)
 		. = ..()
-		desc = "You've been mindhacked by [hacker.real_name] and feel an unwavering loyalty towards [his_or_her(hacker)]."
+		desc = "You've been mindhacked by [hacker.real_name] and feel an unwavering loyalty towards [him_or_her(hacker)]."
 		var/mob/M = owner
 		if (M.mind && ticker.mode)
 			if (!M.mind.special_role)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[TRIVIAL] [HELP WANTED]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #9988 - Typo where "Mindhack indicator says 'you feel unwavering loyalty to _his_' instead of '_him_'"

This fix is currently untested; I don't know how to test the mindhack without another person. Beyond that, I have gotten no errors when running everything, so this probably works.

If there is a way to test this on my own, or if someone else can test and verify this, please let me know!