### PR TITLE
cooldown on pricking yourself with roses

### DIFF
--- a/code/obj/item/plants.dm
+++ b/code/obj/item/plants.dm
@@ -472,6 +472,8 @@
 				if(H.gloves)
 					..()
 					return
+			if(ON_COOLDOWN(src, "prick_hands", 1 SECOND))
+				return
 			boutput(user, "<span class='alert'>You prick yourself on [src]'s thorns trying to pick it up!</span>")
 			random_brute_damage(user, 3)
 			take_bleeding_damage(user,null,3,DAMAGE_STAB)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
[BUG][MINOR][GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a one second cooldown to damaging yourself with a throned rose on pickup

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10418