### PR TITLE
Wire up Carnigorn's printer

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -50215,6 +50215,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/unsimulated/floor/redblack{
 	dir = 4
 	},
@@ -50903,6 +50908,11 @@
 "cSU" = (
 /obj/table/reinforced/auto,
 /obj/machinery/networked/printer,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/unsimulated/floor/red,
 /area/syndicate_station/battlecruiser)
 "cSV" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[mapping][trivial]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Carnigorn has a printer, and it has a network, so this PR wires up the printer to the network.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map correctness #10280