### PR TITLE
Fixes bubsium pulling intangible or anchored mobs

### DIFF
--- a/code/modules/chemistry/Reagents-Misc.dm
+++ b/code/modules/chemistry/Reagents-Misc.dm
@@ -3901,6 +3901,8 @@ datum
 					step_towards(V,M)
 
 				for (var/mob/living/N in orange(clamp(our_amt / 5, 2,10),M))
+					if (isintangible(N) || N.anchored)
+						continue
 					step_towards(N,M)
 					if(ishuman(N) && probmult(1))
 						N.say("[M.name] is an ocean of muscle.")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [SECRET] [CHEMISTRY]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #8532 and also prevents bubsium from pulling people with magboots.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad
