### PR TITLE
Makes Clowns Always Spawn With The "accent_comic" Mutation

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1027,8 +1027,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		M.AddComponent(/datum/component/death_confetti)
 
 		M.bioHolder.AddEffect("clumsy", magical=1)
-		if (prob(50))
-			M.bioHolder.AddEffect("accent_comic", magical=1)
+		M.bioHolder.AddEffect("accent_comic", magical=1)
 
 // AI and Cyborgs
 


### PR DESCRIPTION
[Player Actions] [Balance]


## About the PR:
Clowns will now always spawn with the "accent_comic" mutation, as opposed to previously having a 50% chance to receive it upon joining.
I hope that this is a change small enough to be exempt from the feature freeze.



## Why's this needed? 
Most seem in agreement that the accent should not be chance based: https://forum.ss13.co/showthread.php?tid=19540
The accent distinguishes the Clown from the crew in a unique and thematically fitting way, and shows them to be the chief entertainer among the crew, which I do not think should be something exclusive only to half of anyone's Clown rounds.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Clowns will now always spawn with the comic sans accent mutation.
```