### PR TITLE
donut3's mining/taxi shuttle dock accessible via maintenance

### DIFF
--- a/maps/donut3.dmm
+++ b/maps/donut3.dmm
@@ -272,6 +272,9 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/mail,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "aar" = (
@@ -294,22 +297,6 @@
 	dir = 1
 	},
 /area/station/bridge/customs)
-"aau" = (
-/obj/landmark/magnet_shield,
-/obj/securearea{
-	desc = "A warning that demarcates where the magnetic area begins.";
-	dir = 8;
-	icon_state = "magwarning";
-	name = "Magnet Area Boundary"
-	},
-/obj/grille/catwalk{
-	dir = 10
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/mining/magnet)
 "aav" = (
 /turf/simulated/wall/auto/jen/blue,
 /area/station/maintenance/inner/nw)
@@ -398,19 +385,6 @@
 	icon_state = "catwalk_cross"
 	},
 /area/station/engine/singcore)
-"aaG" = (
-/obj/grille/catwalk{
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
-	},
-/area/station/mining/staff_room)
 "aaH" = (
 /obj/grille/catwalk/cross{
 	dir = 9
@@ -450,12 +424,10 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
+/obj/machinery/light/small/sticky,
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	tag = "icon-catwalk (WEST)"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
 	},
 /area/station/mining/staff_room)
 "aaO" = (
@@ -485,10 +457,10 @@
 	dir = 1
 	},
 /obj/decal/tile_edge/line/yellow{
-	dir = 1;
-	icon_state = "line1"
+	dir = 9;
+	icon_state = "line2"
 	},
-/obj/stool,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/black/grime,
 /area/station/mining/staff_room)
 "aaR" = (
@@ -577,14 +549,11 @@
 /turf/simulated/floor/bot/white,
 /area/station/hangar/sec)
 "aaZ" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 10;
-	icon_state = "line2"
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
-/obj/machinery/light/incandescent/warm,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/black/grime,
-/area/station/mining/staff_room)
+/turf/simulated/wall/auto/jen/yellow,
+/area/station/hangar/qm)
 "aba" = (
 /obj/machinery/light/incandescent/warm{
 	dir = 4
@@ -2791,10 +2760,12 @@
 /area/station/hallway/secondary/construction)
 "aBc" = (
 /obj/disposaloutlet/south,
-/obj/disposalpipe/trunk/transport,
 /obj/machinery/light/emergency{
 	dir = 1;
 	pixel_y = 24
+	},
+/obj/disposalpipe/trunk/transport{
+	dir = 8
 	},
 /turf/simulated/floor/delivery,
 /area/station/hallway/primary/east)
@@ -2818,14 +2789,6 @@
 	},
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
-"aBv" = (
-/obj/stool,
-/obj/decal/tile_edge/line/yellow{
-	dir = 5;
-	icon_state = "line2"
-	},
-/turf/simulated/floor/black/grime,
-/area/station/mining/staff_room)
 "aBA" = (
 /obj/decal/poster/wallsign/fire,
 /turf/simulated/wall/auto/reinforced/supernorn/yellow,
@@ -3478,10 +3441,6 @@
 /area/station/security/hos)
 "aKU" = (
 /obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4;
-	icon_state = "catwalk_cross"
-	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1
 	},
@@ -7635,6 +7594,9 @@
 	pixel_y = 1
 	},
 /obj/machinery/light_switch/north,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
 "bVD" = (
@@ -7926,11 +7888,11 @@
 /area/station/medical/medbay/cloner)
 "bZa" = (
 /obj/machinery/door/airlock/pyro/engineering{
+	dir = 2;
 	req_access = null
 	},
-/obj/decal/mule/dropoff,
-/obj/firedoor_spawn,
 /obj/access_spawn/mining,
+/obj/firedoor_spawn,
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
 "bZp" = (
@@ -8933,15 +8895,15 @@
 /turf/simulated/floor/white,
 /area/station/security/quarters)
 "cpv" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 8;
-	icon_state = "line1"
-	},
 /obj/stool/chair/yellow{
 	dir = 4
 	},
 /obj/landmark/start{
 	name = "Miner"
+	},
+/obj/decal/tile_edge/line/yellow{
+	dir = 10;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
@@ -9124,9 +9086,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/wood,
@@ -9908,12 +9867,12 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "cDt" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
+	},
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
 	},
 /turf/space,
 /area/space)
@@ -12241,9 +12200,6 @@
 /turf/simulated/floor,
 /area/station/ai_monitored/armory)
 "dmY" = (
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/stairs/wide{
 	dir = 4
@@ -13146,13 +13102,11 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
 "dCg" = (
-/obj/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	name = "VACUUM AREA"
+/obj/railing/yellow{
+	dir = 1
 	},
-/turf/simulated/wall/auto/reinforced/jen/yellow,
-/area/station/mining/staff_room)
+/turf/space,
+/area/space)
 "dCu" = (
 /obj/table/auto,
 /obj/item/clipboard{
@@ -13388,13 +13342,12 @@
 	},
 /area/station/mining/staff_room)
 "dFZ" = (
-/obj/machinery/light/runway_light/delay4,
-/obj/lattice{
-	dir = 1;
-	icon_state = "lattice-dir"
-	},
 /obj/disposalpipe/segment/transport{
-	icon_state = "pipe-c"
+	dir = 4
+	},
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/space)
@@ -14045,19 +13998,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
-"dPt" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/obj/machinery/light/small/sticky,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	tag = "icon-catwalk (WEST)"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
-	},
-/area/station/mining/staff_room)
 "dPw" = (
 /obj/machinery/bot/floorbot{
 	name = "\proper THE GROUNDSHATTERER"
@@ -14418,6 +14358,9 @@
 	pixel_y = 24
 	},
 /obj/disposalpipe/trunk,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/quartermaster/office)
 "dTI" = (
@@ -15111,14 +15054,14 @@
 /turf/simulated/floor,
 /area/station/medical/cdc)
 "edt" = (
-/obj/decal/cleanable/dirt/jen,
 /obj/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/grille/catwalk/jen/side{
-	dir = 1
+/obj/machinery/door/airlock/pyro/maintenance{
+	dir = 4;
+	req_access = null
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
@@ -15253,9 +15196,6 @@
 /obj/decal/tile_edge/line/yellow{
 	dir = 4;
 	icon_state = "line1"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
 	},
 /obj/disposalpipe/segment,
 /turf/simulated/floor/black/grime,
@@ -15738,12 +15678,13 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
 "eoe" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/grille/catwalk/jen/side{
-	dir = 10
-	},
 /obj/cable{
 	icon_state = "1-4"
+	},
+/obj/reagent_dispensers/foamtank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
+/obj/machinery/light/small/sticky{
+	dir = 2
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
@@ -17191,18 +17132,6 @@
 	icon_state = "purple2"
 	},
 /area/station/crew_quarters/quartersA)
-"eIJ" = (
-/obj/grille/catwalk{
-	dir = 4
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	tag = "icon-catwalk (WEST)"
-	},
-/area/station/mining/staff_room)
 "eIU" = (
 /obj/decal/tile_edge/line/yellow{
 	dir = 9;
@@ -17563,32 +17492,14 @@
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/lobby)
 "eOB" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 6;
-	icon_state = "line2"
-	},
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 10;
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/table/auto,
-/obj/item/device/gps{
-	pixel_x = -8;
-	rand_pos = 0
-	},
-/obj/item/device/gps{
-	pixel_x = -3;
-	rand_pos = 0
-	},
-/obj/item/device/gps{
-	pixel_x = 2;
-	rand_pos = 0
-	},
-/obj/item/device/gps{
-	pixel_x = 7;
-	rand_pos = 0
+/obj/decal/tile_edge/line/yellow{
+	icon_state = "line1"
 	},
 /turf/simulated/floor/black/grime,
 /area/station/mining/staff_room)
@@ -17602,6 +17513,9 @@
 	dir = 1
 	},
 /obj/item/shipcomponent/mainweapon/phaser,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
 "eOO" = (
@@ -18298,14 +18212,14 @@
 /turf/simulated/floor/blue,
 /area/station/medical/medbay/surgery/storage)
 "eYE" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/grille/catwalk/jen/side{
-	dir = 5
-	},
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
 	icon_state = "0-8"
 	},
+/obj/grille/catwalk/jen/side{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "eYF" = (
@@ -18822,17 +18736,12 @@
 /turf/simulated/wall/auto/reinforced/jen/blue,
 /area/station/medical/morgue)
 "fgN" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/grille/catwalk/jen/side{
+	dir = 6
 	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor,
-/area/station/quartermaster/office)
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/north)
 "fgQ" = (
 /obj/table/wood/round/auto,
 /turf/simulated/floor/carpet/arcade/half,
@@ -19868,8 +19777,10 @@
 	},
 /area/station/hallway/primary/west)
 "fvC" = (
+/obj/grille/catwalk/jen/side{
+	dir = 4
+	},
 /obj/decal/cleanable/dirt/jen,
-/obj/decal/cleanable/rust/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "fvF" = (
@@ -20208,6 +20119,9 @@
 	},
 /obj/tug_cart,
 /obj/machinery/light_switch/west,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "fBW" = (
@@ -20345,17 +20259,6 @@
 	},
 /turf/simulated/grass,
 /area/station/crew_quarters/garden)
-"fCS" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir-b"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/obj/machinery/light/runway_light,
-/turf/space,
-/area/space)
 "fCU" = (
 /obj/decal/tile_edge/line/blue,
 /obj/machinery/atmospherics/portables_connector{
@@ -20557,13 +20460,10 @@
 /turf/simulated/floor/black,
 /area/station/bridge/customs)
 "fEk" = (
-/obj/machinery/computer/mining_shuttle,
-/obj/decal/tile_edge/line/yellow{
-	dir = 1;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/black/grime,
-/area/station/mining/staff_room)
+/obj/decal/cleanable/dirt/jen,
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/north)
 "fEp" = (
 /obj/disposalpipe/segment/brig{
 	dir = 8;
@@ -22315,6 +22215,9 @@
 	},
 /obj/item/storage/belt/utility{
 	pixel_x = 3
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
@@ -24170,17 +24073,12 @@
 	},
 /area/station/science/lobby)
 "gMk" = (
-/obj/grille/catwalk{
-	dir = 4
+/obj/grille/catwalk/jen/side{
+	dir = 8
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	tag = "icon-catwalk (WEST)"
-	},
-/area/station/mining/staff_room)
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/north)
 "gMo" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/grille/catwalk/jen,
@@ -24592,12 +24490,13 @@
 	},
 /area/station/chapel/sanctuary)
 "gSp" = (
-/obj/lattice{
-	icon_state = "lattice-dir"
+/obj/decal/tile_edge/check/yellow{
+	icon_state = "check1";
+	dir = 4
 	},
-/obj/machinery/light/runway_light/delay5,
-/turf/space,
-/area/space)
+/obj/stool/bench,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/north)
 "gSu" = (
 /obj/cable{
 	d1 = 1;
@@ -24612,18 +24511,6 @@
 	dir = 8
 	},
 /area/station/engine/engineering)
-"gSD" = (
-/obj/grille/catwalk{
-	dir = 6
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	tag = "icon-catwalk (WEST)"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
-	},
-/area/station/mining/staff_room)
 "gSQ" = (
 /obj/lattice{
 	icon_state = "lattice-dir"
@@ -26519,16 +26406,16 @@
 	},
 /area/listeningpost)
 "huy" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 9;
-	icon_state = "line1"
+/obj/decal/tile_edge/check/yellow{
+	icon_state = "check1";
+	dir = 8
 	},
-/obj/disposalpipe/segment/transport{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/light/small/sticky{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/east)
+/obj/decal/cleanable/dirt/jen,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/north)
 "huC" = (
 /obj/machinery/shieldgenerator/energy_shield{
 	dir = 4
@@ -28161,6 +28048,9 @@
 /obj/decal/tile_edge/line/yellow{
 	dir = 4;
 	icon_state = "line1"
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
@@ -30425,13 +30315,6 @@
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"iBh" = (
-/obj/decal/tile_edge/line/yellow{
-	icon_state = "line1"
-	},
-/obj/storage/crate,
-/turf/simulated/floor/black/grime,
-/area/station/mining/staff_room)
 "iBp" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 1
@@ -32035,13 +31918,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/ne)
-"jbb" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 4;
-	icon_state = "line1"
-	},
-/turf/simulated/floor/black/grime,
-/area/station/mining/staff_room)
 "jbi" = (
 /obj/disposalpipe/segment/morgue,
 /turf/simulated/floor/specialroom/chapel{
@@ -32897,15 +32773,15 @@
 /turf/simulated/wall/auto/reinforced/jen/yellow,
 /area/station/quartermaster/office)
 "joc" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
 /obj/machinery/camera{
 	dir = 4
 	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
+	},
+/obj/lattice{
+	dir = 4;
+	icon_state = "lattice-dir-b"
 	},
 /turf/space,
 /area/space)
@@ -33287,11 +33163,13 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/se)
 "jun" = (
-/obj/decal/cleanable/dirt/jen,
 /obj/cable{
 	icon_state = "5-8"
 	},
-/obj/grille/catwalk/jen/side,
+/obj/grille/catwalk/jen/side{
+	dir = 10
+	},
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "jus" = (
@@ -33449,9 +33327,6 @@
 /obj/decal/tile_edge/line/yellow{
 	dir = 8;
 	icon_state = "line1"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
 	},
 /obj/vehicle/tug,
 /obj/machinery/light/incandescent/warm{
@@ -33844,17 +33719,8 @@
 /turf/simulated/floor/black,
 /area/station/engine/inner)
 "jDM" = (
-/obj/grille/catwalk/cross{
-	dir = 9
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 9
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	tag = "icon-catwalk (WEST)"
-	},
-/area/station/mining/staff_room)
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/north)
 "jDO" = (
 /obj/grille/catwalk/jen/side,
 /obj/machinery/light/small/sticky,
@@ -36233,11 +36099,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/beepsky)
 "kpd" = (
-/obj/grille/catwalk,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 6
-	},
-/area/space)
+/obj/machinery/door/airlock/pyro/external,
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/north)
 "kpv" = (
 /obj/decorative_pot{
 	anchored = 1
@@ -36729,22 +36593,6 @@
 /obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"kxa" = (
-/obj/landmark/magnet_shield,
-/obj/securearea{
-	desc = "A warning that demarcates where the magnetic area begins.";
-	dir = 8;
-	icon_state = "magwarning";
-	name = "Magnet Area Boundary"
-	},
-/obj/grille/catwalk{
-	dir = 4
-	},
-/turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 4
-	},
-/area/mining/magnet)
 "kxi" = (
 /turf/simulated/floor/carpet/green/fancy,
 /area/station/chapel/sanctuary{
@@ -37445,14 +37293,6 @@
 	dir = 4
 	},
 /area/station/crew_quarters/stockex)
-"kIH" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/machinery/light/small/sticky,
-/obj/grille/catwalk/jen/side{
-	dir = 6
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/north)
 "kIN" = (
 /obj/cable{
 	d1 = 1;
@@ -37475,18 +37315,18 @@
 /turf/simulated/floor/wood/two,
 /area/station/hallway/primary/south)
 "kJF" = (
-/obj/grille/catwalk{
-	dir = 10
+/obj/machinery/computer/mining_shuttle{
+	dir = 4
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
+/obj/decal/tile_edge/check/yellow{
+	icon_state = "check1";
+	dir = 8
 	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	tag = "icon-catwalk (WEST)"
+/obj/decal/tile_edge/check/yellow{
+	icon_state = "check1"
 	},
-/area/station/mining/staff_room)
+/turf/simulated/floor/black/grime,
+/area/station/maintenance/inner/north)
 "kJN" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 8
@@ -37848,7 +37688,9 @@
 /turf/simulated/floor/black/grime,
 /area/station/science/storage)
 "kOH" = (
-/obj/table/auto,
+/obj/stool/chair/comfy/yellow{
+	dir = 4
+	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "kOX" = (
@@ -38504,8 +38346,8 @@
 	dir = 1
 	},
 /obj/decal/tile_edge/line/yellow{
-	dir = 9;
-	icon_state = "line2"
+	dir = 1;
+	icon_state = "line1"
 	},
 /turf/simulated/floor/black,
 /area/station/mining/staff_room)
@@ -38780,18 +38622,6 @@
 	},
 /turf/simulated/floor/carpet/arcade/half,
 /area/station/crew_quarters/arcade/dungeon)
-"lev" = (
-/obj/lattice{
-	dir = 9;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light/delay3,
-/obj/disposalpipe/segment/transport{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/space,
-/area/space)
 "leC" = (
 /obj/table/auto,
 /obj/item/hand_labeler{
@@ -39548,6 +39378,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small/floor/warm,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
 "lpJ" = (
@@ -39974,16 +39807,16 @@
 	},
 /area/station/engine/inner)
 "lwo" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir-b"
+/obj/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/obj/machinery/light/runway_light/delay2,
-/turf/space,
-/area/space)
+/turf/simulated/floor/black,
+/area/station/quartermaster/refinery)
 "lwp" = (
 /obj/table/wood/auto,
 /obj/decal/fakeobjects/apc_broken{
@@ -40504,15 +40337,13 @@
 	},
 /area/station/medical/breakroom)
 "lCY" = (
-/obj/decal/cleanable/dirt/jen,
 /obj/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "4-10"
 	},
-/obj/grille/catwalk/jen/side{
-	dir = 1
-	},
+/obj/grille/catwalk/jen,
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "lDd" = (
@@ -41769,15 +41600,11 @@
 /turf/space,
 /area/space)
 "lTu" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 8;
-	icon_state = "line1"
+/obj/cable{
+	icon_state = "5-8"
 	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/simulated/floor/black/grime,
-/area/station/hangar/qm)
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/north)
 "lTz" = (
 /obj/disposalpipe/segment/morgue{
 	dir = 4
@@ -42212,12 +42039,6 @@
 "mac" = (
 /turf/simulated/floor/purpleblack/corner,
 /area/station/science/lobby)
-"mae" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/reagent_dispensers/fueltank,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/north)
 "mai" = (
 /obj/decal/cleanable/dirt/jen,
 /obj/random_item_spawner/junk/one_or_zero,
@@ -43035,10 +42856,6 @@
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	dir = 1
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	icon_state = "catwalk_cross"
 	},
 /area/station/mining/staff_room)
 "mnt" = (
@@ -45333,7 +45150,6 @@
 	dir = 9;
 	icon_state = "line2"
 	},
-/obj/disposalpipe/segment/transport,
 /obj/machinery/light_switch/west,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
@@ -45382,15 +45198,13 @@
 /turf/simulated/floor/plating,
 /area/station/library)
 "mYf" = (
-/obj/railing/yellow{
-	dir = 4
+/obj/decal/cleanable/dirt/jen,
+/obj/table/auto,
+/obj/machinery/light/small/sticky{
+	dir = 1
 	},
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/space)
+/turf/simulated/floor/plating/jen,
+/area/station/maintenance/inner/north)
 "mYl" = (
 /obj/decal/fakeobjects{
 	desc = "The goods inside the machine probably expired before you were even born.";
@@ -45594,11 +45408,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "nbB" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "nbC" = (
@@ -46158,19 +45968,12 @@
 	},
 /area/station/medical/head)
 "nkb" = (
-/obj/access_spawn/maint,
-/obj/decal/mule/dropoff,
-/obj/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/lattice{
+	icon_state = "lattice-dir";
+	dir = 6
 	},
-/obj/machinery/door/airlock/pyro/maintenance{
-	dir = 4;
-	req_access = null
-	},
-/turf/simulated/floor/plating/jen,
-/area/station/maintenance/inner/north)
+/turf/space,
+/area/space)
 "nkf" = (
 /obj/cable{
 	icon_state = "0-4"
@@ -46457,6 +46260,9 @@
 	},
 /obj/drink_rack/mug{
 	pixel_y = 33
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/station/quartermaster/office)
@@ -47163,6 +46969,9 @@
 	icon_state = "line1"
 	},
 /obj/machinery/arc_electroplater{
+	dir = 4
+	},
+/obj/disposalpipe/segment/transport{
 	dir = 4
 	},
 /turf/simulated/floor/black,
@@ -51157,12 +50966,16 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/north)
 "oGM" = (
-/obj/decal/tile_edge/line/yellow{
-	dir = 9;
-	icon_state = "line2"
+/obj/decal/tile_edge/check/yellow{
+	icon_state = "check1";
+	dir = 4
 	},
+/obj/decal/tile_edge/check/yellow{
+	icon_state = "check1"
+	},
+/obj/stool/bench,
 /turf/simulated/floor/black/grime,
-/area/station/mining/staff_room)
+/area/station/maintenance/inner/north)
 "oGV" = (
 /turf/simulated/floor/bluewhite{
 	dir = 9
@@ -51928,15 +51741,9 @@
 /turf/simulated/floor/circuit,
 /area/listeningpost)
 "oRh" = (
-/obj/machinery/door/airlock/pyro/engineering{
-	dir = 4;
-	req_access = null
-	},
-/obj/decal/mule/dropoff,
-/obj/firedoor_spawn,
-/obj/access_spawn/mining,
-/turf/simulated/floor/black/grime,
-/area/station/mining/staff_room)
+/obj/machinery/light/runway_light/delay5,
+/turf/simulated/floor/specialroom/gym,
+/area/station/crew_quarters/fitness)
 "oRm" = (
 /obj/disposalpipe/segment/mail,
 /turf/simulated/wall/auto/reinforced/jen,
@@ -52539,15 +52346,11 @@
 /turf/simulated/floor/specialroom/arcade,
 /area/station/science/lobby)
 "pbX" = (
-/obj/machinery/computer/power_monitor{
-	dir = 8;
-	name = "Station Power Grid Monitoring"
+/obj/table/auto,
+/obj/item/storage/pill_bottle/cyberpunk{
+	pixel_x = -1;
+	pixel_y = 1
 	},
-/obj/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/data_terminal,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "pcj" = (
@@ -52775,11 +52578,8 @@
 /obj/machinery/mining_magnet{
 	dir = 1
 	},
-/obj/grille/catwalk,
+/obj/lattice,
 /turf/space,
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10
-	},
 /area/space)
 "phx" = (
 /obj/machinery/firealarm{
@@ -53504,9 +53304,14 @@
 /turf/simulated/floor/specialroom/clown,
 /area/station/crew_quarters/clown)
 "ppP" = (
-/obj/railing/yellow,
-/turf/space,
-/area/space)
+/obj/machinery/computer/mining_shuttle{
+	dir = 1
+	},
+/obj/decal/tile_edge/check/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/mining/staff_room)
 "pqm" = (
 /obj/cable,
 /obj/cable{
@@ -53744,9 +53549,6 @@
 	dir = 8;
 	icon_state = "line1"
 	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
 "ptU" = (
@@ -53805,9 +53607,6 @@
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/station/quartermaster/office)
@@ -54882,12 +54681,13 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
 "pJo" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /obj/machinery/light/small/sticky{
 	dir = 1
 	},
-/obj/reagent_dispensers/foamtank,
+/obj/grille/catwalk/jen/side{
+	dir = 5
+	},
+/obj/decal/cleanable/dirt/jen,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "pJr" = (
@@ -55901,9 +55701,7 @@
 /area/station/hangar/arrivals)
 "pYb" = (
 /obj/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-10"
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
@@ -55965,17 +55763,6 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/outer/se)
-"pZc" = (
-/obj/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/simulated/floor/black/grime,
-/area/station/hangar/qm)
 "pZl" = (
 /turf/simulated/floor/shuttlebay{
 	name = "reinforced plating"
@@ -58292,12 +58079,29 @@
 /turf/simulated/floor/sanitary,
 /area/station/chapel/sanctuary)
 "qBQ" = (
-/obj/wingrille_spawn/auto,
-/obj/disposalpipe/segment/transport{
-	dir = 4
+/obj/decal/tile_edge/line/yellow{
+	dir = 10;
+	icon_state = "line2"
 	},
-/turf/simulated/floor/plating,
-/area/station/hangar/qm)
+/obj/table/auto,
+/obj/item/device/gps{
+	pixel_x = -8;
+	rand_pos = 0
+	},
+/obj/item/device/gps{
+	pixel_x = -3;
+	rand_pos = 0
+	},
+/obj/item/device/gps{
+	pixel_x = 2;
+	rand_pos = 0
+	},
+/obj/item/device/gps{
+	pixel_x = 7;
+	rand_pos = 0
+	},
+/turf/simulated/floor/black/grime,
+/area/station/mining/staff_room)
 "qCd" = (
 /obj/rack,
 /obj/item/clothing/shoes/magnetic,
@@ -59360,16 +59164,6 @@
 /obj/machinery/light/small/sticky/harsh,
 /turf/simulated/floor/plating/jen,
 /area/station/science/storage)
-"qRE" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir-b"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/space,
-/area/space)
 "qSd" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/machinery/light/small/sticky{
@@ -59472,14 +59266,6 @@
 	},
 /turf/simulated/floor/specialroom/freezer,
 /area/station/crew_quarters/catering)
-"qTd" = (
-/obj/lattice{
-	dir = 6;
-	icon_state = "lattice-dir-b"
-	},
-/obj/machinery/light/runway_light/delay3,
-/turf/space,
-/area/space)
 "qTj" = (
 /obj/machinery/light/incandescent/netural{
 	dir = 8
@@ -61241,8 +61027,8 @@
 /obj/disposalpipe/segment/transport{
 	dir = 4
 	},
-/turf/simulated/wall/auto/reinforced/jen/yellow,
-/area/station/hangar/qm)
+/turf/simulated/floor/black,
+/area/station/quartermaster/refinery)
 "rta" = (
 /obj/storage/secure/closet/civilian/bartender,
 /obj/item/device/reagentscanner,
@@ -64320,9 +64106,6 @@
 /obj/cable{
 	d2 = 8;
 	icon_state = "0-8"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
 	},
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
@@ -68841,10 +68624,6 @@
 "tEj" = (
 /obj/grille/catwalk{
 	dir = 6
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 10;
-	icon_state = "catwalk_cross"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
 	icon_state = "catwalk_cross"
@@ -73720,8 +73499,13 @@
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/sw)
 "uYt" = (
-/obj/stool/chair/comfy/yellow{
-	dir = 8
+/obj/machinery/computer/power_monitor{
+	dir = 2;
+	name = "Station Power Grid Monitoring"
+	},
+/obj/machinery/power/data_terminal,
+/obj/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
@@ -74064,6 +73848,9 @@
 	},
 /obj/machinery/light/incandescent/warm{
 	dir = 8
+	},
+/obj/disposalpipe/segment/transport{
+	dir = 4
 	},
 /turf/simulated/floor/black/grime,
 /area/station/hangar/qm)
@@ -74588,10 +74375,8 @@
 	},
 /area/station/security/main)
 "vmv" = (
+/obj/grille/catwalk/jen,
 /obj/decal/cleanable/dirt/jen,
-/obj/grille/catwalk/jen/side{
-	dir = 4
-	},
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "vmC" = (
@@ -75689,16 +75474,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "vBl" = (
-/obj/lattice{
-	dir = 4;
-	icon_state = "lattice-dir";
-	tag = "icon-lattice-dir (EAST)"
-	},
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
-/turf/space,
-/area/space)
+/obj/decal/poster/wallsign/space,
+/turf/simulated/wall/auto/reinforced/jen,
+/area/station/maintenance/inner/north)
 "vBo" = (
 /obj/machinery/bathtub,
 /obj/item/rubberduck{
@@ -75882,18 +75660,6 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lobby)
-"vDR" = (
-/obj/grille/catwalk/cross{
-	dir = 10
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	tag = "icon-catwalk (WEST)"
-	},
-/area/station/mining/staff_room)
 "vDU" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/cable{
@@ -75931,9 +75697,6 @@
 	icon_state = "0-2"
 	},
 /obj/cable,
-/obj/disposalpipe/segment/transport{
-	dir = 4
-	},
 /turf/simulated/floor/black,
 /area/station/quartermaster/refinery)
 "vEk" = (
@@ -76891,12 +76654,8 @@
 /obj/grille/catwalk{
 	dir = 4
 	},
-/obj/machinery/light/small/floor/warm,
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 8
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
+	dir = 4;
 	tag = "icon-catwalk (WEST)"
 	},
 /area/station/mining/staff_room)
@@ -79472,11 +79231,7 @@
 	icon_state = "catwalk_cross"
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 8;
-	tag = "icon-catwalk (WEST)"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
+	dir = 10;
 	icon_state = "catwalk_cross"
 	},
 /area/station/mining/staff_room)
@@ -83029,13 +82784,11 @@
 /turf/simulated/floor/plating,
 /area/station/medical/dome)
 "xDj" = (
-/obj/decal/cleanable/dirt/jen,
-/obj/grille/catwalk/jen/side{
-	dir = 8
-	},
 /obj/cable{
 	icon_state = "2-9"
 	},
+/obj/reagent_dispensers/fueltank,
+/obj/decal/mule/beacon/no_auto_dropoff_spawn,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "xDn" = (
@@ -84188,10 +83941,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless/plating/catwalk{
-	dir = 1;
-	icon_state = "catwalk_cross"
-	},
-/turf/simulated/floor/airless/plating/catwalk{
 	dir = 8;
 	tag = "icon-catwalk (WEST)"
 	},
@@ -84903,6 +84652,9 @@
 	icon_state = "line2"
 	},
 /obj/disposalpipe/segment,
+/obj/disposalpipe/segment/transport{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/quartermaster/office)
 "ycU" = (
@@ -85261,14 +85013,7 @@
 /turf/simulated/floor/plating/jen,
 /area/station/hallway/secondary/construction)
 "yhc" = (
-/obj/table/auto,
-/obj/machinery/light/small/sticky{
-	dir = 1
-	},
-/obj/item/storage/pill_bottle/cyberpunk{
-	pixel_x = -1;
-	pixel_y = 1
-	},
+/obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating/jen,
 /area/station/maintenance/inner/north)
 "yhr" = (
@@ -128011,7 +127756,7 @@ weI
 iJM
 eFg
 bPa
-hBW
+oRh
 hBW
 vtH
 tfk
@@ -130136,7 +129881,7 @@ yes
 rdj
 rdj
 rdj
-aLY
+rdj
 rdj
 rdj
 rdj
@@ -130438,7 +130183,6 @@ yes
 rdj
 rdj
 rdj
-aLY
 rdj
 rdj
 rdj
@@ -130448,7 +130192,8 @@ rdj
 rdj
 rdj
 rdj
-cDt
+rdj
+dFZ
 rdj
 rdj
 rdj
@@ -130740,9 +130485,6 @@ yes
 rdj
 rdj
 rdj
-aLY
-rdj
-tXv
 rdj
 rdj
 rdj
@@ -130750,7 +130492,10 @@ rdj
 rdj
 rdj
 rdj
-cDt
+rdj
+rdj
+rdj
+dFZ
 rdj
 rdj
 rdj
@@ -131035,23 +130780,23 @@ gmE
 gmE
 ltD
 hQg
-gpL
+uiL
 xDj
 eoe
 yes
-rdj
-rdj
-rdj
-aLY
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+cNV
+rQl
+cNV
+cNV
+xVz
+cNV
+cNV
+xVz
+cNV
+cNV
+rQl
+cNV
+cNV
 cDt
 rdj
 rdj
@@ -131338,23 +131083,23 @@ olq
 ltD
 eYE
 vmv
-gpL
+gMk
 jun
 yes
 rdj
 rdj
 rdj
-aLY
+qfp
+qfp
+qfp
+qfp
+qfp
+qfp
 rdj
 rdj
 rdj
 rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-vBl
+dFZ
 rdj
 rdj
 rdj
@@ -131641,22 +131386,22 @@ ltD
 pJo
 fvC
 lCY
-uiL
+fgN
 yes
+nlB
+nlB
+yes
+qfp
+qfp
+qfp
+qfp
+qfp
+qfp
+qfp
 rdj
 rdj
 rdj
-aLY
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-vBl
+dFZ
 rdj
 rdj
 rdj
@@ -131940,25 +131685,25 @@ nPk
 nPk
 nPk
 yes
-mae
-mai
-edt
-kIH
 yes
-rdj
-rdj
-rdj
-aLY
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
-rdj
+yes
+edt
+yes
+yes
+huy
+kJF
 vBl
+qfp
+qfp
+qfp
+qfp
+qfp
+qfp
+qfp
+qfp
+rdj
+rdj
+dFZ
 rdj
 rdj
 rdj
@@ -132242,27 +131987,27 @@ rdj
 rdj
 rdj
 yes
-yes
-yes
-nkb
-yes
-yes
+mYf
+nbB
+qWD
+nbB
+fEk
+jDM
+jDM
+kpd
+qfp
+qfp
+qfp
+qfp
+qfp
+qfp
+qfp
+qfp
 rdj
 rdj
-rdj
-aLY
-rdj
-qTd
-cNV
-xVz
-cNV
-rQl
-cNV
-gSp
-cNV
 dFZ
-jFg
-lev
+rdj
+rdj
 rdj
 rdj
 rdj
@@ -132545,26 +132290,26 @@ rdj
 rdj
 nlB
 yhc
-jnB
-qWD
-jnB
-nlB
-rdj
-rdj
-rdj
-aLY
-rdj
-vVp
+nbB
+lTu
+nbB
+xye
+gSp
+oGM
+vBl
 qfp
 qfp
 qfp
 qfp
 qfp
 qfp
+qfp
+qfp
 rdj
 rdj
+dFZ
 rdj
-qRE
+rdj
 rdj
 rdj
 rdj
@@ -132850,13 +132595,10 @@ uYt
 pYb
 nbB
 dwM
+yes
 nlB
-rdj
-rdj
-rdj
-aLY
-rdj
-xcP
+nlB
+yes
 qfp
 qfp
 qfp
@@ -132866,7 +132608,10 @@ qfp
 qfp
 rdj
 rdj
-lwo
+rdj
+dFZ
+rdj
+rdj
 rdj
 rdj
 rdj
@@ -133156,11 +132901,6 @@ yes
 rdj
 rdj
 rdj
-aLY
-rdj
-mYf
-qfp
-qfp
 qfp
 qfp
 qfp
@@ -133168,7 +132908,12 @@ qfp
 qfp
 qfp
 rdj
-qRE
+rdj
+rdj
+rdj
+dFZ
+rdj
+rdj
 rdj
 rdj
 rdj
@@ -133454,23 +133199,23 @@ yes
 nlB
 nlB
 yes
+cNV
+cNV
+rQl
+nkb
+cNV
+xVz
+vRE
+vRE
+xVz
+cNV
+cNV
+rQl
+cNV
+cNV
+cDt
 rdj
 rdj
-rdj
-rdj
-aLY
-ppP
-jDM
-qfp
-qfp
-qfp
-qfp
-qfp
-qfp
-qfp
-qfp
-rdj
-fCS
 rdj
 rdj
 rdj
@@ -133759,20 +133504,20 @@ rdj
 rdj
 rdj
 rdj
+vVp
 rdj
-aLY
-ppP
+rdj
 vRE
-qfp
-qfp
-qfp
-qfp
-qfp
-qfp
-qfp
-qfp
+xSZ
 rdj
-qRE
+rdj
+rdj
+rdj
+rdj
+rdj
+dFZ
+rdj
+rdj
 rdj
 rdj
 rdj
@@ -134061,20 +133806,20 @@ rdj
 rdj
 rdj
 rdj
-rdj
-aLY
-ppP
-eIJ
-qfp
-qfp
-qfp
-qfp
-qfp
-qfp
-qfp
+vVp
 rdj
 rdj
-rsY
+xSZ
+xSZ
+rdj
+rdj
+rdj
+rdj
+rdj
+rdj
+dFZ
+rdj
+vYX
 aWS
 aWS
 aWS
@@ -134363,20 +134108,20 @@ rdj
 rdj
 rdj
 rdj
-rdj
-aLY
+rfc
+cjG
 ppP
-eIJ
-qfp
-qfp
-qfp
-qfp
-qfp
-qfp
+xSZ
+xSZ
+dCg
 rdj
 rdj
 rdj
-uDr
+rdj
+rdj
+dFZ
+rdj
+iwC
 fUK
 tut
 xie
@@ -134668,17 +134413,17 @@ lmX
 vob
 kuM
 vvV
-kJF
-vDR
+xSZ
+xSZ
 dCg
-qKR
-qKR
-dCg
-mYB
 rdj
 rdj
 rdj
-uDr
+rdj
+rdj
+dFZ
+rdj
+iwC
 xie
 xie
 xie
@@ -134970,17 +134715,17 @@ yli
 npG
 kuM
 wyK
-dFX
-dPt
-mYB
-oGM
-ubm
-aaZ
-mYB
+xSZ
+xSZ
+dCg
 rdj
 rdj
 rdj
-uDr
+rdj
+rdj
+dFZ
+rdj
+iwC
 xie
 xie
 xie
@@ -135275,14 +135020,14 @@ kur
 dFX
 aaK
 mYB
-crZ
-qZz
-iBh
+mYB
+mYB
+mYB
 vYX
 iwC
+uDr
 iwC
-iwC
-rsY
+vYX
 xie
 xie
 xie
@@ -135575,16 +135320,16 @@ tkx
 kuM
 qYR
 xSZ
-gMk
+xSZ
 fBA
 aaQ
-qZz
-muN
-bZa
+ubm
+qBQ
+vYX
 aJr
 veF
 vYO
-rsY
+vYX
 fUK
 xie
 irF
@@ -135874,19 +135619,19 @@ yli
 yli
 yli
 hCf
-oXv
+aKU
 hRr
 wCM
-gSD
+tEj
 fBA
-fEk
+crZ
 qZz
 muN
 bZa
 uIk
-vcG
+gUw
 ecY
-lTu
+xDF
 pMR
 xDF
 xDF
@@ -136175,20 +135920,20 @@ yli
 yli
 yli
 yli
-aau
+hCf
 aKU
 mnh
-aaG
+wCM
 tEj
 fBA
-aBv
-jbb
+crZ
+qZz
 eOB
 mhe
 jqB
 lpH
 cLf
-pZc
+cLf
 iZm
 vcG
 vcG
@@ -136477,20 +136222,20 @@ yli
 yli
 yli
 yli
-kxa
+tkx
 php
 gGu
 mSA
 mSA
 mYB
-mCZ
-oRh
-mCZ
+crZ
+qZz
+muN
 cxc
 mhe
 bVB
 vcG
-gUw
+vcG
 oxv
 vcG
 vcG
@@ -136780,19 +136525,19 @@ yli
 yli
 yli
 npG
-kpd
+kuM
 mYB
 lmA
 wCJ
 mCZ
 kZP
-sFK
+fLf
 cpv
 fYG
 mhe
 ghg
 vcG
-gUw
+vcG
 oxv
 fzQ
 vcG
@@ -137394,9 +137139,9 @@ fLf
 fLf
 fsF
 mhe
-mhe
+aaZ
 jnz
-qBQ
+jnz
 gzE
 cvN
 jnz
@@ -138000,7 +137745,7 @@ bUw
 dTI
 aaq
 obs
-fgN
+obs
 eKA
 jIB
 obs
@@ -139206,9 +138951,9 @@ qvg
 gER
 qvg
 plQ
-plQ
-plQ
 nAr
+plQ
+plQ
 plQ
 xUo
 qxQ
@@ -139810,7 +139555,7 @@ vqk
 utU
 idI
 azX
-wmJ
+lwo
 wmJ
 vDZ
 jIJ
@@ -140112,7 +139857,7 @@ nQT
 iQY
 fNb
 hzd
-hzd
+rsY
 ivj
 smU
 qio
@@ -140416,7 +140161,7 @@ lGB
 gVQ
 hTW
 heg
-uwt
+xUo
 xUo
 xUo
 pIM
@@ -140716,9 +140461,9 @@ ygp
 fJf
 uWl
 xUo
-xUo
-xUo
 uwt
+xUo
+xUo
 xXM
 wPZ
 fKb
@@ -141020,7 +140765,7 @@ tHb
 xUo
 aBc
 mXg
-huy
+kow
 xPd
 xPd
 dOa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
* Adds a public taxi dock to below nerd lounge on donut3
* Modifies the existing mining shuttle / prep room and catwalks to still allow for mining access
* Modifies the Engineering/Cargo transport tube path as it no longer has to wiggle around the shuttle location/area


![Supply Fortification 35 2022-09-07 124704](https://user-images.githubusercontent.com/91498627/188966935-89239b04-6a2c-4fb1-819f-5fc2e24557da.png)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
donut3 is the only rotation map without maint-only access to the shuttle.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(+)Donut3's taxi/mining shuttle can now be boarded through a new maintenance dock, south of nerd lounge.
```
