### PR TITLE
Radiation: first message always triggers

### DIFF
--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -2111,7 +2111,7 @@ var/global/icon/human_static_base_idiocy_bullshit_crap = icon('icons/mob/human.d
 	var/actual_dose = ..()
 	if(actual_dose > 0.2 && !internal)
 		src.TakeDamage("All",0,20*clamp(actual_dose/4.0, 0, 1)) //a 2Sv dose all at once will badly burn you
-		if(!ON_COOLDOWN(src,"radiation_feel_message",5 SECONDS))
+		if(!ON_COOLDOWN(src,"radiation_feel_message_burn",5 SECONDS))
 			src.show_message("<span class='alert'>[pick("Your skin blisters!","It hurts!","Oh god, it burns!")]</span>") //definitely get a message for that
-	else if(prob(10) && !ON_COOLDOWN(src,"radiation_feel_message",10 SECONDS))
+	else if((!src.radiation_dose || prob(10)) && !ON_COOLDOWN(src,"radiation_feel_message",10 SECONDS))
 		src.show_message("<span class='alert'>[pick("Your skin prickles","You taste iron","You smell ozone","You feel a wave of pins and needles","Is it hot in here?")]</span>")


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When exposed to rads, if you have no dose already, the first message ("You taste iron", etc) always triggers. 


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Just a tiny thing that was bothering me - the rate limiting on the message was making it so you might not get a message at all if you were unlucky. This prevents that. If you get exposed to rads, and you have none already, you will always get at least one message in chat on the first rad tick.
