### PR TITLE
Fix cogmap's medical printer data terminal

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -55939,8 +55939,6 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/power/data_terminal,
-/obj/cable,
 /obj/table/wood/auto,
 /obj/item/device/radio/headset/medical{
 	pixel_x = -15;
@@ -64216,6 +64214,7 @@
 	},
 /obj/machinery/networked/printer,
 /obj/table/wood/auto,
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/bluewhite{
 	dir = 10
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[trivial][mapping][station systems][bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the printer's data terminal back under the printer.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map correctness #10280
Printers should work :)