### PR TITLE
Fixes #10698 - Smooth wood round tables 

### DIFF
--- a/code/obj/table.dm
+++ b/code/obj/table.dm
@@ -467,7 +467,7 @@ TYPEINFO_NEW(/obj/table/wood)
 TYPEINFO(/obj/table/wood/round)
 TYPEINFO_NEW(/obj/table/wood/round)
 	. = ..()
-	smooth_list = typecacheof(/obj/table/round/auto)
+	smooth_list = typecacheof(/obj/table/wood/round/auto)
 /obj/table/wood/round
 	icon = 'icons/obj/furniture/table_wood_round.dmi'
 	parts_type = /obj/item/furniture_parts/table/wood/round


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[TRIVIAL][BUG]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds a missing path portion to the table type

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Tables smooth