### PR TITLE
Fixes flock not being able to convert pool tiles

### DIFF
--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -678,7 +678,7 @@ var/flock_signal_unleashed = FALSE
 	if(!T)
 		return
 
-	if(istype(T, /turf/simulated/floor))
+	if(istype(T, /turf/simulated/floor) || istype(T, /turf/simulated/pool))
 		T.ReplaceWith("/turf/simulated/floor/feather", FALSE)
 		animate_flock_convert_complete(T)
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets flock convert pool tiles.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Drones and a bits would previously get stuck trying to convert pool tiles over and over because for some godforsaken reason they don't inherit from `/turf/simulated/floor/`