### PR TITLE
Remove a window from donut2 research shuttle

### DIFF
--- a/maps/unused/donut2_new_walls.dmm
+++ b/maps/unused/donut2_new_walls.dmm
@@ -1773,7 +1773,6 @@
 /turf/space,
 /area/shuttle/research/outpost)
 "afX" = (
-/obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/shuttle/wall/cockpit{
 	dir = 8;
 	icon_state = "shuttlecock"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
removes a window stuck in the research shuttle wall.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Donut2 map testing #10285
