### PR TITLE
AI turrets won't target Ghost Critters anymore

### DIFF
--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -124,7 +124,7 @@
 			continue
 		if (!iscarbon(C) && !ismobcritter(C))
 			continue
-		if (isdead(C))
+		if (isdead(C) || isghostcritter(C))
 			continue
 		if (!istype(C.loc,/turf))
 			continue


### PR DESCRIPTION
## About the PR 
I won't label this as a bug-fix because I'm having a hard time trying to consider it a bug. But it's nonetheless a feature that would benefit the game. Besides that, it's what the title says.


## Why's this needed? 

Because Ghost Critters can't really do any harm against the AI or even change it's laws, so there's no reason to actively stun-lock it in AI upload.