### PR TITLE
Fixes #10756 - NTSOs And NTSCs Are Now Provided With A Security Health Implant

### DIFF
--- a/code/datums/jobs.dm
+++ b/code/datums/jobs.dm
@@ -2399,7 +2399,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	cant_spawn_as_rev = 1
 	receives_badge = 1
 	receives_miranda = 1
-	receives_implant = /obj/item/implant/health
+	receives_implant = /obj/item/implant/health/security
 	slot_back = list(/obj/item/storage/backpack/NT)
 	slot_belt = list(/obj/item/storage/belt/security/ntso)
 	slot_jump = list(/obj/item/clothing/under/misc/turds)
@@ -2443,7 +2443,7 @@ ABSTRACT_TYPE(/datum/job/special/halloween/critter)
 	cant_spawn_as_rev = 1
 	receives_badge = 1
 	receives_miranda = 1
-	receives_implant = /obj/item/implant/health
+	receives_implant = /obj/item/implant/health/security
 	slot_back = list(/obj/item/storage/backpack/NT)
 	slot_belt = list(/obj/item/storage/belt/security/ntsc) //special secbelt subtype that spawns with the NTSO gear inside
 	slot_jump = list(/obj/item/clothing/under/misc/turds)


### PR DESCRIPTION
[Medical] [Bug]


## About the PR:
Fixes #10756; NTSOs and NTSCs now spawn with a security health implant, whereas before they spawned with an ordinary health implant.