### PR TITLE
Fix area goof on cog1 north solar array

### DIFF
--- a/maps/cogmap.dmm
+++ b/maps/cogmap.dmm
@@ -60013,8 +60013,8 @@
 	pixel_x = -26
 	},
 /obj/machinery/coffeemaker/engineering{
-	pixel_y = 3;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /obj/item/reagent_containers/food/drinks/creamer{
 	pixel_x = 8;
@@ -121814,15 +121814,15 @@ aay
 aap
 aaZ
 cVP
-fBp
-fBp
-fBp
-fBp
+qAl
+qAl
+qAl
+qAl
 dRb
-fBp
-fBp
-fBp
-fBp
+qAl
+qAl
+qAl
+qAl
 tMA
 aaZ
 aap


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[minor][mapping]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
These vertical catwalks were erroneously part of the western solars, now they're not.
![image](https://user-images.githubusercontent.com/31984217/188733475-fe97c22c-bc1c-46dc-8520-49658a3e0c73.png)

I don't know what's up with the coffee maker in the changes, I guess SDMM just decided to do that as well.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Sensible consistency
