### PR TITLE
Fixes a runtime with bikehorn signallers

### DIFF
--- a/code/obj/item/instruments.dm
+++ b/code/obj/item/instruments.dm
@@ -70,11 +70,12 @@
 		logTheThing(LOG_COMBAT, user, "plays instrument [src]")
 		if (note != clamp(note, 1, length(sounds_instrument)))
 			return FALSE
-		if(ON_COOLDOWN(user, "instrument_play", src.note_time)) // on user because not just clients do music
+		var/atom/player = user || src
+		if(ON_COOLDOWN(player, "instrument_play", src.note_time)) // on user because not just clients do music
 			return FALSE
 
 		if (special_index && note >= special_index) // Add additional time if we just played a special note
-			user.cooldowns["instrument_play"] += 10 SECONDS
+			player.cooldowns["instrument_play"] += 10 SECONDS
 
 		var/turf/T = get_turf(src)
 		playsound(T, sounds_instrument[note], src.volume, randomized_pitch, pitch = pitch_set)
@@ -87,7 +88,7 @@
 							continue
 						george.howl()
 
-			src.post_play_effect(user)
+		src.post_play_effect(user)
 		. = TRUE
 
 	proc/play(var/mob/user)

--- a/code/obj/item/instruments.dm
+++ b/code/obj/item/instruments.dm
@@ -71,7 +71,7 @@
 		if (note != clamp(note, 1, length(sounds_instrument)))
 			return FALSE
 		var/atom/player = user || src
-		if(ON_COOLDOWN(player, "instrument_play", src.note_time)) // on user because not just clients do music
+		if(ON_COOLDOWN(player, "instrument_play", src.note_time)) // on user or src because sometimes instruments play themselves
 			return FALSE
 
 		if (special_index && note >= special_index) // Add additional time if we just played a special note


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #10434 and also moves the `post_play_effect` call one indent back since I don't think it was intended to only be called 5% of the time.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Let the clown honk. Looks like this was broken while fixing The Bagpipes Incident a week ago.
