### PR TITLE
Kondaru doors use proper access spawners

### DIFF
--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -29766,6 +29766,7 @@
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment/vertical,
 /obj/machinery/atmospherics/pipe/simple,
+/obj/access_spawn/security,
 /turf/simulated/floor/red/side,
 /area/station/security/main)
 "bNl" = (
@@ -30323,6 +30324,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/red/side,
 /area/station/maintenance/storage{
 	name = "Secure Atmospherics"
@@ -33383,6 +33385,7 @@
 /obj/machinery/secscanner{
 	pixel_y = 10
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/customs)
 "cax" = (
@@ -38342,7 +38345,6 @@
 "coI" = (
 /obj/table/reinforced/auto,
 /obj/machinery/cashreg,
-/obj/access_spawn/mining,
 /obj/firedoor_spawn,
 /obj/machinery/door/airlock/pyro/glass/windoor,
 /obj/cable{
@@ -38350,6 +38352,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/access_spawn/mining,
 /turf/simulated/floor/orangeblack,
 /area/station/mining/staff_room)
 "coJ" = (
@@ -47883,6 +47886,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage{
 	name = "Secure Atmospherics"
@@ -49014,6 +49018,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/black,
 /area/station/security/main)
 "mrx" = (
@@ -54752,6 +54757,7 @@
 /obj/cable{
 	icon_state = "4-8"
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "rXN" = (
@@ -59019,6 +59025,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/security/main)
 "vZG" = (
@@ -59977,6 +59984,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/hangar/sec)
 "wVa" = (

--- a/maps/kondaru.dmm
+++ b/maps/kondaru.dmm
@@ -23086,6 +23086,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
+/obj/access_spawn/security,
 /turf/simulated/floor/red,
 /area/station/security/checkpoint/escape)
 "bsi" = (
@@ -23168,6 +23169,7 @@
 	dir = 4
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/heads,
 /turf/simulated/floor/grey,
 /area/station/bridge)
 "bsz" = (
@@ -26048,6 +26050,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
+/obj/access_spawn/heads,
 /turf/simulated/floor,
 /area/station/bridge)
 "bCU" = (
@@ -26454,6 +26457,7 @@
 	dir = 4;
 	pixel_x = -20
 	},
+/obj/access_spawn/heads,
 /turf/simulated/floor,
 /area/station/bridge)
 "bDW" = (
@@ -28976,6 +28980,7 @@
 /obj/machinery/door/airlock/pyro/security{
 	name = "Courtroom"
 	},
+/obj/access_spawn/brig,
 /turf/simulated/floor,
 /area/station/security/secwing)
 "bLq" = (
@@ -31297,6 +31302,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/heads,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "bSk" = (
@@ -35013,6 +35019,7 @@
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/heads,
 /turf/simulated/floor/black,
 /area/station/crew_quarters/heads{
 	name = "Diplomatic Quarters"
@@ -43851,6 +43858,7 @@
 /obj/disposalpipe/segment/brig{
 	dir = 1
 	},
+/obj/access_spawn/brig,
 /turf/simulated/floor,
 /area/station/crew_quarters/courtroom)
 "gUW" = (
@@ -44312,6 +44320,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/heads,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "hoh" = (
@@ -49567,6 +49576,7 @@
 	icon_state = "4-8"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/heads,
 /turf/simulated/floor/black,
 /area/station/turret_protected/Zeta)
 "mTB" = (
@@ -54516,6 +54526,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple,
 /obj/firedoor_spawn,
+/obj/access_spawn/heads,
 /turf/simulated/floor/grey,
 /area/station/bridge)
 "rOG" = (
@@ -59930,6 +59941,7 @@
 	icon_state = "1-2"
 	},
 /obj/firedoor_spawn,
+/obj/access_spawn/heads,
 /turf/simulated/floor/black,
 /area/station/bridge)
 "wUh" = (


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds missing access spawners for some of Kondaru's doors - it looks like a lot of command and security doors had them removed?

I haven't worked with access spawners before, but they seem straightforward. Would appreciate someone double-checking my work all the same.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
doors should have proper access at roundstart