### PR TITLE
reverses artifact categories to be like they used to be

### DIFF
--- a/_std/compare.dm
+++ b/_std/compare.dm
@@ -46,7 +46,7 @@
 /proc/compareArtifactTypes(datum/artifact/A1, datum/artifact/A2)
 	if(A1.type_size == A2.type_size)
 		return sorttext(A2.type_name, A1.type_name)
-	return A1.type_size - A2.type_size
+	return A2.type_size - A1.type_size
 
 #ifdef CHEM_REACTION_PRIORITIES
 /proc/cmp_chemical_reaction_priotity(datum/chemical_reaction/a, datum/chemical_reaction/b)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
#10491 was fixed by 1b0632c9decd2f41433fba87fac04a879c2d1503, but the categories are now reversed from how they used to be.
This puts them back to how they used to be (Large > Medium > Small).

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People are probably already used to the existing order, and in my mind having the large ones first just makes more sense, because they are a lot more common, and I think it looks nice if the categories that are just a handful of artifacts are tacked on at the end.

Now:
![image](https://user-images.githubusercontent.com/35579460/187065766-05040e65-f4cf-4b1e-bcd9-bb714bf01670.png)

After change:
![image](https://user-images.githubusercontent.com/35579460/187065748-8e0a4d32-e614-412d-a349-ac39bbf9d699.png)

