### PR TITLE
makes terminal text respect font size setting

### DIFF
--- a/code/modules/networks/computer3/computer3.dm
+++ b/code/modules/networks/computer3/computer3.dm
@@ -362,6 +362,8 @@
 			src.temp += temp_add
 			temp_add = null
 
+		// preference is in a percentage of the default
+		var/font_size = user.client ? (user.client.preferences.font_size/100) * 10 : 10;
 		var/dat = {"<title>Computer Terminal</title>
 		<style type="text/css">
 		body
@@ -385,7 +387,7 @@
 			background-color:[src.setup_bg_color];
 			color:[src.setup_font_color];
 			font-family: "Consolas", monospace;
-			font-size:10pt;
+			font-size:[font_size]pt;
 		}
 
 		#consoleshell


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Scales the terminal text size with the font size client setting.
The Peripheral Text at the bottom already scaled before this patch, which can cause the window to get a scroll bar in some cases if it's set too big, but that was a preexisting issue, this PR does nothing about the window size. I suppose people with very big font sizes can just resize their window if it bothers them?

This is for the text in the black rectangle:
70%
![image](https://user-images.githubusercontent.com/35579460/186268681-8fd99146-1408-4cd9-ad4e-ac269f54fbf9.png)

100%
![image](https://user-images.githubusercontent.com/35579460/186268772-00d3057a-d892-4518-8f4f-dd812ac4022b.png)

120%
![image](https://user-images.githubusercontent.com/35579460/186268853-c290c97e-ca94-41b6-81f1-7a719c6a5aff.png)

150%
![image](https://user-images.githubusercontent.com/35579460/186268911-bbf87a92-1f4f-4b72-abea-95ecbdd6a6fa.png)

170% (this is about the size where the Peripheral text becomes a bit too big for the default window size)
![image](https://user-images.githubusercontent.com/35579460/186269013-a33c0c73-d554-4d5c-b3ac-316b4384ee84.png)


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Some people have issues reading the default text size.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)zjdtmkhzt
(+)Terminals should now respect font size settings.
```
