### PR TITLE
Moves The Forensic Scanner Print Option To The Text Window

### DIFF
--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -154,44 +154,44 @@ that cannot be itched
 	var/target = null
 	var/last_scan = "No scans have been done yet."
 
+	Topic(href, href_list)
+		..()
+		if (href_list["print"])
+			if(!ON_COOLDOWN(src, "print", 2 SECOND))
+				playsound(src, "sound/machines/printer_thermal.ogg", 50, 1)
+				SPAWN(1 SECONDS)
+					var/obj/item/paper/P = new /obj/item/paper
+					P.set_loc(get_turf(src))
+
+					P.info = last_scan
+					P.name = "Forensic readout"
+
 
 	attack_self(mob/user as mob)
 
 		src.add_fingerprint(user)
 
-		var/choice = tgui_alert(user, "What would you like to do with [src]?", "Forensic scanner", list( "Find record", "Print last scan"))
-		switch (choice)
-			if ("Find record")
-				var/holder = src.loc
-				var/search = input(user, "Enter name, fingerprint or blood DNA.", "Find record", "") as null|text
-				if (src.loc != holder || !search || user.stat)
-					return
-				search = copytext(sanitize(search), 1, 200)
-				search = lowertext(search)
+		var/holder = src.loc
+		var/search = input(user, "Enter name, fingerprint or blood DNA.", "Find record", "") as null|text
+		if (src.loc != holder || !search || user.stat)
+			return
+		search = copytext(sanitize(search), 1, 200)
+		search = lowertext(search)
 
-				for (var/datum/db_record/R as anything in data_core.general.records)
-					if (search == lowertext(R["dna"]) || search == lowertext(R["fingerprint"]) || search == lowertext(R["name"]))
+		for (var/datum/db_record/R as anything in data_core.general.records)
+			if (search == lowertext(R["dna"]) || search == lowertext(R["fingerprint"]) || search == lowertext(R["name"]))
 
-						var/data = "--------------------------------<br>\
-						<font color='blue'>Match found in security records:<b> [R["name"]]</b> ([R["rank"]])</font><br>\
-						<br>\
-						<i>Fingerprint:</i><font color='blue'> [R["fingerprint"]]</font><br>\
-						<i>Blood DNA:</i><font color='blue'> [R["dna"]]</font>"
+				var/data = "--------------------------------<br>\
+				<font color='blue'>Match found in security records:<b> [R["name"]]</b> ([R["rank"]])</font><br>\
+				<br>\
+				<i>Fingerprint:</i><font color='blue'> [R["fingerprint"]]</font><br>\
+				<i>Blood DNA:</i><font color='blue'> [R["dna"]]</font>"
 
-						boutput(user, data)
-						return
-
-				user.show_text("No match found in security records.", "red")
+				boutput(user, data)
 				return
-			if("Print last scan")
-				if(!ON_COOLDOWN(src, "print", 2 SECOND))
-					playsound(src, "sound/machines/printer_thermal.ogg", 50, 1)
-					SPAWN(1 SECONDS)
-						var/obj/item/paper/P = new /obj/item/paper
-						P.set_loc(get_turf(src))
 
-						P.info = last_scan
-						P.name = "Forensic readout"
+		user.show_text("No match found in security records.", "red")
+		return
 
 
 	pixelaction(atom/target, params, mob/user, reach)
@@ -209,7 +209,8 @@ that cannot be itched
 
 		user.visible_message("<span class='alert'><b>[user]</b> has scanned [A].</span>")
 		last_scan = scan_forensic(A, visible = 1) // Moved to scanprocs.dm to cut down on code duplication (Convair880).
-		boutput(user, last_scan)
+		var/scan_output = last_scan + "<br>---- <a href='?src=\ref[src];print=1'>PRINT REPORT</a> ----"
+		boutput(user, scan_output)
 		src.add_fingerprint(user)
 
 		if(!active && istype(A, /obj/decal/cleanable/blood))

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -152,19 +152,31 @@ that cannot be itched
 	var/active = 0
 	var/distancescan = 0
 	var/target = null
-	var/last_scan = "No scans have been done yet."
+
+	var/list/scans
+	var/maximum_scans = 25
+	var/number_of_scans = 0
+	var/last_scan = "No scans have been performed yet."
 
 	Topic(href, href_list)
 		..()
 		if (href_list["print"])
+			if (!(src in usr.contents))
+				boutput(usr, "<span class='notice'>You must be holding [src] that made the record in order to print it.</span>")
+				return
+			var/scan_number = text2num(href_list["print"])
+			if (scan_number < number_of_scans - maximum_scans)
+				boutput(usr, "<span class='notice'>[src] only has enough storage to hold the last [maximum_scans] scans!</span>")
+				return
 			if(!ON_COOLDOWN(src, "print", 2 SECOND))
 				playsound(src, 'sound/machines/printer_thermal.ogg', 50, 1)
 				SPAWN(1 SECONDS)
 					var/obj/item/paper/P = new /obj/item/paper
 					P.set_loc(get_turf(src))
 
-					P.info = last_scan
-					P.name = "Forensic readout"
+					var/index = (scan_number % maximum_scans) + 1 // Once a number of scans equal to the maximum number of scans is made, begin to overwrite existing scans, starting from the earliest made.
+					P.info = scans[index]
+					P.name = "forensic readout"
 
 
 	attack_self(mob/user as mob)
@@ -208,8 +220,15 @@ that cannot be itched
 			return
 
 		user.visible_message("<span class='alert'><b>[user]</b> has scanned [A].</span>")
+
+		if (scans == null)
+			scans = new/list(maximum_scans)
 		last_scan = scan_forensic(A, visible = 1) // Moved to scanprocs.dm to cut down on code duplication (Convair880).
-		var/scan_output = last_scan + "<br>---- <a href='?src=\ref[src];print=1'>PRINT REPORT</a> ----"
+		var/index = (number_of_scans % maximum_scans) + 1 // Once a number of scans equal to the maximum number of scans is made, begin to overwrite existing scans, starting from the earliest made.
+		scans[index] = last_scan
+		var/scan_output = last_scan + "<br>---- <a href='?src=\ref[src];print=[number_of_scans];'>PRINT REPORT</a> ----"
+		number_of_scans += 1
+
 		boutput(user, scan_output)
 		src.add_fingerprint(user)
 

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -158,7 +158,7 @@ that cannot be itched
 		..()
 		if (href_list["print"])
 			if(!ON_COOLDOWN(src, "print", 2 SECOND))
-				playsound(src, "sound/machines/printer_thermal.ogg", 50, 1)
+				playsound(src, 'sound/machines/printer_thermal.ogg', 50, 1)
 				SPAWN(1 SECONDS)
 					var/obj/item/paper/P = new /obj/item/paper
 					P.set_loc(get_turf(src))

--- a/code/obj/item/device/scanners.dm
+++ b/code/obj/item/device/scanners.dm
@@ -166,7 +166,7 @@ that cannot be itched
 				return
 			var/scan_number = text2num(href_list["print"])
 			if (scan_number < number_of_scans - maximum_scans)
-				boutput(usr, "<span class='notice'>[src] only has enough storage to hold the last [maximum_scans] scans!</span>")
+				boutput(usr, "<span class='alert'>ERROR: Scanner unable to load report data.</span>")
 				return
 			if(!ON_COOLDOWN(src, "print", 2 SECOND))
 				playsound(src, 'sound/machines/printer_thermal.ogg', 50, 1)


### PR DESCRIPTION
[Game Objects] [QoL]


## About the PR:
Moves the option to print forensic reports issued by the forensic scanner to the text window, alongside the ability to print the previous 25 scans made. The number of scans that the forensic scanner retains in memory may be configured via the `maximum_scans` variable.
![ForensicPrintFunction](https://user-images.githubusercontent.com/88833499/186737422-9b4eaafa-2ff9-471f-a0a3-4a66ffb08546.png)



## Why's this needed?
The print function, while appreciated, is often found to make the forensics scanner more cumbersome to use, asking whether the device should print the last record every time one wishes to search for a fingerprint or blood ID. Moving the button to the text window, appended below the report itself, seems more intuitive.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Moved the forensic scanner's print option to the text window, alongside adding the ability to print previously made scans.
```
