### PR TITLE
Fixes Forklifts having Ghost Crates

### DIFF
--- a/code/obj/vehicle.dm
+++ b/code/obj/vehicle.dm
@@ -2438,8 +2438,8 @@ obj/vehicle/clowncar/proc/log_me(var/mob/rider, var/mob/pax, var/action = "", va
 		for (var/obj/HI in helditems)
 			HI.set_loc(src.loc)
 
-		helditems.len = 0
-		update_overlays()
+	helditems.len = 0
+	update_overlays()
 	return
 
 obj/vehicle/forklift/attackby(var/obj/item/I, var/mob/user)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Changes some indentation to fix forklifts never having their crate count lowered, preventing more crates from being picked up after they picked up 3.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
fixes #5047


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)Forklifts are no longer being haunted by ghost crates
```
