### PR TITLE
Moves The Armouries' Stinger Grenade Boxes To The Special Grenades Crates

### DIFF
--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -85,6 +85,7 @@
 			name = "special grenades crate"
 			spawn_contents = list(/obj/item/storage/box/QM_grenadekit_security = 2,\
 			/obj/item/storage/box/QM_grenadekit_experimentalweapons,\
+			/obj/item/storage/box/stinger_kit,\
 			/obj/item/storage/box/stun_landmines)
 
 	sarin_grenades

--- a/maps/atlas.dmm
+++ b/maps/atlas.dmm
@@ -2154,7 +2154,6 @@
 /obj/item/device/radio/electropack,
 /obj/item/device/radio/signaler,
 /obj/item/device/radio/signaler,
-/obj/item/storage/box/stinger_kit,
 /obj/item/chem_grenade/flashbang,
 /obj/item/storage/box/revimp_kit,
 /obj/item/chem_grenade/pepper,

--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -52934,10 +52934,6 @@
 	},
 /obj/table/auto,
 /obj/machinery/recharger,
-/obj/item/storage/box/stinger_kit{
-	pixel_x = -6;
-	pixel_y = 8
-	},
 /obj/item/reagent_containers/food/snacks/donut/custom/frosted{
 	pixel_x = 7;
 	pixel_y = -6

--- a/maps/cogmap2.dmm
+++ b/maps/cogmap2.dmm
@@ -38155,7 +38155,6 @@
 /obj/table/reinforced/auto,
 /obj/item/chem_grenade/flashbang,
 /obj/item/chem_grenade/flashbang,
-/obj/item/storage/box/stinger_kit,
 /obj/item/storage/box/revimp_kit{
 	pixel_x = 5
 	},

--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -4504,8 +4504,8 @@
 /area/station/hallway/primary/central)
 "asc" = (
 /turf/unsimulated/floor/carpet/blue{
-	icon_state = "blue2";
-	dir = 8
+	dir = 8;
+	icon_state = "blue2"
 	},
 /area/station/hallway/secondary/oshan_arrivals{
 	name = "Destiny Arrivals"
@@ -4664,8 +4664,8 @@
 	},
 /obj/machinery/power/apc/autoname_north,
 /turf/unsimulated/floor/carpet/blue{
-	icon_state = "blue4";
-	dir = 4
+	dir = 4;
+	icon_state = "blue4"
 	},
 /area/station/hallway/secondary/oshan_arrivals{
 	name = "Destiny Arrivals"
@@ -7818,8 +7818,8 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4;
-	name = "Medbay";
-	id = "medbay_door"
+	id = "medbay_door";
+	name = "Medbay"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
@@ -11640,8 +11640,8 @@
 	pixel_x = -13
 	},
 /turf/unsimulated/floor/carpet/blue{
-	icon_state = "blue2";
-	dir = 10
+	dir = 10;
+	icon_state = "blue2"
 	},
 /area/station/hallway/secondary/oshan_arrivals{
 	name = "Destiny Arrivals"
@@ -13023,8 +13023,8 @@
 	name = "Station Intercom"
 	},
 /turf/unsimulated/floor/carpet/blue{
-	icon_state = "blue2";
-	dir = 9
+	dir = 9;
+	icon_state = "blue2"
 	},
 /area/station/hallway/secondary/oshan_arrivals{
 	name = "Destiny Arrivals"
@@ -18442,8 +18442,8 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/botany{
 	dir = 8;
-	name = "Cloning";
-	id = "Cloning"
+	id = "Cloning";
+	name = "Cloning"
 	},
 /turf/simulated/floor/bluewhite{
 	dir = 1
@@ -19300,8 +19300,8 @@
 /area/station/security/equipment)
 "cUy" = (
 /turf/unsimulated/floor/carpet/blue{
-	icon_state = "blue2";
-	dir = 4
+	dir = 4;
+	icon_state = "blue2"
 	},
 /area/station/hallway/secondary/oshan_arrivals{
 	name = "Destiny Arrivals"
@@ -20230,9 +20230,9 @@
 "dnb" = (
 /obj/machinery/computer/security/wooden_tv{
 	desc = "These channels seem to mostly be about robuddies. What is this, some kind of reality show?";
+	dir = 1;
 	name = "Television";
-	network = "Zeta";
-	dir = 1
+	network = "Zeta"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -22410,8 +22410,8 @@
 /area/station/crew_quarters/lounge/starboard)
 "eql" = (
 /turf/unsimulated/floor/carpet/blue{
-	icon_state = "blue2";
-	dir = 6
+	dir = 6;
+	icon_state = "blue2"
 	},
 /area/station/hallway/secondary/oshan_arrivals{
 	name = "Destiny Arrivals"
@@ -30586,8 +30586,8 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/door/airlock/pyro/glass/med{
-	name = "Medbay";
-	id = "hallway_door"
+	id = "hallway_door";
+	name = "Medbay"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
@@ -36972,9 +36972,9 @@
 /area/station/security/hos)
 "lIU" = (
 /obj/machinery/door/unpowered/wood/stall{
+	dir = 4;
 	lock_dir = 2;
-	name = "changing room door";
-	dir = 4
+	name = "changing room door"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/showers)
@@ -37435,7 +37435,6 @@
 /area/station/science/chemistry)
 "lSZ" = (
 /obj/rack,
-/obj/item/storage/box/stinger_kit,
 /obj/item/chem_grenade/flashbang,
 /obj/item/chem_grenade/pepper,
 /obj/item/chem_grenade/pepper,
@@ -42053,8 +42052,8 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/airlock/pyro/glass{
-	name = "Psychiatrist's Office";
-	id = "hallway_door"
+	id = "hallway_door";
+	name = "Psychiatrist's Office"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
@@ -42309,8 +42308,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/south,
 /turf/simulated/floor/stairs{
-	icon_state = "wood_stairs";
-	dir = 4
+	dir = 4;
+	icon_state = "wood_stairs"
 	},
 /area/station/crew_quarters/sauna)
 "ouE" = (
@@ -44056,8 +44055,8 @@
 	},
 /obj/machinery/door/airlock/pyro/medical/alt2{
 	dir = 4;
-	name = "Medbay";
-	id = "hallway_door"
+	id = "hallway_door";
+	name = "Medbay"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
@@ -44534,8 +44533,8 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /turf/unsimulated/floor/carpet/blue{
-	icon_state = "blue2";
-	dir = 5
+	dir = 5;
+	icon_state = "blue2"
 	},
 /area/station/hallway/secondary/oshan_arrivals{
 	name = "Destiny Arrivals"
@@ -46232,8 +46231,8 @@
 	},
 /obj/machinery/door/airlock/pyro/medical/alt2{
 	dir = 4;
-	name = "Medbay";
-	id = "hallway_door"
+	id = "hallway_door";
+	name = "Medbay"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
@@ -52638,8 +52637,8 @@
 	},
 /obj/machinery/door/airlock/pyro/glass/med{
 	dir = 4;
-	name = "Medbay";
-	id = "medbay_door"
+	id = "medbay_door";
+	name = "Medbay"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
@@ -53143,8 +53142,8 @@
 "uiW" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/door/airlock/pyro/glass/med{
-	name = "Medbay";
-	id = "hallway_door"
+	id = "hallway_door";
+	name = "Medbay"
 	},
 /obj/firedoor_spawn,
 /obj/access_spawn/medical,
@@ -54220,8 +54219,8 @@
 "uIi" = (
 /obj/landmark/start/latejoin,
 /turf/unsimulated/floor/carpet/blue{
-	icon_state = "blue2";
-	dir = 1
+	dir = 1;
+	icon_state = "blue2"
 	},
 /area/station/hallway/secondary/oshan_arrivals{
 	name = "Destiny Arrivals"
@@ -57966,8 +57965,8 @@
 /area/station/maintenance/southwest)
 "wAa" = (
 /turf/unsimulated/floor/carpet/blue{
-	icon_state = "blue2";
-	dir = 1
+	dir = 1;
+	icon_state = "blue2"
 	},
 /area/station/hallway/secondary/oshan_arrivals{
 	name = "Destiny Arrivals"

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -4277,8 +4277,8 @@
 /area/station/hangar/main)
 "apu" = (
 /obj/decal/poster/wallsign/space{
-	pixel_y = 2;
-	pixel_x = 33
+	pixel_x = 33;
+	pixel_y = 2
 	},
 /turf/simulated/floor/stairs,
 /area/station/hangar/main)
@@ -6485,11 +6485,11 @@
 	pixel_y = 4
 	},
 /obj/machinery/light_switch{
+	dir = 8;
 	name = "W light switch";
 	on = 0;
 	pixel_x = -22;
-	pixel_y = -4;
-	dir = 8
+	pixel_y = -4
 	},
 /obj/machinery/optable{
 	name = "Autopsy Table"
@@ -6768,9 +6768,9 @@
 	rand_pos = 0
 	},
 /obj/item/device/light/candle{
+	pixel_x = 6;
 	pixel_y = 10;
-	rand_pos = 0;
-	pixel_x = 6
+	rand_pos = 0
 	},
 /obj/item/device/light/candle/small{
 	pixel_x = -12;
@@ -6799,8 +6799,8 @@
 	pixel_y = 10
 	},
 /obj/item/device/light/candle/small{
-	pixel_y = -6;
 	pixel_x = 9;
+	pixel_y = -6;
 	rand_pos = 0
 	},
 /obj/item/device/radio/intercom,
@@ -6827,8 +6827,8 @@
 	pixel_x = -24
 	},
 /obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_y = 12;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 12
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass/wine{
 	pixel_x = 1;
@@ -7415,8 +7415,8 @@
 "azq" = (
 /obj/stool/chair/comfy,
 /obj/blind_switch/area/north{
-	pixel_y = 26;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 26
 	},
 /obj/landmark/start{
 	name = "Chaplain"
@@ -7664,12 +7664,12 @@
 "aAf" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/drinks/fruitmilk{
-	pixel_y = 13;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 13
 	},
 /obj/item/clothing/head/fruithat{
-	pixel_y = 2;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 2
 	},
 /obj/item/reagent_containers/food/snacks/plant/lemon/wedge,
 /turf/simulated/floor/orangeblack/side,
@@ -7703,8 +7703,8 @@
 /obj/machinery/light/incandescent,
 /obj/rack,
 /obj/item/storage/belt/utility{
-	pixel_y = 3;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 3
 	},
 /obj/item/storage/belt/utility,
 /obj/item/device/light/flashlight,
@@ -7714,8 +7714,8 @@
 /obj/rack,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility{
-	pixel_y = 3;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 3
 	},
 /obj/item/device/light/flashlight,
 /obj/machinery/light/emergency{
@@ -8497,13 +8497,13 @@
 	},
 /obj/table/wood/auto,
 /obj/item/device/light/candle{
+	pixel_x = 8;
 	pixel_y = 18;
-	rand_pos = 0;
-	pixel_x = 8
+	rand_pos = 0
 	},
 /obj/item/device/light/candle/small{
-	pixel_y = 3;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = 3
 	},
 /obj/item/device/light/candle/small{
 	pixel_x = -1;
@@ -8593,8 +8593,8 @@
 	icon_state = "line2"
 	},
 /obj/decoration/bookcase{
-	pixel_y = 27;
-	pixel_x = 1
+	pixel_x = 1;
+	pixel_y = 27
 	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/office)
@@ -8607,8 +8607,8 @@
 	icon_state = "line1"
 	},
 /obj/decoration/bookcase{
-	pixel_y = 27;
-	pixel_x = 1
+	pixel_x = 1;
+	pixel_y = 27
 	},
 /turf/simulated/floor/wood/two,
 /area/station/chapel/office)
@@ -8737,12 +8737,12 @@
 	},
 /obj/table/glass/auto,
 /obj/item/paper_bin{
-	pixel_y = -2;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = -2
 	},
 /obj/item/paper{
-	pixel_y = -3;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = -3
 	},
 /obj/item/paper{
 	pixel_y = 6
@@ -8753,8 +8753,8 @@
 	pixel_y = 2
 	},
 /obj/item/paper{
-	pixel_y = -3;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = -3
 	},
 /turf/simulated/floor/neutral/corner{
 	dir = 1
@@ -9267,8 +9267,8 @@
 /area/station/maintenance/inner/central)
 "aFb" = (
 /obj/landmark/spawner{
-	name = "monkeyspawn_mrsmuggles";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_mrsmuggles"
 	},
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
@@ -9336,16 +9336,16 @@
 /obj/table/wood/auto,
 /obj/machinery/light/incandescent,
 /obj/item/decoration/incenseholder{
-	pixel_y = 9;
-	pixel_x = 13
+	pixel_x = 13;
+	pixel_y = 9
 	},
 /obj/item/device/light/candle/small{
 	pixel_x = -1;
 	pixel_y = -1
 	},
 /obj/item/device/light/candle/small{
-	pixel_y = 6;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 6
 	},
 /turf/simulated/floor/carpet{
 	dir = 2;
@@ -9789,8 +9789,8 @@
 /obj/table/wood/auto,
 /obj/machinery/light/incandescent,
 /obj/item/card_box/tarot{
-	pixel_y = 5;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 5
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -11731,12 +11731,12 @@
 /obj/table/reinforced/bar/auto,
 /obj/machinery/glass_recycler{
 	density = 1;
-	pixel_y = -2;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -2
 	},
 /obj/channel{
-	required_to_pass = 210;
-	dir = 1
+	dir = 1;
+	required_to_pass = 210
 	},
 /obj/pool/perspective,
 /turf/simulated/floor/wood{
@@ -11747,17 +11747,17 @@
 /obj/pool/perspective,
 /obj/table/reinforced/bar/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass/random_style/filled/sane{
-	pixel_y = 9;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 9
 	},
 /obj/item/reagent_containers/food/drinks/coconut{
-	pixel_y = 1;
 	pixel_x = 7;
+	pixel_y = 1;
 	rand_pos = 1
 	},
 /obj/channel{
-	required_to_pass = 210;
-	dir = 1
+	dir = 1;
+	required_to_pass = 210
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -11767,12 +11767,12 @@
 /obj/pool/perspective,
 /obj/table/reinforced/bar/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass/random_style/filled/sane{
-	pixel_y = 9;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 9
 	},
 /obj/item/cocktail_stuff/drink_umbrella{
-	pixel_y = 17;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 17
 	},
 /obj/item/decoration/ashtray{
 	pixel_x = 4;
@@ -11783,8 +11783,8 @@
 	pixel_y = 2
 	},
 /obj/channel{
-	required_to_pass = 210;
-	dir = 1
+	dir = 1;
+	required_to_pass = 210
 	},
 /turf/simulated/floor/wood{
 	icon_state = "0,6"
@@ -12461,9 +12461,9 @@
 /area/station/hallway/primary/west)
 "aOE" = (
 /obj/submachine/ice_cream_dispenser{
-	name = "Frozen Margarita Machine";
+	desc = "A machine designed to dispense frozen margaritas.";
 	flavors = list("chocolate","vanilla","margarita");
-	desc = "A machine designed to dispense frozen margaritas."
+	name = "Frozen Margarita Machine"
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/wood{
@@ -13495,8 +13495,8 @@
 	},
 /obj/table/regal/auto,
 /obj/candle_light{
-	pixel_y = 13;
-	pixel_x = 2
+	pixel_x = 2;
+	pixel_y = 13
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 1
@@ -13673,12 +13673,12 @@
 	},
 /obj/item/clothing/mask/cigarette/cigar,
 /obj/item/clothing/mask/cigarette/cigar{
-	pixel_y = -3;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -3
 	},
 /obj/item/device/light/zippo{
-	pixel_y = 8;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 8
 	},
 /obj/table/regal/auto,
 /turf/simulated/floor/wood,
@@ -18710,8 +18710,8 @@
 	pixel_y = 3
 	},
 /obj/item/extinguisher{
-	pixel_y = 8;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 8
 	},
 /turf/simulated/floor/black,
 /area/station/security/hos)
@@ -18978,8 +18978,8 @@
 	icon_state = "bedsheet-red"
 	},
 /obj/item/toy/plush/small/buddy{
-	name = "Nuke Commander Buddy Plush Toy";
-	desc = "Aw, it even has the same angry face too..."
+	desc = "Aw, it even has the same angry face too...";
+	name = "Nuke Commander Buddy Plush Toy"
 	},
 /turf/simulated/floor/carpet{
 	dir = 2;
@@ -19233,7 +19233,6 @@
 "bjI" = (
 /obj/storage/secure/crate/gear/armory/grenades,
 /obj/item/storage/box/stun_landmines,
-/obj/item/storage/box/stinger_kit,
 /turf/simulated/floor/black,
 /area/station/ai_monitored/armory)
 "bjJ" = (
@@ -27202,8 +27201,8 @@
 /area/station/engine/ptl)
 "cwg" = (
 /obj/item/canned_laughter/crushed{
-	pixel_y = -2;
-	pixel_x = -17
+	pixel_x = -17;
+	pixel_y = -2
 	},
 /obj/decal/cleanable/generic,
 /turf/simulated/floor,
@@ -27309,8 +27308,8 @@
 /area/station/quartermaster/refinery)
 "cDS" = (
 /obj/machinery/r_door_control/podbay/security{
-	pixel_x = 24;
-	name = "Security Hangar Door Control"
+	name = "Security Hangar Door Control";
+	pixel_x = 24
 	},
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/sec)
@@ -27405,8 +27404,8 @@
 	pixel_y = 12
 	},
 /obj/machinery/phone{
-	pixel_y = 4;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
@@ -27800,8 +27799,8 @@
 	id = "outpostla"
 	},
 /obj/decal/poster/wallsign/stencil/right/q{
-	pixel_y = 39;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 39
 	},
 /obj/decal/poster/wallsign/stencil/right/m{
 	pixel_y = 39
@@ -28068,8 +28067,8 @@
 	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/croissant{
-	pixel_y = -4;
 	pixel_x = 6;
+	pixel_y = -4;
 	rand_pos = 0
 	},
 /obj/machinery/camera{
@@ -28467,9 +28466,9 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
+	pixel_x = 32;
 	pixel_y = 64;
-	text = "NF";
-	pixel_x = 32
+	text = "NF"
 	},
 /obj/landmark/start{
 	name = "Staff Assistant"
@@ -28914,8 +28913,8 @@
 	icon_state = "4-8"
 	},
 /obj/landmark{
-	name = "kudzustart";
-	icon_state = "kudzu-start"
+	icon_state = "kudzu-start";
+	name = "kudzustart"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -29427,8 +29426,8 @@
 "eJS" = (
 /obj/machinery/power/smes{
 	charge = 5e+006;
-	output = 10000;
-	chargelevel = 100000
+	chargelevel = 100000;
+	output = 10000
 	},
 /obj/cable,
 /turf/simulated/floor/engine,
@@ -29790,16 +29789,16 @@
 "eWm" = (
 /obj/table/reinforced/auto,
 /obj/item/storage/box/glassbox{
-	pixel_y = 11;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 11
 	},
 /obj/item/storage/box/glassbox{
-	pixel_y = -2;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = -2
 	},
 /obj/item/storage/box/syringes{
-	pixel_y = 12;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 12
 	},
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment{
@@ -30060,23 +30059,23 @@
 	},
 /obj/table/reinforced/bar/auto,
 /obj/item/reagent_containers/food/drinks/bottle/bojackson{
-	pixel_y = 19;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 19
 	},
 /obj/item/reagent_containers/food/drinks/bottle/champagne{
 	pixel_y = 19
 	},
 /obj/item/reagent_containers/food/drinks/bottle/hobo_wine{
-	pixel_y = 19;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 19
 	},
 /obj/item/reagent_containers/food/drinks/bottle/tequila{
 	pixel_x = 10;
 	pixel_y = 12
 	},
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
-	pixel_y = 15;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 15
 	},
 /obj/item/reagent_containers/food/drinks/curacao{
 	pixel_x = -9;
@@ -31257,8 +31256,8 @@
 /obj/table/auto,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/sponge{
-	pixel_y = 12;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 12
 	},
 /turf/simulated/floor,
 /area/station/crew_quarters/locker)
@@ -31332,19 +31331,19 @@
 "gye" = (
 /obj/table/auto,
 /obj/item/device/light/glowstick{
-	pixel_y = 6;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 6
 	},
 /obj/item/device/light/glowstick{
 	pixel_y = 6
 	},
 /obj/item/device/light/glowstick{
-	pixel_y = 6;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 6
 	},
 /obj/item/device/light/glowstick{
-	pixel_y = 6;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 6
 	},
 /obj/item/device/light/flashlight,
 /turf/simulated/floor/blueblack{
@@ -31681,8 +31680,8 @@
 /area/station/hallway/primary/north)
 "gQw" = (
 /obj/critter/boogiebot{
-	name = "Illegal Boogie Bot";
-	desc = "Sealed away for our safety."
+	desc = "Sealed away for our safety.";
+	name = "Illegal Boogie Bot"
 	},
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/head/flatcap,
@@ -32520,8 +32519,8 @@
 /area/station/medical/medbay)
 "hHT" = (
 /obj/landmark/spawner{
-	name = "monkeyspawn_tanhony";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_tanhony"
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
@@ -32934,9 +32933,9 @@
 	pixel_y = 4
 	},
 /obj/item/clothing/head/NTberet{
-	pixel_y = -1;
+	desc = "This one smells like medbay, eugh.";
 	pixel_x = 6;
-	desc = "This one smells like medbay, eugh."
+	pixel_y = -1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
@@ -33165,8 +33164,8 @@
 	pixel_y = -24
 	},
 /obj/landmark{
-	name = "blobstart";
-	icon_state = "blob-start"
+	icon_state = "blob-start";
+	name = "blobstart"
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/toilets)
@@ -33562,8 +33561,8 @@
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/glass/bottle/holywater{
-	pixel_y = 4;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 10;
@@ -33962,8 +33961,8 @@
 "jhs" = (
 /obj/table/auto,
 /obj/item/reagent_containers/glass/bottle/holywater{
-	pixel_y = 8;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 8
 	},
 /obj/item/clothing/suit/cultist/nerd,
 /obj/item/clothing/mask/gas/plague,
@@ -34306,8 +34305,8 @@
 "jyc" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/snacks/popcorn{
-	pixel_y = 2;
-	pixel_x = 26
+	pixel_x = 26;
+	pixel_y = 2
 	},
 /obj/item/camera,
 /turf/simulated/floor,
@@ -34740,8 +34739,8 @@
 /area/station/chapel/sanctuary)
 "jYR" = (
 /obj/landmark{
-	name = "blobstart";
-	icon_state = "blob-start"
+	icon_state = "blob-start";
+	name = "blobstart"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
@@ -34966,8 +34965,8 @@
 "kjH" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4;
-	name = "Cloning Foyer";
-	id = "cloning_exit"
+	id = "cloning_exit";
+	name = "Cloning Foyer"
 	},
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
@@ -34988,8 +34987,8 @@
 /area/station/science/bot_storage)
 "kkq" = (
 /obj/landmark/spawner{
-	name = "monkeyspawn_stirstir";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_stirstir"
 	},
 /turf/simulated/floor/grime,
 /area/station/security/brig)
@@ -35582,8 +35581,8 @@
 	name = "AI-Sat"
 	},
 /obj/landmark/start{
-	name = "AI";
-	icon_state = "ai-start"
+	icon_state = "ai-start";
+	name = "AI"
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
@@ -36012,12 +36011,12 @@
 	pixel_y = -2
 	},
 /obj/item/storage/box/plates{
-	pixel_y = 11;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 11
 	},
 /obj/item/storage/box/plates{
-	pixel_y = -2;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -2
 	},
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -36180,8 +36179,8 @@
 	pixel_y = 30
 	},
 /obj/item/clothing/mask/cigarette/propuffs{
-	pixel_y = -6;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = -6
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
@@ -36512,8 +36511,8 @@
 /area/station/quartermaster/office)
 "lLB" = (
 /obj/landmark{
-	name = "kudzustart";
-	icon_state = "kudzu-start"
+	icon_state = "kudzu-start";
+	name = "kudzustart"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -36841,8 +36840,8 @@
 /area/station/hydroponics/bay)
 "mgZ" = (
 /obj/landmark{
-	name = "blobstart";
-	icon_state = "blob-start"
+	icon_state = "blob-start";
+	name = "blobstart"
 	},
 /turf/simulated/floor,
 /area/station/storage/tools)
@@ -37053,8 +37052,8 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/networked/telepad,
 /obj/landmark/spawner{
-	name = "monkeyspawn_albert";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_albert"
 	},
 /turf/simulated/floor/engine,
 /area/station/science/teleporter)
@@ -37327,8 +37326,8 @@
 	pixel_y = -2
 	},
 /obj/machinery/phone{
-	pixel_y = 7;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 7
 	},
 /obj/random_item_spawner/desk_stuff/few,
 /turf/simulated/floor/black/corner{
@@ -37746,10 +37745,10 @@
 /area/station/crew_quarters/market)
 "mVH" = (
 /obj/machinery/door_control{
+	desc = "A remote control switch for a door. This one looks like it operates the QM mass driver to ship objects to QM.";
 	id = "outpostla";
 	name = "Manual Ejection Button";
-	pixel_y = 24;
-	desc = "A remote control switch for a door. This one looks like it operates the QM mass driver to ship objects to QM."
+	pixel_y = 24
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
@@ -38134,18 +38133,18 @@
 "npw" = (
 /obj/item/device/light/candle/small{
 	pixel_x = -4;
-	rand_pos = 0;
-	pixel_y = 7
+	pixel_y = 7;
+	rand_pos = 0
 	},
 /obj/item/device/light/candle{
-	rand_pos = 0;
 	pixel_x = 4;
-	pixel_y = 11
+	pixel_y = 11;
+	rand_pos = 0
 	},
 /obj/table/wood/auto,
 /obj/item/matchbook{
-	pixel_y = -3;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -3
 	},
 /obj/decal/tile_edge/line/black{
 	dir = 6;
@@ -38428,8 +38427,8 @@
 /area/station/crew_quarters/arcade)
 "nDp" = (
 /obj/landmark/spawner{
-	name = "monkeyspawn_normal";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_normal"
 	},
 /turf/simulated/floor/grass{
 	name = "astroturf"
@@ -38558,8 +38557,8 @@
 "nKo" = (
 /obj/table/auto,
 /obj/item/clothing/under/rank{
-	pixel_y = -1;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = -1
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/sanitary/white,
@@ -38896,8 +38895,8 @@
 	pixel_y = 4
 	},
 /obj/item/storage/wall/medical{
-	pixel_y = 2;
-	pixel_x = -28
+	pixel_x = -28;
+	pixel_y = 2
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
@@ -38908,8 +38907,8 @@
 /area/station/crew_quarters/market)
 "oev" = (
 /obj/landmark{
-	name = "kudzustart";
-	icon_state = "kudzu-start"
+	icon_state = "kudzu-start";
+	name = "kudzustart"
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
@@ -39058,8 +39057,8 @@
 "omH" = (
 /obj/table/auto,
 /obj/decoration/decorativeplant/plant3{
-	pixel_y = 10;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 10
 	},
 /obj/item/kitchen/food_box/lollipop{
 	pixel_x = -6
@@ -39224,8 +39223,8 @@
 "otj" = (
 /obj/stool/chair/comfy/shuttle,
 /obj/landmark{
-	name = "JoinLate";
-	icon_state = "latejoin"
+	icon_state = "latejoin";
+	name = "JoinLate"
 	},
 /turf/unsimulated/floor{
 	desc = "";
@@ -39248,8 +39247,8 @@
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/food/drinks/fruitmilk{
-	pixel_y = 13;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 13
 	},
 /obj/random_item_spawner/tableware/three,
 /obj/machinery/light/small/floor,
@@ -39280,8 +39279,8 @@
 /area/station/crew_quarters/kitchen)
 "ouI" = (
 /obj/machinery/chem_dispenser/alcohol{
-	dispensable_reagents = list("margarita");
 	desc = "You see a small, fading warning label on the side of the machine:<br>WARNING: Exclusive property of Margaritaville.";
+	dispensable_reagents = list("margarita");
 	name = "Margaritaville Margarita Dispenser"
 	},
 /obj/machinery/camera{
@@ -39567,8 +39566,8 @@
 "oKv" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass/random_style/filled/sane{
-	pixel_y = 9;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 9
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
@@ -39857,8 +39856,8 @@
 	pixel_y = 29
 	},
 /obj/landmark/spawner{
-	name = "monkeyspawn_normal";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_normal"
 	},
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
@@ -40485,8 +40484,8 @@
 "pCR" = (
 /obj/stool/bar,
 /obj/landmark/spawner{
-	name = "monkeyspawn_mrmuggles";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_mrmuggles"
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -40633,8 +40632,8 @@
 /obj/machinery/door/airlock/pyro/glass,
 /obj/access_spawn/research,
 /obj/decal/poster/wallsign/space{
-	pixel_y = 2;
-	pixel_x = 33
+	pixel_x = 33;
+	pixel_y = 2
 	},
 /turf/simulated/floor/plating,
 /area/station/science/lobby)
@@ -40809,8 +40808,8 @@
 /area/station/crew_quarters/quarters)
 "pWv" = (
 /obj/landmark{
-	name = "blobstart";
-	icon_state = "blob-start"
+	icon_state = "blob-start";
+	name = "blobstart"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
@@ -41189,8 +41188,8 @@
 "qql" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass/flute{
-	pixel_y = 16;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 16
 	},
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
@@ -42109,8 +42108,8 @@
 	pixel_y = 5
 	},
 /obj/item/device/radio{
-	pixel_y = 3;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 3
 	},
 /turf/simulated/floor/orangeblack/side{
 	dir = 6
@@ -42170,8 +42169,8 @@
 /area/station/hallway/primary/south)
 "rnP" = (
 /obj/landmark/spawner{
-	name = "monkeyspawn_normal";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_normal"
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/grass{
@@ -42243,20 +42242,20 @@
 	pixel_y = 12
 	},
 /obj/item/card_box{
-	pixel_y = 4;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 4
 	},
 /obj/item/reagent_containers/food/drinks/bottle/fancy_beer{
-	pixel_y = 3;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 3
 	},
 /obj/item/pen{
 	pixel_x = 9;
 	pixel_y = -11
 	},
 /obj/item/wrapping_paper{
-	pixel_y = -17;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -17
 	},
 /turf/simulated/floor/black/side{
 	dir = 8
@@ -42628,8 +42627,8 @@
 	pixel_y = 16
 	},
 /obj/item/reagent_containers/food/drinks/tea{
-	pixel_y = 9;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 9
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 5
@@ -43120,8 +43119,8 @@
 	icon_state = "4-8"
 	},
 /obj/decal/poster/wallsign/poster_beach{
-	pixel_y = 35;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 35
 	},
 /obj/decal/poster/wallsign/poster_clown{
 	pixel_x = -4;
@@ -44495,8 +44494,8 @@
 "tuF" = (
 /obj/table/regal/auto,
 /obj/item/clothing/head/that{
-	pixel_y = 4;
-	pixel_x = 2
+	pixel_x = 2;
+	pixel_y = 4
 	},
 /turf/simulated/floor/carpet{
 	dir = 4;
@@ -44657,8 +44656,8 @@
 	icon_state = "1-8"
 	},
 /obj/landmark/spawner{
-	name = "monkeyspawn_rathen";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_rathen"
 	},
 /turf/simulated/floor,
 /area/station/engine/inner)
@@ -45122,8 +45121,8 @@
 	icon_state = "1-4"
 	},
 /obj/landmark{
-	name = "blobstart";
-	icon_state = "blob-start"
+	icon_state = "blob-start";
+	name = "blobstart"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/north)
@@ -45335,8 +45334,8 @@
 /area/station/crew_quarters/catering)
 "umY" = (
 /obj/landmark{
-	name = "Observer-Start";
-	icon_state = "generic-spawn"
+	icon_state = "generic-spawn";
+	name = "Observer-Start"
 	},
 /turf/unsimulated/floor{
 	desc = "";
@@ -45363,8 +45362,8 @@
 	dir = 4
 	},
 /obj/landmark{
-	name = "kudzustart";
-	icon_state = "kudzu-start"
+	icon_state = "kudzu-start";
+	name = "kudzustart"
 	},
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -45557,8 +45556,8 @@
 /area/station/maintenance/southwest)
 "uyr" = (
 /obj/landmark/spawner{
-	name = "monkeyspawn_normal";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_normal"
 	},
 /obj/disposalpipe/segment{
 	dir = 1;
@@ -45584,8 +45583,8 @@
 /area/station/engine/ptl)
 "uAd" = (
 /obj/landmark/spawner{
-	name = "monkeyspawn_normal";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_normal"
 	},
 /turf/simulated/floor/grass/random,
 /area/station/medical/dome)
@@ -45943,8 +45942,8 @@
 /area/station/chapel/sanctuary)
 "uRa" = (
 /obj/landmark/spawner{
-	name = "monkeyspawn_horse";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_horse"
 	},
 /turf/simulated/floor,
 /area/station/maintenance/north)
@@ -45980,8 +45979,8 @@
 	},
 /obj/item/decoration/incenseholder{
 	dir = 8;
-	pixel_y = 7;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 7
 	},
 /obj/item/device/light/candle{
 	pixel_x = 9;
@@ -46646,8 +46645,8 @@
 /area/station/science/lobby)
 "vEn" = (
 /obj/landmark/spawner{
-	name = "monkeyspawn_krimpus";
-	icon_state = "chimp-start"
+	icon_state = "chimp-start";
+	name = "monkeyspawn_krimpus"
 	},
 /turf/simulated/floor/grass,
 /area/station/hydroponics/bay)
@@ -47469,8 +47468,8 @@
 /area/station/mining/staff_room)
 "wzX" = (
 /obj/landmark{
-	name = "blobstart";
-	icon_state = "blob-start"
+	icon_state = "blob-start";
+	name = "blobstart"
 	},
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -48037,9 +48036,9 @@
 /area/station/maintenance/inner/central)
 "xce" = (
 /obj/item/bell/hop{
-	pixel_y = 24;
+	anchored = 1;
 	name = "wall mounted service bell";
-	anchored = 1
+	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/courtroom)
@@ -48145,9 +48144,9 @@
 /area/station/storage/tools)
 "xjq" = (
 /obj/item/device/light/candle{
-	rand_pos = 0;
 	pixel_x = -13;
-	pixel_y = 8
+	pixel_y = 8;
+	rand_pos = 0
 	},
 /obj/item/device/light/candle/small{
 	pixel_x = 13;
@@ -48167,8 +48166,8 @@
 "xjP" = (
 /obj/table/wood/round/auto,
 /obj/item/reagent_containers/food/snacks/danish_cherry{
-	pixel_y = 8;
 	pixel_x = -20;
+	pixel_y = 8;
 	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/painauchocolat{
@@ -48185,8 +48184,8 @@
 	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/plant/peach{
-	pixel_y = 9;
 	pixel_x = -5;
+	pixel_y = 9;
 	rand_pos = 0
 	},
 /obj/item/reagent_containers/food/snacks/plant/blueberry{
@@ -48837,8 +48836,8 @@
 /area/station/medical/medbay)
 "xPd" = (
 /obj/landmark{
-	name = "blobstart";
-	icon_state = "blob-start"
+	icon_state = "blob-start";
+	name = "blobstart"
 	},
 /obj/cable{
 	icon_state = "1-2"
@@ -48961,9 +48960,9 @@
 /area/station/crew_quarters/bar)
 "xWQ" = (
 /obj/machinery/firealarm{
+	pixel_x = 32;
 	pixel_y = 64;
-	text = "NF";
-	pixel_x = 32
+	text = "NF"
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/bar)
@@ -49166,8 +49165,8 @@
 	},
 /obj/machinery/light/incandescent/cool{
 	dir = 4;
-	pixel_y = 1;
-	pixel_x = 12
+	pixel_x = 12;
+	pixel_y = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/northwest,
 /turf/simulated/floor/specialroom/freezer{

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -60540,7 +60540,6 @@
 	pixel_x = 20
 	},
 /obj/rack,
-/obj/item/storage/box/stinger_kit,
 /obj/item/chem_grenade/pepper,
 /obj/item/chem_grenade/pepper,
 /obj/item/chem_grenade/pepper,

--- a/maps/oshan.dmm
+++ b/maps/oshan.dmm
@@ -39923,9 +39923,6 @@
 /area/station/ai_monitored/armory)
 "bYq" = (
 /obj/rack,
-/obj/item/storage/box/stinger_kit{
-	pixel_x = 4
-	},
 /obj/item/storage/box/flashbang_kit,
 /obj/item/storage/box/flashbang_kit{
 	pixel_x = -4


### PR DESCRIPTION
[Game Objects] [Balance] [QoL]


## About the PR:
Removes all stinger grenade boxes from the various Armouries of the in-rotation maps, and adds a single box of stinger grenades to the special grenades crate.



## Why's this needed?
All Armouries should have a box of stinger grenades available; currently Donut3 and Clarion's Armouries do not, and if stingers are to be standard equipment, then it feels fitting for them to be in the special grenades crate.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)The Armoury's stinger grenades have been moved to the special grenades crate.
```
