### PR TITLE
Prevents flock from converting the ghostdrone factory and listening post

### DIFF
--- a/code/datums/abilities/flock/flockmind.dm
+++ b/code/datums/abilities/flock/flockmind.dm
@@ -128,7 +128,7 @@
 		return TRUE
 	var/mob/living/intangible/flock/F = holder.owner
 	var/turf/T = get_turf(target)
-	if(!(istype(T, /turf/simulated) || istype(T, /turf/space)))
+	if(!(istype(T, /turf/simulated) || istype(T, /turf/space)) || !flockTurfAllowed(T))
 		boutput(holder.get_controlling_mob(), "<span class='alert'>The flock can't convert this.</span>")
 		return TRUE
 	if(isfeathertile(T))

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -688,11 +688,14 @@ var/flock_signal_unleashed = FALSE
 	/obj/spacevine = null
 	)
 
+/proc/flockTurfAllowed(var/turf/T)
+	var/area/area = get_area(T)
+	return !(istype(area, /area/listeningpost) || istype(area, /area/ghostdrone_factory))
+
 /proc/flock_convert_turf(var/turf/T)
 	if(!T)
 		return
-	var/area/area = get_area(T)
-	if (istype(area, /area/listeningpost) || istype(area, /area/ghostdrone_factory))
+	if (!flockTurfAllowed(T))
 		return
 
 	if(istype(T, /turf/simulated/floor) || istype(T, /turf/simulated/pool))

--- a/code/datums/flock/flock.dm
+++ b/code/datums/flock/flock.dm
@@ -579,6 +579,8 @@ var/flock_signal_unleashed = FALSE
 	removeAnnotation(T, FLOCK_ANNOTATION_RESERVED)
 
 /datum/flock/proc/claimTurf(var/turf/simulated/T)
+	if (!T)
+		return
 	src.all_owned_tiles |= T
 	src.priority_tiles -= T
 	T.AddComponent(/datum/component/flock_interest, src)
@@ -688,6 +690,9 @@ var/flock_signal_unleashed = FALSE
 
 /proc/flock_convert_turf(var/turf/T)
 	if(!T)
+		return
+	var/area/area = get_area(T)
+	if (istype(area, /area/listeningpost) || istype(area, /area/ghostdrone_factory))
 		return
 
 	if(istype(T, /turf/simulated/floor) || istype(T, /turf/simulated/pool))

--- a/code/mob/living/critter/ai/flock/flocktasks.dm
+++ b/code/mob/living/critter/ai/flock/flocktasks.dm
@@ -205,6 +205,8 @@ stare
 	. = list()
 	var/mob/living/critter/flock/F = holder.owner
 	for(var/turf/simulated/floor/T in view(max_dist, holder.owner))
+		if (!flockTurfAllowed(T))
+			continue
 		if(F?.flock && !F.flock.isTurfFree(T, F.real_name))
 			continue
 		. = get_path_to(holder.owner, list(T), max_dist*2, 1)
@@ -242,7 +244,7 @@ stare
 
 /datum/aiTask/sequence/goalbased/flock/build/valid_target(var/atom/target)
 	var/mob/living/critter/flock/F = holder.owner
-	if(!isfeathertile(target))
+	if(!isfeathertile(target) && flockTurfAllowed(get_turf(target)))
 		if(F?.flock && !F.flock.isTurfFree(target, F.real_name))
 			return FALSE
 		return TRUE
@@ -355,7 +357,7 @@ stare
 	. = list()
 	//as drone, we want to prioritise converting doors and walls and containers
 	for(var/turf/simulated/T in view(max_dist, holder.owner))
-		if(!isfeathertile(T) && (
+		if(!isfeathertile(T) && flockTurfAllowed(T) && (
 			istype(T, /turf/simulated/wall) || \
 			locate(/obj/machinery/door/airlock) in T || \
 			locate(/obj/storage) in T))
@@ -368,7 +370,7 @@ stare
 	// if there are absolutely no walls/doors/closets in view, and no reserved tiles, then fine, you can have a floor tile
 	if(!length(.))
 		for(var/turf/simulated/T in view(max_dist, holder.owner))
-			if(!isfeathertile(T))
+			if(!isfeathertile(T) && flockTurfAllowed(T))
 				if(F?.flock && !F.flock.isTurfFree(T, F.real_name))
 					continue
 				. = get_path_to(holder.owner, list(T), max_dist, 1)

--- a/code/mob/living/critter/flock/flockdrone.dm
+++ b/code/mob/living/critter/flock/flockdrone.dm
@@ -986,6 +986,9 @@
 		boutput(user, "<span class='alert'>Not enough resources to convert (you need [FLOCK_CONVERT_COST]).</span>")
 	else
 		if(istype(target, /turf))
+			if (!flockTurfAllowed(target))
+				boutput(user, "<span class='alert'>Something about this area resists your attempt to convert it</span>")
+				return
 			if (user.flock)
 				for (var/name in user.flock.busy_tiles)
 					if (user.flock.busy_tiles[name] == target && name != user.real_name)

--- a/code/mob/living/critter/flockcritter_parent.dm
+++ b/code/mob/living/critter/flockcritter_parent.dm
@@ -252,14 +252,14 @@
 	onUpdate()
 		..()
 		var/mob/living/critter/flock/F = owner
-		if (!F || isdead(F) || !target || !in_interact_range(F, target) || isfeathertile(target) || !F.can_afford(FLOCK_CONVERT_COST))
+		if (!F || isdead(F) || !target || !in_interact_range(F, target) || isfeathertile(target) || !F.can_afford(FLOCK_CONVERT_COST) || !flockTurfAllowed(target))
 			interrupt(INTERRUPT_ALWAYS)
 			return
 
 	onStart()
 		..()
 		var/mob/living/critter/flock/F = owner
-		if(!F || isdead(F) || !target || !in_interact_range(F, target) || isfeathertile(target) || !F.can_afford(FLOCK_CONVERT_COST))
+		if(!F || isdead(F) || !target || !in_interact_range(F, target) || isfeathertile(target) || !F.can_afford(FLOCK_CONVERT_COST) || !flockTurfAllowed(target))
 			interrupt(INTERRUPT_ALWAYS)
 			return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE] [BUG] [GAMEMODES]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just slaps a check for ghostdrone and listening post areas in the convert code


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Flock were never supposed to be able to break into listening post, and while I enjoyed pod fights around ghostdrone it is becoming very meta.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)LeahTheTech
(+)Flock can no longer break into the listening post or convert the ghostdrone factory. Bad radio pigeons.
```
