### PR TITLE
No power alert from prefab APCs

### DIFF
--- a/assets/maps/prefabs/prefab_drug_den.dmm
+++ b/assets/maps/prefabs/prefab_drug_den.dmm
@@ -149,7 +149,7 @@
 /turf/simulated/floor/wood,
 /area/prefab/drug_den/party)
 "ks" = (
-/obj/machinery/power/apc/autoname_east,
+/obj/machinery/power/apc/autoname_east/nopoweralert,
 /obj/cable,
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/wood,

--- a/assets/maps/prefabs/prefab_janitor.dmm
+++ b/assets/maps/prefabs/prefab_janitor.dmm
@@ -194,10 +194,7 @@
 /turf/simulated/floor,
 /area/janitor_setpiece)
 "aF" = (
-/obj/machinery/power/apc/autoname_south{
-	cell_type = 7500;
-	start_charge = 45
-	},
+/obj/machinery/power/apc/autoname_south/nopoweralert,
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"

--- a/assets/maps/prefabs/prefab_janitor.dmm
+++ b/assets/maps/prefabs/prefab_janitor.dmm
@@ -194,7 +194,10 @@
 /turf/simulated/floor,
 /area/janitor_setpiece)
 "aF" = (
-/obj/machinery/power/apc/autoname_south/nopoweralert,
+/obj/machinery/power/apc/autoname_south/nopoweralert{
+	cell_type = 7500;
+	start_charge = 45
+	},
 /obj/cable{
 	d2 = 2;
 	icon_state = "0-2"

--- a/assets/maps/prefabs/prefab_outpost.dmm
+++ b/assets/maps/prefabs/prefab_outpost.dmm
@@ -680,7 +680,7 @@
 /area/mining/miningoutpost)
 "cg" = (
 /obj/decal/cleanable/dirt,
-/obj/machinery/power/apc/autoname_north,
+/obj/machinery/power/apc/autoname_north/nopoweralert,
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"

--- a/assets/maps/prefabs/prefab_safehouse.dmm
+++ b/assets/maps/prefabs/prefab_safehouse.dmm
@@ -772,7 +772,7 @@
 /turf/simulated/floor/plating,
 /area/prefab/safehouse)
 "Dl" = (
-/obj/machinery/power/apc/autoname_north,
+/obj/machinery/power/apc/autoname_north/nopoweralert,
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"

--- a/assets/maps/prefabs/prefab_sequestered_cloner.dmm
+++ b/assets/maps/prefabs/prefab_sequestered_cloner.dmm
@@ -368,7 +368,7 @@
 /area/prefab/sequestered_cloner)
 "xI" = (
 /obj/cable,
-/obj/machinery/power/apc/puzzle_apc{
+/obj/machinery/power/apc/puzzle_apc/nopoweralert{
 	autoname_on_spawn = 0;
 	desc = "A note is attached: To leave, power this APC and press the neighboring button. The APC can be a little slow.";
 	name = "Engine Test APC";

--- a/assets/maps/prefabs/prefab_von_ricken.dmm
+++ b/assets/maps/prefabs/prefab_von_ricken.dmm
@@ -438,7 +438,7 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/prefab/von_ricken)
 "pQ" = (
-/obj/machinery/power/apc/autoname_east,
+/obj/machinery/power/apc/autoname_east/nopoweralert,
 /obj/cable,
 /obj/cable{
 	icon_state = "0-10"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[mapping][qol]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes all prefab APCs to use the `nopoweralert` variant

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
AIs should not get alerted when these APCs have low power

In practice I've seen the Rental Office APC power alert across multiple rounds and it's just confusing if you're not aware that it's a prefab area name.