### PR TITLE
Replaces typechecks with istool macros

### DIFF
--- a/_std/macros/items.dm
+++ b/_std/macros/items.dm
@@ -11,6 +11,7 @@
 #define iswrenchingtool(x) (istool(x, TOOL_WRENCHING))
 #define ischoppingtool(x) (istool(x, TOOL_CHOPPING))
 #define isweldingtool(x) (istool(x, TOOL_WELDING))
+#define issawingtool(x) (istool(x, TOOL_SAWING))
 
 /// Returns true if the given x is a grab (obj/item/grab)
 #define isgrab(x) (istype(x, /obj/item/grab/))

--- a/code/WorkInProgress/EmergencyPodFab.dm
+++ b/code/WorkInProgress/EmergencyPodFab.dm
@@ -12,7 +12,7 @@
 	var/failing = 0
 
 	attackby(obj/item/W, mob/living/user)
-		if (istype(W, /obj/item/crowbar))
+		if (ispryingtool(W))
 			boutput(user, "There's no maintenance panel to open.")
 			return
 		if (isweldingtool(W))

--- a/code/WorkInProgress/dialogue/dialogue_polaris.dm
+++ b/code/WorkInProgress/dialogue/dialogue_polaris.dm
@@ -766,7 +766,7 @@
 		var/taken = 0
 
 		canShow(var/client/C)
-			if(taken == 0 && istype(C.mob.equipped(), /obj/item/crowbar)) return 1
+			if(taken == 0 && ispryingtool(C.mob.equipped())) return 1
 			else return 0
 
 		onActivate(var/client/C)

--- a/code/datums/abilities/kudzumen.dm
+++ b/code/datums/abilities/kudzumen.dm
@@ -784,14 +784,4 @@
 //O is obj to be destroyed, W is obj used to destroy.
 //This is total shit too, but I'm in a hurry again. I'll be back, -Kyle
 /proc/destroys_kudzu_object(var/obj/O, var/obj/item/W as obj, var/mob/user)
-		var/destroyed = 0
-		if (istool(W, TOOL_CUTTING | TOOL_SAWING | TOOL_SCREWING | TOOL_SNIPPING | TOOL_WELDING)) destroyed = 1
-		else if (istype(W, /obj/item/axe)) destroyed = 1
-		else if (istype(W, /obj/item/circular_saw)) destroyed = 1
-		else if (istype(W, /obj/item/kitchen/utensil/knife)) destroyed = 1
-		else if (istype(W, /obj/item/scalpel)) destroyed = 1
-		else if (istype(W, /obj/item/sword)) destroyed = 1
-		else if (istype(W, /obj/item/saw)) destroyed = 1
-
-		return destroyed
-
+	return istool(W, TOOL_CUTTING | TOOL_SAWING | TOOL_SCREWING | TOOL_SNIPPING | TOOL_WELDING)

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -297,14 +297,14 @@ ABSTRACT_TYPE(/mob/living/critter)
 	attackby(var/obj/item/I, var/mob/M)
 		if (isdead(src)) 	//Just copied from pets_small_animals.dm with only small modifications. yep!
 			if (src.skinresult && max_skins)
-				if (istype(I, /obj/item/circular_saw) || istype(I, /obj/item/kitchen/utensil/knife) || istype(I, /obj/item/scalpel) || istype(I, /obj/item/raw_material/shard) || istype(I, /obj/item/sword) || istype(I, /obj/item/saw) || istype(I, /obj/item/wirecutters))
+				if (issawingtool(I) || iscuttingtool(I))
 					for (var/i, i<rand(1, max_skins), i++)
 						var/obj/item/S = new src.skinresult
 						S.set_loc(src.loc)
 					src.skinresult = null
 					M.visible_message("<span class='alert'>[M] skins [src].</span>","You skin [src].")
 					return
-			if (src.butcherable && (istype(I, /obj/item/circular_saw) || istype(I, /obj/item/kitchen/utensil/knife) || istype(I, /obj/item/scalpel) || istype(I, /obj/item/raw_material/shard) || istype(I, /obj/item/sword) || istype(I, /obj/item/saw) || istype(I, /obj/item/wirecutters)))
+			if (issawingtool(I) || iscuttingtool(I))
 				actions.start(new/datum/action/bar/icon/butcher_living_critter(src,src.butcher_time), M)
 				return
 

--- a/code/modules/atmospherics/machinery/unary/cryo_cell.dm
+++ b/code/modules/atmospherics/machinery/unary/cryo_cell.dm
@@ -240,7 +240,7 @@
 				user.u_equip(I)
 				I.set_loc(src)
 				src.UpdateIcon()
-		else if (istype(I, /obj/item/wrench))
+		else if (iswrenchingtool(I))
 			if (!src.defib)
 				boutput(user, "<span class='alert'>[src] does not have a Defibrillator installed.</span>")
 			else

--- a/code/modules/food_and_drink/bread.dm
+++ b/code/modules/food_and_drink/bread.dm
@@ -24,7 +24,7 @@
 			return
 
 	attackby(obj/item/W, mob/user)
-		if (istype(W, /obj/item/axe) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/sword) || istype(W,/obj/item/knife/butcher))
+		if (iscuttingtool(W) || issawingtool(W))
 			if(user.bioHolder.HasEffect("clumsy") && prob(50))
 				user.visible_message("<span class='alert'><b>[user]</b> fumbles and jabs [himself_or_herself(user)] in the eye with [W].</span>")
 				user.change_eye_blurry(5)
@@ -358,7 +358,7 @@
 		BLOCK_SETUP(BLOCK_ROD)
 
 	attackby(obj/item/W, mob/user)
-		if (istype(W, /obj/item/axe) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/sword) || istype(W,/obj/item/knife/butcher))
+		if (iscuttingtool(W) || issawingtool(W))
 			if(user.bioHolder.HasEffect("clumsy") && prob(50))
 				user.visible_message("<span class='alert'><b>[user]</b> fumbles and jabs [himself_or_herself(user)] in the eye with [W].</span>")
 				user.change_eye_blurry(5)

--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -403,7 +403,7 @@
 			user.u_equip(src)
 			user.put_in_hand_or_drop(P)
 			qdel(src)
-		else if (istype(W, /obj/item/axe) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/sword) || istype(W,/obj/item/saw) || istype(W,/obj/item/knife/butcher))
+		else if (iscuttingtool(W) || issawingtool(W))
 			boutput(user, "<span class='notice'>You cut the dough into two strips.</span>")
 			if (prob(25))
 				JOB_XP(user, "Chef", 1)
@@ -532,7 +532,7 @@
 	icon_state = "dough-sweet"
 
 	attackby(obj/item/W, mob/user)
-		if (istype(W, /obj/item/axe) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/sword) || istype(W,/obj/item/saw) || istype(W,/obj/item/knife/butcher))
+		if (iscuttingtool(W) || issawingtool(W))
 			boutput(user, "<span class='notice'>You cut [src] into smaller pieces...</span>")
 			for(var/i = 1, i <= 4, i++)
 				new /obj/item/reagent_containers/food/snacks/ingredient/dough_cookie(get_turf(src))
@@ -583,7 +583,7 @@
 			qdel(src)
 		if (prob(25))
 			JOB_XP(user, "Chef", 1)
-		else if (istype(W, /obj/item/axe) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/sword) || istype(W,/obj/item/saw) || istype(W,/obj/item/knife/butcher))
+		else if (iscuttingtool(W) || issawingtool(W))
 			boutput(user, "<span class='notice'>You cut [src] into smaller pieces...</span>")
 			for(var/i = 1, i <= 3, i++)
 				new /obj/item/reagent_containers/food/snacks/ingredient/tortilla(get_turf(src))

--- a/code/modules/food_and_drink/plants.dm
+++ b/code/modules/food_and_drink/plants.dm
@@ -254,7 +254,7 @@ ABSTRACT_TYPE(/obj/item/reagent/containers/food/snacks/plant)
 				HYPpassplantgenes(DNA,PDNA)
 			qdel(W)
 			qdel(src)
-		else if (istype(W, /obj/item/axe) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/sword) || istype(W,/obj/item/saw) || istype(W,/obj/item/knife/butcher) && !istype (src, /obj/item/reagent_containers/food/snacks/plant/orange/wedge))
+		else if (iscuttingtool(W) || issawingtool(W) && !istype (src, /obj/item/reagent_containers/food/snacks/plant/orange/wedge))
 			if (istype (src, /obj/item/reagent_containers/food/snacks/plant/orange/wedge))
 				boutput(user, "<span class='alert'>You can't cut wedges into wedges! What kind of insanity is that!?</span>")
 				return

--- a/code/modules/food_and_drink/snacks.dm
+++ b/code/modules/food_and_drink/snacks.dm
@@ -2205,7 +2205,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/soup)
 
 	attackby(obj/item/W, mob/user)
 		if (wrapped)
-			if (istype(W, /obj/item/axe) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/sword) || istype(W,/obj/item/saw) || istype(W,/obj/item/knife/butcher))
+			if (iscuttingtool(W) || issawingtool(W))
 				user.visible_message("<span class='alert'>[user] performs an act of wonton destruction!</span>","You slice open the wrapper.")
 				wrapped.set_loc(get_turf(src))
 				src.reagents = null
@@ -2282,7 +2282,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks/soup)
 	food_effects = list("food_brute")
 
 	attackby(obj/item/W, mob/user)
-		if (istype(W, /obj/item/axe) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/sword) || istype(W,/obj/item/saw) || istype(W,/obj/item/knife/butcher))
+		if (iscuttingtool(W) || issawingtool(W))
 			boutput(user, "<span class='notice'>You cut [src] into halves</span>")
 			new /obj/item/reagent_containers/food/snacks/emuffin(get_turf(src))
 			new /obj/item/reagent_containers/food/snacks/emuffin(get_turf(src))

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -404,7 +404,7 @@
 		if (issilicon(user))
 			return
 
-		if (istype(W, /obj/item/wrench))
+		if (iswrenchingtool(W))
 
 			add_fingerprint(user)
 			src.anchored = !src.anchored

--- a/code/modules/transport/pods/warp_travel.dm
+++ b/code/modules/transport/pods/warp_travel.dm
@@ -71,14 +71,14 @@
 		packable = 1
 
 	attackby(obj/item/W, mob/user)
-		if (istype(W, /obj/item/wrench))
+		if (iswrenchingtool(W))
 			if (!packable)
 				boutput(user,"This beacon's retraction hardware is locked into place and can't be altered.")
 				return
 			src.visible_message("<b>[user.name]</b> undeploys [src].")
 			playsound(src, "sound/items/Ratchet.ogg", 40, 1)
 			src.startpack()
-		else if (istype(W, /obj/item/device/multitool))
+		else if (ispulsingtool(W))
 			if (!packable)
 				boutput(user,"This beacon's designation circuits are hard-wired and can't be altered.")
 				return
@@ -193,7 +193,7 @@
 		..()
 
 	attackby(obj/item/W, mob/user)
-		if (istype(W, /obj/item/wrench) && !src.deploying)
+		if (iswrenchingtool(W) && !src.deploying)
 			for (var/turf/T in range(src.tile_range,src))
 				if (!T.allows_vehicles)
 					boutput(user,"<span style=\"color:red\">The area surrounding the beacon isn't sufficiently navigable for vehicles.</span>")
@@ -206,7 +206,7 @@
 			src.deploying = 1
 			src.deploybeacon()
 
-		else if (istype(W, /obj/item/device/multitool/) && !src.deploying)
+		else if (ispulsingtool(W) && !src.deploying)
 			var/str = input(user,"Set designation","Re-Designate Buoy","") as null|text
 			if (!str || !length(str))
 				boutput(user, "<span style=\"color:red\">No valid input detected.</span>")

--- a/code/obj/alien/weeds.dm
+++ b/code/obj/alien/weeds.dm
@@ -17,13 +17,6 @@
 		if (!W) return
 		if (!user) return
 		if (istool(W, TOOL_CUTTING | TOOL_SAWING | TOOL_SCREWING | TOOL_SNIPPING | TOOL_WELDING)) qdel(src)
-		else if (istype(W, /obj/item/axe)) qdel(src)
-		else if (istype(W, /obj/item/circular_saw)) qdel(src)
-		else if (istype(W, /obj/item/kitchen/utensil/knife)) qdel(src)
-		else if (istype(W, /obj/item/scalpel)) qdel(src)
-		else if (istype(W, /obj/item/shard)) qdel(src)
-		else if (istype(W, /obj/item/sword)) qdel(src)
-		else if (istype(W, /obj/item/saw)) qdel(src)
 		..()
 
 	proc/Life()

--- a/code/obj/bookcase.dm
+++ b/code/obj/bookcase.dm
@@ -60,7 +60,7 @@
 			boutput(user, "\The [src] is too full!")
 			return
 
-	else if (istype(W, /obj/item/wrench))
+	else if (iswrenchingtool(W))
 		if (length(src.bookshelf_contents) > 0)
 			boutput(user, "You can't take apart \the [src] if there's still books on it.")
 			return

--- a/code/obj/critter/Brullbar.dm
+++ b/code/obj/critter/Brullbar.dm
@@ -96,7 +96,7 @@
 		user.lastattacked = src
 		if (!src.alive)
 			// TODO: tie this into surgery()
-			if (istype(W, /obj/item/scalpel))
+			if (iscuttingtool(W))
 				if (user.zone_sel.selecting == "l_arm")
 					if (src.left_arm_stage == 0)
 						user.visible_message("<span class='alert'>[user] slices through the skin and flesh of [src]'s left arm with [W].</span>", "<span class='alert'>You slice through the skin and flesh of [src]'s left arm with [W].</span>")
@@ -139,7 +139,7 @@
 							src.right_arm = null
 						src.update_dead_icon()
 
-			else if (istype(W, /obj/item/circular_saw))
+			else if (issawingtool(W))
 				if (user.zone_sel.selecting == "l_arm")
 					if (src.left_arm_stage == 1)
 						user.visible_message("<span class='alert'>[user] saws through the bone of [src]'s left arm with [W].</span>", "<span class='alert'>You saw through the bone of [src]'s left arm with [W].</span>")

--- a/code/obj/critter/big_animals.dm
+++ b/code/obj/critter/big_animals.dm
@@ -67,7 +67,7 @@
 	attackby(obj/item/W, mob/living/user)
 		if (!src.alive)
 			// TODO: tie this into surgery()
-			if (istype(W, /obj/item/scalpel))
+			if (iscuttingtool(W))
 				if (user.zone_sel.selecting == "l_arm")
 					if (src.left_arm_stage == 0)
 						user.visible_message("<span class='combat'>[user] slices through the skin and flesh of [src]'s left arm with [W].</span>", "<span class='alert'>You slice through the skin and flesh of [src]'s left arm with [W].</span>")
@@ -96,7 +96,7 @@
 							src.right_arm = null
 						src.update_dead_icon()
 
-			else if (istype(W, /obj/item/circular_saw))
+			else if (issawingtool(W))
 				if (user.zone_sel.selecting == "l_arm")
 					if (src.left_arm_stage == 1)
 						user.visible_message("<span class='combat'>[user] saws through the bone of [src]'s left arm with [W].</span>", "<span class='alert'>You saw through the bone of [src]'s left arm with [W].</span>")

--- a/code/obj/critter/critter_parent.dm
+++ b/code/obj/critter/critter_parent.dm
@@ -225,7 +225,7 @@
 		..()
 		if (!src.alive)
 			if (src.skinresult && max_skins)
-				if (istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/raw_material/shard) || istype(W, /obj/item/sword) || istype(W, /obj/item/saw) || issnippingtool(W))
+				if (issawingtool(W) || iscuttingtool(W) || issnippingtool(W))
 
 					for(var/i, i<rand(1, max_skins), i++)
 						new src.skinresult (src.loc)

--- a/code/obj/critter/pets_small_animals.dm
+++ b/code/obj/critter/pets_small_animals.dm
@@ -141,7 +141,7 @@
 
 	attackby(obj/item/W, mob/living/user)
 		if (!src.alive)
-			if (istype(W, /obj/item/knife/butcher) || istype(W, /obj/item/circular_saw) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/scalpel) || istype(W, /obj/item/raw_material/shard) || istype(W, /obj/item/sword) || istype(W, /obj/item/saw) || issnippingtool(W))
+			if (iscuttingtool(W) || issawingtool(W) || issnippingtool(W))
 				src.on_revive()
 				. = ..()
 		else

--- a/code/obj/item/mob_parts/robot_parts.dm
+++ b/code/obj/item/mob_parts/robot_parts.dm
@@ -90,7 +90,7 @@ ABSTRACT_TYPE(/obj/item/parts/robot_parts)
 			remove_stage = 0
 
 		else if(remove_stage == 0 || remove_stage == 2)
-			if(istype(tool, /obj/item/scalpel) || istype(tool, /obj/item/raw_material/shard) || istype(tool, /obj/item/kitchen/utensil/knife))
+			if(iscuttingtool(tool))
 				remove_stage++
 			else
 				wrong_tool = 1

--- a/code/obj/item/organs/head.dm
+++ b/code/obj/item/organs/head.dm
@@ -371,7 +371,7 @@
 		if (src.skull || src.brain)
 
 			// scalpel surgery
-			if (istype(W, /obj/item/scalpel) || istype(W, /obj/item/razor_blade) || istype(W, /obj/item/knife/butcher) || istype(W, /obj/item/kitchen/utensil/knife) || istype(W, /obj/item/raw_material/shard))
+			if (iscuttingtool(W))
 				if (src.right_eye && src.right_eye.op_stage == 1.0 && user.find_in_hand(W) == user.r_hand)
 					playsound(src, "sound/impact_sounds/Slimy_Cut_1.ogg", 50, 1)
 					user.visible_message("<span class='alert'><b>[user]</b> cuts away the flesh holding [src]'s right eye in with [W]!</span>",\

--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -479,7 +479,7 @@
 			..()
 
 	attackby(obj/item/W, mob/user)
-		if (istype(W, /obj/item/wirecutters/) && src.thorned)
+		if (issnippingtool(W) && src.thorned)
 			boutput(user, "<span class='notice'>You snip off [src]'s thorns.</span>")
 			src.thorned = 0
 			src.desc += " Its thorns have been snipped off."

--- a/code/obj/machinery/clonepod.dm
+++ b/code/obj/machinery/clonepod.dm
@@ -600,7 +600,7 @@
 			qdel(W)
 			return
 
-		else if(istype(W, /obj/item/screwdriver) && clonehack == 1) // Wait nevermind the clone wars were a terrible idea
+		else if(isscrewingtool(W) && clonehack) // Wait nevermind the clone wars were a terrible idea
 			if (src.occupant && src.attempting)
 				boutput(user, "<space class='alert'>You must wait for the current cloning cycle to finish before you can remove the mindhack module.</span>")
 				return

--- a/code/obj/machinery/phone.dm
+++ b/code/obj/machinery/phone.dm
@@ -130,7 +130,7 @@
 				qdel(PH)
 				hang_up()
 			return
-		if(istype(P,/obj/item/wirecutters))
+		if(issnippingtool(P))
 			if(src.connected == 1)
 				if(user)
 					boutput(user,"You cut the phone line leading to the phone.")
@@ -140,7 +140,7 @@
 					boutput(user,"You repair the line leading to the phone.")
 				src.connected = 1
 			return
-		if(istype(P,/obj/item/device/multitool))
+		if(ispulsingtool(P))
 			if(src.labelling == 1)
 				return
 			src.labelling = 1

--- a/code/obj/machinery/phone/phone.dm
+++ b/code/obj/machinery/phone/phone.dm
@@ -130,7 +130,7 @@
 				qdel(PH)
 				hang_up()
 			return
-		if(istype(P,/obj/item/wirecutters))
+		if(issnippingtool(P))
 			if(src.connected == 1)
 				if(user)
 					boutput(user,"You cut the phone line leading to the phone.")
@@ -140,7 +140,7 @@
 					boutput(user,"You repair the line leading to the phone.")
 				src.connected = 1
 			return
-		if(istype(P,/obj/item/device/multitool))
+		if(ispulsingtool(P))
 			if(src.labelling == 1)
 				return
 			src.labelling = 1

--- a/code/obj/machinery/spaceheater.dm
+++ b/code/obj/machinery/spaceheater.dm
@@ -100,7 +100,7 @@
 			if(!open && user.using_dialog_of(src))
 				user.Browse(null, "window=spaceheater")
 				src.remove_dialog(user)
-		else if (istype(I, /obj/item/wrench))
+		else if (iswrenchingtool(I))
 			if (user)
 				user.show_text("You [anchored ? "release" : "anchor"] the [src]", "blue")
 			src.anchored = !src.anchored

--- a/code/obj/playable_piano.dm
+++ b/code/obj/playable_piano.dm
@@ -83,7 +83,7 @@
 						return
 					src.visible_message("<span class='alert'>[user] sticks \the [W] into a slot on \the [src] and twists it! \The [src] rumbles indifferently.")
 
-		else if (istype(W, /obj/item/screwdriver)) //unanchoring piano
+		else if (isscrewingtool(W)) //unanchoring piano
 			if (anchored)
 				user.visible_message("[user] starts loosening the piano's castors...", "You start loosening the piano's castors...")
 				if (!do_after(user, 3 SECONDS) || anchored != 1)
@@ -102,7 +102,7 @@
 				user.visible_message("[user] tightens the piano's castors!", "You tighten the piano's castors!")
 				return
 
-		else if (istype(W, /obj/item/crowbar)) //prying off panel
+		else if (ispryingtool(W)) //prying off panel
 			if (is_busy)
 				boutput(user, "You can't do that while the piano is running!")
 				return
@@ -131,7 +131,7 @@
 				UpdateIcon(0)
 				qdel(W)
 
-		else if (istype(W, /obj/item/wirecutters)) //turning off looping... forever!
+		else if (issnippingtool(W)) //turning off looping... forever!
 			if (is_looping == 2)
 				boutput(user, "There's no wires to snip!")
 				return
@@ -142,7 +142,7 @@
 			playsound(user, "sound/items/Wirecutter.ogg", 65, 1)
 			user.visible_message("<span class='alert'>[user] snips the looping control wire!</span>", "You snip the looping control wire!")
 
-		else if (istype(W, /obj/item/device/multitool)) //resetting piano the hard way
+		else if (ispulsingtool(W)) //resetting piano the hard way
 			if (panel_exposed == 0)
 				..()
 				return
@@ -197,11 +197,11 @@
 		..()
 
 	proc/allowChange(var/mob/M) //copypasted from mechanics code because why do something someone else already did better
-		if(hasvar(M, "l_hand") && istype(M:l_hand, /obj/item/device/multitool)) return 1
-		if(hasvar(M, "r_hand") && istype(M:r_hand, /obj/item/device/multitool)) return 1
+		if(hasvar(M, "l_hand") && ispulsingtool(M:l_hand)) return 1
+		if(hasvar(M, "r_hand") && ispulsingtool(M:r_hand)) return 1
 		if(hasvar(M, "module_states"))
 			for(var/atom/A in M:module_states)
-				if(istype(A, /obj/item/device/multitool))
+				if(ispulsingtool(A))
 					return 1
 		return 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [CLEANLINESS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #10156 and a lot of unreported bugs by adding `istool` macros to all the old code that doesn't use them.
Adds `issawingtool` since that didn't exist for some reason.
Hopefully this isn't too big of a refactor.
Actual gameplay changes include letting silicons modify a lot more machines with their omnitool (and syndicate omnitools), being able to cut off brullbar and bear arms with makeshift surgery tools, as well as doing eye surgery with makeshift tools.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Macros are good, tools should work on things