### PR TITLE
Fixes #2854 - Ghostdrones pulled from chargers free up the charger now

### DIFF
--- a/code/obj/machinery/drone_recharger.dm
+++ b/code/obj/machinery/drone_recharger.dm
@@ -42,12 +42,13 @@
 				return
 			if (!occupant.cell)
 				return
-			else if (occupant.cell.charge >= occupant.cell.maxcharge) //fully charged yo
+			else if (occupant.cell.charge >= occupant.cell.maxcharge && !src.occupant.newDrone) //fully charged yo
 				occupant.cell.charge = occupant.cell.maxcharge
 				src.turnOff("fullcharge")
 				return
-			else
+			else if (occupant.cell.charge < occupant.cell.maxcharge)
 				occupant.cell.charge += src.chargerate
+				occupant.cell.charge = min(occupant.cell.maxcharge, occupant.cell.charge)
 				use_power(50)
 				return
 		return 1
@@ -87,21 +88,20 @@
 		return 1
 
 	proc/turnOff(reason)
-		if (!src.occupant || src.occupant.newDrone) return 0
+		if (src.occupant)
+			var/list/msg = list("<span class='notice'>")
+			if (reason == "nopower")
+				msg += "The [src] spits you out seconds before running out of power."
+			else if (reason == "fullcharge")
+				msg += "The [src] beeps happily and disengages. You are full."
+			else
+				msg += "The [src] disengages, allowing you to float [pick("serenely", "hurriedly", "briskly", "lazily")] away."
+			boutput(src.occupant, "[msg.Join()]</span>")
 
-		var/list/msg = list("<span class='notice'>")
-		if (reason == "nopower")
-			msg += "The [src] spits you out seconds before running out of power."
-		else if (reason == "fullcharge")
-			msg += "The [src] beeps happily and disengages. You are full."
-		else
-			msg += "The [src] disengages, allowing you to float [pick("serenely", "hurriedly", "briskly", "lazily")] away."
-		boutput(src.occupant, "[msg.Join()]</span>")
-
-		src.occupant.charging = 0
-		src.occupant.setFace(src.occupant.faceType, src.occupant.faceColor)
-		src.occupant.updateHoverDiscs(src.occupant.faceColor)
-		src.occupant.updateSprite()
+			src.occupant.charging = 0
+			src.occupant.setFace(src.occupant.faceType, src.occupant.faceColor)
+			src.occupant.updateHoverDiscs(src.occupant.faceColor)
+			src.occupant.updateSprite()
 		src.occupant = null
 
 		//Do closing thing


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Looked like someone tried to fix a bug with the ghostdrones and accidentally beefed it. Now it's fixed - ghost drones should now free up the charger when they are removed from it or die.

Fixes #2854