### PR TITLE
Renames Detomax Bomb to Self-destruct

### DIFF
--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -899,7 +899,7 @@ Code:
 	name = "Bomb Readme"
 
 	data = {"
-Electronic Self-destruct Program Manual<hr>
+Electronic Bomb Program Manual<hr>
 Using electronic "Detomatix" MISSILE program is simple!<br>
 <ul>
 <li>Open PDA MESSENGER and SCAN FOR PDAS!</li>

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -802,7 +802,7 @@ Code:
 
 //Whoever runs this gets to explode.
 /datum/computer/file/pda_program/bomb
-	name = "BOMB"
+	name = "SELF-DESTRUCT"
 	size = 8
 	var/detonating = 0
 
@@ -896,25 +896,25 @@ Code:
 		return
 
 /datum/computer/file/text/bomb_manual
-	name = "Bomb Readme"
+	name = "Self-destruct Readme"
 
 	data = {"
-Electronic Bomb Program Manual<hr>
+Electronic Self-destruct Program Manual<hr>
 Using electronic "Detomatix" MISSILE program is simple!<br>
 <ul>
 <li>Open PDA MESSENGER and SCAN FOR PDAS!</li>
 <li>now run MISSILE.PPROG and select IMPORT PDA LIST</li>
 <li>select up to four (4) PDAs you want EXPLODED from DISTANCE!</li>
 </ul><br>
-Using electronic "Detomatix" BOMB program is perhaps less simple!<br>
+Using electronic "Detomatix" SELF-DESTRUCT program is perhaps less simple!<br>
 <ul>
-<li>Copy BOMB.PPROG to main drive, as cart programs cannot be edited!</li>"
-<li>Simply rename new BOMB.PPROG to unassuming, safe name such as <i>"PRETTY PLANTS.PPROG"</i></li>
+<li>Copy SELF-DESTRUCT.PPROG to main drive, as cart programs cannot be edited!</li>"
+<li>Simply rename new SELF-DESTRUCT.PPROG to unassuming, safe name such as <i>"PRETTY PLANTS.PPROG"</i></li>
 <li>Now, COPY renamed file and open MESSENGER.  Select your target and SEND THEM the file!</li>
 <li>Finally, they run file expecting some attractive plants, but instead get EXPLODED PDA!</li>
 </ul>
 <br>
-<b>Caution: </b>Do not run BOMB.PPROG on your own system!  It will explode!
+<b>Caution: </b>Do not run SELF-DESTRUCT.PPROG on your own system!  It will explode!
 "}
 
 //Security ticket writer - not really a small prog any more but oh well

--- a/code/obj/item/device/pda2/smallprogs.dm
+++ b/code/obj/item/device/pda2/smallprogs.dm
@@ -896,7 +896,7 @@ Code:
 		return
 
 /datum/computer/file/text/bomb_manual
-	name = "Self-destruct Readme"
+	name = "Bomb Readme"
 
 	data = {"
 Electronic Self-destruct Program Manual<hr>


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [GAME OBJECTS]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Renames the detomax bomb program to self-destruct


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People keep getting confused about which program is which, this should clarify that.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Wisemonster
(+)The detomax bomb program has be renamed to self-destruct.
```
