### PR TITLE
Capped space movement at base speed

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1711,6 +1711,10 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 
 	. *= multiplier
 
+	var/turf/T = get_turf(src)
+	if (T?.turf_flags & CAN_BE_SPACE_SAMPLE)
+		. = max(., base_speed)
+
 	if (next_step_delay)
 		. += next_step_delay
 		next_step_delay = 0

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -1711,10 +1711,6 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 
 	. *= multiplier
 
-	var/turf/T = get_turf(src)
-	if (T?.turf_flags & CAN_BE_SPACE_SAMPLE)
-		. = max(., base_speed)
-
 	if (next_step_delay)
 		. += next_step_delay
 		next_step_delay = 0
@@ -1727,6 +1723,10 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 		var/minSpeed = (1.0- runScaling * base_speed) / (1 - runScaling) // ensures sprinting with 1.2 tally drops it to 0.75
 		if (pulling) minSpeed = base_speed // not so fast, fucko
 		. = min(., minSpeed + (. - minSpeed) * runScaling) // i don't know what I'm doing, help
+
+	var/turf/T = get_turf(src)
+	if (T?.turf_flags & CAN_BE_SPACE_SAMPLE)
+		. = max(., base_speed)
 
 
 //this lets subtypes of living alter their movement delay WITHIN that big proc above - not before or after (which would fuck up the numbers greatly)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Caps space movement at base speed for all living subtypes (this includes critters and borgs).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Stacking movement modifiers and then going into space allowed you to reach absurd speeds that let you outrun pods. I think, since space is a very "safe" zone for antagonists, it should be possible to pursue them with pods rather than having to resort to stacking the same movement modifiers (e.g. meth, mech boots, etc).


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)RichardGere
(+)Capped space movement at base speed.
```
