### PR TITLE
Allows Mech Scanning of Radiation Collectors and Control units.

### DIFF
--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -1234,6 +1234,8 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	var/active = 0
 	var/obj/item/tank/plasma/P = null
 	var/obj/machinery/power/collector_control/CU = null
+	deconstruct_flags = DECON_WELDER | DECON_MULTITOOL | DECON_CROWBAR | DECON_WRENCH
+	mats = 20
 
 /obj/machinery/power/collector_array/New()
 	..()
@@ -1363,6 +1365,8 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	var/obj/machinery/power/collector_array/CAE = null
 	var/obj/machinery/power/collector_array/CAW = null
 	var/list/obj/machinery/the_singularity/S = null
+	deconstruct_flags = DECON_WELDER | DECON_MULTITOOL | DECON_CROWBAR | DECON_WRENCH
+	mats = 20
 
 /obj/machinery/power/collector_control/New()
 	..()

--- a/code/obj/machinery/singularity.dm
+++ b/code/obj/machinery/singularity.dm
@@ -1366,7 +1366,7 @@ for some reason I brought it back and tried to clean it up a bit and I regret ev
 	var/obj/machinery/power/collector_array/CAW = null
 	var/list/obj/machinery/the_singularity/S = null
 	deconstruct_flags = DECON_WELDER | DECON_MULTITOOL | DECON_CROWBAR | DECON_WRENCH
-	mats = 20
+	mats = 25
 
 /obj/machinery/power/collector_control/New()
 	..()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL][QOL][FEATURE][systems][objects] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
PR lets players both scan and deconstruct Radiation Collector Arrays and Control Units. The cost of Arrays are 20 mats, with units being 25 mats. If this turns out too cheap, I'll up it to highly conductive.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
More deconstructable and craftable machines are good, and this is something a lot of engineer players have requested. This may also help with more creative, and probably dangerous, singularity setups.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Moberry
(*)Radiation Collectors can now be deconstructed and scanned by mechanics!
```
