### PR TITLE
Chameleon Outfits Now Have The Option To Create New And Delete Existing Outfit Sets

### DIFF
--- a/code/obj/item/clothing/chameleon_js.dm
+++ b/code/obj/item/clothing/chameleon_js.dm
@@ -8,6 +8,7 @@
 	uses_multiple_icon_states = 1
 	item_state = "black"
 	var/list/clothing_choices = list()
+	var/current_choice = new/datum/chameleon_jumpsuit_pattern
 
 	New()
 		..()
@@ -71,6 +72,7 @@
 
 	proc/change_outfit(var/datum/chameleon_jumpsuit_pattern/T)
 		if (T)
+			src.current_choice = T
 			src.name = T.name
 			src.desc = T.desc
 			src.icon_state = T.icon_state
@@ -301,6 +303,7 @@
 	icon = 'icons/obj/clothing/item_hats.dmi'
 	uses_multiple_icon_states = 1
 	var/list/clothing_choices = list()
+	var/current_choice = new/datum/chameleon_hat_pattern
 	blocked_from_petasusaphilic = TRUE
 	item_function_flags = IMMUNE_TO_ACID
 	seal_hair = 0
@@ -366,6 +369,7 @@
 
 	proc/change_outfit(var/datum/chameleon_hat_pattern/T)
 		if (T)
+			src.current_choice = T
 			src.name = T.name
 			src.desc = T.desc
 			src.icon_state = T.icon_state
@@ -538,6 +542,7 @@
 	uses_multiple_icon_states = 1
 	over_hair = FALSE
 	var/list/clothing_choices = list()
+	var/current_choice = new/datum/chameleon_suit_pattern
 
 	New()
 		..()
@@ -602,6 +607,7 @@
 
 	proc/change_outfit(var/datum/chameleon_suit_pattern/T)
 		if (T)
+			src.current_choice = T
 			src.name = T.name
 			src.desc = T.desc
 			src.icon_state = T.icon_state
@@ -845,6 +851,7 @@
 	wear_image_icon = 'icons/mob/clothing/eyes.dmi'
 	uses_multiple_icon_states = 1
 	var/list/clothing_choices = list()
+	var/current_choice = new/datum/chameleon_glasses_pattern
 
 	New()
 		..()
@@ -905,6 +912,7 @@
 
 	proc/change_outfit(var/datum/chameleon_glasses_pattern/T)
 		if (T)
+			src.current_choice = T
 			src.name = T.name
 			src.desc = T.desc
 			src.icon_state = T.icon_state
@@ -971,6 +979,7 @@
 	wear_image_icon = 'icons/mob/clothing/feet.dmi'
 	uses_multiple_icon_states = 1
 	var/list/clothing_choices = list()
+	var/current_choice = new/datum/chameleon_shoes_pattern
 	step_sound = "step_default"
 
 	New()
@@ -1036,6 +1045,7 @@
 
 	proc/change_outfit(var/datum/chameleon_shoes_pattern/T)
 		if (T)
+			src.current_choice = T
 			src.name = T.name
 			src.desc = T.desc
 			src.icon_state = T.icon_state
@@ -1150,6 +1160,7 @@
 	inhand_image_icon = 'icons/mob/inhand/hand_feethand.dmi'
 	uses_multiple_icon_states = 1
 	var/list/clothing_choices = list()
+	var/current_choice = new/datum/chameleon_gloves_pattern
 	material_prints = "black leather fibers"
 	hide_prints = 1
 	scramble_prints = 0
@@ -1215,6 +1226,7 @@
 
 	proc/change_outfit(var/datum/chameleon_gloves_pattern/T)
 		if (T)
+			src.current_choice = T
 			src.name = T.name
 			src.desc = T.desc
 			src.icon_state = T.icon_state
@@ -1300,6 +1312,7 @@
 	wear_image_icon = 'icons/mob/clothing/belt.dmi'
 	uses_multiple_icon_states = 1
 	var/list/clothing_choices = list()
+	var/current_choice = new/datum/chameleon_belt_pattern
 
 	New()
 		..()
@@ -1361,6 +1374,7 @@
 
 	proc/change_outfit(var/datum/chameleon_belt_pattern/T)
 		if (T)
+			src.current_choice = T
 			src.name = T.name
 			src.desc = T.desc
 			src.icon_state = T.icon_state
@@ -1419,6 +1433,7 @@
 	wear_image_icon = 'icons/mob/clothing/back.dmi'
 	uses_multiple_icon_states = TRUE
 	var/list/clothing_choices = list()
+	var/current_choice = new/datum/chameleon_backpack_pattern
 	spawn_contents = list()
 	in_list_or_max = TRUE
 	can_hold = list(/obj/item/storage/belt/chameleon)
@@ -1506,6 +1521,7 @@
 
 	proc/change_outfit(var/datum/chameleon_backpack_pattern/T)
 		if (T)
+			src.current_choice = T
 			src.name = T.name
 			src.desc = T.desc
 			src.icon_state = T.icon_state
@@ -1648,6 +1664,52 @@
 			if(!which)
 				return
 
+			if (which.function == "delete_outfit")
+				var/datum/chameleon_outfit_choices/outfit_to_delete = tgui_input_list(usr, "Delete which chameleon outfit set?", "Chameleon Outfit Remote", outfit_choices)
+
+				if(!outfit_to_delete)
+					return
+				if(outfit_to_delete.function)
+					boutput(user, "<span class='alert'>The chameleon outfit prevents you from deleting this function!</span>")
+					return
+
+				src.outfit_choices -= outfit_to_delete
+
+				boutput(user, "<span class='notice'>Outfit set deleted!</span>")
+				return
+
+			if(which.function == "new_outfit")
+				var/name = tgui_input_text(usr, "Name of new outfit set:", "Chameleon Outfit Remote")
+				if(!name)
+					return
+				for(var/datum/chameleon_outfit_choices/P in src.outfit_choices)
+					if(P.name == name)
+						boutput(user, "<span class='alert'>That outfit set name is already saved in the chameleon outfit banks!</span>")
+						return
+
+				var/datum/chameleon_outfit_choices/P = new /datum/chameleon_outfit_choices(src)
+				P.name = name
+				if(connected_jumpsuit)
+					P.jumpsuit_type = connected_jumpsuit.current_choice
+				if(connected_hat)
+					P.hat_type = connected_hat.current_choice
+				if(connected_suit)
+					P.suit_type = connected_suit.current_choice
+				if(connected_glasses)
+					P.glasses_type = connected_glasses.current_choice
+				if(connected_shoes)
+					P.shoes_type = connected_shoes.current_choice
+				if(connected_gloves)
+					P.gloves_type = connected_gloves.current_choice
+				if(connected_belt)
+					P.belt_type = connected_belt.current_choice
+				if(connected_backpack)
+					P.backpack_type = connected_backpack.current_choice
+				src.outfit_choices += P
+
+				boutput(user, "<span class='notice'>New outfit set created!</span>")
+				return
+
 			if(connected_jumpsuit || which.jumpsuit_type)
 				connected_jumpsuit.change_outfit(which.jumpsuit_type)
 
@@ -1673,6 +1735,7 @@
 				connected_backpack.change_outfit(which.backpack_type)
 
 /datum/chameleon_outfit_choices
+	var/function = null
 	var/name = "Staff Assistant"
 	var/jumpsuit_type = new/datum/chameleon_jumpsuit_pattern/rank
 	var/hat_type = new/datum/chameleon_hat_pattern/
@@ -1935,3 +1998,11 @@
 		gloves_type = new/datum/chameleon_gloves_pattern/latex
 		belt_type = new/datum/chameleon_belt_pattern
 		backpack_type = new/datum/chameleon_backpack_pattern
+
+	new_outfit
+		function = "new_outfit"
+		name = "New Outfit Set"
+
+	delete_outfit
+		function = "delete_outfit"
+		name = "Delete Outfit Set"


### PR DESCRIPTION
[Game Objects] [Feature] [QoL]



## About the PR:
Adds two new options to the chameleon jumpsuit remote, allowing it to create new outfit sets and to delete existing ones. New sets are are comprised of the current choice of outfit for each indiviual item of chameleon apparel.



## Why's this needed?
Chameleon outfits currently only have the ability to disguise as the basic uniforms of each role or job on the fly, often prompting the player to spend several minutes adjusting their outfit to match that of their impersonation target or customising it to suit their own preferred version of an outfit. A delete option has also been added to avoid the cluttering of the chameleon remote menu and to allow the removal of unwanted or unneeded disguises.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Chameleon outfits now have the option to create new and delete existing outfit sets.
```