### PR TITLE
Fixes blind nukies and wizards not getting visors

### DIFF
--- a/code/datums/abilities/wizard.dm
+++ b/code/datums/abilities/wizard.dm
@@ -58,10 +58,11 @@
 
 	wizard_mob.set_clothing_icon_dirty()
 
+	wizard_mob.equip_sensory_items()
+
 	boutput(wizard_mob, "You're a wizard now. You have a few starting spells; use the [SB] to choose the rest!")
 	if (!vr)
 		wizard_mob.show_antag_popup("wizard")
-	return
 
 ////////////////////////////////////////////// Helper procs ////////////////////////////////////////////////////
 

--- a/code/procs/antagonist_procs.dm
+++ b/code/procs/antagonist_procs.dm
@@ -281,6 +281,8 @@
 	synd_mob.equip_if_possible(new /obj/item/requisition_token/syndicate(synd_mob), synd_mob.slot_r_store)
 	synd_mob.equip_if_possible(new /obj/item/tank/emergency_oxygen(synd_mob), synd_mob.slot_l_store)
 
+	synd_mob.equip_sensory_items()
+
 	var/obj/item/card/id/syndicate/I = new /obj/item/card/id/syndicate(synd_mob) // for whatever reason, this is neccessary
 	if(leader)
 		I = new /obj/item/card/id/syndicate/commander(synd_mob)

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -547,13 +547,19 @@
 
 	return
 
-/mob/living/carbon/human/proc/Equip_Job_Slots(var/datum/job/JOB)
+/// Equip items from sensory traits
+/mob/living/carbon/human/proc/equip_sensory_items()
 	if (src.traitHolder.hasTrait("blind"))
+		src.drop_from_slot(src.glasses)
 		src.equip_if_possible(new /obj/item/clothing/glasses/visor(src), src.slot_glasses)
 	if (src.traitHolder.hasTrait("shortsighted"))
+		src.drop_from_slot(src.glasses)
 		src.equip_if_possible(new /obj/item/clothing/glasses/regular(src), src.slot_glasses)
 	if (src.traitHolder.hasTrait("deaf"))
+		src.drop_from_slot(src.ears)
 		src.equip_if_possible(new /obj/item/device/radio/headset/deaf(src), src.slot_ears)
+
+/mob/living/carbon/human/proc/Equip_Job_Slots(var/datum/job/JOB)
 	equip_job_items(JOB, src)
 	if (JOB.slot_back)
 		if (istype(src.back, /obj/item/storage))
@@ -691,7 +697,8 @@
 		src.put_in_hand_or_drop(new /obj/item/reagent_containers/food/snacks/cookie/dog)
 	else if (src.traitHolder && src.traitHolder.hasTrait("skeleton"))
 		src.put_in_hand_or_drop(new /obj/item/joint_wax)
-	return
+
+	src.equip_sensory_items()
 
 /mob/living/carbon/human/proc/spawnId(rank)
 	var/obj/item/card/id/C = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #10085 and makes the item in the slot replaced by the trait item be dropped instead of deleted, since I'm not sure nukies can get replacement headsets.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Blind trait should always spawn you with a visor, deaf trait should always spawn you with an auditory headset.
