### PR TITLE
Bumps Rust-G Dependency Version to 1.0.2

### DIFF
--- a/_std/rust_g.dm
+++ b/_std/rust_g.dm
@@ -182,7 +182,7 @@
 /proc/rustg_read_toml_file(path)
 	var/list/output = rustg_raw_read_toml_file(path)
 	if (output["success"])
-		return output["content"]
+		return json_decode(output["content"])
 	else
 		CRASH(output["content"])
 

--- a/buildByond.conf
+++ b/buildByond.conf
@@ -3,9 +3,9 @@ BYOND_MINOR_VERSION=1585
 
 SPACEMAN_DMM_VERSION=suite-1.7.2
 
-# f82e57b
+# 93ae889
 # --no-default-features --features "acreplace, cellularnoise, dmi, file, git, http, json, log, noise, time, toml, url, batchnoise, hash, worleynoise"
-RUST_G_VERSION=1.0.0
+RUST_G_VERSION=1.0.2
 
 NODE_VERSION=12
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Hey there,

I was bored, and I found out that the rust-g minimum version you had listed was a bit out of date. I added the DM side fix done in https://github.com/tgstation/rust-g/pull/112 (https://github.com/tgstation/rust-g/commit/b6afd895ff0f77d0ae6cdda5bda9689fadd8e002), and this should also have the patch for the Pallette Information https://github.com/tgstation/rust-g/pull/107 (https://github.com/tgstation/rust-g/commit/c19cdfba9f864f1c55808fd9c0ffa3b46bacefa6).

I'm not certain how often you use this stuff over here, but I figured I should be a friendly neighbor and get you guys up-to-speed before something conks out down the line.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Gets you guys up to speed for patches for bug fixes that completely break some stuff.

## Changelog

I don't believe this is needed since this is purely code-side.
