### PR TITLE
Fixes ghosts from locking stall doors and other AI/intangible shenanigans

### DIFF
--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -652,7 +652,7 @@
 	return src.Attackby(null, user)
 
 /obj/machinery/door/unpowered/attackby(obj/item/I, mob/user)
-	if (src.operating || isintangible(user))
+	if (src.operating || isintangible(user) || isdead(user))
 		return
 	src.add_fingerprint(user)
 	if (src.allowed(user))

--- a/code/obj/machinery/door/door_parent.dm
+++ b/code/obj/machinery/door/door_parent.dm
@@ -646,13 +646,13 @@
 	cant_emag = TRUE
 
 /obj/machinery/door/unpowered/attack_ai(mob/user as mob)
-	return src.Attackhand(user)
+	return
 
 /obj/machinery/door/unpowered/attack_hand(mob/user)
 	return src.Attackby(null, user)
 
 /obj/machinery/door/unpowered/attackby(obj/item/I, mob/user)
-	if (src.operating)
+	if (src.operating || isintangible(user))
 		return
 	src.add_fingerprint(user)
 	if (src.allowed(user))
@@ -798,6 +798,8 @@
 	set category = "Local"
 	set src in oview(1)
 
+	if (isdead(user) || isintangible(user))
+		return
 	if (!src.density || src.operating)
 		boutput(user, "<span class='alert'>You COULD flip the lock on [src] while it's open, but it wouldn't actually accomplish anything!</span>")
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FIX] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Fixes ghosts being able to lock/unlock doors with `simple_lock` and AI/dead/intangible players from opening doors as well.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

In the wise words of someone else, 𝒷𝓊ℊ𝓈 𝒷𝒶𝒹. And #10570 and #10580.