### PR TITLE
Fixes robotic critters taking eye damage from welding

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1362,3 +1362,6 @@ ABSTRACT_TYPE(/mob/living/critter/robotic)
 
 	vomit()
 		return
+
+	isBlindImmune()
+		return TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[BUG] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
^


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gunbots do not have eyes and need to weld themselves to heal


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Gunbots no longer take eye damage from welding
```
