### PR TITLE
Converts interdictor blueprints into a manudrive

### DIFF
--- a/code/obj/item/manudrive.dm
+++ b/code/obj/item/manudrive.dm
@@ -47,3 +47,11 @@
 		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint that permits the user to manufacture AI law racks."
 		icon_state = "datadiskcom"
 		temp_recipe_string = list(/datum/manufacture/mechanics/lawrack)
+
+	interdictor_parts //Compacts the parts into a single manudrive
+		name = "Engineering Manudrive: Spatial Interdictor Assembly Blueprint"
+		desc = "A drive for data storage that can be inserted and removed from manufacturers to temporarily add recipes to a manufacturer. This drive carries a blueprint that permits the user to manufacture spatial interdictor rods and frames."
+		icon_state = "datadisk2"
+		temp_recipe_string = list(/datum/manufacture/interdictor_frame,
+		/datum/manufacture/interdictor_rod_lambda,
+		/datum/manufacture/interdictor_rod_sigma)

--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -131,7 +131,7 @@
 
 	interdictor
 		name = "interdictor assembly kit"
-		desc = "Contains mainboards, blueprints and a usage guide for spatial interdictors."
+		desc = "Contains mainboards, a manudrive and a usage guide for spatial interdictors."
 		req_access = list(access_engineering)
 
 		make_my_stuff()

--- a/code/obj/storage/secure_crates.dm
+++ b/code/obj/storage/secure_crates.dm
@@ -136,31 +136,23 @@
 
 		make_my_stuff()
 			if (..()) // make_my_stuff is called multiple times due to lazy init, so the parent returns 1 if it actually fired and 0 if it already has
-				var/obj/item/interdictor_board/B1 = new(src)
-				B1.pixel_x = -6
-				B1.pixel_y = -3
+				var/obj/item/disk/data/floppy/manudrive/interdictor_parts/B1 = new(src)
+				B1.pixel_x = 8
+				B1.pixel_y = 3
 
 				var/obj/item/interdictor_board/B2 = new(src)
 				B2.pixel_x = -6
+				B2.pixel_y = -3
 
 				var/obj/item/interdictor_board/B3 = new(src)
 				B3.pixel_x = -6
-				B3.pixel_y = 3
 
-				var/obj/item/paper/manufacturer_blueprint/interdictor_rod_lambda/B4 = new(src)
-				B4.pixel_x = 8
-				B4.pixel_y = -5
+				var/obj/item/interdictor_board/B4 = new(src)
+				B4.pixel_x = -6
+				B4.pixel_y = 3
 
-				var/obj/item/paper/manufacturer_blueprint/interdictor_rod_sigma/B5 = new(src)
-				B5.pixel_x = 8
-				B5.pixel_y = -1
-
-				var/obj/item/paper/manufacturer_blueprint/interdictor_frame/B6 = new(src)
-				B6.pixel_x = 8
-				B6.pixel_y = 3
-
-				var/obj/item/paper/book/from_file/interdictor_guide/B7 = new(src)
-				B7.pixel_y = 1
+				var/obj/item/paper/book/from_file/interdictor_guide/B5 = new(src)
+				B5.pixel_y = 1
 				return 1
 
 /obj/storage/secure/crate/medical


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[GAME OBJECTS] [FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr changes the blueprints in the interdictor kit to instead all be on a manudrive.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes construction of the interdictor more versatile, instead of restricting the blueprints to whatever manufacture you first put them in.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)The interdictor blueprints are now on a single manudrive.
```
