### PR TITLE
Clarion ship-shields do not block cargo

### DIFF
--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -37471,7 +37471,10 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/launcher_loader/north,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "cargo_in"
+	},
 /turf/simulated/floor/caution/westeast,
 /area/station/quartermaster/office)
 "bBS" = (
@@ -37967,6 +37970,7 @@
 	name = "Door-linked Atmospheric Forcefield";
 	powerlevel = 1
 	},
+/obj/machinery/launcher_loader/north,
 /turf/simulated/floor/caution/misc,
 /area/station/quartermaster/office)
 "bCZ" = (
@@ -38573,13 +38577,6 @@
 /obj/decal/poster/wallsign/space,
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/quartermaster/storage)
-"bEe" = (
-/obj/lattice{
-	dir = 10;
-	icon_state = "lattice-dir"
-	},
-/turf/space,
-/area/station/quartermaster/office)
 "bEf" = (
 /obj/lattice{
 	dir = 10;
@@ -43451,6 +43448,13 @@
 	},
 /turf/simulated/floor/circuit,
 /area/station/turret_protected/ai)
+"dzu" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "cargo_in"
+	},
+/turf/space,
+/area/space)
 "dCy" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4
@@ -44833,6 +44837,13 @@
 	dir = 6
 	},
 /area/station/security/brig)
+"gIl" = (
+/obj/lattice{
+	dir = 10;
+	icon_state = "lattice-dir"
+	},
+/turf/space,
+/area/station/shield_zone)
 "gIr" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -47073,6 +47084,17 @@
 	dir = 6
 	},
 /area/station/hangar/sec)
+"lPc" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "cargo_in"
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "cargo_in"
+	},
+/turf/space,
+/area/space)
 "lQu" = (
 /obj/table/reinforced/auto,
 /obj/disposalpipe/segment/brig,
@@ -90335,10 +90357,10 @@ bzx
 bAx
 bBP
 bCX
-bEe
-aay
-aay
-aay
+bDq
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90592,11 +90614,11 @@ bzy
 bAy
 bBQ
 bzw
-bDq
+gIl
 aay
-aaa
-aaa
-aaa
+aay
+aay
+aay
 aaa
 aaa
 aaa
@@ -90850,9 +90872,9 @@ bAz
 bBR
 bCY
 bEf
-aay
-aay
-aay
+dzu
+lPc
+aaa
 aaa
 aaa
 aaa

--- a/maps/clarion.dmm
+++ b/maps/clarion.dmm
@@ -47084,17 +47084,6 @@
 	dir = 6
 	},
 /area/station/hangar/sec)
-"lPc" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "cargo_in"
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "cargo_in"
-	},
-/turf/space,
-/area/space)
 "lQu" = (
 /obj/table/reinforced/auto,
 /obj/disposalpipe/segment/brig,
@@ -90873,7 +90862,7 @@ bBR
 bCY
 bEf
 dzu
-lPc
+dzu
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[FEATURE][MAPPING]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adjust ship shield area to not block cargo
Moves door-closing AMDL under door
Adds some external conveyors for cargo to queue up

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Map parity (Atlas, Destiny allow cargo while ship-shields are up)
Cargo intake tidying

## Screenshots
### Before / Current
![image](https://user-images.githubusercontent.com/91498627/189754404-35279ecc-c450-45f4-9736-f33cff21617e.png)
### After / This PR
![image](https://user-images.githubusercontent.com/91498627/189752609-9e2815c3-8488-4754-ad59-fea3975af674.png)
