### PR TITLE
Lets cows walk on mousetraps

### DIFF
--- a/code/obj/item/mousetrap.dm
+++ b/code/obj/item/mousetrap.dm
@@ -329,7 +329,7 @@
 			var/mob/living/carbon/human/H = target
 			switch(type)
 				if ("feet")
-					if (!H.shoes)
+					if (!H.shoes && !H.mutantrace?.can_walk_on_shards)
 						affecting = H.organs[pick("l_leg", "r_leg")]
 						H.changeStatus("weakened", 3 SECONDS)
 				if ("l_arm", "r_arm")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [QOL] [GAME OBJECTS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Lets cows trigger mousetraps without being stunned for being shoeless.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Cows have stronk feet also Snerp was malding


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Cows can now walk on mousetraps without hurting their hooves.
```
