### PR TITLE
optimizes getProperty and get_station_areas

### DIFF
--- a/_std/defines/materials.dm
+++ b/_std/defines/materials.dm
@@ -1,7 +1,3 @@
-#define VALUE_CURRENT 1
-#define VALUE_MAX 2
-#define VALUE_MIN 4
-
 //materials
 
 /// Crystals, Minerals

--- a/code/datums/gamemodes/battle_royale.dm
+++ b/code/datums/gamemodes/battle_royale.dm
@@ -571,11 +571,12 @@ proc/get_accessible_station_areas()
 		return global.station_areas
 	// All areas
 	var/list/L = list()
-	for_by_tcl(AR, /area/station)
-		for(var/turf/T in AR)
-			if(!isfloor(T) && is_blocked_turf(T) && istype(T,/area/sim/test_area) && T.z == 1)
+	for_by_tcl(area, /area/station)
+		for(var/turf/T in area)
+			if(!isfloor(T) && is_blocked_turf(T) && T.z == 1)
 				continue
-			L[AR.name] = AR
+			L[area.name] = area
+			break
 	global.area_list_is_up_to_date = 1
 	global.station_areas = L
 	return L

--- a/code/modules/materials/Mat_Materials.dm
+++ b/code/modules/materials/Mat_Materials.dm
@@ -73,17 +73,9 @@ ABSTRACT_TYPE(/datum/material)
 			if(initial(propPath.default_value) > 0)
 				src.setProperty(initial(propPath.id), initial(propPath.default_value))
 
-	proc/getProperty(var/property, var/type = VALUE_CURRENT)
-		for(var/datum/material_property/P in properties)
-			if(P.id == property)
-				switch(type)
-					if(VALUE_CURRENT)
-						return properties[P]
-					if(VALUE_MIN)
-						return P.min_value
-					if(VALUE_MAX)
-						return P.max_value
-		return 0
+	proc/getProperty(var/property)
+		var/value = src.properties[property]
+		return isnull(value) ? 0 : value
 
 	proc/removeProperty(var/property)
 		for(var/datum/material_property/P in properties)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [CLEANLINESS][PERFORMANCE]-->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
optimizes getProperty and get_station_areas
(mainly getProperty)

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
a proc that is called over 600k times at roundstart alone should not be slow