### PR TITLE
Fixes shinai disarming redsaw

### DIFF
--- a/code/obj/item/kendo.dm
+++ b/code/obj/item/kendo.dm
@@ -155,6 +155,8 @@
 
 			if((attacker.a_intent=="disarm") && prob(20) && defender.equipped())
 				var/obj/item/I = defender.equipped()
+				if (I.cant_drop)
+					return
 				defender.u_equip(I)
 				I.set_loc(defender.loc)
 				var/target_turf = get_offset_target_turf(I.loc,rand(5)-rand(5),rand(5)-rand(5))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
[BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Disarming someone using a shinai while they have an attached redsaw made the saw visually vanish while still being attached. This fixes that.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad, check `cant_drop` please
