### PR TITLE
Mechanical droppers auto swap mode

### DIFF
--- a/code/modules/chemistry/tools/droppers.dm
+++ b/code/modules/chemistry/tools/droppers.dm
@@ -138,6 +138,7 @@
 	on_reagent_change()
 		if (src.reagents.total_volume && !src.fluid_image)
 			src.fluid_image = image(src.icon, "ppipette-fluid")
+
 		if (src.reagents.is_full() && src.transfer_mode == TO_SELF)
 			src.transfer_mode = TO_TARGET
 		else if (!src.reagents.total_volume && src.transfer_mode == TO_TARGET)

--- a/code/modules/chemistry/tools/droppers.dm
+++ b/code/modules/chemistry/tools/droppers.dm
@@ -138,6 +138,11 @@
 	on_reagent_change()
 		if (src.reagents.total_volume && !src.fluid_image)
 			src.fluid_image = image(src.icon, "ppipette-fluid")
+		if (src.reagents.is_full() && src.transfer_mode == TO_SELF)
+			src.transfer_mode = TO_TARGET
+		else if (!src.reagents.total_volume && src.transfer_mode == TO_TARGET)
+			src.transfer_mode = TO_SELF
+		src.UpdateIcon()
 		..()
 
 	ui_interact(mob/user, datum/tgui/ui)


### PR DESCRIPTION
[QOL]
## About the PR
Mechanical droppers automatically swap modes if they are filled or emptied completely

## Why's this needed?
Unlike syringes mechanical droppers dont have a quick swap for the modes making some processes quite tedious, especially ones involving large amounts of chems relative to the 10u they can hold.