### PR TITLE
Plantmaster no longer relocates attached/cyborg items

### DIFF
--- a/code/obj/submachine/seed.dm
+++ b/code/obj/submachine/seed.dm
@@ -253,8 +253,12 @@
 			var/obj/item/I = src.inserted
 			if (!I) boutput(usr, "<span class='alert'>No receptacle found to eject.</span>")
 			else
-				I.set_loc(src.loc) // causes Exited proc to be called
-				usr.put_in_hand_or_eject(I) // try to eject it into the users hand, if we can
+				if (I.cant_drop) // cyborg/item arms
+					src.inserted = null
+					src.updateUsrDialog()
+				else
+					I.set_loc(src.loc) // causes Exited proc to be called
+					usr.put_in_hand_or_eject(I) // try to eject it into the users hand, if we can
 
 		else if(href_list["ejectseeds"])
 			for (var/obj/item/seed/S in src.seeds)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[bug][minor][player actions][silicons]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a check for item arms & cyborgs for the plantmaster's eject beaker functionality, and adjusts ejection behavior accordingly.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #3767
