### PR TITLE
Fixes #3314 - Sponge can wipe paint off now

### DIFF
--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -634,6 +634,9 @@ WET FLOOR SIGN
 				JOB_XP(user, "Janitor", 3)
 				if (target.reagents)
 					target.reagents.trans_to(src, 5)
+				if((target.color != initial(target.color)) || (target.icon != initial(target.icon))) //if painted, un-paint
+					target.color = initial(target.color)
+					target.icon = initial(target.icon)
 				playsound(src, 'sound/items/sponge.ogg', 20, 1)
 				if (ismob(target))
 					animate_smush(target)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds the ability for a sponge to wipe off paint by restoring initial icon and colour.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #3314 - Looks like pali intended to do this and just never got around to it


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizze
(+)You can now clean up paint with a wet sponge.
```
