### PR TITLE
small plastic cutlery improvements

### DIFF
--- a/code/obj/item/kitchen.dm
+++ b/code/obj/item/kitchen.dm
@@ -86,8 +86,8 @@ TRAYS
 		var/utensil_color = replacetext(src.icon_state,replacethis,"")
 		var/obj/item/kitchen/utensil/knife/plastic/k = new /obj/item/kitchen/utensil/knife/plastic
 		k.icon_state = "snapped_[utensil_color]"
-		k.snapped = 1
-		k.name = "snapped [k.name]"
+		k.snapped = TRUE
+		k.name = "snapped [src.name]"
 		if(spawnatloc)
 			k.set_loc(location)
 		else
@@ -107,7 +107,7 @@ TRAYS
 		if (!spoon_surgery(M,user))
 			return ..()
 
-	custom_suicide = 1
+	custom_suicide = TRUE
 	suicide(var/mob/user as mob)
 		if (!src.user_can_suicide(user))
 			return 0
@@ -175,7 +175,7 @@ TRAYS
 		if(!scalpel_surgery(M,user))
 			return ..()
 
-	custom_suicide = 1
+	custom_suicide = TRUE
 	suicide(var/mob/user as mob)
 		if(!src.user_can_suicide(user))
 			return 0
@@ -190,6 +190,7 @@ TRAYS
 	desc = "A cheap plastic spoon, prone to breaking. Used to carry liquid objects from the container to the mouth."
 	force = 1
 	throwforce = 1
+	w_class = W_CLASS_TINY
 
 	New()
 		..()
@@ -219,6 +220,7 @@ TRAYS
 	desc = "A cheap plastic fork, prone to breaking. Helps with eating some foods."
 	force = 1
 	throwforce = 1
+	w_class = W_CLASS_TINY
 
 	New()
 		..()
@@ -245,9 +247,10 @@ TRAYS
 /obj/item/kitchen/utensil/knife/plastic
 	name = "plastic knife"
 	icon_state = "knife_plastic"
+	desc = "A long bit plastic that is serrated on one side, prone to breaking. It is used for cutting foods. Also useful for butchering dead animals, somehow."
 	force = 1
 	throwforce = 1
-	desc = "A long bit plastic that is serated on one side, prone to breaking. It is used for cutting foods. Also useful for butchering dead animals, somehow."
+	w_class = W_CLASS_TINY
 
 	New()
 		..()
@@ -291,9 +294,8 @@ TRAYS
 			k.set_loc(get_turf(user))
 			s.set_loc(get_turf(user))
 			user.u_equip(src)
-			src.set_loc(user)
 			if(prob(30))
-				user.show_text("<b>The plastic silverware go EVERYWHERE!</b>","red")
+				user.show_text("<b>The plastic silverware goes EVERYWHERE!</b>","red")
 				var/list/throw_targets = list()
 				for (var/i=1, i<=3, i++)
 					throw_targets += get_offset_target_turf(src.loc, rand(5)-rand(5), rand(5)-rand(5))


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
- Fixes a bug where the name of snapped utensils would always be "snapped plastic knife" even if it was originally a spoon or fork
- Fixes some typos
- Makes plastic cutlery tiny, because you can already fit 3 of them into a tiny bag and plastic cutlery is smaller than regular cutlery, and they have a chance of breaking anyway. This also lets janitors vacuum it all up, especially after breaking.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bugs are bad
plastic cutlery can be small? it's fun and I've had janitors be sad they couldn't vacuum the snapped parts that people leave behind
