### PR TITLE
Adds Artist as a gimmick job.

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -1783,6 +1783,18 @@ ABSTRACT_TYPE(/datum/job/civilian)
 		src.access = get_access("Psychiatrist")
 		return
 
+/datum/job/special/random/artist
+	name = "Artist"
+	wages = PAY_UNTRAINED
+	slot_foot = list(/obj/item/clothing/shoes/brown)
+	slot_jump = list(/obj/item/clothing/under/misc/casualjeansblue)
+	slot_head = list(/obj/item/clothing/head/mime_beret)
+	slot_ears = list(/obj/item/device/radio/headset/civilian)
+	slot_poc1 = list(/obj/item/spacecash/twenty)
+	slot_poc2 = list(/obj/item/pen/pencil)
+	slot_lhan = list(/obj/item/storage/toolbox/artistic)
+	items_in_backpack = list(/obj/item/canvas, /obj/item/canvas, /obj/item/storage/box/crayon/basic ,/obj/item/paint_can/random)
+
 #ifdef HALLOWEEN
 /*
  * Halloween jobs


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Artist gimmick role, complete with pencil! 

I was going to give the artist a custom apron, but I want to push this out and see if people like the job first

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Low responsibility, highly interactable job. Anyone can pick it up and know what to do, while still being free enough to add in their own individual gimmicks. 

Honestly, I don't know why this wasn't added beforehand. 

We already have the canvases, the paints, the clothing, the centcomm art gallery, why do we not have The Artist.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)TheTrueMunchkin
(+)Artist is now a playable gimmick job. Go paint your dreams!
```
