### PR TITLE
Remove must_drop_loot flag from gunbot critters

### DIFF
--- a/code/WorkInProgress/Hydrothings.dm
+++ b/code/WorkInProgress/Hydrothings.dm
@@ -960,7 +960,6 @@ obj/critter/madnessowl/switchblade
 	current_projectile = new/datum/projectile/bullet/lmg
 	projectile_spread = 20
 	attack_cooldown = 35
-	must_drop_loot = 1
 	smashes_shit = 1
 
 	select_target(var/atom/newtarget)

--- a/code/obj/critter/drone.dm
+++ b/code/obj/critter/drone.dm
@@ -22,7 +22,6 @@
 	flying = 1
 	mats = list("POW-1" = 5, "MET-2" = 12, "CON-2" = 12, "DEN-1" = 6)
 	var/score = 10
-	var/must_drop_loot = 0
 	dead_state = "drone-dead"
 	var/obj/item/droploot = null
 	var/damaged = 0 // 1, 2, 3
@@ -224,12 +223,10 @@
 		dying = 1 // this was dying = 0. ha ha.
 		SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_DRONE_DEATH, src)
 		SPAWN(2 SECONDS)
-			if (must_drop_loot)
-				if (prob(25))
-					new /obj/item/device/prox_sensor(src.loc)
-
-				if(droploot)
-					new droploot(src.loc)
+			if (prob(25))
+				new /obj/item/device/prox_sensor(src.loc)
+			if(droploot)
+				new droploot(src.loc)
 			..()
 			return
 
@@ -866,7 +863,6 @@
 	bound_height = 96
 	bound_width = 96
 	score = 10000
-	must_drop_loot = 1
 	dead_state = "ydrone-dead"
 	droploot = /obj/item/device/key/iridium
 	alertsound1 = 'sound/machines/engine_alert2.ogg'


### PR DESCRIPTION
[BUG][MAJOR][OBJECTS]

<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This flag is no longer used and caused problems when it was not
properly removed with the rest of the Pod Colosseum.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Fixes #10528 

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Stonepillar
(*)Fixed syndicate drones not dropping their loot (including sharkdrones!)
```
