### PR TITLE
Fixes lawbringer AOE hitting through spellshield

### DIFF
--- a/code/modules/projectiles/energy_bolt.dm
+++ b/code/modules/projectiles/energy_bolt.dm
@@ -270,7 +270,7 @@ toxic - poisons
 			new /obj/effects/energy_bolt_aoe_burst(get_turf(O))
 
 		for (var/mob/M in range(1, O)) //direct hit power is a 'bonus for aim', so we want this to hit the target
-			if (isliving(M) && M != P.shooter) //don't stun ourself while shooting in close quarters
+			if (isliving(M) && !check_target_immunity(M, FALSE, src) && M != P.shooter) //don't stun ourself while shooting in close quarters
 				var/mob/living/L = M
 				L.changeStatus("slowed", 2 SECONDS)
 				L.do_disorient(stamina_damage = 40, weakened = 0, stunned = 0, disorient = 20, remove_stamina_below_zero = 0)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The lawbringer AOE projectile wasn't checking target immunities, now it does.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad, rip Sian