### PR TITLE
Fixes #10635 - John Bill Is Now Considered An NPC

### DIFF
--- a/code/WorkInProgress/warcrimes.dm
+++ b/code/WorkInProgress/warcrimes.dm
@@ -152,6 +152,7 @@ ABSTRACT_TYPE(/obj/machinery/vending/meat)
 	real_name = "John Bill"
 	interesting = "Found in a coffee can at age fifteen. Went to jail for fraud. Recently returned to the can."
 	gender = MALE
+	is_npc = TRUE
 	var/talk_prob = 7
 	var/greeted_murray = 0
 	var/list/snacks = null


### PR DESCRIPTION
[Game Objects] [Bug]



## About the PR:
Fixes #10635.
`is_npc = TRUE` seems to be missing from John Bill.