### PR TITLE
Paintfix 2: Electric Spongealoo

### DIFF
--- a/code/modules/forensics/atom_forensic.dm
+++ b/code/modules/forensics/atom_forensic.dm
@@ -197,8 +197,7 @@
 		if (isobserver(src) || isintangible(src) || iswraith(src)) // Just in case.
 			return
 
-		if (src.color) //wash off paint! might be dangerous, so possibly move this check into humans only if it causes problems with critters
-			src.color = initial(src.color)
+		src.remove_filter(list("paint_color", "paint_pattern")) //wash off any paint
 
 		if (ishuman(src))
 			var/mob/living/carbon/human/M = src

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -634,11 +634,7 @@ WET FLOOR SIGN
 				JOB_XP(user, "Janitor", 3)
 				if (target.reagents)
 					target.reagents.trans_to(src, 5)
-				if((target.color != initial(target.color)) || (target.icon != initial(target.icon))) //if painted, un-paint
-					target.color = initial(target.color)
-					target.icon = initial(target.icon)
-					if(target.material)
-						target.setMaterialAppearance(target.material)
+				target.remove_filter(list("paint_color", "paint_pattern"))
 				playsound(src, 'sound/items/sponge.ogg', 20, 1)
 				if (ismob(target))
 					animate_smush(target)

--- a/code/obj/item/paint.dm
+++ b/code/obj/item/paint.dm
@@ -262,52 +262,36 @@ var/list/cached_colors = new/list()
 	flags = FPRINT | EXTRADELAY | TABLEPASS | CONDUCT
 	w_class = W_CLASS_SMALL
 
+	New()
+		..()
+		generate_icon()
+
 	attack_hand(mob/user)
 		..()
-
 		generate_icon()
 
 	afterattack(atom/target as mob|obj|turf, mob/user as mob)
-		if(target == loc || BOUNDS_DIST(src, target) > 0 || istype(target,/obj/machinery/vending/paint) ) return
+		if(target == loc || BOUNDS_DIST(src, target) > 0 || istype(target,/obj/machinery/vending/paint) ) return FALSE
 
-		if(!uses)
+		if(uses <= 0)
 			boutput(user, "It's empty.")
-			return
+			return FALSE
 
-		boutput(user, "You paint \the [target].")
-		for(var/mob/O in oviewers(world.view, user))
-			O.show_message("<span class='notice'>[user] paints \the [target].</span>", 1)
-
+		user.visible_message("<span class='notice'>[user] paints \the [target].</span>", "You paint \the [target]", "<span class='notice'>You hear a wet splat.</span>")
 		playsound(src, "sound/impact_sounds/Slimy_Splat_1.ogg", 40, 1)
 
 		uses--
-		if(!uses) overlays = null
+		if(uses <= 0) overlays = null
 
-		/*
-		if( (paint_color+"[initial(target.icon)]") in cached_colors )
-			target.icon = cached_colors[(paint_color+"[initial(target.icon)]")]
-		else
-			var/icon/new_icon = icon(target.icon)
-			new_icon.ColorTone(paint_color)
-			cached_colors += (paint_color+"[initial(target.icon)]")
-			cached_colors[(paint_color+"[initial(target.icon)]")] = new_icon
-			target.icon = new_icon
-		*/
-		var/oldVal = target.color
-		target.color = src.actual_paint_color
-		target.onVarChanged("color", oldVal, actual_paint_color) // to force redraws on worn items if needed
-
-		//var/icon/new_icon = icon(initial(target.icon))
-		//new_icon.ColorTone(color)
-		//target.icon = new_icon
-
-		return
+		target.add_filter("paint_color", 1, color_matrix_filter(normalize_color_to_matrix(src.actual_paint_color)))
+		return TRUE
 
 	proc/generate_icon()
+		overlays = null
+		if(uses <= 0) return
 		if (!paint_overlay)
 			paint_overlay = image('icons/misc/old_or_unused.dmi',"paint_overlay")
 		paint_overlay.color = paint_color
-		overlays = null
 		overlays += paint_overlay
 		var/list/color_list = hex_to_rgb_list(src.paint_color)
 		src.actual_paint_color = list(
@@ -320,110 +304,73 @@ var/list/cached_colors = new/list()
 	name = "random paint can"
 	uses = 5
 	New()
-		..()
-		SPAWN(0.5 SECONDS)
-			var/colorname = "Weird"
-			switch(rand(1,6))
-				if(1)
-					paint_color = rgb(255,10,10)
-					colorname = "red"
-				if(2)
-					paint_color = rgb(10,255,10)
-					colorname = "green"
-				if(3)
-					paint_color = rgb(10,10,255)
-					colorname = "blue"
-				if(4)
-					paint_color = rgb(255,255,10)
-					colorname = "yellow"
-				if(5)
-					paint_color = rgb(255,10,255)
-					colorname = "purple"
-				if(6)
-					paint_color = rgb(150,150,150)
-					colorname = "gray"
+		var/colorname = "Weird"
+		switch(rand(1,6))
+			if(1)
+				paint_color = rgb(255,10,10)
+				colorname = "red"
+			if(2)
+				paint_color = rgb(10,255,10)
+				colorname = "green"
+			if(3)
+				paint_color = rgb(10,10,255)
+				colorname = "blue"
+			if(4)
+				paint_color = rgb(255,255,10)
+				colorname = "yellow"
+			if(5)
+				paint_color = rgb(255,10,255)
+				colorname = "purple"
+			if(6)
+				paint_color = rgb(150,150,150)
+				colorname = "gray"
 
-			name = "[colorname] paint can"
-			desc = "[colorname] paint. In a can. Whoa!"
-			src.generate_icon()
+		name = "[colorname] paint can"
+		desc = "[colorname] paint. In a can. Whoa!"
+		..()
 
 /obj/item/paint_can/rainbow
 	name = "rainbow paint can"
 	desc = "This Paint Can contains rich, thick, rainbow paint. No, we don't know how it works either."
-	var/colorlist[]
-	var/currentcolor
+	var/colorlist = list()
+	var/currentcolor = 1
 	New()
-		..()
-
 		//A rainbow of colours! Joy!
 		src.colorlist = list(rgb(255,0,0),rgb(255,165,0), rgb(255,255,0), rgb(0,128,0), rgb(0,0,255), rgb(075,0,128), rgb(238,128,238))
-		src.currentcolor = 1
+		src.currentcolor = rand(1, length(src.colorlist))
 		src.paint_color = colorlist[currentcolor]
-
+		..()
 
 	afterattack(atom/target as mob|obj|turf, mob/user as mob)
-		..()
+		if(!..()) return
 		src.currentcolor += 1
-		if (src.currentcolor == 8)
+		if (src.currentcolor > length(src.colorlist))
 			src.currentcolor = 1
 
 		src.paint_color = colorlist[currentcolor]
-
 		src.generate_icon()
-
-		return
+		return TRUE
 
 /obj/item/paint_can/rainbow/plaid
 	name = "pattern paint can"
 	desc = "A perfectly ordinary can of paint. Oh, except that it paints patterns."
-	var/patternlist[]
-	var/currentpattern
+	var/patternlist = list()
+	var/currentpattern = 1
 
 	New()
 		..()
-
 		src.patternlist = list("tartan", "strongplaid", "polka", "hearts")
-		currentpattern = 1
+		for(var/i=1 to length(src.patternlist))
+			src.patternlist[i] =  new /icon('icons/obj/paint.dmi', patternlist[i])
+
+		currentpattern = rand(1, length(src.patternlist))
 
 	afterattack(atom/target as mob|obj|turf, mob/user as mob)
-		if(target == loc || BOUNDS_DIST(src, target) > 0 || istype(target,/obj/machinery/vending/paint) ) return
+		if(!..()) return
 
-		if(!uses)
-			boutput(user, "It's empty.")
-			return
-
-		boutput(user, "You paint \the [target].")
-		for(var/mob/O in oviewers(world.view, user))
-			O.show_message("<span class='notice'>[user] paints \the [target].</span>", 1)
-
-		playsound(src, "sound/impact_sounds/Slimy_Splat_1.ogg", 40, 1)
-
-		uses--
-		if(!uses) overlays = null
-
-		if( (paint_color+"[initial(target.icon)]") in cached_colors )
-			target.icon = cached_colors[(paint_color+"[initial(target.icon)]")]
-		else
-			var/icon/new_icon = icon(target.icon)
-
-			//Add pattern here.
-			var/icon/pattern = new('icons/obj/paint.dmi', patternlist[currentpattern])
-			new_icon.Blend(pattern,ICON_MULTIPLY)
-
-			new_icon.ColorTone(paint_color)
-			cached_colors += (paint_color+"[initial(target.icon)]")
-			cached_colors[(paint_color+"[initial(target.icon)]")] = new_icon
-			target.icon = new_icon
-
-
-		src.currentcolor += 1
-		if (src.currentcolor == 8)
-			src.currentcolor = 1
-
-		src.paint_color = colorlist[currentcolor]
+		target.add_filter("paint_pattern", 1, layering_filter(icon=src.patternlist[src.currentpattern], color=src.actual_paint_color, blend_mode=BLEND_MULTIPLY))
 
 		src.currentpattern += 1
-		if (src.currentpattern == 4)
+		if (src.currentpattern > length(src.patternlist))
 			src.currentpattern = 1
-
-		src.generate_icon()
+		return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I probably should've just done this the first time. Changes paint cans (and the sponge paint removing) to use filters instead of the horrific thing it did before, which was blending icons together and caching them.
I also cleaned up the paint_can code cos it wasn't great.

Minor impact: it looks a tiny bit weird on windows where there are connection overlays. Not really sure what that's about.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10272 


