### PR TITLE
Fixes #10165 - Vega Fueltank Now Works With Other Vega Flamethrowers

### DIFF
--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -220,6 +220,20 @@ A Flamethrower in various states of assembly
 			. += "<br>\A [linkedflamer] is stowed away neatly in a compartment."
 
 	attackby(obj/item/W, mob/user)
+		if (src.loc == user && W != linkedflamer && istype(W, /obj/item/gun/flamethrower/backtank))
+			if (linkedflamer && (linkedflamer in src.contents))
+				boutput(user, "<span class='notice'>There already a flamethrower stowed in your [src.name].</span>")
+			else
+				var/obj/item/gun/flamethrower/backtank/flamer = W
+				if (flamer.fueltank != null)
+					var/obj/item/tank/jetpack/backtank/B = flamer.fueltank
+					B.linkedflamer = null
+				if (linkedflamer != null)
+					linkedflamer.gastank = null
+					linkedflamer.fueltank = null
+				linkedflamer = flamer
+				flamer.gastank = src
+				flamer.fueltank = src
 		if(src.loc == user && linkedflamer && W == linkedflamer)
 			boutput(user, "<span class='notice'>You stow [W] into your [src.name].</span>")
 			user.u_equip(W)


### PR DESCRIPTION
[GameObjects] [QoL] [Bug]


## About the PR:
Fixes #10165 by allowing the Vega Fuelpack to work with instances of the Vega Flamethrower other than the one spawned with it.
To use another flamethrower with the fuelpack, stow the flamethrower into the fuelpack, then unstow it. If there is a better way of implementing this, please let me know.