### PR TITLE
Oshan Pest Starts Bug Fix

### DIFF
--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -13608,10 +13608,6 @@
 	pixel_y = 32
 	},
 /obj/decal/cleanable/dirt,
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
-	},
 /turf/simulated/floor,
 /area/station/security/brig)
 "aGy" = (
@@ -25281,10 +25277,6 @@
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5;
 	level = 2
-	},
-/obj/landmark{
-	icon_state = "x3";
-	name = "peststart"
 	},
 /turf/simulated/floor/plating/random,
 /area/station/crew_quarters/catering)
@@ -46167,6 +46159,13 @@
 /obj/machinery/light_switch/auto,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/baroffice)
+"lPB" = (
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/turf/simulated/floor/plating/random,
+/area/station/maintenance/west)
 "lTa" = (
 /obj/disposalpipe/segment/brig{
 	dir = 1;
@@ -47765,6 +47764,13 @@
 /obj/landmark/spawner/loot,
 /turf/simulated/floor/damaged2,
 /area/space)
+"uTp" = (
+/obj/landmark{
+	icon_state = "x3";
+	name = "peststart"
+	},
+/turf/simulated/floor/grass/random,
+/area/station/garden/zen)
 "uTy" = (
 /obj/submachine/cargopad{
 	name = "Security Pod Bay Pad"
@@ -76872,7 +76878,7 @@ bmS
 bnC
 bil
 ceX
-aNA
+lPB
 bqm
 boV
 brM
@@ -84758,7 +84764,7 @@ cgr
 bJE
 bJE
 bTA
-bRk
+uTp
 bRk
 bRk
 bRk


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Edits two of the pest spawns in Oshan: prison brig spawn, and kitchen freezer spawn. Moves the kitchen spawn down a room, and the prison brig spawn is moved into the aviary. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10207
Pests shouldn't spawn in areas they cannot escape from. Spawning in the brig, while funny, usually leads to instant death for these starts. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Roddy
(+)Moved some pest spawns on Oshan.
```
[p-minor] [c-bug]