### PR TITLE
Fix health icon being used for relay tealprint

### DIFF
--- a/code/obj/flock/structure/flock_structure_ghost.dm
+++ b/code/obj/flock/structure/flock_structure_ghost.dm
@@ -49,6 +49,8 @@
 	if (src.flock)
 		if(building == /obj/flock_structure/relay)
 			src.flock.relay_in_progress_or_finished = TRUE
+			src.uses_health_icon = FALSE
+			src.flock.removeAnnotation(src, FLOCK_ANNOTATION_HEALTH)
 
 /obj/flock_structure/ghost/disposing()
 	if (src.flock)


### PR DESCRIPTION
[BUG - MINOR]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR fixes a bug where a health icon was being used for the relay tealprint.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bug fix