### PR TITLE
Pepperoni, Meatball and Mushroom Pizza Fix

### DIFF
--- a/code/modules/food_and_drink/ingredients.dm
+++ b/code/modules/food_and_drink/ingredients.dm
@@ -645,22 +645,7 @@
 	var/toppingstext = null
 
 	attackby(obj/item/W, mob/user)
-		if (istype(W,/obj/item/reagent_containers/food/snacks/mushroom))
-			var/pizzam = new /obj/item/reagent_containers/food/snacks/ingredient/pizzam
-			user.put_in_hand_or_drop(pizzam)
-			qdel (W)
-			qdel (src)
-		else if (istype(W,/obj/item/reagent_containers/food/snacks/meatball))
-			var/pizzab = new /obj/item/reagent_containers/food/snacks/ingredient/pizzab
-			user.put_in_hand_or_drop(pizzab)
-			qdel (W)
-			qdel (src)
-		else if (istype(W,/obj/item/reagent_containers/food/snacks/ingredient/pepperoni))
-			var/pizzap = new /obj/item/reagent_containers/food/snacks/ingredient/pizzap
-			user.put_in_hand_or_drop(pizzap)
-			qdel (W)
-			qdel (src)
-		else if (istype(W, /obj/item/reagent_containers/food/snacks/))
+		if (istype(W, /obj/item/reagent_containers/food/snacks/))
 			var/obj/item/reagent_containers/food/snacks/F = W
 			if(!F.custom_food)
 				return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Pepperoni, Meatball and Mushroom would overwrite the pizza they were added to into a different object that only contained that topping and prevented you from adding any others, this has been fixed.
This fix does **NOT** affect the pizzas created by the pizza vendor in any way.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It's nice to add more topping variety to pizzas, and it's also annoying to try to make a pizza with lots of toppings and lose them because you added one of these 3 toppings.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)CrystalClover
(+)Fixed custom pizzas so that Pepperoni, Meatball and Mushroom can be added alongside other toppings
```
