### PR TITLE
Increased capacity of cleaner refill bottle

### DIFF
--- a/code/modules/chemistry/tools/bottles.dm
+++ b/code/modules/chemistry/tools/bottles.dm
@@ -425,6 +425,6 @@
 	name = "cleaner bottle"
 	desc = "A bottle filled with cleaning fluid."
 	icon_state = "largebottle-labeled"
-	initial_volume = 50
+	initial_volume = 100
 	initial_reagents = "cleaner"
 	amount_per_transfer_from_this = 10


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Cleaner bottle in Janitorial now contains 100u of Space Cleaner rather than 50u


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cleaner Spray Bottles can hold 100 units, so I think it's odd that the refill Cleaner Bottles only fill it half-way.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)CrystalClover
(+)Increased Cleaner bottle base reagent size to 100u (these are the refills in janitorial closets).
```
