### PR TITLE
Reclaimers check if you can drop an item before accepting it.

### DIFF
--- a/code/obj/item/material.dm
+++ b/code/obj/item/material.dm
@@ -910,12 +910,12 @@
 			if (.)
 				user.visible_message("<b>[user.name]</b> loads [W] into [src].")
 				playsound(src, sound_load, 40, 1)
-		else if (load_reclaim(W, user))
-			boutput(user, "You load [W] into [src].")
-			playsound(src, sound_load, 40, 1)
 		else if (W.cant_drop)
 			boutput(user, "<span class='alert'>You can't put that in [src] when it's attached to you!</span>")
 			return ..()
+		else if (load_reclaim(W, user))
+			boutput(user, "You load [W] into [src].")
+			playsound(src, sound_load, 40, 1)
 		else
 			. = ..()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[silicons][bug][major]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
If you can't drop an item, it shouldn't go into a reclaimer.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9382
This stops engineering cyborgs from plonking all their materials into a reclaimer and resetting their module for Free Stuff.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(+)Engineering cyborgs can no longer insert their material stacks into a reclaimer.
```
