### PR TITLE
Barrier Description Correction

### DIFF
--- a/code/obj/item/barrier.dm
+++ b/code/obj/item/barrier.dm
@@ -19,7 +19,9 @@
 
 	can_disarm = 1
 	two_handed = 0
-	var/use_two_handed = 0 // Potentially could be used for subtypes; set it to 1 so that the object occupies two hands when activated.
+
+	/// Potentially could be used for subtypes; set it to 1 so that the object occupies two hands when activated.
+	var/use_two_handed = 0
 
 	var/status = 0
 	var/obj/itemspecialeffect/barrier/E = 0

--- a/code/obj/item/barrier.dm
+++ b/code/obj/item/barrier.dm
@@ -1,6 +1,6 @@
 /obj/item/barrier
 	name = "barrier"
-	desc = "A personal barrier. Activate this item with both hands free to use it."
+	desc = "A personal barrier. Activate this item inhand to deploy it."
 	icon = 'icons/obj/items/weapons.dmi'
 	icon_state = "barrier_0"
 	inhand_image_icon = 'icons/mob/inhand/hand_weapons.dmi'
@@ -19,7 +19,7 @@
 
 	can_disarm = 1
 	two_handed = 0
-	var/use_two_handed = 0
+	var/use_two_handed = 0 // Potentially could be used for subtypes; set it to 1 so that the object occupies two hands when activated.
 
 	var/status = 0
 	var/obj/itemspecialeffect/barrier/E = 0


### PR DESCRIPTION
[Bug - Minor]


## About the PR:
Changes the description of the barrier from _"A personal barrier. Activate this item with both hands free to use it."_ to _"A personal barrier. Activate this item inhand to deploy it."_ in order to accurately reflect how it operates. Additionally makes a comment beside `var/use_two_handed` to prevent future confusion.

No corresponding issue.