### PR TITLE
Adds blinds switches to central command

### DIFF
--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -68519,6 +68519,12 @@
 	temperature = 372.15
 	},
 /area/iomoon)
+"eWY" = (
+/obj/blind_switch/area/north,
+/turf/unsimulated/floor/wood/two,
+/area/centcom/offices{
+	icon_state = "blue"
+	})
 "eXz" = (
 /obj/decal/fakeobjects/lightbulb_broken,
 /turf/unsimulated/floor/orange,
@@ -70450,6 +70456,10 @@
 	},
 /turf/unsimulated/floor/black,
 /area/iomoon/base/underground)
+"jiS" = (
+/obj/blind_switch/area/north,
+/turf/unsimulated/floor/wood/two,
+/area/centcom/lobby)
 "jiZ" = (
 /obj/decal/fakeobjects{
 	anchored = 1;
@@ -153982,7 +153992,7 @@ aES
 aES
 aES
 sWb
-dLh
+jiS
 dMj
 dMM
 dMM
@@ -155857,7 +155867,7 @@ dRD
 dEQ
 vij
 wel
-dvW
+eWY
 dvW
 dFj
 wel


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[TRIVIAL][MAPPING][CODE QUALITY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds two blind switches in central command, one for each set of blinds.

I'm not sure why this doesn't trigger on every map correctness run, but this should fix it.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map correctness #10280

