### PR TITLE
Silicons only apply touch to artifacts when not using a tool

### DIFF
--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -232,9 +232,6 @@
 	return
 
 /obj/proc/Artifact_attackby(obj/item/W, mob/user)
-	if (isrobot(user) && !istype(W,/obj/item/))
-		src.ArtifactStimulus("silitouch", 1)
-
 	if (istype(W,/obj/item/artifact/activator_key))
 		var/obj/item/artifact/activator_key/ACT = W
 		if (!src.ArtifactSanityCheck())

--- a/code/obj/artifacts/artifactprocs.dm
+++ b/code/obj/artifacts/artifactprocs.dm
@@ -232,7 +232,7 @@
 	return
 
 /obj/proc/Artifact_attackby(obj/item/W, mob/user)
-	if (isrobot(user))
+	if (isrobot(user) && !istype(W,/obj/item/))
 		src.ArtifactStimulus("silitouch", 1)
 
 	if (istype(W,/obj/item/artifact/activator_key))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[Silicons][science][bug][minor]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Only apply the silicon touch stimulus when you are not using an item.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #8291