### PR TITLE
Improved Donut 2 Janitorial

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -22007,8 +22007,6 @@
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
-/obj/vehicle/floorbuffer,
-/obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/white/checker{
 	dir = 4
 	},
@@ -22019,6 +22017,7 @@
 	dir = 8;
 	pixel_x = 4
 	},
+/obj/vehicle/floorbuffer,
 /turf/simulated/floor/specialroom/arcade,
 /area/station/janitor/office)
 "buZ" = (
@@ -22655,24 +22654,22 @@
 	},
 /area/station/hallway/primary/south)
 "bxi" = (
-/obj/machinery/disposal,
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/specialroom/arcade,
-/area/station/janitor/office)
-"bxj" = (
-/obj/machinery/light/incandescent,
 /obj/rack,
 /obj/item/mop,
 /obj/item/sponge,
 /obj/item/storage/box/lightbox/bulbs,
 /obj/item/storage/box/lightbox/tubes,
 /obj/item/device/radio,
-/obj/disposalpipe/segment{
-	dir = 4;
-	pixel_y = 0
-	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/specialroom/arcade,
+/area/station/janitor/office)
+"bxj" = (
+/obj/mopbucket,
+/obj/item/sponge,
+/obj/item/chem_grenade/cleaner,
+/obj/item/chem_grenade/cleaner,
+/obj/item/chem_grenade/cleaner,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/white/checker{
 	dir = 4
 	},
@@ -22685,18 +22682,13 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/disposalpipe/junction,
+/obj/disposalpipe/segment,
 /turf/simulated/floor/white/checker{
 	dir = 4
 	},
 /area/station/janitor/office)
 "bxl" = (
-/obj/stool,
-/obj/item/chem_grenade/cleaner,
-/obj/item/chem_grenade/cleaner,
-/obj/item/chem_grenade/cleaner,
-/obj/item/sponge,
-/obj/mopbucket,
+/obj/storage/closet/biohazard,
 /turf/simulated/floor/white/checker{
 	dir = 4
 	},


### PR DESCRIPTION


<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Improved Donut 2 Janitorial by altering its layout, adding a Biohazard closet and removing a Disposal Unit

![Capture](https://user-images.githubusercontent.com/94804240/187792236-1daa4fab-e3f8-422a-8ff0-a4891bc9e9c6.PNG)
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Janitorial was lacking a Biohazard locker, and I removed the disposal unit in the bottom left corner because theres already a cart disposal, and theres a disposal unit AND the disposal crusher right below janitorial.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)CrystalClover
(+)Restructured Donut 2 Janitorial
(+)Added Level 3 Biohazard Locker to Donut 2 Janitorial
(+)Removed unnecessary Disposal Unit in Donut 2 Janitorial
```
