### PR TITLE
artifact forms now fabricatable at science fabricator

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1726,7 +1726,7 @@ ABSTRACT_TYPE(/datum/manufacture)
 	item_outputs = list(/obj/item/paper_bin/artifact_paper)
 	time = 10 SECONDS
 	create = 1
-	category = "Tool"
+	category = "Resource"
 
 // Mining Gear
 #ifndef UNDERWATER_MAP

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1718,6 +1718,16 @@ ABSTRACT_TYPE(/datum/manufacture)
 	time = 5 SECONDS
 	create = 1
 	category = "Tool"
+
+/datum/manufacture/artifactforms
+	name ="Artifact Analysis Forms"
+	item_paths = list("MET-1", "FAB-1")
+	item_amounts = list(2,5)
+	item_outputs = list(/obj/item/paper_bin/artifact_paper)
+	time = 10 SECONDS
+	create = 1
+	category = "Tool"
+
 // Mining Gear
 #ifndef UNDERWATER_MAP
 /datum/manufacture/mining_magnet

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2209,6 +2209,7 @@
 		/datum/manufacture/welder,
 		/datum/manufacture/patch,
 		/datum/manufacture/atmos_can,
+		/datum/manufacture/artifactforms,
 		/datum/manufacture/fluidcanister,
 		/datum/manufacture/spectrogoggles,
 		/datum/manufacture/reagentscanner,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The new Science Fabricator now has an option to fabricate a new tray of artifact analysis forms.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People keep losing/destroying/dissolving/etc the one you start with, and there is no way to get a new one.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u) zjdtmkhzt
(+) Lost your tray of artifact forms in a terrible accident? You can now make a new one at the Science Fabricator!
```
