### PR TITLE
Prevent silicons from reacting to itchy materials

### DIFF
--- a/code/modules/materials/Mat_MaterialProcs.dm
+++ b/code/modules/materials/Mat_MaterialProcs.dm
@@ -159,6 +159,7 @@ triggerOnEntered(var/atom/owner, var/atom/entering)
 	desc = "It makes your hands itch."
 
 	execute(var/mob/M, var/obj/item/I, mult)
+		if(issilicon(M)) return // silicons can't get itchy
 		if(probmult(20)) M.emote(pick("twitch", "laugh", "sneeze", "cry"))
 		if(probmult(10))
 			boutput(M, "<span class='notice'><b>Something tickles!</b></span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG][MINOR][SILICONS][MATSCI]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stops the generic itchy proc from affecting silicons. they don't even have half of those emotes anyway.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #4617
