### PR TITLE
Buffs flockdrones against pods

### DIFF
--- a/code/modules/transport/pods/vehicle.dm
+++ b/code/modules/transport/pods/vehicle.dm
@@ -441,7 +441,7 @@
 
 		var/damage = 0
 		damage = round((P.power*P.proj_data.ks_ratio), 1.0)
-		if (damage <= 0 && P.proj_data.ks_ratio <= 0) //make stun weapons do some damage
+		if (damage <= 10 && P.proj_data.ks_ratio <= 0.1) //make stun weapons do some damage
 			damage = round(P.power, 1.0)
 
 		var/hitsound = null


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[A-GAMEMODES] [C-BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes how pods calculate projectile damage so flock incapacitor shots correctly deal around 40 damage rather than 4. Shouldn't affect too much else.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flock currently are almost completely unable to damage pods due to some `ks_ratio` weirdness.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Flockdrones now do ~40 damage per shot to pods, up from 4 (yes really)
```
