### PR TITLE
Seeded Mining Events use weights

### DIFF
--- a/code/datums/controllers/mining_controls.dm
+++ b/code/datums/controllers/mining_controls.dm
@@ -10,6 +10,7 @@ var/list/asteroid_blocked_turfs = list()
 	var/list/ore_types_uncommon = list()
 	var/list/ore_types_rare = list()
 	var/list/events = list()
+	var/list/weighted_events = list()
 	// magnet vars
 	var/turf/magnetic_center = null
 	var/area/mining/magnet/magnet_area = null
@@ -43,7 +44,9 @@ var/list/asteroid_blocked_turfs = list()
 				continue
 
 			if (istype(O, /datum/ore/event/))
-				events += O
+				var/datum/ore/event/E = O
+				events += E
+				weighted_events[E] = initial(E.weight)
 				ore_types_common -= O
 			if (O.rarity_tier == 2)
 				ore_types_uncommon += O

--- a/code/modules/mining/mining_encounters.dm
+++ b/code/modules/mining/mining_encounters.dm
@@ -985,7 +985,7 @@
 		amount--
 		if (turfs.len < 1)
 			break
-		E = pick(mining_controls.events)
+		E = weighted_pick(mining_controls.weighted_events)
 		AST = pick(turfs)
 		if (!istype(AST) || (E.restrict_to_turf_type && AST.type != E.restrict_to_turf_type))
 			turfs -= AST

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -209,6 +209,7 @@
 	events = list(/datum/ore/event/loot_crate)
 	tiles_per_rock_min = 2
 	tiles_per_rock_max = 8
+	event_chance = 1
 	hardness_mod = 2
 	rarity_tier = 3
 	amount_per_tile_min = 1
@@ -246,6 +247,7 @@
 	name = "nanite cluster"
 	output = /obj/item/material_piece/cloth/carbon
 	events = list(/datum/ore/event/loot_crate)
+	event_chance = 1
 	tiles_per_rock_min = 5
 	tiles_per_rock_max = 15
 	hardness_mod = 2

--- a/code/modules/mining/tile_events.dm
+++ b/code/modules/mining/tile_events.dm
@@ -7,6 +7,7 @@
 	var/scan_decal = null
 	var/prevent_excavation = 0
 	var/restrict_to_turf_type = null
+	var/weight = 100
 
 	set_up(var/datum/ore/event/parent_event)
 		..()
@@ -66,14 +67,12 @@
 	analysis_string = "Caution! Large object embedded in rock!"
 	excavation_string = "An abandoned crate was unearthed!"
 	scan_decal = "scan-object"
+	weight = 10
 
 	onExcavate(var/turf/simulated/wall/auto/asteroid/AST)
 		if (..())
 			return
-		if(prob(10))
-			new /obj/storage/crate/loot(AST)
-		else
-			new/obj/storage/crate(AST)
+		new /obj/storage/crate/loot(AST)
 
 /datum/ore/event/artifact
 	analysis_string = "Caution! Large object embedded in rock!"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL][Balance][internal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Introduces a weighted events list for the mining controller, default 100
Sets the weight of the `loot_crate` event to 10 (i.e. instead of `proc(10)`)
Removes the empty crate chance form the `loot_crate` event
Reduces the event chance for nanite cluster and miracle matter ore from default 8/100 -> to 1/100 to compensate

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
allows for more fine-grained control over mining events
Fixes #10477
no more empty crates, please