### PR TITLE
Immediately interrupt shambler pin attempts

### DIFF
--- a/code/obj/item/grab.dm
+++ b/code/obj/item/grab.dm
@@ -521,7 +521,7 @@
 
 	onStart()
 		..()
-		if(BOUNDS_DIST(owner, target) > 0 || target == null || owner == null || BOUNDS_DIST(owner, T) > 0)
+		if(BOUNDS_DIST(owner, target) > 0 || target == null || owner == null || BOUNDS_DIST(owner, T) > 0 || isabomination(target))
 			interrupt(INTERRUPT_ALWAYS)
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
On attempting to pin a shambling abomination, it will be immediately interrupted/cancelled. You will still have your grab.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Suggested alternative from https://github.com/goonstation/goonstation/pull/9404#issuecomment-1181314757

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(*)Shambling abominations can no longer be pinned.
```
