### PR TITLE
Cyborgs won't be warned about wormhole radiation

### DIFF
--- a/code/modules/transport/pods/warp_travel.dm
+++ b/code/modules/transport/pods/warp_travel.dm
@@ -144,7 +144,9 @@
 		return
 	if (ismob(M))
 		var/mob/T = M
-		boutput(T, "<span class='alert'>You are exposed to some pretty swole strange particles, this can't be good...</span>")
+		if (!issilicon(M)) // Borgs don't care about rads (for the meantime)
+			boutput(T, "<span class='alert'>You are exposed to some pretty swole strange particles, this can't be good...</span>")
+
 		if(prob(1))
 			T.gib()
 			T.unlock_medal("Where we're going, we won't need eyes to see", 1)


### PR DESCRIPTION
[QOL] [BORGS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When walking through a warp portal from pods/subs, anything under `/mob/living/silicon` won't be warned about radiation particles around them.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->

Cyborgs currently don't react to radiation, so it's there just to scare new cyborg players. Carbon and critters will still be warned about radiation, since most of them are affected by it.
