### PR TITLE
Ghosts can watch you use TGUI machines

### DIFF
--- a/code/mob/dead/target_observer.dm
+++ b/code/mob/dead/target_observer.dm
@@ -120,6 +120,15 @@
 		if (isobj(target))
 			src.RegisterSignal(target, list(COMSIG_PARENT_PRE_DISPOSING), .verb/stop_observing)
 
+	click(atom/target, params, location, control)
+		if(!isnull(target) && (target.flags & TGUI_INTERACTIVE))
+			if(ismob(src.target))
+				var/mob/mob_target = src.target
+				for(var/datum/tgui/ui in mob_target.tgui_open_uis)
+					if(ui.src_object == target)
+						return target.ui_interact(src)
+		return ..()
+
 
 	verb
 		stop_observing()

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -61,6 +61,8 @@
 /mob/proc/shared_ui_interaction(src_object)
 	if(!client) // Close UIs if mindless.
 		return UI_CLOSE
+	else if(istype(src, /mob/dead/target_observer))
+		return UI_UPDATE
 	else if(stat) // Disable UIs if unconcious.
 		return UI_DISABLED
 	else if(!can_act(src, include_cuffs = 1)) // Update UIs if incapicitated but concious.

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -70,3 +70,6 @@ var/global/datum/ui_state/tgui_default_state/tgui_default_state = new /datum/ui_
 	if(. > UI_CLOSE)
 		. = min(., shared_living_ui_distance(src_object)) //critters can only use things they're near.
 
+/mob/dead/target_observer/default_can_use_topic(src_object)
+	. = ..()
+	return UI_UPDATE

--- a/code/modules/tgui/states/not_incapacitated.dm
+++ b/code/modules/tgui/states/not_incapacitated.dm
@@ -22,6 +22,8 @@ var/global/datum/ui_state/tgui_not_incapacitated_state/tgui_not_incapacitated_tu
 	turf_check = no_turfs
 
 /datum/ui_state/tgui_not_incapacitated_state/can_use_topic(src_object, mob/user)
+	if(istype(user, /mob/dead/target_observer))
+		return UI_UPDATE
 	if(user.stat)
 		return UI_CLOSE
 	if(!can_act(user) || (turf_check && !isturf(user.loc)))

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -106,6 +106,10 @@
 	if(closing)
 		return
 	closing = TRUE
+	for(var/mob/dead/target_observer/ghost in src.user.observers)
+		for(var/datum/tgui/ghost_win in ghost.tgui_open_uis)
+			if(ghost_win.src_object == src.src_object)
+				ghost_win.close()
 	// If we don't have window_id, open proc did not have the opportunity
 	// to finish, therefore it's safe to skip this whole block.
 	if(window)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes it so that observers who are possessing a mob can view TGUI windows that that mob has open (limited to machines that can be clicked in the world), and those windows will be closed when the observed mob closes theirs.

I wanted the UI status to perfectly reflect what the observed mob was doing, but this is the best that I can do.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Observer main buff.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Amylizzle
(*)Ghosts can shoulder surf your TGUI windows now. You're always being watched.
(*)As an observer, when you're observing someone, click on the machine they're using to open the window they see.
```
