### PR TITLE
fix a bug with the multiplier of smelling salts

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -660,14 +660,13 @@ datum
 					REMOVE_ATOM_PROPERTY(M, PROP_MOB_STAMINA_REGEN_BONUS, "r_smelling_salt")
 				..()
 
-			on_mob_life(var/mob/M, var/method=INGEST, var/mult = 1)
+			on_mob_life(var/mob/M, var/mult = 1)
 				if(!M)
 					M = holder.my_atom
 				flush(M, 3 * mult, flushed_reagents)
 
-				if(method == INGEST)
-					if (M.health < -5 && M.health > -30)
-						M.HealDamage("All", 1 * mult, 1 * mult, 1 * mult)
+				if (M.health < -5 && M.health > -30)
+					M.HealDamage("All", 1 * mult, 1 * mult, 1 * mult)
 				if(M.getStatusDuration("radiation") && prob(30))
 					M.take_radiation_dose(-0.005 SIEVERTS * mult)
 				if (prob(5))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The on_mob_life proc had the method arg even though that proc doesn't actually get that arg.
Thus it was also used as the mult, making this act twice as quickly assuming no lag, I guess?

This probably has some balance implications in regards to purging/healing more slowly, staying in the system longer for the stamina buff, idk.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad