### PR TITLE
converts some string paths into normal paths

### DIFF
--- a/code/modules/antagonists/changeling/abilities/morph_arm.dm
+++ b/code/modules/antagonists/changeling/abilities/morph_arm.dm
@@ -7,8 +7,8 @@
 	target_anything = 0
 	pointCost = 0
 	can_use_in_container = 1
-	var/list/potential_r_arms = list("/obj/item/parts/human_parts/arm/right/claw", "/obj/item/parts/human_parts/arm/right/abomination")
-	var/list/potential_l_arms = list("/obj/item/parts/human_parts/arm/left/claw","/obj/item/parts/human_parts/arm/left/abomination")
+	var/list/potential_r_arms = list(/obj/item/parts/human_parts/arm/right/claw, /obj/item/parts/human_parts/arm/right/abomination)
+	var/list/potential_l_arms = list(/obj/item/parts/human_parts/arm/left/claw,/obj/item/parts/human_parts/arm/left/abomination)
 
 	cast(atom/target)
 		if (..())
@@ -56,7 +56,7 @@
 		if (!new_limb)
 			return 1
 
-		C.limbs.replace_with(target_limb, text2path(new_limb), C, 0)
+		C.limbs.replace_with(target_limb, new_limb, C, 0)
 		var/adjective = pick("terrifying","scary","menacing","badass","deadly","disgusting","grody")
 		holder.owner.visible_message(text("<span class='alert'><B>[holder.owner]'s [(target_limb == "r_arm") ? "right" : "left"] arm quivers and rearranges itself into a [adjective] new form!</B></span>"))
 		logTheThing(LOG_COMBAT, C, "morphs a [new_limb], [log_loc(C)].")
@@ -64,11 +64,11 @@
 
 		SPAWN(cooldown)
 			if (target_limb == "r_arm")
-				if (C.limbs.r_arm && istype(C.limbs.r_arm,text2path(new_limb)))
+				if (C.limbs.r_arm && istype(C.limbs.r_arm, new_limb))
 					C.limbs.replace_with(target_limb, /obj/item/parts/human_parts/arm/right, C, 0)
 					boutput(holder.owner, "<span class='notice'><B>Our right arm shrinks back to normal size.</B></span>")
 			else
-				if (C.limbs.l_arm && istype(C.limbs.l_arm,text2path(new_limb)))
+				if (C.limbs.l_arm && istype(C.limbs.l_arm, new_limb))
 					C.limbs.replace_with(target_limb, /obj/item/parts/human_parts/arm/left, C, 0)
 					boutput(holder.owner, "<span class='notice'><B>Our left arm shrinks back to normal size.</B></span>")
 		return 0

--- a/code/modules/medical/genetics/bioEffects/powers.dm
+++ b/code/modules/medical/genetics/bioEffects/powers.dm
@@ -122,7 +122,7 @@
 	blockGaps = 2
 	stability_loss = 5
 	ability_path = /datum/targetable/geneticsAbility/mattereater
-	var/target_path = "/obj/item/"
+	var/target_path = /obj/item/
 
 /datum/targetable/geneticsAbility/mattereater
 	name = "Matter Eater"
@@ -139,14 +139,11 @@
 			return TRUE
 		using = TRUE
 
-		var/datum/bioEffect/power/mattereater/ME = linked_power
-		var/base_path = text2path("[ME.target_path]")
-		if (!ispath(base_path))
-			base_path = /obj/item/
-		var/list/items = get_filtered_atoms_in_touch_range(owner,base_path)
-		if (ismob(owner.loc) || istype(owner.loc,/obj/))
+		var/datum/bioEffect/power/mattereater/mattereater = linked_power
+		var/list/items = get_filtered_atoms_in_touch_range(owner, mattereater.target_path)
+		if (ismob(owner.loc) || istype(owner.loc, /obj/))
 			for (var/atom/A in owner.loc.contents)
-				if (istype(A,ME.target_path))
+				if (istype(A, mattereater.target_path))
 					items += A
 
 		if (linked_power.power > 1)
@@ -163,7 +160,7 @@
 			using = FALSE
 			return TRUE
 
-		if (!(the_object in get_filtered_atoms_in_touch_range(owner, base_path)) && !istype(the_object, /obj/the_server_ingame_whoa))
+		if (!(the_object in get_filtered_atoms_in_touch_range(owner, mattereater.target_path)) && !istype(the_object, /obj/the_server_ingame_whoa))
 			owner.show_text("<span class='alert'>Man, that thing is long gone, far away, just let it go.</span>")
 			return TRUE
 
@@ -230,14 +227,11 @@
 			return 1
 		using = 1
 
-		var/datum/bioEffect/power/mattereater/ME = linked_power
-		var/base_path = text2path("[ME.target_path]")
-		if (!ispath(base_path))
-			base_path = /obj/item/
-		var/list/items = get_filtered_atoms_in_touch_range(owner,base_path)
-		if (ismob(owner.loc) || istype(owner.loc,/obj/))
+		var/datum/bioEffect/power/mattereater/mattereater = linked_power
+		var/list/items = get_filtered_atoms_in_touch_range(owner, mattereater.target_path)
+		if (ismob(owner.loc) || istype(owner.loc, /obj/))
 			for (var/atom/A in owner.loc.contents)
-				if (istype(A,ME.target_path))
+				if (istype(A, mattereater.target_path))
 					items += A
 
 		if (linked_power.power > 1)

--- a/code/obj/item/implant.dm
+++ b/code/obj/item/implant.dm
@@ -1594,59 +1594,59 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 
 /obj/item/implantcase/health
 	name = "glass case - 'Health'"
-	implant_type = "/obj/item/implant/health"
+	implant_type = /obj/item/implant/health
 
 /obj/item/implantcase/sec
 	name = "glass case - 'Security Access'"
-	implant_type = "/obj/item/implant/sec"
+	implant_type = /obj/item/implant/sec
 /*
 /obj/item/implantcase/nt
 	name = "glass case - 'Weapon Auth 2'"
-	implant_type = "/obj/item/implant/nt"
+	implant_type = /obj/item/implant/nt
 
 /obj/item/implantcase/ntc
 	name = "glass case - 'Weapon Auth 3'"
-	implant_type = "/obj/item/implant/ntc"
+	implant_type = /obj/item/implant/ntc
 */
 /obj/item/implantcase/freedom
 	name = "glass case - 'Freedom'"
-	implant_type = "/obj/item/implant/freedom"
+	implant_type = /obj/item/implant/freedom
 
 /obj/item/implantcase/counterrev
 	name = "glass case - 'Counter-Rev'"
-	implant_type = "/obj/item/implant/counterrev"
+	implant_type = /obj/item/implant/counterrev
 
 /obj/item/implantcase/microbomb
 	name = "glass case - 'Microbomb'"
-	implant_type = "/obj/item/implant/revenge/microbomb"
+	implant_type = /obj/item/implant/revenge/microbomb
 
 /obj/item/implantcase/robotalk
 	name = "glass case - 'Machine Translator'"
-	implant_type = "/obj/item/implant/robotalk"
+	implant_type = /obj/item/implant/robotalk
 
 /obj/item/implantcase/bloodmonitor
 	name = "glass case - 'Blood Monitor'"
-	implant_type = "/obj/item/implant/bloodmonitor"
+	implant_type = /obj/item/implant/bloodmonitor
 
 /obj/item/implantcase/mindhack
 	name = "glass case - 'Mindhack'"
-	implant_type = "/obj/item/implant/mindhack"
+	implant_type = /obj/item/implant/mindhack
 
 /obj/item/implantcase/super_mindhack
 	name = "glass case - 'Mindhack DELUXE'"
-	implant_type = "/obj/item/implant/mindhack/super"
+	implant_type = /obj/item/implant/mindhack/super
 
 /obj/item/implantcase/robust
 	name = "glass case - 'Robusttec'"
-	implant_type = "/obj/item/implant/robust"
+	implant_type = /obj/item/implant/robust
 
 /obj/item/implantcase/antirot
 	name = "glass case - 'Rotbusttec'"
-	implant_type = "/obj/item/implant/antirot"
+	implant_type = /obj/item/implant/antirot
 
 /obj/item/implantcase/access
 	name = "glass case - 'Electronic Access'"
-	implant_type = "/obj/item/implant/access"
+	implant_type = /obj/item/implant/access
 
 	get_desc(dist)
 		if (dist <= 1 && src.imp)
@@ -1655,7 +1655,7 @@ ABSTRACT_TYPE(/obj/item/implant/revenge)
 				. += "It appears to contain \a [src.imp.name] with [I.uses] charges."
 
 	unlimited
-		implant_type = "/obj/item/implant/access/infinite"
+		implant_type = /obj/item/implant/access/infinite
 		get_desc(dist)
 			if (dist <= 1 && src.imp)
 				. += "It appears to contain \a [src.imp.name] with unlimited charges."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [CODE QUALITY][OBJECTS] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
replaces some item paths in strings with normal paths

mild matter eater refactoring

**matter eater will no longer default to obj/item if its target_path is invalid and will runtime instead**
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
paths in strings bad