### PR TITLE
Donut 2 Room Changes: Remixed

### DIFF
--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -25478,7 +25478,7 @@
 	dir = 8;
 	icon_state = "fred2"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "bNk" = (
 /obj/wingrille_spawn/auto/reinforced,
 /obj/cable{
@@ -25601,7 +25601,7 @@
 	dir = 1;
 	icon_state = "fred2"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "bRR" = (
 /obj/lattice{
 	dir = 9;
@@ -26334,7 +26334,7 @@
 "cFD" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "cFT" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -26355,7 +26355,7 @@
 /turf/simulated/floor/carpet{
 	icon_state = "fred2"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "cGu" = (
 /obj/cable/black{
 	icon_state = "2-4"
@@ -28036,7 +28036,7 @@
 	dir = 10;
 	icon_state = "fred2"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "ecM" = (
 /turf/simulated/wall/auto/supernorn,
 /area/station/engine/ptl)
@@ -28045,7 +28045,7 @@
 /area/station/turret_protected/AIsat)
 "edp" = (
 /turf/simulated/floor/carpet/grime,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/arcade/dungeon)
 "edx" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -32148,7 +32148,7 @@
 	dir = 9;
 	icon_state = "fred2"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "hFy" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -32237,7 +32237,7 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/carpet/grime,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/arcade/dungeon)
 "hKJ" = (
 /obj/machinery/conveyor/west{
 	id = "cargo-art-in"
@@ -33799,9 +33799,6 @@
 /obj/decal/poster/wallsign/danger_highvolt,
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/gen_storage)
-"jkE" = (
-/turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/barber_shop)
 "jlr" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -35107,7 +35104,7 @@
 /turf/simulated/floor/stairs{
 	icon_state = "Stairs2_wide"
 	},
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/arcade/dungeon)
 "kwi" = (
 /obj/machinery/light/incandescent,
 /obj/item/neon_lining/cut,
@@ -36306,7 +36303,7 @@
 /obj/item/clothing/head/biglizard,
 /obj/item/clothing/suit/wizrobe/purple,
 /turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "lyw" = (
 /obj/effects/background_objects/star_blue,
 /obj/effects/background_objects/star_red,
@@ -36859,7 +36856,7 @@
 	dir = 4;
 	icon_state = "fred2"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "lYX" = (
 /turf/simulated/floor/yellow/side{
 	dir = 4
@@ -37753,7 +37750,7 @@
 /obj/random_item_spawner/pizza,
 /obj/storage/crate/pizza,
 /turf/simulated/floor/carpet/grime,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/arcade/dungeon)
 "mNv" = (
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/science/lobby)
@@ -37898,7 +37895,7 @@
 	dir = 6;
 	icon_state = "fred2"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "mSm" = (
 /obj/machinery/genetics_scanner,
 /obj/machinery/camera{
@@ -37960,7 +37957,7 @@
 	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/carpet/grime,
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "mUN" = (
 /obj/landmark/start{
 	name = "Engineer"
@@ -38554,7 +38551,7 @@
 	},
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "nwq" = (
 /obj/lattice{
 	dir = 2;
@@ -39969,7 +39966,7 @@
 	name = "Assistant"
 	},
 /turf/simulated/floor/carpet/grime,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/arcade/dungeon)
 "oJW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -40018,6 +40015,9 @@
 	},
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"oLx" = (
+/turf/simulated/wall/auto/supernorn,
+/area/station/crew_quarters/arcade/dungeon)
 "oLE" = (
 /obj/stool,
 /obj/machinery/light/incandescent,
@@ -40506,7 +40506,7 @@
 	dir = 5;
 	icon_state = "fred1"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "peT" = (
 /obj/item/raw_material/shard/glass,
 /turf/simulated/floor/plating,
@@ -40683,7 +40683,7 @@
 	dir = 5;
 	icon_state = "fred1"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "ppd" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/escape{
@@ -41538,7 +41538,7 @@
 	dir = 9;
 	icon_state = "fred1"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "qgJ" = (
 /obj/machinery/sparker{
 	dir = 1;
@@ -43181,7 +43181,7 @@
 /obj/table/wood/auto,
 /obj/random_item_spawner/tableware/three,
 /turf/simulated/floor/carpet/grime,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/arcade/dungeon)
 "rvM" = (
 /obj/item/cigbutt{
 	pixel_x = -1;
@@ -43259,7 +43259,7 @@
 "rxV" = (
 /obj/machinery/vending/cola/red,
 /turf/simulated/floor/carpet/grime,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/arcade/dungeon)
 "ryq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -43446,6 +43446,9 @@
 	dir = 8
 	},
 /area/station/mining/staff_room)
+"rJf" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/arcade/dungeon)
 "rJk" = (
 /obj/iv_stand,
 /turf/simulated/floor/engine,
@@ -44651,7 +44654,7 @@
 	dir = 4;
 	icon_state = "fred2"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "sCz" = (
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
@@ -45826,7 +45829,7 @@
 	dir = 1;
 	icon_state = "fred2"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "tyd" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -46253,7 +46256,7 @@
 /turf/simulated/floor/stairs{
 	icon_state = "Stairs_wide"
 	},
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/arcade/dungeon)
 "tQe" = (
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -46593,7 +46596,7 @@
 	dir = 9;
 	icon_state = "fred1"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "uhd" = (
 /obj/cable{
 	icon_state = "2-8"
@@ -46843,7 +46846,7 @@
 "usb" = (
 /obj/machinery/vending/pizza,
 /turf/simulated/floor/carpet/grime,
-/area/station/maintenance/inner/central)
+/area/station/crew_quarters/arcade/dungeon)
 "utf" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -46952,7 +46955,7 @@
 	dir = 8;
 	icon_state = "fred2"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "uyl" = (
 /obj/random_item_spawner/tools/one_or_zero,
 /turf/simulated/floor/plating,
@@ -48350,7 +48353,7 @@
 	dir = 5;
 	icon_state = "fred2"
 	},
-/area/station/crew_quarters/barber_shop)
+/area/station/crew_quarters/arcade/dungeon)
 "vJy" = (
 /obj/firedoor_spawn,
 /obj/access_spawn/crematorium,
@@ -49104,9 +49107,6 @@
 /obj/access_spawn/research,
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
-"wxU" = (
-/turf/simulated/wall/auto/reinforced/supernorn,
-/area/station/crew_quarters/barber_shop)
 "wyb" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -85129,15 +85129,15 @@ aOE
 aEk
 qwo
 azU
-lpG
-wxU
+oLx
+rJf
 cFD
 cFD
-wxU
-wxU
-acd
-acd
-acd
+rJf
+rJf
+rJf
+rJf
+rJf
 aXP
 aYE
 aXP
@@ -85431,13 +85431,13 @@ fck
 bLC
 hll
 azU
-lpG
+oLx
 hFr
 bMT
 uxw
 ecC
 mUe
-aCy
+oLx
 usb
 mNs
 aXP
@@ -85733,12 +85733,12 @@ aNS
 aEk
 fcg
 azU
-lpG
+oLx
 bQH
 ugE
 peB
 cGc
-jkE
+edp
 tPS
 edp
 edp
@@ -86035,12 +86035,12 @@ hJE
 aLj
 hll
 aFq
-lpG
+oLx
 tyc
 poZ
 qgt
 cGc
-jkE
+edp
 kvI
 oJE
 hKE
@@ -86337,13 +86337,13 @@ dFk
 xFa
 nFf
 aXf
-lpG
+oLx
 vJw
 sBZ
 lYT
 mSh
 lyh
-aCy
+oLx
 rxV
 rvd
 aXP
@@ -86639,15 +86639,15 @@ uvh
 aLj
 azk
 aAl
-lpG
-lpG
-lpG
+oLx
+oLx
+oLx
 nvW
-lpG
-lpG
-aCy
-aBQ
-aBQ
+oLx
+oLx
+oLx
+rJf
+rJf
 aXP
 aYE
 aXP

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -2167,6 +2167,14 @@
 	dir = 1
 	},
 /area/station/science/lobby)
+"aie" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "kondaru_funeral";
+	name = "funerary driver"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/chapel/sanctuary)
 "aif" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -4290,6 +4298,12 @@
 	dir = 4
 	},
 /obj/storage/crate,
+/obj/item/furniture_parts/table/reinforced/bar,
+/obj/item/furniture_parts/table/reinforced/bar,
+/obj/item/furniture_parts/table/reinforced/bar,
+/obj/item/furniture_parts/woodenstool,
+/obj/item/furniture_parts/woodenstool,
+/obj/item/furniture_parts/woodenstool,
 /turf/simulated/floor,
 /area/station/maintenance/north)
 "arl" = (
@@ -5630,16 +5644,19 @@
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "avT" = (
-/obj/machinery/door/poddoor/pyro{
-	id = "kondaru_funeral";
-	name = "Funerary Driver Door"
+/obj/table/auto,
+/obj/item/clothing/suit/cultist/nerd,
+/obj/item/reagent_containers/glass/bottle/holywater{
+	pixel_x = -2;
+	pixel_y = 8
 	},
-/obj/machinery/mass_driver{
-	dir = 1;
-	id = "kondaru_funeral";
-	name = "funerary driver"
+/obj/item/clothing/mask/gas/plague,
+/obj/machinery/light/incandescent,
+/obj/machinery/power/apc/autoname_north,
+/obj/cable{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/black,
+/turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "avU" = (
 /turf/simulated/floor/plating,
@@ -5864,21 +5881,11 @@
 	layer = 2
 	},
 /area/station/solar/west)
-"awK" = (
-/obj/submachine/chef_sink/chem_sink{
-	dir = 8;
-	pixel_x = 4
+"awL" = (
+/obj/machinery/traymachine/morgue{
+	dir = 8
 	},
 /turf/simulated/floor/sanitary,
-/area/station/medical/crematorium)
-"awL" = (
-/obj/machinery/mass_driver{
-	dir = 1;
-	id = "kondaru_funeral";
-	name = "funerary driver"
-	},
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/black,
 /area/station/medical/crematorium)
 "awN" = (
 /turf/simulated/wall/auto/supernorn,
@@ -6089,14 +6096,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
 "axw" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/machinery/activation_button/driver_button{
-	id = "kondaru_funeral";
-	name = "Funerary Driver Button";
-	pixel_x = -24
-	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/black,
+/obj/machinery/disposal/small/west,
+/obj/disposalpipe/trunk,
+/turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "axx" = (
 /obj/item/device/light/candle{
@@ -6447,38 +6449,15 @@
 	},
 /turf/simulated/floor/orangeblack/side,
 /area/station/hangar/main)
-"ayr" = (
-/obj/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/autoname_west,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 4;
-	name = "autoname - SS13";
-	tag = ""
-	},
-/obj/disposaloutlet{
-	dir = 4;
-	mailgroup = "chaplain";
-	mailgroup2 = "security";
-	message = "Delivery alert in Crematorium.";
-	name = "Crematorium Outlet"
-	},
-/obj/disposalpipe/trunk/morgue{
-	dir = 4;
-	name = "crematorium pipe"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/medical/crematorium)
 "ays" = (
-/obj/machinery/disposal/small/west,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/disposalpipe/trunk,
-/turf/simulated/floor/sanitary,
+/obj/disposalpipe/segment,
+/obj/wingrille_spawn/auto/reinforced,
+/obj/window_blinds/cog2,
+/turf/simulated/floor/plating,
 /area/station/medical/crematorium)
 "ayv" = (
 /obj/decal/tile_edge/line/black{
@@ -6492,6 +6471,9 @@
 	layer = 2.8
 	},
 /obj/stool/wooden,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
 "ayx" = (
@@ -6681,14 +6663,11 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/pyro/glass,
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
-/obj/firedoor_spawn,
-/obj/access_spawn/crematorium,
-/turf/simulated/floor/black,
-/area/station/medical/crematorium)
+/turf/simulated/floor/wood/seven,
+/area/station/chapel/sanctuary)
 "azk" = (
 /obj/random_item_spawner/junk/one_or_zero,
 /obj/decal/cleanable/dirt/dirt2,
@@ -6754,7 +6733,6 @@
 /obj/landmark/start{
 	name = "Chaplain"
 	},
-/obj/machinery/light/incandescent,
 /obj/machinery/light_switch{
 	name = "N light switch";
 	on = 0;
@@ -7094,11 +7072,6 @@
 /obj/loudspeaker,
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
-"aAp" = (
-/obj/item/instrument/large/organ,
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/wood/seven,
-/area/station/chapel/sanctuary)
 "aAq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -7108,11 +7081,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/carpet,
-/area/station/chapel/sanctuary)
-"aAr" = (
-/obj/item/instrument/large/piano,
-/obj/machinery/light/incandescent,
-/turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
 "aAs" = (
 /obj/item/clothing/under/suit/dress,
@@ -7547,12 +7515,6 @@
 	icon_state = "fred2"
 	},
 /area/station/chapel/sanctuary)
-"aBY" = (
-/obj/wingrille_spawn/auto/reinforced,
-/obj/disposalpipe/segment,
-/obj/window_blinds/cog2,
-/turf/simulated/floor/plating,
-/area/station/medical/crematorium)
 "aBZ" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -7700,16 +7662,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aCA" = (
-/obj/cable{
-	icon_state = "4-8"
-	},
-/obj/disposalpipe/segment/morgue{
-	dir = 4;
-	name = "crematorium pipe"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/medical/crematorium)
 "aCB" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
@@ -8418,14 +8370,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "aED" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
 /obj/disposalpipe/segment/morgue{
-	dir = 2;
-	icon_state = "pipe-c";
 	name = "crematorium pipe"
 	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/pyro/glass,
+/obj/access_spawn/crematorium,
+/obj/firedoor_spawn,
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "aEF" = (
@@ -9146,16 +9099,6 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"aGS" = (
-/obj/machinery/traymachine/morgue{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/sanitary,
-/area/station/medical/crematorium)
 "aGT" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -9458,6 +9401,11 @@
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
+/obj/table/podium_wood,
+/obj/item/storage/bible{
+	pixel_y = 7
+	},
+/obj/machinery/light/small/floor,
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
 "aIa" = (
@@ -9690,7 +9638,7 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor,
 /area/station/maintenance/west)
 "aIF" = (
 /obj/disposalpipe/segment{
@@ -10532,6 +10480,7 @@
 /obj/disposalpipe/trunk/ejection{
 	dir = 4
 	},
+/obj/machinery/light/incandescent,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
 "aLt" = (
@@ -11033,13 +10982,9 @@
 "aMF" = (
 /obj/pool/perspective,
 /obj/table/reinforced/bar/auto,
-/obj/item/reagent_containers/food/drinks/drinkingglass/random_style/filled/sane{
-	pixel_x = -5;
-	pixel_y = 9
-	},
 /obj/item/reagent_containers/food/drinks/coconut{
-	pixel_x = 7;
-	pixel_y = 1;
+	pixel_x = -1;
+	pixel_y = 7;
 	rand_pos = 1
 	},
 /obj/channel{
@@ -11437,30 +11382,6 @@
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/food/snacks/ice_cream_cone{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/snacks/ice_cream_cone{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/snacks/ice_cream_cone{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/snacks/ice_cream_cone{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/snacks/ice_cream_cone{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/snacks/ice_cream_cone{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/snacks/ice_cream_cone{
 	pixel_x = -1;
 	pixel_y = 4
 	},
@@ -11586,10 +11507,6 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
 "aOg" = (
-/obj/machinery/camera{
-	c_tag = "Detective's Office";
-	dir = 2
-	},
 /obj/machinery/disposal/mail{
 	mail_tag = "detective";
 	mailgroup = "security";
@@ -11598,6 +11515,16 @@
 	},
 /obj/disposalpipe/trunk/mail{
 	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	name = "autoname  - SS13";
+	pixel_y = 18;
+	tag = ""
 	},
 /turf/simulated/floor/carpet/grime,
 /area/station/security/detectives_office)
@@ -11952,14 +11879,6 @@
 "aPt" = (
 /turf/simulated/floor/specialroom/gym,
 /area/station/crew_quarters/fitness)
-"aPv" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4;
-	req_access = null
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/station/maintenance/inner/central)
 "aPw" = (
 /obj/machinery/door/airlock/pyro/glass{
 	dir = 4
@@ -12282,12 +12201,6 @@
 /obj/decal/cleanable/rust,
 /turf/simulated/floor/sanitary/white,
 /area/station/maintenance/west)
-"aQE" = (
-/obj/decal/cleanable/dirt/dirt3,
-/obj/random_item_spawner/junk/one_or_zero,
-/obj/storage/crate,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "aQF" = (
 /obj/submachine/chef_sink/chem_sink{
 	pixel_y = 8
@@ -12304,17 +12217,15 @@
 /turf/simulated/wall/auto/supernorn,
 /area/station/medical/medbay/cloner)
 "aQI" = (
-/obj/iv_stand,
-/obj/item/reagent_containers/iv_drip/saline,
-/obj/machinery/light/small,
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 1;
-	name = "autoname - SS13";
-	tag = ""
+/obj/stool/chair/office/blue{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/blue/fancy/narrow/west,
-/area/station/medical/medbay/treatment2)
+/obj/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/carpet/blue/fancy/edge,
+/area/station/medical/medbay/psychiatrist)
 "aQJ" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -12918,21 +12829,9 @@
 	},
 /area/station/crew_quarters/stockex)
 "aSQ" = (
-/obj/item/cigarbox{
-	pixel_y = 11;
-	rand_pos = 0
+/turf/simulated/floor/carpet/blue/fancy/edge{
+	dir = 1
 	},
-/obj/item/clothing/mask/cigarette/cigar,
-/obj/item/clothing/mask/cigarette/cigar{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/device/light/zippo{
-	pixel_x = 10;
-	pixel_y = 8
-	},
-/obj/table/regal/auto,
-/turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "aSR" = (
 /obj/cable{
@@ -13152,10 +13051,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/west)
-"aTz" = (
-/obj/decoration/regallamp,
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/stockex)
 "aTA" = (
 /obj/grille/steel,
 /turf/space,
@@ -13861,6 +13756,7 @@
 	icon_state = "plant";
 	tag = "icon-plant (NORTH)"
 	},
+/obj/item/reagent_containers/pill/methamphetamine,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "aVB" = (
@@ -14129,6 +14025,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engine/substation/west)
+"aWt" = (
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/psychiatrist)
 "aWu" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -15763,7 +15663,7 @@
 /obj/access_spawn/medical,
 /obj/firedoor_spawn,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/treatment)
+/area/station/medical/medbay/psychiatrist)
 "baM" = (
 /obj/table/wood/auto,
 /obj/item/paper_bin{
@@ -15919,15 +15819,6 @@
 	dir = 2
 	},
 /area/station/medical/medbay)
-"bbh" = (
-/obj/table/auto,
-/obj/item/decoration/flower_vase/vase7,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/reagent_containers/syringe/haloperidol{
-	pixel_x = 6
-	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/treatment1)
 "bbi" = (
 /obj/machinery/firealarm{
 	pixel_y = 24;
@@ -16093,7 +15984,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
 "bbJ" = (
-/obj/machinery/light/incandescent,
 /obj/machinery/atmospherics/unary/cold_sink/freezer/cryo/west,
 /turf/simulated/floor/bluewhite{
 	dir = 6
@@ -16625,14 +16515,11 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "bdB" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4;
-	req_access = null
+/obj/cable{
+	icon_state = "2-4"
 	},
-/obj/access_spawn/medical,
-/obj/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+/turf/simulated/floor/white,
+/area/station/medical/medbay/treatment)
 "bdD" = (
 /obj/table/auto,
 /obj/item/clipboard,
@@ -16873,13 +16760,6 @@
 	},
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/engine/inner)
-"ber" = (
-/obj/machinery/light/incandescent,
-/obj/disposalpipe/segment/mail,
-/turf/simulated/floor/red/side{
-	dir = 4
-	},
-/area/station/hallway/primary/east)
 "beu" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk/east,
@@ -17303,16 +17183,16 @@
 	},
 /area/station/hallway/primary/west)
 "bfZ" = (
-/obj/iv_stand,
-/obj/item/reagent_containers/iv_drip/saline,
-/obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "autotag";
 	dir = 1;
 	name = "autoname - SS13";
 	tag = ""
 	},
-/turf/simulated/floor/carpet/blue/fancy/narrow/west,
+/obj/stool/bed/moveable,
+/obj/item/clothing/suit/bedsheet/blue,
+/obj/machinery/light/small/floor,
+/turf/simulated/floor/carpet/blue/fancy/narrow/east,
 /area/station/medical/medbay/treatment1)
 "bgb" = (
 /obj/cable{
@@ -19610,6 +19490,7 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
+/obj/stool/chair/office/red,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -20173,13 +20054,15 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "bqN" = (
-/turf/simulated/floor,
+/turf/simulated/floor/yellow,
 /area/station/engine/storage)
 "bqO" = (
 /obj/machinery/light/incandescent,
 /obj/machinery/manufacturer/general,
 /obj/item/device/radio/intercom/engineering,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
 /area/station/engine/storage)
 "bqP" = (
 /obj/machinery/camera{
@@ -20188,12 +20071,16 @@
 	},
 /obj/machinery/shieldgenerator/energy_shield,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
 /area/station/engine/storage)
 "bqQ" = (
 /obj/machinery/shieldgenerator/energy_shield,
 /obj/decal/mule/beacon/no_auto_dropoff_spawn,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/corner{
+	dir = 8
+	},
 /area/station/engine/storage)
 "bqS" = (
 /obj/shrub{
@@ -20420,7 +20307,9 @@
 /obj/item/sheet/steel/fullstack,
 /obj/item/sheet/steel/reinforced/fullstack,
 /obj/item/sheet/steel/reinforced/fullstack,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
 /area/station/engine/storage)
 "brQ" = (
 /obj/table/auto,
@@ -20428,7 +20317,7 @@
 /obj/item/sheet/glass/fullstack,
 /obj/item/sheet/glass/reinforced/fullstack,
 /obj/item/sheet/glass/reinforced/fullstack,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/corner,
 /area/station/engine/storage)
 "brR" = (
 /obj/cable{
@@ -20445,7 +20334,10 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/caution/north,
+/obj/decal/tile_edge/stripe/extra_big{
+	dir = 1
+	},
+/turf/simulated/floor/yellow/corner,
 /area/station/engine/engineering)
 "brT" = (
 /obj/machinery/dispenser{
@@ -20458,7 +20350,9 @@
 /obj/cable{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
 /area/station/engine/engineering)
 "brV" = (
 /obj/wingrille_spawn/auto/reinforced,
@@ -20645,7 +20539,6 @@
 	name = "autoname - SS13";
 	tag = ""
 	},
-/obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/mail{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -20694,23 +20587,24 @@
 /obj/item/device/t_scanner,
 /obj/item/storage/toolbox/electrical,
 /obj/random_item_spawner/tools/one,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
 /area/station/engine/storage)
 "bsI" = (
 /obj/cable{
 	icon_state = "2-4"
 	},
 /obj/landmark/gps_waypoint,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow,
 /area/station/engine/storage)
 "bsJ" = (
 /obj/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
-/area/station/engine/storage)
-"bsK" = (
-/turf/simulated/floor/bot,
+/turf/simulated/floor/yellow/side{
+	dir = 9
+	},
 /area/station/engine/storage)
 "bsL" = (
 /obj/table/auto,
@@ -20721,7 +20615,9 @@
 /obj/item/cell/supercell,
 /obj/item/cell/supercell,
 /obj/item/cell/supercell,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
 /area/station/engine/storage)
 "bsN" = (
 /obj/machinery/abcu,
@@ -20891,19 +20787,21 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
 /area/station/engine/storage)
 "btF" = (
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/yellow,
 /area/station/engine/storage)
 "btG" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/yellow,
 /area/station/engine/storage)
 "btH" = (
 /obj/rack,
@@ -20919,7 +20817,9 @@
 /obj/item/clothing/head/helmet/hardhat,
 /obj/item/chem_grenade/firefighting,
 /obj/item/chem_grenade/firefighting,
-/turf/simulated/floor/bot,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
 /area/station/engine/storage)
 "btI" = (
 /obj/table/auto,
@@ -20928,12 +20828,16 @@
 /obj/item/storage/box/lightbox/tubes,
 /obj/item/storage/box/lightbox/tubes,
 /obj/item/storage/box/lightbox/bulbs,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/corner{
+	dir = 1
+	},
 /area/station/engine/storage)
 "btK" = (
 /obj/disposalpipe/segment/mail,
 /obj/storage/closet/wardrobe/yellow/engineering,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
 /area/station/engine/engineering)
 "btL" = (
 /obj/machinery/light/small{
@@ -21093,7 +20997,9 @@
 /obj/item/cable_coil,
 /obj/item/cable_coil,
 /obj/random_item_spawner/tools/one,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/corner{
+	dir = 4
+	},
 /area/station/engine/storage)
 "buF" = (
 /obj/table/auto,
@@ -21106,14 +21012,18 @@
 /obj/item/chem_grenade/metalfoam,
 /obj/item/chem_grenade/metalfoam,
 /obj/item/chem_grenade/metalfoam,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
 /area/station/engine/storage)
 "buG" = (
 /obj/machinery/disposal,
 /obj/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
 /area/station/engine/storage)
 "buH" = (
 /obj/disposalpipe/segment{
@@ -21122,7 +21032,9 @@
 	},
 /obj/machinery/light/incandescent,
 /obj/reagent_dispensers/fueltank,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 1
+	},
 /area/station/engine/storage)
 "buI" = (
 /obj/cable,
@@ -21133,22 +21045,22 @@
 	pixel_y = 0
 	},
 /obj/reagent_dispensers/foamtank,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/corner{
+	dir = 1
+	},
 /area/station/engine/storage)
 "buJ" = (
-/turf/simulated/floor,
-/area/station/engine/engineering)
-"buL" = (
-/obj/cable{
-	icon_state = "1-2"
+/turf/simulated/floor/yellow/side{
+	dir = 4
 	},
-/turf/simulated/floor,
 /area/station/engine/engineering)
 "buM" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/light/incandescent,
 /obj/storage/secure/closet/engineering/electrical,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
 /area/station/engine/engineering)
 "buN" = (
 /obj/cable{
@@ -21398,9 +21310,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/power/lgenerator,
-/turf/simulated/floor/yellow/side{
-	dir = 4
-	},
+/turf/simulated/floor/yellow/corner,
 /area/station/engine/engineering)
 "bvP" = (
 /obj/cable{
@@ -21430,7 +21340,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/yellow/side{
-	dir = 2
+	dir = 6
 	},
 /area/station/engine/engineering)
 "bvR" = (
@@ -21440,9 +21350,7 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "bvS" = (
 /obj/disposalpipe/segment/mail,
@@ -21456,7 +21364,7 @@
 	pixel_y = 0
 	},
 /obj/storage/secure/closet/engineering/engineer,
-/turf/simulated/floor/orangeblack/corner{
+/turf/simulated/floor/yellow/side{
 	dir = 8
 	},
 /area/station/engine/engineering)
@@ -21746,7 +21654,6 @@
 	c_tag = "South Primary Hallway Midport";
 	dir = 9
 	},
-/obj/decal/cleanable/cobweb2,
 /obj/machinery/light/emergency{
 	dir = 1;
 	icon_state = "ebulb1"
@@ -22171,7 +22078,10 @@
 /obj/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/computer/power_monitor,
+/obj/machinery/computer/power_monitor{
+	dir = 4;
+	icon_state = "power"
+	},
 /turf/simulated/floor/yellow/corner{
 	dir = 4
 	},
@@ -22180,7 +22090,9 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/obj/storage/closet/welding_supply,
+/obj/stool/chair/yellow{
+	dir = 8
+	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -22528,6 +22440,7 @@
 	pixel_y = 24;
 	text = "NF"
 	},
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/yellow/side{
 	dir = 1
 	},
@@ -22546,12 +22459,16 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/incandescent,
-/obj/machinery/camera{
-	c_tag = "South Primary Hallway"
-	},
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 3;
+	name = "autoname - SS13";
+	pixel_y = 20;
+	tag = ""
 	},
 /turf/simulated/floor/yellow/side{
 	dir = 1
@@ -22726,6 +22643,7 @@
 /area/station/engine/elect)
 "bAE" = (
 /obj/machinery/rkit,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bAF" = (
@@ -23253,7 +23171,9 @@
 /area/station/atmos/highcap_storage)
 "bCt" = (
 /obj/machinery/light/incandescent,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 4
+	},
 /area/station/engine/engineering)
 "bCu" = (
 /obj/machinery/camera{
@@ -23680,6 +23600,7 @@
 /area/station/engine/elect)
 "bEo" = (
 /obj/machinery/vending/mechanics,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/yellow,
 /area/station/engine/elect)
 "bEp" = (
@@ -25550,7 +25471,13 @@
 	icon_state = "pest-start";
 	name = "peststart"
 	},
-/turf/simulated/floor/plating,
+/obj/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fred2"
+	},
 /area/station/crew_quarters/barber_shop)
 "bNk" = (
 /obj/wingrille_spawn/auto/reinforced,
@@ -25575,6 +25502,12 @@
 	dir = 8
 	},
 /area/station/science/lobby)
+"bOc" = (
+/obj/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/yellow,
+/area/station/engine/storage)
 "bON" = (
 /obj/machinery/light/incandescent,
 /obj/storage/closet/wardrobe/black/formalwear,
@@ -25620,6 +25553,7 @@
 	},
 /obj/access_spawn/kitchen,
 /obj/firedoor_spawn,
+/obj/access_spawn/bar,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "bPo" = (
@@ -25659,8 +25593,14 @@
 	dir = 1;
 	status = 2
 	},
-/obj/item/basketball,
-/turf/simulated/floor/plating,
+/obj/stool/chair,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fred2"
+	},
 /area/station/crew_quarters/barber_shop)
 "bRR" = (
 /obj/lattice{
@@ -25705,6 +25645,7 @@
 	pixel_x = 7;
 	pixel_y = -5
 	},
+/obj/item_dispenser/latex_gloves,
 /turf/simulated/floor/specialroom/medbay,
 /area/station/medical/medbay/restroom)
 "bWe" = (
@@ -25781,10 +25722,14 @@
 	name = "A tasteful shrub";
 	tag = "null"
 	},
+/obj/item/device/radio/intercom/medical{
+	dir = 1
+	},
 /obj/machinery/camera{
 	c_tag = "autotag";
-	dir = 1;
+	dir = 4;
 	name = "autoname - SS13";
+	pixel_x = -10;
 	tag = ""
 	},
 /turf/simulated/floor/white,
@@ -26134,7 +26079,7 @@
 	icon_state = "1-2"
 	},
 /obj/disposalpipe/junction/right/north,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/purple/side,
 /area/station/maintenance/west)
 "cst" = (
 /turf/simulated/floor/white,
@@ -26303,16 +26248,9 @@
 	},
 /turf/simulated/floor/dojo/sand,
 /area/station/crew_quarters/pool)
-"cBp" = (
-/obj/disposalpipe/segment{
-	dir = 1
-	},
-/obj/cable{
-	icon_state = "1-2"
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
+"cCj" = (
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
 "cCz" = (
 /obj/decal/cleanable/blood/splatter{
 	icon_state = "floor4";
@@ -26411,8 +26349,12 @@
 /turf/simulated/floor/plating,
 /area/station/wreckage)
 "cGc" = (
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
+/obj/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/carpet{
+	icon_state = "fred2"
+	},
 /area/station/crew_quarters/barber_shop)
 "cGu" = (
 /obj/cable/black{
@@ -26569,6 +26511,19 @@
 	dir = 10
 	},
 /area/station/security/processing)
+"cPJ" = (
+/obj/stool/chair/comfy/barber_chair{
+	dir = 4
+	},
+/obj/machinery/drainage,
+/obj/decal/stage_edge{
+	layer = 2.8
+	},
+/obj/landmark/start{
+	name = "Assistant"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "cPX" = (
 /obj/disposalpipe/segment{
 	dir = 2;
@@ -26822,7 +26777,9 @@
 	},
 /obj/machinery/light/incandescent,
 /obj/item/paper/donut2smesinstructions,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
 /area/station/engine/engineering)
 "cZx" = (
 /turf/simulated/floor/grasstodirt{
@@ -27058,6 +27015,9 @@
 	},
 /turf/simulated/floor/black,
 /area/station/science/lab)
+"dlZ" = (
+/turf/simulated/wall/false_wall,
+/area/station/medical/medbay/treatment1)
 "dmc" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -27189,10 +27149,6 @@
 /obj/access_spawn/maint,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
-"dro" = (
-/obj/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/medbay/treatment1)
 "drI" = (
 /obj/decal/poster/wallsign/gym,
 /turf/simulated/wall/auto/supernorn,
@@ -27219,21 +27175,11 @@
 	},
 /area/station/hallway/primary/north)
 "dse" = (
-/obj/table/wood/round/auto,
-/obj/item/reagent_containers/food/snacks/croissant{
-	rand_pos = 0
-	},
-/obj/item/reagent_containers/food/snacks/croissant{
-	pixel_x = 6;
-	pixel_y = -4;
-	rand_pos = 0
-	},
 /obj/machinery/camera{
 	c_tag = "Inner Maintenance West";
 	dir = 4
 	},
-/obj/disposalpipe/segment/vertical,
-/turf/simulated/floor/wood,
+/turf/simulated/wall/auto/supernorn,
 /area/station/crew_quarters/stockex)
 "dsL" = (
 /obj/submachine/seed_manipulator{
@@ -27249,6 +27195,13 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"dtT" = (
+/obj/machinery/power/apc/autoname_west,
+/obj/cable,
+/turf/simulated/floor/carpet/blue/fancy/edge{
+	dir = 9
+	},
+/area/station/medical/medbay/psychiatrist)
 "dtU" = (
 /obj/machinery/light_switch{
 	name = "W light switch";
@@ -27317,6 +27270,14 @@
 	dir = 8
 	},
 /area/station/science/chemistry)
+"dvD" = (
+/obj/item/device/radio/intercom/medical{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge{
+	dir = 10
+	},
+/area/station/medical/medbay/psychiatrist)
 "dwF" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/segment/morgue{
@@ -27499,9 +27460,16 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
 "dEj" = (
-/obj/wingrille_spawn/auto/reinforced,
-/turf/simulated/floor/plating,
-/area/station/medical/medbay/treatment2)
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 8;
+	icon_state = "camera";
+	name = "autoname  - SS13";
+	network = "SS13";
+	tag = ""
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/psychiatrist)
 "dFk" = (
 /obj/decal/cleanable/dirt/dirt2,
 /obj/cable{
@@ -27824,6 +27792,19 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/white,
 /area/station/science/lab)
+"dUq" = (
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 5;
+	name = "autoname - SS13";
+	pixel_x = -10;
+	tag = ""
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/stairs/wood,
+/area/station/crew_quarters/barber_shop)
 "dUF" = (
 /obj/disposalpipe/segment,
 /turf/simulated/floor/grime,
@@ -27981,12 +27962,14 @@
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/fitness)
 "dZM" = (
-/obj/stool/chair/couch{
-	dir = 8;
-	icon_state = "chair_couch-brown"
+/obj/table/endtable_classic,
+/obj/item/reagent_containers/food/drinks/tea{
+	pixel_x = -8;
+	pixel_y = 16
 	},
-/obj/landmark/start{
-	name = "Staff Assistant"
+/obj/item/reagent_containers/food/drinks/tea{
+	pixel_x = 4;
+	pixel_y = 9
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 9
@@ -28049,12 +28032,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "ecC" = (
-/obj/storage/crate,
-/obj/item/clothing/head/wig,
-/obj/item/dye_bottle,
-/obj/item/dye_bottle,
-/obj/item/clothing/under/misc/barber,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/carpet{
+	dir = 10;
+	icon_state = "fred2"
+	},
 /area/station/crew_quarters/barber_shop)
 "ecM" = (
 /turf/simulated/wall/auto/supernorn,
@@ -28063,8 +28044,7 @@
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/AIsat)
 "edp" = (
-/obj/landmark/random_room/size3x3,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/carpet/grime,
 /area/station/maintenance/inner/central)
 "edx" = (
 /obj/cable{
@@ -28126,13 +28106,36 @@
 	},
 /turf/simulated/floor/plating/airless/asteroid/lighted,
 /area/space)
+"egJ" = (
+/obj/table/reinforced/auto,
+/obj/access_spawn/kitchen,
+/obj/firedoor_spawn,
+/obj/machinery/door/airlock/pyro/glass/windoor{
+	autoclose = 0;
+	dir = 4
+	},
+/obj/machinery/door/poddoor/pyro/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "kitchen";
+	layer = 4;
+	name = "Kitchen Shutter";
+	opacity = 0;
+	panel_open = 1
+	},
+/obj/machinery/glass_recycler{
+	glass_amt = 5;
+	pixel_y = 4
+	},
+/turf/simulated/floor/specialroom/cafeteria,
+/area/station/crew_quarters/kitchen)
 "egX" = (
-/obj/machinery/disposal/small/east,
-/obj/disposalpipe/trunk/east,
 /obj/landmark{
 	icon_state = "pest-start";
 	name = "peststart"
 	},
+/obj/decoration/regallamp,
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 10
 	},
@@ -28454,7 +28457,9 @@
 /area/station/crew_quarters/stockex)
 "ets" = (
 /obj/disposalpipe/segment/mail,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 8
+	},
 /area/station/engine/engineering)
 "etx" = (
 /obj/wingrille_spawn/auto/reinforced,
@@ -28573,6 +28578,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/wreckage)
+"exB" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/stool/chair/comfy,
+/turf/simulated/floor/black/side,
+/area/station/crew_quarters/quarters)
 "exF" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -28606,7 +28618,21 @@
 /turf/simulated/floor/blue/checker,
 /area/station/crew_quarters/pool)
 "eyO" = (
-/turf/simulated/floor/carpet/blue/fancy/narrow/eastwest,
+/obj/table/regal/auto,
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_y = 2;
+	pixel_x = -5
+	},
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/device/light/zippo/gold{
+	rand_pos = 0;
+	pixel_y = 15;
+	pixel_x = -7
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge,
 /area/station/crew_quarters/stockex)
 "ezc" = (
 /obj/wingrille_spawn/auto/reinforced,
@@ -28705,11 +28731,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/scidisposal)
 "eDO" = (
-/obj/storage/closet/office,
 /obj/disposalpipe/segment/mail{
 	dir = 4;
 	icon_state = "pipe-s"
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -28983,11 +29009,13 @@
 /turf/simulated/floor/grime,
 /area/station/quartermaster/refinery)
 "eOn" = (
-/obj/item/clothing/suit/bedsheet/blue,
-/obj/machinery/light/small/floor,
-/obj/stool/bed/moveable,
-/turf/simulated/floor/carpet/blue/fancy/narrow/east,
-/area/station/medical/medbay/treatment2)
+/obj/machinery/computer3/generic/med_data{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge{
+	dir = 6
+	},
+/area/station/medical/medbay/psychiatrist)
 "eOq" = (
 /obj/submachine/ice_cream_dispenser,
 /obj/disposalpipe/segment{
@@ -29132,6 +29160,10 @@
 /obj/machinery/camera{
 	c_tag = "West Electrical Substation";
 	dir = 8
+	},
+/obj/item/clothing/head/that{
+	pixel_x = 5;
+	pixel_y = 8
 	},
 /turf/simulated/floor/carpet{
 	dir = 5;
@@ -29284,14 +29316,6 @@
 	},
 /turf/simulated/floor/dirt,
 /area/station/ranch)
-"faN" = (
-/obj/machinery/vending/capsule,
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
-	},
-/turf/simulated/floor/black/side,
-/area/station/crew_quarters/quarters)
 "faU" = (
 /obj/machinery/door/poddoor/pyro{
 	dir = 4;
@@ -29524,11 +29548,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
+"fjW" = (
+/obj/iv_stand,
+/obj/item/reagent_containers/iv_drip/saline,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/carpet/blue/fancy/narrow/west,
+/area/station/medical/medbay/treatment1)
 "fkj" = (
-/obj/machinery/power/apc/autoname_west,
-/obj/cable,
-/turf/simulated/floor/white,
-/area/station/medical/medbay/treatment2)
+/obj/table/auto,
+/obj/item/clipboard{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/item/kitchen/food_box/lollipop{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/pen{
+	rand_pos = 0
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge{
+	dir = 1
+	},
+/area/station/medical/medbay/psychiatrist)
 "fkY" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -29541,6 +29586,10 @@
 /obj/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/east)
+"fls" = (
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/wood/six,
+/area/station/maintenance/west)
 "flv" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -29704,6 +29753,15 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/ai)
+"fsC" = (
+/obj/decal/cleanable/rust/jen,
+/obj/decal/cleanable/dirt/dirt4,
+/obj/landmark{
+	icon_state = "blob-start";
+	name = "blobstart"
+	},
+/turf/simulated/floor/wood/six,
+/area/station/maintenance/west)
 "fsH" = (
 /obj/stool/chair,
 /obj/disposalpipe/segment/vertical,
@@ -29751,6 +29809,12 @@
 	dir = 4
 	},
 /area/station/crew_quarters/locker)
+"ftD" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/yellow,
+/area/station/engine/storage)
 "fuh" = (
 /obj/stool/bar,
 /obj/machinery/light/small/floor,
@@ -29871,12 +29935,12 @@
 /turf/simulated/floor,
 /area/station/maintenance/southwest)
 "fCp" = (
-/obj/machinery/light_switch/north,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 21
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -30034,6 +30098,15 @@
 	dir = 2
 	},
 /area/station/science/lobby)
+"fJk" = (
+/obj/machinery/traymachine/locking/crematorium{
+	id = "crematorium"
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/medical/crematorium)
 "fKj" = (
 /obj/storage/closet/welding_supply,
 /turf/simulated/floor/plating,
@@ -30083,15 +30156,21 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
 "fLo" = (
-/obj/shrub{
-	dir = 8;
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "plant"
-	},
+/obj/machinery/vending/cards,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
 /area/station/crew_quarters/quarters)
+"fLF" = (
+/obj/submachine/chef_sink/chem_sink{
+	layer = 3;
+	pixel_y = 8
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/medical/crematorium)
 "fMJ" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -30187,7 +30266,6 @@
 /turf/simulated/floor,
 /area/station/science/lobby)
 "fRR" = (
-/obj/disposalpipe/segment/vertical,
 /turf/simulated/floor/carpet{
 	dir = 2;
 	icon_state = "blue1"
@@ -30493,14 +30571,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
 "gja" = (
-/obj/machinery/door/airlock/pyro/glass,
-/obj/access_spawn/medical,
-/obj/firedoor_spawn,
-/obj/cable{
-	icon_state = "1-2"
+/obj/landmark/start{
+	name = "Medical Doctor"
 	},
+/obj/stool/chair/comfy/blue,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/treatment2)
+/area/station/medical/medbay/psychiatrist)
 "gjf" = (
 /obj/disposalpipe/segment/mail{
 	dir = 4;
@@ -30532,6 +30608,30 @@
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
+"gkI" = (
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/snacks/plant/apple{
+	pixel_x = 7;
+	pixel_y = 8;
+	rand_pos = 0
+	},
+/obj/item/reagent_containers/food/snacks/plant/blueberry{
+	rand_pos = 0
+	},
+/obj/item/reagent_containers/food/snacks/plant/peach{
+	pixel_x = -5;
+	pixel_y = 9;
+	rand_pos = 0
+	},
+/obj/item/reagent_containers/food/snacks/plant/blueberry{
+	pixel_x = 5;
+	pixel_y = -3;
+	rand_pos = 0
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge{
+	dir = 6
+	},
+/area/station/crew_quarters/stockex)
 "glV" = (
 /obj/cable{
 	icon_state = "2-4"
@@ -30553,10 +30653,8 @@
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "gmh" = (
-/obj/item/storage/toilet/random{
-	dir = 8
-	},
 /obj/machinery/light/small,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
 "gmL" = (
@@ -30765,7 +30863,6 @@
 /area/station/storage/tools)
 "gvO" = (
 /obj/storage/cart/medcart,
-/obj/item_dispenser/latex_gloves,
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/item/clothing/suit/bedsheet/blue,
 /obj/item/clothing/under/patient_gown,
@@ -30864,7 +30961,6 @@
 /obj/item/plate{
 	pixel_y = 3
 	},
-/obj/random_item_spawner/tableware/four,
 /obj/item/shaker/mustard{
 	pixel_x = -4;
 	pixel_y = -9
@@ -30873,6 +30969,7 @@
 	pixel_x = 4;
 	pixel_y = -8
 	},
+/obj/random_item_spawner/tableware/two,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},
@@ -31601,7 +31698,7 @@
 /obj/landmark/start{
 	name = "Engineer"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "hou" = (
 /turf/simulated/wall/auto/supernorn,
@@ -31717,19 +31814,19 @@
 /turf/simulated/floor/grime,
 /area/station/security/equipment)
 "hsT" = (
-/obj/machinery/disposal/small/south,
-/obj/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24;
-	text = "NF"
+/obj/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-s"
 	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/treatment)
+/area/station/medical/medbay/psychiatrist)
 "hty" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -31795,7 +31892,7 @@
 	pixel_y = 6
 	},
 /obj/table/reinforced/auto,
-/obj/machinery/light/incandescent,
+/obj/machinery/light_switch/west,
 /turf/simulated/floor/bluewhite{
 	dir = 8
 	},
@@ -32042,8 +32139,15 @@
 	},
 /area/station/quartermaster/magnet)
 "hFr" = (
-/obj/machinery/hair_dye_dispenser,
-/turf/simulated/floor/plating,
+/obj/table/endtable_classic,
+/obj/item/storage/box/nerd_kit{
+	pixel_y = 5
+	},
+/obj/item/card_box/plain,
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "fred2"
+	},
 /area/station/crew_quarters/barber_shop)
 "hFy" = (
 /obj/machinery/firealarm{
@@ -32127,6 +32231,13 @@
 "hJE" = (
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/arcade)
+"hKE" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/maintenance/inner/central)
 "hKJ" = (
 /obj/machinery/conveyor/west{
 	id = "cargo-art-in"
@@ -32223,8 +32334,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/inner/central)
 "hQX" = (
-/obj/machinery/light_switch/east,
-/turf/simulated/floor/plating,
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/obj/decal/cleanable/rust/jen,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/simulated/floor/wood/six,
 /area/station/maintenance/west)
 "hRa" = (
 /obj/machinery/disposal/small/south,
@@ -32353,15 +32469,15 @@
 	pixel_y = 6;
 	rand_pos = 0
 	},
-/obj/item/genetics_injector/dna_activator{
-	name = "expended dna activator: deuteranopia";
-	pixel_x = -8;
-	pixel_y = -10
-	},
 /obj/item/reagent_containers/food/snacks/ingredient/tomatoslice{
 	pixel_x = 7;
 	pixel_y = -6;
 	rand_pos = 0
+	},
+/obj/item/genetics_injector/dna_activator{
+	pixel_y = -10;
+	pixel_x = -8;
+	name = "dna activator: deuteranopia"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
@@ -32482,7 +32598,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/south)
 "ieA" = (
-/obj/table/wood/round/auto,
 /obj/item/device/light/zippo{
 	pixel_x = -1;
 	pixel_y = -1;
@@ -32497,7 +32612,9 @@
 	pixel_x = 6;
 	pixel_y = 9
 	},
-/turf/simulated/floor/plating,
+/obj/table/endtable_classic,
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/wood/six,
 /area/station/maintenance/west)
 "ieJ" = (
 /obj/cable{
@@ -32597,7 +32714,7 @@
 	},
 /area/station/science/chemistry)
 "ijG" = (
-/obj/storage/secure/closet/personal,
+/obj/machinery/vending/capsule,
 /turf/simulated/floor/black/side{
 	dir = 8
 	},
@@ -33175,8 +33292,12 @@
 	},
 /area/station/crew_quarters/locker)
 "iMS" = (
-/turf/simulated/floor/black/side,
-/area/station/crew_quarters/quarters)
+/obj/machinery/door/unpowered/wood,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "iNJ" = (
 /obj/table/wood/auto,
 /obj/machinery/phone{
@@ -33258,12 +33379,6 @@
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
 /area/station/quartermaster/office)
-"iRc" = (
-/obj/item/clothing/suit/bedsheet/blue,
-/obj/machinery/light/small/floor,
-/obj/stool/bed/moveable,
-/turf/simulated/floor/carpet/blue/fancy/narrow/east,
-/area/station/medical/medbay/treatment1)
 "iRh" = (
 /obj/cable{
 	icon_state = "1-4"
@@ -33283,6 +33398,11 @@
 /obj/disposalpipe/junction/right/north,
 /turf/simulated/floor/orangeblack,
 /area/station/engine/elect)
+"iSt" = (
+/obj/decal/cleanable/rust/jen,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/simulated/floor/wood/six,
+/area/station/maintenance/west)
 "iSW" = (
 /obj/rack,
 /obj/item/tank/air,
@@ -33620,17 +33740,9 @@
 /turf/simulated/floor/shuttlebay,
 /area/station/hangar/science)
 "jhs" = (
-/obj/table/auto,
-/obj/item/reagent_containers/glass/bottle/holywater{
-	pixel_x = -2;
-	pixel_y = 8
+/obj/cable{
+	icon_state = "4-8"
 	},
-/obj/item/clothing/suit/cultist/nerd,
-/obj/item/clothing/mask/gas/plague,
-/obj/decal/poster/wallsign/biohazard{
-	pixel_x = 31
-	},
-/obj/machinery/light/incandescent,
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "jht" = (
@@ -33687,6 +33799,9 @@
 /obj/decal/poster/wallsign/danger_highvolt,
 /turf/simulated/wall/auto/supernorn,
 /area/station/science/gen_storage)
+"jkE" = (
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/barber_shop)
 "jlr" = (
 /obj/disposalpipe/segment{
 	dir = 8;
@@ -33731,9 +33846,9 @@
 /turf/simulated/floor,
 /area/station/science/testchamber)
 "jmM" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor/black/corner,
-/area/station/crew_quarters/quarters)
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/barber_shop)
 "jne" = (
 /obj/table/reinforced/bar/auto,
 /obj/item/reagent_containers/food/drinks/drinkingglass/wine{
@@ -33791,7 +33906,6 @@
 	dir = 4;
 	icon_state = "pipe-s"
 	},
-/obj/machinery/light/incandescent,
 /turf/simulated/floor/purple/corner,
 /area/station/hallway/primary/south)
 "jpx" = (
@@ -33887,17 +34001,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
-"jvI" = (
-/obj/cable{
-	icon_state = "2-8"
-	},
-/obj/disposalpipe/segment{
-	dir = 1
-	},
-/obj/random_item_spawner/junk/one_or_zero,
-/obj/random_item_spawner/junk/one_or_zero,
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "jwl" = (
 /obj/machinery/light/emergency{
 	dir = 1;
@@ -33905,6 +34008,14 @@
 	},
 /obj/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/disposal/small/south,
+/obj/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24;
+	text = "NF"
 	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay/treatment)
@@ -33960,6 +34071,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/west)
+"jxJ" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "jyc" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/snacks/popcorn{
@@ -34078,7 +34199,13 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/pool)
 "jEI" = (
-/turf/simulated/floor/carpet/blue/fancy/narrow/west,
+/obj/stool/chair/comfy{
+	dir = 4;
+	icon_state = "chair_comfy"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge{
+	dir = 10
+	},
 /area/station/crew_quarters/stockex)
 "jEU" = (
 /obj/submachine/ATM{
@@ -34191,9 +34318,15 @@
 /area/station/security/brig)
 "jKb" = (
 /obj/stool/chair/couch{
-	dir = 4
+	dir = 8;
+	icon_state = "chair_couch-brown"
 	},
-/obj/disposalpipe/segment/vertical,
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/obj/decal/poster/wallsign/landscape{
+	pixel_y = 29
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 1
 	},
@@ -34308,6 +34441,28 @@
 	dir = 4
 	},
 /area/station/hangar/sec)
+"jNj" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch/north,
+/obj/shrub{
+	dir = 4;
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "plant"
+	},
+/turf/simulated/floor/black/side,
+/area/station/crew_quarters/quarters)
+"jNs" = (
+/obj/cable{
+	icon_state = "1-4"
+	},
+/obj/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "jNY" = (
 /obj/stool/chair{
 	dir = 4
@@ -34375,7 +34530,7 @@
 /area/station/maintenance/scidisposal)
 "jRq" = (
 /turf/simulated/wall/auto/supernorn,
-/area/station/medical/medbay/treatment2)
+/area/station/medical/medbay/psychiatrist)
 "jST" = (
 /obj/machinery/vending/coffee{
 	name = "Dusty Coffee Machine"
@@ -34436,10 +34591,6 @@
 /obj/disposalpipe/segment/morgue{
 	name = "crematorium pipe"
 	},
-/obj/table/podium_wood,
-/obj/item/storage/bible{
-	pixel_y = 7
-	},
 /turf/simulated/floor/carpet{
 	dir = 1;
 	icon_state = "fred2"
@@ -34458,16 +34609,10 @@
 	icon_state = "pipe-c"
 	},
 /obj/cable{
-	icon_state = "1-2"
-	},
-/obj/cable{
 	icon_state = "1-8"
 	},
-/obj/landmark/start{
-	name = "Medical Doctor"
-	},
 /turf/simulated/floor/white,
-/area/station/medical/medbay/treatment)
+/area/station/medical/medbay/psychiatrist)
 "jZe" = (
 /obj/machinery/door/airlock/pyro{
 	dir = 4;
@@ -34478,6 +34623,7 @@
 	},
 /obj/access_spawn/bar,
 /obj/firedoor_spawn,
+/obj/access_spawn/kitchen,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "jZf" = (
@@ -34568,7 +34714,11 @@
 /area/station/medical/staff)
 "kdn" = (
 /obj/storage/cart,
-/turf/simulated/floor/plating,
+/obj/item/gun/russianrevolver,
+/obj/item/clothing/suit/bedsheet,
+/obj/item/clothing/suit/bedsheet,
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/wood/six,
 /area/station/maintenance/west)
 "kdo" = (
 /obj/cable{
@@ -34580,6 +34730,11 @@
 "kdq" = (
 /turf/simulated/wall/false_wall,
 /area/station/crew_quarters/toilets)
+"kea" = (
+/turf/simulated/floor/stairs/wood2/middle{
+	dir = 8
+	},
+/area/station/crew_quarters/stockex)
 "kfa" = (
 /obj/cable{
 	icon_state = "1-8"
@@ -34877,7 +35032,7 @@
 	codes_txt = "delivery;dir=4";
 	location = "Mechanics"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/yellow,
 /area/station/engine/storage)
 "ktd" = (
 /obj/decal/floatingtiles{
@@ -34890,6 +35045,16 @@
 	dir = 8
 	},
 /area/station/science/lobby)
+"ktN" = (
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/cable{
+	icon_state = "2-8"
+	},
+/obj/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/west)
 "kuo" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -34938,6 +35103,11 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"kvI" = (
+/turf/simulated/floor/stairs{
+	icon_state = "Stairs2_wide"
+	},
+/area/station/maintenance/inner/central)
 "kwi" = (
 /obj/machinery/light/incandescent,
 /obj/item/neon_lining/cut,
@@ -35240,8 +35410,8 @@
 /obj/item/plate{
 	pixel_y = 3
 	},
-/obj/random_item_spawner/tableware/three,
 /obj/machinery/light/small/floor,
+/obj/random_item_spawner/tableware/two,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},
@@ -35273,17 +35443,13 @@
 /obj/random_item_spawner/tools/few,
 /turf/simulated/floor/plating,
 /area/station/maintenance/west)
-"kNA" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4;
-	req_access = null
+"kNK" = (
+/obj/landmark/gps_waypoint,
+/obj/decal/stage_edge{
+	layer = 2.8
 	},
-/obj/access_spawn/maint,
-/obj/firedoor_spawn,
-/turf/simulated/floor/stairs/wide/other{
-	dir = 4
-	},
-/area/station/maintenance/west)
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "kNP" = (
 /obj/cable/black{
 	icon_state = "2-8"
@@ -35317,6 +35483,10 @@
 /obj/machinery/light/incandescent,
 /turf/space,
 /area/space)
+"kOZ" = (
+/obj/item/instrument/large/piano,
+/turf/simulated/floor/wood/seven,
+/area/station/chapel/sanctuary)
 "kPo" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5;
@@ -35325,6 +35495,7 @@
 /obj/machinery/light/emergency,
 /obj/machinery/power/apc/autoname_south,
 /obj/cable,
+/obj/machinery/light/incandescent,
 /turf/simulated/floor/bluewhite,
 /area/station/medical/medbay/treatment)
 "kPH" = (
@@ -35565,12 +35736,6 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/clown)
 "kYM" = (
-/obj/stool/chair/comfy{
-	dir = 8
-	},
-/obj/landmark/start{
-	name = "Staff Assistant"
-	},
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 4
 	},
@@ -35986,14 +36151,15 @@
 	},
 /area/station/mining/staff_room)
 "ltk" = (
-/obj/table/auto,
 /obj/machinery/light/small{
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/obj/random_item_spawner/tableware/two,
-/obj/random_item_spawner/pizza,
-/turf/simulated/floor/plating,
+/obj/table/auto,
+/obj/item/cloth/handkerchief/white,
+/obj/item/reagent_containers/food/snacks/lollipop/random_medical,
+/obj/decal/cleanable/rust/jen,
+/turf/simulated/floor/wood/six,
 /area/station/maintenance/west)
 "ltT" = (
 /obj/machinery/disposal,
@@ -36043,29 +36209,9 @@
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
 "lwk" = (
-/obj/table/auto,
-/obj/bedsheetbin,
-/obj/item/toy/plush/small{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/toy/plush/small/stress_ball{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/obj/machinery/camera{
-	c_tag = "autotag";
-	dir = 8;
-	icon_state = "camera";
-	name = "autoname  - SS13";
-	network = "SS13";
-	tag = ""
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/cabinet/psychiatry,
 /turf/simulated/floor/white,
-/area/station/medical/medbay/treatment)
+/area/station/medical/medbay/psychiatrist)
 "lwl" = (
 /obj/machinery/conveyor/south{
 	id = "zetadisposals";
@@ -36145,6 +36291,27 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
+"lyh" = (
+/obj/storage/closet/dresser{
+	anchored = 1;
+	name = "costume dresser"
+	},
+/obj/item/clothing/suit/bedsheet/cape/green,
+/obj/item/clothing/suit/bedsheet/cape/blue,
+/obj/item/clothing/suit/bedsheet/cape/red,
+/obj/item/clothing/suit/monkey,
+/obj/item/clothing/suit/nursedress,
+/obj/item/clothing/suit/robuddy,
+/obj/item/clothing/head/bandana/random_color,
+/obj/item/clothing/head/biglizard,
+/obj/item/clothing/suit/wizrobe/purple,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/barber_shop)
+"lyw" = (
+/obj/effects/background_objects/star_blue,
+/obj/effects/background_objects/star_red,
+/turf/simulated/floor/plating/airless,
+/area/space)
 "lyD" = (
 /obj/stool/chair/wooden{
 	dir = 1
@@ -36157,6 +36324,13 @@
 	icon_state = "fblue2"
 	},
 /area/station/crew_quarters/bar)
+"lzh" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/medical/crematorium)
 "lzn" = (
 /obj/disposalpipe/junction/right/west,
 /turf/simulated/floor/yellow/side{
@@ -36336,6 +36510,11 @@
 	tag = "icon-catwalk (WEST)"
 	},
 /area/space)
+"lGM" = (
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
+/area/station/engine/storage)
 "lGS" = (
 /obj/machinery/power/apc/autoname_north,
 /obj/reagent_dispensers/watertank,
@@ -36414,7 +36593,7 @@
 "lJA" = (
 /obj/random_item_spawner/tools/one_or_zero,
 /obj/machinery/light/small,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/purple/side,
 /area/station/maintenance/west)
 "lJO" = (
 /turf/simulated/floor/blueblack{
@@ -36464,9 +36643,6 @@
 /turf/simulated/floor/carpet/blue/fancy/edge/north,
 /area/station/medical/head)
 "lMl" = (
-/obj/item/storage/toilet/random{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -36586,7 +36762,9 @@
 	dir = 8;
 	icon_state = "chair_comfy"
 	},
-/turf/simulated/floor/plating,
+/obj/decal/cleanable/rust/jen,
+/obj/decal/cleanable/dirt/dirt2,
+/turf/simulated/floor/wood/six,
 /area/station/maintenance/west)
 "lSw" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
@@ -36614,13 +36792,6 @@
 "lTq" = (
 /turf/simulated/floor/grass/leafy,
 /area/station/wreckage)
-"lUF" = (
-/obj/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/west)
 "lWf" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -36677,7 +36848,17 @@
 /obj/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/obj/stool/chair{
+	dir = 8;
+	icon_state = "chair"
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "fred2"
+	},
 /area/station/crew_quarters/barber_shop)
 "lYX" = (
 /turf/simulated/floor/yellow/side{
@@ -36746,17 +36927,14 @@
 "mdv" = (
 /obj/storage/crate,
 /obj/item/lamp_manufacturer/organic,
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
 /obj/item/sheet/steel/fullstack,
 /obj/item/storage/box/lightbox/bulbs,
 /obj/decal/poster/wallsign/poster_sol{
 	pixel_y = 31
 	},
 /obj/item/crowbar,
-/turf/simulated/floor/plating,
+/obj/item/weldingtool,
+/turf/simulated/floor/wood/six,
 /area/station/maintenance/west)
 "mdZ" = (
 /obj/reagent_dispensers/fueltank,
@@ -36923,6 +37101,12 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/stairs/medical/wide/other,
 /area/station/crew_quarters/pool)
+"mjV" = (
+/obj/machinery/disposal/cart_port,
+/obj/storage/cart/trash,
+/obj/disposalpipe/trunk/east,
+/turf/simulated/floor/purple/side,
+/area/station/maintenance/west)
 "mkJ" = (
 /obj/table/auto,
 /obj/machinery/cell_charger,
@@ -36995,6 +37179,12 @@
 /obj/landmark/spawner/loot,
 /turf/simulated/floor/plating/airless/asteroid/lighted,
 /area/space)
+"mms" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/white,
+/area/station/medical/medbay/psychiatrist)
 "mnm" = (
 /obj/machinery/door/airlock/pyro/maintenance/alt{
 	dir = 4;
@@ -37558,6 +37748,12 @@
 "mNm" = (
 /turf/simulated/floor/plating,
 /area/station/quartermaster/refinery)
+"mNs" = (
+/obj/table/wood/auto,
+/obj/random_item_spawner/pizza,
+/obj/storage/crate/pizza,
+/turf/simulated/floor/carpet/grime,
+/area/station/maintenance/inner/central)
 "mNv" = (
 /turf/simulated/floor/carpet/red/fancy/edge/south,
 /area/station/science/lobby)
@@ -37698,7 +37894,10 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/carpet{
+	dir = 6;
+	icon_state = "fred2"
+	},
 /area/station/crew_quarters/barber_shop)
 "mSm" = (
 /obj/machinery/genetics_scanner,
@@ -37750,11 +37949,25 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"mUe" = (
+/obj/item/chair/folded,
+/obj/item/chair/folded,
+/obj/item/chair/folded{
+	pixel_y = 5
+	},
+/obj/item/chair/folded{
+	pixel_y = 10
+	},
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/carpet/grime,
+/area/station/crew_quarters/barber_shop)
 "mUN" = (
 /obj/landmark/start{
 	name = "Engineer"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 10
+	},
 /area/station/engine/storage)
 "mUQ" = (
 /obj/submachine/chicken_incubator,
@@ -38014,6 +38227,11 @@
 "nfc" = (
 /obj/decal/poster/wallsign/poster_y4nt{
 	pixel_x = 30
+	},
+/obj/table/auto,
+/obj/item/hand_labeler{
+	pixel_x = 6;
+	pixel_y = 9
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -38278,6 +38496,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"ntu" = (
+/obj/machinery/manufacturer/mechanic,
+/obj/machinery/light/incandescent,
+/turf/simulated/floor/yellow,
+/area/station/engine/elect)
 "nuk" = (
 /obj/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -38340,11 +38563,6 @@
 /obj/machinery/light/runway_light/delay5,
 /turf/space,
 /area/space)
-"nwu" = (
-/obj/machinery/vending/cards,
-/obj/machinery/light_switch/north,
-/turf/simulated/floor/black/side,
-/area/station/crew_quarters/quarters)
 "nwM" = (
 /obj/item/space_thing,
 /turf/simulated/floor/plating/airless/asteroid,
@@ -38551,7 +38769,6 @@
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
 "nFa" = (
-/obj/machinery/light/incandescent,
 /obj/disposalpipe/segment,
 /obj/random_item_spawner/junk/one_or_zero,
 /turf/simulated/floor,
@@ -39046,6 +39263,10 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/garden/owlery)
+"ofh" = (
+/obj/machinery/hair_dye_dispenser,
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
 "ofj" = (
 /obj/wingrille_spawn/auto/reinforced,
 /turf/simulated/floor/plating,
@@ -39412,8 +39633,8 @@
 	pixel_x = 5;
 	pixel_y = 13
 	},
-/obj/random_item_spawner/tableware/three,
 /obj/machinery/light/small/floor,
+/obj/random_item_spawner/tableware/two,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},
@@ -39521,13 +39742,26 @@
 /area/station/hallway/primary/north)
 "oys" = (
 /obj/table/auto,
-/obj/item/decoration/flower_vase/vase7,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/reagent_containers/syringe/haloperidol{
-	pixel_x = 6
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 10
 	},
-/turf/simulated/floor/white,
-/area/station/medical/medbay/treatment2)
+/obj/item/reagent_containers/food/drinks/tea{
+	pixel_x = -12;
+	pixel_y = 16
+	},
+/obj/item/toy/plush/small{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/toy/plush/small/stress_ball{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge{
+	dir = 5
+	},
+/area/station/medical/medbay/psychiatrist)
 "oyG" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -39708,7 +39942,7 @@
 /obj/item/plate{
 	pixel_y = 3
 	},
-/obj/random_item_spawner/tableware/four,
+/obj/random_item_spawner/tableware/two,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},
@@ -39719,6 +39953,23 @@
 	dir = 4
 	},
 /area/station/janitor/office)
+"oJd" = (
+/obj/disposalpipe/segment/morgue{
+	dir = 2;
+	icon_state = "pipe-c";
+	name = "crematorium pipe"
+	},
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/medical/crematorium)
+"oJE" = (
+/obj/landmark/start{
+	name = "Assistant"
+	},
+/turf/simulated/floor/carpet/grime,
+/area/station/maintenance/inner/central)
 "oJW" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -40242,7 +40493,19 @@
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
 "peB" = (
-/turf/simulated/floor/plating,
+/obj/table/wood/round/auto,
+/obj/item/paper_bin{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "fred1"
+	},
 /area/station/crew_quarters/barber_shop)
 "peT" = (
 /obj/item/raw_material/shard/glass,
@@ -40259,6 +40522,18 @@
 /obj/cable,
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/captain)
+"pfp" = (
+/obj/machinery/door/airlock/pyro/classic{
+	aiControlDisabled = 1;
+	ai_no_access = 1;
+	desc = "Its hinges have a bunch of split wire ends sticking out...";
+	dir = 4;
+	name = "busted airlock";
+	secondsElectrified = -1;
+	welded = null
+	},
+/turf/simulated/floor/wood/six,
+/area/station/maintenance/west)
 "pgJ" = (
 /obj/disposalpipe/segment{
 	dir = 4;
@@ -40393,11 +40668,21 @@
 	},
 /area/station/science/chemistry)
 "poZ" = (
-/obj/stool/barber_chair{
-	desc = "A traditional barbershop chair, obviously a very old one at that.  What it is doing on a space station you haven't the foggiest.";
-	name = "Old Barber Chair"
+/obj/table/wood/round/auto,
+/obj/item/clothing/mask/skull{
+	pixel_x = -4
 	},
-/turf/simulated/floor/plating,
+/obj/item/clothing/suit/cultist/nerd{
+	pixel_x = 7
+	},
+/obj/item/clothing/head/apprentice{
+	pixel_x = -3;
+	pixel_y = 14
+	},
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "fred1"
+	},
 /area/station/crew_quarters/barber_shop)
 "ppd" = (
 /obj/landmark/gps_waypoint,
@@ -40479,6 +40764,9 @@
 /turf/space,
 /area/space)
 "puY" = (
+/obj/decal/fakeobjects/pole{
+	pixel_x = -14
+	},
 /turf/simulated/floor/black/side{
 	dir = 6
 	},
@@ -40582,12 +40870,9 @@
 /obj/cable{
 	icon_state = "2-4"
 	},
-/obj/table/auto,
-/obj/machinery/computer3/generic/personal,
 /obj/machinery/light/incandescent,
-/turf/simulated/floor/black/side{
-	dir = 4
-	},
+/obj/stool/chair/comfy,
+/turf/simulated/floor/black/corner,
 /area/station/crew_quarters/quarters)
 "pyu" = (
 /obj/machinery/conveyor/south{
@@ -40710,6 +40995,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/bar)
+"pCU" = (
+/obj/submachine/chef_sink/chem_sink{
+	dir = 4;
+	pixel_x = -9
+	},
+/obj/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
 "pDx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -40811,7 +41106,9 @@
 /area/station/maintenance/east)
 "pJc" = (
 /obj/machinery/portable_reclaimer,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
 /area/station/engine/storage)
 "pJD" = (
 /obj/grille/catwalk{
@@ -41033,12 +41330,11 @@
 /turf/simulated/floor/dirt,
 /area/station/wreckage)
 "pWl" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	req_access = null
+/obj/cable{
+	icon_state = "2-8"
 	},
-/obj/firedoor_spawn,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/quarters)
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "pWv" = (
 /obj/landmark{
 	icon_state = "blob-start";
@@ -41226,6 +41522,23 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"qgp" = (
+/obj/decal/cleanable/dirt/dirt5,
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/wood/six,
+/area/station/maintenance/west)
+"qgt" = (
+/obj/table/wood/round/auto,
+/obj/item/paper/book/from_file/critter_compendium,
+/obj/item/paper/book/from_file/monster_manual_revised{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "fred1"
+	},
+/area/station/crew_quarters/barber_shop)
 "qgJ" = (
 /obj/machinery/sparker{
 	dir = 1;
@@ -41437,12 +41750,13 @@
 /turf/simulated/floor/black,
 /area/station/crew_quarters/catering)
 "qqb" = (
-/obj/stool/chair{
-	dir = 1;
-	icon_state = "chair"
-	},
 /obj/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = -1
 	},
 /turf/simulated/floor/black/side{
 	dir = 4
@@ -41537,6 +41851,22 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
 /area/station/science/lobby)
+"qth" = (
+/obj/storage/crate,
+/obj/item/clothing/head/wig,
+/obj/item/dye_bottle,
+/obj/item/clothing/under/misc/barber,
+/obj/item/scissors,
+/obj/item/razor_blade,
+/obj/item/clothing/head/bald_cap,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/gloves/latex,
+/obj/machinery/power/apc/autoname_east,
+/obj/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
 "qtB" = (
 /obj/disposalpipe/segment/mail,
 /obj/machinery/disposal/small/west,
@@ -41605,6 +41935,13 @@
 	name = "very reinforced wall"
 	},
 /area/station/science/storage)
+"qwe" = (
+/obj/machinery/disposal/small/east,
+/obj/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/stockex)
 "qwi" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -41655,8 +41992,9 @@
 	},
 /area/space)
 "qxT" = (
-/obj/stool/chair/comfy,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/blue/fancy/edge{
+	dir = 5
+	},
 /area/station/crew_quarters/stockex)
 "qyl" = (
 /obj/machinery/door/airlock/pyro/glass,
@@ -41799,6 +42137,32 @@
 	dir = 8
 	},
 /area/station/hallway/primary/west)
+"qCP" = (
+/obj/table/auto,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/reagent_containers/syringe/haloperidol{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/syringe/haloperidol{
+	pixel_x = 6
+	},
+/obj/item/decoration/flower_vase/vase7,
+/turf/simulated/floor/white,
+/area/station/medical/medbay/treatment1)
+"qEf" = (
+/obj/table/auto,
+/obj/item/razor_blade,
+/obj/item/dye_bottle{
+	pixel_y = 12;
+	pixel_x = -5
+	},
+/obj/item/storage/pill_bottle/hairgrownium{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
 "qEO" = (
 /obj/machinery/plantpot{
 	anchored = 1
@@ -41996,8 +42360,8 @@
 /obj/item/plate{
 	pixel_y = 3
 	},
-/obj/random_item_spawner/tableware/four,
 /obj/random_item_spawner/snacks/one_or_zero,
+/obj/random_item_spawner/tableware/two,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},
@@ -42354,13 +42718,6 @@
 	},
 /turf/simulated/floor/grass/leafy,
 /area/station/ranch)
-"qZb" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	req_access = null
-	},
-/obj/access_spawn/maint,
-/turf/simulated/floor/plating,
-/area/station/crew_quarters/barber_shop)
 "rab" = (
 /obj/wingrille_spawn/auto,
 /turf/simulated/floor/plating,
@@ -42405,6 +42762,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/scidisposal)
+"rbz" = (
+/turf/simulated/floor/orangeblack/corner{
+	dir = 8
+	},
+/area/station/engine/storage)
 "rbF" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42414,6 +42776,13 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/station/crew_quarters/captain)
+"rbP" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	req_access = null
+	},
+/obj/access_spawn/maint,
+/turf/simulated/floor/wood,
+/area/station/maintenance/west)
 "rcM" = (
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/shuttlebay,
@@ -42808,6 +43177,11 @@
 	},
 /turf/simulated/floor,
 /area/station/science/lobby)
+"rvd" = (
+/obj/table/wood/auto,
+/obj/random_item_spawner/tableware/three,
+/turf/simulated/floor/carpet/grime,
+/area/station/maintenance/inner/central)
 "rvM" = (
 /obj/item/cigbutt{
 	pixel_x = -1;
@@ -42882,6 +43256,10 @@
 /obj/disposalpipe/junction,
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"rxV" = (
+/obj/machinery/vending/cola/red,
+/turf/simulated/floor/carpet/grime,
+/area/station/maintenance/inner/central)
 "ryq" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -42978,10 +43356,11 @@
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/baroffice)
 "rDh" = (
-/obj/disposalpipe/trunk/east,
-/obj/machinery/disposal/cart_port,
-/obj/storage/cart/trash,
-/turf/simulated/floor/plating,
+/obj/disposalpipe/segment{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/purple/side,
 /area/station/maintenance/west)
 "rDK" = (
 /obj/lattice{
@@ -43123,7 +43502,23 @@
 /turf/space,
 /area/space)
 "rLt" = (
-/obj/machinery/traymachine/morgue,
+/obj/disposaloutlet{
+	dir = 4;
+	mailgroup = "chaplain";
+	mailgroup2 = "security";
+	message = "Delivery alert in Crematorium.";
+	name = "Crematorium Outlet"
+	},
+/obj/disposalpipe/trunk/morgue{
+	dir = 4;
+	name = "crematorium pipe"
+	},
+/obj/machinery/camera{
+	c_tag = "autotag";
+	dir = 4;
+	name = "autoname - SS13";
+	tag = ""
+	},
 /turf/simulated/floor/sanitary,
 /area/station/medical/crematorium)
 "rMl" = (
@@ -43135,15 +43530,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/turret_protected/AIsat)
-"rMK" = (
-/obj/table/endtable_classic,
-/obj/item/reagent_containers/food/drinks/tea{
-	pixel_x = -8;
-	pixel_y = 16
+"rMB" = (
+/obj/disposalpipe/segment{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/tea{
-	pixel_x = 4;
-	pixel_y = 9
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/stockex)
+"rMK" = (
+/obj/stool/chair/couch{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
 	},
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 5
@@ -43616,13 +44014,14 @@
 /turf/simulated/floor/grass/leafy,
 /area/station/wreckage)
 "sgG" = (
-/obj/machinery/door/unpowered/wood/pyro{
-	dir = 4
-	},
 /obj/firedoor_spawn,
 /obj/disposalpipe/segment{
 	dir = 4;
 	pixel_y = 0
+	},
+/obj/machinery/door/airlock/pyro{
+	dir = 4;
+	name = "Chapel Office"
 	},
 /turf/simulated/floor/wood/seven,
 /area/station/chapel/sanctuary)
@@ -43731,7 +44130,9 @@
 	name = "mail chute-'Engineering'"
 	},
 /obj/disposalpipe/trunk/mail,
-/turf/simulated/floor,
+/turf/simulated/floor/orangeblack/corner{
+	dir = 8
+	},
 /area/station/engine/engineering)
 "skY" = (
 /obj/securearea{
@@ -43953,6 +44354,13 @@
 	dir = 9
 	},
 /area/station/security/processing)
+"sqi" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/inner/central)
 "sqw" = (
 /obj/machinery/phone/wall{
 	pixel_y = -20
@@ -43991,6 +44399,16 @@
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
 /area/station/maintenance/southwest)
+"srx" = (
+/obj/stool/chair/comfy/barber_chair{
+	dir = 4
+	},
+/obj/machinery/drainage,
+/obj/landmark/start{
+	name = "Assistant"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "srT" = (
 /obj/item/device/radio/intercom/AI,
 /turf/simulated/floor/black,
@@ -44084,6 +44502,14 @@
 	dir = 1
 	},
 /area/station/hydroponics/bay)
+"svk" = (
+/obj/storage/closet/fire,
+/obj/item/clothing/head/helmet/firefighter,
+/obj/item/clothing/suit/fire,
+/obj/decal/cleanable/dirt/dirt5,
+/obj/decal/cleanable/cobweb,
+/turf/simulated/floor/wood/six,
+/area/station/maintenance/west)
 "svo" = (
 /obj/decal/cleanable/blood/tracks{
 	dir = 4
@@ -44187,6 +44613,15 @@
 /obj/critter/rockworm,
 /turf/simulated/floor/plating/airless/asteroid/lighted,
 /area/space)
+"sAp" = (
+/obj/cable{
+	icon_state = "4-8"
+	},
+/obj/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/black/side,
+/area/station/crew_quarters/quarters)
 "sAM" = (
 /obj/decal/tile_edge/stripe/corner/extra_big2{
 	dir = 9
@@ -44206,7 +44641,16 @@
 /obj/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/stool/chair{
+	dir = 8
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/carpet{
+	dir = 4;
+	icon_state = "fred2"
+	},
 /area/station/crew_quarters/barber_shop)
 "sCz" = (
 /turf/simulated/floor/black,
@@ -44237,6 +44681,10 @@
 /obj/decal/mule/dropoff,
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
+"sDo" = (
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
 "sDr" = (
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor/wood,
@@ -44465,6 +44913,13 @@
 	dir = 1
 	},
 /area/station/science/lobby)
+"sKE" = (
+/obj/machinery/light_switch/west,
+/obj/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood,
+/area/station/crew_quarters/barber_shop)
 "sKK" = (
 /obj/submachine/seed_vendor,
 /turf/simulated/floor/green/side{
@@ -44576,13 +45031,15 @@
 	desc = "A black countertop table for storing kitchen-y objects.";
 	name = "kitchen counter"
 	},
-/obj/machinery/glass_recycler{
-	glass_amt = 5;
-	pixel_y = 4
-	},
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/specialroom/cafeteria,
 /area/station/crew_quarters/kitchen)
+"sNC" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/sanitary,
+/area/station/medical/crematorium)
 "sNX" = (
 /turf/simulated/wall/auto/reinforced/supernorn,
 /area/station/turret_protected/ai)
@@ -44692,7 +45149,9 @@
 /area/station/hallway/primary/south)
 "sRo" = (
 /obj/machinery/light/incandescent,
-/turf/simulated/floor,
+/turf/simulated/floor/yellow/side{
+	dir = 2
+	},
 /area/station/engine/storage)
 "sRx" = (
 /obj/landmark/gps_waypoint,
@@ -44944,6 +45403,13 @@
 /obj/disposalpipe/segment/vertical,
 /turf/simulated/floor,
 /area/station/science/lobby)
+"tcs" = (
+/obj/storage/crate,
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/random_item_spawner/junk/one_or_zero,
+/obj/decal/cleanable/dirt/dirt3,
+/turf/simulated/floor,
+/area/station/maintenance/west)
 "tdi" = (
 /obj/item/hand_labeler,
 /obj/table/reinforced/chemistry/auto,
@@ -44953,11 +45419,9 @@
 	},
 /area/station/science/chemistry)
 "tdY" = (
-/obj/stool/chair/comfy,
-/obj/landmark/start{
-	name = "Staff Assistant"
+/turf/simulated/floor/carpet/blue/fancy/edge{
+	dir = 9
 	},
-/turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "teD" = (
 /obj/cable{
@@ -45284,17 +45748,6 @@
 /obj/landmark/gps_waypoint,
 /turf/simulated/floor,
 /area/station/janitor/supply)
-"tuF" = (
-/obj/table/regal/auto,
-/obj/item/clothing/head/that{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/turf/simulated/floor/carpet{
-	dir = 4;
-	icon_state = "blue2"
-	},
-/area/station/crew_quarters/stockex)
 "tuJ" = (
 /obj/machinery/light/incandescent,
 /obj/machinery/light_switch/north,
@@ -45312,9 +45765,7 @@
 /obj/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/yellow/side{
-	dir = 2
-	},
+/turf/simulated/floor/yellow,
 /area/station/engine/engineering)
 "tvX" = (
 /obj/cable{
@@ -45365,12 +45816,22 @@
 /obj/machinery/light/incandescent,
 /turf/simulated/floor/green/side,
 /area/station/hydroponics/bay)
+"tyc" = (
+/obj/landmark{
+	icon_state = "pest-start";
+	name = "peststart"
+	},
+/obj/stool/chair,
+/turf/simulated/floor/carpet{
+	dir = 1;
+	icon_state = "fred2"
+	},
+/area/station/crew_quarters/barber_shop)
 "tyd" = (
 /obj/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/incandescent,
-/obj/machinery/vending/coffee,
 /turf/simulated/floor/wood,
 /area/station/crew_quarters/stockex)
 "tzt" = (
@@ -45573,6 +46034,7 @@
 /obj/item/clothing/mask/mime,
 /obj/item/clothing/head/mime_beret,
 /obj/critter/domestic_bee/mimebee,
+/obj/item/clothing/under/misc/mime,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/quarters)
 "tGI" = (
@@ -45787,6 +46249,11 @@
 	dir = 4
 	},
 /area/station/medical/medbay/treatment)
+"tPS" = (
+/turf/simulated/floor/stairs{
+	icon_state = "Stairs_wide"
+	},
+/area/station/maintenance/inner/central)
 "tQe" = (
 /turf/simulated/floor/dirt,
 /area/station/ranch)
@@ -45852,7 +46319,10 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/obj/submachine/ATM{
+	pixel_x = -31
+	},
+/turf/simulated/floor/delivery,
 /area/station/hallway/primary/south)
 "tVE" = (
 /obj/disposalpipe/segment{
@@ -46111,8 +46581,18 @@
 /turf/simulated/floor/grime,
 /area/station/security/equipment)
 "ugE" = (
-/obj/landmark/gps_waypoint,
-/turf/simulated/floor/plating,
+/obj/table/wood/round/auto,
+/obj/item/diceholder/dicebox{
+	pixel_y = 3
+	},
+/obj/item/dice/d20{
+	pixel_x = 5;
+	pixel_y = 11
+	},
+/turf/simulated/floor/carpet{
+	dir = 9;
+	icon_state = "fred1"
+	},
 /area/station/crew_quarters/barber_shop)
 "uhd" = (
 /obj/cable{
@@ -46317,12 +46797,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
-"upK" = (
-/obj/machinery/traymachine/locking/crematorium{
-	id = "crematorium"
-	},
-/turf/simulated/floor/sanitary,
-/area/station/medical/crematorium)
 "upP" = (
 /obj/machinery/light/incandescent,
 /obj/machinery/vending/air_vendor,
@@ -46366,6 +46840,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/north)
+"usb" = (
+/obj/machinery/vending/pizza,
+/turf/simulated/floor/carpet/grime,
+/area/station/maintenance/inner/central)
 "utf" = (
 /obj/disposalpipe/segment/mail{
 	dir = 8;
@@ -46412,6 +46890,15 @@
 /obj/disposalpipe/segment/mail,
 /turf/simulated/floor/carpet/purple/fancy/innercorner/se,
 /area/station/crew_quarters/hor)
+"uvN" = (
+/obj/landmark/start{
+	name = "Assistant"
+	},
+/obj/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/two,
+/area/station/crew_quarters/barber_shop)
 "uvO" = (
 /obj/cable{
 	icon_state = "0-2"
@@ -46436,11 +46923,9 @@
 /turf/space,
 /area/space)
 "uxc" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/plating,
+/obj/decal/cleanable/rust/jen,
+/obj/decal/cleanable/generic,
+/turf/simulated/floor/wood/six,
 /area/station/maintenance/west)
 "uxd" = (
 /obj/random_item_spawner/junk/one_or_zero,
@@ -46457,10 +46942,16 @@
 /turf/simulated/floor/black,
 /area/station/turret_protected/ai)
 "uxw" = (
-/obj/storage/crate,
-/obj/item/scissors,
-/obj/item/razor_blade,
-/turf/simulated/floor/plating,
+/obj/stool/chair{
+	dir = 4
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
+/turf/simulated/floor/carpet{
+	dir = 8;
+	icon_state = "fred2"
+	},
 /area/station/crew_quarters/barber_shop)
 "uyl" = (
 /obj/random_item_spawner/tools/one_or_zero,
@@ -46509,17 +47000,6 @@
 	dir = 4
 	},
 /area/station/science/chemistry)
-"uBx" = (
-/obj/machinery/door/airlock/pyro/maintenance/alt{
-	dir = 4;
-	req_access = null
-	},
-/obj/access_spawn/maint,
-/obj/firedoor_spawn,
-/turf/simulated/floor/stairs/wide{
-	dir = 4
-	},
-/area/station/maintenance/west)
 "uBA" = (
 /obj/machinery/light/incandescent,
 /obj/disposalpipe/junction/left/west,
@@ -46614,7 +47094,13 @@
 	},
 /area/station/medical/staff)
 "uHl" = (
-/turf/simulated/floor/carpet/blue/fancy/narrow/east,
+/obj/stool/chair/comfy{
+	dir = 8;
+	icon_state = "chair_comfy"
+	},
+/turf/simulated/floor/carpet/blue/fancy/edge{
+	dir = 6
+	},
 /area/station/crew_quarters/stockex)
 "uHm" = (
 /obj/grille/catwalk{
@@ -47309,6 +47795,9 @@
 /obj/machinery/manufacturer/mining,
 /turf/simulated/floor/yellow/side,
 /area/station/mining/staff_room)
+"vkK" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/maintenance/west)
 "vkL" = (
 /obj/decal/tile_edge/stripe/extra_big{
 	dir = 6;
@@ -47417,6 +47906,10 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
+"voi" = (
+/obj/item/instrument/large/organ,
+/turf/simulated/floor/wood/seven,
+/area/station/chapel/sanctuary)
 "vpm" = (
 /obj/cable/black{
 	icon_state = "1-8"
@@ -47766,6 +48259,13 @@
 /area/station/hangar/science)
 "vFY" = (
 /obj/machinery/light/incandescent,
+/obj/stool/chair/comfy{
+	dir = 4;
+	icon_state = "chair_comfy"
+	},
+/obj/landmark/start{
+	name = "Staff Assistant"
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge{
 	dir = 8
 	},
@@ -47846,8 +48346,22 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/autoname_east,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/carpet{
+	dir = 5;
+	icon_state = "fred2"
+	},
 /area/station/crew_quarters/barber_shop)
+"vJy" = (
+/obj/firedoor_spawn,
+/obj/access_spawn/crematorium,
+/obj/machinery/activation_button/driver_button{
+	id = "kondaru_funeral";
+	name = "Funerary Driver Button";
+	pixel_x = -24
+	},
+/obj/machinery/door/airlock/pyro/glass,
+/turf/simulated/floor/sanitary,
+/area/station/chapel/sanctuary)
 "vJC" = (
 /obj/fitness/speedbag/clown,
 /turf/simulated/floor/wood/three,
@@ -47916,6 +48430,24 @@
 	dir = 8
 	},
 /area/station/medical/robotics)
+"vMd" = (
+/obj/machinery/door/poddoor/pyro{
+	id = "kondaru_funeral";
+	name = "Funerary Driver Door"
+	},
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "kondaru_funeral";
+	name = "funerary driver"
+	},
+/obj/forcefield/energyshield/perma{
+	desc = "A door-linked force field that prevents gasses from passing through it.";
+	dir = 2;
+	name = "Door-linked Atmospheric Forcefield";
+	powerlevel = 1
+	},
+/turf/simulated/floor/sanitary,
+/area/station/chapel/sanctuary)
 "vMe" = (
 /obj/machinery/light_switch/east,
 /turf/simulated/floor/blue/side{
@@ -48330,6 +48862,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/south)
+"wiL" = (
+/obj/cable{
+	icon_state = "1-2"
+	},
+/obj/wingrille_spawn/auto/reinforced,
+/turf/simulated/floor/plating,
+/area/station/engine/engineering)
 "wjW" = (
 /obj/storage/closet/fire,
 /obj/random_item_spawner/junk/one_or_zero,
@@ -48404,6 +48943,7 @@
 "woY" = (
 /obj/item/rubberduck,
 /obj/rack,
+/obj/item/reagent_containers/bath_bomb,
 /obj/item/reagent_containers/bath_bomb,
 /turf/simulated/floor/sanitary,
 /area/station/crew_quarters/locker)
@@ -48564,6 +49104,9 @@
 /obj/access_spawn/research,
 /turf/simulated/floor/plating,
 /area/station/science/gen_storage)
+"wxU" = (
+/turf/simulated/wall/auto/reinforced/supernorn,
+/area/station/crew_quarters/barber_shop)
 "wyb" = (
 /obj/cable{
 	icon_state = "1-2"
@@ -48640,7 +49183,18 @@
 /turf/simulated/floor/plating,
 /area/station/crew_quarters/quarters)
 "wCY" = (
-/obj/disposalpipe/segment/bent/west,
+/obj/table/wood/round/auto,
+/obj/item/reagent_containers/food/snacks/croissant{
+	rand_pos = 0
+	},
+/obj/machinery/camera{
+	c_tag = "Inner Maintenance West";
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/plant/cherry{
+	rand_pos = 0;
+	pixel_x = 13
+	},
 /turf/simulated/floor/carpet/blue/fancy/edge,
 /area/station/crew_quarters/stockex)
 "wDo" = (
@@ -48872,6 +49426,14 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/science/lab)
+"wNr" = (
+/obj/stool/wooden,
+/obj/landmark{
+	icon_state = "blob-start";
+	name = "blobstart"
+	},
+/turf/simulated/floor/wood/seven,
+/area/station/chapel/sanctuary)
 "wNO" = (
 /obj/cable{
 	icon_state = "4-8"
@@ -48882,6 +49444,10 @@
 /obj/storage/closet/fire,
 /turf/simulated/floor/plating,
 /area/station/maintenance/northeast)
+"wOm" = (
+/obj/wingrille_spawn/auto,
+/turf/simulated/floor/plating,
+/area/station/medical/medbay/treatment1)
 "wOn" = (
 /turf/simulated/floor/yellow/side{
 	dir = 6
@@ -48998,9 +49564,6 @@
 /obj/landmark/start{
 	name = "Medical Doctor"
 	},
-/obj/item/device/radio/intercom/medical{
-	dir = 1
-	},
 /turf/simulated/floor/white,
 /area/station/medical/medbay)
 "wUy" = (
@@ -49094,6 +49657,15 @@
 /obj/disposalpipe/segment/bent/north,
 /turf/simulated/floor/grime,
 /area/station/security/equipment)
+"wYd" = (
+/obj/machinery/door/airlock/pyro/maintenance/alt{
+	dir = 4;
+	req_access = null
+	},
+/obj/access_spawn/medical,
+/obj/firedoor_spawn,
+/turf/simulated/floor/white,
+/area/station/maintenance/west)
 "wYe" = (
 /obj/shrub{
 	dir = 1
@@ -49285,38 +49857,6 @@
 	},
 /turf/simulated/floor/carpet/blue/decal/outercross,
 /area/station/chapel/sanctuary)
-"xjP" = (
-/obj/table/wood/round/auto,
-/obj/item/reagent_containers/food/snacks/danish_cherry{
-	pixel_x = -20;
-	pixel_y = 8;
-	rand_pos = 0
-	},
-/obj/item/reagent_containers/food/snacks/painauchocolat{
-	pixel_x = -11;
-	pixel_y = -2;
-	rand_pos = 0
-	},
-/obj/item/reagent_containers/food/snacks/plant/apple{
-	pixel_x = 7;
-	pixel_y = 8;
-	rand_pos = 0
-	},
-/obj/item/reagent_containers/food/snacks/plant/blueberry{
-	rand_pos = 0
-	},
-/obj/item/reagent_containers/food/snacks/plant/peach{
-	pixel_x = -5;
-	pixel_y = 9;
-	rand_pos = 0
-	},
-/obj/item/reagent_containers/food/snacks/plant/blueberry{
-	pixel_x = 5;
-	pixel_y = -3;
-	rand_pos = 0
-	},
-/turf/simulated/floor/wood,
-/area/station/crew_quarters/stockex)
 "xjR" = (
 /obj/table/auto,
 /obj/item/reagent_containers/food/snacks/burger/heartburger{
@@ -49783,6 +50323,13 @@
 /area/station/turret_protected/AIbasecore1{
 	name = "Upload Station"
 	})
+"xCV" = (
+/obj/wingrille_spawn/auto,
+/obj/decal/poster/wallsign/barber{
+	pixel_y = -16
+	},
+/turf/simulated/floor/plating,
+/area/station/crew_quarters/barber_shop)
 "xDC" = (
 /obj/stool/wooden,
 /obj/landmark/start{
@@ -50202,7 +50749,6 @@
 /obj/item/plate{
 	pixel_y = 3
 	},
-/obj/random_item_spawner/tableware/four,
 /obj/random_item_spawner/snacks/one_or_zero,
 /obj/item/shaker/pepper{
 	pixel_x = 7;
@@ -50212,6 +50758,7 @@
 	pixel_x = 17;
 	pixel_y = 18
 	},
+/obj/random_item_spawner/tableware/two,
 /turf/simulated/floor/carpet{
 	icon_state = "fblue1"
 	},
@@ -60129,14 +60676,14 @@ aaa
 aaa
 aaa
 aaa
-avq
+vkK
 awR
 awR
 lSb
 ieA
 awR
 awR
-avq
+vkK
 rsm
 avq
 acf
@@ -60431,14 +60978,14 @@ aaa
 aaa
 aaa
 aaa
-avq
-arO
-arN
-vYL
-arN
-arN
+vkK
+svk
+fls
+fsC
+fls
+iSt
 kdn
-avq
+vkK
 arN
 avq
 apU
@@ -60733,14 +61280,14 @@ aaa
 aaa
 aaa
 aaa
-avq
+vkK
 mdv
 hQX
-arN
-arN
+fls
+qgp
 uxc
 ltk
-avq
+vkK
 arN
 avq
 apU
@@ -61038,9 +61585,9 @@ avq
 avq
 avq
 avq
-uBx
-kNA
 avq
+avq
+pfp
 avq
 avq
 aEx
@@ -61348,13 +61895,13 @@ arN
 aVl
 avq
 avq
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+avq
+avq
+avq
+avq
+avq
+avq
+avq
 aaa
 aaa
 aaa
@@ -61651,11 +62198,11 @@ rTZ
 hug
 avq
 avq
-avq
-avq
-avq
-avq
-avq
+arN
+arN
+arN
+arN
+jxi
 avq
 aaa
 aaa
@@ -61952,12 +62499,12 @@ oxC
 aZG
 arN
 aIC
-avq
+ejQ
 arN
 arN
 arN
 arN
-jxi
+arN
 avq
 aaa
 aaa
@@ -62254,16 +62801,16 @@ oxC
 aYi
 arN
 arN
-ejQ
+avq
 arN
 arN
 arN
 arN
 arN
 avq
+acv
 aaa
-aaa
-aaa
+acf
 aaa
 aaa
 aaa
@@ -62557,15 +63104,15 @@ aYi
 arN
 arN
 avq
-arN
-arN
-arN
-arN
-arN
 avq
-acv
-aaa
-acf
+avq
+cmW
+avq
+avq
+avq
+avq
+avq
+avq
 aaa
 aaa
 aaa
@@ -62858,15 +63405,15 @@ oxC
 bcf
 kSx
 aug
+arN
+arN
+arN
+arN
+arN
 avq
-avq
-avq
-cmW
-avq
-avq
-avq
-avq
-avq
+arN
+arN
+sDI
 avq
 aaa
 aaa
@@ -63158,17 +63705,17 @@ aVj
 oxC
 oxC
 avq
-lUF
-ayH
-arN
-arN
-arN
-arN
+cPX
+ktN
+jxJ
+wgc
+wgc
+jNs
 mGU
-avq
+ejQ
 arN
 arN
-sDI
+arN
 avq
 aaa
 aaa
@@ -63459,15 +64006,15 @@ etA
 bbO
 huX
 jee
-avq
-cPX
-jvI
-cBp
-iXr
-iXr
-rTZ
+aXH
+wYd
+bgV
+bgV
+bgV
+bgV
+dnP
 mGU
-ejQ
+avq
 arN
 arN
 arN
@@ -63763,18 +64310,18 @@ hWc
 kPo
 aXH
 bdB
-bgV
-bgV
-bgV
-bgV
+bcZ
+gpB
+fjW
+dlZ
 dnP
 arN
 avq
-arN
-arN
-arN
 avq
-aaa
+avq
+avq
+avq
+avq
 aaa
 aaa
 aaa
@@ -64065,17 +64612,17 @@ bbC
 bbJ
 aXH
 fCp
-bcZ
-gpB
+wOm
+qCP
 bfZ
 bgV
 dnP
 arN
-avq
-avq
-avq
-avq
-avq
+hug
+sOn
+gfx
+tcs
+mjV
 oaU
 gPg
 gPg
@@ -64367,16 +64914,16 @@ bvs
 swW
 aXH
 jwl
-dro
-bbh
-iRc
+bgV
+bgV
+bgV
 bgV
 dnP
 arN
-hug
-sOn
-gfx
-aQE
+arN
+arN
+arN
+uYC
 rDh
 oaU
 lGS
@@ -64667,19 +65214,19 @@ aSE
 sXa
 nmD
 bYu
-aXH
+aWt
 hsT
-jRq
-jRq
-jRq
+mms
+dtT
+dvD
 jRq
 lMn
 aRN
 aQv
 aug
 arN
-arN
-aIG
+uYC
+rDh
 oaU
 nxu
 ttH
@@ -65271,7 +65818,7 @@ baD
 jrJ
 aSE
 wUl
-aXH
+aWt
 lwk
 dEj
 oys
@@ -70730,7 +71277,7 @@ fOq
 moV
 mxZ
 taY
-mxZ
+egJ
 bjm
 bjm
 bjm
@@ -70969,12 +71516,12 @@ aaa
 avq
 aVl
 aVk
-avq
-avq
-avq
-avq
-azA
-azA
+lpG
+lpG
+lpG
+lpG
+lpG
+lpG
 azA
 azA
 kzo
@@ -71271,11 +71818,11 @@ avq
 avq
 mGU
 aVk
-avq
-arN
-arN
-sDI
-azA
+rbP
+cCj
+pCU
+dUq
+sKE
 jmM
 pxT
 qqb
@@ -71573,13 +72120,13 @@ aQv
 aQv
 lzN
 qAT
-ejQ
-arN
-arN
-arN
+lpG
+ofh
+uvN
+kNK
 pWl
 iMS
-aEF
+sAp
 tqq
 aFB
 jNY
@@ -71875,13 +72422,13 @@ arN
 mGU
 vDj
 tHS
-avq
-arN
-arN
-arN
-azA
-faN
-aEF
+lpG
+qEf
+qth
+cPJ
+srx
+jmM
+exB
 aFB
 vYY
 weR
@@ -72177,13 +72724,13 @@ mGU
 aAP
 aAP
 aAP
-avq
-avq
-avq
-avq
-azA
-nwu
-aEF
+lpG
+lpG
+lpG
+xCV
+jmM
+lpG
+jNj
 aFB
 aFB
 eVm
@@ -72504,7 +73051,7 @@ aaa
 aaA
 aRr
 tik
-toi
+rMB
 dse
 jKb
 fRR
@@ -72806,11 +73353,11 @@ aaa
 aaA
 aRs
 aSf
-aSN
-xjP
+rMB
+aRr
 rMK
 kYM
-aKN
+gkI
 aRs
 aaa
 aXP
@@ -73108,8 +73655,8 @@ aaa
 aaA
 aRs
 tyd
-aSN
-aTz
+rMB
+aRr
 aSN
 aSN
 aSN
@@ -73410,8 +73957,8 @@ aaa
 aaA
 aRs
 iyx
-aSN
-aSN
+toi
+qwe
 aSN
 aSN
 aSN
@@ -74921,9 +75468,9 @@ aaA
 fUw
 fUw
 iED
-fUw
-fUw
+kea
 pEb
+fUw
 fUw
 fUw
 aaa
@@ -75224,9 +75771,9 @@ aai
 aRs
 aUL
 lzt
-lzt
 aUj
 aRs
+aaa
 aaa
 aaa
 aXP
@@ -75272,7 +75819,7 @@ tya
 btx
 bCk
 uPW
-bAG
+ntu
 bzg
 hYl
 bEm
@@ -75526,9 +76073,9 @@ aaa
 aRs
 eUb
 ydN
-tuF
 dag
 aRs
+aaa
 aaa
 aaa
 aXP
@@ -75829,8 +76376,8 @@ fUw
 aRs
 aRs
 aRs
-aRs
 fUw
+aaa
 aaa
 aaa
 aXP
@@ -78282,7 +78829,7 @@ bpY
 bqO
 bqN
 bsI
-btE
+ftD
 btE
 bvL
 bwU
@@ -78583,7 +79130,7 @@ nGP
 bpY
 bqP
 bqN
-bsJ
+bOc
 btF
 buG
 bvK
@@ -79488,14 +80035,14 @@ phs
 phs
 dOD
 bpY
+lGM
 bqN
-bsK
 btH
 bzi
 bzi
 bwY
 bxK
-bzi
+sDo
 bzi
 bzY
 bAS
@@ -79762,7 +80309,7 @@ acK
 apU
 aaa
 aaA
-acK
+lyw
 aWx
 aai
 apU
@@ -79790,7 +80337,7 @@ nEB
 mra
 xAE
 bpY
-bqN
+rbz
 bsL
 btI
 bzi
@@ -80697,14 +81244,14 @@ bmY
 cwW
 bzi
 brT
-buJ
-buJ
-buJ
+bxc
+bxc
+bxc
 bvR
 hEx
 bxa
 byv
-bmY
+wiL
 bAb
 bAT
 bBE
@@ -81000,8 +81547,8 @@ aaa
 bzi
 cZh
 hmV
-buL
-buL
+bxa
+bxa
 tvN
 vqo
 bxc
@@ -84583,14 +85130,14 @@ aEk
 qwo
 azU
 lpG
-lpG
+wxU
 cFD
 cFD
-lpG
-lpG
-aaa
-aaa
-aaa
+wxU
+wxU
+acd
+acd
+acd
 aXP
 aYE
 aXP
@@ -84889,10 +85436,10 @@ hFr
 bMT
 uxw
 ecC
-lpG
+mUe
 aCy
-aCy
-aCy
+usb
+mNs
 aXP
 aYE
 aXP
@@ -85191,9 +85738,9 @@ bQH
 ugE
 peB
 cGc
-lpG
-azU
-azU
+jkE
+tPS
+edp
 edp
 aXP
 aYE
@@ -85489,14 +86036,14 @@ aLj
 hll
 aFq
 lpG
-bMT
+tyc
 poZ
-peB
-peB
-qZb
-azU
-azU
-azU
+qgt
+cGc
+jkE
+kvI
+oJE
+hKE
 aXP
 aYE
 aXP
@@ -85795,10 +86342,10 @@ vJw
 sBZ
 lYT
 mSh
-lpG
-azU
-azU
-azU
+lyh
+aCy
+rxV
+rvd
 aXP
 aYE
 aXP
@@ -86099,8 +86646,8 @@ nvW
 lpG
 lpG
 aCy
-aPv
-aCy
+aBQ
+aBQ
 aXP
 aYE
 aXP
@@ -86396,7 +86943,7 @@ aQb
 cvs
 azU
 azU
-azU
+sqi
 mmb
 aIt
 aIt
@@ -88484,7 +89031,7 @@ aEq
 aEq
 aEq
 aEq
-aEq
+awN
 aFi
 aFi
 awN
@@ -88785,9 +89332,9 @@ aEq
 qKY
 awG
 rLt
-ayr
 axu
 aAo
+fwf
 azh
 azn
 mMf
@@ -89086,10 +89633,10 @@ apl
 aEq
 aFZ
 awH
-avS
-aCA
+lzh
 axu
-aAp
+voi
+azh
 aBg
 aLy
 aCO
@@ -89386,11 +89933,11 @@ udm
 acK
 kiY
 axu
-upK
 avS
 avS
-aCA
+lzh
 axu
+azh
 moS
 ayf
 aAm
@@ -89688,9 +90235,9 @@ aaa
 aaa
 abZ
 axu
-avS
-avS
-avS
+fJk
+sNC
+oJd
 aED
 azj
 aHY
@@ -89991,11 +90538,11 @@ aaa
 aaa
 axu
 jhs
-awK
-aGS
+avS
 avS
 axu
 vRm
+azh
 xKb
 aCa
 aDz
@@ -90038,7 +90585,7 @@ bbX
 aXV
 bcS
 nFa
-fln
+wkd
 fln
 fln
 fln
@@ -90292,12 +90839,12 @@ aaa
 aaa
 aaa
 aEq
-aEq
-aEq
-aEq
+fLF
+avS
 avS
 axu
-aAr
+kOZ
+azh
 aHC
 aCb
 aFo
@@ -90593,13 +91140,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aEq
 avT
 awL
 axw
 ays
-aBY
 aAs
+aAu
 axA
 aHJ
 aCP
@@ -90643,7 +91190,7 @@ aXV
 ljp
 aJC
 bdX
-ber
+aQM
 aQM
 beK
 aQf
@@ -90895,12 +91442,12 @@ aaa
 aaa
 aaa
 aaa
-aGM
 aEq
 aEq
 aEq
 aEq
 aEq
+awN
 awN
 sgG
 avj
@@ -91199,7 +91746,7 @@ aaa
 aaa
 aaa
 aaa
-uUX
+aHD
 quQ
 ayz
 azl
@@ -91800,9 +92347,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aGM
+aHD
+uUX
 uUX
 axy
 ayw
@@ -92103,13 +92650,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-uUX
+vMd
+aie
+vJy
 xjq
 ayx
 azm
-dJU
+wNr
 aBi
 avj
 nvT
@@ -92404,9 +92951,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aGM
+aHD
+uUX
 uUX
 uSf
 ayw
@@ -93011,7 +93558,7 @@ aaa
 aaa
 aaa
 aap
-uUX
+aHD
 qIZ
 ayz
 azp
@@ -93313,13 +93860,13 @@ aaa
 aaa
 aaa
 aaA
-awN
+aHD
+aHD
 uUX
 uUX
 uUX
-uUX
-awN
-awN
+aHD
+aHD
 aCW
 aDH
 aDH

--- a/maps/donut2.dmm
+++ b/maps/donut2.dmm
@@ -19312,6 +19312,10 @@
 	pixel_y = 3
 	},
 /obj/item/device/prisoner_scanner,
+/obj/item/hand_labeler{
+	pixel_x = 6;
+	pixel_y = 9
+	},
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -19490,7 +19494,6 @@
 /obj/disposalpipe/segment/ejection{
 	dir = 4
 	},
-/obj/stool/chair/office/red,
 /turf/simulated/floor/redblack{
 	dir = 4
 	},
@@ -36304,11 +36307,6 @@
 /obj/item/clothing/suit/wizrobe/purple,
 /turf/simulated/floor/carpet/grime,
 /area/station/crew_quarters/arcade/dungeon)
-"lyw" = (
-/obj/effects/background_objects/star_blue,
-/obj/effects/background_objects/star_red,
-/turf/simulated/floor/plating/airless,
-/area/space)
 "lyD" = (
 /obj/stool/chair/wooden{
 	dir = 1
@@ -36642,6 +36640,10 @@
 "lMl" = (
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/item/storage/toilet/random{
+	dir = 8;
+	pixel_x = 8
 	},
 /turf/simulated/floor/white,
 /area/station/crew_quarters/observatory)
@@ -38224,11 +38226,6 @@
 "nfc" = (
 /obj/decal/poster/wallsign/poster_y4nt{
 	pixel_x = 30
-	},
-/obj/table/auto,
-/obj/item/hand_labeler{
-	pixel_x = 6;
-	pixel_y = 9
 	},
 /turf/simulated/floor/redblack{
 	dir = 4
@@ -80309,7 +80306,7 @@ acK
 apU
 aaa
 aaA
-lyw
+acK
 aWx
 aai
 apU


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To automatically tag this PR, add the label(s) surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds in a barber shop, a nerd dungeon, and a psych office. Redoes some other rooms that I was unhappy with (chapel worship room, stock exchange). Minor changes to certain spawns (reduces amount of tableware that spawns in the bar, adjusts blob spawns).


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Donut 2 progress is good progress. Rooms are better balanced (hopefully) for classic, while also adding in some areas that were requested and I finally managed to squeeze into the map.

PR remade because I blew up the old one. 


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete this section.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```changelog
(u)Roddy
(+)Donut 2 Barbershop moved to crew quarters, new nerd dungeon in maint behind arcade. Made other small fixes and tweaks
```
[mapping] [QoL]