### PR TITLE
Fixes some hunter cloaking device bugs

### DIFF
--- a/code/obj/item/device/cloak_device.dm
+++ b/code/obj/item/device/cloak_device.dm
@@ -32,9 +32,10 @@
 			src.deactivate(user)
 		else
 			if (src.activate(user))
-				user.show_text("You can't have more than one active [src.name] on your person.", "red")
-			else
 				user.show_text("The [src.name] is now active.", "blue")
+			else
+				user.show_text("You can't have more than one active [src.name] on your person.", "red")
+
 
 	update_icon()
 		if (src.active)
@@ -97,6 +98,11 @@
 	emp_act()
 		if (src.active && ismob(src.loc))
 			src.deactivate(src.loc)
+
+	disposing()
+		if (src.active && ismob(src.loc))
+			src.deactivate(src.loc)
+		..()
 
 	limited
 		name = "limited-use cloaking device"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #10520 and also the fact that the message for trying to activate multiple cloakers at once was set up backwards somehow, causing successfully activating it to display the error message.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs bad
