### PR TITLE
removes prodoc glasses from nukie medic

### DIFF
--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -587,7 +587,6 @@
 		/obj/item/storage/pouch/shotgun/weak,
 		/obj/item/weldingtool/high_cap,
 		/obj/item/storage/belt/utility/prepared,
-		/obj/item/clothing/glasses/meson,
 		/obj/item/clothing/suit/space/syndicate/specialist/engineer,
 		/obj/item/clothing/head/helmet/space/syndicate/specialist/engineer)
 

--- a/code/obj/storage/crates.dm
+++ b/code/obj/storage/crates.dm
@@ -569,8 +569,7 @@
 	medic_rework
 		name = "Class Crate - Field Medic"
 		desc = "A crate containing a Specialist Operative loadout. This one is packed with medical supplies."
-		spawn_contents = list(/obj/item/clothing/glasses/healthgoggles/upgraded,
-		/obj/item/device/analyzer/healthanalyzer/upgraded,
+		spawn_contents = list(/obj/item/device/analyzer/healthanalyzer/upgraded,
 		/obj/item/storage/medical_pouch,
 		/obj/item/storage/belt/syndicate_medic_belt,
 		/obj/item/storage/backpack/satchel/syndie/syndicate_medic_satchel,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [QOL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes upgraded prodoc healthglasses from the nukie medic crate


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
medic gas mask does everything prodocs do thus making the prodocs just a newbie trap that makes some medics remove their flash proof sunglasses for no reason
