### PR TITLE
Pixel pointing

### DIFF
--- a/code/atom.dm
+++ b/code/atom.dm
@@ -16,6 +16,9 @@
 	/// Override for the texture size used by setTexture.
 	var/texture_size = 0
 
+	/// Should points thrown at this take into account the click pixel value
+	var/pixel_point = FALSE
+
 	/// If hear_talk is triggered on this object, make my contents hear_talk as well
 	var/open_to_sound = 0
 

--- a/code/mob.dm
+++ b/code/mob.dm
@@ -3102,7 +3102,7 @@
 	set name = "Point"
 	src.point_at(A)
 
-/mob/proc/point_at(var/atom/target) //overriden by living and dead
+/mob/proc/point_at(var/atom/target, var/pixel_x, var/pixel_y) //overriden by living and dead
 	.=0
 
 /mob/verb/pull_verb(atom/movable/A as mob|obj in oview(1, usr))

--- a/code/mob/dead/hivemind_observer.dm
+++ b/code/mob/dead/hivemind_observer.dm
@@ -57,17 +57,18 @@
 	point_at(atom/target, var/pixel_x, var/pixel_y)
 		if(ON_COOLDOWN(src, "hivemind_member_point", 1 SECOND))
 			return
+		make_hive_point(target, pixel_x, pixel_y, color="#e2a059")
+
+	/// Like make_point, but the point is an image that is only displayed to hivemind members
+	proc/make_hive_point(atom/movable/target, var/pixel_x, var/pixel_y, color="#ffffff", time=2 SECONDS)
+		var/turf/target_turf = get_turf(target)
+		var/image/point = image(point_img, loc = target_turf, layer = EFFECTS_LAYER_1)
 		if (!target.pixel_point)
 			pixel_x = target.pixel_x
 			pixel_y = target.pixel_y
 		else
 			pixel_x -= 16 - target.pixel_x
 			pixel_y -= 16 - target.pixel_y
-		make_hive_point(get_turf(target), pixel_x, pixel_y, color="#e2a059")
-
-	/// Like make_point, but the point is an image that is only displayed to hivemind members
-	proc/make_hive_point(atom/movable/target, var/pixel_x, var/pixel_y, color="#ffffff", time=2 SECONDS)
-		var/image/point = image(point_img, loc = target, layer = EFFECTS_LAYER_1)
 		point.pixel_x = pixel_x
 		point.pixel_y = pixel_y
 		point.color = color
@@ -81,7 +82,7 @@
 			member.client.images += point
 			viewers += member.client
 		var/matrix/M = matrix()
-		M.Translate((hivemind_owner.owner.x - target.x)*32 - pixel_x, (hivemind_owner.owner.y - target.y)*32 - pixel_y)
+		M.Translate((hivemind_owner.owner.x - target_turf.x)*32 - pixel_x, (hivemind_owner.owner.y - target_turf.y)*32 - pixel_y)
 		point.transform = M
 		animate(point, transform=null, time=2)
 		SPAWN(time)

--- a/code/mob/dead/hivemind_observer.dm
+++ b/code/mob/dead/hivemind_observer.dm
@@ -41,7 +41,7 @@
 
 	click(atom/target, params)
 		if (src.client.check_key(KEY_POINT))
-			point_at(target)
+			point_at(target, text2num(params["icon-x"]), text2num(params["icon-y"]))
 			return
 		if (try_launch_attack(target))
 			return
@@ -54,15 +54,25 @@
 				src.set_cursor('icons/cursors/point.dmi')
 				return
 
-	point_at(atom/target)
+	point_at(atom/target, var/pixel_x, var/pixel_y)
 		if(ON_COOLDOWN(src, "hivemind_member_point", 1 SECOND))
 			return
-		make_hive_point(target, color="#e2a059")
+		if (!target.pixel_point)
+			pixel_x = target.pixel_x
+			pixel_y = target.pixel_y
+		else
+			pixel_x -= 16 - target.pixel_x
+			pixel_y -= 16 - target.pixel_y
+		make_hive_point(get_turf(target), pixel_x, pixel_y, color="#e2a059")
 
 	/// Like make_point, but the point is an image that is only displayed to hivemind members
-	proc/make_hive_point(atom/movable/target, color="#ffffff", time=2 SECONDS)
+	proc/make_hive_point(atom/movable/target, var/pixel_x, var/pixel_y, color="#ffffff", time=2 SECONDS)
 		var/image/point = image(point_img, loc = target, layer = EFFECTS_LAYER_1)
+		point.pixel_x = pixel_x
+		point.pixel_y = pixel_y
 		point.color = color
+		point.layer = EFFECTS_LAYER_1
+		point.plane = PLANE_HUD
 		var/list/client/viewers = new
 		for (var/mob/member in hivemind_owner.get_current_hivemind())
 			if (!member.client)
@@ -71,7 +81,7 @@
 			member.client.images += point
 			viewers += member.client
 		var/matrix/M = matrix()
-		M.Translate((hivemind_owner.owner.x - target.x)*32, (hivemind_owner.owner.y - target.y)*32)
+		M.Translate((hivemind_owner.owner.x - target.x)*32 - pixel_x, (hivemind_owner.owner.y - target.y)*32 - pixel_y)
 		point.transform = M
 		animate(point, transform=null, time=2)
 		SPAWN(time)

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -90,14 +90,8 @@
 	if(prob(20))
 		point_invisibility = INVIS_NONE
 #endif
-	if (!target.pixel_point)
-		pixel_x = target.pixel_x
-		pixel_y = target.pixel_y
-	else
-		pixel_x -= 16 - target.pixel_x
-		pixel_y -= 16 - target.pixel_y
 	if (!ON_COOLDOWN(src, "point", 0.5 SECONDS))
-		make_point(get_turf(target), pixel_x=pixel_x, pixel_y=pixel_y, color="#5c00e6", invisibility=point_invisibility, pointer=src)
+		make_point(target, pixel_x=pixel_x, pixel_y=pixel_y, color="#5c00e6", invisibility=point_invisibility, pointer=src)
 
 
 #define GHOST_LUM	1		// ghost luminosity

--- a/code/mob/dead/observer.dm
+++ b/code/mob/dead/observer.dm
@@ -55,7 +55,7 @@
 /mob/dead/observer/click(atom/target, params, location, control)
 
 	if (src.in_point_mode || (src.client && src.client.check_key(KEY_POINT)))
-		src.point(target)
+		src.point_at(target, text2num(params["icon-x"]), text2num(params["icon-y"]))
 		if (src.in_point_mode)
 			src.toggle_point_mode()
 		return
@@ -76,7 +76,7 @@
 	REMOVE_ATOM_PROPERTY(src, PROP_MOB_INVISIBILITY, "clientless")
 
 
-/mob/dead/observer/point_at(var/atom/target)
+/mob/dead/observer/point_at(atom/target, var/pixel_x, var/pixel_y)
 	if (!isturf(src.loc))
 		return
 
@@ -90,8 +90,14 @@
 	if(prob(20))
 		point_invisibility = INVIS_NONE
 #endif
+	if (!target.pixel_point)
+		pixel_x = target.pixel_x
+		pixel_y = target.pixel_y
+	else
+		pixel_x -= 16 - target.pixel_x
+		pixel_y -= 16 - target.pixel_y
 	if (!ON_COOLDOWN(src, "point", 0.5 SECONDS))
-		make_point(get_turf(target), pixel_x=target.pixel_x, pixel_y=target.pixel_y, color="#5c00e6", invisibility=point_invisibility, pointer=src)
+		make_point(get_turf(target), pixel_x=pixel_x, pixel_y=pixel_y, color="#5c00e6", invisibility=point_invisibility, pointer=src)
 
 
 #define GHOST_LUM	1		// ghost luminosity

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -614,14 +614,8 @@
 		src.visible_message("<span class='emote'><b>[src]</b> points to [target].</span>")
 	else
 		src.visible_message("<span style='font-weight:bold;color:#f00;font-size:120%;'>[src] points \the [G] at [target]!</span>")
-	if (!target.pixel_point)
-		pixel_x = target.pixel_x
-		pixel_y = target.pixel_y
-	else
-		pixel_x -= 16 - target.pixel_x
-		pixel_y -= 16 - target.pixel_y
 	if (!ON_COOLDOWN(src, "point", 0.5 SECONDS))
-		make_point(get_turf(target), pixel_x=pixel_x, pixel_y=pixel_y, color=src.bioHolder.mobAppearance.customization_first_color, pointer=src)
+		make_point(target, pixel_x=pixel_x, pixel_y=pixel_y, color=src.bioHolder.mobAppearance.customization_first_color, pointer=src)
 
 
 /mob/living/proc/set_burning(var/new_value)

--- a/code/mob/living.dm
+++ b/code/mob/living.dm
@@ -472,7 +472,7 @@
 			return
 
 		if (src.in_point_mode || (src.client && src.client.check_key(KEY_POINT)))
-			src.point(target)
+			src.point_at(target, text2num(params["icon-x"]), text2num(params["icon-y"]))
 			if (src.in_point_mode)
 				src.toggle_point_mode()
 			return
@@ -595,7 +595,7 @@
 	src.in_point_mode = !(src.in_point_mode)
 	src.update_cursor()
 
-/mob/living/point_at(var/atom/target)
+/mob/living/point_at(var/atom/target, var/pixel_x, var/pixel_y)
 	if (!isturf(src.loc) || !isalive(src) || src.restrained())
 		return
 
@@ -614,9 +614,14 @@
 		src.visible_message("<span class='emote'><b>[src]</b> points to [target].</span>")
 	else
 		src.visible_message("<span style='font-weight:bold;color:#f00;font-size:120%;'>[src] points \the [G] at [target]!</span>")
-
+	if (!target.pixel_point)
+		pixel_x = target.pixel_x
+		pixel_y = target.pixel_y
+	else
+		pixel_x -= 16 - target.pixel_x
+		pixel_y -= 16 - target.pixel_y
 	if (!ON_COOLDOWN(src, "point", 0.5 SECONDS))
-		make_point(get_turf(target), pixel_x=target.pixel_x, pixel_y=target.pixel_y, color=src.bioHolder.mobAppearance.customization_first_color, pointer=src)
+		make_point(get_turf(target), pixel_x=pixel_x, pixel_y=pixel_y, color=src.bioHolder.mobAppearance.customization_first_color, pointer=src)
 
 
 /mob/living/proc/set_burning(var/new_value)

--- a/code/mob/living/silicon/ghostdrone.dm
+++ b/code/mob/living/silicon/ghostdrone.dm
@@ -368,7 +368,7 @@
 			return
 
 		if (src.in_point_mode || src.client?.check_key(KEY_POINT))
-			src.point(target)
+			src.point_at(target, text2num(params["icon-x"]), text2num(params["icon-y"]))
 			if (src.in_point_mode)
 				src.toggle_point_mode()
 			return

--- a/code/modules/medical/pathology/pathogen_symptoms.dm
+++ b/code/modules/medical/pathology/pathogen_symptoms.dm
@@ -623,7 +623,7 @@ datum/pathogeneffects/malevolent/serious_paranoia
 		var/what = pick("I am the traitor.", "I will kill you.", "You will die, [M].")
 		if (prob(50))
 			boutput(M, "<B>[O]</B> points at [M].")
-			make_point(get_turf(M))
+			make_point(M)
 		boutput(M, "<B>[O]</B> [action], \"[what]\"")
 
 	proc/backpack(var/mob/M, var/mob/living/O)

--- a/code/obj/decal.dm
+++ b/code/obj/decal.dm
@@ -122,19 +122,26 @@ proc/make_point(atom/movable/target, pixel_x=0, pixel_y=0, color="#ffffff", time
 	// note that `target` can also be a turf, but byond sux and I can't declare the var as atom because areas don't have vis_contents
 	if(QDELETED(target)) return
 	var/obj/decal/point/point = new
+	if (!target.pixel_point)
+		pixel_x = target.pixel_x
+		pixel_y = target.pixel_y
+	else
+		pixel_x -= 16 - target.pixel_x
+		pixel_y -= 16 - target.pixel_y
 	point.pixel_x = pixel_x
 	point.pixel_y = pixel_y
 	point.color = color
 	point.invisibility = invisibility
-	target.vis_contents += point
-	if(pointer && GET_DIST(pointer, target) <= 10) // check so that you can't shoot points across the station
+	var/turf/target_turf = get_turf(target)
+	target_turf.vis_contents += point
+	if(pointer && GET_DIST(pointer, target_turf) <= 10) // check so that you can't shoot points across the station
 		var/matrix/M = matrix()
-		M.Translate((pointer.x - target.x)*32 - pixel_x, (pointer.y - target.y)*32 - pixel_y)
+		M.Translate((pointer.x - target_turf.x)*32 - pixel_x, (pointer.y - target_turf.y)*32 - pixel_y)
 		point.transform = M
 		animate(point, transform=null, time=2)
 	SPAWN(time)
-		if(target)
-			target.vis_contents -= point
+		if(target_turf)
+			target_turf.vis_contents -= point
 		qdel(point)
 	return point
 

--- a/code/obj/item/canvas.dm
+++ b/code/obj/item/canvas.dm
@@ -48,6 +48,7 @@
 	stamina_cost = 0
 	stamina_crit_chance = 0
 
+	pixel_point = TRUE
 
 	New()
 		..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL] [FEATURE] [PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds support for pixel pointing and adds it to canvases.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Currently you point at the center of objects, which is mostly fine but can look weird on some larger ones such as the centcom canvas, also it's nice to be able to point at specific features of a player's canvas drawing, also I need this for the nukie map coming soon™


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Canvases now support pixel-precise pointing.
```
