### PR TITLE
makes the cyborg teleporter upgrade use tgui_input_list instead of input and few cyborg fixes

### DIFF
--- a/code/mob/living/silicon/robot.dm
+++ b/code/mob/living/silicon/robot.dm
@@ -1905,7 +1905,10 @@
 		if (upgrade.active)
 			if (!upgrade || upgrade.loc != src || (src.mind && src.mind.current != src) || !isrobot(src)) // Blame the teleport upgrade.
 				return
-			if (src.cell && src.cell.charge >= upgrade.drainrate)
+			if (!src.cell)
+				src.show_text("You do not have a power cell!", "red")
+				return
+			if (src.cell.charge >= upgrade.drainrate)
 				src.cell.charge -= upgrade.drainrate
 			else
 				src.show_text("You do not have enough power to activate \the [upgrade]; you need [upgrade.drainrate]!", "red")

--- a/code/modules/robotics/robot/upgrade/parent.dm
+++ b/code/modules/robotics/robot/upgrade/parent.dm
@@ -6,37 +6,28 @@ ABSTRACT_TYPE(/obj/item/roboupgrade)
 	inhand_image_icon = 'icons/mob/inhand/hand_tools.dmi'
 	item_state = "electronic"
 
-	// Is this upgrade used like an item?
+	/// Is this upgrade used like an item?
 	var/active = 0
-	// Does this upgrade always work once installed?
+	/// Does this upgrade always work once installed?
 	var/passive = 0
-	// live ingame variable
+	/// live ingame variable
 	var/activated = 0
-	// How much charge the upgrade consumes while installed
+	/// How much charge the upgrade consumes while installed
 	var/drainrate = 0
-	// How many times a limited upgrade can be used before it is consumed (infinite if negative)
+	/// How many times a limited upgrade can be used before it is consumed (infinite if negative)
 	var/charges = -1
-	// Can be removed from the cyborg
+	/// Can be removed from the cyborg
 	var/removable = 1
-	// Used for cyborg update_appearance proc
+	/// Used for cyborg update_appearance proc
 	var/borg_overlay = null
 
-/obj/item/roboupgrade/attack_self(mob/user as mob)
-	if (!isrobot(user))
-		boutput(user, "<span class='alert'>Only cyborgs can activate this item.</span>")
-	else
-		if (!src.activated)
-			src.upgrade_activate()
-		else
-			src.upgrade_deactivate()
-
-/obj/item/roboupgrade/proc/upgrade_activate(mob/living/silicon/robot/user as mob)
+/obj/item/roboupgrade/proc/upgrade_activate(mob/living/silicon/robot/user)
 	if (!user)
 		return 1
 	if (!src.activated)
 		src.activated = 1
 
-/obj/item/roboupgrade/proc/upgrade_deactivate(mob/living/silicon/robot/user as mob)
+/obj/item/roboupgrade/proc/upgrade_deactivate(mob/living/silicon/robot/user)
 	if (!user)
 		return 1
 	src.activated = 0

--- a/code/modules/robotics/robot/upgrade/recharge_pack.dm
+++ b/code/modules/robotics/robot/upgrade/recharge_pack.dm
@@ -2,16 +2,12 @@
 	name = "cyborg recharge pack"
 	desc = "A single-use reserve battery that can recharge a cyborg's cell to full capacity."
 	icon_state = "up-recharge"
-	active = 1
+	active = TRUE
 	charges = 1
 
-/obj/item/roboupgrade/rechargepack/upgrade_activate(var/mob/living/silicon/robot/user as mob)
-	if (!user)
+/obj/item/roboupgrade/rechargepack/upgrade_activate(var/mob/living/silicon/robot/user)
+	if (..())
 		return
-	if (user.cell)
-		var/obj/item/cell/C = user.cell
-		C.charge = C.maxcharge
-		boutput(user, "<span class='notice'>Cell has been recharged to [user.cell.charge]!</span>")
-	else
-		boutput(user, "<span class='alert'>You don't have a cell to recharge!</span>")
-		src.charges++
+	var/obj/item/cell/C = user.cell
+	C.charge = C.maxcharge
+	boutput(user, "<span class='notice'>Cell has been recharged to [user.cell.charge]!</span>")

--- a/code/modules/robotics/robot/upgrade/teleporter.dm
+++ b/code/modules/robotics/robot/upgrade/teleporter.dm
@@ -2,13 +2,11 @@
 	name = "cyborg teleporter upgrade"
 	desc = "A personal teleportation device that allows a cyborg to transport itself instantly to any teleporter beacon."
 	icon_state = "up-teleport"
-	active = 1
+	active = TRUE
 	drainrate = 250
 
-/obj/item/roboupgrade/teleport/upgrade_activate(var/mob/living/silicon/robot/user as mob)
-	if (!user || !src || src.loc != user || !issilicon(user) || !src.active)
-		return
-	if (user.getStatusDuration("stunned") > 0 || user.getStatusDuration("weakened") || user.getStatusDuration("paralysis") >  0 || !isalive(user))
+/obj/item/roboupgrade/teleport/upgrade_activate(var/mob/living/silicon/robot/user)
+	if (is_incapacitated(user))
 		user.show_text("Not when you're incapacitated.", "red")
 		return
 	if (!isturf(user.loc))
@@ -45,20 +43,17 @@
 				areaindex[tmpname] = 1
 			L[tmpname] = I
 
-	var/desc = input("Area to jump to","Teleportation") in L
+	var/desc = tgui_input_list(user,"Area to jump to","Teleportation",L)
 
-	if (!user || !src || src.loc != user || !issilicon(user))
+	if (!user || !src || src.loc != user || !isrobot(user))
 		if (user)
 			user.show_text("Teleportation failed.", "red")
 		return
 	if (user.mind && user.mind.current != src.loc) // Debrained or whatever.
 		user.show_text("Teleportation failed.", "red")
 		return
-	if (user.getStatusDuration("stunned") || getStatusDuration("weakened") || user.getStatusDuration("paralysis") >  0 || !isalive(user))
+	if (is_incapacitated(user))
 		user.show_text("Not when you're incapacitated.", "red")
-		return
-	if (!src.active)
-		user.show_text("Cannot teleport, upgrade is inactive.", "red")
 		return
 	if (!desc || !L[desc])
 		user.show_text("Invalid selection.", "red")

--- a/code/modules/robotics/robot/upgrade/teleporter.dm
+++ b/code/modules/robotics/robot/upgrade/teleporter.dm
@@ -43,7 +43,7 @@
 				areaindex[tmpname] = 1
 			L[tmpname] = I
 
-	var/desc = tgui_input_list(user,"Area to jump to","Teleportation",sortList(L))
+	var/desc = tgui_input_list(user, "Area to jump to","Teleportation", sortList(L))
 
 	if (!user || !src || src.loc != user || !isrobot(user))
 		if (user)

--- a/code/modules/robotics/robot/upgrade/teleporter.dm
+++ b/code/modules/robotics/robot/upgrade/teleporter.dm
@@ -43,7 +43,7 @@
 				areaindex[tmpname] = 1
 			L[tmpname] = I
 
-	var/desc = tgui_input_list(user,"Area to jump to","Teleportation",L)
+	var/desc = tgui_input_list(user,"Area to jump to","Teleportation",sortList(L))
 
 	if (!user || !src || src.loc != user || !isrobot(user))
 		if (user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG][QOL][BALANCE][CLEANLINESS] -->
(hope this doesnt count as a feature as the only part that isnt straight up a bug fix/cleanliness change is changing the tele upgrade to use the tgui input list, if the tgui_input_list part counts as a feature i will revert that one and just only PR the rest of the changes)
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
cyborg teleporter upgrade now uses the tgui input list rather then the normal one

cyborg teleporter upgrade stun check now actually works (fixes #9297)

removes a couple useless checks which are already handled by the proc activating the upgrade itself

"removes" the ability for borgs to toggle an upgrade by using it in hands with C (they dont have hands to begin with so it doesnt actually even mean much)

fixes the message for upgrades failing due to lacking a power cell

removes a useless check in the recharge pack

**existing bug that is known bug not fixed:** upgrades consume power upon trying to use them even if stuff like their stun check stopping them happens
**small behavior change**: tgui_input_list unlike the normal one can have multiple ones open at once
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad, tgui_input_list good

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+) Cyborg teleport upgrade no longer works while stunned
```
