### PR TITLE
Adds Scientist's Jumpsuits And Research Backpacks To Science Manufacturers

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1656,6 +1656,15 @@ ABSTRACT_TYPE(/datum/manufacture)
 
 /******************** Science **************************/
 
+/datum/manufacture/jumpsuit_scientist
+	name = "Scientist's Jumpsuit"
+	item_paths = list("FAB-1")
+	item_amounts = list(4)
+	item_outputs = list(/obj/item/clothing/under/rank/scientist)
+	time = 5 SECONDS
+	create = 1
+	category = "Clothing"
+
 /datum/manufacture/biosuit
 	name = "Biosuit Set"
 	item_paths = list("FAB-1","CRY-1")

--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1665,6 +1665,15 @@ ABSTRACT_TYPE(/datum/manufacture)
 	create = 1
 	category = "Clothing"
 
+/datum/manufacture/research_backpack
+	name = "Research Backpack"
+	item_paths = list("FAB-1")
+	item_amounts = list(8)
+	item_outputs = list(/obj/item/storage/backpack/research)
+	time = 10 SECONDS
+	create = 1
+	category = "Clothing"
+
 /datum/manufacture/biosuit
 	name = "Biosuit Set"
 	item_paths = list("FAB-1","CRY-1")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2216,6 +2216,7 @@
 		/datum/manufacture/mechdropper,
 		/datum/manufacture/biosuit,
 		/datum/manufacture/labcoat,
+		/datum/manufacture/research_backpack,
 		/datum/manufacture/jumpsuit_scientist,
 		/datum/manufacture/jumpsuit_white,
 		/datum/manufacture/patient_gown,

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2216,6 +2216,7 @@
 		/datum/manufacture/mechdropper,
 		/datum/manufacture/biosuit,
 		/datum/manufacture/labcoat,
+		/datum/manufacture/jumpsuit_scientist,
 		/datum/manufacture/jumpsuit_white,
 		/datum/manufacture/patient_gown,
 		/datum/manufacture/blindfold,


### PR DESCRIPTION
[QoL]


## About the PR:
Adds the option to print Scientist's jumpsuits and research backpacks from the science manufacturer.



## Why's this needed? 
Currently Science jumpsuits and research backpacks are only available from the wardrobes and lockers, which on some maps are in short supply, it feels fitting to add them to the manufacturer.
Also I do hope this is small enough to be exempt from the feature freeze.