### PR TITLE
Fixes flock barricades being solid when they shouldn't be

### DIFF
--- a/code/obj/flock/furniture.dm
+++ b/code/obj/flock/furniture.dm
@@ -381,7 +381,7 @@
 		. = TRUE
 
 /obj/grille/flock/Cross(atom/movable/mover)
-	return istype(mover,/mob/living/critter/flock)
+	return !src.density || istype(mover,/mob/living/critter/flock)
 
 /obj/grille/flock/special_desc(dist, mob/user)
 	if (!isflockmob(user))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Destroyed flock barricades were still solid due to overriding `Cross`


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad
