### PR TITLE
Fixes glue not actually slowing you down to any noticeable extent

### DIFF
--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -63,8 +63,11 @@
 		if(T.sticky)
 			if(src.getStatusDuration("slowed")<1)
 				boutput(src, "<span class='notice'>You get slowed down by the sticky floor!</span>")
-			if(src.getStatusDuration("slowed")< 30 SECONDS)
-				src.changeStatus("slowed", 2 SECONDS, optional = 2)
+			if(src.getStatusDuration("slowed")< 20 SECONDS)
+				src.changeStatus("slowed", 4 SECONDS, optional = 15)
+			if(src.lying || src.getStatusDuration("slowed")> 15 SECONDS)
+				boutput(src, "<span class='alert'>You get stuck to the sticky floor!</span>")
+				src.changeStatus("stunned", 4 SECONDS)
 
 /mob/living/carbon/relaymove(var/mob/user, direction)
 	if(user in src.stomach_contents)

--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -63,7 +63,7 @@
 		if(T.sticky)
 			if(src.getStatusDuration("slowed")<1)
 				boutput(src, "<span class='notice'>You get slowed down by the sticky floor!</span>")
-			if(src.getStatusDuration("slowed")< 20 SECONDS)
+			if(src.getStatusDuration("slowed") < 20 SECONDS)
 				src.changeStatus("slowed", 4 SECONDS, optional = 15)
 			if(src.lying)  //if you lie down on glue you get your face stuck haha
 				boutput(src, "<span class='alert'>You get stuck to the sticky floor!</span>")

--- a/code/mob/living/carbon.dm
+++ b/code/mob/living/carbon.dm
@@ -65,7 +65,7 @@
 				boutput(src, "<span class='notice'>You get slowed down by the sticky floor!</span>")
 			if(src.getStatusDuration("slowed")< 20 SECONDS)
 				src.changeStatus("slowed", 4 SECONDS, optional = 15)
-			if(src.lying || src.getStatusDuration("slowed")> 15 SECONDS)
+			if(src.lying)  //if you lie down on glue you get your face stuck haha
 				boutput(src, "<span class='alert'>You get stuck to the sticky floor!</span>")
 				src.changeStatus("stunned", 4 SECONDS)
 


### PR DESCRIPTION
[LABEL][bug][balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the glue slowdown to be more than the 2 i unknowingly set it to. Now stepping on glue actually noticeably slows you down + the maximum slowdown time was reduced from 30 to 20 so the slowdown isn't too bad.
Also added getting stuck to the glue(briefly) if you lie down on it, but if that's too much i can remove it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I was a dummy when i made the glue floor code and changed the standard slowdown value of 10 to 2.

