### PR TITLE
Fix Flockdrones moving into broken door playing sound

### DIFF
--- a/code/obj/machinery/door/feather.dm
+++ b/code/obj/machinery/door/feather.dm
@@ -57,12 +57,6 @@
 	make_cleanable( /obj/decal/cleanable/flockdrone_debris, T)
 	qdel(src)
 
-/obj/machinery/door/feather/open()
-	if(broken)
-		return TRUE
-	else
-		return ..()
-
 /obj/machinery/door/feather/heal_damage()
 	src.icon_state = "door1"
 	src.broken = FALSE
@@ -128,7 +122,9 @@
 	return FALSE
 
 /obj/machinery/door/feather/open()
-	if(..())
+	if (src.broken)
+		return FALSE
+	if (..())
 		playsound(src.loc, "sound/misc/flockmind/flockdrone_door.ogg", 50, 1)
 
 /obj/machinery/door/feather/close()


### PR DESCRIPTION
[BUG - MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a small bug where moving into a broken Flock door as a Flockdrone was playing the opening sound for it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix