### PR TITLE
Fixes #10384 - Pointblank Shots Now Perform An Actionbar Where Required

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1027,8 +1027,7 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		M.AddComponent(/datum/component/death_confetti)
 
 		M.bioHolder.AddEffect("clumsy", magical=1)
-		if (prob(50))
-			M.bioHolder.AddEffect("accent_comic", magical=1)
+		M.bioHolder.AddEffect("accent_comic", magical=1)
 
 // AI and Cyborgs
 

--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1027,7 +1027,8 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		M.AddComponent(/datum/component/death_confetti)
 
 		M.bioHolder.AddEffect("clumsy", magical=1)
-		M.bioHolder.AddEffect("accent_comic", magical=1)
+		if (prob(50))
+			M.bioHolder.AddEffect("accent_comic", magical=1)
 
 // AI and Cyborgs
 

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -47,7 +47,6 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	var/add_residue = 0 // Does this gun add gunshot residue when fired (Convair880)?
 
 	var/charge_up = 0 //Does this gun have a charge up time and how long is it? 0 = normal instant shots.
-	var/skip_charge_up = FALSE
 	var/shoot_delay = 4
 
 	var/muzzle_flash = null //set to a different icon state name if you want a different muzzle flash when fired, flash anims located in icons/mob/mob.dmi
@@ -206,9 +205,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 
 	onEnd()
 		..()
-		ownerGun.skip_charge_up = TRUE // This is to bypass the 'charge_up' check in 'shoot_point_blank', as to prevent an actionbar loop. This is better than duplicating the entire 'shoot_point_blank' proc.
-		ownerGun.shoot_point_blank(target, user, second_shot)
-		ownerGun.skip_charge_up = FALSE
+		ownerGun.shoot_point_blank(target, user, second_shot, TRUE)
 
 /obj/item/gun/pixelaction(atom/target, params, mob/user, reach, continuousFire = 0)
 	if (reach)
@@ -254,7 +251,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 						gun.shoot(target_turf,user_turf,user, pox+rand(-2,2), poy+rand(-2,2), is_dual_wield)
 
 	if(!ON_COOLDOWN(src, "shoot_delay", src.shoot_delay))
-		if(charge_up && !skip_charge_up && !can_dual_wield && canshoot())
+		if(charge_up && !can_dual_wield && canshoot())
 			actions.start(new/datum/action/bar/icon/guncharge(src, pox, poy, user_turf, target_turf, charge_up, icon, icon_state), user)
 		else
 			shoot(target_turf, user_turf, user, pox, poy, is_dual_wield)
@@ -285,7 +282,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 #endif
 		return
 
-/obj/item/gun/proc/shoot_point_blank(atom/target, var/mob/user as mob, var/second_shot = 0)
+/obj/item/gun/proc/shoot_point_blank(atom/target, var/mob/user as mob, var/second_shot = 0, var/skip_charge_up = FALSE)
 	if (!target || !user)
 		return FALSE
 

--- a/code/obj/item/gun/gun_parent.dm
+++ b/code/obj/item/gun/gun_parent.dm
@@ -47,6 +47,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 	var/add_residue = 0 // Does this gun add gunshot residue when fired (Convair880)?
 
 	var/charge_up = 0 //Does this gun have a charge up time and how long is it? 0 = normal instant shots.
+	var/skip_charge_up = FALSE
 	var/shoot_delay = 4
 
 	var/muzzle_flash = null //set to a different icon state name if you want a different muzzle flash when fired, flash anims located in icons/mob/mob.dmi
@@ -205,10 +206,9 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 
 	onEnd()
 		..()
-		var/charge_up = ownerGun.charge_up
-		ownerGun.charge_up = 0 // This is to bypass the 'charge_up' check in 'shoot_point_blank', as to prevent an actionbar loop. This is better than duplicating the entire 'shoot_point_blank' proc.
+		ownerGun.skip_charge_up = TRUE // This is to bypass the 'charge_up' check in 'shoot_point_blank', as to prevent an actionbar loop. This is better than duplicating the entire 'shoot_point_blank' proc.
 		ownerGun.shoot_point_blank(target, user, second_shot)
-		ownerGun.charge_up = charge_up
+		ownerGun.skip_charge_up = FALSE
 
 /obj/item/gun/pixelaction(atom/target, params, mob/user, reach, continuousFire = 0)
 	if (reach)
@@ -254,7 +254,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 						gun.shoot(target_turf,user_turf,user, pox+rand(-2,2), poy+rand(-2,2), is_dual_wield)
 
 	if(!ON_COOLDOWN(src, "shoot_delay", src.shoot_delay))
-		if(charge_up && !can_dual_wield && canshoot())
+		if(charge_up && !skip_charge_up && !can_dual_wield && canshoot())
 			actions.start(new/datum/action/bar/icon/guncharge(src, pox, poy, user_turf, target_turf, charge_up, icon, icon_state), user)
 		else
 			shoot(target_turf, user_turf, user, pox, poy, is_dual_wield)
@@ -293,7 +293,7 @@ var/list/forensic_IDs = new/list() //Global list of all guns, based on bioholder
 		user.show_text("<span class='combat bold'>Your internal law subroutines kick in and prevent you from using [src]!</span>")
 		return FALSE
 
-	if (charge_up && !can_dual_wield && canshoot())
+	if (charge_up && !skip_charge_up && !can_dual_wield && canshoot())
 		actions.start(new/datum/action/bar/icon/guncharge_pointblank(src, target, user, second_shot, charge_up, icon, icon_state), user)
 		return
 


### PR DESCRIPTION
[Player Actions] [Bug]


## About the PR:
Fixes #10384 by implementing a new actionbar to handle pointblank shots, as the ordinary actionbar is incompatible with `shoot_point_blank()`.
If there is a better way of doing this without a refactor of `shoot_point_blank()`, please do say, as the `onEnd()` of the new actionbar is incredibly cursed.

Also please ignore that I checked out to a new branch while still on the clown accent branch.