### PR TITLE
Rework Flockdrone repairing

### DIFF
--- a/code/mob/living/critter/flock/flockbit.dm
+++ b/code/mob/living/critter/flock/flockbit.dm
@@ -7,6 +7,7 @@
 	pays_to_construct = FALSE
 	health_brute = 5
 	health_burn = 5
+	repair_per_resource = 1
 	fits_under_table = TRUE
 	flags = TABLEPASS
 

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -17,6 +17,7 @@
 	var/datum/equipmentHolder/flockAbsorption/absorber
 	health_brute = 30
 	health_burn = 30
+	repair_per_resource = 2
 
 	///Custom contextActions list so we can handle opening them ourselves
 	var/list/datum/contextAction/contexts = list()
@@ -1027,8 +1028,8 @@
 		if (!found_target)
 			boutput(user, "<span class='alert'>The target is in perfect condition!</span>")
 		else
-			if(user.resources < FLOCK_REPAIR_COST)
-				boutput(user, "<span class='alert'>Not enough resources to repair (you need [FLOCK_REPAIR_COST]).</span>")
+			if(user.resources <= 0)
+				boutput(user, "<span class='alert'>You have no resources available for repairing.</span>")
 			else
 				actions.start(new /datum/action/bar/flock_repair(target), user)
 
@@ -1042,8 +1043,8 @@
 			return
 		if (isdead(F))
 			return
-		if(user.resources < FLOCK_REPAIR_COST)
-			boutput(user, "<span class='alert'>Not enough resources to repair (you need [FLOCK_REPAIR_COST]).</span>")
+		if(user.resources <= 0)
+			boutput(user, "<span class='alert'>You have no resources available for repairing.</span>")
 		else
 			actions.start(new/datum/action/bar/flock_repair(F), user)
 	else

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -477,7 +477,7 @@
 			var/burn_weight = 1 - brute_weight
 
 			flockcritter.HealDamage("All", health_given * brute_weight, health_given * burn_weight)
-			F.pay_resources(ceil(health_given / F.repair_per_resource))
+			F.pay_resources(ceil(health_given / flockcritter.repair_per_resource))
 			keep_repairing = flockcritter.get_health_percentage() < 1
 			if (flockcritter.is_npc)
 				flockcritter.ai.interrupt()

--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -147,6 +147,7 @@
 	mat_changedesc = FALSE
 	var/health_attack = 100
 	var/health_max = 100
+	var/repair_per_resource = 2.5
 	var/hitsound = "sound/impact_sounds/Generic_Hit_Heavy_1.ogg"
 
 	take_damage(var/force, var/mob/user as mob)
@@ -193,8 +194,10 @@
 			if(user.drop_item())
 				W?.set_loc(src.loc)
 
-/obj/storage/closet/flock/proc/repair()
-	src.health_attack = min(src.health_attack + 25, src.health_max)
+/obj/storage/closet/flock/proc/repair(resources_available)
+	var/health_given = min(min(resources_available, FLOCK_REPAIR_COST) * src.repair_per_resource, src.health_max - src.health_attack)
+	src.health_attack += health_given
+	return ceil(health_given / src.repair_per_resource)
 
 /obj/storage/closet/flock/proc/deconstruct()
 	var/turf/T = get_turf(src)
@@ -335,6 +338,7 @@
 	icon_state = "barricade"
 	health = 50
 	health_max = 50
+	var/repair_per_resource = 1
 	shock_when_entered = FALSE
 	auto = FALSE
 	mat_appearances_to_ignore = list("steel","gnesis")
@@ -401,9 +405,11 @@
 		return
 	..()
 
-/obj/grille/flock/proc/repair()
-	src.health = min(src.health + 10, src.health_max)
+/obj/grille/flock/proc/repair(resources_available)
+	var/health_given = min(min(resources_available, FLOCK_REPAIR_COST) * src.repair_per_resource, src.health_max - src.health)
+	src.health += health_given
 	if (ruined)
 		src.set_density(TRUE)
 		src.ruined = FALSE
 	src.UpdateIcon()
+	return ceil(health_given / src.repair_per_resource)

--- a/code/obj/flock/structure/flock_structure_parent.dm
+++ b/code/obj/flock/structure/flock_structure_parent.dm
@@ -19,6 +19,7 @@ ABSTRACT_TYPE(/obj/flock_structure)
 	var/build_time = 6 // in seconds
 	var/health = 30
 	var/health_max = 30
+	var/repair_per_resource = 5
 	var/uses_health_icon = TRUE
 	var/bruteVuln = 1.2
 	///Should it twitch on being hit?
@@ -188,9 +189,11 @@ ABSTRACT_TYPE(/obj/flock_structure)
 			B.throw_at(get_edge_cheap(location, pick(alldirs)), rand(10), 3)
 	qdel(src)
 
-/obj/flock_structure/proc/repair()
-	src.health = min(src.health + 50, src.health_max)
+/obj/flock_structure/proc/repair(resources_available)
+	var/health_given = min(min(resources_available, FLOCK_REPAIR_COST) * src.repair_per_resource, src.health_max - src.health)
+	src.health += health_given
 	src.update_health_icon()
+	return ceil(health_given / src.repair_per_resource)
 
 /obj/flock_structure/attack_hand(var/mob/user)
 	attack_particle(user, src)

--- a/code/obj/machinery/door/feather.dm
+++ b/code/obj/machinery/door/feather.dm
@@ -11,6 +11,7 @@
 	var/broken = FALSE
 	health = 200
 	health_max = 200
+	var/repair_per_resource = 2
 
 /obj/machinery/door/feather/New()
 	..()
@@ -71,13 +72,16 @@
 	src.name = initial(name)
 	src.desc = initial(desc)
 
-/obj/machinery/door/feather/proc/repair()
-	src.health = min(20, src.health_max - src.health) + src.health
+/obj/machinery/door/feather/proc/repair(resources_available)
+	var/health_given = min(min(resources_available, FLOCK_REPAIR_COST) * src.repair_per_resource, src.health_max - src.health)
+	src.health += health_given
+
 	if (src.broken && src.health_max / 2 < src.health)
 		src.name = initial(src.name)
 		src.desc = initial(src.desc)
 		src.broken = FALSE
 		src.icon_state = initial(src.icon_state)
+	return ceil(health_given / src.repair_per_resource)
 
 /obj/machinery/door/feather/proc/deconstruct()
 	var/turf/T = get_turf(src)

--- a/code/obj/window.dm
+++ b/code/obj/window.dm
@@ -1056,6 +1056,7 @@
 // flock windows
 
 /obj/window/auto/feather
+	var/repair_per_resource = 1
 
 /obj/window/auto/feather/New()
 	connects_to += /turf/simulated/wall/auto/feather
@@ -1071,8 +1072,10 @@
 		<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%
 		<br><span class='bold'>###=-</span></span>"}
 
-/obj/window/auto/feather/proc/repair()
-	src.health = min(src.health + 10, src.health_max)
+/obj/window/auto/feather/proc/repair(resources_available)
+	var/health_given = min(min(resources_available, FLOCK_REPAIR_COST) * src.repair_per_resource, src.health_max - src.health)
+	src.health += health_given
+	return ceil(health_given / src.repair_per_resource)
 
 /obj/window/auto/feather/Crossed(atom/movable/mover)
 	. = ..()
@@ -1099,6 +1102,7 @@
 	mat_changedesc = FALSE
 	health = 50 // as strong as reinforced glass, but not as strong as plasmaglass
 	health_max = 50
+	var/repair_per_resource = 1
 	density = TRUE
 
 /obj/window/feather/New()
@@ -1114,8 +1118,10 @@
 		<br><span class='bold'>System Integrity:</span> [round((src.health/src.health_max)*100)]%
 		<br><span class='bold'>###=-</span></span>"}
 
-/obj/window/feather/proc/repair()
-	src.health = min(src.health + 10, src.health_max)
+/obj/window/feather/proc/repair(resources_available)
+	var/health_given = min(min(resources_available, FLOCK_REPAIR_COST) * src.repair_per_resource, src.health_max - src.health)
+	src.health += health_given
+	return ceil(health_given / src.repair_per_resource)
 
 /obj/window/feather/north
 	dir = NORTH

--- a/code/turf/turf_flock.dm
+++ b/code/turf/turf_flock.dm
@@ -14,6 +14,7 @@
 	step_material = "step_plating"
 	step_priority = STEP_PRIORITY_MED
 	var/health = 50
+	var/repair_per_resource = 1
 	var/col_r = 0.1
 	var/col_g = 0.7
 	var/col_b = 0.6
@@ -80,13 +81,15 @@
 		if (flockdrone.floorrunning)
 			flockdrone.end_floorrunning()
 
-/turf/simulated/floor/feather/proc/repair()
+/turf/simulated/floor/feather/proc/repair(resources_available)
 	if (src.broken)
 		src.name = initial(src.name)
 		src.desc = initial(src.desc)
 		src.icon_state = initial(src.icon_state)
 		src.broken = FALSE
-	src.health = min(src.health + 10, initial(src.health))
+	var/health_given = min(min(resources_available, FLOCK_REPAIR_COST) * src.repair_per_resource, initial(src.health) - src.health)
+	src.health += health_given
+	return ceil(health_given / src.repair_per_resource)
 
 /turf/simulated/floor/feather/burn_tile()
 	return
@@ -167,6 +170,7 @@
 	mod = "flock"
 	health = 250
 	var/max_health = 250
+	var/repair_per_resource = 5
 	flags = USEDELAY | ALWAYS_SOLID_FLUID | IS_PERSPECTIVE_FLUID
 	mat_appearances_to_ignore = list("steel", "gnesis")
 	mat_changename = FALSE
@@ -311,14 +315,16 @@
 		for (var/turf/simulated/wall/auto/feather/W in orange(1, src))
 			W.UpdateIcon()
 
-/turf/simulated/wall/auto/feather/proc/repair()
+/turf/simulated/wall/auto/feather/proc/repair(resources_available)
 	if (src.broken)
 		src.name = initial(src.name)
 		src.desc = initial(src.desc)
 		src.broken = FALSE
 		src.UpdateIcon()
 		src.setMaterial(getMaterial("gnesis"))
-	src.health = min(src.health + 50, src.max_health)
+	var/health_given = min(min(resources_available, FLOCK_REPAIR_COST) * src.repair_per_resource, src.max_health - src.health)
+	src.health += health_given
+	return ceil(health_given / src.repair_per_resource)
 
 /turf/simulated/wall/auto/feather/Entered(var/mob/living/critter/flock/drone/F, atom/oldloc)
 	..()


### PR DESCRIPTION
[QoL][REWORK]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR reworks Flockdrone repairing.

Flockdrone repairing is now a continuous action instead of being one action per click.

Resources used to heal a Flock thing are now scaled based on how many resources you have and how much health you can repair on the target instead of being a constant amount per repair.

Flock things now have a variable that determines how much of their health is healed per resource used.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
A continuous repair action would be nice

Allows a more accurate resource count to be used for repairing something instead of a constant amount when that amount may not be needed

Keeping track of health healed per resource on Flock things makes it easier to change how quickly something can be repaired