### PR TITLE
makes neurodepressant be flushed by smelling salts

### DIFF
--- a/code/modules/chemistry/Reagents-Medical.dm
+++ b/code/modules/chemistry/Reagents-Medical.dm
@@ -646,7 +646,7 @@ datum
 			transparency = 40
 			value = 3
 			threshold = THRESHOLD_INIT
-			var/list/flushed_reagents = list("neurotoxin","capulettium","sulfonal","ketamine","sodium_thiopental","pancuronium")
+			var/list/flushed_reagents = list("neurotoxin","capulettium","sulfonal","ketamine","sodium_thiopental","pancuronium", "neurodepressant")
 
 			cross_threshold_over()
 				if(ismob(holder?.my_atom))


### PR DESCRIPTION
[LABEL][chemistry][qol]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR adds neurodepressant to the list of chems flushed by Smelling Salts


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
neurodepressant currently isn't flushed by smelling salts, and it really should considering it's literally in it's description that it gets rid of depressant and knockout drugs, + neurodepressant is a byproduct of neurotoxin


