### PR TITLE
Merges Robusttin with Spaceacillian

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -2099,17 +2099,6 @@ datum
 			required_reagents = list("mutadone" = 3, "lithium" = 1)
 			result_amount = 4
 
-		cold_medicine
-			name = "Robustissin"
-			id = "cold_medicine"
-			result = "cold_medicine"
-			required_reagents = list("menthol" = 1, "morphine" = 1, "hydrogen" = 1, "acetone" = 1)
-			result_amount = 4
-			mix_phrase = "The chemicals fizz together and a strange grape scent rises from the container."
-
-		cold_medicine/cold_medicine2
-			id = "cold_medicine2"
-			required_reagents = list("antihistamine" = 1, "oil" = 1, "salicylic_acid" = 1, "menthol" = 1)
 
 		cyanide
 			name = "Cyanide"

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -49,6 +49,7 @@ datum
 			fluid_g = 180
 			fluid_b = 120
 			transparency = 255
+			overdose = 30
 			depletion_rate = 0.2
 			value = 3 // 2c + 1c
 
@@ -61,6 +62,31 @@ datum
 					M.changeStatus("poisoned", -10 SECONDS * mult)
 				..()
 				return
+
+			do_overdose(var/severity, var/mob/M, var/mult = 1)
+				var/effect = ..(severity, M)
+				M.druggy = max(M.druggy, 15)
+				M.stuttering += rand(0,2)
+				if(severity == 1)
+					if(effect <= 4)
+						M.emote(pick("blink","shiver","drool"))
+						M.change_misstep_chance(8 * mult)
+					else if (effect <= 9)
+						M.emote("twitch")
+						M.setStatusMin("weakened", 3 SECONDS * mult)
+					else if(effect <= 12)
+						M.setStatusMin("weakened", 5 SECONDS * mult)
+						M.druggy ++
+				else if (severity == 2)
+					if(effect <= 4)
+						M.emote(pick("shiver","moan","groan","laugh"))
+						M.change_misstep_chance(14 * mult)
+					else if (effect <= 10)
+						M.emote("twitch")
+						M.setStatusMin("weakened", 3 SECONDS * mult)
+					else if (effect <= 13)
+						M.setStatusMin("weakened", 5 SECONDS * mult)
+						M.druggy ++
 
 		medical/morphine // // COGWERKS CHEM REVISION PROJECT. roll the antihistamine effects into this?
 			name = "morphine"

--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -158,59 +158,6 @@ datum
 				..()
 				return
 
-		medical/cold_medicine
-			name = "robustissin"
-			id = "cold_medicine"
-			description = "A pharmaceutical compound used to treat minor colds, coughs, and other ailments."
-			reagent_state = LIQUID
-			fluid_r = 107
-			fluid_g = 29
-			fluid_b = 122
-			transparency = 70
-			addiction_prob = 6
-			overdose = 30
-			value = 7 // Okay there are two recipes, so two different values... I'll just go with the lower one.
-
-			on_mob_life(var/mob/living/M, var/mult = 1)
-				if(!M) M = holder.my_atom
-				if(probmult(8))
-					M.emote(pick("smile","giggle","yawn"))
-				for(var/datum/ailment_data/disease/virus in M.ailments)
-					if(probmult(25) && istype(virus.master,/datum/ailment/disease/cold))
-						M.cure_disease(virus)
-					if(probmult(25) && istype(virus.master,/datum/ailment/disease/flu))
-						M.cure_disease(virus)
-					if(probmult(25) && istype(virus.master,/datum/ailment/disease/food_poisoning))
-						M.cure_disease(virus)
-				..()
-				return
-
-			do_overdose(var/severity, var/mob/M, var/mult = 1)
-				var/effect = ..(severity, M)
-				M.druggy = max(M.druggy, 15)
-				M.stuttering += rand(0,2)
-				if(severity == 1)
-					if(effect <= 4)
-						M.emote(pick("blink","shiver","drool"))
-						M.change_misstep_chance(8 * mult)
-					else if (effect <= 9)
-						M.emote("twitch")
-						M.setStatusMin("weakened", 3 SECONDS * mult)
-					else if(effect <= 12)
-						M.setStatusMin("weakened", 5 SECONDS * mult)
-						M.druggy ++
-				else if (severity == 2)
-					if(effect <= 4)
-						M.emote(pick("shiver","moan","groan","laugh"))
-						M.change_misstep_chance(14 * mult)
-					else if (effect <= 10)
-						M.emote("twitch")
-						M.setStatusMin("weakened", 3 SECONDS * mult)
-					else if (effect <= 13)
-						M.setStatusMin("weakened", 5 SECONDS * mult)
-						M.druggy ++
-
-
 		medical/teporone // COGWERKS CHEM REVISION PROJECT. marked for revision
 			name = "teporone"
 			id = "teporone"

--- a/code/modules/chemistry/tools/bottles.dm
+++ b/code/modules/chemistry/tools/bottles.dm
@@ -140,12 +140,6 @@
 	amount_per_transfer_from_this = 5
 	initial_reagents = "morphine"
 
-/obj/item/reagent_containers/glass/bottle/coldmedicine
-	name = "bottle (robustissin)"
-	desc = "A small bottle containing robustissin, for treating common ailments.  It has a warning label on it about dizziness and minor toxicity."
-	bottle_style = "2"
-	amount_per_transfer_from_this = 5
-	initial_reagents = "cold_medicine"
 
 /// cogwerks - adding some new bottles for traitor medics
 // haine - I added beedril/royal beedril to these, and my heart-related disease reagents. yolo (remove these if they're a dumb idea, idk)

--- a/code/modules/food_and_drink/popsicles.dm
+++ b/code/modules/food_and_drink/popsicles.dm
@@ -78,7 +78,6 @@
 			if("grape")
 				src.desc = "A purple popsicle, which appears to be \"Raisin' Hell Raisin\" flavor, which features a boost of \"Super Energy Raisin Juice,\" whatever that is."
 				R.add_reagent("wine", 5)
-				R.add_reagent("robustissin", 5) //?
 				R.add_reagent("coffee", 5)
 				R.add_reagent("bread", 5)
 				R.add_reagent("milk", 5)

--- a/code/modules/medical/diseases/cold.dm
+++ b/code/modules/medical/diseases/cold.dm
@@ -4,8 +4,9 @@
 	spread = "Airborne"
 	virulence = 30 // Reduced from 100 %. Station-wide, basically incurable and unavoidable epidemics weren't fun (Convair880).
 	resistance_prob = 25 // Increased from 0 %.
-	cure = "Sleep"
+	cure = "Sleep, Spaceacillin"
 	associated_reagent = "mucus"
+	reagentcure = list("coffee", "spaceacillin")
 	affected_species = list("Human")
 //
 /datum/ailment/disease/cold/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)

--- a/code/modules/medical/diseases/flu.dm
+++ b/code/modules/medical/diseases/flu.dm
@@ -4,8 +4,9 @@
 	spread = "Airborne"
 	virulence = 30 // Reduced from 100 %. Station-wide, basically incurable and unavoidable epidemics weren't fun (Convair880).
 	resistance_prob = 25 // Increased from 0 %.
-	cure = "Sleep"
+	cure = "Sleep, Spaceacillin"
 	associated_reagent = "green mucus"
+	reagentcure = list("spaceacillin")
 	affected_species = list("Human")
 
 /datum/ailment/disease/flu/stage_act(var/mob/living/affected_mob, var/datum/ailment_data/D, mult)

--- a/code/modules/medical/diseases/frog_flu.dm
+++ b/code/modules/medical/diseases/frog_flu.dm
@@ -2,9 +2,9 @@
 	name = "Frog Flu"
 	max_stages = 4
 	spread = "Non-Contagious"
-	cure = "Robustissin, Robust Coffee, getting robusted"
+	cure = "Robust Coffee, getting robusted"
 	associated_reagent = "sheltestgrog"
-	reagentcure = list("robustissin", "coffee")
+	reagentcure = list("coffee")
 	affected_species = list("Human")
 	stage_prob = 5
 

--- a/code/modules/vending/vending.dm
+++ b/code/modules/vending/vending.dm
@@ -1185,7 +1185,6 @@
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/bottle/saline, 5)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/bottle/synaptizine, 4)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/bottle/spaceacillin, 3)
-		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/glass/bottle/coldmedicine, 3)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/pill/mannitol, 8)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/pill/mutadone, 5)
 		product_list += new/datum/data/vending_product(/obj/item/reagent_containers/pill/salbutamol, 8)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This pr removes Robusttin from the game, and with the exception of frog flu adds spaceallin as a cure to the diseases that robusttin otherwise wouldve cured . This also moves the overdose effect of robusttin to spaceacillin.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Robusttin is just really useless, the only thing it cures is really niche diseases, and spaceallin already fills the niche of generalist disease fixer chem. I think the amount of chemicals medical gets can be overwhelming and this chemical doesnt really have a reason to exist, the overdose effects is fun though so its being moved to spaceacillin.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(uIkea
(+)Robusttin has been removed and spaceacillin can now cure The flu and the common cold. Spaceallin now has the overdose effect of Robussttin
```
