### PR TITLE
fix vampire cape reward bug

### DIFF
--- a/code/WorkInProgress/rewardsLocker.dm
+++ b/code/WorkInProgress/rewardsLocker.dm
@@ -825,7 +825,7 @@
 					M.real_name = "strange vampire outfit"
 					M.desc = "How many breads <i>have</i> you eaten in your life? It's a good question. (Base Item: [prev])"
 					H.set_clothing_icon_dirty()
-				return 1
+					return 1
 
 		boutput(activator, "<span class='alert'>Unable to redeem... you must be wearing a vampire cape. Guess it's the thought that <i>counts<i>. </span>")
 		return


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
presumably fixes #10630 
If you were wearing an outer suit that was not the cape, the reward would think it succeeded, thus not giving the message about what you should be wearing, while also preventing you from claiming the reward again that round.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
bug bad