### PR TITLE
Fix wiring in donut3 medical director's office

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -5676,6 +5676,11 @@
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet{
 	icon_state = "fblue3"
 	},


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
[MAPPING][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds missing wire to donut3's Medical Director's office

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
station rooms should be powered by default