### PR TITLE
makes werewolves no longer forcibly turn into a werewolf

### DIFF
--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -18,7 +18,7 @@
 		W.addAbility(/datum/targetable/werewolf/werewolf_tainted_saliva)
 		W.addAbility(/datum/targetable/werewolf/werewolf_defense)
 		W.addAbility(/datum/targetable/werewolf/werewolf_transform)
-
+		// W.addAbility(/datum/targetable/werewolf/werewolf_spread_affliction) //not using for now, but could be fun later ish.
 		src.resistances += /datum/ailment/disease/lycanthropy
 
 		if (src.mind && src.mind.special_role != ROLE_OMNITRAITOR)

--- a/code/datums/abilities/werewolf.dm
+++ b/code/datums/abilities/werewolf.dm
@@ -5,51 +5,24 @@
 
 /* 	/		/		/		/		/		/		Setup		/		/		/		/		/		/		/		/		*/
 
-/mob/proc/make_werewolf(var/force=0)
+/mob/proc/make_werewolf()
 	if (ishuman(src))
 		var/datum/abilityHolder/werewolf/A = src.get_ability_holder(/datum/abilityHolder/werewolf)
 		if (A && istype(A))
 			return
 		var/datum/abilityHolder/werewolf/W = src.add_ability_holder(/datum/abilityHolder/werewolf)
-		//W.addAbility(/datum/targetable/werewolf/werewolf_transform)
 		W.addAbility(/datum/targetable/werewolf/werewolf_feast)
 		W.addAbility(/datum/targetable/werewolf/werewolf_pounce)
 		W.addAbility(/datum/targetable/werewolf/werewolf_thrash)
 		W.addAbility(/datum/targetable/werewolf/werewolf_throw)
 		W.addAbility(/datum/targetable/werewolf/werewolf_tainted_saliva)
 		W.addAbility(/datum/targetable/werewolf/werewolf_defense)
-		// W.addAbility(/datum/targetable/werewolf/werewolf_spread_affliction)	//not using for now, but could be fun later ish.
-		if (force)
-			W.addAbility(/datum/targetable/werewolf/werewolf_transform)
-			boutput(src, "<span class='alert'>You are a full werewolf, you can transform immediately!</span>")
-		else
-			SPAWN(W.awaken_time)
-				handle_natural_werewolf(W)
+		W.addAbility(/datum/targetable/werewolf/werewolf_transform)
 
 		src.resistances += /datum/ailment/disease/lycanthropy
 
 		if (src.mind && src.mind.special_role != ROLE_OMNITRAITOR)
 			src.show_antag_popup("werewolf")
-
-	else return
-
-/mob/proc/handle_natural_werewolf(var/datum/abilityHolder/werewolf/W)
-	src.emote("shiver")
-	boutput(src, "<span class='alert'><b>You feel feral!</b></span>")
-	sleep(5 SECONDS)
-	if (!src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis"))
-		boutput(src, "<span class='alert'><b>You suddenly feel very weak.</b></span>")
-		src.emote("collapse")
-	SPAWN(8 SECONDS)
-		if (!src.getStatusDuration("weakened"))
-			src.emote("collapse")
-		boutput(src, "<span class='alert'><b>Your body feels as if it's on fire! You think it's... IT'S CHANGING! You should probably get somewhere private!</b></span>")
-		sleep(rand(300, 500))
-		src.emote("scream")
-		if (!src.getStatusDuration("weakened") && !src.getStatusDuration("paralysis"))
-			src.emote("collapse")
-		W.addAbility(/datum/targetable/werewolf/werewolf_transform)
-		src.werewolf_transform() // Not really a fan of this. I wish werewolves all suffered from lycanthropy and that should be how you pass it on, but w/e
 
 ////////////////////////////////////////////// Helper procs //////////////////////////////
 

--- a/code/datums/abilities/werewolf/werewolf_spread_affliction.dm
+++ b/code/datums/abilities/werewolf/werewolf_spread_affliction.dm
@@ -123,7 +123,7 @@
 			else if (ishuman(HH))
 				if (isturf(M.loc) && isturf(HH.loc))
 					if (!HH.disease_resistance_check("/datum/ailment/disease/lycanthropy","Lycanthropy"))
-						HH.make_werewolf(1)
+						HH.make_werewolf()
 						HH.full_heal()
 						HH.setStatus("weakened", 15 SECONDS)
 						HH.werewolf_transform() // Not really a fan of this. I wish werewolves all suffered from lycanthropy and that should be how you pass it on, but w/e

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -4712,7 +4712,7 @@ var/global/noir = 0
 			if(ROLE_WEREWOLF)
 				M.mind.special_role = ROLE_WEREWOLF
 				M.show_text("<h2><font color=red><B>You have become a werewolf!</B></font></h2>", "red")
-				M.make_werewolf(1)
+				M.make_werewolf()
 			if(ROLE_GRINCH)
 				M.mind.special_role = ROLE_GRINCH
 				M.make_grinch()
@@ -4752,7 +4752,7 @@ var/global/noir = 0
 				M.verbs += /client/proc/gearspawn_wizard
 				M.make_changeling()
 				M.make_vampire()
-				M.make_werewolf(1)
+				M.make_werewolf()
 				M.make_wrestler(1)
 				M.make_grinch()
 				M.show_text("<h2><font color=red><B>You have become an omnitraitor!</B></font></h2>", "red")

--- a/code/modules/admin/antagifiers.dm
+++ b/code/modules/admin/antagifiers.dm
@@ -192,7 +192,7 @@
 		color = "#000000"
 
 		makeAntag(mob/living/carbon/human/M as mob)
-			M.make_werewolf(1)
+			M.make_werewolf()
 			boutput(M, "<span class='combat'>Awooooooo!</span>")
 
 	wrestler

--- a/code/modules/events/antag_ghost_respawn.dm
+++ b/code/modules/events/antag_ghost_respawn.dm
@@ -239,7 +239,7 @@
 				var/mob/living/R2 = M3.humanize()
 				if (R2 && istype(R2))
 					M3 = R2
-					R2.make_werewolf(1)
+					R2.make_werewolf()
 					role = ROLE_WEREWOLF
 					objective_path = /datum/objective_set/werewolf
 				else


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [BALANCE][REMOVAL][GAMEMODES] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

makes werewolves no longer forcibly turn into a werewolf soon after spawning (or well at all)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
werewolves forcibly transforming often prevents any form of early game preparing (which is basically always needed by antags to not get trivially robusted)

ironically enough this mechanic meant to make wws act aggressive earlier often just dooms them by forcing them to fight unprepared
## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)ZWRh3
(*) Werewolves no longer forcibly transform.
```
