### PR TITLE
vampires no longer break thindoors they fly through as a bat

### DIFF
--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -259,7 +259,7 @@
 			if (SD.cant_emag != 0 || SD.isblocked() != 0)
 				boutput(user, "<span class='alert'>It's shut tight!</span>")
 			else
-				SD.open(1)
+				SD.open()
 				success = 1
 
 		if (istype(src, /obj/machinery/door/airlock))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I am not sure why, but this behavior looks fully intentional to me? May be worth trying to remember why we had it like this in the first place.
Anyway, this makes it so they close afterwards, like other kinds of doors.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #10160 
