### PR TITLE
Captains now spawn with an emergency tank

### DIFF
--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -63,6 +63,7 @@
 	desc = "A fancy designer bag made out of space snake leather and encrusted with plastic expertly made to look like gold."
 	icon_state = "capbackpack"
 	item_state = "capbackpack"
+	spawn_contents = list(/obj/item/storage/box/starter/withO2)
 
 	blue
 		desc = "A fancy designer bag made out of rare blue space snake leather and encrusted with plastic expertly made to look like gold."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
[CLOTHING] [BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR guarantees that the captain will always spawn with an emergency oxygen tank in their internals box.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Literally every other head role spawns with them. A full set of internals is essential enough that the captain probably shouldn't have to scrounge for them as soon as a breach happens.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)RubberRats
(+)Captains now always spawn with an emergency oxygen tank in their bag.
```
