### PR TITLE
Removes The Sunglasses, NVGs, And 12ga Rubber Slugs From The Special Equipment Locker

### DIFF
--- a/code/obj/storage/secure_closets.dm
+++ b/code/obj/storage/secure_closets.dm
@@ -379,12 +379,7 @@
 	req_access = list(access_maxsec)
 	spawn_contents = list(/obj/item/requisition_token/security = 2,
 	/obj/item/requisition_token/security/assistant = 2,
-	/obj/item/turret_deployer/riot = 2,
-	/obj/item/clothing/glasses/nightvision = 2,
-	/obj/item/clothing/glasses/sunglasses,
-	/obj/item/clothing/glasses/sunglasses,
-	/obj/item/ammo/bullets/abg,
-	/obj/item/ammo/bullets/abg,)
+	/obj/item/turret_deployer/riot = 2)
 
 /obj/storage/secure/closet/brig
 	name = "\improper Confiscated Items safe"


### PR DESCRIPTION
[Game Objects] [Balance]


## About the PR:
Removes the two pairs of sunglasses, two pairs of night vision goggles, and two boxes of 12ga rubber slugs from the special equipment locker in the Armoury.
All Armouries currently have at least two pairs of night vision goggles in addition to the ones inside of the locker, with the median being three to four pairs in addition, and rubber slugs may be dispensed from the AmmoTech, so this should not pose the issue of removing at times vital Armoury equipment.



## Why's this needed?
The sunglasses, night vision goggles, and 12ga rubber slugs feel entirely unneeded in the special equipment locker, and lean more towards feeling like filler content if anything.
This does leave the locker feeling a bit empty, however it can only be opened by the HoS, even if the Armoury is authorised, implying that the locker is for equipment that could easily be misused or abused by Officers (requisition tokens, NARCS), and equipment should only be added to it if it falls within this category. Perhaps a few pairs of Sord's SecHUD NVGs could be added to it in a future PR?



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Removed the sunglasses, NVGs, and 12ga rubber slugs from the special equipment locker in the Armoury.
```