### PR TITLE
Buffs basic drinking bottle volume

### DIFF
--- a/code/modules/chemistry/tools/food_and_drink.dm
+++ b/code/modules/chemistry/tools/food_and_drink.dm
@@ -833,7 +833,7 @@ ABSTRACT_TYPE(/obj/item/reagent_containers/food/snacks)
 	var/alt_filled_state = null // does our icon state gain a 1 if we've got fluid? put that 1 in this here var if so!
 	var/fluid_underlay_shows_volume = FALSE // determines whether this bottle is special and shows reagent volume
 	var/shatter = 0
-	initial_volume = 50
+	initial_volume = 100
 	g_amt = 60
 
 	New()


### PR DESCRIPTION
## About the PR
Buffs the basic drinking bottle volume from 50 to 100.

## Why's this needed?
It's weird that every other drinking bottle type has a volume of 100, but not the basic drinking bottle. It costs the same amount of glass to make them in the glass recycler, and it has around the same sprite size.


## Changelog

```changelog
(u)Idiot
(+)Buffs basic drinking bottle volume
```
