### PR TITLE
Fix AI APC command not working for unpowered APCs

### DIFF
--- a/code/mob/living/intangible/ai-camera.dm
+++ b/code/mob/living/intangible/ai-camera.dm
@@ -395,7 +395,7 @@
 		var/area/A = get_area(src)
 		if(istype(A, /area/station/))
 			var/obj/machinery/power/apc/P = A.area_apc
-			if(P?.operating)
+			if(P)
 				P.attack_ai(src)
 				return
 


### PR DESCRIPTION
[BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where the AI APC command button wasn't working for APCS that had their main breakers off.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix
