### PR TITLE
Remove blast shield under cogmap AI core APC wall

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -56309,16 +56309,7 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "ai_core";
-	name = "AI Core Shield";
-	opacity = 0
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/circuit,
+/turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai)
 "kPG" = (
 /obj/window/reinforced{

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -56317,7 +56317,8 @@
 	name = "AI Core Shield";
 	opacity = 0
 	},
-/turf/simulated/wall/auto/reinforced/supernorn,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
 "kPG" = (
 /obj/window/reinforced{


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[TRIVIAL][MAPPING][CODE QUALITY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Replaces a wall in the AI core with a window so the blast shutters can close over it.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map correctness #10280