### PR TITLE
AI Change Designation only goes on cooldown after successful rename

### DIFF
--- a/code/mob/living/silicon/ai.dm
+++ b/code/mob/living/silicon/ai.dm
@@ -1990,8 +1990,8 @@ var/global/list/ai_emotions = list("Happy" = "ai_happy", \
 	if (!message_mob.client || isdead(src))
 		return
 
-	if (!ON_COOLDOWN(src, "ai_self_rename", src.rename_cooldown))
-		choose_name(retries = 3, default_name = src.real_name, renaming_mob = message_mob)
+	if (!GET_COOLDOWN(src, "ai_self_rename"))
+		choose_name(retries = 3, renaming_mob = message_mob)
 	else
 		src.show_text("This ability is still on cooldown for [round(GET_COOLDOWN(src, "ai_self_rename") / 10)] seconds!", "red")
 
@@ -2450,6 +2450,7 @@ proc/get_mobs_trackable_by_AI()
 					src.real_name = newname
 					if (src.deployed_to_eyecam)
 						src.eyecam.real_name = newname
+					ON_COOLDOWN(src, "ai_self_rename", src.rename_cooldown)
 					break
 				else
 					continue


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Silicons][Bug][Player Actions]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Only set the cooldown for name changing when a name is successfully changed

This ties the initial AI name change into the same cooldown as Change Designation, so there is no longer a "freebie" name change

I believe this change also addresses a subtle ckey leak by using Change Designation verb before having set a name at all, 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9562
Fixes #9322
