### PR TITLE
Only detonate the relay once plz

### DIFF
--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -111,6 +111,8 @@
 				src?.flock.claimTurf(flock_convert_turf(T))
 
 /obj/flock_structure/relay/proc/unleash_the_signal()
+	if(src.finished)
+		return
 	src.finished = TRUE
 	processing_items -= src
 	var/turf/location = get_turf(src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #10231 by adding an early return to `unleash_the_signal()`
Couldn't reproduce on local, but I'm guessing the problem was that `process()` was called multiple times before the detonation due to server load.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
To stop everybody getting permanent hearing loss.

