### PR TITLE
Fix #3306 - add actionbar to tear_apart door

### DIFF
--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -220,19 +220,12 @@
 #ifdef HALLOWEEN
 	user.emote("scream")
 #endif
-	if (do_after(user, 100) && !(user.getStatusDuration("stunned") || user.getStatusDuration("weakened") || user.getStatusDuration("paralysis") > 0 || !isalive(user) || user.restrained()))
-		var/success = 0
-		SPAWN(0.6 SECONDS)
-			success = try_force_open(user)
-			if (success != 0)
-				src.operating = -1 // It's broken now.
-				src.visible_message("<span class='alert'>[user] pries open [src]!</span>")
-	else
-		user.show_text("You were interrupted.", "red")
+	SETUP_GENERIC_ACTIONBAR(user, src, 10 SECONDS, /obj/machinery/door/proc/try_force_open, list(user, TRUE), src.icon, src.icon_state, \
+	"<span class='alert'>[user] pries open [src]!</span>", \
+	INTERRUPT_ACT | INTERRUPT_STUNNED | INTERRUPT_ACTION | INTERRUPT_MOVE)
 
-	return
 
-/obj/machinery/door/proc/try_force_open(mob/user as mob)
+/obj/machinery/door/proc/try_force_open(mob/user as mob, var/break_door = FALSE)
 	var/success = 0
 	if (src)
 		if (istype(src, /obj/machinery/door/poddoor))
@@ -272,7 +265,8 @@
 				else
 					AL.open()
 				success = 1
-
+	if(success && break_door)
+		src.operating = -1
 	return success
 
 /obj/machinery/door/proc/requiresID()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a visible action bar with appropriate interrupts to `tear_open()` instead of `do_after()`
Fixes #3306 kinda