### PR TITLE
removes geneticist gender

### DIFF
--- a/code/WorkInProgress/warcrimes.dm
+++ b/code/WorkInProgress/warcrimes.dm
@@ -699,7 +699,6 @@ Urs' Hauntdog critter
 	is_npc = 1
 	uses_mobai = 1
 	real_name = "Juicer Gene"
-	gender = NEUTER
 	max_health = 50
 
 	New()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This mob has their gender set to neuter, which causes a runtime whenever they try to gasp or something, because there are no neuter gasp noises in the soundfiles.
## Why's this needed? <!-- Describe why you think this should be added to the game. -->
runtimes bad

