### PR TITLE
Antagonist datum tidying and bugfixing

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -226,7 +226,7 @@ datum/mind
 		return null
 
 	/// Attempts to add the antagonist datum of ID role_id to this mind.
-	proc/add_antagonist(role_id, do_equip = TRUE, do_objectives = TRUE, do_relocate = TRUE, silent = FALSE, source = ANTAGONIST_SOURCE_ROUND_START, respect_mutual_exclusives = TRUE, do_pseudo = FALSE)
+	proc/add_antagonist(role_id, do_equip = TRUE, do_objectives = TRUE, do_relocate = TRUE, silent = FALSE, source = ANTAGONIST_SOURCE_ROUND_START, respect_mutual_exclusives = TRUE, do_pseudo = FALSE, late_setup = FALSE)
 		// Check for mutual exclusivity for real antagonists
 		if (respect_mutual_exclusives && !do_pseudo && length(src.antagonists))
 			for (var/datum/antagonist/A as anything in src.antagonists)
@@ -238,7 +238,7 @@ datum/mind
 		for (var/V in concrete_typesof(/datum/antagonist))
 			var/datum/antagonist/A = V
 			if (initial(A.id) == role_id)
-				src.antagonists.Add(new A(src, do_equip, do_objectives, do_relocate, silent, source, do_pseudo))
+				src.antagonists.Add(new A(src, do_equip, do_objectives, do_relocate, silent, source, do_pseudo, late_setup))
 				src.current.antagonist_overlay_refresh(TRUE, FALSE)
 				return !isnull(src.get_antagonist(role_id))
 		return FALSE

--- a/code/modules/admin/player_options.dm
+++ b/code/modules/admin/player_options.dm
@@ -81,7 +81,7 @@
 		if (antag_len)
 			antag = "<b>[antag_len] antagonist role\s present.</b><br>"
 			for (var/datum/antagonist/this_antag as anything in M.mind.antagonists)
-				antag += "[this_antag.display_name] &mdash; <a href='?src=\ref[src];action=remove_antagonist;targetmob=\ref[M];target_antagonist=\ref[this_antag]'>Remove</a><br>"
+				antag += "<span class='antag'>[this_antag.display_name]</span> &mdash; <a href='?src=\ref[src];action=remove_antagonist;targetmob=\ref[M];target_antagonist=\ref[this_antag]'>Remove</a><br>"
 			antag += "<a href='?src=\ref[src];targetmob=\ref[M];action=add_antagonist'>Add Antagonist Role</a><br>"
 			antag += "<a href='?src=\ref[src];targetmob=\ref[M];action=wipe_antagonists'>Remove All Antagonist Roles</a><br>"
 		else if (M.mind.special_role != null)

--- a/code/modules/antagonists/arcfiend/abilities/_arcfiend_ability_holder.dm
+++ b/code/modules/antagonists/arcfiend/abilities/_arcfiend_ability_holder.dm
@@ -13,16 +13,20 @@
 		..()
 		. = list()
 		.["Energy:"] = round(src.points)
-		.["Total:"] = round(src.lifetime_energy)
+		var/total_display = round(src.lifetime_energy)
+		if (total_display >= 10000)
+			total_display = "[round(total_display / 1000, 1.1)]k"
+		.["Total:"] = total_display
 
 	addPoints(add_points, target_ah_type = src.type)
-		src.lifetime_energy += add_points
 		var/points = min((MAX_ARCFIEND_POINTS - src.points), add_points)
-		if (points > 0 && ishuman(src.owner))
-			var/mob/living/carbon/human/H = src.owner
-			if (H.sims)
-				H.sims.affectMotive("Thirst", points * 0.1)
-				H.sims.affectMotive("Hunger", points * 0.1)
+		if (points > 0)
+			src.lifetime_energy += points
+			if (ishuman(src.owner))
+				var/mob/living/carbon/human/H = src.owner
+				if (H.sims)
+					H.sims.affectMotive("Thirst", points * 0.1)
+					H.sims.affectMotive("Hunger", points * 0.1)
 		. = ..(points, target_ah_type)
 		src.updateText()
 		src.updateButtons()

--- a/code/modules/antagonists/arcfiend/abilities/arc_flash.dm
+++ b/code/modules/antagonists/arcfiend/abilities/arc_flash.dm
@@ -28,7 +28,7 @@
 		for (var/i in 1 to src.chain_count)
 			var/list/potential_targets = list()
 			for (var/mob/M in range(src.chain_range, get_turf(chain_source)))
-				if (M in exempt_targets || isobserver(M))
+				if (M in exempt_targets || isobserver(M) || isintangible(M))
 					continue
 				potential_targets.Add(M)
 			if (length(potential_targets))

--- a/code/modules/antagonists/arcfiend/abilities/arc_flash.dm
+++ b/code/modules/antagonists/arcfiend/abilities/arc_flash.dm
@@ -28,7 +28,7 @@
 		for (var/i in 1 to src.chain_count)
 			var/list/potential_targets = list()
 			for (var/mob/M in range(src.chain_range, get_turf(chain_source)))
-				if (M in exempt_targets)
+				if (M in exempt_targets || isobserver(M))
 					continue
 				potential_targets.Add(M)
 			if (length(potential_targets))

--- a/code/modules/events/sleeperagent.dm
+++ b/code/modules/events/sleeperagent.dm
@@ -112,8 +112,6 @@
 
 	proc/awaken_sleeper_agent(var/mob/living/carbon/human/H, var/source)
 		H.mind.add_antagonist(ROLE_SLEEPER_AGENT, source = ANTAGONIST_SOURCE_RANDOM_EVENT)
-		if(!(H.mind in ticker.mode.traitors))
-			ticker.mode.traitors += H.mind
 		message_admins("[key_name(H)] awakened as a sleeper agent antagonist. Source: [source ? "[source]" : "random event"]")
 		logTheThing("admin", H, null, "awakened as a sleeper agent antagonist. Source: [source ? "[source]" : "random event"]")
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUGFIX][CLEANLINESS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This is a bugfixing batch for antagonist datums. A few related issues have cropped up over the past few days, and this is a quick stability pass, and in addition to fixing the issues below, it includes the following:
* Late-joining traitors will now use a "late setup" system. Antagonists with a late setup will have their setup proc paused just after the beginning. Every second for the following minute, it will check if the mind has an assigned role, and if it does, setup proceeds immediately. If for whatever reason the mind still has no assigned role after 60 seconds, the datum will alert admins that it failed. 
  * This is intended to be a lag-agnostic fix for latejoining traitors not receiving their equipment correctly due to lack of job items at the time, but if it's a yucky solution I'll come up with something else.
* Objectives no longer display twice for latejoining traitors and arcfiends.
* Arcfiends now have their lifetime energy correctly tallied, and it will abbreviate to things like `11.5k` if the total is above 10000. I'm not sure if that latter part is necessary; yell at me if you want it removed.
* Arc Flash should no longer chain to observers. (This was apparently a bug beforehand!)
* Antagonists are now added to `ticker.mode.traitors` automatically on creation (or `ticker.mode.Agimmicks` if the antagonist is admin-created). They are also automatically removed from these lists upon the antagonist being removed. At some point down the line when this system is closer to done, the traitors variable should be changed entirely, but for the time being this will do.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #10032 
Fixes #10033 
Fixes #10054 
Fixes #10062 

## Testing
I tested spawning in during a traitor round, both at roundstart and latejoin (with the probabilities set to 100% for testing purposes.) Uplinks were given correctly both times; the latejoin traitor received their welcome message and other stuff a second or two after I gained my job equipment, and some debug messages sprinkled in showed that it was given one second afterwards (as it was cycle 2 of 60).

I also made myself into an arcfiend using the player options panel and went around draining stuff and using abilities, to ensure that the lifetime points were being tallied correctly. For whatever reason my machine has always failed to display the maptext correctly (the number for energy displays a line below, which cuts off the total) but it did play nice and display correctly eventually:

![dreamseeker_FOZGwQS1aR](https://user-images.githubusercontent.com/47678781/182853585-0f1d049b-67fb-4c87-83f8-d9e48e8f41f2.png)

## Changelog
N/A