### PR TITLE
Bat form cannot used on restricted Z-levels

### DIFF
--- a/code/datums/abilities/vampire/phaseshift_vampire.dm
+++ b/code/datums/abilities/vampire/phaseshift_vampire.dm
@@ -9,7 +9,7 @@
 	pointCost = 0
 	when_stunned = 1
 	not_when_handcuffed = 0
-	restricted_area_check = 1
+	restricted_area_check = 0
 
 	unlock_message = "You have gained Bat Form. When toggled on, you will be able to enter Bat Form by sprinting."
 

--- a/code/datums/abilities/wizard/phaseshift.dm
+++ b/code/datums/abilities/wizard/phaseshift.dm
@@ -152,6 +152,8 @@
 		return
 	if (!H.canmove)
 		return
+	if(isrestrictedz(H.loc.z))
+		return
 
 	if (isliving(H))
 		var/mob/living/owner = H


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BALANCE][PLAYER ACTIONS]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Moves the restricted z-level check from the bat form toggle to the actual power use itself.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Fixes #9806

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(+)Vampire's bat form no longer works on restricted z levels.
```
