### PR TITLE
Ghost Critters will not be targeted by the AI turrets (once again)

### DIFF
--- a/code/obj/machinery/turret.dm
+++ b/code/obj/machinery/turret.dm
@@ -124,7 +124,7 @@
 			continue
 		if (!iscarbon(C) && !ismobcritter(C))
 			continue
-		if (isdead(C))
+		if (isdead(C) || isghostcritter(C))
 			continue
 		if (!istype(C.loc,/turf))
 			continue


### PR DESCRIPTION
## About the PR 

Yes, this is the second time I'm opening this PR. I had to erase my fork of the codebase and the old PR wouldn't open up even after I made a new branch, so I've got to make a new one.


## Why's this needed?

Ghost Critters cannot interact with the AI or the law modules in any meaningful way. Also fixes #10042.