### PR TITLE
Fixes the previously inverted jetpack ability icon

### DIFF
--- a/code/WorkInProgress/AbilityItem.dm
+++ b/code/WorkInProgress/AbilityItem.dm
@@ -442,24 +442,24 @@
 
 /obj/ability_button/jetpack2_toggle
 	name = "Toggle jetpack MKII"
-	icon_state = "jet2on"
+	icon_state = "jetoff"
 
 	execute_ability()
 		var/obj/item/tank/jetpack/jetpackmk2/J = the_item
 		J.toggle()
-		if(J.on) icon_state = "jet2off"
-		else  icon_state = "jet2on"
+		if(J.on) icon_state = "jet2on"
+		else  icon_state = "jet2off"
 		..()
 
 /obj/ability_button/jetpack_toggle
 	name = "Toggle jetpack"
-	icon_state = "jeton"
+	icon_state = "jetoff"
 
 	execute_ability()
 		var/obj/item/tank/jetpack/J = the_item
 		J.toggle()
-		if(J.on) icon_state = "jetoff"
-		else  icon_state = "jeton"
+		if(J.on) icon_state = "jeton"
+		else  icon_state = "jetoff"
 		..()
 
 ////////////////////////////////////////////////////////////

--- a/code/datums/movement_controller/jetpack.dm
+++ b/code/datums/movement_controller/jetpack.dm
@@ -11,13 +11,13 @@
 
 /obj/ability_button/jetpack_toggle_kyle
 	name = "Toggle jetpack"
-	icon_state = "jeton"
+	icon_state = "jetoff"
 
 	execute_ability()
 		var/obj/item/tank/jetpack/kyle/J = the_item
 		J.toggle()
-		if(J.on) icon_state = "jetoff"
-		else  icon_state = "jeton"
+		if(J.on) icon_state = "jeton"
+		else  icon_state = "jetoff"
 
 		J.jetpack_controller = new/datum/movement_controller/jetpack(the_mob, J)
 		..()


### PR DESCRIPTION
<!-- [UI] [bugfix] [trivial] -->

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Changes a bad if statement in `/obj/ability_button/jetpack_toggle` so that jetpacks will now use the `jetoff` ability icon while off and the `jeton` ability graphic while on. Similar change for `/obj/ability_button/jetpack2_toggle` and `/obj/ability_button/jetpack_toggle_kyle`, whatever that is.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Finally got annoyed enough with explaining to new miners as they drift away from the magnet platform that the big red X over their jetpack icon actually means that its on that I made a PR to fix it. Turns out, the if statement that controls use of the on/off graphics was just backwards. Every other ability (to my knowledge) which toggles its icon based on its on/off state shows its current status on the icon (internals for example with the on/off text), so this brings jetpacks to that standard.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Cherman0
(+)Made jetpack ability icons properly reflect whether the jetpack is on or off.
```