### PR TITLE
Donut3 Engineer's Coffeemaker is now Engineering flavoured

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -72303,7 +72303,7 @@
 /area/station/security/detectives_office)
 "uEH" = (
 /obj/table/auto,
-/obj/machinery/coffeemaker{
+/obj/machinery/coffeemaker/engineering{
 	pixel_y = 3
 	},
 /obj/machinery/light_switch/north,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial][mapping]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the coffee maker in engineering an engineering coffee maker, complete with `E` c:

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Consistency