### PR TITLE
Fixes incorrectly pathed ghostdrone carpets

### DIFF
--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -1824,7 +1824,7 @@
 	light_type = /obj/item/light/tube/yellowish;
 	pixel_y = 21
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "eE" = (
 /obj/machinery/arc_electroplater,
@@ -2223,14 +2223,14 @@
 	pixel_y = 28
 	},
 /obj/storage/secure/closet/civilian/chaplain,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "fK" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
 /obj/landmark/gps_waypoint,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "fL" = (
 /obj/cable{
@@ -2241,7 +2241,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "fM" = (
 /obj/plasticflaps,
@@ -15548,11 +15548,11 @@
 /area/ghostdrone_factory)
 "Mh" = (
 /obj/decal/cleanable/robot_debris/gib,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "Mi" = (
 /obj/decal/cleanable/dirt,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "Mj" = (
 /obj/disposalpipe/segment{
@@ -15561,7 +15561,7 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 4
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "Mk" = (
 /obj/disposalpipe/segment{
@@ -15592,10 +15592,10 @@
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "Mp" = (
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "Mq" = (
 /obj/grille/catwalk,
@@ -15610,7 +15610,7 @@
 /area/ghostdrone_factory)
 "Ms" = (
 /obj/storage/crate/packing,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "Mt" = (
 /obj/disposalpipe/segment{
@@ -15618,7 +15618,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "Mu" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -15630,13 +15630,13 @@
 	name = "factory pipe"
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "Mv" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "Mw" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -15647,7 +15647,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "Mx" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -15657,7 +15657,7 @@
 	dir = 4;
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "My" = (
 /obj/decal/tile_edge/stripe/extra_big{
@@ -15668,11 +15668,11 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "Mz" = (
 /obj/item/ghostboard,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "MA" = (
 /obj/machinery/shuttle/engine/heater{
@@ -15682,12 +15682,12 @@
 /area/ghostdrone_factory)
 "MB" = (
 /obj/storage/secure/filing_cabinet,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "MC" = (
 /obj/table/auto,
 /obj/computer3frame/desktop,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "MD" = (
 /obj/table/auto,
@@ -15695,11 +15695,11 @@
 /obj/item/paper,
 /obj/item/pen/pencil,
 /obj/decal/cleanable/dirt,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "ME" = (
 /obj/item/device/radio/beacon,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "MF" = (
 /obj/table/auto,
@@ -15707,7 +15707,7 @@
 /obj/item/cigpacket,
 /obj/item/clothing/mask/cigarette,
 /obj/item/decoration/ashtray,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "MG" = (
 /obj/machinery/shuttle/engine/propulsion{
@@ -15720,18 +15720,18 @@
 	dir = 1
 	},
 /obj/decal/cleanable/dirt,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "MI" = (
 /obj/decal/cleanable/dirt,
 /mob/living/critter/spider/baby,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "MJ" = (
 /obj/stool/chair/office/red{
 	dir = 1
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "MK" = (
 /obj/grille/steel,
@@ -18143,7 +18143,7 @@
 	pixel_x = 23;
 	pixel_y = 2
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/chapel/office)
 "SA" = (
 /obj/disposalpipe/segment,

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -16169,7 +16169,7 @@
 	icon_state = "dwaine";
 	name = "old mainframe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aHa" = (
 /obj/table/reinforced/chemistry/auto,
@@ -16294,7 +16294,7 @@
 	icon_state = "tapedrive-p";
 	name = "downed server"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aHk" = (
 /turf/simulated/floor/carpet{
@@ -16636,7 +16636,7 @@
 	pixel_y = 21
 	},
 /obj/machinery/computer3/terminal,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aIc" = (
 /obj/machinery/light{
@@ -17106,7 +17106,7 @@
 "aJk" = (
 /obj/table/wood/auto,
 /obj/computer3frame/desktop,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aJl" = (
 /obj/table/wood/auto,
@@ -17118,7 +17118,7 @@
 	info = "They won't tell us how exactly this factory works, but I swear every once and a while I feel a faint breeze on me. There's something fishy about this place. James and I are probably going to ditch this place. Backwater assignment anyways, nobody will notice.";
 	name = "Scrawled Note"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aJm" = (
 /obj/storage/closet/biohazard,
@@ -17633,7 +17633,7 @@
 /turf/simulated/floor/plating/random,
 /area/ghostdrone_factory)
 "aKE" = (
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aKF" = (
 /obj/machinery/light_switch/west{
@@ -18035,7 +18035,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aLy" = (
 /obj/securearea{
@@ -20763,7 +20763,7 @@
 /obj/decal/fakeobjects/airmonitor_broken{
 	pixel_y = 28
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aQY" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -36169,7 +36169,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bxK" = (
 /obj/storage/closet/office,
@@ -36856,7 +36856,7 @@
 /obj/table/wood/auto,
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/burger/moldy,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bzb" = (
 /obj/cable{
@@ -36901,7 +36901,7 @@
 "bze" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bzf" = (
 /obj/cable{
@@ -40008,7 +40008,7 @@
 /obj/table/wood/auto,
 /obj/item/wrench,
 /obj/item/paper/book/from_file/the_trial,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bFS" = (
 /obj/machinery/door/airlock/pyro/engineering,
@@ -42616,7 +42616,7 @@
 /area/ghostdrone_factory)
 "bMq" = (
 /obj/machinery/drone_recharger/factory,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bMr" = (
 /obj/disposalpipe/block_sensing_outlet{
@@ -42656,7 +42656,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bMy" = (
 /obj/disposalpipe/segment{
@@ -42679,7 +42679,7 @@
 	dir = 4;
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bMB" = (
 /obj/disposalpipe/segment{
@@ -42687,7 +42687,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bMC" = (
 /obj/disposalpipe/segment{
@@ -42740,7 +42740,7 @@
 /obj/table/auto,
 /obj/item/sheet/glass/reinforced/fullstack,
 /obj/item/light/tube,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bMH" = (
 /obj/table/auto,
@@ -42750,7 +42750,7 @@
 /obj/item/light/bulb,
 /obj/item/light/tube,
 /obj/item/light/tube,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bMI" = (
 /obj/table/auto,
@@ -42785,7 +42785,7 @@
 /obj/item/sheet/steel/fullstack,
 /obj/item/light/bulb,
 /obj/item/light/bulb,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bMS" = (
 /obj/machinery/drainage/big,

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -27216,7 +27216,7 @@
 	icon_state = "dwaine";
 	name = "old mainframe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bta" = (
 /obj/decal/fakeobjects{
@@ -27227,7 +27227,7 @@
 	icon_state = "tapedrive-p";
 	name = "downed server"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "btb" = (
 /obj/machinery/light{
@@ -27236,12 +27236,12 @@
 	pixel_y = 21
 	},
 /obj/machinery/computer3/terminal,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "btc" = (
 /obj/table/wood/auto,
 /obj/computer3frame/desktop,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "btd" = (
 /obj/table/wood/auto,
@@ -27253,7 +27253,7 @@
 	info = "They won't tell us how exactly this factory works, but I swear every once and a while I feel a faint breeze on me. There's something fishy about this place. James and I are probably going to ditch this place. Backwater assignment anyways, nobody will notice.";
 	name = "Scrawled Note"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bte" = (
 /turf/simulated/floor/plating/random,
@@ -27484,7 +27484,7 @@
 /turf/space,
 /area/space)
 "btP" = (
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "btQ" = (
 /obj/cable{
@@ -27783,13 +27783,13 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "buJ" = (
 /obj/decal/fakeobjects/airmonitor_broken{
 	pixel_y = 28
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "buK" = (
 /obj/machinery/light{
@@ -27797,7 +27797,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "buL" = (
 /obj/cable{
@@ -27960,12 +27960,12 @@
 /obj/table/wood/auto,
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/burger/moldy,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bvt" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bvu" = (
 /obj/table/wood/auto,
@@ -27977,7 +27977,7 @@
 /obj/table/wood/auto,
 /obj/item/wrench,
 /obj/item/paper/book/from_file/the_trial,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bvx" = (
 /turf/simulated/floor/shuttlebay,
@@ -30380,7 +30380,7 @@
 /area/ghostdrone_factory)
 "bBZ" = (
 /obj/machinery/drone_recharger/factory,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bCa" = (
 /obj/disposalpipe/block_sensing_outlet{
@@ -30657,7 +30657,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bCP" = (
 /obj/disposalpipe/segment{
@@ -30680,7 +30680,7 @@
 	dir = 4;
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bCS" = (
 /obj/disposalpipe/segment{
@@ -30688,7 +30688,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bCT" = (
 /obj/machinery/light,
@@ -31047,7 +31047,7 @@
 /obj/table/auto,
 /obj/item/sheet/glass/reinforced/fullstack,
 /obj/item/light/tube,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bDU" = (
 /obj/table/auto,
@@ -31057,7 +31057,7 @@
 /obj/item/light/bulb,
 /obj/item/light/tube,
 /obj/item/light/tube,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bDV" = (
 /obj/table/auto,
@@ -31092,7 +31092,7 @@
 /obj/item/sheet/steel/fullstack,
 /obj/item/light/bulb,
 /obj/item/light/bulb,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "bDZ" = (
 /obj/table/auto,

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -1324,7 +1324,7 @@
 	icon_state = "dwaine";
 	name = "old mainframe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "acK" = (
 /obj/decal/fakeobjects{
@@ -1335,7 +1335,7 @@
 	icon_state = "tapedrive-p";
 	name = "downed server"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "acL" = (
 /obj/machinery/light{
@@ -1344,12 +1344,12 @@
 	pixel_y = 21
 	},
 /obj/machinery/computer3/terminal,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "acM" = (
 /obj/table/wood/auto,
 /obj/computer3frame/desktop,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "acN" = (
 /obj/table/wood/auto,
@@ -1361,7 +1361,7 @@
 	info = "They won't tell us how exactly this factory works, but I swear every once and a while I feel a faint breeze on me. There's something fishy about this place. James and I are probably going to ditch this place. Backwater assignment anyways, nobody will notice.";
 	name = "Scrawled Note"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "acO" = (
 /turf/simulated/floor/plating/random,
@@ -1437,7 +1437,7 @@
 	},
 /area/space)
 "acY" = (
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "acZ" = (
 /obj/grille/catwalk{
@@ -1602,13 +1602,13 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "adu" = (
 /obj/decal/fakeobjects/airmonitor_broken{
 	pixel_y = 28
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "adv" = (
 /obj/machinery/light{
@@ -1616,7 +1616,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "adw" = (
 /obj/lattice{
@@ -1848,12 +1848,12 @@
 /obj/table/wood/auto,
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/burger/moldy,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aec" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aed" = (
 /obj/table/wood/auto,
@@ -1865,7 +1865,7 @@
 /obj/table/wood/auto,
 /obj/item/wrench,
 /obj/item/paper/book/from_file/the_trial,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aef" = (
 /obj/lattice{
@@ -4081,7 +4081,7 @@
 /area/ghostdrone_factory)
 "ajD" = (
 /obj/machinery/drone_recharger/factory,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "ajE" = (
 /obj/disposalpipe/block_sensing_outlet{
@@ -4582,7 +4582,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "akP" = (
 /obj/disposalpipe/segment{
@@ -4605,7 +4605,7 @@
 	dir = 4;
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "akS" = (
 /obj/disposalpipe/segment{
@@ -4613,7 +4613,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "akT" = (
 /obj/machinery/light/small,
@@ -5084,7 +5084,7 @@
 /obj/table/auto,
 /obj/item/sheet/glass/reinforced/fullstack,
 /obj/item/light/tube,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "alX" = (
 /obj/table/auto,
@@ -5094,7 +5094,7 @@
 /obj/item/light/bulb,
 /obj/item/light/tube,
 /obj/item/light/tube,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "alY" = (
 /obj/table/auto,
@@ -5129,7 +5129,7 @@
 /obj/item/sheet/steel/fullstack,
 /obj/item/light/bulb,
 /obj/item/light/bulb,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "amc" = (
 /turf/simulated/wall/auto/reinforced/supernorn,

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -2685,7 +2685,7 @@
 /area/station/maintenance/inner/east)
 "azV" = (
 /obj/table/auto,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/maintenance/inner/east)
 "azX" = (
 /obj/cable{
@@ -9045,7 +9045,7 @@
 /obj/landmark/spawner{
 	name = "monkeyspawn_mrsmuggles"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/primary/southeast)
 "cql" = (
 /obj/machinery/light/incandescent/warm{
@@ -10905,7 +10905,7 @@
 	icon_state = "1-2"
 	},
 /obj/access_spawn,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
 "cTz" = (
 /obj/item/device/radio/beacon,
@@ -13350,7 +13350,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/secondary/construction2)
 "dEN" = (
 /obj/decal/tile_edge/stripe/extra_big,
@@ -22916,7 +22916,7 @@
 	pixel_y = 20;
 	tag = ""
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/primary/southeast)
 "goQ" = (
 /obj/cable{
@@ -23478,7 +23478,7 @@
 /obj/machinery/light/small/sticky{
 	dir = 1
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/maintenance/inner/east)
 "gxy" = (
 /turf/simulated/floor/carpet,
@@ -23703,7 +23703,7 @@
 	dir = 1;
 	pixel_y = 24
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
 "gAU" = (
 /obj/disposalpipe/segment/morgue{
@@ -24115,7 +24115,7 @@
 /obj/table/wood/round/auto,
 /obj/decal/cleanable/dirt/jen,
 /obj/random_item_spawner/circuitboards/four,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/secondary/construction2)
 "gIj" = (
 /turf/simulated/floor/specialroom/chapel{
@@ -26793,7 +26793,7 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "hwV" = (
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/maintenance/inner/east)
 "hxc" = (
 /obj/disposalpipe/segment/mail{
@@ -29338,7 +29338,7 @@
 	dir = 8
 	},
 /obj/machinery/light/incandescent/netural,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
 "iij" = (
 /obj/disposalpipe/segment/morgue{
@@ -32001,7 +32001,7 @@
 /area/station/maintenance/outer/west)
 "iYL" = (
 /obj/decal/cleanable/dirt/jen,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/secondary/construction2)
 "iZc" = (
 /obj/disposalpipe/segment{
@@ -32899,7 +32899,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/secondary/construction2)
 "jmA" = (
 /obj/decal/tile_edge/line/black{
@@ -33560,7 +33560,7 @@
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "jwX" = (
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/secondary/construction2)
 "jxq" = (
 /obj/grille/catwalk/jen/side{
@@ -35434,7 +35434,7 @@
 /area/station/maintenance/inner/sw)
 "jZO" = (
 /obj/machinery/vending/cola/red,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/primary/southeast)
 "kaf" = (
 /obj/cable{
@@ -35816,7 +35816,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
 "kgo" = (
 /obj/table/reinforced/auto,
@@ -37905,7 +37905,7 @@
 	icon_state = "dwaine";
 	name = "old mainframe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "kOd" = (
 /obj/wingrille_spawn/auto/tuff,
@@ -38622,7 +38622,7 @@
 /obj/table/auto,
 /obj/item/sheet/glass/reinforced/fullstack,
 /obj/item/light/tube,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "kZq" = (
 /obj/table/reinforced/bar/auto,
@@ -39057,7 +39057,7 @@
 	icon_state = "tapedrive-p";
 	name = "downed server"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "lfO" = (
 /obj/machinery/light/incandescent/warm{
@@ -39194,7 +39194,7 @@
 /obj/decal/cleanable/dirt/jen,
 /obj/random_item_spawner/desk_stuff/g_clip_bin_fpen/three,
 /obj/disposalpipe/segment,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/secondary/construction2)
 "lhS" = (
 /obj/decal/tile_edge/line/green{
@@ -39210,7 +39210,7 @@
 	pixel_y = 21
 	},
 /obj/machinery/computer3/terminal,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "lie" = (
 /obj/machinery/light/incandescent/netural,
@@ -39555,7 +39555,7 @@
 "lnT" = (
 /obj/table/wood/auto,
 /obj/computer3frame/desktop,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "lnW" = (
 /obj/storage/crate{
@@ -40170,7 +40170,7 @@
 	info = "They won't tell us how exactly this factory works, but I swear every once and a while I feel a faint breeze on me. There's something fishy about this place. James and I are probably going to ditch this place. Backwater assignment anyways, nobody will notice.";
 	name = "Scrawled Note"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "lwq" = (
 /obj/wingrille_spawn/auto/tuff,
@@ -41109,7 +41109,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
 "lJy" = (
 /obj/cable{
@@ -41711,7 +41711,7 @@
 	},
 /area/station/medical/medbay/cloner)
 "lQN" = (
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "lQS" = (
 /obj/decal/tile_edge/line/green{
@@ -42807,7 +42807,7 @@
 	dir = 4;
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "mgy" = (
 /turf/simulated/floor/black,
@@ -45528,7 +45528,7 @@
 	icon_state = "robust-broken";
 	name = "broken vending machine"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/maintenance/inner/east)
 "mYu" = (
 /obj/railing/orange/reinforced{
@@ -46028,7 +46028,7 @@
 	layer = 9.1;
 	pixel_x = -10
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "ngg" = (
 /obj/disposalpipe/segment/mail{
@@ -46993,7 +46993,7 @@
 /obj/decal/fakeobjects/airmonitor_broken{
 	pixel_y = 28
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "ntX" = (
 /obj/machinery/microwave,
@@ -47903,7 +47903,7 @@
 	layer = 9.1;
 	pixel_x = 10
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "nIN" = (
 /obj/disposalpipe/segment/mail{
@@ -49995,7 +49995,7 @@
 /obj/table/wood/auto,
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/burger/moldy,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "onh" = (
 /turf/simulated/floor/purpleblack{
@@ -52176,7 +52176,7 @@
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff,
 /obj/machinery/light/incandescent/netural,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
 "oSS" = (
 /obj/railing/orange{
@@ -53777,7 +53777,7 @@
 "psg" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "psA" = (
 /obj/machinery/power/apc/autoname_north,
@@ -54971,7 +54971,7 @@
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/primary/southeast)
 "pHz" = (
 /obj/item/clothing/suit/bedsheet/red,
@@ -55503,7 +55503,7 @@
 /obj/table/wood/auto,
 /obj/item/wrench,
 /obj/item/paper/book/from_file/the_trial,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "pQm" = (
 /obj/table/auto,
@@ -59436,7 +59436,7 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
 "qRg" = (
 /obj/lattice{
@@ -65816,7 +65816,7 @@
 /obj/item/light/bulb,
 /obj/item/light/tube,
 /obj/item/light/tube,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "sIK" = (
 /turf/space,
@@ -66069,7 +66069,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "sMz" = (
 /obj/cable{
@@ -66811,7 +66811,7 @@
 /obj/machinery/computer/stockexchange{
 	dir = 4
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
 "sYV" = (
 /obj/pool/perspective{
@@ -68832,7 +68832,7 @@
 /obj/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/wreckage{
 	name = "Restricted Area"
 	})
@@ -70562,7 +70562,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/secondary/construction2)
 "ucN" = (
 /obj/machinery/door/airlock/pyro/glass/security{
@@ -70703,7 +70703,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "ufe" = (
 /obj/storage/secure/closet/medical/medkit,
@@ -73586,7 +73586,7 @@
 /area/station/medical/medbay/pharmacy)
 "uUY" = (
 /obj/machinery/vending/snack,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/hallway/primary/southeast)
 "uVi" = (
 /obj/cable{
@@ -75408,21 +75408,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
-"vwG" = (
-/obj/wingrille_spawn/auto/tuff,
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "lockdown";
-	name = "Bridge Lockdown Doors";
-	opacity = 0
-	},
-/obj/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/bridge)
 "vwH" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_normal"
@@ -75544,7 +75529,7 @@
 "vyj" = (
 /obj/table/auto,
 /obj/random_item_spawner/desk_stuff,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
 "vyo" = (
 /obj/table/auto,
@@ -77028,7 +77013,7 @@
 /obj/machinery/computer/stockexchange{
 	dir = 8
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
 "vSP" = (
 /obj/submachine/chef_oven{
@@ -80411,7 +80396,7 @@
 	pixel_x = -11;
 	pixel_y = 5
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/stockex)
 "wPF" = (
 /obj/grille/catwalk/jen/side{
@@ -84157,7 +84142,7 @@
 /obj/item/sheet/steel/fullstack,
 /obj/item/light/bulb,
 /obj/item/light/bulb,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "xRU" = (
 /obj/machinery/manufacturer/gas,
@@ -85548,7 +85533,7 @@
 /area/station/turret_protected/armory_outside)
 "yld" = (
 /obj/machinery/drone_recharger/factory,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "yli" = (
 /turf/space,
@@ -116310,7 +116295,7 @@ vyE
 abv
 fwb
 svq
-vwG
+pVh
 rdj
 dVe
 dVe

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -35290,7 +35290,7 @@
 /obj/item/matchbook,
 /obj/item/cigpacket,
 /obj/machinery/light/incandescent/warm,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/radio/lab)
 "bMI" = (
 /obj/stool/chair/office{

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -5645,7 +5645,7 @@
 	icon_state = "dwaine";
 	name = "old mainframe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aso" = (
 /obj/decal/fakeobjects{
@@ -5656,17 +5656,17 @@
 	icon_state = "tapedrive-p";
 	name = "downed server"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "asp" = (
 /obj/machinery/light/incandescent,
 /obj/machinery/computer3/terminal,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "asq" = (
 /obj/table/wood/auto,
 /obj/computer3frame/desktop,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "asr" = (
 /obj/table/wood/auto,
@@ -5678,7 +5678,7 @@
 	info = "They won't tell us how exactly this factory works, but I swear every once and a while I feel a faint breeze on me. There's something fishy about this place. James and I are probably going to ditch this place. Backwater assignment anyways, nobody will notice.";
 	name = "Scrawled Note"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "ass" = (
 /turf/simulated/floor/plating/random,
@@ -5920,7 +5920,7 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/main)
 "asX" = (
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "asZ" = (
 /obj/window/reinforced{
@@ -6113,13 +6113,13 @@
 /area/station/hangar/main)
 "atu" = (
 /obj/machinery/light/incandescent,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "atv" = (
 /obj/decal/fakeobjects/airmonitor_broken{
 	pixel_y = 28
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "atx" = (
 /obj/landmark/gps_waypoint,
@@ -6329,12 +6329,12 @@
 /obj/table/wood/auto,
 /obj/item/plate,
 /obj/item/reagent_containers/food/snacks/burger/moldy,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "atX" = (
 /obj/table/wood/auto,
 /obj/random_item_spawner/desk_stuff,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "atY" = (
 /obj/table/wood/auto,
@@ -6346,7 +6346,7 @@
 /obj/table/wood/auto,
 /obj/item/wrench,
 /obj/item/paper/book/from_file/the_trial,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aua" = (
 /obj/machinery/power/data_terminal,
@@ -8365,7 +8365,7 @@
 /area/ghostdrone_factory)
 "azs" = (
 /obj/machinery/drone_recharger/factory,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "azt" = (
 /obj/disposalpipe/block_sensing_outlet{
@@ -8872,7 +8872,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aAz" = (
 /obj/disposalpipe/segment{
@@ -8896,7 +8896,7 @@
 	icon_state = "pipe-s";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aAC" = (
 /obj/disposalpipe/segment{
@@ -8904,7 +8904,7 @@
 	icon_state = "pipe-c";
 	name = "factory pipe"
 	},
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aAD" = (
 /obj/reagent_dispensers/fueltank,
@@ -9222,7 +9222,7 @@
 /obj/table/auto,
 /obj/item/sheet/glass/reinforced/fullstack,
 /obj/item/light/tube,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aBm" = (
 /obj/table/auto,
@@ -9232,7 +9232,7 @@
 /obj/item/light/bulb,
 /obj/item/light/tube,
 /obj/item/light/tube,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aBn" = (
 /obj/table/auto,
@@ -9267,7 +9267,7 @@
 /obj/item/sheet/steel/fullstack,
 /obj/item/light/bulb,
 /obj/item/light/bulb,
-/turf/simulated/grimycarpet,
+/turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
 "aBs" = (
 /obj/stool/chair,


### PR DESCRIPTION
[Mapping] [Bug]
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces the turf/simulated/grimycarpet with turf/simulated/floor/carpet/grimy in most map's ghostfactories. Disallowing pods to go across the carpet and allowing flocks to convert carpet there


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->


