### PR TITLE
Adds click delay to a bunch of limbs

### DIFF
--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -434,6 +434,7 @@
 			return
 
 		if (isobj(target))
+			user.lastattacked = target
 			switch (user.smash_through(target, list("window", "grille", "blob")))
 				if (0)
 					if (isitem(target))

--- a/code/datums/limb.dm
+++ b/code/datums/limb.dm
@@ -434,7 +434,6 @@
 			return
 
 		if (isobj(target))
-			user.lastattacked = target
 			switch (user.smash_through(target, list("window", "grille", "blob")))
 				if (0)
 					if (isitem(target))
@@ -445,6 +444,7 @@
 						return
 
 				if (1)
+					user.lastattacked = target
 					return
 
 		..()
@@ -692,6 +692,7 @@
 							return
 
 				if (1)
+					user.lastattacked = target
 					return
 
 		..()
@@ -1212,6 +1213,7 @@
 						C.cut(user,user.loc)
 						return
 				if (1)
+					user.lastattacked = target
 					return
 		..()
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds click delay to bear, brullbar and claw arms when attacking objects that the limbs can smash through (e.g. grilles, windows, blob tiles)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is primarily targeting the bear arm's ability to attack blob tiles without a click delay, but imo it's also kinda silly that they can attack grilles and windows with no delay too.


