### PR TITLE
Shift the multitool in kondaru disposals down by 5 pixels

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -8681,7 +8681,7 @@
 /obj/item/crowbar,
 /obj/item/device/multitool{
 	pixel_x = 9;
-	pixel_y = -1
+	pixel_y = -6
 	},
 /turf/simulated/floor/grime,
 /area/station/maintenance/disposal)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
[qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Moves the multitool in the Kondaru Wastes Disposals slightly down so that it no longer occludes the crowbar.
![image](https://user-images.githubusercontent.com/65367576/182050656-28b5f81f-589c-46a3-b7da-70ba4bbe9ec8.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

It shouldn't be blocking the crowbar, and it's a much-needed improvement to the Disposals room.

