### PR TITLE
donut3 map fixes: armory nuke, ai core blast shield, blinds

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -33363,7 +33363,8 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/wall/auto/reinforced/jen/blue,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/circuit,
 /area/station/turret_protected/AIsat)
 "jtX" = (
 /obj/item/device/radio/intercom/medical{
@@ -44349,6 +44350,11 @@
 	dir = 1
 	},
 /obj/machinery/networked/nuclear_charge,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)
 "mFg" = (
@@ -61839,6 +61845,15 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
+"rzh" = (
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/blind_switch/area/west,
+/turf/simulated/floor/carpet/arcade/half,
+/area/station/crew_quarters/arcade/dungeon)
 "rzm" = (
 /obj/table/reinforced/bar/auto{
 	name = "table"
@@ -129547,7 +129562,7 @@ ero
 pFQ
 qMj
 sMk
-sMk
+rzh
 nRR
 leu
 ltD

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -33342,15 +33342,6 @@
 	},
 /area/station/security/detectives_office)
 "jtV" = (
-/obj/machinery/door/poddoor/pyro/shutters{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "ai_core";
-	layer = 4;
-	name = "AI Core Shield";
-	opacity = 0
-	},
 /obj/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -33363,8 +33354,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/circuit,
+/turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/turret_protected/AIsat)
 "jtX" = (
 /obj/item/device/radio/intercom/medical{

--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -44350,10 +44350,6 @@
 	dir = 1
 	},
 /obj/machinery/networked/nuclear_charge,
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/data_terminal,
 /turf/simulated/floor/engine,
 /area/station/ai_monitored/armory)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MAJOR][MAPPING][CODE QUALITY][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* (!) Puts a data terminal under the armory's nuclear charge (not connected to any network by default) 
* In AI Core, removes blast shield from under reinforced wall
* Adds a blinds button to the nerd dungeon

Marking major solely on account of wiring up the nuke, since you know: nuke.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map correctness #10280