### PR TITLE
Battle wrench -> BATTLE wrench

### DIFF
--- a/code/obj/item/tool/wrench.dm
+++ b/code/obj/item/tool/wrench.dm
@@ -49,7 +49,7 @@
 	icon_state = "wrench-battle" //todo: new sprites
 	item_state = "wrench-battle"
 	force = 10
-	stamina_damage = 35
+	stamina_damage = 55
 
 	New()
 		..()

--- a/code/obj/item/tool/wrench.dm
+++ b/code/obj/item/tool/wrench.dm
@@ -48,7 +48,7 @@
 	desc = "A heavy industrial wrench that packs a mean punch when used as a bludgeon. Can be applied to the Nuclear bomb to repair it in small increments."
 	icon_state = "wrench-battle" //todo: new sprites
 	item_state = "wrench-battle"
-	force = 10
+	force = 15
 	stamina_damage = 55
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Buffs the battle wrench stamina damage 35 -> 55 and force 10 -> 15.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently the battle wrench is actually a worse weapon than a regular wrench, despite having a description that suggests it packs a punch. Now it does the same stamina damage as an air tank with a bit more brute, making it somewhat viable as a last resort self defense tool.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)The nuke ops combat engineer battle wrench now hits a lot harder.
```
