### PR TITLE
Reduces the amount of chemicals that leave your blood stream when you bleed.

### DIFF
--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -385,8 +385,8 @@ this is already used where it needs to be used, you can probably ignore it.
 
 	var/mob/living/H = some_idiot
 
-	var/blood_color_to_pass = DEFAULT_BLOOD_COLOR
-	var/reagents_to_transfer = min(num_amount * (0.2 + 0.8 * (H.reagents?.total_volume**(5/4)/(H.reagents?.total_volume**(5/4) + H.blood_volume))), H.reagents.total_volume)
+	var/blood_color_to_pass = DEFAULT_BLOOD_COLOR //this makes it so the amounts of chemicals you bleed scales nonlinearly with the amount of chemicals in you compared to the amount of blood
+	var/reagents_to_transfer = min(num_amount * (0.2 + (0.8 * (H.reagents?.total_volume**(5/4)/(H.reagents?.total_volume**(5/4) + H.blood_volume)))), H.reagents.total_volume)
 	var/blood_to_transfer = num_amount - reagents_to_transfer
 
 	if (istype(H))
@@ -497,8 +497,8 @@ this is already used where it needs to be used, you can probably ignore it.
 
 	if (isvampire(some_idiot) && (some_idiot.get_vampire_blood() <= 0) || (!isvampire(some_idiot) && !some_idiot.reagents && !some_idiot.blood_volume))
 		return 0
-
-	var/reagents_to_transfer = (amount *(0.2 + 0.8 *(some_idiot.reagents.total_volume**(5/4)/(some_idiot.reagents.total_volume**(5/4) + some_idiot.blood_volume))))
+								//this makes it so the amounts of chemicals you extract scales nonlinearly with the amount of chemicals in you compared to the amount of blood
+	var/reagents_to_transfer = (amount *(0.2 + (0.8 *(some_idiot.reagents.total_volume**(5/4)/(some_idiot.reagents.total_volume**(5/4) + some_idiot.blood_volume)))))
 	var/blood_to_transfer = (amount - min(reagents_to_transfer, some_idiot.reagents.total_volume))
 
 	var/datum/bioHolder/bloodHolder = null

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -386,9 +386,7 @@ this is already used where it needs to be used, you can probably ignore it.
 	var/mob/living/H = some_idiot
 
 	var/blood_color_to_pass = DEFAULT_BLOOD_COLOR
-<<<<<<< HEAD
 	var/reagents_to_transfer = (num_amount * (H.reagents?.total_volume/(H.reagents?.total_volume + H.blood_volume)))
->>>>>>> 965c43e61f5f3a64b8040153874e9150cddfd617
 	var/blood_to_transfer = (num_amount - min(reagents_to_transfer, H.reagents.total_volume))
 
 	if (istype(H))

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -386,7 +386,7 @@ this is already used where it needs to be used, you can probably ignore it.
 	var/mob/living/H = some_idiot
 
 	var/blood_color_to_pass = DEFAULT_BLOOD_COLOR
-	var/reagents_to_transfer = (num_amount * (H.reagents?.total_volume/(H.reagents?.total_volume + H.blood_volume)))
+	var/reagents_to_transfer = min(num_amount * (0.2 + 0.8 * (H.reagents?.total_volume**(5/4)/(H.reagents?.total_volume**(5/4) + H.blood_volume))), H.reagents.total_volume)
 	var/blood_to_transfer = num_amount - reagents_to_transfer
 
 	if (istype(H))

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -498,7 +498,7 @@ this is already used where it needs to be used, you can probably ignore it.
 	if (isvampire(some_idiot) && (some_idiot.get_vampire_blood() <= 0) || (!isvampire(some_idiot) && !some_idiot.reagents && !some_idiot.blood_volume))
 		return 0
 
-	var/reagents_to_transfer = (amount / 5) * 2
+	var/reagents_to_transfer = (amount *(0.2 + 0.8 *(some_idiot.reagents.total_volume**(5/4)/(some_idiot.reagents.total_volume**(5/4) + some_idiot.blood_volume))))
 	var/blood_to_transfer = (amount - min(reagents_to_transfer, some_idiot.reagents.total_volume))
 
 	var/datum/bioHolder/bloodHolder = null

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -498,7 +498,7 @@ this is already used where it needs to be used, you can probably ignore it.
 	if (isvampire(some_idiot) && (some_idiot.get_vampire_blood() <= 0) || (!isvampire(some_idiot) && !some_idiot.reagents && !some_idiot.blood_volume))
 		return 0
 								//this makes it so the amounts of chemicals you extract scales nonlinearly with the amount of chemicals in you compared to the amount of blood
-	var/reagents_to_transfer = (amount *(0.2 + (0.8 *(some_idiot.reagents.total_volume**(5/4)/(some_idiot.reagents.total_volume**(5/4) + some_idiot.blood_volume)))))
+	var/reagents_to_transfer = (amount * (0.2 + (0.8 * (some_idiot.reagents.total_volume**(5/4)/(some_idiot.reagents.total_volume**(5/4) + some_idiot.blood_volume)))))
 	var/blood_to_transfer = (amount - min(reagents_to_transfer, some_idiot.reagents.total_volume))
 
 	var/datum/bioHolder/bloodHolder = null

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -386,7 +386,7 @@ this is already used where it needs to be used, you can probably ignore it.
 	var/mob/living/H = some_idiot
 
 	var/blood_color_to_pass = DEFAULT_BLOOD_COLOR
-	var/reagents_to_transfer = (num_amount / 20)
+	var/reagents_to_transfer = (num_amount * (H.reagents?.total_volume/(H.reagents?.total_volume + H.blood_volume)))
 	var/blood_to_transfer = (num_amount - min(reagents_to_transfer, H.reagents.total_volume))
 
 	if (istype(H))

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -387,7 +387,7 @@ this is already used where it needs to be used, you can probably ignore it.
 
 	var/blood_color_to_pass = DEFAULT_BLOOD_COLOR
 	var/reagents_to_transfer = (num_amount * (H.reagents?.total_volume/(H.reagents?.total_volume + H.blood_volume)))
-	var/blood_to_transfer = (num_amount - min(reagents_to_transfer, H.reagents.total_volume))
+	var/blood_to_transfer = num_amount - reagents_to_transfer
 
 	if (istype(H))
 		blood_color_to_pass = H.blood_color

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -475,7 +475,7 @@ this is already used where it needs to be used, you can probably ignore it.
 
 		if (B.reagents && H.reagents?.total_volume)
 			//BLOOD_DEBUG("[H] transfers reagents to blood decal [log_reagents(H)]")
-			H.reagents.trans_to(B, min(round(num_amount / 2, 1), 5))
+			H.reagents.trans_to(B, min((num_amount / 8), 4))
 	else
 		return
 

--- a/code/modules/medical/blood_system.dm
+++ b/code/modules/medical/blood_system.dm
@@ -386,6 +386,8 @@ this is already used where it needs to be used, you can probably ignore it.
 	var/mob/living/H = some_idiot
 
 	var/blood_color_to_pass = DEFAULT_BLOOD_COLOR
+	var/reagents_to_transfer = (num_amount / 20)
+	var/blood_to_transfer = (num_amount - min(reagents_to_transfer, H.reagents.total_volume))
 
 	if (istype(H))
 		blood_color_to_pass = H.blood_color
@@ -459,8 +461,8 @@ this is already used where it needs to be used, you can probably ignore it.
 			H.change_vampire_blood(-5) //num_amount // gunna go with a set number as a test
 			//BLOOD_DEBUG("[H] bleeds -5 from vamp_blood_remaining and their vamp_blood_remaining becomes [H.get_vampire_blood()]")
 		else
-			H.blood_volume -= num_amount // time to bleed
-			//BLOOD_DEBUG("[H] bleeds [num_amount] and their blood level becomes [H.blood_volume]")
+			H.blood_volume -= blood_to_transfer // time to bleed
+			//BLOOD_DEBUG("[H] bleeds [blood_to_transfer] and their blood level becomes [H.blood_volume]")
 
 			if (H.blood_volume < 0) // you shouldn't have negative blood okay
 				H.blood_volume = 0
@@ -470,13 +472,12 @@ this is already used where it needs to be used, you can probably ignore it.
 		bloodHolder.CopyOther(some_idiot.bioHolder)
 		bloodHolder.ownerName = some_idiot.real_name
 
-		B.add_volume(blood_color_to_pass, H.blood_id, num_amount, vis_amount, blood_reagent_data=bloodHolder)
+		B.add_volume(blood_color_to_pass, H.blood_id, blood_to_transfer, vis_amount, blood_reagent_data=bloodHolder)
 		//BLOOD_DEBUG("[H] adds volume to existing blood decal")
 
 		if (B.reagents && H.reagents?.total_volume)
 			//BLOOD_DEBUG("[H] transfers reagents to blood decal [log_reagents(H)]")
-			H.reagents.trans_to(B, min((num_amount / 8), 4))
-	else
+			H.reagents.trans_to(B, (num_amount - blood_to_transfer))
 		return
 
 /* ====================================== */

--- a/strings/changelog.txt
+++ b/strings/changelog.txt
@@ -1,5 +1,9 @@
 
 (t)wed sep 07 22
+(u)Ikea, Zonespace, and Yellow/Myco
+(p)9898
+(e)|
+(*)Pressing the PDA crisis or security alert now alerts people nearby through the use of a sound effect, chatbox message, and overhead text.
 (u)Sord
 (*)Donut 2's Research Outpost now has a public telescience pad. No research access required.
 (u)Stonepillar


### PR DESCRIPTION
[LABEL][Balance][Chemistry]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR changes the way bleeding functions to work more as syringe reagent transfer does, where it divides the amount of chems between a part blood and a part reagents, also severely reduces the amount of reagents that leave your blood when you bleed.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Bleeding tends to remove a insane amount of chemicals from your body(the round component makes it so it's expecially good at removing chemicals that are in small amounts), making it a seemingly better way to get rid of chemicals than charcoal or even calomel in some cases. With this change the amount of chemicals that leave your body will be more in tune with reality, and only make it so you leave trace amounts in decals and fluid pools, hopefully making stabbing yourself once to get rid of some cyanide not a thing anymore, as well as making chems such as heparin not simply flush themselves (when making ricin, i had to make the blood puking purely cosmetical else the lethal dose would start varying wildly for instance).


```changelog
(u)Hans
(+)You now bleed blood and reagents at the ratio to which you have them on your body. It's also now scaled by how much you are bleeding.
```
