### PR TITLE
Little bit of radiation protection for space suits

### DIFF
--- a/code/obj/item/clothing/helmets.dm
+++ b/code/obj/item/clothing/helmets.dm
@@ -34,6 +34,7 @@
 		setProperty("disorient_resist_eye", 8)
 		setProperty("disorient_resist_ear", 8)
 		setProperty("space_movespeed", 0.2)
+		setProperty("radprot", 5)
 
 	oldish
 		icon_state = "space-OLD"

--- a/code/obj/item/clothing/suits.dm
+++ b/code/obj/item/clothing/suits.dm
@@ -1058,6 +1058,7 @@
 		setProperty("meleeprot", 3)
 		setProperty("rangedprot", 0.5)
 		setProperty("space_movespeed", 0.6)
+		setProperty("radprot", 10)
 
 /obj/item/clothing/suit/space/emerg
 	name = "emergency suit"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a little bit of radiation protection to space suits. Suits provide 10 radOhms, helmets provide 5.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Space suits should protect you from the horrors of space better than a cloth t-shirt, and one of the horrors of space is the radiation. A staffie uniform should not be equally protective as a full miner's space suit.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Space suits provide a little bit of radiation protection.
```
