### PR TITLE
Damaged random plating is correctly floored

### DIFF
--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -216,8 +216,10 @@
 		if (prob(20))
 			if (prob(50))
 				src.break_tile()
+				src.icon_old = null
 			else
 				src.burn_tile()
+				src.icon_old = null
 
 
 /////////////////////////////////////////

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -181,8 +181,10 @@
 		if (prob(20))
 			if (prob(50))
 				src.break_tile()
+				src.icon_old = null // we're already plating
 			else
 				src.burn_tile()
+				src.icon_old = null
 			src.UpdateIcon()
 		if (prob(2))
 			make_cleanable(/obj/decal/cleanable/dirt,src)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[Game Objects][Bug]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
When map-placed random floor plating is spawned in as broken/burned, clear the `icon_old` value so it is no longer set to 'plating'.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
When random floor tiles are burned/broken at roundstart, putting a floor tile on them doesn't replace them with standard flooring, but the normal underfloor plating icon.

This PR fixes that behavior, making it so they are given the correct regular flooring type when a floor tile is placed on them.

## Example Screenshots
### Existing/Current Behavior
#### Before Plating
![image](https://user-images.githubusercontent.com/91498627/189501729-131ca96b-7ddf-4e7f-972d-c3d03f71d1ae.png)
#### After Plating
![image](https://user-images.githubusercontent.com/91498627/189501836-f7b6fc48-00f7-4997-8387-e49e21822edc.png)


### This PR/New Behavior
#### Before Plating
![image](https://user-images.githubusercontent.com/91498627/189501575-40a6615d-12e8-436c-870d-9a445772ea63.png)
#### After Plating
![image](https://user-images.githubusercontent.com/91498627/189501629-ebcc1d1b-7869-4ae0-a660-c075cf672208.png)
