### PR TITLE
Meson cyber-eyes and blindness protect you from Singularity Mezzing

### DIFF
--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -389,9 +389,16 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	for (var/mob/living/carbon/M in oviewers(radius*EVENT_GROWTH+EVENT_MINIMUM, src.get_center()))
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
-			if (istype(H.glasses,/obj/item/clothing/glasses/meson))
+			if (H.bioHolder?.HasEffect("blind") || H.blinded )
+				return
+			else if (istype(H.glasses,/obj/item/clothing/glasses/meson))
 				M.show_text("You look directly into [src.name], good thing you had your protective eyewear on!", "green")
 				return
+			else // if you have eyes, they could be meson eyes
+				if((!H.organHolder?.left_eye || istype(H.organHolder?.left_eye, /obj/item/organ/eye/cyber/meson)) &&
+					(!H.organHolder?.right_eye || istype(H.organHolder?.right_eye, /obj/item/organ/eye/cyber/meson)))
+					M.show_text("You look directly into [src.name], good thing your eyes are protected!", "green")
+					return
 		M.changeStatus("stunned", 7 SECONDS)
 		M.visible_message("<span class='alert'><B>[M] stares blankly at [src]!</B></span>",\
 		"<B>You look directly into [src]!<br><span class='alert'>You feel weak!</span></B>")

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -395,8 +395,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 				M.show_text("You look directly into [src.name], good thing you had your protective eyewear on!", "green")
 				return
 			else // if you have eyes, they could be meson eyes
-				if((!H.organHolder?.left_eye || istype(H.organHolder?.left_eye, /obj/item/organ/eye/cyber/meson)) &&
-					(!H.organHolder?.right_eye || istype(H.organHolder?.right_eye, /obj/item/organ/eye/cyber/meson)))
+				if((!H.organHolder?.left_eye || istype(H.organHolder?.left_eye, /obj/item/organ/eye/cyber/meson)) && (!H.organHolder?.right_eye || istype(H.organHolder?.right_eye, /obj/item/organ/eye/cyber/meson)))
 					M.show_text("You look directly into [src.name], good thing your eyes are protected!", "green")
 					return
 		M.changeStatus("stunned", 7 SECONDS)

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -389,13 +389,13 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	for (var/mob/living/carbon/M in oviewers(radius*EVENT_GROWTH+EVENT_MINIMUM, src.get_center()))
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
-			if (H.bioHolder?.HasEffect("blind") || H.blinded )
+			if (H.bioHolder?.HasEffect("blind") || H.blinded)
 				return
 			else if (istype(H.glasses,/obj/item/clothing/glasses/meson))
 				M.show_text("You look directly into [src.name], good thing you had your protective eyewear on!", "green")
 				return
-			else // if you have eyes, they could be meson eyes
-				if((!H.organHolder?.left_eye || istype(H.organHolder?.left_eye, /obj/item/organ/eye/cyber/meson)) && (!H.organHolder?.right_eye || istype(H.organHolder?.right_eye, /obj/item/organ/eye/cyber/meson)))
+			// remaining eye(s) meson cybereyes?
+			else if((!H.organHolder?.left_eye || istype(H.organHolder?.left_eye, /obj/item/organ/eye/cyber/meson)) && (!H.organHolder?.right_eye || istype(H.organHolder?.right_eye, /obj/item/organ/eye/cyber/meson)))
 					M.show_text("You look directly into [src.name], good thing your eyes are protected!", "green")
 					return
 		M.changeStatus("stunned", 7 SECONDS)

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -396,8 +396,8 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 				return
 			// remaining eye(s) meson cybereyes?
 			else if((!H.organHolder?.left_eye || istype(H.organHolder?.left_eye, /obj/item/organ/eye/cyber/meson)) && (!H.organHolder?.right_eye || istype(H.organHolder?.right_eye, /obj/item/organ/eye/cyber/meson)))
-					M.show_text("You look directly into [src.name], good thing your eyes are protected!", "green")
-					return
+				M.show_text("You look directly into [src.name], good thing your eyes are protected!", "green")
+				return
 		M.changeStatus("stunned", 7 SECONDS)
 		M.visible_message("<span class='alert'><B>[M] stares blankly at [src]!</B></span>",\
 		"<B>You look directly into [src]!<br><span class='alert'>You feel weak!</span></B>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
[BUG][GAME OBJECTS][MINOR]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Being blinded or having Meson Cyber-eyes in whatever eyes you have protects you from the singularity's Mezzing event.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Meson eyes should work like meson goggles if all your eyes are mesons, and you can't look directly at something if you can't see.