### PR TITLE
fix conductivity tooltip lying to you

### DIFF
--- a/code/WorkInProgress/ObjectProperties.dm
+++ b/code/WorkInProgress/ObjectProperties.dm
@@ -219,7 +219,7 @@ var/list/globalPropList = null
 		tooltipImg = "conduct.png"
 		defaultValue = 0.1
 		getTooltipDesc(var/obj/propOwner, var/propVal)
-			return "[propVal * 100]% [propVal <= 0.2 ? "(Safe)":""]"
+			return "[propVal * 100]% [propVal <= 0.3 ? "(Safe)":""]"
 
 	stammax
 		name = "Max. Stamina"

--- a/code/WorkInProgress/ObjectProperties.dm
+++ b/code/WorkInProgress/ObjectProperties.dm
@@ -219,7 +219,7 @@ var/list/globalPropList = null
 		tooltipImg = "conduct.png"
 		defaultValue = 0.1
 		getTooltipDesc(var/obj/propOwner, var/propVal)
-			return "[propVal * 100]% [propVal <= 0.3 ? "(Safe)":""]"
+			return "[propVal * 100]% [propVal <= 0.29 ? "(Safe)":""]"
 
 	stammax
 		name = "Max. Stamina"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [BUG] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
its tooltip calls conductivity under .2 safe despite the actual limit for not getting shocked being .29


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad