### PR TITLE
Revert "Adds Scientist's Jumpsuits And Research Backpacks To Science Manufacturers"

### DIFF
--- a/code/datums/manufacturing.dm
+++ b/code/datums/manufacturing.dm
@@ -1665,24 +1665,6 @@ ABSTRACT_TYPE(/datum/manufacture)
 
 /******************** Science **************************/
 
-/datum/manufacture/jumpsuit_scientist
-	name = "Scientist's Jumpsuit"
-	item_paths = list("FAB-1")
-	item_amounts = list(4)
-	item_outputs = list(/obj/item/clothing/under/rank/scientist)
-	time = 5 SECONDS
-	create = 1
-	category = "Clothing"
-
-/datum/manufacture/research_backpack
-	name = "Research Backpack"
-	item_paths = list("FAB-1")
-	item_amounts = list(8)
-	item_outputs = list(/obj/item/storage/backpack/research)
-	time = 10 SECONDS
-	create = 1
-	category = "Clothing"
-
 /datum/manufacture/biosuit
 	name = "Biosuit Set"
 	item_paths = list("FAB-1","CRY-1")

--- a/code/obj/machinery/manufacturer.dm
+++ b/code/obj/machinery/manufacturer.dm
@@ -2218,8 +2218,6 @@
 		/datum/manufacture/mechdropper,
 		/datum/manufacture/biosuit,
 		/datum/manufacture/labcoat,
-		/datum/manufacture/research_backpack,
-		/datum/manufacture/jumpsuit_scientist,
 		/datum/manufacture/jumpsuit_white,
 		/datum/manufacture/patient_gown,
 		/datum/manufacture/blindfold,


### PR DESCRIPTION
Reverts goonstation/goonstation#10167

Sorry this is my fault for not checking PRs recently. Basically I think it's bad to make job-specific gear so easily obtainable and I think you should have to go through at least some effort of stealing it from a locked locker or another player. 