### PR TITLE
Use /datum/game_mode property to indicate if antag tokens are supported

### DIFF
--- a/code/client.dm
+++ b/code/client.dm
@@ -752,6 +752,7 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 	antag_tokens = amt
 	if( cloud_available() )
 		cloud_put( "antag_tokens", amt )
+		. = TRUE
 	/*
 	var/savefile/AT = LoadSavefile("data/AntagTokens.sav")
 	if (!AT) return
@@ -759,7 +760,8 @@ var/global/list/vpn_ip_checks = list() //assoc list of ip = true or ip = false. 
 	AT[ckey] << antag_tokens*/
 
 /client/proc/use_antag_token()
-	src.set_antag_tokens(--antag_tokens)
+	if( src.set_antag_tokens(--antag_tokens) )
+		logTheThing(LOG_DEBUG, src, "Antag token used. [antag_tokens] tokens remaining.")
 
 
 /client/proc/load_persistent_bank()

--- a/code/datums/gamemodes/arcfiend.dm
+++ b/code/datums/gamemodes/arcfiend.dm
@@ -1,6 +1,7 @@
 /datum/game_mode/mixed/arcfiend
 	name = "arcfiend"
 	config_tag = "arcfiend"
+	antag_token_support = TRUE
 	latejoin_antag_compatible = 1
 	latejoin_antag_roles = list(ROLE_ARCFIEND)
 	traitor_types = list(ROLE_ARCFIEND = 1)

--- a/code/datums/gamemodes/assday_classic.dm
+++ b/code/datums/gamemodes/assday_classic.dm
@@ -8,6 +8,7 @@
 	config_tag = "everyone-is-a-traitor"
 	latejoin_antag_compatible = 1
 	latejoin_antag_roles = list(ROLE_TRAITOR, ROLE_CHANGELING, ROLE_WRAITH)
+	antag_token_support = TRUE
 
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)

--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -38,8 +38,6 @@ var/global/area/current_battle_spawn = null
 	boutput(world, "<B>You are approaching [station_name(1)] in the Battle Shuttle! Jump out of the ship to land on the station!</B>")
 
 /datum/game_mode/battle_royale/pre_setup()
-	for(var/datum/mind/mind in antag_token_list())
-		mind.current?.client?.using_antag_token = FALSE
 	// EVERYONE IS A BATTLER
 	for(var/client/C)
 		var/mob/new_player/player = C.mob

--- a/code/datums/gamemodes/blob.dm
+++ b/code/datums/gamemodes/blob.dm
@@ -3,6 +3,7 @@
 	config_tag = "blob"
 	shuttle_available = 2
 
+	antag_token_support = TRUE
 	var/const/blobs_minimum = 2
 	var/const/blobs_possible = 4
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)

--- a/code/datums/gamemodes/changeling.dm
+++ b/code/datums/gamemodes/changeling.dm
@@ -3,6 +3,7 @@
 	config_tag = "changeling"
 	latejoin_antag_compatible = 1
 	latejoin_antag_roles = list(ROLE_CHANGELING)
+	antag_token_support = TRUE
 
 	var/const/changelings_possible = 4
 

--- a/code/datums/gamemodes/conspiracy.dm
+++ b/code/datums/gamemodes/conspiracy.dm
@@ -3,6 +3,7 @@
 	config_tag = "conspiracy"
 	latejoin_antag_compatible = 1
 	latejoin_only_if_all_antags_dead = 1 // No hunters until the conspiracy is dead, thanks
+	antag_token_support = TRUE
 
 	var/maxConspirators = 6
 	var/agent_radiofreq = 1401

--- a/code/datums/gamemodes/extended.dm
+++ b/code/datums/gamemodes/extended.dm
@@ -6,8 +6,6 @@
 
 /datum/game_mode/extended/pre_setup()
 	. = ..()
-	for(var/datum/mind/mind in antag_token_list())
-		mind.current?.client?.using_antag_token = FALSE
 
 	for(var/datum/random_event/event in random_events.events)
 		if(istype(event, /datum/random_event/major/ion_storm))

--- a/code/datums/gamemodes/football.dm
+++ b/code/datums/gamemodes/football.dm
@@ -33,8 +33,6 @@ var/global/list/list/datum/mind/football_players = list("blue" = list(), "red" =
 		boutput(world, "<B>Get ready to play some football!</B>")
 
 	pre_setup()
-		for(var/datum/mind/mind in antag_token_list())
-			mind.current?.client?.using_antag_token = FALSE
 		// EVERYONE IS A football player.
 		for(var/client/C)
 			var/mob/new_player/player = C.mob

--- a/code/datums/gamemodes/gangwar.dm
+++ b/code/datums/gamemodes/gangwar.dm
@@ -3,6 +3,7 @@
 	name = "gang"
 	config_tag = "gang"
 
+	antag_token_support = TRUE
 	var/list/leaders = list()
 	var/list/gangs = list()
 

--- a/code/datums/gamemodes/gm_parent.dm
+++ b/code/datums/gamemodes/gm_parent.dm
@@ -22,6 +22,7 @@
 
 	var/datum/game_mode/spy_theft/spy_market = 0	//In case any spies are spawned into a round that is NOT spy_theft, we need a place to hold their spy market.
 
+	var/antag_token_support = FALSE // players can redeem antag tokens for this game mode
 	var/do_antag_random_spawns = 1
 	var/do_random_events = 1
 	var/escape_possible = 1		//for determining if players lose their held spacebux item on round end if they are able to "escape" in this mode.

--- a/code/datums/gamemodes/mixed.dm
+++ b/code/datums/gamemodes/mixed.dm
@@ -3,6 +3,7 @@
 	config_tag = "mixed"
 	latejoin_antag_compatible = 1
 	latejoin_antag_roles = list(ROLE_TRAITOR = 1, ROLE_CHANGELING = 1, ROLE_VAMPIRE = 1, ROLE_WRESTLER = 1, ROLE_WEREWOLF = 1, ROLE_ARCFIEND = 1)
+	antag_token_support = TRUE
 
 	var/const/traitors_possible = 8 // cogwerks - lowered from 10
 	var/const/werewolf_players_req = 15

--- a/code/datums/gamemodes/mixed_rp.dm
+++ b/code/datums/gamemodes/mixed_rp.dm
@@ -5,6 +5,7 @@
 	 //went with a trivial solution of adding more identical items to the list
 	 //Input needed here
 
+	antag_token_support = TRUE
 	latejoin_antag_roles = list(ROLE_TRAITOR = 2, ROLE_CHANGELING = 1, ROLE_VAMPIRE = 1,  ROLE_WRESTLER = 1, ROLE_ARCFIEND = 1)
 	traitor_types = list(ROLE_TRAITOR = 1, ROLE_CHANGELING = 1, ROLE_VAMPIRE = 1, ROLE_SPY_THIEF = 1, ROLE_ARCFIEND = 1, ROLE_TRAITOR = 1)
 

--- a/code/datums/gamemodes/nuclear.dm
+++ b/code/datums/gamemodes/nuclear.dm
@@ -19,6 +19,7 @@
 	var/token_players_assigned = 0
 
 	do_antag_random_spawns = 0
+	antag_token_support = TRUE
 	escape_possible = 0
 
 /datum/game_mode/nuclear/announce()

--- a/code/datums/gamemodes/pod_wars.dm
+++ b/code/datums/gamemodes/pod_wars.dm
@@ -60,8 +60,6 @@ var/list/pw_rewards_tier3 = null
 
 //setup teams and commanders
 /datum/game_mode/pod_wars/pre_setup()
-	for(var/datum/mind/mind in antag_token_list())
-		mind.current?.client?.using_antag_token = FALSE
 	board = new()
 	stats_manager = new()
 	if (!setup_teams())

--- a/code/datums/gamemodes/revolution.dm
+++ b/code/datums/gamemodes/revolution.dm
@@ -12,6 +12,7 @@
 	config_tag = "revolution"
 	shuttle_available = 0
 
+	antag_token_support = TRUE
 	var/list/datum/mind/head_revolutionaries = list()
 	var/list/datum/mind/revolutionaries = list()
 	var/finished = 0

--- a/code/datums/gamemodes/spy_theft.dm
+++ b/code/datums/gamemodes/spy_theft.dm
@@ -8,6 +8,7 @@
 	name = "spy_thief"
 	config_tag = "spy_theft"
 
+	antag_token_support = TRUE
 	latejoin_antag_compatible = 1
 	latejoin_antag_roles = list(ROLE_TRAITOR)
 	var/const/waittime_l = 600	// Minimum after round start to send threat information to printer

--- a/code/datums/gamemodes/traitor.dm
+++ b/code/datums/gamemodes/traitor.dm
@@ -3,6 +3,7 @@
 	config_tag = "traitor"
 	latejoin_antag_compatible = 1
 	latejoin_antag_roles = list(ROLE_TRAITOR)
+	antag_token_support = TRUE
 
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)

--- a/code/datums/gamemodes/vampire.dm
+++ b/code/datums/gamemodes/vampire.dm
@@ -2,6 +2,7 @@
 	name = "vampire"
 	config_tag = "vampire"
 	latejoin_antag_compatible = 1
+	antag_token_support = TRUE
 	latejoin_antag_roles = list(ROLE_VAMPIRE)
 	traitor_types = list(ROLE_VAMPIRE = 1)
 

--- a/code/datums/gamemodes/wizard.dm
+++ b/code/datums/gamemodes/wizard.dm
@@ -2,6 +2,7 @@
 	name = "wizard"
 	config_tag = "wizard"
 	shuttle_available = 2
+	antag_token_support = TRUE
 	latejoin_antag_compatible = 1
 	latejoin_only_if_all_antags_dead = 1
 	latejoin_antag_roles = list(ROLE_CHANGELING, ROLE_VAMPIRE)

--- a/code/datums/gameticker.dm
+++ b/code/datums/gameticker.dm
@@ -320,7 +320,7 @@ var/global/current_state = GAME_STATE_WORLD_INIT
 						antagWeighter.record(role = ROLE_FLOCKMIND, ckey = F.ckey)
 
 				else if (player.mind)
-					if (player.client.using_antag_token)
+					if (player.client.using_antag_token && ticker.mode.antag_token_support)
 						player.client.use_antag_token()	//Removes a token from the player
 					player.create_character()
 					qdel(player)

--- a/code/mob/new_player.dm
+++ b/code/mob/new_player.dm
@@ -773,8 +773,7 @@ a.latejoin-card:hover {
 		if(!(!ticker || current_state <= GAME_STATE_PREGAME))
 			src.show_text("Round has already started. You can't redeem tokens now. (You have [src.client.antag_tokens].)", "red")
 		else if(src.client.antag_tokens > 0)
-			if(master_mode in list("secret","traitor","nuclear","blob","wizard","changeling","mixed","mixed_rp","vampire","intrigue"))
-				src.client.using_antag_token = 1
+			src.client.using_antag_token = 1
 			src.show_text("Token redeemed, if mode supports redemption your new total will be [src.client.antag_tokens - 1].", "red")
 		else
 			src.show_text("You don't even have any tokens. How did you get here?", "red")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves determination of whether a Antag Token should be used out of `master_mode` and onto the specific `/datum/game_mode`

Explicitly using a number of game modes will properly use antag tokens.
* Arcfiend
* Conspiracy
* Spy Theft
* Gang
* Revolution

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Makes utilization of Antagonist Tokens more explicit where coupling is separated from a list in a separate file.

Extended implementation lead to confusion about what modes would use a token, but this was intended as a special exception.
