### PR TITLE
Disables being able to snip large television cameras

### DIFF
--- a/code/obj/machinery/camera.dm
+++ b/code/obj/machinery/camera.dm
@@ -16,6 +16,7 @@
 	var/last_paper = 0
 	///Cameras only the AI can see through
 	var/ai_only = FALSE
+	var/reinforced = FALSE
 
 	//This camera is a node pointing to the other bunch of cameras nearby for AI movement purposes
 	var/obj/machinery/camera/c_north = null
@@ -62,6 +63,7 @@
 	icon_state = "television"
 	anchored = 1
 	density = 1
+	reinforced = TRUE
 	var/securedstate = 2
 
 /obj/machinery/camera/television/attackby(obj/item/W, mob/user)
@@ -285,7 +287,7 @@
 		user.visible_message("<span class='alert'>[user] wipes [src] with the bloody end of [W.name]. What the fuck?</span>", "<span class='alert'>You wipe [src] with the bloody end of [W.name]. What the fuck?</span>")
 		return
 
-	if (issnippingtool(W))
+	if (issnippingtool(W) && !src.reinforced)
 		if (src.camera_status)
 			src.break_camera(user)
 		else

--- a/code/obj/machinery/camera.dm
+++ b/code/obj/machinery/camera.dm
@@ -16,6 +16,7 @@
 	var/last_paper = 0
 	///Cameras only the AI can see through
 	var/ai_only = FALSE
+	///Cant be snipped by wirecutters
 	var/reinforced = FALSE
 
 	//This camera is a node pointing to the other bunch of cameras nearby for AI movement purposes


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes ##4033 by making these cameras be unable to be snipped


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes ##4033

