### PR TITLE
Drop grab when entering prison

### DIFF
--- a/code/obj/artifacts/artifact_objects/prison.dm
+++ b/code/obj/artifacts/artifact_objects/prison.dm
@@ -32,6 +32,9 @@
 		if (prisoner)
 			return
 		if (isliving(user))
+			if (length(user.grabbed_by) > 0)
+				for (var/obj/item/grab/grab in user.grabbed_by)
+					grab.assailant.u_equip(grab)
 			O.visible_message("<span class='alert'><b>[O]</b> suddenly pulls [user.name] inside and slams shut!</span>")
 			if (src.living)
 				new /mob/living/object/artifact(O.loc, O, user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Upon entering a prison artifact anyone who is grabbing you will drop their grab


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10487