### PR TITLE
makes people spawn with noslips on BR

### DIFF
--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -333,7 +333,6 @@ proc/hide_weapons_everywhere(var/total_battlers = 1)
 	weapon_supplies.Add(/obj/item/storage/grenade_pouch/high_explosive)
 	weapon_supplies.Add(/obj/item/storage/grenade_pouch/incendiary)
 	weapon_supplies.Add(/obj/item/storage/grenade_pouch/mixed_explosive)
-	weapon_supplies.Add(/obj/item/storage/banana_grenade_pouch)
 	weapon_supplies.Add(/obj/item/storage/beartrap_pouch)
 
 	var/list/armor_supplies = list()

--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -507,7 +507,7 @@ proc/equip_battler(mob/living/carbon/human/battler)
 	hat.setProperty("heatprot", 5)
 	battler.equip_if_possible(jumpsuit, battler.slot_w_uniform)
 	battler.equip_if_possible(hat, battler.slot_head)
-	battler.equip_if_possible(new /obj/item/clothing/shoes/swat(battler), battler.slot_shoes)
+	battler.equip_if_possible(new /obj/item/clothing/shoes/swat/noslip(battler), battler.slot_shoes)
 	var/obj/item/clothing/head/vest = new /obj/item/clothing/suit/armor/vest/light
 	vest.delProperty("heatprot")
 	vest.delProperty("coldprot")

--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -339,7 +339,6 @@ proc/hide_weapons_everywhere(var/total_battlers = 1)
 	// Feel free to add more!
 	armor_supplies.Add(/obj/item/clothing/shoes/rocket)
 	armor_supplies.Add(/obj/item/clothing/shoes/swat/heavy)
-	armor_supplies.Add(/obj/item/clothing/shoes/galoshes)
 	armor_supplies.Add(/obj/item/clothing/suit/armor/vest)
 	armor_supplies.Add(/obj/item/clothing/suit/armor/NT)
 	armor_supplies.Add(/obj/item/clothing/suit/armor/NT_alt)

--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -338,7 +338,7 @@ proc/hide_weapons_everywhere(var/total_battlers = 1)
 	var/list/armor_supplies = list()
 	// Feel free to add more!
 	armor_supplies.Add(/obj/item/clothing/shoes/rocket)
-	armor_supplies.Add(/obj/item/clothing/shoes/swat/heavy)
+	armor_supplies.Add(/obj/item/clothing/shoes/swat/knight)
 	armor_supplies.Add(/obj/item/clothing/suit/armor/vest)
 	armor_supplies.Add(/obj/item/clothing/suit/armor/NT)
 	armor_supplies.Add(/obj/item/clothing/suit/armor/NT_alt)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BALANCE] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
makes players on the BR gamemode start with noslips shoes
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
i have seen a ton of BR games turn into slip hell in pools of blood when people try to travel trough the halls at above walk speed, this is very bad given that you have merely 60 seconds to get to a safezone, this also changes the combat meta a bit but i doubt the change to it is major

also removes: galoshes, HOS boots, banana nades from the weapon/armor item pools due to being useless
HOS shoes replaced by nukie knight shoes in its pool