### PR TITLE
Adds An Armoury Deauthorisation Announcement

### DIFF
--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -138,7 +138,7 @@
 		if(src.authed)
 
 			logTheThing(LOG_STATION, usr, "unauthorized armory access")
-			command_announcement("<br><b><span class='alert'>Armory weapons access has been revoked from all general security personnel; all personnel are advised to hand in riot gear to the Head of Security.</span></b>", "Security Level Decreased", "sound/misc/announcement_1.ogg")
+			command_announcement("<br><b><span class='alert'>Armory weapons access has been revoked from all standard security personnel; all personnel are advised to hand in riot gear to the Head of Security.</span></b>", "Security Level Decreased", "sound/misc/announcement_1.ogg")
 			authed = 0
 			src.ClearSpecificOverlays("screen_image")
 			icon_state = "drawbr"

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -138,6 +138,7 @@
 		if(src.authed)
 
 			logTheThing(LOG_STATION, usr, "unauthorized armory access")
+			command_announcement("<br><b><span class='alert'>Armory weapons access has been revoked from all general security personnel; all personnel are advised to hand in riot gear to the Head of Security.</span></b>", "Security Level Decreased", "sound/misc/announcement_1.ogg")
 			authed = 0
 			src.ClearSpecificOverlays("screen_image")
 			icon_state = "drawbr"

--- a/code/obj/machinery/computer/security/riot.dm
+++ b/code/obj/machinery/computer/security/riot.dm
@@ -138,7 +138,7 @@
 		if(src.authed)
 
 			logTheThing(LOG_STATION, usr, "unauthorized armory access")
-			command_announcement("<br><b><span class='alert'>Armory weapons access has been revoked from all standard security personnel; all personnel are advised to hand in riot gear to the Head of Security.</span></b>", "Security Level Decreased", "sound/misc/announcement_1.ogg")
+			command_announcement("<br><b><span class='alert'>Armory weapons access has been revoked from all security personnel. All crew are advised to hand in riot gear to the Head of Security.</span></b>", "Security Level Decreased", "sound/misc/announcement_1.ogg")
 			authed = 0
 			src.ClearSpecificOverlays("screen_image")
 			icon_state = "drawbr"


### PR DESCRIPTION
[Game Objects] [QoL]


## About the PR:
Adds a command announcement for when the Armoury is deauthorised:
> Security Level Decreased
> Armory weapons access has been revoked from all standard security personnel; all personnel are advised to hand in riot gear to the Head of Security.



## Why's this needed?
By and large it is often advisable to inform the crew that the Armoury has been deauthorised, usually marking an end to whatever crisis has befallen the station; ideally this should be part of the game mechanics rather than falling to the HoS to make an announcement.



## Changelog:
```changelog
(u)Mr. Moriarty
(+)Added an announcement for when the Armoury is deauthorised.
```
