### PR TITLE
Allows Destiny qm To print sell to market barcodes

### DIFF
--- a/maps/destiny.dmm
+++ b/maps/destiny.dmm
@@ -27054,7 +27054,7 @@
 	dir = 1;
 	icon_state = "line1"
 	},
-/obj/machinery/computer/barcode/qm{
+/obj/machinery/computer/barcode/qm/no_belthell{
 	dir = 8
 	},
 /turf/simulated/floor,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[STATION SYSTEMS] [GAME OBJECTS] [BUG]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Allows the barcode printer in Destiny qm to print to the shipping market.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #5531


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)Destiny qm can now print barcodes to the shipping market.
```
