### PR TITLE
slamgun can no longer be attached as an arm

### DIFF
--- a/code/obj/item/gun/kinetic.dm
+++ b/code/obj/item/gun/kinetic.dm
@@ -1177,6 +1177,7 @@ ABSTRACT_TYPE(/obj/item/gun/kinetic)
 	ammo_cats = list(AMMO_SHOTGUN_ALL)
 	max_ammo_capacity = 1
 	auto_eject = 0
+	object_flags = NO_GHOSTCRITTER | NO_ARM_ATTACH
 	spread_angle = 10 // sorry, no sniping with slamguns
 
 	can_dual_wield = 0


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
prevents attaching slamguns as arms (no balance impact because they didnt even work in item arm form anyway), fixes #9946


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad