### PR TITLE
Makes sentient flockspeak easier to pick out

### DIFF
--- a/browserassets/css/browserOutput.css
+++ b/browserassets/css/browserOutput.css
@@ -350,7 +350,8 @@ img.emoji {
 .flocksay {color: #488276;}
 .flocksay a {color: #488276;}
 .flocksay a:visited {color: #488276;}
-.flockmindsay {color: #66ad9e; font-size: 120%;}
+.flocksay.sentient {color:white; background-color:#66ad9e;}
+.flocksay.sentient.flockmind {font-size: 120%;}
 .flocknpc {color: #869995; font-size: 80%;}
 .flocksay.ping {font-style: italic;}
 .ghostdronesay {color: #d81aef;}
@@ -493,7 +494,8 @@ body.theme-dark .martianimperial {color: #e26794;}
 body.theme-dark .flocksay {color: #6fbbac;}
 body.theme-dark .flocksay a {color: #6dc0af;}
 body.theme-dark .flocksay a:visited {color: #6ec2b1;}
-body.theme-dark .flockmindsay {color: #82dbc8;}
+body.theme-dark .flocksay.sentient {color: #111; background-color:#82dbc8;}
+body.theme-dark .flocksay.sentient.flockmind {font-size: 120%;}
 body.theme-dark .flocknpc {color: #afc9c3;}
 body.theme-dark .ghostdronesay {color: #ca4ed8;}
 body.theme-dark .roboticsay {color: #111; background-color: #c4c3c3;}

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -269,7 +269,7 @@ var/flock_signal_unleashed = FALSE
 			SPAWN(3 SECONDS)
 				F.client?.images -= arrow
 				qdel(arrow)
-		var/class = "flocksay ping [istype(F, /mob/living/intangible/flock/flockmind) ? "flockmindsay" : ""]"
+		var/class = "flocksay ping [istype(F, /mob/living/intangible/flock/flockmind) ? "flockmind" : ""]"
 		var/prefix = "<span class='bold'>\[[src.name]\] </span><span class='name'>[pinger.name]</span>"
 		boutput(F, "<span class='[class]'><a href='?src=\ref[F];origin=\ref[target];ping=[TRUE]'>[prefix]: Interrupt request, target: [target] in [get_area(target)].</a></span>")
 	playsound_global(src.traces + src.flockmind, 'sound/misc/flockmind/ping.ogg', 50, 0.5)

--- a/code/procs/mobprocs/chatprocs.dm
+++ b/code/procs/mobprocs/chatprocs.dm
@@ -1002,7 +1002,7 @@
 		structure_speaking = speaker
 
 	var/name = ""
-	var/class = "flocksay"
+	var/class = "flocksay sentient"
 	var/is_npc = FALSE
 	var/is_flockmind = istype(mob_speaking, /mob/living/intangible/flock/flockmind)
 
@@ -1026,7 +1026,7 @@
 			name = mob_speaking.real_name
 
 	if(is_flockmind)
-		class = "flocksay flockmindsay"
+		class = "flocksay sentient flockmind"
 	else if(is_npc)
 		class = "flocksay flocknpc"
 	else if(isnull(mob_speaking))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
[QOL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Gives messages from flockminds and traces the same inverted treatment as silicon talk, thrallspeak etc.
![image](https://user-images.githubusercontent.com/20713227/185727306-c1fe07a5-dcf9-4897-b8c8-6d7fcf140bb9.png)
![image](https://user-images.githubusercontent.com/20713227/185727317-4ab0b05b-4a3a-4b7c-a2b2-80d82ae3b237.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
I meant to do this a while back, it's currently very easy to miss messages from actual players in the stream of messages from drones, structures etc.
Also this PR can't crash the server! I think.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Messages from sentient elements of the flock are now much easier to pick out.
```
