### PR TITLE
Donut 2 Pool/Arcade/Gym Update

### DIFF
--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -8825,6 +8825,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/vending/pizza{
+	anchored = 1
+	},
 /turf/simulated/floor/neutral/corner{
 	dir = 1
 	},
@@ -9055,19 +9058,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aEh" = (
-/obj/machinery/vending/pizza,
-/turf/simulated/floor/arrival{
-	dir = 2
-	},
-/area/station/hallway/primary/north)
 "aEi" = (
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/arrival{
-	dir = 2
-	},
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/hallway/primary/north)
 "aEj" = (
+/obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/arrival{
 	dir = 2
 	},
@@ -9342,73 +9338,26 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aFa" = (
-/obj/disposalpipe/segment,
 /obj/machinery/light/small{
 	dir = 4;
 	icon_state = "bulb1"
 	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aFb" = (
-/obj/machinery/door/airlock/pyro/glass{
-	name = "Pool"
+/obj/landmark/spawner{
+	name = "monkeyspawn_mrsmuggles";
+	icon_state = "chimp-start"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
-"aFd" = (
-/obj/storage/closet/dresser,
-/obj/item/clothing/suit/bathrobe,
-/obj/item/clothing/suit/bathrobe,
-/obj/item/clothing/under/gimmick/macho{
-	color = "#555555";
-	desc = "They're a little bit tight.";
-	name = "speedo"
-	},
-/obj/item/clothing/under/swimsuit/random,
-/obj/item/clothing/under/swimsuit/random,
-/obj/item/clothing/under/swimsuit/random,
-/obj/item/clothing/under/shorts/random{
-	name = "swimming trunks";
-	rand_pos = 1
-	},
-/obj/item/clothing/under/shorts/random{
-	name = "swimming trunks";
-	rand_pos = 1
-	},
-/obj/item/clothing/under/shorts/random{
-	name = "swimming trunks";
-	rand_pos = 1
-	},
-/obj/item/clothing/shoes/flippers,
-/obj/item/clothing/shoes/flippers,
-/turf/simulated/floor/white,
+/turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aFe" = (
-/obj/item/clothing/shoes/flippers,
-/obj/item/clothing/shoes/flippers,
-/obj/item/inner_tube/random{
-	pixel_y = 8
-	},
-/obj/item/inner_tube/random{
-	pixel_y = 8
-	},
-/obj/item/clothing/gloves/water_wings{
-	pixel_y = 8
-	},
-/obj/item/clothing/gloves/water_wings{
-	pixel_y = 8
-	},
-/obj/table/auto,
-/obj/item/clothing/under/shorts/blue{
-	desc = "In space?";
-	name = "swimming trunks"
-	},
-/obj/item/clothing/under/shorts/blue{
-	desc = "In space?";
-	name = "swimming trunks"
-	},
-/turf/simulated/floor/white,
+/obj/machinery/traymachine/locking/tanning,
+/turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aFf" = (
 /obj/machinery/light/incandescent,
@@ -9687,42 +9636,7 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/central)
-"aFS" = (
-/obj/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
 "aFT" = (
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
-"aFU" = (
-/obj/stool/chair{
-	desc = "";
-	foldable = 0;
-	icon_state = "chair_pool"
-	},
-/obj/item/clothing/glasses/sunglasses/tanning,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/obj/decal/poster/wallsign/pool{
-	pixel_y = 29
-	},
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
-"aFV" = (
-/obj/stool/chair{
-	desc = "";
-	foldable = 0;
-	icon_state = "chair_pool"
-	},
-/obj/item/reagent_containers/food/drinks/water,
-/obj/item/clothing/glasses/sunglasses/tanning,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "aFW" = (
@@ -9941,13 +9855,16 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/substation/north)
 "aGE" = (
-/turf/simulated/floor/greenwhite,
-/area/station/crew_quarters/pool)
-"aGG" = (
-/obj/item/device/radio/intercom{
-	dir = 8
+/obj/decal/stage_edge/alt,
+/obj/stool/chair{
+	desc = "";
+	icon_state = "chair_pool"
 	},
-/turf/simulated/floor/greenwhite,
+/obj/item/clothing/glasses/sunglasses/tanning,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aGI" = (
 /obj/disposalpipe/segment/mail,
@@ -10142,69 +10059,19 @@
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
 "aHs" = (
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/crew_quarters/pool)
-"aHt" = (
+/obj/pool/perspective,
 /obj/pool/perspective{
-	dir = 9;
-	icon_state = "pool";
-	tag = "icon-pool (NORTHWEST)"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/crew_quarters/pool)
-"aHu" = (
-/obj/pool/perspective{
-	dir = 1;
-	icon_state = "pool";
-	tag = "icon-pool (NORTH)"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/crew_quarters/pool)
-"aHv" = (
-/obj/pool/perspective{
-	density = 0;
-	dir = 1;
-	icon_state = "pool";
-	tag = "icon-pool (NORTH)"
-	},
-/obj/pool{
-	density = 0;
 	dir = 8;
-	icon = 'icons/obj/fluid.dmi';
-	icon_state = "ladder";
-	name = "ladder"
+	tag = "icon-pool (WEST)"
 	},
-/obj/channel{
-	required_to_pass = 210
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/crew_quarters/pool)
-"aHw" = (
-/obj/pool/perspective{
-	dir = 5;
-	icon_state = "pool";
-	tag = "icon-pool (NORTHEAST)"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aHx" = (
 /obj/machinery/camera{
 	c_tag = "Pool";
 	dir = 8
 	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aHz" = (
 /obj/stool/chair/comfy/shuttle/green{
@@ -10388,27 +10255,20 @@
 /area/station/chapel/sanctuary)
 "aIa" = (
 /obj/pool/perspective{
-	dir = 8;
-	icon_state = "pool";
-	tag = "icon-pool (WEST)"
+	dir = 1;
+	tag = "icon-pool (NORTH)"
 	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aIb" = (
 /turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
 "aIc" = (
 /obj/pool/perspective{
-	dir = 4;
-	icon_state = "pool";
-	tag = "icon-pool (EAST)"
+	dir = 5;
+	tag = "icon-pool (NORTHEAST)"
 	},
-/obj/pool_springboard,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aIe" = (
 /obj/cable{
@@ -10592,17 +10452,6 @@
 	dir = 8
 	},
 /area/station/medical/robotics)
-"aIA" = (
-/obj/item/paper_bin,
-/obj/item/pen{
-	pixel_x = -7
-	},
-/obj/item/pen/fancy,
-/obj/item/pen/marker/red,
-/obj/item/pen/marker/blue,
-/obj/table/round/auto,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "aIB" = (
 /obj/machinery/secscanner{
 	dir = 4;
@@ -10712,21 +10561,13 @@
 	dir = 6
 	},
 /area/station/ai_monitored/storage/eva)
-"aIQ" = (
-/obj/fluid_spawner{
-	amount = 1200
-	},
-/turf/simulated/pool/no_animate,
-/area/station/crew_quarters/pool)
 "aIR" = (
 /obj/pool/perspective{
 	dir = 4;
-	icon_state = "pool";
 	tag = "icon-pool (EAST)"
 	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/obj/item/rubberduck,
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aIS" = (
 /obj/cable{
@@ -10933,41 +10774,20 @@
 	dir = 6
 	},
 /area/station/ai_monitored/storage/eva)
-"aJv" = (
-/obj/pool/perspective{
-	dir = 10;
-	icon_state = "pool";
-	tag = "icon-pool (SOUTHWEST)"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/crew_quarters/pool)
 "aJw" = (
-/obj/pool/perspective,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/obj/item/beach_ball,
+/turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
 "aJx" = (
 /obj/pool/perspective{
-	dir = 6;
-	icon_state = "pool";
-	tag = "icon-pool (SOUTHEAST)"
+	dir = 4;
+	tag = "icon-pool (EAST)"
 	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/obj/pool_springboard,
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aJy" = (
-/obj/machinery/light_switch{
-	name = "E light switch";
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/turf/simulated/floor/auto/sand/rough,
 /area/station/crew_quarters/pool)
 "aJz" = (
 /obj/disposalpipe/segment/mail{
@@ -11180,31 +11000,11 @@
 /obj/spook,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aKn" = (
-/obj/shrub,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/crew_quarters/pool)
 "aKo" = (
-/obj/table/auto,
-/obj/item/beach_ball{
-	pixel_y = 10
+/obj/fluid_spawner{
+	amount = 2100
 	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/crew_quarters/pool)
-"aKp" = (
-/obj/stool/chair{
-	desc = "";
-	foldable = 0;
-	icon_state = "chair_pool"
-	},
-/obj/item/clothing/glasses/sunglasses/tanning,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
 "aKq" = (
 /obj/cable{
@@ -11476,53 +11276,32 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aLd" = (
-/obj/table/auto,
-/obj/item/storage/toolbox/emergency,
-/obj/item/device/radio,
-/obj/item/storage/firstaid/oxygen,
-/obj/item/storage/firstaid/oxygen,
-/turf/simulated/floor/grass{
-	name = "astroturf"
+/obj/pool/perspective{
+	dir = 10;
+	tag = "icon-pool (SOUTHWEST)"
 	},
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aLe" = (
-/obj/stool,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/obj/pool/perspective,
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aLf" = (
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/grass{
-	name = "astroturf"
+/obj/pool/perspective{
+	dir = 9;
+	tag = "icon-pool (NORTHWEST)"
 	},
-/area/station/crew_quarters/pool)
-"aLg" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aLh" = (
-/obj/cable{
-	icon_state = "0-8"
+/obj/pool/perspective{
+	dir = 4;
+	tag = "icon-pool (EAST)"
 	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "S APC";
-	pixel_y = -24
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aLi" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aLj" = (
 /turf/simulated/wall/auto/supernorn,
@@ -11842,12 +11621,10 @@
 	},
 /area/station/medical/medbay/lobby)
 "aLR" = (
-/obj/machinery/disposal{
-	name = "Monkey Dome Feeding Chute"
-	},
 /obj/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/floorflusher,
 /turf/simulated/floor/green/side{
 	dir = 8
 	},
@@ -12066,58 +11843,65 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aME" = (
-/obj/stool/chair{
-	dir = 4
+/obj/pool/perspective{
+	dir = 10;
+	tag = "icon-pool (SOUTHWEST)"
 	},
-/turf/simulated/floor/carpet/arcade,
+/obj/table/reinforced/bar/auto,
+/obj/machinery/glass_recycler{
+	density = 1;
+	pixel_y = 2
+	},
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/arcade)
 "aMF" = (
-/obj/table/round/auto,
-/obj/item/game_kit,
-/turf/simulated/floor/carpet/arcade,
+/obj/pool/perspective,
+/obj/table/reinforced/bar/auto,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wine{
+	pixel_x = 1;
+	pixel_y = 11
+	},
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/arcade)
 "aMG" = (
-/obj/stool/chair{
-	dir = 8
+/obj/pool/perspective,
+/obj/table/reinforced/bar/auto,
+/obj/item/reagent_containers/food/drinks/drinkingglass/random_style/filled/sane{
+	pixel_y = 9;
+	pixel_x = 6
 	},
-/obj/cable{
-	icon_state = "1-4"
+/obj/item/cocktail_stuff/drink_umbrella{
+	pixel_y = 17;
+	pixel_x = 10
 	},
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/item/decoration/ashtray{
+	pixel_x = 4;
+	pixel_y = -3
 	},
-/turf/simulated/floor/carpet/arcade,
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/arcade)
 "aMH" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/computer/tetris,
-/turf/simulated/floor/carpet/arcade,
+/obj/pool/perspective,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
 "aMI" = (
-/obj/cable{
-	icon_state = "4-8"
+/obj/pool/perspective{
+	dir = 6;
+	tag = "icon-pool (SOUTHEAST)"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/arcade,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
 "aMK" = (
-/obj/machinery/computer/arcade,
-/obj/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/arcade,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
 "aML" = (
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/cable{
-	icon_state = "2-8"
-	},
+/obj/stool/bar,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aMM" = (
@@ -12338,11 +12122,9 @@
 	},
 /area/station/medical/robotics)
 "aNI" = (
-/obj/landmark/spawner{
-	name = "monkeyspawn_mrsmuggles";
-	icon_state = "chimp-start"
-	},
-/turf/simulated/floor/greenwhite,
+/obj/decal/stage_edge/alt,
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/auto/sand,
 /area/station/crew_quarters/pool)
 "aNJ" = (
 /obj/cable{
@@ -12423,24 +12205,76 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "aNQ" = (
-/obj/machinery/sim/vr_bed{
-	dir = 4;
-	name = "VR simulation pod";
-	network = "arcadevr"
+/obj/table/reinforced/bar/auto,
+/obj/item_dispenser/icedispenser{
+	dir = 8;
+	pixel_x = 4;
+	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/arcade,
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/ice_cream_cone{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
 /area/station/crew_quarters/arcade)
 "aNR" = (
-/obj/machinery/sim/vr_bed{
-	dir = 8;
-	name = "VR simulation pod";
-	network = "arcadevr"
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
 	},
-/turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aNS" = (
-/obj/stool,
-/turf/simulated/floor/carpet/arcade,
+/obj/machinery/door/unpowered/wood/pyro{
+	dir = 8
+	},
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
 /area/station/crew_quarters/arcade)
 "aNT" = (
 /obj/table/reinforced,
@@ -12464,12 +12298,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
-"aNU" = (
-/obj/table/round/auto,
-/obj/item/dice/magic8ball,
-/obj/item/device/light/lava_lamp,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
 "aNV" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -12483,40 +12311,42 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/sim/vr_bed{
+	dir = 8;
+	name = "VR simulation pod";
+	network = "arcadevr"
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"aNX" = (
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
 "aNY" = (
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
-"aNZ" = (
-/obj/decal/boxingrope,
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
+/obj/storage/closet/dresser,
+/obj/item/clothing/mask/wrestling,
+/obj/item/clothing/mask/wrestling/black,
+/obj/item/clothing/mask/wrestling/blue,
+/obj/item/clothing/mask/wrestling/green,
+/obj/item/clothing/under/shorts/luchador,
+/obj/item/clothing/under/shorts/luchador/green,
+/obj/item/clothing/under/shorts/luchador/red,
+/obj/item/clothing/under/shorts/blue,
+/obj/item/clothing/under/shorts/red,
+/obj/item/clothing/under/shorts/black,
+/obj/item/clothing/under/shorts/trashsinglet,
+/obj/machinery/light/incandescent,
+/obj/item/clothing/gloves/boxing,
+/obj/item/clothing/gloves/boxing,
+/obj/item/clothing/gloves/boxing,
+/obj/item/clothing/gloves/boxing,
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aOa" = (
+/obj/fitness/speedbag/clown,
 /obj/machinery/camera{
-	c_tag = "Fitness Room";
-	dir = 0
+	c_tag = "autotag";
+	name = "autoname - SS13";
+	pixel_x = -3;
+	pixel_y = 13
 	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
-"aOb" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aOc" = (
 /obj/disposalpipe/switch_junction{
@@ -12600,9 +12430,7 @@
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/stairs{
-	icon_state = "Stairs_wide"
-	},
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aOn" = (
 /obj/disposalpipe/segment/mail{
@@ -12729,18 +12557,10 @@
 	},
 /area/station/hallway/primary/west)
 "aOE" = (
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"aOF" = (
-/obj/table/round/auto,
-/obj/item/clothing/mask/skull,
-/turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
-"aOG" = (
-/obj/table/round/auto,
-/obj/item/storage/box/nerd_kit,
-/turf/simulated/floor/carpet/arcade,
+/obj/submachine/ice_cream_dispenser,
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
 /area/station/crew_quarters/arcade)
 "aOH" = (
 /obj/machinery/power/apc{
@@ -12750,18 +12570,13 @@
 	pixel_y = -24
 	},
 /obj/cable,
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9
-	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aOJ" = (
-/obj/stool/bench/red,
-/obj/decal/boxingrope{
-	dir = 4;
-	icon_state = "ringrope"
+/obj/stool/chair/boxingrope_corner{
+	dir = 5
 	},
-/turf/simulated/floor/specialroom/gym,
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aOL" = (
 /obj/machinery/door/airlock/pyro/external,
@@ -12954,11 +12769,6 @@
 "aPt" = (
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"aPu" = (
-/turf/simulated/floor/stairs{
-	dir = 4
-	},
-/area/station/crew_quarters/fitness)
 "aPv" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4;
@@ -12986,14 +12796,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/east)
-"aPy" = (
-/obj/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/grass{
-	name = "astroturf"
-	},
-/area/station/crew_quarters/pool)
 "aPz" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -13115,11 +12917,8 @@
 	},
 /area/station/hallway/primary/west)
 "aPX" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
+/obj/critter/sealpup,
+/turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
 "aPY" = (
 /obj/cable{
@@ -13149,14 +12948,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/hangar/science)
-"aQd" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
 "aQe" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -13607,40 +13398,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
-"aRx" = (
-/obj/decal/stage_edge,
-/obj/table{
-	layer = 4
-	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
-"aRy" = (
-/obj/decal/stage_edge,
-/obj/table{
-	layer = 4
-	},
-/obj/item/wrestlingbell{
-	layer = 4.1
-	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
 "aRz" = (
 /obj/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
-"aRA" = (
-/obj/table,
-/obj/item/storage/firstaid,
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
 "aRB" = (
 /obj/machinery/light/emergency{
 	dir = 8;
@@ -13856,37 +13619,6 @@
 	dir = 4
 	},
 /area/station/hangar/sec)
-"aSp" = (
-/obj/stool/chair{
-	dir = 1;
-	icon_state = "chair"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
-"aSq" = (
-/obj/storage/closet/dresser,
-/obj/item/clothing/mask/wrestling,
-/obj/item/clothing/mask/wrestling/black,
-/obj/item/clothing/mask/wrestling/blue,
-/obj/item/clothing/mask/wrestling/green,
-/obj/item/clothing/under/shorts/luchador,
-/obj/item/clothing/under/shorts/luchador/green,
-/obj/item/clothing/under/shorts/luchador/red,
-/obj/item/clothing/under/shorts/blue,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/black,
-/obj/item/clothing/under/shorts/trashsinglet,
-/obj/machinery/light/incandescent,
-/obj/item/clothing/gloves/boxing,
-/obj/item/clothing/gloves/boxing,
-/obj/item/clothing/gloves/boxing,
-/obj/item/clothing/gloves/boxing,
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
 "aSs" = (
 /obj/machinery/light/incandescent,
 /obj/cable{
@@ -14052,18 +13784,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/medical/head)
-"aSZ" = (
-/turf/simulated/floor/stairs{
-	icon_state = "stairs_middle"
-	},
-/area/station/crew_quarters/fitness)
 "aTa" = (
 /obj/item/device/radio/intercom{
 	dir = 8
 	},
-/turf/simulated/floor/stairs{
-	icon_state = "Stairs2_wide"
-	},
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aTc" = (
 /turf/simulated/floor/red/side{
@@ -14282,14 +14007,6 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"aTF" = (
-/obj/fitness/stacklifter,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"aTH" = (
-/obj/fitness/weightlifter,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aTI" = (
@@ -14522,12 +14239,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4;
-	req_access = null
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/fitness)
 "aUm" = (
 /obj/machinery/camera{
@@ -14545,14 +14257,6 @@
 "aUo" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"aUp" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4;
-	req_access = null
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
 /area/station/crew_quarters/fitness)
 "aUq" = (
 /obj/machinery/camera{
@@ -18713,15 +18417,6 @@
 "bgN" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/security/hos)
-"bgO" = (
-/obj/decal/boxingrope{
-	dir = 9;
-	icon_state = "ringrope"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
 "bgP" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/ai_monitored/armory)
@@ -20024,7 +19719,11 @@
 /area/station/crew_quarters/market)
 "blq" = (
 /obj/machinery/camera{
-	c_tag = "Public Market"
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
@@ -20532,13 +20231,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"bnd" = (
-/obj/decal/boxingrope,
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
 "bne" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -20670,15 +20362,6 @@
 /obj/fitness/weightlifter,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
-"bnD" = (
-/obj/decal/boxingrope{
-	dir = 5;
-	icon_state = "ringrope"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
 "bnP" = (
 /obj/table/reinforced/auto,
 /obj/random_item_spawner/desk_stuff/one,
@@ -20887,11 +20570,10 @@
 /turf/simulated/floor/grime,
 /area/station/security/brig)
 "bos" = (
-/obj/decal/boxingrope{
-	dir = 8;
-	icon_state = "ringrope"
+/obj/stool/chair/boxingrope_corner{
+	dir = 9
 	},
-/turf/simulated/floor/specialroom/gym,
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "boz" = (
 /obj/machinery/power/apc{
@@ -20933,6 +20615,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/vending/player,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
 "boD" = (
@@ -21380,7 +21063,11 @@
 /area/station/hallway/primary/south)
 "bqK" = (
 /obj/machinery/camera{
-	c_tag = "South Primary Hallway Bar Exterior"
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
@@ -23349,15 +23036,6 @@
 /obj/submachine/ATM{
 	pixel_x = 32
 	},
-/obj/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/window/reinforced{
-	dir = 2;
-	icon_state = "rwindow"
-	},
-/obj/machinery/door/window/westleft,
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/south)
 "bxQ" = (
@@ -23487,7 +23165,9 @@
 	icon_state = "shrub"
 	},
 /obj/machinery/light/incandescent,
-/turf/simulated/floor,
+/turf/simulated/floor/green/side{
+	dir = 10
+	},
 /area/station/hallway/primary/south)
 "byn" = (
 /obj/cable{
@@ -25678,14 +25358,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar/south)
-"bFM" = (
-/obj/decal/boxingropeenter{
-	dir = 4;
-	icon_state = "ringrope";
-	pixel_x = 0
-	},
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
 "bFN" = (
 /obj/machinery/atmospherics/pipe/simple/insulated/horizontal,
 /turf/space,
@@ -25800,14 +25472,6 @@
 /obj/item/device/light/glowstick,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"bGi" = (
-/obj/stool/bench/blue,
-/obj/decal/boxingrope{
-	dir = 8;
-	icon_state = "ringrope"
-	},
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
 "bGj" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -27231,6 +26895,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/scidisposal)
+"bLC" = (
+/turf/simulated/wall/false_wall,
+/area/station/crew_quarters/arcade)
 "bMx" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -27835,6 +27502,23 @@
 	layer = 2
 	},
 /area/station/solar/east)
+"cBj" = (
+/obj/pool/perspective{
+	dir = 1;
+	tag = "icon-pool (NORTH)"
+	},
+/obj/pool{
+	density = 0;
+	dir = 8;
+	icon = 'icons/obj/fluid.dmi';
+	icon_state = "ladder";
+	name = "ladder"
+	},
+/obj/channel{
+	required_to_pass = 210
+	},
+/turf/simulated/floor/auto/sand,
+/area/station/crew_quarters/pool)
 "cBp" = (
 /obj/disposalpipe/segment{
 	dir = 1
@@ -28291,13 +27975,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/space)
-"dbM" = (
-/obj/decal/boxingrope{
-	dir = 4;
-	icon_state = "ringrope"
-	},
-/turf/simulated/floor/specialroom/gym,
-/area/station/crew_quarters/fitness)
 "dca" = (
 /obj/access_spawn/hos,
 /obj/firedoor_spawn,
@@ -28338,6 +28015,13 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
+"dfn" = (
+/obj/pool/perspective{
+	dir = 4;
+	tag = "icon-pool (EAST)"
+	},
+/turf/simulated/floor/auto/sand,
+/area/station/crew_quarters/arcade)
 "dgc" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
@@ -29248,6 +28932,15 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
+"ejp" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 8;
+	pixel_x = 4
+	},
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/arcade)
 "ejB" = (
 /obj/grille/catwalk/cross{
 	dir = 6
@@ -29268,6 +28961,13 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"eka" = (
+/obj/pool/perspective{
+	dir = 8;
+	tag = "icon-pool (WEST)"
+	},
+/turf/simulated/floor/auto/sand,
+/area/station/crew_quarters/pool)
 "ekx" = (
 /obj/stool/chair/red{
 	dir = 1
@@ -29619,6 +29319,14 @@
 /obj/decal/cleanable/oil/streak,
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
+"eyx" = (
+/obj/shrub{
+	dir = 4;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "eyO" = (
 /turf/simulated/floor/carpet/blue/fancy/narrow/eastwest,
 /area/station/crew_quarters/stockex)
@@ -29902,6 +29610,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
+"eNr" = (
+/obj/shrub{
+	dir = 6
+	},
+/obj/item/clothing/head/butt,
+/turf/simulated/floor,
+/area/station/crew_quarters/fitness)
 "eNH" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -30550,16 +30265,9 @@
 	icon_state = "1-2"
 	},
 /obj/landmark/gps_waypoint,
+/obj/machinery/computer/arcade,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"frP" = (
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/south)
 "fsH" = (
 /obj/stool/chair,
 /obj/disposalpipe/segment/vertical,
@@ -30812,17 +30520,6 @@
 /obj/random_item_spawner/furniture_parts/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
-"fHI" = (
-/obj/stool/chair{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
-/area/station/crew_quarters/fitness)
 "fHS" = (
 /obj/grille/catwalk,
 /obj/machinery/light/incandescent,
@@ -32740,8 +32437,7 @@
 /area/station/mining/staff_room)
 "hMH" = (
 /obj/decal/boxingrope{
-	dir = 9;
-	icon_state = "ringrope"
+	dir = 8
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -33432,6 +33128,9 @@
 	intact = 0
 	},
 /area/station/solar/west)
+"iDy" = (
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "iED" = (
 /turf/simulated/floor/stairs/wood2/wide{
 	dir = 4
@@ -33443,6 +33142,11 @@
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
+"iFP" = (
+/obj/wingrille_spawn/auto,
+/obj/machinery/computer/tanning,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/pool)
 "iFY" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -33864,16 +33568,7 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
 "jcS" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Inner Maintenance East Airlock";
-	dir = 6;
-	icon_state = "camera";
-	tag = ""
-	},
-/obj/submachine/claw_machine,
+/obj/machinery/door/unpowered/wood/pyro,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "jeb" = (
@@ -34338,6 +34033,13 @@
 /obj/item/paper/book/from_file/cookbook,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
+"jEl" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4;
+	req_access = null
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "jEI" = (
 /turf/simulated/floor/carpet/blue/fancy/narrow/west,
 /area/station/crew_quarters/stockex)
@@ -34389,6 +34091,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/west)
+"jHJ" = (
+/obj/machinery/chem_dispenser/soda,
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/arcade)
 "jIf" = (
 /obj/machinery/optable,
 /obj/machinery/drainage,
@@ -34826,6 +34534,13 @@
 	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
+"kiD" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "kiY" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -35594,6 +35309,10 @@
 "lad" = (
 /obj/storage/secure/closet/fridge/kitchen,
 /obj/machinery/light/incandescent,
+/obj/machinery/camera{
+	c_tag = "Kitchen South";
+	dir = 1
+	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "laM" = (
@@ -36005,14 +35724,6 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
-"lyA" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/machinery/traymachine/locking/tanning,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
 "lyD" = (
 /obj/stool/chair/wooden{
 	dir = 1
@@ -36386,10 +36097,10 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "lQh" = (
-/obj/decal/stage_edge,
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
+/obj/stool/chair/boxingrope_corner{
+	dir = 10
 	},
+/turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "lQI" = (
 /obj/wingrille_spawn/auto/reinforced,
@@ -36653,7 +36364,7 @@
 /area/station/hangar/engine)
 "mjN" = (
 /obj/landmark/gps_waypoint,
-/turf/simulated/floor/greenwhite,
+/turf/simulated/floor/stairs/medical/wide/other,
 /area/station/crew_quarters/pool)
 "mkJ" = (
 /obj/table/auto,
@@ -36702,6 +36413,17 @@
 	dir = 6
 	},
 /area/station/hydroponics/bay)
+"mlI" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/sim/vr_bed{
+	dir = 8;
+	name = "VR simulation pod";
+	network = "arcadevr"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "mmb" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -37090,8 +36812,7 @@
 /area/station/hallway/primary/west)
 "mIj" = (
 /obj/decal/boxingrope{
-	dir = 5;
-	icon_state = "ringrope"
+	dir = 4
 	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
@@ -37256,6 +36977,9 @@
 	dir = 4
 	},
 /area/station/hallway/primary/south)
+"mOL" = (
+/turf/simulated/floor/auto/sand,
+/area/station/crew_quarters/arcade)
 "mPf" = (
 /obj/decal/cleanable/fungus{
 	pixel_y = 32
@@ -37392,6 +37116,10 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"mVd" = (
+/obj/decal/boxingrope,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "mVs" = (
 /obj/machinery/door/poddoor/pyro{
 	density = 0;
@@ -38030,6 +37758,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"nDk" = (
+/obj/stool/bar,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "nDp" = (
 /obj/landmark/spawner{
 	name = "monkeyspawn_normal";
@@ -38045,13 +37777,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hangar/engine)
-"nEM" = (
-/obj/machinery/camera{
-	c_tag = "Kitchen South";
-	dir = 1
-	},
-/turf/simulated/floor/specialroom/cafeteria,
-/area/station/crew_quarters/kitchen)
 "nEX" = (
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
@@ -38295,6 +38020,10 @@
 	},
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
+"nTV" = (
+/obj/machinery/computer/tetris,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "nUH" = (
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
@@ -38311,6 +38040,41 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
+"nVD" = (
+/obj/storage/closet/dresser,
+/obj/item/clothing/under/gimmick/macho{
+	color = "#555555";
+	desc = "They're a little bit tight.";
+	name = "speedo"
+	},
+/obj/item/clothing/under/swimsuit/random,
+/obj/item/clothing/under/swimsuit/random,
+/obj/item/clothing/under/swimsuit/random,
+/obj/item/clothing/under/shorts/random{
+	name = "swimming trunks";
+	rand_pos = 1
+	},
+/obj/item/clothing/under/shorts/random{
+	name = "swimming trunks";
+	rand_pos = 1
+	},
+/obj/item/clothing/under/shorts/random{
+	name = "swimming trunks";
+	rand_pos = 1
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/flippers{
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/fuzzy,
+/obj/item/clothing/suit/bathrobe,
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "nVU" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -38350,6 +38114,12 @@
 /area/station/turret_protected/AIbasecore1{
 	name = "Upload Station"
 	})
+"nZe" = (
+/obj/decal/stage_edge/alt,
+/obj/table/glass/auto,
+/obj/towelbin,
+/turf/simulated/floor/auto/sand/rough,
+/area/station/crew_quarters/pool)
 "nZu" = (
 /obj/machinery/neosmelter,
 /turf/simulated/floor/shuttlebay{
@@ -38752,6 +38522,12 @@
 /obj/submachine/mixer,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"ouI" = (
+/obj/machinery/chem_dispenser/alcohol,
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/arcade)
 "owD" = (
 /obj/chicken_nesting_box,
 /turf/simulated/floor/grass/leafy,
@@ -39785,6 +39561,7 @@
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/access_spawn/kitchen,
 /obj/firedoor_spawn,
+/obj/access_spawn/hydro,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "pBb" = (
@@ -39804,6 +39581,9 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"pBP" = (
+/turf/simulated/floor/stairs/medical/wide,
+/area/station/crew_quarters/pool)
 "pCd" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/horizontal,
 /turf/simulated/floor/specialroom/freezer{
@@ -40094,13 +39874,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
-"pXt" = (
-/obj/fitness/stacklifter,
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
 "pYh" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -40273,6 +40046,12 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/space)
+"qiW" = (
+/obj/stool/chair/boxingrope_corner{
+	dir = 6
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "qje" = (
 /obj/disposalpipe/segment/mail,
 /obj/cable{
@@ -40694,6 +40473,28 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/redwhite,
 /area/station/medical/medbay/surgery)
+"qIt" = (
+/obj/storage/crate,
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/obj/item/clothing/glasses/vr{
+	network = "arcadevr"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "qIT" = (
 /obj/disposalpipe/junction{
 	dir = 1;
@@ -41443,6 +41244,12 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
+"ryB" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/auto/supernorn,
+/area/station/maintenance/inner/central)
 "rze" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -42069,11 +41876,6 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 0;
-	name = "autoname - SS13"
-	},
 /obj/decal/poster/wallsign/poster_beach{
 	pixel_y = 35;
 	pixel_x = 3
@@ -42081,6 +41883,14 @@
 /obj/decal/poster/wallsign/poster_clown{
 	pixel_x = -4;
 	pixel_y = 42
+	},
+/obj/machinery/vending/player,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/market)
@@ -42517,9 +42327,7 @@
 /area/station/turret_protected/ai)
 "sDr" = (
 /obj/landmark/gps_waypoint,
-/turf/simulated/floor/wood{
-	icon_state = "0,6"
-	},
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "sDs" = (
 /obj/cable{
@@ -42757,6 +42565,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
+"sMn" = (
+/obj/decal/stage_edge/alt,
+/obj/table/glass/auto,
+/obj/item/inner_tube/random,
+/obj/item/clothing/gloves/water_wings,
+/turf/simulated/floor/auto/sand,
+/area/station/crew_quarters/pool)
 "sMr" = (
 /obj/cable,
 /obj/cable{
@@ -43241,9 +43056,8 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/glass,
-/obj/firedoor_spawn,
-/turf/simulated/floor,
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
 /area/station/crew_quarters/arcade)
 "tnd" = (
 /obj/cable{
@@ -44337,6 +44151,13 @@
 	dir = 9
 	},
 /area/station/bridge)
+"uuM" = (
+/obj/shrub{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "uvr" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -44913,6 +44734,30 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
+"uVA" = (
+/obj/table/reinforced/auto,
+/obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	autoclose = 0;
+	dir = 4
+	},
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "kitchen";
+	layer = 4;
+	name = "Kitchen Shutter";
+	opacity = 0;
+	p_open = 1
+	},
+/obj/machinery/glass_recycler{
+	density = 1;
+	pixel_y = 2
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "uVV" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -45740,6 +45585,9 @@
 /obj/stool/chair,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
+"vZG" = (
+/turf/simulated/pool/no_animate,
+/area/station/crew_quarters/arcade)
 "vZH" = (
 /obj/machinery/door/unpowered/wood{
 	dir = 8;
@@ -46523,6 +46371,10 @@
 	dir = 8
 	},
 /area/station/hallway/primary/south)
+"wTK" = (
+/obj/submachine/claw_machine,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "wTZ" = (
 /obj/table/reinforced/chemistry/auto,
 /turf/simulated/floor/engine,
@@ -46793,10 +46645,6 @@
 	},
 /obj/item/device/light/glowstick,
 /obj/item/reagent_containers/food/drinks/fueltank,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 4
-	},
 /turf/simulated/floor,
 /area/station/storage/tools)
 "xjq" = (
@@ -47060,6 +46908,7 @@
 /obj/access_spawn/kitchen,
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment,
+/obj/access_spawn/hydro,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "xuC" = (
@@ -47238,6 +47087,12 @@
 	intact = 0
 	},
 /area/station/solar/west)
+"xFa" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	req_access = null
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "xHg" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/purplewhite,
@@ -67358,7 +67213,7 @@ uhd
 pcj
 ibI
 leh
-nEM
+leh
 pAK
 mKQ
 jft
@@ -67960,7 +67815,7 @@ fOq
 moV
 mxZ
 taY
-mxZ
+uVA
 bjm
 bjm
 bjm
@@ -70363,7 +70218,7 @@ aGx
 mmb
 azU
 bgH
-frP
+bqK
 ygD
 bwR
 bjo
@@ -80286,7 +80141,7 @@ aCF
 ayW
 ptD
 aFa
-aEc
+azU
 aFq
 aFq
 azU
@@ -80587,10 +80442,10 @@ aJQ
 ayW
 ayW
 aCy
-aCy
 aFQ
 aCy
-azW
+aCy
+jEl
 aCy
 aCy
 aEl
@@ -80888,15 +80743,15 @@ aBb
 ayZ
 aCG
 aDp
-aEh
-aEk
-lyA
+ayR
+kiD
+aFT
 aGE
-aHs
+aLi
 aLf
-aHs
-aHs
-aKn
+eka
+eka
+eka
 aLd
 aCy
 aMD
@@ -81191,18 +81046,18 @@ aye
 aCH
 axS
 aEi
-aEl
-aFS
-aGE
-aHt
+eyx
+aFT
+nZe
+aJy
 aIa
-aIa
-aJv
-aHs
+aPX
+aIb
+aIb
 aLe
 aCy
 aLj
-azW
+aCy
 aLj
 aLj
 aLj
@@ -81495,17 +81350,17 @@ axS
 aEj
 aFb
 aFT
-aGE
-aHu
-aIb
+pBP
+aLi
+cBj
 aIb
 aJw
+aIb
 aHs
-aHs
-aEl
+eka
 aME
-aMe
-aNQ
+jHJ
+ouI
 aNQ
 aLj
 aFq
@@ -81795,19 +81650,19 @@ aIJ
 axc
 axS
 aEj
-aFb
+iDy
 aFT
 mjN
-aHv
+aLi
+aIa
 aIb
 aIb
-aJw
-aHs
-aLf
-aEl
+aIb
+aIb
+aIb
 aMF
-aMe
-aMe
+aNR
+aNR
 aOE
 aLj
 aEn
@@ -82096,22 +81951,22 @@ jnM
 aIJ
 axc
 axS
-aEj
-aEl
+aEi
+uuM
 doj
 aNI
-aHu
+aLi
+aIa
+aPX
 aIb
-aIb
-aJw
 aKo
-aPy
+aIb
 aPX
 aMG
-aMe
 aNR
+ejp
 aNR
-aLj
+bLC
 azU
 azU
 lpG
@@ -82399,19 +82254,19 @@ spH
 axc
 axR
 aEk
-aEk
-aFU
+nVD
+aFT
 aGE
-aHu
+aJy
+aIa
 aIb
-aIQ
-aJw
-aKp
-aLg
-aLj
+aIb
+aIb
+aIb
+vZG
 aMH
-aMe
-aNS
+aLj
+aLj
 aNS
 aLj
 azU
@@ -82700,21 +82555,21 @@ jnM
 aIJ
 axc
 axS
-aEl
-aFd
+iFP
+iDy
 aFT
-aGE
-aHw
+sMn
+aLi
 aIc
 aIR
 aJx
-aHs
 aLh
-aLj
+aLh
+dfn
 aMI
+wTK
 aMe
-aIA
-aOF
+aMe
 aLj
 azU
 aFq
@@ -83004,20 +82859,20 @@ axc
 axQ
 aEl
 aFe
-aFV
-aGG
+aFT
+aGE
 aHx
-aLf
-aHs
-aJy
-aKn
 aLi
-aLj
+aJy
+aJy
+aLi
+aLi
+mOL
 jcS
 aMe
-aNU
-aOG
-aLj
+aMe
+aMe
+xFa
 azU
 azU
 lpG
@@ -83312,13 +83167,13 @@ aEl
 aEl
 aEl
 aEl
-aEk
-aLj
+aEl
 aLj
 aMK
+aMK
 aMe
-aNS
-aNS
+aMe
+aMe
 aLj
 azk
 aAl
@@ -83918,12 +83773,12 @@ aIf
 aJz
 aJC
 aQL
-aMe
-aMe
-aOE
+nTV
+nDk
+qIt
 aNW
-aMd
-aTK
+mlI
+ryB
 aAt
 aQJ
 elW
@@ -84220,11 +84075,11 @@ aIT
 aJA
 aJC
 aQL
-aQL
-aQL
+aXV
+aXV
 aPr
-aNr
-aNr
+aPr
+aPr
 aPr
 aPr
 aPr
@@ -84524,14 +84379,14 @@ aIf
 aJz
 aJC
 aJC
-aPr
-bgO
+aNr
+aUn
 bos
-bos
-bGi
+hMH
+hMH
 hMH
 lQh
-aNX
+aPr
 aOm
 aTE
 aUm
@@ -84827,15 +84682,15 @@ aJA
 aJC
 aJC
 aNr
-aNZ
+aUn
+mVd
 aPt
 aPt
 aPt
 aQK
-aRx
-aSp
-aSZ
-aTF
+aPr
+aUn
+aUn
 aUn
 aPr
 azU
@@ -85129,14 +84984,14 @@ aJA
 aJC
 aJC
 aNr
-bnd
+aUo
+mVd
 aPt
 aPt
 aPt
 aQK
-aRy
-aSp
-aSZ
+aPr
+aUn
 aUn
 aUn
 aPr
@@ -85431,15 +85286,15 @@ aLm
 aJC
 aJC
 aNr
-aNZ
+aUn
+mVd
 aPt
 aPt
 aPt
 aQK
-aRx
-aSp
-aSZ
-aTH
+aPr
+aUn
+aUn
 aUo
 aPr
 aFq
@@ -85733,14 +85588,14 @@ aLn
 aJC
 aJC
 aNr
-bnD
+aUn
 aOJ
-bFM
-dbM
 mIj
-lQh
-aNY
-aSZ
+mIj
+mIj
+qiW
+aPr
+aUn
 aUn
 aUn
 aWh
@@ -86035,15 +85890,15 @@ aLo
 aJC
 aJC
 aNr
-aNY
-fHI
-aPu
-aQd
-aNY
-aNY
-aNY
-aSZ
-pXt
+aUn
+aUn
+aUn
+aUn
+aUn
+aUn
+aUn
+aUn
+aUn
 aUn
 aPr
 azU
@@ -86338,12 +86193,12 @@ aMf
 aJC
 aPr
 aOa
-aNY
+aUn
 aNY
 sDr
-aNY
-aNY
-aNY
+aUn
+aUn
+aUn
 aTa
 aTI
 aUn
@@ -86639,16 +86494,16 @@ aLo
 aMg
 aMf
 aPr
-aOb
-aQd
-aNY
-aNY
-fHI
-aRA
-aSq
+aUo
+aUn
+aUn
+aUn
+aUn
+aUn
 aPr
 aPr
-aUp
+aPr
+aPr
 aPr
 azU
 aBk
@@ -86948,7 +86803,7 @@ aPw
 aNr
 aNr
 aNr
-aPr
+eNr
 aXV
 azU
 azU

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -3820,6 +3820,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"anb" = (
+/obj/item/inner_tube/flamingo,
+/turf/simulated/pool/no_animate,
+/area/station/crew_quarters/pool)
 "ani" = (
 /turf/space,
 /area/shuttle/escape/station)
@@ -7733,6 +7737,9 @@
 "aAl" = (
 /obj/decal/cleanable/dirt/dirt2,
 /obj/decal/cleanable/dirt/dirt2,
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aAm" = (
@@ -9058,16 +9065,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aEi" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/north)
 "aEj" = (
 /obj/machinery/door/airlock/pyro/glass,
 /turf/simulated/floor/arrival{
 	dir = 2
 	},
-/area/station/hallway/primary/north)
+/area/station/crew_quarters/pool)
 "aEk" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/pool)
@@ -9356,7 +9359,9 @@
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aFe" = (
-/obj/machinery/traymachine/locking/tanning,
+/obj/table/glass/auto,
+/obj/item/reagent_containers/food/snacks/candy/taffy/watermelon,
+/obj/item/reagent_containers/food/drinks/water,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "aFf" = (
@@ -9635,7 +9640,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/pool)
 "aFT" = (
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
@@ -9864,7 +9869,7 @@
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aGI" = (
 /obj/disposalpipe/segment/mail,
@@ -10064,14 +10069,17 @@
 	dir = 8;
 	tag = "icon-pool (WEST)"
 	},
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aHx" = (
 /obj/machinery/camera{
 	c_tag = "Pool";
 	dir = 8
 	},
-/turf/simulated/floor/auto/sand,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aHz" = (
 /obj/stool/chair/comfy/shuttle/green{
@@ -10258,7 +10266,7 @@
 	dir = 1;
 	tag = "icon-pool (NORTH)"
 	},
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aIb" = (
 /turf/simulated/pool/no_animate,
@@ -10268,7 +10276,7 @@
 	dir = 5;
 	tag = "icon-pool (NORTHEAST)"
 	},
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aIe" = (
 /obj/cable{
@@ -10567,7 +10575,7 @@
 	tag = "icon-pool (EAST)"
 	},
 /obj/item/rubberduck,
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aIS" = (
 /obj/cable{
@@ -10784,10 +10792,14 @@
 	tag = "icon-pool (EAST)"
 	},
 /obj/pool_springboard,
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aJy" = (
-/turf/simulated/floor/auto/sand/rough,
+/obj/machinery/light/incandescent,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aJz" = (
 /obj/disposalpipe/segment/mail{
@@ -11002,7 +11014,7 @@
 /area/station/maintenance/inner/central)
 "aKo" = (
 /obj/fluid_spawner{
-	amount = 2100
+	amount = 3600
 	},
 /turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
@@ -11280,28 +11292,22 @@
 	dir = 10;
 	tag = "icon-pool (SOUTHWEST)"
 	},
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aLe" = (
 /obj/pool/perspective,
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aLf" = (
 /obj/pool/perspective{
 	dir = 9;
 	tag = "icon-pool (NORTHWEST)"
 	},
-/turf/simulated/floor/auto/sand,
-/area/station/crew_quarters/pool)
-"aLh" = (
-/obj/pool/perspective{
-	dir = 4;
-	tag = "icon-pool (EAST)"
-	},
-/turf/simulated/floor/auto/sand,
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aLi" = (
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aLj" = (
 /turf/simulated/wall/auto/supernorn,
@@ -11852,8 +11858,10 @@
 	density = 1;
 	pixel_y = 2
 	},
-/turf/simulated/floor/auto/sand,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aMF" = (
 /obj/pool/perspective,
 /obj/table/reinforced/bar/auto,
@@ -11861,8 +11869,10 @@
 	pixel_x = 1;
 	pixel_y = 11
 	},
-/turf/simulated/floor/auto/sand,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aMG" = (
 /obj/pool/perspective,
 /obj/table/reinforced/bar/auto,
@@ -11878,13 +11888,15 @@
 	pixel_x = 4;
 	pixel_y = -3
 	},
-/turf/simulated/floor/auto/sand,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aMH" = (
 /obj/pool/perspective,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/arcade)
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aMI" = (
 /obj/pool/perspective{
 	dir = 6;
@@ -11902,6 +11914,10 @@
 	icon_state = "1-2"
 	},
 /obj/stool/bar,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/decal/cleanable/dirt/dirt2,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aMM" = (
@@ -12124,7 +12140,7 @@
 "aNI" = (
 /obj/decal/stage_edge/alt,
 /obj/machinery/vending/coffee,
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aNJ" = (
 /obj/cable{
@@ -12262,20 +12278,26 @@
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/arcade)
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aNR" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/arcade)
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aNS" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 8
 	},
+/obj/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/arcade)
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aNT" = (
 /obj/table/reinforced,
 /obj/item/paper_bin,
@@ -12300,10 +12322,12 @@
 /area/station/bridge)
 "aNV" = (
 /obj/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /obj/cable{
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -12558,18 +12582,14 @@
 /area/station/hallway/primary/west)
 "aOE" = (
 /obj/submachine/ice_cream_dispenser,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/arcade)
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "aOH" = (
-/obj/machinery/power/apc{
-	areastring = "Arcade";
-	dir = 2;
-	name = "Arcade APC";
-	pixel_y = -24
-	},
 /obj/cable,
+/obj/machinery/power/apc/autoname_south,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aOJ" = (
@@ -13139,24 +13159,20 @@
 /turf/simulated/floor/carpet/blue/fancy/narrow/west,
 /area/station/medical/medbay/treatment2)
 "aQJ" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/light/small{
 	dir = 4;
 	icon_state = "bulb1"
 	},
 /obj/decal/cleanable/dirt/dirt2,
+/obj/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aQK" = (
 /obj/decal/boxingrope,
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"aQL" = (
-/obj/wingrille_spawn/auto,
-/turf/simulated/floor/plating,
-/area/station/hallway/primary/east)
 "aQM" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/red/side{
@@ -26897,7 +26913,7 @@
 /area/station/maintenance/scidisposal)
 "bLC" = (
 /turf/simulated/wall/false_wall,
-/area/station/crew_quarters/arcade)
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "bMx" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -27430,6 +27446,13 @@
 	oxygen = 30.8366
 	},
 /area/station/crew_quarters/kitchen/freezer)
+"cvs" = (
+/obj/decal/cleanable/dirt/dirt2,
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "cvC" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	icon_state = "on";
@@ -27517,7 +27540,7 @@
 /obj/channel{
 	required_to_pass = 210
 	},
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "cBp" = (
 /obj/disposalpipe/segment{
@@ -28020,8 +28043,8 @@
 	dir = 4;
 	tag = "icon-pool (EAST)"
 	},
-/turf/simulated/floor/auto/sand,
-/area/station/crew_quarters/arcade)
+/turf/simulated/floor/dojo/sand,
+/area/station/crew_quarters/pool)
 "dgc" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 9
@@ -28160,10 +28183,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
-"doj" = (
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/white,
-/area/station/crew_quarters/pool)
 "doJ" = (
 /obj/machinery/light/incandescent,
 /obj/storage/closet/wardrobe/black,
@@ -28216,6 +28235,10 @@
 /obj/item/clothing/suit/monkey,
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
+"dqU" = (
+/obj/machinery/computer/tanning,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/pool)
 "dqY" = (
 /obj/lattice{
 	dir = 2;
@@ -28469,6 +28492,16 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment2)
+"dFk" = (
+/obj/decal/cleanable/dirt/dirt2,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "dFs" = (
 /obj/machinery/power/pt_laser{
 	dir = 8
@@ -28695,6 +28728,9 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
 /area/station/science/lab)
+"dTr" = (
+/turf/simulated/floor/stairs/wood2/wide,
+/area/station/crew_quarters/fitness)
 "dUF" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/grime,
@@ -28937,10 +28973,13 @@
 	dir = 8;
 	pixel_x = 4
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/arcade)
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "ejB" = (
 /obj/grille/catwalk/cross{
 	dir = 6
@@ -28966,7 +29005,8 @@
 	dir = 8;
 	tag = "icon-pool (WEST)"
 	},
-/turf/simulated/floor/auto/sand,
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "ekx" = (
 /obj/stool/chair/red{
@@ -29325,6 +29365,7 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "eyO" = (
@@ -29956,6 +29997,15 @@
 	dir = 8
 	},
 /area/station/hallway/primary/west)
+"fcg" = (
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"fck" = (
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "fco" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/electrical{
@@ -32146,6 +32196,15 @@
 	dir = 8
 	},
 /area/station/bridge)
+"hvh" = (
+/obj/machinery/light/small/floor,
+/turf/simulated/pool/no_animate,
+/area/station/crew_quarters/pool)
+"hvO" = (
+/obj/critter/sealpup,
+/obj/machinery/light/small/floor,
+/turf/simulated/pool/no_animate,
+/area/station/crew_quarters/pool)
 "hxT" = (
 /obj/item/device/prox_sensor{
 	pixel_x = -8;
@@ -32774,6 +32833,19 @@
 /obj/decal/cleanable/dirt/dirt3,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"ikc" = (
+/obj/stool/bar,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "ike" = (
 /obj/machinery/hydro_mister,
 /turf/simulated/floor/grey,
@@ -33142,11 +33214,6 @@
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
-"iFP" = (
-/obj/wingrille_spawn/auto,
-/obj/machinery/computer/tanning,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/pool)
 "iFY" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -33569,6 +33636,9 @@
 /area/station/crew_quarters/quarters)
 "jcS" = (
 /obj/machinery/door/unpowered/wood/pyro,
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "jeb" = (
@@ -33676,6 +33746,12 @@
 	},
 /turf/simulated/floor/blue,
 /area/station/medical/medbay)
+"jhz" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
 "jhA" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/plating/airless,
@@ -34096,7 +34172,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/arcade)
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "jIf" = (
 /obj/machinery/optable,
 /obj/machinery/drainage,
@@ -36153,6 +36229,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"lWw" = (
+/turf/simulated/floor/stairs/wood2/wide{
+	dir = 6
+	},
+/area/station/crew_quarters/fitness)
 "lXX" = (
 /obj/disposalpipe/junction{
 	dir = 8
@@ -36414,9 +36495,6 @@
 	},
 /area/station/hydroponics/bay)
 "mlI" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/sim/vr_bed{
 	dir = 8;
 	name = "VR simulation pod";
@@ -36707,6 +36785,12 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/ghostdrone_factory)
+"mDa" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "mDg" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -36978,8 +37062,11 @@
 	},
 /area/station/hallway/primary/south)
 "mOL" = (
-/turf/simulated/floor/auto/sand,
-/area/station/crew_quarters/arcade)
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/dojo/sand,
+/area/station/crew_quarters/pool)
 "mPf" = (
 /obj/decal/cleanable/fungus{
 	pixel_y = 32
@@ -37721,6 +37808,18 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
+"nBH" = (
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "0,6"
+	},
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "nBY" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -37760,6 +37859,10 @@
 /area/station/hallway/primary/east)
 "nDk" = (
 /obj/stool/bar,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "nDp" = (
@@ -38022,6 +38125,12 @@
 /area/station/hangar/sec)
 "nTV" = (
 /obj/machinery/computer/tetris,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	name = "autoname  - SS13";
+	pixel_y = 18;
+	tag = ""
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "nUH" = (
@@ -38118,7 +38227,7 @@
 /obj/decal/stage_edge/alt,
 /obj/table/glass/auto,
 /obj/towelbin,
-/turf/simulated/floor/auto/sand/rough,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "nZu" = (
 /obj/machinery/neosmelter,
@@ -38400,6 +38509,15 @@
 "opL" = (
 /turf/simulated/floor/carpet/green,
 /area/station/crew_quarters/courtroom)
+"opR" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "ora" = (
 /obj/machinery/door/unpowered/wood/pyro{
 	dir = 4
@@ -38524,10 +38642,16 @@
 /area/station/crew_quarters/kitchen)
 "ouI" = (
 /obj/machinery/chem_dispenser/alcohol,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/arcade)
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "owD" = (
 /obj/chicken_nesting_box,
 /turf/simulated/floor/grass/leafy,
@@ -39526,6 +39650,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"pyM" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/dojo/sand,
+/area/station/crew_quarters/pool)
 "pyR" = (
 /obj/landmark/gps_waypoint,
 /obj/cable{
@@ -39582,6 +39712,9 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "pBP" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/stairs/medical/wide,
 /area/station/crew_quarters/pool)
 "pCd" = (
@@ -40684,6 +40817,19 @@
 	dir = 8
 	},
 /area/station/crew_quarters/quarters)
+"qQn" = (
+/obj/pool/perspective{
+	dir = 8;
+	tag = "icon-pool (WEST)"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	tag = ""
+	},
+/turf/simulated/floor/dojo/sand,
+/area/station/crew_quarters/pool)
 "qQM" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41063,6 +41209,13 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
+"rql" = (
+/obj/pool/perspective{
+	dir = 8;
+	tag = "icon-pool (WEST)"
+	},
+/turf/simulated/floor/dojo/sand,
+/area/station/crew_quarters/pool)
 "rqV" = (
 /obj/table/auto,
 /obj/item/paper_bin{
@@ -41244,12 +41397,6 @@
 	dir = 4
 	},
 /area/station/hydroponics/bay)
-"ryB" = (
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/maintenance/inner/central)
 "rze" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -41731,6 +41878,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"sdt" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
 "sdA" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -42052,6 +42205,16 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"soU" = (
+/obj/machinery/traymachine/locking/tanning,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	name = "autoname  - SS13";
+	pixel_y = 18;
+	tag = ""
+	},
+/turf/simulated/floor/blue/checker,
+/area/station/crew_quarters/pool)
 "spf" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -42570,7 +42733,7 @@
 /obj/table/glass/auto,
 /obj/item/inner_tube/random,
 /obj/item/clothing/gloves/water_wings,
-/turf/simulated/floor/auto/sand,
+/turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "sMr" = (
 /obj/cable,
@@ -43455,6 +43618,14 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
+"tEO" = (
+/obj/machinery/power/apc/autoname_west,
+/obj/cable{
+	d2 = 8;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/white,
+/area/station/crew_quarters/pool)
 "tFy" = (
 /obj/storage/secure/closet/civilian/bartender,
 /obj/item/gun/russianrevolver,
@@ -44156,8 +44327,13 @@
 	icon = 'icons/obj/stationobjs.dmi';
 	icon_state = "plant"
 	},
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
+"uvh" = (
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "uvr" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -45585,9 +45761,6 @@
 /obj/stool/chair,
 /turf/simulated/floor,
 /area/station/crew_quarters/quarters)
-"vZG" = (
-/turf/simulated/pool/no_animate,
-/area/station/crew_quarters/arcade)
 "vZH" = (
 /obj/machinery/door/unpowered/wood{
 	dir = 8;
@@ -45892,6 +46065,9 @@
 /obj/machinery/computer/tetris,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
+"wqR" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
 "wsO" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/grasstodirt{
@@ -46777,6 +46953,12 @@
 	},
 /turf/simulated/floor/specialroom/bar,
 /area/station/crew_quarters/bar)
+"xnD" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/dojo/sand,
+/area/station/crew_quarters/pool)
 "xnK" = (
 /obj/disposalpipe/segment/vertical,
 /turf/space,
@@ -47091,8 +47273,11 @@
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	req_access = null
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/arcade,
-/area/station/crew_quarters/arcade)
+/area/station/maintenance/inner/central)
 "xHg" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/purplewhite,
@@ -80441,17 +80626,17 @@ ayW
 aJQ
 ayW
 ayW
-aCy
+aEk
 aFQ
-aCy
-aCy
+aEk
+aEk
 jEl
-aCy
-aCy
+aEk
+aEk
 aEl
 aEl
 aEl
-aCy
+aEk
 aFs
 azU
 azU
@@ -80743,17 +80928,17 @@ aBb
 ayZ
 aCG
 aDp
-ayR
+aEk
 kiD
-aFT
+tEO
 aGE
 aLi
 aLf
-eka
-eka
-eka
+rql
+qQn
+rql
 aLd
-aCy
+aEk
 aMD
 azU
 azU
@@ -81045,22 +81230,22 @@ aye
 aye
 aCH
 axS
-aEi
+aEl
 eyx
-aFT
+sdt
 nZe
-aJy
+aLi
 aIa
-aPX
+hvO
 aIb
 aIb
 aLe
+aEk
+wqR
 aCy
-aLj
-aCy
-aLj
-aLj
-aLj
+wqR
+wqR
+wqR
 azU
 aEn
 aCy
@@ -81349,9 +81534,9 @@ axc
 axS
 aEj
 aFb
-aFT
+jhz
 pBP
-aLi
+pyM
 cBj
 aIb
 aJw
@@ -81362,7 +81547,7 @@ aME
 jHJ
 ouI
 aNQ
-aLj
+wqR
 aFq
 aEn
 aCy
@@ -81653,18 +81838,18 @@ aEj
 iDy
 aFT
 mjN
-aLi
+xnD
 aIa
-aIb
+anb
 aIb
 aIb
 aIb
 aIb
 aMF
-aNR
-aNR
+fck
+fck
 aOE
-aLj
+wqR
 aEn
 azU
 lpG
@@ -81951,19 +82136,19 @@ jnM
 aIJ
 axc
 axS
-aEi
+aEl
 uuM
-doj
+aFT
 aNI
-aLi
+xnD
 aIa
 aPX
 aIb
 aKo
-aIb
+hvh
 aPX
 aMG
-aNR
+nBH
 ejp
 aNR
 bLC
@@ -82253,23 +82438,23 @@ jnM
 spH
 axc
 axR
-aEk
+dqU
 nVD
 aFT
 aGE
-aJy
+xnD
 aIa
+hvh
 aIb
 aIb
 aIb
 aIb
-vZG
 aMH
-aLj
-aLj
+wqR
+wqR
 aNS
-aLj
-azU
+wqR
+fcg
 azU
 lpG
 bQH
@@ -82555,21 +82740,21 @@ jnM
 aIJ
 axc
 axS
-iFP
-iDy
+aEl
+soU
 aFT
 sMn
-aLi
+xnD
 aIc
 aIR
 aJx
-aLh
-aLh
+dfn
+dfn
 dfn
 aMI
 wTK
-aMe
-aMe
+ikc
+mDa
 aLj
 azU
 aFq
@@ -82862,19 +83047,19 @@ aFe
 aFT
 aGE
 aHx
-aLi
+mOL
+mOL
 aJy
-aJy
-aLi
-aLi
+mOL
+mOL
 mOL
 jcS
-aMe
-aMe
-aMe
+aMd
+opR
+dFk
 xFa
-azU
-azU
+elW
+aXf
 lpG
 vJw
 sBZ
@@ -83172,8 +83357,8 @@ aLj
 aMK
 aMK
 aMe
-aMe
-aMe
+mDa
+uvh
 aLj
 azk
 aAl
@@ -83478,7 +83663,7 @@ aNV
 aOH
 aLj
 aQb
-aEn
+cvs
 azU
 azU
 azU
@@ -83772,14 +83957,14 @@ aIf
 aIf
 aJz
 aJC
-aQL
+aMK
 nTV
 nDk
 qIt
 aNW
 mlI
-ryB
-aAt
+aLj
+aEn
 aQJ
 elW
 aAt
@@ -84074,9 +84259,9 @@ aIg
 aIT
 aJA
 aJC
-aQL
-aXV
-aXV
+aMK
+aLj
+aLj
 aPr
 aPr
 aPr
@@ -84377,7 +84562,7 @@ aIU
 aJB
 aIf
 aJz
-aJC
+bhx
 aJC
 aNr
 aUn
@@ -84386,7 +84571,7 @@ hMH
 hMH
 hMH
 lQh
-aPr
+aNr
 aOm
 aTE
 aUm
@@ -84688,7 +84873,7 @@ aPt
 aPt
 aPt
 aQK
-aPr
+aNr
 aUn
 aUn
 aUn
@@ -84990,7 +85175,7 @@ aPt
 aPt
 aPt
 aQK
-aPr
+aNr
 aUn
 aUn
 aUn
@@ -85292,7 +85477,7 @@ aPt
 aPt
 aPt
 aQK
-aPr
+aNr
 aUn
 aUn
 aUo
@@ -85594,7 +85779,7 @@ mIj
 mIj
 mIj
 qiW
-aPr
+aNr
 aUn
 aUn
 aUn
@@ -85896,7 +86081,7 @@ aUn
 aUn
 aUn
 aUn
-aUn
+dTr
 aUn
 aUn
 aUn
@@ -86198,7 +86383,7 @@ aNY
 sDr
 aUn
 aUn
-aUn
+lWw
 aTa
 aTI
 aUn

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -7364,6 +7364,9 @@
 "azk" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/decal/cleanable/dirt/dirt2,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "azl" = (
@@ -7812,6 +7815,7 @@
 	icon_state = "1-2"
 	},
 /obj/decal/cleanable/dirt/dirt2,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aAu" = (
@@ -8832,9 +8836,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/vending/pizza{
-	anchored = 1
-	},
 /turf/simulated/floor/neutral/corner{
 	dir = 1
 	},
@@ -9345,10 +9346,6 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/obj/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aFb" = (
@@ -9634,13 +9631,6 @@
 	},
 /turf/simulated/wall/auto/supernorn,
 /area/station/maintenance/inner/central)
-"aFQ" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/pool)
 "aFT" = (
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
@@ -10079,6 +10069,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aHz" = (
@@ -10794,13 +10785,6 @@
 /obj/pool_springboard,
 /turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
-"aJy" = (
-/obj/machinery/light/incandescent,
-/obj/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/dojo/sand,
-/area/station/crew_quarters/pool)
 "aJz" = (
 /obj/disposalpipe/segment/mail{
 	dir = 1;
@@ -11292,6 +11276,7 @@
 	dir = 10;
 	tag = "icon-pool (SOUTHWEST)"
 	},
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aLe" = (
@@ -11307,6 +11292,10 @@
 /turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aLi" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
 /turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aLj" = (
@@ -11689,6 +11678,10 @@
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aMe" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aMf" = (
@@ -11846,6 +11839,10 @@
 	status = 2
 	},
 /obj/reagent_dispensers/beerkeg,
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aME" = (
@@ -11861,18 +11858,23 @@
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "aMF" = (
 /obj/pool/perspective,
 /obj/table/reinforced/bar/auto,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wine{
-	pixel_x = 1;
-	pixel_y = 11
+/obj/item/reagent_containers/food/drinks/drinkingglass/random_style/filled/sane{
+	pixel_y = 9;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/drinks/coconut{
+	pixel_y = 1;
+	pixel_x = 7;
+	rand_pos = 1
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "aMG" = (
 /obj/pool/perspective,
 /obj/table/reinforced/bar/auto,
@@ -11891,12 +11893,12 @@
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "aMH" = (
 /obj/pool/perspective,
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "aMI" = (
 /obj/pool/perspective{
 	dir = 6;
@@ -12278,7 +12280,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "aNR" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -12286,10 +12288,11 @@
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "aNS" = (
 /obj/machinery/door/unpowered/wood/pyro{
-	dir = 8
+	dir = 8;
+	name = "Margaritaville"
 	},
 /obj/cable{
 	icon_state = "4-8"
@@ -12297,7 +12300,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "aNT" = (
 /obj/table/reinforced,
 /obj/item/paper_bin,
@@ -12342,33 +12345,19 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
-"aNY" = (
-/obj/storage/closet/dresser,
-/obj/item/clothing/mask/wrestling,
-/obj/item/clothing/mask/wrestling/black,
-/obj/item/clothing/mask/wrestling/blue,
-/obj/item/clothing/mask/wrestling/green,
-/obj/item/clothing/under/shorts/luchador,
-/obj/item/clothing/under/shorts/luchador/green,
-/obj/item/clothing/under/shorts/luchador/red,
-/obj/item/clothing/under/shorts/blue,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/black,
-/obj/item/clothing/under/shorts/trashsinglet,
-/obj/machinery/light/incandescent,
-/obj/item/clothing/gloves/boxing,
-/obj/item/clothing/gloves/boxing,
-/obj/item/clothing/gloves/boxing,
-/obj/item/clothing/gloves/boxing,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
 "aOa" = (
-/obj/fitness/speedbag/clown,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	name = "autoname - SS13";
+/obj/table/reinforced/auto,
+/obj/item/clothing/gloves/boxing{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/clothing/gloves/boxing{
 	pixel_x = -3;
-	pixel_y = 13
+	pixel_y = 3
+	},
+/obj/item/clothing/gloves/boxing{
+	pixel_x = 2;
+	pixel_y = -2
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
@@ -12445,16 +12434,14 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aOm" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "S APC";
-	pixel_x = -23;
-	pixel_y = 0
-	},
 /obj/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/power/apc/autoname_west,
+/obj/decal/stage_edge{
+	layer = 2.8
+	},
+/turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "aOn" = (
 /obj/disposalpipe/segment/mail{
@@ -12581,12 +12568,16 @@
 	},
 /area/station/hallway/primary/west)
 "aOE" = (
-/obj/submachine/ice_cream_dispenser,
+/obj/submachine/ice_cream_dispenser{
+	name = "Bootleg Margarita Machine";
+	desc = "Well, that's not quite a margarita... maybe that's why it was so cheap.";
+	flavors = list("chocolate","vanilla","margarita")
+	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "aOH" = (
 /obj/cable,
 /obj/machinery/power/apc/autoname_south,
@@ -12959,6 +12950,9 @@
 	dir = 0;
 	name = "autoname - SS13"
 	},
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aQc" = (
@@ -13167,6 +13161,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aQK" = (
@@ -13804,7 +13799,13 @@
 /obj/item/device/radio/intercom{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/stairs/wood2/wide{
+	dir = 6
+	},
 /area/station/crew_quarters/fitness)
 "aTc" = (
 /turf/simulated/floor/red/side{
@@ -14023,14 +14024,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"aTI" = (
-/obj/machinery/light/small{
-	brightness = 2;
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "aTK" = (
 /obj/cable{
@@ -14265,14 +14259,21 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood,
+/obj/shrub{
+	dir = 4;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant";
+	pixel_y = 4
+	},
+/turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "aUn" = (
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "aUo" = (
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/wood,
+/obj/fitness/speedbag/clown,
+/turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "aUq" = (
 /obj/machinery/camera{
@@ -24608,6 +24609,10 @@
 /obj/machinery/camera,
 /turf/space,
 /area/space)
+"bDz" = (
+/obj/stool/chair,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "bDB" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/black,
@@ -26913,7 +26918,7 @@
 /area/station/maintenance/scidisposal)
 "bLC" = (
 /turf/simulated/wall/false_wall,
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "bMx" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -27463,6 +27468,14 @@
 "cwb" = (
 /turf/simulated/floor,
 /area/station/engine/ptl)
+"cwg" = (
+/obj/item/canned_laughter/crushed{
+	pixel_y = -2;
+	pixel_x = -17
+	},
+/obj/decal/cleanable/generic,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "cwW" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -27527,6 +27540,7 @@
 /area/station/solar/east)
 "cBj" = (
 /obj/pool/perspective{
+	density = 0;
 	dir = 1;
 	tag = "icon-pool (NORTH)"
 	},
@@ -28094,6 +28108,10 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"djq" = (
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/wood/three,
+/area/station/crew_quarters/fitness)
 "dkS" = (
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor,
@@ -28500,6 +28518,7 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "dFs" = (
@@ -28728,9 +28747,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
 /area/station/science/lab)
-"dTr" = (
-/turf/simulated/floor/stairs/wood2/wide,
-/area/station/crew_quarters/fitness)
 "dUF" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/grime,
@@ -28816,6 +28832,24 @@
 	dir = 4
 	},
 /area/station/medical/research)
+"dYF" = (
+/obj/decal/tile_edge/line/black{
+	dir = 1;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line1"
+	},
+/obj/decal/stage_edge{
+	layer = 2.8
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
 "dZC" = (
 /obj/machinery/shower{
 	dir = 1
@@ -28833,6 +28867,13 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
+"dZL" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "dZM" = (
 /obj/stool/chair/couch{
 	dir = 8;
@@ -28979,7 +29020,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "ejB" = (
 /obj/grille/catwalk/cross{
 	dir = 6
@@ -29082,6 +29123,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"enQ" = (
+/obj/disposalpipe/segment,
+/obj/item/clothing/glasses/sunglasses/tanning,
+/obj/stool/chair/comfy/blue{
+	dir = 8;
+	icon_state = "chair_comfy-blue"
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "enT" = (
 /obj/stool/chair/syndicate,
 /obj/npc/trader/exclown{
@@ -29652,11 +29705,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "eNr" = (
-/obj/shrub{
-	dir = 6
+/obj/machinery/vending/pizza{
+	anchored = 1
 	},
-/obj/item/clothing/head/butt,
-/turf/simulated/floor,
+/turf/simulated/floor/delivery,
 /area/station/crew_quarters/fitness)
 "eNH" = (
 /obj/cable{
@@ -29999,13 +30051,16 @@
 /area/station/hallway/primary/west)
 "fcg" = (
 /obj/machinery/light/incandescent,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "fck" = (
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "fco" = (
 /obj/table/auto,
 /obj/item/storage/toolbox/electrical{
@@ -30289,6 +30344,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/scidisposal)
+"frb" = (
+/obj/decal/stage_edge{
+	layer = 2.8
+	},
+/obj/reagent_dispensers/watertank/fountain,
+/turf/simulated/floor/wood/three,
+/area/station/crew_quarters/fitness)
 "frp" = (
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -32010,6 +32072,12 @@
 	},
 /turf/space,
 /area/space)
+"hll" = (
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "hlz" = (
 /obj/decal/tile_edge/stripe/extra_big,
 /turf/unsimulated/floor/arrival,
@@ -32018,6 +32086,32 @@
 /obj/disposalpipe/segment/horizontal,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/hor)
+"hmm" = (
+/obj/table/reinforced/auto,
+/obj/item/clothing/gloves/kote{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/clothing/gloves/kote{
+	pixel_x = -1
+	},
+/obj/item/clothing/gloves/kote{
+	pixel_x = -1
+	},
+/obj/item/clothing/head/helmet/men{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/helmet/men,
+/obj/item/clothing/suit/armor/douandtare{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/douandtare,
+/obj/item/shinai_bag,
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "hmN" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -32350,6 +32444,12 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/AIsat)
+"hEQ" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "hES" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room North";
@@ -32508,6 +32608,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
+"hNl" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "hOo" = (
 /obj/disposalpipe/segment,
 /obj/cable{
@@ -32794,6 +32904,22 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"igk" = (
+/obj/disposalpipe/segment,
+/obj/table/glass/auto,
+/obj/item/reagent_containers/food/drinks/drinkingglass/cocktail{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"igC" = (
+/obj/decal/boxingrope{
+	dir = 8
+	},
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "igT" = (
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/test_apparatus/gas_sensor{
@@ -32844,6 +32970,7 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "ike" = (
@@ -33750,6 +33877,10 @@
 /obj/cable{
 	icon_state = "2-8"
 	},
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
 "jhA" = (
@@ -34046,6 +34177,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"jyc" = (
+/obj/table/auto,
+/obj/item/reagent_containers/food/snacks/popcorn{
+	pixel_y = 2;
+	pixel_x = 26
+	},
+/obj/item/camera,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "jyi" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -34114,6 +34254,10 @@
 	dir = 4;
 	req_access = null
 	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "jEI" = (
@@ -34172,7 +34316,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "jIf" = (
 /obj/machinery/optable,
 /obj/machinery/drainage,
@@ -34499,6 +34643,16 @@
 	icon_state = "fred2"
 	},
 /area/station/security/hos)
+"jZH" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "jZO" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -34612,9 +34766,7 @@
 /area/station/crew_quarters/bar)
 "kiD" = (
 /obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/disposalpipe/trunk,
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "kiY" = (
@@ -34744,6 +34896,17 @@
 	},
 /turf/simulated/floor/delivery,
 /area/station/engine/inner)
+"koB" = (
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line2"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
 "kpr" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -35308,6 +35471,10 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
+"kUu" = (
+/obj/loudspeaker,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "kUH" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -35427,6 +35594,12 @@
 	dir = 1
 	},
 /area/station/hangar/arrivals)
+"lcJ" = (
+/obj/disposalpipe/junction{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "lcU" = (
 /obj/storage/secure/closet/medical/medicine,
 /turf/simulated/floor/white/checker,
@@ -35681,6 +35854,12 @@
 "lud" = (
 /turf/simulated/floor/black,
 /area/station/security/checkpoint/research)
+"lum" = (
+/obj/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/wood/three,
+/area/station/crew_quarters/fitness)
 "lus" = (
 /turf/simulated/floor/red/side,
 /area/station/security/processing)
@@ -36151,6 +36330,14 @@
 	},
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
+"lNZ" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "lOQ" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -36230,9 +36417,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "lWw" = (
-/turf/simulated/floor/stairs/wood2/wide{
-	dir = 6
+/obj/disposalpipe/segment{
+	dir = 1
 	},
+/turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "lXX" = (
 /obj/disposalpipe/junction{
@@ -36508,6 +36696,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
+"mmj" = (
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "mnm" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4;
@@ -36687,6 +36882,14 @@
 	intact = 0
 	},
 /area/station/solar/west)
+"mxw" = (
+/obj/decal/boxingropeenter{
+	dir = 4;
+	icon_state = "ringrope";
+	pixel_x = 0
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "mxZ" = (
 /obj/table/reinforced/auto,
 /obj/access_spawn/kitchen,
@@ -37073,6 +37276,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"mPo" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	req_access = null
+	},
+/obj/access_spawn/maint,
+/obj/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/maintenance/inner/central)
 "mPI" = (
 /obj/machinery/networked/test_apparatus/electrobox,
 /obj/machinery/power/data_terminal,
@@ -37189,6 +37402,12 @@
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/surgery)
+"mTi" = (
+/obj/table/reinforced/auto,
+/obj/item/wrestlingbell,
+/obj/item/device/microphone,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "mUN" = (
 /obj/landmark/start{
 	name = "Engineer"
@@ -37819,7 +38038,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "nBY" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -37883,6 +38102,15 @@
 "nEX" = (
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
+"nFf" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/junction{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "nFv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -38208,6 +38436,10 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
+"nYq" = (
+/obj/reagent_dispensers/watertank/fountain,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "nYT" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -38289,6 +38521,22 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"obN" = (
+/obj/table/reinforced/auto,
+/obj/item/storage/firstaid/brute{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/item/storage/firstaid/brute{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/food/drinks/water{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "odr" = (
 /obj/cable,
 /obj/wingrille_spawn/auto/reinforced,
@@ -38341,6 +38589,21 @@
 	intact = 0
 	},
 /area/station/solar/south)
+"ohS" = (
+/obj/fitness/weightlifter,
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line2"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line1"
+	},
+/obj/decal/stage_edge{
+	layer = 2.8
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
 "oio" = (
 /obj/machinery/portableowl/attached{
 	name = "an Owl with a chip out of his beak"
@@ -38516,6 +38779,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "ora" = (
@@ -38651,7 +38915,7 @@
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+/area/station/crew_quarters/pool)
 "owD" = (
 /obj/chicken_nesting_box,
 /turf/simulated/floor/grass/leafy,
@@ -38821,6 +39085,13 @@
 	dir = 8
 	},
 /area/station/science/lab)
+"oEa" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/wood/three,
+/area/station/crew_quarters/fitness)
 "oEP" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -38881,6 +39152,16 @@
 	icon_state = "fblue1"
 	},
 /area/station/crew_quarters/bar)
+"oJW" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/station/crew_quarters/arcade)
 "oKp" = (
 /obj/disposalpipe/junction{
 	dir = 0;
@@ -39489,14 +39770,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
-"ptD" = (
-/obj/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+"ptj" = (
+/obj/decal/stage_edge{
+	layer = 2.8
 	},
-/obj/machinery/drone_recharger,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "ptL" = (
 /obj/lattice{
 	dir = 1;
@@ -39654,6 +39933,10 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "pyR" = (
@@ -39700,6 +39983,11 @@
 	dir = 8
 	},
 /area/station/hangar/arrivals)
+"pBy" = (
+/turf/simulated/floor/stairs{
+	dir = 8
+	},
+/area/station/crew_quarters/fitness)
 "pBG" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -39714,6 +40002,9 @@
 "pBP" = (
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 1
 	},
 /turf/simulated/floor/stairs/medical/wide,
 /area/station/crew_quarters/pool)
@@ -39888,6 +40179,14 @@
 	dir = 1
 	},
 /area/station/hallway/primary/north)
+"pQH" = (
+/obj/machinery/disposal,
+/obj/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "pQI" = (
 /obj/machinery/computer3/generic/med_data{
 	dir = 4
@@ -40407,6 +40706,12 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
 /area/station/science/lobby)
+"qup" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "quH" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -40456,6 +40761,18 @@
 	},
 /turf/simulated/floor/bluewhite/corner,
 /area/station/medical/medbay/pharmacy)
+"qwo" = (
+/obj/decal/cleanable/dirt/dirt2,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"qwR" = (
+/obj/decal/boxingrope,
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "qxy" = (
 /obj/grille/catwalk{
 	dir = 10;
@@ -40540,6 +40857,13 @@
 	name = "reinforced plating"
 	},
 /area/station/engine/ptl)
+"qCk" = (
+/obj/decal/boxingrope{
+	dir = 8
+	},
+/obj/stool,
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "qCA" = (
 /obj/disposalpipe/segment/bent/south,
 /obj/machinery/drone_recharger,
@@ -40628,6 +40952,10 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"qIv" = (
+/obj/loudspeaker,
+/turf/simulated/floor/wood/three,
+/area/station/crew_quarters/fitness)
 "qIT" = (
 /obj/disposalpipe/junction{
 	dir = 1;
@@ -40713,6 +41041,11 @@
 /obj/access_spawn/engineering,
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
+"qNj" = (
+/obj/stool/chair,
+/obj/decal/cleanable/generic,
+/turf/simulated/floor,
+/area/station/hallway/primary/east)
 "qNq" = (
 /turf/simulated/floor,
 /area/station/hangar/arrivals)
@@ -41342,6 +41675,16 @@
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
+"rvW" = (
+/obj/decal/boxingrope,
+/obj/machinery/camera{
+	c_tag = "autotag";
+	name = "autoname  - SS13";
+	pixel_y = 18;
+	tag = ""
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "rwt" = (
 /obj/machinery/plantpot{
 	anchored = 1
@@ -41703,6 +42046,17 @@
 /obj/submachine/slot_machine,
 /turf/simulated/floor/grime,
 /area/station/security/brig)
+"rTD" = (
+/obj/decal/tile_edge/line/black{
+	dir = 10;
+	icon_state = "line2"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
 "rTJ" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -41881,6 +42235,10 @@
 "sdt" = (
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
@@ -42902,6 +43260,13 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor,
 /area/station/science/artifact)
+"sWx" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/dojo/sand,
+/area/station/crew_quarters/pool)
 "sXa" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -43337,6 +43702,10 @@
 /obj/decal/cleanable/dirt/dirt5,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"tsR" = (
+/obj/disposalpipe/junction,
+/turf/simulated/floor/wood/three,
+/area/station/crew_quarters/fitness)
 "tte" = (
 /obj/shrub{
 	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
@@ -43623,6 +43992,10 @@
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-4"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/pool)
@@ -44202,6 +44575,13 @@
 	icon_state = "floor"
 	},
 /area/shuttle/arrival/station)
+"uns" = (
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/stairs/wood2/wide,
+/area/station/crew_quarters/fitness)
 "unO" = (
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
@@ -44813,6 +45193,13 @@
 	},
 /turf/simulated/floor/black,
 /area/station/security/interrogation)
+"uSn" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "uSC" = (
 /obj/machinery/light,
 /turf/simulated/floor,
@@ -45543,17 +45930,16 @@
 	},
 /area/station/crew_quarters/market)
 "vJw" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "E APC";
-	pixel_x = 24;
-	pixel_y = 0
-	},
 /obj/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/autoname_east,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/barber_shop)
+"vJC" = (
+/obj/fitness/speedbag/clown,
+/turf/simulated/floor/wood/three,
+/area/station/crew_quarters/fitness)
 "vKo" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -45794,6 +46180,15 @@
 	icon_state = "orangecorner"
 	},
 /area/station/science/lobby)
+"wbU" = (
+/obj/stool,
+/obj/decal/boxingropeenter{
+	dir = 4;
+	icon_state = "ringrope";
+	pixel_x = 0
+	},
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "wbZ" = (
 /obj/cable/black{
 	icon_state = "4-8"
@@ -46065,9 +46460,24 @@
 /obj/machinery/computer/tetris,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
-"wqR" = (
-/turf/simulated/wall/auto/supernorn,
-/area/station/crew_quarters/cafeteria/the_rising_tide_bar)
+"wrA" = (
+/obj/decal/cleanable/dirt/dirt2,
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
+"wrG" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "wsO" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/grasstodirt{
@@ -46189,13 +46599,13 @@
 	},
 /area/station/mining/staff_room)
 "wzX" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
 /obj/landmark{
 	name = "blobstart";
 	icon_state = "blob-start"
+	},
+/obj/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
@@ -46349,6 +46759,9 @@
 	icon_state = "engine_caution_east"
 	},
 /area/station/science/lab)
+"wIq" = (
+/turf/simulated/floor/wood/three,
+/area/station/crew_quarters/fitness)
 "wIP" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/escape{
@@ -46473,6 +46886,23 @@
 	dir = 6
 	},
 /area/station/quartermaster/office)
+"wOT" = (
+/obj/storage/closet/dresser,
+/obj/item/clothing/mask/wrestling,
+/obj/item/clothing/mask/wrestling/black,
+/obj/item/clothing/mask/wrestling/blue,
+/obj/item/clothing/mask/wrestling/green,
+/obj/item/clothing/under/shorts/luchador,
+/obj/item/clothing/under/shorts/luchador/green,
+/obj/item/clothing/under/shorts/luchador/red,
+/obj/item/clothing/under/shorts/blue,
+/obj/item/clothing/under/shorts/red,
+/obj/item/clothing/under/shorts/black,
+/obj/item/clothing/under/shorts/trashsinglet,
+/obj/item/clothing/gloves/boxing,
+/obj/item/storage/box/kendo_box/hakama,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "wPr" = (
 /turf/simulated/floor/white,
 /area/station/medical/medbay/cloner)
@@ -47212,6 +47642,21 @@
 /obj/random_item_spawner/med_tool/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"xAZ" = (
+/obj/fitness/stacklifter,
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "line2"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 6;
+	icon_state = "line1"
+	},
+/obj/decal/stage_edge{
+	layer = 2.8
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
 "xBY" = (
 /obj/stool/chair/office{
 	dir = 1
@@ -47276,6 +47721,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/disposalpipe/segment,
 /turf/simulated/floor/carpet/arcade,
 /area/station/maintenance/inner/central)
 "xHg" = (
@@ -47715,6 +48161,24 @@
 	},
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
+"yer" = (
+/obj/decal/tile_edge/line/black{
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 5;
+	icon_state = "line1"
+	},
+/obj/decal/tile_edge/line/black{
+	dir = 9;
+	icon_state = "line1"
+	},
+/turf/simulated/floor/specialroom/gym/alt,
+/area/station/crew_quarters/fitness)
 "yeB" = (
 /obj/storage/secure/closet/medical/cloning,
 /obj/machinery/light/emergency{
@@ -47814,6 +48278,18 @@
 /obj/access_spawn/engineering,
 /turf/simulated/floor/grime,
 /area/station/atmos/highcap_storage)
+"yjK" = (
+/obj/machinery/light/incandescent,
+/obj/shrub{
+	desc = "It's probably not suspicious that this plant is not only still alive, but thriving.";
+	dir = 8;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant";
+	tag = "icon-plant (NORTH)"
+	},
+/obj/loudspeaker,
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "yjM" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -76098,7 +76574,7 @@ aCv
 mmb
 azU
 aES
-azU
+aYB
 eAg
 nyG
 enT
@@ -79727,7 +80203,7 @@ aGx
 aCy
 aCy
 aCy
-aCy
+bcj
 bcj
 bcj
 bcj
@@ -80023,17 +80499,17 @@ aJp
 aCE
 ayW
 wzX
-azU
-azU
-azU
-azU
-azU
-azU
-azU
-aFq
-aFq
-azU
-azU
+azV
+azV
+azV
+lcJ
+azV
+azV
+hQw
+enQ
+igk
+azV
+aEc
 aNo
 aCy
 aaa
@@ -80324,18 +80800,18 @@ aBa
 aJH
 aCF
 ayW
-ptD
+dAe
 aFa
 azU
 aFq
+lNZ
+azU
+azU
 aFq
-azU
-azU
-azU
 aKm
 aFs
-azU
 aFq
+uSn
 azU
 aCy
 aCy
@@ -80627,7 +81103,7 @@ aJQ
 ayW
 ayW
 aEk
-aFQ
+aEk
 aEk
 aEk
 jEl
@@ -80637,7 +81113,7 @@ aEl
 aEl
 aEl
 aEk
-aFs
+hll
 azU
 azU
 azU
@@ -80940,11 +81416,11 @@ rql
 aLd
 aEk
 aMD
-azU
-azU
-azU
-azU
-azU
+azV
+azV
+azV
+azV
+aEc
 azU
 aCy
 aaa
@@ -81241,12 +81717,12 @@ aIb
 aIb
 aLe
 aEk
-wqR
-aCy
-wqR
-wqR
-wqR
-azU
+aEk
+aEk
+aEk
+aEk
+aEk
+hll
 aEn
 aCy
 aaa
@@ -81547,8 +82023,8 @@ aME
 jHJ
 ouI
 aNQ
-wqR
-aFq
+aEk
+uSn
 aEn
 aCy
 aaa
@@ -81849,8 +82325,8 @@ aMF
 fck
 fck
 aOE
-wqR
-aEn
+aEk
+qwo
 azU
 lpG
 lpG
@@ -82152,7 +82628,7 @@ nBH
 ejp
 aNR
 bLC
-azU
+hll
 azU
 lpG
 hFr
@@ -82450,10 +82926,10 @@ aIb
 aIb
 aIb
 aMH
-wqR
-wqR
+aEk
+aEk
 aNS
-wqR
+aEk
 fcg
 azU
 lpG
@@ -82756,7 +83232,7 @@ wTK
 ikc
 mDa
 aLj
-azU
+hll
 aFq
 lpG
 peB
@@ -83049,16 +83525,16 @@ aGE
 aHx
 mOL
 mOL
-aJy
 mOL
+sWx
 mOL
 mOL
 jcS
-aMd
+oJW
 opR
 dFk
 xFa
-elW
+nFf
 aXf
 lpG
 vJw
@@ -83964,15 +84440,15 @@ qIt
 aNW
 mlI
 aLj
-aEn
+wrA
 aQJ
-elW
+aBL
 aAt
-elW
-aWB
-aVB
-elW
-elW
+aBL
+jZH
+hNl
+aBL
+wrG
 lKr
 aNo
 aXP
@@ -84274,9 +84750,9 @@ aPr
 aPr
 aUl
 aPr
-azU
+hll
 mmb
-aYB
+azU
 aXP
 aYE
 aXP
@@ -84563,20 +85039,20 @@ aJB
 aIf
 aJz
 bhx
-aJC
+jyc
 aNr
-aUn
 bos
+igC
 hMH
-hMH
-hMH
+qCk
 lQh
-aNr
+obN
+yjK
 aOm
 aTE
 aUm
 aPr
-azU
+hll
 mmb
 azO
 aXP
@@ -84865,20 +85341,20 @@ aJC
 aJC
 aJA
 aJC
-aJC
+bDz
 aNr
-aUn
-mVd
+rvW
 aPt
 aPt
 aPt
 aQK
-aNr
-aUn
-aUn
-aUn
+ptj
+qup
+xAZ
+rTD
+vJC
 aPr
-azU
+hll
 mmb
 azU
 aXP
@@ -85167,20 +85643,20 @@ aJC
 bhx
 aJA
 aJC
-aJC
+qNj
 aNr
-aUo
 mVd
 aPt
 aPt
 aPt
 aQK
-aNr
-aUn
-aUn
-aUn
+ptj
+qup
+dYF
+yer
+djq
 aPr
-azU
+hll
 mmb
 aDm
 aXP
@@ -85469,20 +85945,20 @@ aHE
 aHE
 aLm
 aJC
-aJC
+cwg
 aNr
-aUn
-mVd
+qwR
 aPt
 aPt
 aPt
 aQK
-aNr
-aUn
-aUn
+ptj
+qup
+ohS
+koB
 aUo
 aPr
-aFq
+uSn
 mmb
 aDm
 aXP
@@ -85773,18 +86249,18 @@ aLn
 aJC
 aJC
 aNr
-aUn
 aOJ
-mIj
-mIj
+wbU
+mxw
 mIj
 qiW
-aNr
-aUn
-aUn
-aUn
+ptj
+qup
+frb
+wIq
+oEa
 aWh
-azU
+hll
 mqE
 nml
 aXP
@@ -86075,18 +86551,18 @@ aLo
 aJC
 aJC
 aNr
+wOT
+hEQ
+pBy
+mTi
+hEQ
 aUn
 aUn
-aUn
-aUn
-aUn
-aUn
-dTr
-aUn
-aUn
-aUn
-aPr
-azU
+uns
+lum
+tsR
+mPo
+mmj
 tZf
 aBK
 aZn
@@ -86379,14 +86855,14 @@ aJC
 aPr
 aOa
 aUn
-aNY
+aUn
 sDr
-aUn
-aUn
+dZL
+lWw
 lWw
 aTa
-aTI
-aUn
+djq
+qIv
 aPr
 azU
 mmb
@@ -86679,12 +87155,12 @@ aLo
 aMg
 aMf
 aPr
-aUo
+hmm
+nYq
 aUn
 aUn
-aUn
-aUn
-aUn
+pQH
+kUu
 aPr
 aPr
 aPr

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -7285,7 +7285,7 @@
 	},
 /obj/machinery/door/airlock/pyro/alt,
 /obj/firedoor_spawn,
-/turf/simulated/floor,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "ayZ" = (
 /obj/disposalpipe/segment/mail,
@@ -7631,21 +7631,21 @@
 /area/station/maintenance/inner/central)
 "azY" = (
 /obj/machinery/portable_atmospherics/pump,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "azZ" = (
 /obj/item/extinguisher{
 	pixel_y = 8
 	},
 /obj/reagent_dispensers/foamtank,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aAa" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aAb" = (
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aAd" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -8015,13 +8015,13 @@
 	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aAZ" = (
 /obj/item/device/light/glowstick,
 /obj/item/device/light/glowstick,
 /obj/machinery/shieldgenerator/meteorshield,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aBa" = (
 /obj/machinery/light_switch{
@@ -8032,7 +8032,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aBb" = (
 /obj/disposalpipe/segment/mail,
@@ -8278,12 +8278,12 @@
 	pixel_x = -24
 	},
 /obj/machinery/recharge_station,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aBU" = (
 /obj/item/device/light/glowstick,
 /obj/item/device/light/glowstick,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aBW" = (
 /obj/machinery/light/incandescent,
@@ -8500,7 +8500,7 @@
 	dir = 1
 	},
 /obj/machinery/disposal,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aCD" = (
 /obj/machinery/power/apc{
@@ -8514,12 +8514,12 @@
 	c_tag = "Emergency Storage";
 	dir = 10
 	},
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aCE" = (
 /obj/storage/closet/fire,
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aCF" = (
 /obj/storage/closet/emergency,
@@ -8527,7 +8527,7 @@
 /obj/item/tank/air,
 /obj/item/tank/air,
 /obj/item/tank/air,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aCG" = (
 /obj/disposalpipe/segment/mail,
@@ -8535,6 +8535,7 @@
 	c_tag = "North Hallway East";
 	dir = 4
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/neutral/side{
 	dir = 8
 	},
@@ -8835,6 +8836,27 @@
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/table/glass/auto,
+/obj/item/paper_bin{
+	pixel_y = -2;
+	pixel_x = -4
+	},
+/obj/item/paper{
+	pixel_y = -3;
+	pixel_x = 6
+	},
+/obj/item/paper{
+	pixel_y = 6
+	},
+/obj/item/paper{
+	info = "I'm in your station... : )";
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/paper{
+	pixel_y = -3;
+	pixel_x = 6
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 1
@@ -10054,14 +10076,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/north)
-"aHs" = (
-/obj/pool/perspective,
-/obj/pool/perspective{
-	dir = 8;
-	tag = "icon-pool (WEST)"
-	},
-/turf/simulated/floor/dojo/sand,
-/area/station/crew_quarters/pool)
 "aHx" = (
 /obj/machinery/camera{
 	c_tag = "Pool";
@@ -10242,7 +10256,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aHY" = (
 /obj/cable{
@@ -10682,7 +10696,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aJf" = (
 /turf/simulated/floor/plating,
@@ -10736,7 +10750,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aJr" = (
 /obj/disposalpipe/segment/mail{
@@ -10830,7 +10844,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aJI" = (
 /obj/storage/crate,
@@ -10889,7 +10903,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
-/turf/simulated/floor,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "aJR" = (
 /obj/rack,
@@ -11273,23 +11287,15 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "aLd" = (
-/obj/pool/perspective{
-	dir = 10;
-	tag = "icon-pool (SOUTHWEST)"
-	},
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/dojo/sand,
-/area/station/crew_quarters/pool)
-"aLe" = (
-/obj/pool/perspective,
-/turf/simulated/floor/dojo/sand,
+/turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
 "aLf" = (
-/obj/pool/perspective{
-	dir = 9;
-	tag = "icon-pool (NORTHWEST)"
-	},
 /obj/machinery/light/incandescent,
+/obj/pool/perspective{
+	dir = 1;
+	tag = "icon-pool (NORTH)"
+	},
 /turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
 "aLi" = (
@@ -11847,15 +11853,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "aME" = (
-/obj/pool/perspective{
-	dir = 10;
-	tag = "icon-pool (SOUTHWEST)"
-	},
 /obj/table/reinforced/bar/auto,
 /obj/machinery/glass_recycler{
 	density = 1;
-	pixel_y = 2
+	pixel_y = -2;
+	pixel_x = -6
 	},
+/obj/channel{
+	required_to_pass = 210;
+	dir = 1
+	},
+/obj/pool/perspective,
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
@@ -11871,6 +11879,10 @@
 	pixel_y = 1;
 	pixel_x = 7;
 	rand_pos = 1
+	},
+/obj/channel{
+	required_to_pass = 210;
+	dir = 1
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -11890,6 +11902,14 @@
 /obj/item/decoration/ashtray{
 	pixel_x = 4;
 	pixel_y = -3
+	},
+/obj/item/shaker/salt{
+	pixel_x = -10;
+	pixel_y = 2
+	},
+/obj/channel{
+	required_to_pass = 210;
+	dir = 1
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -12571,9 +12591,9 @@
 /area/station/hallway/primary/west)
 "aOE" = (
 /obj/submachine/ice_cream_dispenser{
-	name = "Bootleg Margarita Machine";
-	desc = "Well, that's not quite a margarita... maybe that's why it was so cheap.";
-	flavors = list("chocolate","vanilla","margarita")
+	name = "Frozen Margarita Machine";
+	flavors = list("chocolate","vanilla","margarita");
+	desc = "A machine designed to dispense frozen margaritas."
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/wood{
@@ -12583,6 +12603,10 @@
 "aOH" = (
 /obj/cable,
 /obj/machinery/power/apc/autoname_south,
+/obj/landmark{
+	icon_state = "pest-start";
+	name = "peststart"
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "aOJ" = (
@@ -12881,6 +12905,9 @@
 "aPP" = (
 /obj/stool/chair/office/blue{
 	dir = 4
+	},
+/obj/landmark/start{
+	name = "Medical Doctor"
 	},
 /turf/simulated/floor/bluewhite/corner{
 	dir = 4
@@ -16809,6 +16836,9 @@
 	},
 /obj/machinery/light_switch/west{
 	pixel_y = -12
+	},
+/obj/landmark/start{
+	name = "Medical Doctor"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 8
@@ -28293,6 +28323,10 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/medical/medbay/treatment1)
+"drI" = (
+/obj/decal/poster/wallsign/gym,
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/fitness)
 "dsa" = (
 /obj/machinery/light/emergency{
 	dir = 4;
@@ -28697,6 +28731,9 @@
 	text = "NF";
 	pixel_x = 32
 	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "dQM" = (
@@ -29060,12 +29097,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "eka" = (
-/obj/pool/perspective{
-	dir = 8;
-	tag = "icon-pool (WEST)"
-	},
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/dojo/sand,
+/obj/stool/bench,
+/turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
 "ekx" = (
 /obj/stool/chair/red{
@@ -30367,6 +30401,7 @@
 	layer = 2.8
 	},
 /obj/reagent_dispensers/watertank/fountain,
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "frp" = (
@@ -30785,6 +30820,13 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"fPg" = (
+/obj/machinery/light/incandescent,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/wood/three,
+/area/station/crew_quarters/fitness)
 "fPH" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -30872,6 +30914,9 @@
 /area/station/turret_protected/AIbasecore1{
 	name = "Upload Station"
 	})
+"fUw" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/stockex)
 "fUX" = (
 /obj/securearea{
 	desc = "";
@@ -32466,6 +32511,9 @@
 /obj/stool/chair{
 	dir = 8
 	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "hES" = (
@@ -32806,6 +32854,11 @@
 /obj/machinery/light_switch/west,
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
+"hZd" = (
+/obj/disposalpipe/segment,
+/obj/machinery/hydro_growlamp,
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "hZn" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
@@ -34361,6 +34414,9 @@
 	on = 0;
 	pixel_x = -24
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
@@ -34660,6 +34716,9 @@
 	},
 /obj/cable{
 	icon_state = "1-8"
+	},
+/obj/landmark/start{
+	name = "Medical Doctor"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -37464,6 +37523,7 @@
 /obj/table/reinforced/auto,
 /obj/item/wrestlingbell,
 /obj/item/device/microphone,
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "mUN" = (
@@ -38089,7 +38149,6 @@
 /obj/landmark/start{
 	name = "Staff Assistant"
 	},
-/obj/machinery/power/apc/autoname_east,
 /obj/cable{
 	icon_state = "0-2"
 	},
@@ -38206,6 +38265,9 @@
 	name = "autoname - SS13";
 	pixel_x = 0;
 	tag = ""
+	},
+/obj/landmark/start{
+	name = "Medical Doctor"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge,
 /area/station/medical/staff)
@@ -38423,6 +38485,11 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"nTZ" = (
+/obj/critter/sealpup,
+/obj/stool/bench,
+/turf/simulated/pool/no_animate,
+/area/station/crew_quarters/pool)
 "nUH" = (
 /turf/simulated/floor/engine,
 /area/station/science/testchamber)
@@ -38585,17 +38652,17 @@
 /area/station/hallway/primary/south)
 "obN" = (
 /obj/table/reinforced/auto,
-/obj/item/storage/firstaid/brute{
-	pixel_x = -6;
-	pixel_y = 12
-	},
-/obj/item/storage/firstaid/brute{
-	pixel_x = 8;
-	pixel_y = 12
-	},
 /obj/item/reagent_containers/food/drinks/water{
 	pixel_x = 6;
 	pixel_y = 7
+	},
+/obj/item/item_box/medical_patches/mini_styptic{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/storage/wall/medical{
+	pixel_y = 2;
+	pixel_x = -28
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
@@ -38967,7 +39034,11 @@
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
 "ouI" = (
-/obj/machinery/chem_dispenser/alcohol,
+/obj/machinery/chem_dispenser/alcohol{
+	dispensable_reagents = list("margarita");
+	desc = "You see a small, fading warning label on the side of the machine:<br>WARNING: Exclusive property of Margaritaville.";
+	name = "Margaritaville Margarita Dispenser"
+	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
@@ -39774,6 +39845,10 @@
 /obj/stool,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
+"pmW" = (
+/obj/decal/cleanable/ketchup,
+/turf/simulated/floor/delivery,
+/area/station/hallway/primary/east)
 "poJ" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/grass{
@@ -40140,7 +40215,7 @@
 /area/station/hangar/arrivals)
 "pFN" = (
 /obj/machinery/shieldgenerator/meteorshield,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "pGh" = (
 /obj/decal/tile_edge/stripe/corner/extra_big2{
@@ -40929,6 +41004,13 @@
 	dir = 8
 	},
 /obj/stool,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/landmark{
+	icon_state = "pest-start";
+	name = "peststart"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "qCA" = (
@@ -41217,23 +41299,28 @@
 	},
 /turf/simulated/floor,
 /area/station/security/equipment)
+"qPX" = (
+/obj/stool/chair{
+	dir = 1
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "qQd" = (
 /turf/simulated/floor/black/corner{
 	dir = 8
 	},
 /area/station/crew_quarters/quarters)
 "qQn" = (
-/obj/pool/perspective{
-	dir = 8;
-	tag = "icon-pool (WEST)"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 4;
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/simulated/floor/dojo/sand,
+/turf/simulated/pool/no_animate,
 /area/station/crew_quarters/pool)
 "qQM" = (
 /obj/cable{
@@ -41614,13 +41701,6 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
-"rql" = (
-/obj/pool/perspective{
-	dir = 8;
-	tag = "icon-pool (WEST)"
-	},
-/turf/simulated/floor/dojo/sand,
-/area/station/crew_quarters/pool)
 "rqV" = (
 /obj/table/auto,
 /obj/item/paper_bin{
@@ -42161,6 +42241,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
+"rUL" = (
+/obj/stool/bench,
+/turf/simulated/pool/no_animate,
+/area/station/crew_quarters/pool)
 "rVf" = (
 /obj/cable/black{
 	icon_state = "4-8"
@@ -44424,7 +44508,7 @@
 	},
 /obj/access_spawn/maint,
 /obj/firedoor_spawn,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "udi" = (
 /obj/disposalpipe/segment,
@@ -46259,6 +46343,9 @@
 	icon_state = "ringrope";
 	pixel_x = 0
 	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
 "wbZ" = (
@@ -46780,7 +46867,7 @@
 /area/station/maintenance/west)
 "wES" = (
 /obj/machinery/space_heater,
-/turf/simulated/floor/grime,
+/turf/simulated/floor/black,
 /area/station/storage/emergency)
 "wFj" = (
 /turf/simulated/floor/carpet/green/fancy/edge/south,
@@ -47068,6 +47155,9 @@
 	name = "Medical Intercom"
 	},
 /obj/machinery/light/incandescent,
+/obj/landmark/start{
+	name = "Medical Doctor"
+	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "wUy" = (
@@ -48250,6 +48340,10 @@
 /obj/decal/tile_edge/line/black{
 	dir = 9;
 	icon_state = "line1"
+	},
+/obj/landmark{
+	icon_state = "pest-start";
+	name = "peststart"
 	},
 /turf/simulated/floor/specialroom/gym/alt,
 /area/station/crew_quarters/fitness)
@@ -72436,14 +72530,14 @@ aCy
 aCy
 aaa
 aaA
-aRr
+fUw
 bON
 aSN
 aSN
 aSN
 tte
 aVy
-aRr
+fUw
 aaa
 aXP
 aYE
@@ -72738,14 +72832,14 @@ aCy
 aaa
 aaa
 aaA
-aRr
-aRr
+fUw
+fUw
 iED
 gbt
 gbt
 pEb
-aRr
-aRr
+fUw
+fUw
 aaa
 aXP
 aYE
@@ -73645,12 +73739,12 @@ aaa
 aaa
 aaa
 aaa
-aRr
+fUw
 aRs
 aRs
 aRs
 aRs
-aRr
+fUw
 aaa
 aaa
 aXP
@@ -80578,8 +80672,8 @@ azV
 azV
 lcJ
 azV
-azV
 hQw
+hZd
 enQ
 igk
 azV
@@ -81171,10 +81265,10 @@ lBp
 axc
 ayc
 ayW
-ayW
-ayW
+ayX
+ayX
 aJQ
-ayW
+ayX
 ayW
 aEk
 aEk
@@ -81484,9 +81578,9 @@ tEO
 iXG
 aLi
 aLf
-rql
+aIb
 qQn
-rql
+aIb
 aLd
 aEk
 aMD
@@ -81789,7 +81883,7 @@ aIa
 hvO
 aIb
 aIb
-aLe
+aJw
 aEk
 aEk
 aEk
@@ -82089,9 +82183,9 @@ pBP
 pyM
 cBj
 aIb
-aJw
 aIb
-aHs
+aIb
+aIb
 eka
 aME
 jHJ
@@ -82394,7 +82488,7 @@ anb
 aIb
 aIb
 aIb
-aIb
+rUL
 aMF
 fck
 fck
@@ -82696,7 +82790,7 @@ aPX
 aIb
 aKo
 hvh
-aPX
+nTZ
 aMG
 nBH
 ejp
@@ -83309,7 +83403,7 @@ aLj
 hll
 aFq
 lpG
-peB
+bMT
 poZ
 peB
 peB
@@ -85423,7 +85517,7 @@ aPt
 aPt
 aQK
 ptj
-qup
+qPX
 xAZ
 rTD
 vJC
@@ -85728,7 +85822,7 @@ ptj
 qup
 dYF
 yer
-djq
+fPg
 aPr
 hll
 mmb
@@ -86027,7 +86121,7 @@ aPt
 aPt
 aQK
 ptj
-qup
+qPX
 ohS
 koB
 vJC
@@ -86329,7 +86423,7 @@ mxw
 mIj
 qiW
 ptj
-qup
+qPX
 frb
 wIq
 oEa
@@ -87228,7 +87322,7 @@ aHE
 aLo
 aMg
 aMf
-aPr
+drI
 hmm
 nYq
 aUn
@@ -87537,7 +87631,7 @@ aPw
 aPw
 aNr
 aNr
-aNr
+aPr
 eNr
 aXV
 azU
@@ -87840,7 +87934,7 @@ aJC
 aJC
 aRB
 bhx
-aJC
+pmW
 aXV
 aUq
 ssc

--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -9068,6 +9068,7 @@
 /area/station/maintenance/inner/central)
 "aEj" = (
 /obj/machinery/door/airlock/pyro/glass,
+/obj/firedoor_spawn,
 /turf/simulated/floor/arrival{
 	dir = 2
 	},
@@ -12297,6 +12298,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
@@ -14269,11 +14271,6 @@
 /area/station/crew_quarters/fitness)
 "aUn" = (
 /turf/simulated/floor/wood,
-/area/station/crew_quarters/fitness)
-"aUo" = (
-/obj/machinery/light/incandescent,
-/obj/fitness/speedbag/clown,
-/turf/simulated/floor/wood/three,
 /area/station/crew_quarters/fitness)
 "aUq" = (
 /obj/machinery/camera{
@@ -28039,6 +28036,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/scidisposal)
+"dek" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	name = "E light switch";
+	pixel_x = 24
+	},
+/turf/simulated/floor/dojo/sand,
+/area/station/crew_quarters/pool)
 "dfk" = (
 /obj/machinery/launcher_loader/west{
 	id = "outpostla"
@@ -28681,6 +28688,17 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor,
 /area/station/hangar/engine)
+"dPY" = (
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 64;
+	text = "NF";
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/fitness)
 "dQM" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -32911,6 +32929,11 @@
 	pixel_x = -9;
 	pixel_y = 4
 	},
+/obj/item/clothing/head/NTberet{
+	pixel_y = -1;
+	pixel_x = 6;
+	desc = "This one smells like medbay, eugh."
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "igC" = (
@@ -33681,6 +33704,23 @@
 	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
+"iXG" = (
+/obj/decal/stage_edge/alt,
+/obj/stool/chair{
+	desc = "";
+	icon_state = "chair_pool"
+	},
+/obj/item/clothing/glasses/sunglasses/tanning,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = -1
+	},
+/turf/simulated/floor/dojo/sand,
+/area/station/crew_quarters/pool)
 "iXI" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4
@@ -33766,6 +33806,7 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "jeb" = (
@@ -34258,6 +34299,8 @@
 	dir = 4;
 	pixel_y = 0
 	},
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "jEI" = (
@@ -34313,6 +34356,11 @@
 /area/station/hallway/primary/west)
 "jHJ" = (
 /obj/machinery/chem_dispenser/soda,
+/obj/machinery/light_switch{
+	name = "W light switch";
+	on = 0;
+	pixel_x = -24
+	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
 	},
@@ -34767,6 +34815,11 @@
 "kiD" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk,
+/obj/machinery/light_switch{
+	name = "N light switch";
+	pixel_x = -7;
+	pixel_y = 24
+	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "kiY" = (
@@ -35473,6 +35526,10 @@
 /area/station/hydroponics/bay)
 "kUu" = (
 /obj/loudspeaker,
+/obj/machinery/light_switch{
+	name = "S light switch";
+	pixel_y = -24
+	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "kUH" = (
@@ -37284,6 +37341,7 @@
 /obj/disposalpipe/segment{
 	dir = 1
 	},
+/obj/firedoor_spawn,
 /turf/simulated/floor/wood,
 /area/station/maintenance/inner/central)
 "mPI" = (
@@ -38359,6 +38417,10 @@
 	pixel_y = 18;
 	tag = ""
 	},
+/obj/machinery/light_switch{
+	name = "E light switch";
+	pixel_x = 24
+	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
 "nUH" = (
@@ -38911,6 +38973,11 @@
 	dir = 4;
 	name = "autoname - SS13";
 	tag = ""
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = -1
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -40949,6 +41016,11 @@
 	},
 /obj/item/clothing/glasses/vr{
 	network = "arcadevr"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 25;
+	pixel_y = 6
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
@@ -47722,6 +47794,8 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment,
+/obj/access_spawn/maint,
+/obj/firedoor_spawn,
 /turf/simulated/floor/carpet/arcade,
 /area/station/maintenance/inner/central)
 "xHg" = (
@@ -81407,7 +81481,7 @@ aDp
 aEk
 kiD
 tEO
-aGE
+iXG
 aLi
 aLf
 rql
@@ -83527,7 +83601,7 @@ mOL
 mOL
 mOL
 sWx
-mOL
+dek
 mOL
 jcS
 oJW
@@ -85956,7 +86030,7 @@ ptj
 qup
 ohS
 koB
-aUo
+vJC
 aPr
 uSn
 mmb
@@ -86552,7 +86626,7 @@ aJC
 aJC
 aNr
 wOT
-hEQ
+dPY
 pBy
 mTi
 hEQ


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Updates the pool, the arcade, and the gym of Donut 2. The updates include adding a small bar to the pool, making the gym look spiffy, and increasing the pool size. Also some misc fixes.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pool was ugly before. Now you too can go to Margaritaville.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Roddy
(*)Updated the Donut 2 Pool/Arcade/Gym area.
```
 [mapping] 