### PR TITLE
Normalize Slipping Hazard name

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -971,7 +971,7 @@ ABSTRACT_TYPE(/obj/trait/job)
 	mutantRace = /datum/mutantrace/pug
 
 /obj/trait/super_slips
-	name = "Slipping Hazard (+1)"
+	name = "Slipping Hazard"
 	id = "super_slips"
 	desc = "You never were good at managing yourself slipping."
 	points = 1


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial][bug][ui]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
normalizes name of Slipping Hazard trait to not have its point bonus as part of the name

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
the name shows up verbatim, so the medical records show the trait with a `(+1)`
Reduces chance of future misleading/incorrect signage if i.e. `points` was changed without the name changing.