### PR TITLE
Put people going through the sec chute to "Released" status

### DIFF
--- a/code/obj/machinery/floorflusher.dm
+++ b/code/obj/machinery/floorflusher.dm
@@ -228,6 +228,11 @@
 					boutput(M, "You feel your handcuffs being removed.")
 					M.handcuffs.drop_handcuffs(M)
 
+				//Might as well set their security record to "released"
+				SPAWN(1)
+					var/datum/db_record/R = data_core.security.find_record("name", M.name)
+					if(!isnull(R))
+						R["criminal"]="Released"
 	// timed process
 	// charge the gas reservoir and perform flush if ready
 	process()

--- a/code/obj/machinery/floorflusher.dm
+++ b/code/obj/machinery/floorflusher.dm
@@ -229,10 +229,9 @@
 					M.handcuffs.drop_handcuffs(M)
 
 				//Might as well set their security record to "released"
-				SPAWN(1)
-					var/datum/db_record/R = data_core.security.find_record("name", M.name)
-					if(!isnull(R))
-						R["criminal"]="Released"
+				var/datum/db_record/R = data_core.security.find_record("name", M.name)
+				if(!isnull(R) && ((R["criminal"]=="Incarcerated") || (R["criminal"]=="*Arrest*")))
+					R["criminal"]="Released"
 	// timed process
 	// charge the gas reservoir and perform flush if ready
 	process()

--- a/code/obj/machinery/floorflusher.dm
+++ b/code/obj/machinery/floorflusher.dm
@@ -230,8 +230,8 @@
 
 				//Might as well set their security record to "released"
 				var/datum/db_record/R = data_core.security.find_record("name", M.name)
-				if(!isnull(R) && ((R["criminal"]=="Incarcerated") || (R["criminal"]=="*Arrest*")))
-					R["criminal"]="Released"
+				if(!isnull(R) && ((R["criminal"] == "Incarcerated") || (R["criminal"] == "*Arrest*")))
+					R["criminal"] = "Released"
 	// timed process
 	// charge the gas reservoir and perform flush if ready
 	process()


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
[A-Game-Objects][C-QoL][size/XS]
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
The flusher already removed cuffs, so now it will also set your criminal record to "Released"


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
People often throw criminals in the brig without clearing their arrest status, leading to them being wrongfully arrested again later. This should make things faster and hopefully prevent unnecessary arrests due to miscommunication or laziness.

## Changelog
```changelog
(u)BotchKing
(+)Changes criminal status to "released" upon being flushed
```
