### PR TITLE
people on BR now start with armory/HOS office access

### DIFF
--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -563,8 +563,7 @@ proc/equip_battler(mob/living/carbon/human/battler)
 	var/obj/item/card/id/captains_spare/I = new /obj/item/card/id/captains_spare // for whatever reason, this is neccessary
 	I.registered = "[battler.name]"
 	I.assignment = "Battler"
-	I.icon_state = "gold"
-	I.icon = 'icons/obj/items/card.dmi'
+	I.access |= access_maxsec
 	battler.equip_if_possible(I, battler.slot_wear_id)
 	//battler.Equip_Bank_Purchase(battler.mind.purchased_bank_item)
 	battler.set_clothing_icon_dirty()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [BUG][GAMEMODES][BALANCE] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
bug label because it fixes the fact that starting in HOS office is possible and often leads to being stuck until the rad storm ends you

gives all battlers on the BR gamemode maxsec access
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
prevents being stuck in HOS office by leaving the shuttle while its flying over it

if i read the code right armory and HOS office are fully valid safe areas too you dont have the time to break a door on BR often especially when rushing to a safe area during the 60 seconds prior to a storm

NOTE: if armory gear itself is an issue then it should be removed stealing 2 id cards of corpses/taking the RCD/hacking tools and insuls is not exactly something that will stop anyone who actually has even a bit of time
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(+)On the battle royale gamemode people will now start with armory/HOS office access.
```
