### PR TITLE
rename mining shuttle to "NT Transit Shuttle"

### DIFF
--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -240,7 +240,7 @@
 	if(miningshuttle_location)
 		dat += "Shuttle Location: Station"
 	else
-		dat += "Shuttle Location: Mining Outpost"
+		dat += "Shuttle Location: Diner"
 	dat += "<BR>"
 	if(active)
 		dat += "Moving"
@@ -272,7 +272,7 @@
 	if(!active)
 		for(var/obj/machinery/computer/mining_shuttle/C in machine_registry[MACHINES_SHUTTLECOMPS])
 			active = 1
-			C.visible_message("<span class='alert'>The Mining Shuttle has been called and will leave shortly!</span>")
+			C.visible_message("<span class='alert'>The Diner Shuttle has been called and will leave shortly!</span>")
 		SPAWN(10 SECONDS)
 			call_shuttle()
 
@@ -300,7 +300,7 @@
 
 	for(var/obj/machinery/computer/mining_shuttle/C in machine_registry[MACHINES_SHUTTLECOMPS])
 		active = 0
-		C.visible_message("<span class='alert'>The Mining Shuttle has moved!</span>")
+		C.visible_message("<span class='alert'>The Diner Shuttle has moved!</span>")
 
 	return
 
@@ -781,7 +781,7 @@ proc/bioele_accident()
 
 
 // JOHN BILL'S JUICIN' BUS
-// This is used for reliable transport between Z3 and Z5 (ever since the diner moved to Z5)
+// This is used for reliable transport between Z3 and Z5 (ever since the diner moved to Z5 (it got moved back))
 // And also for certain adventure zones!
 // You can ask warc for details but c'mon it's just copypasted prison shuttle code (for now)
 

--- a/code/obj/machinery/computer/shuttle.dm
+++ b/code/obj/machinery/computer/shuttle.dm
@@ -272,7 +272,7 @@
 	if(!active)
 		for(var/obj/machinery/computer/mining_shuttle/C in machine_registry[MACHINES_SHUTTLECOMPS])
 			active = 1
-			C.visible_message("<span class='alert'>The Diner Shuttle has been called and will leave shortly!</span>")
+			C.visible_message("<span class='alert'>The NT Transit Shuttle has been called and will leave shortly!</span>")
 		SPAWN(10 SECONDS)
 			call_shuttle()
 
@@ -300,7 +300,7 @@
 
 	for(var/obj/machinery/computer/mining_shuttle/C in machine_registry[MACHINES_SHUTTLECOMPS])
 		active = 0
-		C.visible_message("<span class='alert'>The Diner Shuttle has moved!</span>")
+		C.visible_message("<span class='alert'>The NT Transit Shuttle has moved!</span>")
 
 	return
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
String changes to the transit shuttle between the station and the space diner to say "Diner shuttle" instead of "Mining shuttle". I did not feel like re-typing and map-modifying `/obj/machinery/computer/mining_shuttle`, so just strings.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
In-game clarity on where stuff goes is good