### PR TITLE
Adds a trait that removes your legs

### DIFF
--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -512,6 +512,13 @@
 	icon_state = "placeholder"
 	points = 0
 
+/obj/trait/nolegs
+    name = "Stumped"
+    desc = "Because of a freak accident involving a piano, a forklift, and lots of vodka, both of your legs had to be amputated. Fortunately, NT has kindly supplied you with a wheelchair (due to regulations) out of the goodness of their heart."
+    id = "nolegs"
+    icon_state = "placeholder"
+    points = 0
+
 // Skill - White Border
 
 /datum/trait/smoothtalker

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -514,7 +514,7 @@
 
 /datum/trait/nolegs
 	name = "Stumped"
-	desc = "Because of a freak accident involving a piano, a forklift, and lots of vodka, both of your legs had to be amputated. Fortunately, NT has kindly supplied you with a wheelchair (due to regulations) out of the goodness of their heart."
+	desc = "Because of a freak accident involving a piano, a forklift, and lots of vodka, both of your legs had to be amputated. Fortunately, NT has kindly supplied you with a wheelchair out of the goodness of their heart. (due to regulations)"
 	id = "nolegs"
 	icon_state = "placeholder"
 	points = 0

--- a/code/datums/traits.dm
+++ b/code/datums/traits.dm
@@ -512,12 +512,12 @@
 	icon_state = "placeholder"
 	points = 0
 
-/obj/trait/nolegs
-    name = "Stumped"
-    desc = "Because of a freak accident involving a piano, a forklift, and lots of vodka, both of your legs had to be amputated. Fortunately, NT has kindly supplied you with a wheelchair (due to regulations) out of the goodness of their heart."
-    id = "nolegs"
-    icon_state = "placeholder"
-    points = 0
+/datum/trait/nolegs
+	name = "Stumped"
+	desc = "Because of a freak accident involving a piano, a forklift, and lots of vodka, both of your legs had to be amputated. Fortunately, NT has kindly supplied you with a wheelchair (due to regulations) out of the goodness of their heart."
+	id = "nolegs"
+	icon_state = "placeholder"
+	points = 0
 
 // Skill - White Border
 

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -35,7 +35,8 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/bp_itabag,\
 
 	new /datum/bank_purchaseable/limbless,\
-	new /datum/bank_purchaseable/legless,\
+//	new /datum/bank_purchaseable/legless,\
+
 	new /datum/bank_purchaseable/space_diner,\
 	new /datum/bank_purchaseable/mail_order,\
 	new /datum/bank_purchaseable/missile_arrival,\
@@ -435,7 +436,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 			return 0
 
 // not sure if theres a better way to do this, so i just put // before every line
-//	legless 
+//	legless
 //		name = "No Legs"
 //		cost = 5000
 //		path = /obj/item/furniture_parts/wheelchair

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -35,7 +35,6 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/bp_itabag,\
 
 	new /datum/bank_purchaseable/limbless,\
-//	new /datum/bank_purchaseable/legless,
 	new /datum/bank_purchaseable/space_diner,\
 	new /datum/bank_purchaseable/mail_order,\
 	new /datum/bank_purchaseable/missile_arrival,\
@@ -433,28 +432,6 @@ var/global/list/persistent_bank_purchaseables =	list(\
 						boutput( H, "<span class='notice'><b>Your limbs magically disappear! Oh, no!</b></span>" )
 				return 1
 			return 0
-
-// not sure if theres a better way to do this, so i just put // before every line
-//	legless
-//		name = "No Legs"
-//		cost = 5000
-//		path = /obj/item/furniture_parts/wheelchair
-//		icon = 'icons/obj/furniture/chairs.dmi'
-//		icon_state = "wheelchair"
-//		icon_dir = EAST
-//
-//		Create(var/mob/living/M)
-//			if (ishuman(M))
-//				var/mob/living/carbon/human/H = M
-//				SPAWN(6 SECONDS)
-//					if (H.limbs)
-//						if (H.limbs.l_leg)
-//							H.limbs.l_leg.delete()
-//						if (H.limbs.r_leg)
-//							H.limbs.r_leg.delete()
-//						boutput( H, "<span class='notice'><b>You haven't got a leg to stand on!</b></span>" )
-//				return 1
-//			return 0
 
 	space_diner
 		name = "Space Diner Patron"

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -434,26 +434,27 @@ var/global/list/persistent_bank_purchaseables =	list(\
 				return 1
 			return 0
 
-	legless
-		name = "No Legs"
-		cost = 5000
-		path = /obj/item/furniture_parts/wheelchair
-		icon = 'icons/obj/furniture/chairs.dmi'
-		icon_state = "wheelchair"
-		icon_dir = EAST
-
-		Create(var/mob/living/M)
-			if (ishuman(M))
-				var/mob/living/carbon/human/H = M
-				SPAWN(6 SECONDS)
-					if (H.limbs)
-						if (H.limbs.l_leg)
-							H.limbs.l_leg.delete()
-						if (H.limbs.r_leg)
-							H.limbs.r_leg.delete()
-						boutput( H, "<span class='notice'><b>You haven't got a leg to stand on!</b></span>" )
-				return 1
-			return 0
+// not sure if theres a better way to do this, so i just put // before every line
+//	legless 
+//		name = "No Legs"
+//		cost = 5000
+//		path = /obj/item/furniture_parts/wheelchair
+//		icon = 'icons/obj/furniture/chairs.dmi'
+//		icon_state = "wheelchair"
+//		icon_dir = EAST
+//
+//		Create(var/mob/living/M)
+//			if (ishuman(M))
+//				var/mob/living/carbon/human/H = M
+//				SPAWN(6 SECONDS)
+//					if (H.limbs)
+//						if (H.limbs.l_leg)
+//							H.limbs.l_leg.delete()
+//						if (H.limbs.r_leg)
+//							H.limbs.r_leg.delete()
+//						boutput( H, "<span class='notice'><b>You haven't got a leg to stand on!</b></span>" )
+//				return 1
+//			return 0
 
 	space_diner
 		name = "Space Diner Patron"

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -35,8 +35,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/bp_itabag,\
 
 	new /datum/bank_purchaseable/limbless,\
-//	new /datum/bank_purchaseable/legless,\
-
+//	new /datum/bank_purchaseable/legless,
 	new /datum/bank_purchaseable/space_diner,\
 	new /datum/bank_purchaseable/mail_order,\
 	new /datum/bank_purchaseable/missile_arrival,\

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -686,14 +686,14 @@
 						qdel(src.limbs.r_arm.remove(0))
 				boutput(src, "<b>Your singular arm makes you feel responsible for crimes you couldn't possibly have committed.</b>" )
 
-    if (src.traitHolder && src.traitHolder.hasTrait("nolegs"))
-        if (src.limbs)
-            SPAWN(6 SECONDS)
-                if (src.limbs.l_leg)
-                    src.limbs.l_leg.delete()
-                if (src.limbs.r_leg)
-                    src.limbs.r_leg.delete()
-            src.put_in_hand_or_drop(new /obj/stool/chair/comfy/wheelchair)
+	if (src.traitHolder && src.traitHolder.hasTrait("nolegs"))
+		if (src.limbs)
+			SPAWN(6 SECONDS)
+				if (src.limbs.l_leg)
+					src.limbs.l_leg.delete()
+				if (src.limbs.r_leg)
+					src.limbs.r_leg.delete()
+			src.put_in_hand_or_drop(new /obj/stool/chair/comfy/wheelchair)
 
 	// Special mutantrace items
 	if (src.traitHolder && src.traitHolder.hasTrait("pug"))

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -693,7 +693,7 @@
 					src.limbs.l_leg.delete()
 				if (src.limbs.r_leg)
 					src.limbs.r_leg.delete()
-			src.put_in_hand_or_drop(new /obj/stool/chair/comfy/wheelchair)
+			new /obj/stool/chair/comfy/wheelchair(get_turf(src))
 
 	// Special mutantrace items
 	if (src.traitHolder && src.traitHolder.hasTrait("pug"))

--- a/code/procs/jobprocs.dm
+++ b/code/procs/jobprocs.dm
@@ -686,6 +686,15 @@
 						qdel(src.limbs.r_arm.remove(0))
 				boutput(src, "<b>Your singular arm makes you feel responsible for crimes you couldn't possibly have committed.</b>" )
 
+    if (src.traitHolder && src.traitHolder.hasTrait("nolegs"))
+        if (src.limbs)
+            SPAWN(6 SECONDS)
+                if (src.limbs.l_leg)
+                    src.limbs.l_leg.delete()
+                if (src.limbs.r_leg)
+                    src.limbs.r_leg.delete()
+            src.put_in_hand_or_drop(new /obj/stool/chair/comfy/wheelchair)
+
 	// Special mutantrace items
 	if (src.traitHolder && src.traitHolder.hasTrait("pug"))
 		src.put_in_hand_or_drop(new /obj/item/reagent_containers/food/snacks/cookie/dog)


### PR DESCRIPTION
## About the PR

Adds a new trait called 'Stumped', it removes both your legs on roundstart and gives you a wheelchair.

## Why's this needed?

Playing as a wheelchair bound character is hard to set up, since you have to go to medbay, get your legs taken off (or pay 5000 spacebux), and get a wheelchair. This makes it so theres a fast and easy way to do it that doesn't involve paying loads of spacebux.

## Changelog

```changelog
(u)Idiot
(+)Adds Stumped trait that spawns you with no legs and a free wheelchair.
(-)Removes No Legs spacebux purchase.
```
