### PR TITLE
Convert the radio station printer into a fake object

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -691,10 +691,16 @@
 /area/radiostation/hallway)
 "acm" = (
 /obj/table/auto,
-/obj/machinery/networked/printer,
 /obj/machinery/light_switch/west{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/decal/fakeobjects{
+	icon = 'icons/obj/networked.dmi';
+	icon_state = "printer0";
+	name = "Broken Printer";
+	true_name = "printer?";
+	desc = "It looks like it was never even plugged in. Did this ever work?!"
 	},
 /turf/simulated/floor/black,
 /area/radiostation/bridge)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[mapping][trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The printer aboard the radio station ship doesn't work as it has no data terminal under it.
As the radio station doesn't have a wired network, I've opted to just make this explicitly broken in this PR.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map correctness #10280