### PR TITLE
Fixes #9791 - Fix drone without flock

### DIFF
--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -118,8 +118,9 @@
 /mob/living/critter/flock/drone/Login()
 	..()
 	src.client?.set_color()
-	if(isnull(controller) && src.flock)
-		controller = new/mob/living/intangible/flock/trace(src, src.flock)
+	if(isnull(controller))
+		if(src.flock)
+			controller = new/mob/living/intangible/flock/trace(src, src.flock)
 		src.is_npc = FALSE
 	if(src.dormant)
 		src.undormantize()
@@ -318,7 +319,8 @@
 		src.is_npc = TRUE
 
 /mob/living/critter/flock/drone/proc/pause_ai()
-	if(src.controller || src.dormant) //can't pause_ai when controlled or dormant, this shouldn't ever happen
+	if(src.controller || src.dormant || !src.flock) //can't pause_ai when controlled or dormant, this shouldn't ever happen. Also can't pause without a flock.
+		src.wander_count = 0
 		return
 	src.ai.stop_move()
 	src.ai_paused = TRUE


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
You should now be able to posses a drone without a flock and have it properly process when you eject/die.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Mostly for admemery, since that's currently the only way this could happen, but also to fix #9791 

