### PR TITLE
Change manufacturer type in Kondaru HoP's office

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -27529,12 +27529,12 @@
 /turf/simulated/floor/red/side,
 /area/station/hallway/primary/south)
 "bHd" = (
-/obj/machinery/manufacturer/personnel,
 /obj/machinery/light{
 	dir = 1;
 	layer = 9.1;
 	pixel_y = 21
 	},
+/obj/machinery/manufacturer/hop_and_uniform,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "bHe" = (


### PR DESCRIPTION
[GAME-OBJECTS][QoL]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR just changes the equipment manufacturer in the HoP's office in Kondaru to an equipment and uniform manufacturer.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes it a bit faster to demote people when needed by security. Also allows HoP to hand out uniforms.