### PR TITLE
Fixes #10544 - rockbox gems are ejected properly

### DIFF
--- a/code/obj/mining_cloud_storage.dm
+++ b/code/obj/mining_cloud_storage.dm
@@ -276,7 +276,7 @@
 			for(var/i in 1 to amount_ejected)
 				var/obj/item/raw_material/ore = new OCD.type_path(src)
 				ore.removeMaterial()
-				ore.setMaterial(OCD.stats[length(OCD.stats)], (ore.initial_material_name == ore.name), (ore.initial_material_name == ore.name), FALSE) //for the most part, this will only affect gemstones by preserving their type, but also quality
+				ore.setMaterial(OCD.stats[length(OCD.stats)], (lowertext(ore.initial_material_name) != lowertext(ore.material_name)), (lowertext(ore.initial_material_name) != lowertext(ore.material_name)), FALSE) //for the most part, this will only affect gemstones by preserving their type, but also quality
 				ore.initial_material_name = ore.material.name
 				OCD.stats.Cut(length(OCD.stats))
 				ore.set_loc(eject_location)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Fixes #10544
Minor problem: miracle matter gets called "miraculum miracle matter" and is a bit more transparent. Miracle matter is annoying.
