### PR TITLE
Makes vampire bite actionbars private

### DIFF
--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -414,6 +414,10 @@
 		if (istype(H))
 			H.vamp_isbiting = HH
 
+		HH.client?.images += bar.img
+		HH.client?.images += border.img
+		HH.client?.images += icon_image
+
 		src.loopStart()
 
 	loopStart()
@@ -448,6 +452,12 @@
 		src.end()
 
 		..()
+
+	onDelete()
+		. = ..()
+		HH.client?.images -= bar.img
+		HH.client?.images -= border.img
+		HH.client?.images -= icon_image
 
 	proc/end()
 		if (istype(H))

--- a/code/datums/abilities/vampire/vampire_bite.dm
+++ b/code/datums/abilities/vampire/vampire_bite.dm
@@ -161,6 +161,7 @@
 	eat_twitch(src.owner)
 	playsound(src.owner.loc,"sound/items/drink.ogg", rand(5,20), 1, pitch = 1.4)
 	HH.was_harmed(M, special = "vamp")
+	bleed(HH, 1, 3, get_turf(src.owner))
 
 /datum/abilityHolder/vampiric_thrall/var/list/blood_tally
 /datum/abilityHolder/vampiric_thrall/var/const/max_take_per_mob = 250
@@ -359,7 +360,7 @@
 		boutput(M, "<span class='notice'>You bite [HH] and begin to drain them of blood.</span>")
 		HH.visible_message("<span class='alert'><B>[M] bites [HH]!</B></span>")
 
-		actions.start(new/datum/action/bar/icon/vamp_blood_suc(M,H,HH,src), M)
+		actions.start(new/datum/action/bar/private/icon/vamp_blood_suc(M,H,HH,src), M)
 
 		return 0
 
@@ -367,7 +368,7 @@
 	thrall = 1
 
 
-/datum/action/bar/icon/vamp_blood_suc
+/datum/action/bar/private/icon/vamp_blood_suc
 	duration = 30
 	interrupt_flags = INTERRUPT_MOVE | INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION
 	id = "vamp_blood_suck"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the giant action bar over your head while drinking blood as a vampire a private action bar visible only to the vampire and the victim. To somewhat compensate the vampire will now drip a small amount of their victim's blood onto the floor at their feet.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The vamp bite actionbar is extremely noticeable, and can sometimes be seen through walls or in AI camera static. The ability already requires you to be adjacent, makes a lot of noise, has a chat message and a little slurp animation. Ling absorb actionbar is private, even the vampire ranged blood steal actionbar is private.
Also Cheffie complained until I made this.

```changelog
(u)LeahTheTech
(+)Vampire bite action bars are now only visible to the vampire, and biting a victim will now cause a little of their blood to drip to the floor at your feet.
```
