### PR TITLE
buffs cyborg cleaner bottles and code cleanliness

### DIFF
--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -38,14 +38,10 @@ WET FLOOR SIGN
 /obj/item/spraybottle/detective
 	name = "luminol bottle"
 	desc = "A spray bottle labeled 'Luminol - Blood Detection Agent'. That's what those fancy detectives use to see blood!"
-
+	rc_flags = RC_VISIBLE | RC_SPECTRO | RC_SCALE
 	New()
 		..()
 		reagents.add_reagent("luminol", initial_volume)
-
-	examine()
-		. = ..()
-		. += "[src.reagents.total_volume] units left!"
 
 /obj/item/spraybottle/cleaner/
 	name = "cleaner spray bottle"

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -63,7 +63,7 @@ WET FLOOR SIGN
 
 	on_reagent_change()
 		..()
-		if (src.reagents.total_volume < reagents.maximum_volume)
+		if (src.reagents.total_volume < src.reagents.maximum_volume)
 			processing_items |= src
 
 	process()

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -56,8 +56,8 @@ WET FLOOR SIGN
 	name = "cybernetic cleaner spray bottle"
 	desc = "A cleaner spray bottle jury-rigged to synthesize space cleaner."
 	icon_state = "cleaner_robot"
-	var/refill_speed = 5
-	
+	var/refill_speed = 2.5
+	initial_volume = 50
 	disposing()
 		..()
 		processing_items.Remove(src)
@@ -81,10 +81,6 @@ WET FLOOR SIGN
 	icon_state = "cleaner_robot"
 	initial_volume = 25
 	refill_speed = 0.75
-
-	New()
-		..()
-		reagents.add_reagent("cleaner", initial_volume)
 
 /obj/janitorTsunamiWave
 	name = "chemicals"

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -39,6 +39,7 @@ WET FLOOR SIGN
 	name = "luminol bottle"
 	desc = "A spray bottle labeled 'Luminol - Blood Detection Agent'. That's what those fancy detectives use to see blood!"
 	rc_flags = RC_VISIBLE | RC_SPECTRO | RC_SCALE
+
 	New()
 		..()
 		reagents.add_reagent("luminol", initial_volume)

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -68,7 +68,7 @@ WET FLOOR SIGN
 
 	process()
 		..()
-		if (src.reagents.total_volume < reagents.maximum_volume)
+		if (src.reagents.total_volume < src.reagents.maximum_volume)
 			src.reagents.add_reagent("cleaner", refill_speed)
 		else
 			processing_items.Remove(src)

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -21,6 +21,7 @@ WET FLOOR SIGN
 	throw_range = 10
 	tooltip_flags = REBUILD_DIST | REBUILD_SPECTRO
 	move_triggered = 1
+	var/initial_volume = 100
 
 /obj/item/spraybottle/move_trigger(var/mob/M, kindof)
 	if (..() && reagents)
@@ -32,7 +33,7 @@ WET FLOOR SIGN
 
 /obj/item/spraybottle/New()
 	..()
-	create_reagents(100)
+	create_reagents(initial_volume)
 
 /obj/item/spraybottle/detective
 	name = "luminol bottle"
@@ -40,11 +41,11 @@ WET FLOOR SIGN
 
 	New()
 		..()
-		reagents.add_reagent("luminol", 100)
+		reagents.add_reagent("luminol", initial_volume)
 
 	examine()
 		. = ..()
-		. += "[bicon(src)] [src.reagents.total_volume] units of luminol left!"
+		. += "[src.reagents.total_volume] units left!"
 
 /obj/item/spraybottle/cleaner/
 	name = "cleaner spray bottle"
@@ -52,29 +53,26 @@ WET FLOOR SIGN
 
 	New()
 		..()
-		reagents.add_reagent("cleaner", 100)
+		reagents.add_reagent("cleaner", initial_volume)
 
-/obj/item/spraybottle/cleaner/robot/New()
-	..()
-	create_reagents(25)// no more 100 units on spawn for you, mister!
 /obj/item/spraybottle/cleaner/robot
 	name = "cybernetic cleaner spray bottle"
 	desc = "A cleaner spray bottle jury-rigged to synthesize space cleaner."
 	icon_state = "cleaner_robot"
-
+	var/refill_speed = 5
 	disposing()
 		..()
 		processing_items.Remove(src)
 
-	afterattack(atom/A, mob/user)
-		. = ..()
-		if (src.reagents.total_volume < 25)
+	on_reagent_change()
+		..()
+		if (src.reagents.total_volume < reagents.maximum_volume)
 			processing_items |= src
 
 	process()
 		..()
-		if (src.reagents.total_volume < 25)
-			src.reagents.add_reagent("cleaner", 1)
+		if (src.reagents.total_volume < reagents.maximum_volume)
+			src.reagents.add_reagent("cleaner", refill_speed)
 		else
 			processing_items.Remove(src)
 		return 0
@@ -83,16 +81,12 @@ WET FLOOR SIGN
 	name = "cybernetic cleaning spray bottle"
 	desc = "A small spray bottle that slowly synthesises space cleaner."
 	icon_state = "cleaner_robot"
+	initial_volume = 25
+	refill_speed = 0.75
 
-	process()
+	New()
 		..()
-		if (src.reagents.total_volume < 25)
-			src.reagents.add_reagent("cleaner", 0.75)
-		else
-			processing_items.Remove(src)
-		return 0
-
-
+		reagents.add_reagent("cleaner", initial_volume)
 
 /obj/janitorTsunamiWave
 	name = "chemicals"

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -57,6 +57,7 @@ WET FLOOR SIGN
 	desc = "A cleaner spray bottle jury-rigged to synthesize space cleaner."
 	icon_state = "cleaner_robot"
 	var/refill_speed = 5
+	
 	disposing()
 		..()
 		processing_items.Remove(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [QOL][TRIVIAL][CLEANLINESS] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
changes detectives luminol spray bottle examine text to be better

makes civilian borg module spray bottle regenerate 5u per cycle instead of 1u, buff its max capacity from 25u to 100u

patches a tiny bug of the cyborg bottle not refilling until you try to spray if you empty it via non attack means like smoke powder

tiny code improvements
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
makes the cleaning bottle cyborg item not painful to use
cleanliness
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+) Civilian cyborg cleaning spray bottles refill speed has been increased from 1u to 5u, maximum volume changed from 25 to 100.
```
