### PR TITLE
Removes the antique lawbringer.

### DIFF
--- a/code/modules/jobxp/JobXPRewards.dm
+++ b/code/modules/jobxp/JobXPRewards.dm
@@ -307,8 +307,7 @@ mob/verb/checkrewards()
 			src.claimedNumbers[usr.key] --
 			return
 
-		var/actual_reward_path = prob(1) ? /obj/item/gun/energy/lawbringer/old : src.reward_path
-		var/obj/item/gun/energy/lawbringer/LG = new actual_reward_path()
+		var/obj/item/gun/energy/lawbringer/LG = new reward_path()
 		var/obj/item/paper/lawbringer_pamphlet/LGP = new/obj/item/paper/lawbringer_pamphlet()
 		if (!istype(LG))
 			boutput(C.mob, "Something terribly went wrong. The reward path got screwed up somehow. call 1-800-CODER. But you're an HoS! You don't need no stinkin' guns anyway!")

--- a/code/modules/robotics/bot/guardbot.dm
+++ b/code/modules/robotics/bot/guardbot.dm
@@ -1836,8 +1836,6 @@
 			src.overlays += image(budgun.icon, budgun.icon_state, layer = 10, pixel_x = src.gun_x_offset, pixel_y = src.gun_y_offset)
 			if (istype(src.budgun, /obj/item/gun/energy/lawbringer))	// ugh
 				var/image/lawbringer_lights = image('icons/obj/items/gun.dmi', "lawbringer-d100", 11, pixel_x = src.gun_x_offset, pixel_y = src.gun_y_offset)	// ugh
-				if (istype(src.budgun, /obj/item/gun/energy/lawbringer/old))
-					lawbringer_lights.icon_state = "old-lawbringer-d100"
 				switch(lawbringer_state)	// ugh
 					if ("clown")
 						lawbringer_lights.color = "#FFC0CB"

--- a/code/obj/item/gun/energy.dm
+++ b/code/obj/item/gun/energy.dm
@@ -1330,12 +1330,6 @@
 			return
 
 ///////////////////////////////////////////////////
-/obj/item/gun/energy/lawbringer/old
-	name = "antique Lawbringer"
-	icon = 'icons/obj/items/gun.dmi'
-	icon_state = "old-lawbringer0"
-	old = 1
-
 /obj/item/gun/energy/lawbringer
 	name = "\improper Lawbringer"
 	icon = 'icons/obj/items/gun.dmi'
@@ -1559,11 +1553,6 @@
 		if (!owner_prints || (user.bioHolder.Uid == owner_prints))
 			return 1
 		return 0
-
-	proc/make_antique()
-		icon_state = "old-lawbringer0"
-		old = 1
-		UpdateIcon()
 
 	shoot(var/target,var/start,var/mob/user)
 		if (canshoot())

--- a/code/obj/item/storage/backpack_belt_etc.dm
+++ b/code/obj/item/storage/backpack_belt_etc.dm
@@ -692,7 +692,6 @@
 	/obj/item/gun/energy/laser_gun,
 	/obj/item/gun/energy/egun,
 	/obj/item/gun/energy/lawbringer,
-	/obj/item/gun/energy/lawbringer/old,
 	/obj/item/gun/energy/wavegun,
 	/obj/item/gun/kinetic/revolver,
 	/obj/item/gun/kinetic/zipgun,


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->
[removal]
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Removes the antique lawbringer and anything I could find referencing it. This should make the allow some more visual clarity as to what is and isn't the lawbringer.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This sprite looks bad, which normally would be a reason to resprite it but the issue is that the lawbringer already has a resprited version as it's base. Not much of a point of it existing other than being a gag. The issue with that gag however is that it impacts a sprite that should REALLY be recognizable. I've seen plenty of players get confused about the antique which is not something you'd want out of something as important as the lawbringer.

## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)DimWhat
(+)Removed the antique lawbringer skin
```
