### PR TITLE
Fix small bug with additive radioactivity

### DIFF
--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -50,10 +50,14 @@ TYPEINFO(/datum/component/radioactive)
 				src._added_to_items_processing = TRUE
 		else
 			global.processing_items.Add(src) //gross - in the event that this component is put on something that isn't an item, use the item processing loop anyway
+		src.do_filters()
+
+	proc/do_filters()
 		var/atom/PA = parent
 		var/color = (neutron ? "#2e3ae4" : "#18e022") + num2hex(min(128, round(255 * radStrength/100)), 2) //base color + alpha
 		PA.add_filter("radiation_color_\ref[src]", 1, color_matrix_filter(normalize_color_to_matrix(PA.color ? PA.color : "#FFF")))
-		src._backup_color = PA.color
+		if(isnull(src._backup_color))
+			src._backup_color = PA.color
 		PA.color = null
 		PA.add_simple_light("radiation_light_\ref[src]", rgb2num(color))
 		PA.add_filter("radiation_outline_\ref[src]", 2, outline_filter(size=1.3, color=color))
@@ -97,6 +101,7 @@ TYPEINFO(/datum/component/radioactive)
 				src.decays = R.decays
 			else if (R.neutron == src.neutron && R.decays == src.decays) //if compatible, stack
 				src.radStrength = min(src.radStrength+R.radStrength, 100)
+			src.do_filters()
 			//else
 				//either you tried to apply a decay to a permanent, or a non-neutron to a neutron
 				//in which case, do nothing
@@ -112,6 +117,7 @@ TYPEINFO(/datum/component/radioactive)
 				M.take_radiation_dose(mult * (neutron ? 0.8 SIEVERTS: 0.2 SIEVERTS) * (radStrength/100) * 1/((GET_DIST(M, PA)/(src.effect_range+1)) + 1))
 		if(src.decays && prob(33))
 			src.radStrength = max(0, src.radStrength - (1 * mult))
+			src.do_filters()
 		if(!src.radStrength)
 			src.RemoveComponent()
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The radioactive glow filters weren't being updated when they ought to have been. Fortunately, nothing in the game uses this yet so nobody would've noticed, but my nuke engine pr didn't look right and this is why. Only spotted it because balance changes made things less glowy.