### PR TITLE
Fixes fibre wire and quarterstaff bugs

### DIFF
--- a/code/WorkInProgress/SpyGuyStuff.dm
+++ b/code/WorkInProgress/SpyGuyStuff.dm
@@ -956,8 +956,9 @@ proc/Create_Tommyname()
 
 // It will crumple when dropped
 /obj/item/garrote/dropped(mob/user)
+	if (src.wire_readied)
+		set_readiness(0)
 	..()
-	set_readiness(0)
 
 /obj/item/garrote/throw_impact(atom/hit_atom, datum/thrown_thing/thr)
 	..(hit_atom)

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -651,7 +651,7 @@
 	// can_disarm = 1
 	two_handed = 0
 	var/use_two_handed = 1
-	var/status = 0
+	var/status = FALSE
 	var/one_handed_force = 7
 	var/two_handed_force = 13
 
@@ -688,9 +688,9 @@
 		..()
 
 	dropped(mob/user)
-		if (status)
-			setTwoHanded(0)
-			status = 0
+		if (src.status)
+			setTwoHanded(FALSE)
+			src.status = FALSE
 		..()
 
 ////////////////////////////////////////// Butcher's knife /////////////////////////////////////////

--- a/code/obj/item/misc_weapons.dm
+++ b/code/obj/item/misc_weapons.dm
@@ -688,8 +688,9 @@
 		..()
 
 	dropped(mob/user)
-		setTwoHanded(0)
-		status = 0
+		if (status)
+			setTwoHanded(0)
+			status = 0
 		..()
 
 ////////////////////////////////////////// Butcher's knife /////////////////////////////////////////


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes a bug with fibre wire and quarterstaffs where swapping hands with them would cause them to be equipped in both hands at the same time and unable to become twohanded.
Also fixes a bug where said items would become invisible when taken out of a container.
Fixes #9714
Probably fixes #10091, though it's hard to tell if that's the same bug.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Starting to chip away at all the fibre wire jank.