### PR TITLE
Speculative fixes to some flock runtimes

### DIFF
--- a/code/datums/controllers/process/flock.dm
+++ b/code/datums/controllers/process/flock.dm
@@ -12,8 +12,9 @@
 	doWork()
 		var/i
 		for (var/obj/flock_structure/O as anything in by_cat[TR_CAT_FLOCK_STRUCTURE])
-			O.process(O.get_multiplier())
-			O.last_process = TIME
+			if (!QDELETED(O))
+				O.process(O.get_multiplier())
+				O.last_process = TIME
 			if (!(i++ % 10))
 				scheck()
 

--- a/code/datums/controllers/process/mob_ai.dm
+++ b/code/datums/controllers/process/mob_ai.dm
@@ -11,7 +11,7 @@ datum/controller/process/mob_ai
 
 			last_object = X
 
-			if (!M)
+			if (QDELETED(M))
 				continue
 
 			//in case it isn't obvious, what we're doing here is giving each mob a raffle ticket, and mod 30ing it to determine if a mob should tick


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[BUG] [RUNTIMES] [INTERNAL]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just adds a `QDELETED` check in the flock structure and mob_ai process loops.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Azrun found some runtimes.
