### PR TITLE
Heavily lowers chance of falling down stairs on a wheelchair

### DIFF
--- a/code/obj/stool.dm
+++ b/code/obj/stool.dm
@@ -1076,9 +1076,9 @@
 				M.visible_message("<span class='alert'>[M] is tossed out of [src] as it tips [T ? "while rolling over [T]" : "over"]!</span>",\
 				"<span class='alert'>You're tossed out of [src] as it tips [T ? "while rolling over [T]" : "over"]!</span>")
 				var/turf/target = get_edge_target_turf(src, src.dir)
-				M.throw_at(target, 5, 1)
-				M.changeStatus("stunned", 8 SECONDS)
-				M.changeStatus("weakened", 5 SECONDS)
+				M.throw_at(target, 3, 1)
+				M.changeStatus("stunned", 5 SECONDS)
+				M.changeStatus("weakened", 3 SECONDS)
 			else
 				src.visible_message("<span class='alert'>[src] tips [T ? "as it rolls over [T]" : "over"]!</span>")
 		else

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1133,7 +1133,7 @@ DEFINE_FLOORS(minitiles/black,
 	Entered(atom/A as mob|obj)
 		if (istype(A, /obj/stool/chair/comfy/wheelchair))
 			var/obj/stool/chair/comfy/wheelchair/W = A
-			if (!W.lying && prob(40))
+			if (!W.lying && prob(15))
 				if (W.buckled_guy && W.buckled_guy.m_intent == "walk")
 					return ..()
 				else

--- a/code/turf/floors.dm
+++ b/code/turf/floors.dm
@@ -1133,7 +1133,7 @@ DEFINE_FLOORS(minitiles/black,
 	Entered(atom/A as mob|obj)
 		if (istype(A, /obj/stool/chair/comfy/wheelchair))
 			var/obj/stool/chair/comfy/wheelchair/W = A
-			if (!W.lying && prob(15))
+			if (!W.lying && prob(10))
 				if (W.buckled_guy && W.buckled_guy.m_intent == "walk")
 					return ..()
 				else


### PR DESCRIPTION
## About the PR

Changes chance of falling down stairs on a wheelchair from 40% to 10%, and lowers the duration of the stun by 3 seconds.

## Why's this needed?

Falling down stairs is funny the first time, not when it happens every 5-20 seconds. Especially on maps like Cogmap 2.

## Changelog

```changelog
(u)Idiot
(+)Lowers chance of falling down stairs on a wheelchair heavily, and reduces duration of the stuns that come from it.
```
