### PR TITLE
Click Dragging A Fluid To A Reagent Container Now Attempts To Transfer Fluid To That Container

### DIFF
--- a/_std/defines/obj.dm
+++ b/_std/defines/obj.dm
@@ -11,6 +11,8 @@
 #define HAS_DIRECTIONAL_BLOCKING (1<<3)
 /// prevents ghost critter interaction. On obj so it can cover machinery, items etc...
 #define NO_GHOSTCRITTER (1<<4)
+/// Determines whether an object should have its reagents quickly refilled by mousedrop.
+#define REFILL_ON_MOUSEDROP (1<<5)
 
 /// At which alpha do opague objects become see-through?
 #define MATERIAL_ALPHA_OPACITY 190

--- a/code/WorkInProgress/DrMelonsStuff.dm
+++ b/code/WorkInProgress/DrMelonsStuff.dm
@@ -95,6 +95,7 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "bathtub"
 	flags = OPENCONTAINER
+	object_flags = REFILL_ON_MOUSEDROP
 	var/mob/living/carbon/human/occupant = null
 	var/default_reagent = "water"
 	var/on = FALSE
@@ -145,7 +146,7 @@
 		else if (istype(over_object, /turf))
 			drain_bathtub(usr)
 			return
-		if (!istype(over_object, /obj/item/reagent_containers/glass) && !istype(over_object, /obj/item/reagent_containers/food/drinks) && !istype(over_object, /obj/reagent_dispensers) && !istype(over_object, /obj/item/spraybottle) && !istype(over_object, /obj/machinery/plantpot) && !istype(over_object, /obj/mopbucket) && !istype(over_object, /obj/item/reagent_containers/mender) && !istype(over_object, /obj/item/tank/jetpack/backtank) && !istype(over_object, /obj/machinery/bathtub))
+		if (!(over_object.object_flags & REFILL_ON_MOUSEDROP))
 			return ..()
 		if (usr.stat || usr.getStatusDuration("weakened") || BOUNDS_DIST(usr, src) > 0 || BOUNDS_DIST(usr, over_object) > 0)
 			boutput(usr, "<span class='alert'>That's too far!</span>")

--- a/code/modules/chemistry/Chemistry-Tools.dm
+++ b/code/modules/chemistry/Chemistry-Tools.dm
@@ -20,19 +20,6 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 	var/incompatible_with_chem_dispensers = 0
 	var/can_mousedrop = 1
 	move_triggered = 1
-	///Types that should be quickly refilled by mousedrop
-	var/static/list/mousedrop_refill = list(
-		/obj/item/reagent_containers/glass,
-		/obj/item/reagent_containers/food/drinks,
-		/obj/reagent_dispensers,
-		/obj/item/spraybottle,
-		/obj/machinery/plantpot,
-		/obj/mopbucket,
-		/obj/item/reagent_containers/mender,
-		/obj/item/tank/jetpack/backtank,
-		/obj/item/reagent_containers/syringe/baster,
-		/obj/machinery/bathtub
-	)
 
 	var/last_new_initial_reagents = 0 //fuck
 
@@ -115,12 +102,10 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 				return
 		// First filter out everything we don't want to refill or empty quickly.
 		// feels like there should be a macro for this or something
-		var/type_found = FALSE
-		for (var/type in mousedrop_refill)
-			if (istype(over_object, type))
-				type_found = TRUE
-				break
-		if (!type_found)
+		if (!(istype(over_object, /obj)))
+			return
+		var/obj/object = over_object
+		if (!(object.object_flags & REFILL_ON_MOUSEDROP))
 			return ..()
 
 		if (!istype(src, /obj/item/reagent_containers/glass) && !istype(src, /obj/item/reagent_containers/food/drinks))
@@ -147,6 +132,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers)
 	var/can_recycle = TRUE //can this be put in a glass recycler?
 	var/splash_all_contents = 1
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | SUPPRESSATTACK
+	object_flags = REFILL_ON_MOUSEDROP
 
 	afterattack(obj/target, mob/user , flag)
 		user.lastattacked = target

--- a/code/modules/chemistry/tools/beakers.dm
+++ b/code/modules/chemistry/tools/beakers.dm
@@ -14,7 +14,7 @@
 	var/image/fluid_image
 	var/icon_style = "beaker"
 	rc_flags = RC_SCALE | RC_VISIBLE | RC_SPECTRO
-	object_flags = NO_GHOSTCRITTER
+	object_flags = NO_GHOSTCRITTER | REFILL_ON_MOUSEDROP
 
 	on_reagent_change()
 		..()

--- a/code/modules/chemistry/tools/bottles.dm
+++ b/code/modules/chemistry/tools/bottles.dm
@@ -15,7 +15,7 @@
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	amount_per_transfer_from_this = 10
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | SUPPRESSATTACK
-	object_flags = NO_GHOSTCRITTER
+	object_flags = NO_GHOSTCRITTER | REFILL_ON_MOUSEDROP
 
 	New()
 		if (!src.bottle_style)

--- a/code/modules/chemistry/tools/dispensers.dm
+++ b/code/modules/chemistry/tools/dispensers.dm
@@ -11,7 +11,7 @@
 	density = 1
 	anchored = 0
 	flags = FPRINT | FLUID_SUBMERGE
-	object_flags = NO_GHOSTCRITTER
+	object_flags = NO_GHOSTCRITTER | REFILL_ON_MOUSEDROP
 	pressure_resistance = 2*ONE_ATMOSPHERE
 	p_class = 1.5
 
@@ -61,8 +61,8 @@
 			for (var/i = 0, i < 9, i++) // ugly hack
 				reagents.temperature_reagents(exposed_temperature, exposed_volume)
 
-	mouse_drop(atom/over_object as obj)
-		if (!istype(over_object, /obj/item/reagent_containers/glass) && !istype(over_object, /obj/item/reagent_containers/food/drinks) && !istype(over_object, /obj/item/spraybottle) && !istype(over_object, /obj/machinery/plantpot) && !istype(over_object, /obj/mopbucket) && !istype(over_object, /obj/machinery/hydro_mister) && !istype(over_object, /obj/item/tank/jetpack/backtank))
+	mouse_drop(obj/over_object as obj)
+		if (!(over_object.object_flags & REFILL_ON_MOUSEDROP))
 			return ..()
 
 		if (BOUNDS_DIST(usr, src) > 0 || BOUNDS_DIST(usr, over_object) > 0)

--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -453,6 +453,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 	inhand_image_icon = 'icons/mob/inhand/hand_food.dmi'
 	icon_state = null
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | SUPPRESSATTACK
+	object_flags = REFILL_ON_MOUSEDROP
 	rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	var/gulp_size = 5 //This is now officially broken ... need to think of a nice way to fix it.
 	var/splash_all_contents = 1

--- a/code/modules/chemistry/tools/patches.dm
+++ b/code/modules/chemistry/tools/patches.dm
@@ -465,6 +465,7 @@
 	var/borg = 0
 	initial_volume = 200
 	flags = FPRINT | TABLEPASS | OPENCONTAINER | ONBELT | NOSPLASH | ATTACK_SELF_DELAY
+	object_flags = REFILL_ON_MOUSEDROP
 	click_delay = 0.7 SECONDS
 	rc_flags = RC_SCALE | RC_VISIBLE | RC_SPECTRO
 

--- a/code/modules/chemistry/tools/syringes.dm
+++ b/code/modules/chemistry/tools/syringes.dm
@@ -304,6 +304,7 @@
 	desc = "For adding delicious liquids to food."
 	icon_prefix = "baster"
 	icon_state = "baster_0"
+	object_flags = REFILL_ON_MOUSEDROP
 	initial_volume = 100
 	amount_per_transfer_from_this = 25
 

--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -232,7 +232,7 @@ var/mutable_appearance/fluid_ma
 
 		src.group.reagents.skip_next_update = 1
 		src.group.update_amt_per_tile()
-		var/amt = min(src.group.contained_amt, container.reagents.maximum_volume - container.reagents.total_volume)
+		var/amt = min(src.group.amt_per_tile, container.reagents.maximum_volume - container.reagents.total_volume)
 		boutput(usr, "<span class='notice'>You fill [container] with [amt] units of [src].</span>")
 		src.group.drain(src, amt / src.group.amt_per_tile, container) // drain uses weird units
 

--- a/code/modules/fluids/fluid_core.dm
+++ b/code/modules/fluids/fluid_core.dm
@@ -215,7 +215,9 @@ var/mutable_appearance/fluid_ma
 		T.Attackhand(user)
 
 	mouse_drop(obj/over_object, src_location, over_location)
-		if (istype(src, /obj/fluid/airborne) || !istype(over_object, /obj/item/reagent_containers/glass) && !istype(over_object, /obj/item/reagent_containers/food/drinks) && !istype(over_object, /obj/reagent_dispensers) && !istype(over_object, /obj/item/spraybottle) && !istype(over_object, /obj/machinery/plantpot) && !istype(over_object, /obj/mopbucket) && !istype(over_object, /obj/item/reagent_containers/mender) && !istype(over_object, /obj/item/tank/jetpack/backtank) && !istype(over_object, /obj/machinery/bathtub))
+		if (!(over_object in usr.contents))
+			return
+		if (!(over_object.object_flags & REFILL_ON_MOUSEDROP))
 			return ..()
 		if (usr.stat || usr.getStatusDuration("weakened") || BOUNDS_DIST(usr, src) > 0 || BOUNDS_DIST(usr, over_object) > 0)
 			boutput(usr, "<span class='alert'>That's too far!</span>")

--- a/code/obj/item/flamethrower.dm
+++ b/code/obj/item/flamethrower.dm
@@ -196,6 +196,7 @@ A Flamethrower in various states of assembly
 	base_icon_state = "syndflametank"
 	desc = "A back mounted fueltank/jetpack system for use with a tactical flamethrower."
 	flags = FPRINT | TABLEPASS | CONDUCT | ONBACK | OPENCONTAINER
+	object_flags = REFILL_ON_MOUSEDROP
 	var/obj/item/gun/flamethrower/backtank/linkedflamer
 	inventory_counter_enabled = 1
 	move_triggered = 1

--- a/code/obj/item/mops_cleaners.dm
+++ b/code/obj/item/mops_cleaners.dm
@@ -14,6 +14,7 @@ WET FLOOR SIGN
 	icon_state = "cleaner"
 	item_state = "cleaner"
 	flags = ONBELT|TABLEPASS|OPENCONTAINER|FPRINT|EXTRADELAY|SUPPRESSATTACK
+	object_flags = REFILL_ON_MOUSEDROP
 	var/rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	throwforce = 3
 	w_class = W_CLASS_SMALL

--- a/code/obj/machinery/plantpot.dm
+++ b/code/obj/machinery/plantpot.dm
@@ -211,6 +211,7 @@
 	mats = 2
 	deconstruct_flags = DECON_SCREWDRIVER | DECON_WRENCH | DECON_CROWBAR
 	flags = NOSPLASH
+	object_flags = REFILL_ON_MOUSEDROP
 	processing_tier = PROCESSING_SIXTEENTH
 	machine_registry_idx = MACHINES_PLANTPOTS
 	power_usage = 25
@@ -1877,6 +1878,7 @@ proc/HYPmutationcheck_sub(var/lowerbound,var/upperbound,var/checkedvariable)
 	desc = "A device that constantly sprays small amounts of chemical onto nearby plants."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "fogmachine0"
+	flags = FPRINT | REFILL_ON_MOUSEDROP | FLUID_SUBMERGE | TGUI_INTERACTIVE
 	density = 1
 	anchored = 0
 	mats = 6

--- a/code/obj/mopbucket.dm
+++ b/code/obj/mopbucket.dm
@@ -4,9 +4,9 @@
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "mopbucket"
 	density = 1
-	flags = FPRINT
 	pressure_resistance = ONE_ATMOSPHERE
 	flags = FPRINT | TABLEPASS | OPENCONTAINER
+	object_flags = REFILL_ON_MOUSEDROP
 	var/rc_flags = RC_FULLNESS | RC_VISIBLE | RC_SPECTRO
 	var/image/fluid_image
 	p_class = 1.2
@@ -58,8 +58,8 @@
 	else
 		return ..()
 
-/obj/mopbucket/mouse_drop(atom/over_object as obj)
-	if (!istype(over_object, /obj/item/reagent_containers/glass) && !istype(over_object, /obj/item/reagent_containers/food/drinks) && !istype(over_object, /obj/item/spraybottle) && !istype(over_object, /obj/machinery/plantpot) && !istype(over_object, /obj/mopbucket))
+/obj/mopbucket/mouse_drop(obj/over_object as obj)
+	if (!(over_object.object_flags & REFILL_ON_MOUSEDROP))
 		return ..()
 
 	if (BOUNDS_DIST(usr, src) > 0 || BOUNDS_DIST(usr, over_object) > 0)


### PR DESCRIPTION
[Player Actions] [Feature] [QoL]


## About the PR:
Similar to dragging one reagent container to another, dragging a fluid to a container will now attempt to transfer some of the fluid to that container, the volume transferred currently being at minimum the empty volume remaining in the container, and at maximum the total amount of reagents per tile covered by the fluid puddle.
To facilitate the above, the `mousedrop_refill` list (and the many snowflake checks used in place of it) was refactored into a bitflag system.



## Why's this needed?
Quality of life; attempting to transfer reagents from a fluid puddle to a container requires both patience and either using two containers to slowly transfer reagents or clicking inbetween fluid updates to dump then swiftly pick up the reagents again.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Click dragging a fluid puddle to a reagent container now attempts to transfer fluid to that container.
```
