### PR TITLE
Add missing blinds switches to Clarion

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -5179,6 +5179,10 @@
 /area/station/hangar/sec)
 "ajx" = (
 /obj/storage/secure/closet/security/equipment,
+/obj/blind_switch/area/north{
+	pixel_y = 25;
+	pixel_x = -7
+	},
 /turf/simulated/floor/redblack{
 	dir = 1
 	},
@@ -11458,6 +11462,7 @@
 	name = "autoname  - SS13";
 	pixel_x = -10
 	},
+/obj/blind_switch/area/west,
 /turf/simulated/floor/carpet/grime,
 /area/station/chapel/office{
 	name = "Chaplain's Office"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[TRIVIAL][MAPPING][CODE QUALITY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds missing blind switches to the escape security checkpoint and the chaplain's office on Clarion.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map correctness #10280