### PR TITLE
Cargo crates always land at intended destination

### DIFF
--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -507,7 +507,7 @@
 					if (P && !P.density)
 						P.close()
 
-		shipped_thing.throw_at(target, 100, 1)
+		shipped_thing.throw_at(target, get_dist(spawnpoint, target), 1)
 
 	proc/get_path_to_market()
 		var/list/bounds = get_area_turfs(/area/supply/delivery_point)

--- a/code/modules/economy/shippingmarket.dm
+++ b/code/modules/economy/shippingmarket.dm
@@ -42,6 +42,7 @@
 	var/artifact_resupply_amount = 0
 	/// an artifact crate is already "on the way"
 	var/artifacts_on_the_way = FALSE
+	var/static/launch_distance = 0
 
 	New()
 		..()
@@ -75,6 +76,18 @@
 
 		time_between_shifts = 4500 // 7.5 minutes base.
 		time_until_shift = time_between_shifts + rand(-1500,1500)
+
+		var/turf/spawnpoint
+		for(var/turf/T in get_area_turfs(/area/supply/spawn_point))
+			spawnpoint = T
+			break
+
+		var/turf/target
+		for(var/turf/T in get_area_turfs(/area/supply/delivery_point))
+			target = T
+			break
+
+		src.launch_distance = get_dist(spawnpoint, target)
 
 	proc/add_commodity(var/datum/commodity/new_c)
 		src.commodities["[new_c.comtype]"] = new_c
@@ -507,7 +520,7 @@
 					if (P && !P.density)
 						P.close()
 
-		shipped_thing.throw_at(target, get_dist(spawnpoint, target), 1)
+		shipped_thing.throw_at(target, src.launch_distance, 1)
 
 	proc/get_path_to_market()
 		var/list/bounds = get_area_turfs(/area/supply/delivery_point)

--- a/code/obj/machinery/computer/QM_supply.dm
+++ b/code/obj/machinery/computer/QM_supply.dm
@@ -144,7 +144,8 @@ var/global/datum/cdc_contact_controller/QM_CDC = new()
 /obj/machinery/computer/supplycomp/emag_act(var/mob/user, var/obj/item/card/emag/E)
 	if(!hacked)
 		if(user)
-			boutput(user, "<span class='notice'>Special supplies unlocked.</span>")
+			boutput(user, "<span class='notice'>The intake safety shorts out. Special supplies unlocked.</span>")
+		shippingmarket.launch_distance = 200 // dastardly
 		src.hacked = 1
 		return 1
 	return 0

--- a/maps/horizon.dmm
+++ b/maps/horizon.dmm
@@ -47249,6 +47249,11 @@
 	dir = 1
 	},
 /obj/lattice,
+/obj/machinery/conveyor{
+	dir = 8;
+	name = "cargo belt - west";
+	operating = 1
+	},
 /turf/space,
 /area/supply/delivery_point)
 "cpA" = (
@@ -50427,9 +50432,7 @@
 	})
 "czu" = (
 /turf/simulated/floor/carpet/purple/fancy/edge/east,
-/area/station/science/artifact{
-	name = "Artifact Lounge"
-	})
+/area/supply/delivery_point)
 "czv" = (
 /obj/table/wood/auto,
 /obj/machinery/networked/storage/scanner{
@@ -52234,6 +52237,18 @@
 /obj/reagent_dispensers/foamtank,
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/northwest)
+"cMu" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 1
+	},
+/obj/lattice,
+/obj/machinery/conveyor{
+	dir = 8;
+	name = "cargo belt - west";
+	operating = 1
+	},
+/turf/space,
+/area/space)
 "cNT" = (
 /obj/disposalpipe/segment/transport,
 /obj/disposalpipe/segment/mineral{
@@ -137004,7 +137019,7 @@ asH
 bqb
 bqb
 bqb
-bqb
+cMu
 bzS
 iNi
 bFw
@@ -137306,7 +137321,7 @@ aEo
 bqb
 bqb
 bqb
-bqb
+cMu
 bzT
 iNi
 bFw

--- a/maps/manta.dmm
+++ b/maps/manta.dmm
@@ -37052,6 +37052,12 @@
 	},
 /turf/simulated/floor/grime,
 /area/diner/backroom)
+"kSX" = (
+/obj/machinery/conveyor/north{
+	id = "north"
+	},
+/turf/space/fluid/manta/nospawn,
+/area/space)
 "kWs" = (
 /obj/machinery/light/incandescent/netural,
 /turf/simulated/floor/wood/eight{
@@ -70499,8 +70505,8 @@ bdV
 bIU
 bdY
 ark
-ark
-ark
+kSX
+kSX
 adx
 aaa
 aaa

--- a/maps/ozymandias.dmm
+++ b/maps/ozymandias.dmm
@@ -18755,7 +18755,7 @@
 "fkv" = (
 /obj/table/wood/auto,
 /obj/displaycase{
-	displayed = new /obj/item/captaingun;
+	displayed = new/obj/item/captaingun;
 	pixel_y = 6
 	},
 /obj/machinery/light/small{
@@ -41368,10 +41368,6 @@
 	},
 /turf/simulated/floor/green/checker,
 /area/station/storage/emergency)
-"leM" = (
-/obj/machinery/light/small/floor,
-/turf/simulated/floor/airless/plating,
-/area/station/quartermaster/cargobay)
 "leR" = (
 /obj/stool/chair{
 	dir = 1
@@ -51601,7 +51597,7 @@
 /area/station/medical/medbay/surgery/storage)
 "nNk" = (
 /obj/storage/crate/internals{
-	spawn_contents = list(/obj/item/clothing/mask/gas = 2,/obj/item/tank/emergency_oxygen = 1,/obj/item/tank/air = 1,/obj/item/clothing/head/emerg = 2,/obj/item/clothing/suit/space/emerg = 2)
+	spawn_contents = list(/obj/item/clothing/mask/gas=2,/obj/item/tank/emergency_oxygen=1,/obj/item/tank/air=1,/obj/item/clothing/head/emerg=2,/obj/item/clothing/suit/space/emerg=2)
 	},
 /turf/simulated/floor/plating/random,
 /area/station/maintenance/southwest)
@@ -60758,9 +60754,6 @@
 	},
 /turf/simulated/floor/sanitary,
 /area/station/quartermaster/office)
-"qfP" = (
-/turf/space,
-/area/supply/delivery_point)
 "qgb" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -65124,7 +65117,7 @@
 	id = "qmin"
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/cargobay)
+/area/space)
 "rnd" = (
 /obj/machinery/manufacturer/general{
 	desc = "It's covered in more gunk than a truck stop ashtray. Is this thing even safe?";
@@ -73069,7 +73062,7 @@
 	id = "qmin"
 	},
 /turf/simulated/floor/airless/plating,
-/area/station/quartermaster/cargobay)
+/area/supply/delivery_point)
 "tig" = (
 /obj/machinery/camera{
 	c_tag = "autotag";
@@ -73986,7 +73979,7 @@
 /area/station/hangar/qm)
 "ttH" = (
 /obj/storage/crate/internals{
-	spawn_contents = list(/obj/item/clothing/mask/gas = 2,/obj/item/tank/emergency_oxygen = 1,/obj/item/tank/air = 1,/obj/item/clothing/head/emerg = 2,/obj/item/clothing/suit/space/emerg = 2)
+	spawn_contents = list(/obj/item/clothing/mask/gas=2,/obj/item/tank/emergency_oxygen=1,/obj/item/tank/air=1,/obj/item/clothing/head/emerg=2,/obj/item/clothing/suit/space/emerg=2)
 	},
 /turf/simulated/floor,
 /area/station/hangar/qm)
@@ -159071,7 +159064,7 @@ fdT
 xGX
 aJu
 fdT
-leM
+avG
 rna
 xGX
 aJu
@@ -159676,7 +159669,7 @@ xGX
 aJu
 fdT
 xGX
-qfP
+aJu
 wqf
 aJu
 aJu


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[QOL][BALANCE]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Instead of always throwing with 100 range, calculate the distance and throw with exactly enough distance to land.

When an emag is using on a QM console, crates are now thrown with 200 distance.

Makes adjustments to off-rotation maps (manta, ozymandias, horizon) in one batch to ensure they still function.

NOTE: People rushing cargo crate orders will lead to more clogs, specifically on maps don't have any exterior inbound conveyors (Clarion, Destiny). This will reduce total potential cargo volume input. 

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
proper timing between crate orders consistent between maps
crates should by default land at the delivery point, not smack into walls/people
Fixes #10204

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)glowbold
(+)Cargo orders now consistently land on intake belts.
(+)Using an EMAG on a QM supply console removes intake targeting.
```