### PR TITLE
Flock Relay causes shuttle to arrive in 60 seconds

### DIFF
--- a/code/obj/flock/structure/relay.dm
+++ b/code/obj/flock/structure/relay.dm
@@ -132,10 +132,10 @@
 			emergency_shuttle.disabled = FALSE
 			emergency_shuttle.incall()
 			emergency_shuttle.can_recall = FALSE
-			emergency_shuttle.settimeleft(180) // cut the time down to keep some sense of urgency
+			emergency_shuttle.settimeleft(60) // cut the time down to keep some sense of urgency
 			boutput(world, "<span class='notice'><B>Alert: The emergency shuttle has been called.</B></span>")
 			boutput(world, "<span class='notice'>- - - <b>Reason:</b> Hostile transmission intercepted. Sending rapid response emergency shuttle.</span>")
-			boutput(world, "<span class='notice'><B>It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.</B></span>")
+			boutput(world, "<span class='notice'><B>It will arrive in [round(emergency_shuttle.timeleft())] seconds.</B></span>")
 	sleep(2 SECONDS)
 	for(var/x = -2 to 2)
 		for(var/y = -2 to 2)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fairly substantially shortens the shuttle call time when the relay detonates (from 180 to 60 seconds)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's supposed to feel like a mad rush to escape when the relay detonates, not a leisurely stroll. 3 minutes is way too much.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Flock response emergency shuttle now comes in 60 seconds (down from 3 minutes).
```
