### PR TITLE
Clarion security blind fixes

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -43748,7 +43748,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
+/area/station/security/hos)
 "csQ" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
@@ -44395,6 +44395,15 @@
 	icon_state = "wooden"
 	},
 /area/station/science/research_director)
+"ebk" = (
+/obj/blind_switch/area/south{
+	pixel_x = -13;
+	pixel_y = -31
+	},
+/turf/simulated/floor/red/side{
+	dir = 1
+	},
+/area/station/security/main)
 "edf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -44474,7 +44483,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/main)
 "eml" = (
 /obj/machinery/light{
 	dir = 4;
@@ -45565,7 +45574,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/main)
 "gOV" = (
 /obj/machinery/recharger/wall{
 	dir = 1;
@@ -45790,7 +45799,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/red,
-/area/station/ai_monitored/armory)
+/area/station/security/hos)
 "hpd" = (
 /obj/cable{
 	d1 = 2;
@@ -46060,7 +46069,9 @@
 	icon_state = "1-4"
 	},
 /obj/blind_switch/area/north{
-	pixel_y = 28
+	pixel_y = 28;
+	pixel_x = 22;
+	dir = 1
 	},
 /turf/simulated/floor/black,
 /area/station/security/main)
@@ -46385,7 +46396,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
+/area/station/security/hos)
 "iMu" = (
 /obj/decal/tile_edge/line/green{
 	icon_state = "line1"
@@ -46755,7 +46766,7 @@
 	},
 /obj/wingrille_spawn/auto/crystal,
 /turf/simulated/floor/plating,
-/area/station/ai_monitored/armory)
+/area/station/security/hos)
 "jUC" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/insulated{
@@ -50570,7 +50581,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/main)
 "tKo" = (
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
@@ -80670,7 +80681,7 @@ gSK
 bgp
 uhp
 aWB
-kLn
+ebk
 aZc
 xfP
 wFe
@@ -81192,7 +81203,7 @@ aQR
 euS
 bfd
 bgo
-bhl
+aQR
 biA
 bjP
 bjR
@@ -82220,7 +82231,7 @@ aQR
 nYD
 uOr
 sVF
-bhl
+aQR
 stU
 rcS
 bld
@@ -82477,7 +82488,7 @@ nXC
 oaj
 etG
 qNC
-bhl
+csQ
 pms
 wMt
 flb

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -44395,15 +44395,6 @@
 	icon_state = "wooden"
 	},
 /area/station/science/research_director)
-"ebk" = (
-/obj/blind_switch/area/south{
-	pixel_x = -13;
-	pixel_y = -31
-	},
-/turf/simulated/floor/red/side{
-	dir = 1
-	},
-/area/station/security/main)
 "edf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -80681,7 +80672,7 @@ gSK
 bgp
 uhp
 aWB
-ebk
+kLn
 aZc
 xfP
 wFe


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[MINOR][MAPPING][CODE QUALITY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Expands HOS office area to include all related blinds
* Adjusts button in interrogation area to not be covered by blinds
* Adjusts security area to include all related interrogation blinds

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map correctness #10280

