### PR TITLE
Fixes #10647 - Fire elementals get their own gib now, and flock cages work better

### DIFF
--- a/code/mob/living/critter/arena/fire_elemental.dm
+++ b/code/mob/living/critter/arena/fire_elemental.dm
@@ -4,7 +4,7 @@
 	desc = "You can't tell if this person is on fire, or made of it. Or both."
 	density = 1
 	icon_state = "fire_elemental"
-	custom_gib_handler = /proc/gibs
+	custom_gib_handler = /proc/fire_elemental_gibs
 	hand_count = 3
 	can_throw = 1
 	can_grab = 1
@@ -68,9 +68,9 @@
 		return(max(..(), 80))
 
 	death(var/gibbed)
-		..(gibbed, 0)
 		playsound(src.loc, 'sound/impact_sounds/burn_sizzle.ogg', 100, 1)
-		make_cleanable(/obj/decal/cleanable/ash,src.loc)
+		..(gibbed, 0)
 		if (!gibbed)
+			make_cleanable(/obj/decal/cleanable/ash,src.loc)
 			ghostize()
 			qdel(src)

--- a/code/obj/flock/cage.dm
+++ b/code/obj/flock/cage.dm
@@ -211,7 +211,7 @@
 				if(target:health <= 0)
 					if(isliving(target))
 						var/mob/living/M = target
-						M.set_loc(src.loc)
+						M.set_loc(src)
 						M.gib()
 						occupant = null
 						playsound(src, 'sound/impact_sounds/Flesh_Tear_2.ogg', 80, 1)
@@ -221,9 +221,9 @@
 							occupant = null
 							playsound(src, 'sound/impact_sounds/Flesh_Tear_2.ogg', 80, 1)
 							src.visible_message("<span class='alert bold'>[src] rips what's left of its occupant to shreds!</span>")
-						target.set_loc(null)
-						qdel(target)
-						target = null
+					target.set_loc(null)
+					qdel(target)
+					target = null
 			else
 				reagents.add_reagent(target_fluid, 10)
 				qdel(target)

--- a/code/procs/gibs.dm
+++ b/code/procs/gibs.dm
@@ -257,3 +257,22 @@
 
 	// CORE SPLAT
 	gib = make_cleanable( /obj/decal/cleanable/flockdrone_debris/fluid,location)
+
+
+/proc/fire_elemental_gibs(atom/location, var/list/diseases, var/list/ejectables, var/blood_DNA, var/blood_type)
+	if(!location) return
+	// WHO LIKES COPY PASTED CODE? I DO I LOVE IT DELICIOUS YUM YUM
+	var/obj/decal/cleanable/ash/gib = null
+	playsound(location, 'sound/effects/mag_fireballlaunch.ogg', 50, 1, pitch = 0.5)
+	// RANDOM
+	gib = make_cleanable(/obj/decal/cleanable/ash, location)
+	gib.streak_cleanable()
+	// RANDOM
+	gib = make_cleanable(/obj/decal/cleanable/ash, location)
+	gib.streak_cleanable()
+
+	handle_ejectables(location, ejectables)
+
+	// CORE SPLAT
+	gib = make_cleanable(/obj/decal/cleanable/ash, location)
+	fireflash(location, 1)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Stops flock cages from relying on `gib()` to properly delete and clean up the ref to target, which works for humans just fine but apparently not for elementals for some reason. 
Also fire elementals get a firey gib now, instead of exploding into meat.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #10647


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(+)Fire elementals explode into flame when gibbed now.
```
